### PR TITLE
fix: wrap schema migrations in _execute_write for atomicity

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -250,103 +250,121 @@ class SessionDB:
                 self._conn = None
 
     def _init_schema(self):
-        """Create tables and FTS if they don't exist, run migrations."""
-        cursor = self._conn.cursor()
+        """Create tables and FTS if they don't exist, run migrations.
 
-        cursor.executescript(SCHEMA_SQL)
+        Each migration runs inside ``_execute_write`` so that ALTER TABLE +
+        version bump is atomic — a crash mid-migration rolls back rather
+        than leaving the DB at an inconsistent version.
+        """
+        def _create_base_tables(conn):
+            # Individual executes instead of executescript (which auto-commits)
+            for stmt in SCHEMA_SQL.split(";"):
+                stmt = stmt.strip()
+                if stmt:
+                    conn.execute(stmt)
+        self._execute_write(_create_base_tables)
 
-        # Check schema version and run migrations
-        cursor.execute("SELECT version FROM schema_version LIMIT 1")
-        row = cursor.fetchone()
+        # Read current schema version (read-only, no transaction needed)
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute("SELECT version FROM schema_version LIMIT 1")
+            row = cursor.fetchone()
+
         if row is None:
-            cursor.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
+            def _insert_version(conn):
+                conn.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
+            self._execute_write(_insert_version)
         else:
             current_version = row["version"] if isinstance(row, sqlite3.Row) else row[0]
+
             if current_version < 2:
-                # v2: add finish_reason column to messages
-                try:
-                    cursor.execute("ALTER TABLE messages ADD COLUMN finish_reason TEXT")
-                except sqlite3.OperationalError:
-                    pass  # Column already exists
-                cursor.execute("UPDATE schema_version SET version = 2")
+                def _migrate_v2(conn):
+                    try:
+                        conn.execute("ALTER TABLE messages ADD COLUMN finish_reason TEXT")
+                    except sqlite3.OperationalError as e:
+                        if "duplicate column" not in str(e).lower():
+                            raise
+                    conn.execute("UPDATE schema_version SET version = 2")
+                self._execute_write(_migrate_v2)
+
             if current_version < 3:
-                # v3: add title column to sessions
-                try:
-                    cursor.execute("ALTER TABLE sessions ADD COLUMN title TEXT")
-                except sqlite3.OperationalError:
-                    pass  # Column already exists
-                cursor.execute("UPDATE schema_version SET version = 3")
+                def _migrate_v3(conn):
+                    try:
+                        conn.execute("ALTER TABLE sessions ADD COLUMN title TEXT")
+                    except sqlite3.OperationalError as e:
+                        if "duplicate column" not in str(e).lower():
+                            raise
+                    conn.execute("UPDATE schema_version SET version = 3")
+                self._execute_write(_migrate_v3)
+
             if current_version < 4:
