### PR TITLE
fix(cli): restore MiniMax doctor health-check skip (regression)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -941,9 +941,11 @@ def run_doctor(args):
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("NVIDIA NIM",       ("NVIDIA_API_KEY",),                             "https://integrate.api.nvidia.com/v1/models", "NVIDIA_BASE_URL", True),
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
-        # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
-        ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
-        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        # MiniMax APIs do not expose a /v1/models endpoint on any surface —
+        # both api.minimax.io/v1/models and api.minimaxi.com/v1/models return
+        # HTTP 404. Keep health-check disabled. See issue #811.
+        ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
+        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -808,9 +808,11 @@ def run_doctor(args):
         ("DeepSeek",         ("DEEPSEEK_API_KEY",),                           "https://api.deepseek.com/v1/models",  "DEEPSEEK_BASE_URL", True),
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
-        # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
-        ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
-        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        # MiniMax APIs do not expose a /v1/models endpoint on any surface —
+        # both api.minimax.io/v1/models and api.minimaxi.com/v1/models return
+        # HTTP 404. Keep health-check disabled. See issue #811.
+        ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
+        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -487,3 +487,36 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     )
     assert not any(url == "https://opencode.ai/zen/go/v1/models" for url, _, _ in calls)
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
+
+
+def test_minimax_provider_health_check_disabled():
+    """MiniMax APIs don't expose a /v1/models endpoint on any surface.
+
+    Both ``api.minimax.io/v1/models`` and ``api.minimaxi.com/v1/models`` return
+    HTTP 404 — the real chat endpoint (``POST /v1/text/chatcompletion_v2``) is
+    available, but doctor's OpenAI-style ``/models`` probe is not a valid
+    health check for MiniMax. Regression guard for issue #811: an earlier
+    attempt to enable the health check caused doctor to spam HTTP 404 warnings
+    for every user with a MiniMax key.
+    """
+    import inspect
+
+    source = inspect.getsource(doctor_mod.run_doctor)
+
+    minimax_entries = [
+        line.strip()
+        for line in source.splitlines()
+        if line.lstrip().startswith('("MiniMax"')
+        or line.lstrip().startswith('("MiniMax (China)"')
+    ]
+    assert len(minimax_entries) == 2, (
+        f"expected two MiniMax entries in _apikey_providers, found {len(minimax_entries)}"
+    )
+    for entry in minimax_entries:
+        # The last tuple field is supports_health_check; it must be False so
+        # doctor skips the /models probe and just prints "(key configured)".
+        assert entry.rstrip().endswith("False),"), (
+            "MiniMax provider entry must keep supports_health_check=False; "
+            "see https://github.com/NousResearch/hermes-agent/issues/811\n"
+            f"Offending line: {entry!r}"
+        )

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -397,3 +397,36 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     )
     assert not any(url == "https://opencode.ai/zen/go/v1/models" for url, _, _ in calls)
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
+
+
+def test_minimax_provider_health_check_disabled():
+    """MiniMax APIs don't expose a /v1/models endpoint on any surface.
+
+    Both ``api.minimax.io/v1/models`` and ``api.minimaxi.com/v1/models`` return
+    HTTP 404 — the real chat endpoint (``POST /v1/text/chatcompletion_v2``) is
+    available, but doctor's OpenAI-style ``/models`` probe is not a valid
+    health check for MiniMax. Regression guard for issue #811: an earlier
+    attempt to enable the health check caused doctor to spam HTTP 404 warnings
+    for every user with a MiniMax key.
+    """
+    import inspect
+
+    source = inspect.getsource(doctor_mod.run_doctor)
+
+    minimax_entries = [
+        line.strip()
+        for line in source.splitlines()
+        if line.lstrip().startswith('("MiniMax"')
+        or line.lstrip().startswith('("MiniMax (China)"')
+    ]
+    assert len(minimax_entries) == 2, (
+        f"expected two MiniMax entries in _apikey_providers, found {len(minimax_entries)}"
+    )
+    for entry in minimax_entries:
+        # The last tuple field is supports_health_check; it must be False so
+        # doctor skips the /models probe and just prints "(key configured)".
+        assert entry.rstrip().endswith("False),"), (
+            "MiniMax provider entry must keep supports_health_check=False; "
+            "see https://github.com/NousResearch/hermes-agent/issues/811\n"
+            f"Offending line: {entry!r}"
+        )


### PR DESCRIPTION
## Summary

- Restores `supports_health_check=False` for both MiniMax and MiniMax (China) entries in `hermes doctor`'s `_apikey_providers` list
- Adds a regression test to prevent re-enabling the flag

## Problem

`d442f25a` ("fix: align MiniMax provider with official API docs") re-enabled the `/v1/models` health check for MiniMax, assuming the OpenAI-compat `/v1` surface supports `/models` even though the Anthropic-compat `/anthropic` surface does not. **That assumption is incorrect — neither surface exposes `/v1/models`:**

```
$ curl -s -o /dev/null -w "%{http_code}" https://api.minimax.io/v1/models
404
$ curl -s -o /dev/null -w "%{http_code}" https://api.minimaxi.com/v1/models
404
```

The real chat endpoint works fine (`POST /v1/text/chatcompletion_v2` → 200), so the runtime agent path is unaffected. Only `hermes doctor` is broken: every user with a `MINIMAX_API_KEY` or `MINIMAX_CN_API_KEY` sees a spurious `⚠ MiniMax (HTTP 404)` warning.

This was originally fixed in #811 (which set the flag to `False`), and `d442f25a` inadvertently reverted that fix.

## Fix

Restores the pre-`d442f25a` behavior:
- `supports_health_check` → `False`
- `default_url` → `None`
- Comment references #811

## Test plan

- [x] New test `test_minimax_provider_health_check_disabled` in `tests/hermes_cli/test_doctor.py` — fails if the flag gets re-enabled
- [x] Full `test_doctor.py` suite passes (18/18)
- [x] Manually verified with `hermes doctor` — MiniMax now shows `✓ MiniMax (China) (key configured)` instead of `⚠ MiniMax (China) (HTTP 404)`

Tested on macOS (Darwin 25.3.0), Python 3.11.4, Hermes `27eeea05`.

Refs: #811