-                # v4: add unique index on title (NULLs allowed, only non-NULL must be unique)
-                try:
-                    cursor.execute(
+                def _migrate_v4(conn):
+                    conn.execute(
                         "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
                         "ON sessions(title) WHERE title IS NOT NULL"
                     )
-                except sqlite3.OperationalError:
-                    pass  # Index already exists
-                cursor.execute("UPDATE schema_version SET version = 4")
-            if current_version < 5:
-                new_columns = [
-                    ("cache_read_tokens", "INTEGER DEFAULT 0"),
-                    ("cache_write_tokens", "INTEGER DEFAULT 0"),
-                    ("reasoning_tokens", "INTEGER DEFAULT 0"),
-                    ("billing_provider", "TEXT"),
-                    ("billing_base_url", "TEXT"),
-                    ("billing_mode", "TEXT"),
-                    ("estimated_cost_usd", "REAL"),
-                    ("actual_cost_usd", "REAL"),
-                    ("cost_status", "TEXT"),
-                    ("cost_source", "TEXT"),
-                    ("pricing_version", "TEXT"),
-                ]
-                for name, column_type in new_columns:
-                    try:
-                        # name and column_type come from the hardcoded tuple above,
-                        # not user input. Double-quote identifier escaping is applied
-                        # as defense-in-depth; SQLite DDL cannot be parameterized.
-                        safe_name = name.replace('"', '""')
-                        cursor.execute(f'ALTER TABLE sessions ADD COLUMN "{safe_name}" {column_type}')
-                    except sqlite3.OperationalError:
-                        pass
-                cursor.execute("UPDATE schema_version SET version = 5")
-            if current_version < 6:
-                # v6: add reasoning columns to messages table — preserves assistant
-                # reasoning text and structured reasoning_details across gateway
-                # session turns.  Without these, reasoning chains are lost on
-                # session reload, breaking multi-turn reasoning continuity for
-                # providers that replay reasoning (OpenRouter, OpenAI, Nous).
-                for col_name, col_type in [
-                    ("reasoning", "TEXT"),
-                    ("reasoning_details", "TEXT"),
-                    ("codex_reasoning_items", "TEXT"),
-                ]:
-                    try:
-                        safe = col_name.replace('"', '""')
-                        cursor.execute(
-                            f'ALTER TABLE messages ADD COLUMN "{safe}" {col_type}'
-                        )
-                    except sqlite3.OperationalError:
-                        pass  # Column already exists
-                cursor.execute("UPDATE schema_version SET version = 6")
+                    conn.execute("UPDATE schema_version SET version = 4")
+                self._execute_write(_migrate_v4)
 
-        # Unique title index — always ensure it exists (safe to run after migrations
-        # since the title column is guaranteed to exist at this point)
-        try:
-            cursor.execute(
+            if current_version < 5:
+                def _migrate_v5(conn):
+                    for name, column_type in [
+                        ("cache_read_tokens", "INTEGER DEFAULT 0"),
+                        ("cache_write_tokens", "INTEGER DEFAULT 0"),
+                        ("reasoning_tokens", "INTEGER DEFAULT 0"),
+                        ("billing_provider", "TEXT"),
+                        ("billing_base_url", "TEXT"),
+                        ("billing_mode", "TEXT"),
+                        ("estimated_cost_usd", "REAL"),
+                        ("actual_cost_usd", "REAL"),
+                        ("cost_status", "TEXT"),
+                        ("cost_source", "TEXT"),
+                        ("pricing_version", "TEXT"),
+                    ]:
+                        try:
+                            safe_name = name.replace('"', '""')
+                            conn.execute(f'ALTER TABLE sessions ADD COLUMN "{safe_name}" {column_type}')
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column" not in str(e).lower():
+                                raise
+                    conn.execute("UPDATE schema_version SET version = 5")
+                self._execute_write(_migrate_v5)
+
+            if current_version < 6:
+                def _migrate_v6(conn):
+                    for col_name, col_type in [
+                        ("reasoning", "TEXT"),
+                        ("reasoning_details", "TEXT"),
+                        ("codex_reasoning_items", "TEXT"),
+                    ]:
+                        try:
+                            safe = col_name.replace('"', '""')
+                            conn.execute(
+                                f'ALTER TABLE messages ADD COLUMN "{safe}" {col_type}'
+                            )
+                        except sqlite3.OperationalError as e:
+                            if "duplicate column" not in str(e).lower():
+                                raise
+                    conn.execute("UPDATE schema_version SET version = 6")
+                self._execute_write(_migrate_v6)
+
+        # Unique title index — always ensure it exists
+        def _ensure_title_index(conn):
+            conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
                 "ON sessions(title) WHERE title IS NOT NULL"
             )
-        except sqlite3.OperationalError:
-            pass  # Index already exists
+        self._execute_write(_ensure_title_index)
 
-        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
-        try:
-            cursor.execute("SELECT * FROM messages_fts LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
-
-        self._conn.commit()
+        # FTS5 setup
+        with self._lock:
+            try:
+                self._conn.execute("SELECT * FROM messages_fts LIMIT 0")
+            except sqlite3.OperationalError:
+                # FTS table doesn't exist — create it.
+                # executescript is safe here because it's creating new objects
+                # (no existing data at risk) and runs outside a transaction.
+                self._conn.executescript(FTS_SQL)
 
     # =========================================================================
     # Session lifecycle

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1375,3 +1375,67 @@ class TestConcurrentWriteSafety:
         assert "30" in src, (
             "SQLite timeout should be at least 30s to handle CLI/gateway lock contention"
         )
+
+
+# =========================================================================
+# Schema migration atomicity (#8030)
+# =========================================================================
+
+class TestSchemaMigrationAtomicity:
+    """Verify _init_schema migrations use _execute_write for atomicity."""
+
+    def test_v1_to_v6_migration(self, tmp_path):
+        """DB at schema v1 should migrate to v6 with all columns present."""
+        import sqlite3
+
+        path = tmp_path / "old.db"
+        conn = sqlite3.connect(str(path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (1);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT NOT NULL,
+                user_id TEXT, model TEXT, model_config TEXT,
+                system_prompt TEXT, parent_session_id TEXT,
+                started_at REAL NOT NULL, ended_at REAL,
+                end_reason TEXT, message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL, content TEXT,
+                tool_call_id TEXT, tool_calls TEXT, tool_name TEXT,
+                timestamp REAL NOT NULL, token_count INTEGER
+            );
+        """)
+        conn.commit()
+        conn.close()
+
+        db = SessionDB(db_path=path)
+        # Should be at v6 now
+        conn2 = sqlite3.connect(str(path))
+        ver = conn2.execute("SELECT version FROM schema_version").fetchone()[0]
+        conn2.close()
+        assert ver == 6
+
+        # Verify v6 columns work
+        db.create_session("s1", source="test")
+        db.append_message("s1", "assistant", "answer", reasoning="think")
+        msgs = db.get_messages("s1")
+        assert len(msgs) == 1
+        db.close()
+
+    def test_fresh_db_gets_current_version(self, tmp_path):
+        """New DB should start at SCHEMA_VERSION without running migrations."""
+        import sqlite3
+        from hermes_state import SCHEMA_VERSION
+
+        path = tmp_path / "fresh.db"
+        db = SessionDB(db_path=path)
+        conn = sqlite3.connect(str(path))
+        ver = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        conn.close()
+        assert ver == SCHEMA_VERSION
+        db.close()


### PR DESCRIPTION
## Summary

- Each schema migration (v2 through v6) now runs inside `_execute_write()` — ALTER TABLE + version bump is atomic, crash rolls back both
- Base table creation uses individual `execute()` calls instead of `executescript()` (which auto-commits mid-script and can leave partial DDL committed)
- Error handling tightened: only "duplicate column" errors are swallowed, other `OperationalError`s (disk I/O, locked DB) now propagate instead of being silently passed

## Test plan

- [x] `test_v1_to_v6_migration` — verifies DB at schema v1 migrates to v6 with all columns present
- [x] `test_fresh_db_gets_current_version` — verifies new DB starts at SCHEMA_VERSION
- [x] All 139 existing hermes_state tests pass

Closes #8030

🤖 Generated with [Claude Code](https://claude.com/claude-code)