### PR TITLE
fix: persist Codex continuity across resumed sessions

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -65,6 +65,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    codex_previous_response_id TEXT,
+    codex_previous_response_history_len INTEGER DEFAULT 0,
+    codex_previous_response_history_fingerprint TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -329,6 +332,23 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: persist native Codex Responses continuity boundary on the
+                # session row so resumed agents can keep threading upstream via
+                # previous_response_id instead of falling back to full replay.
+                for col_name, col_type in [
+                    ("codex_previous_response_id", "TEXT"),
+                    ("codex_previous_response_history_len", "INTEGER DEFAULT 0"),
+                    ("codex_previous_response_history_fingerprint", "TEXT"),
+                ]:
+                    try:
+                        safe = col_name.replace('"', '""')
+                        cursor.execute(
+                            f'ALTER TABLE sessions ADD COLUMN "{safe}" {col_type}'
+                        )
+                    except sqlite3.OperationalError:
+                        pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -407,6 +427,37 @@ class SessionDB:
                 "UPDATE sessions SET system_prompt = ? WHERE id = ?",
                 (system_prompt, session_id),
             )
+        self._execute_write(_do)
+
+    def update_codex_previous_response(
+        self,
+        session_id: str,
+        response_id: Optional[str],
+        history_len: int = 0,
+        history_fingerprint: Optional[str] = None,
+    ) -> None:
+        """Persist the native Codex Responses continuity boundary for a session."""
+        normalized_response_id = response_id.strip() if isinstance(response_id, str) and response_id.strip() else None
+        normalized_history_len = int(history_len) if isinstance(history_len, int) and history_len >= 0 else 0
+        normalized_fingerprint = (
+            history_fingerprint if isinstance(history_fingerprint, str) and history_fingerprint else None
+        )
+
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions
+                   SET codex_previous_response_id = ?,
+                       codex_previous_response_history_len = ?,
+                       codex_previous_response_history_fingerprint = ?
+                   WHERE id = ?""",
+                (
+                    normalized_response_id,
+                    normalized_history_len,
+                    normalized_fingerprint,
+                    session_id,
+                ),
+            )
+
         self._execute_write(_do)
 
     def update_token_counts(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     codex_previous_response_id TEXT,
     codex_previous_response_history_len INTEGER DEFAULT 0,
     codex_previous_response_history_fingerprint TEXT,
+    codex_previous_response_backend TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -349,6 +350,17 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 7")
+            if current_version < 8:
+                # v8: scope persisted previous_response_id continuity to the
+                # backend that minted it so resumed sessions can't send a native
+                # response id across different Responses backends.
+                try:
+                    cursor.execute(
+                        'ALTER TABLE sessions ADD COLUMN "codex_previous_response_backend" TEXT'
+                    )
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 8")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -435,6 +447,7 @@ class SessionDB:
         response_id: Optional[str],
         history_len: int = 0,
         history_fingerprint: Optional[str] = None,
+        backend: Optional[str] = None,
     ) -> None:
         """Persist the native Codex Responses continuity boundary for a session."""
         normalized_response_id = response_id.strip() if isinstance(response_id, str) and response_id.strip() else None
@@ -442,18 +455,21 @@ class SessionDB:
         normalized_fingerprint = (
             history_fingerprint if isinstance(history_fingerprint, str) and history_fingerprint else None
         )
+        normalized_backend = backend.strip() if isinstance(backend, str) and backend.strip() else None
 
         def _do(conn):
             conn.execute(
                 """UPDATE sessions
                    SET codex_previous_response_id = ?,
                        codex_previous_response_history_len = ?,
-                       codex_previous_response_history_fingerprint = ?
+                       codex_previous_response_history_fingerprint = ?,
+                       codex_previous_response_backend = ?
                    WHERE id = ?""",
                 (
                     normalized_response_id,
                     normalized_history_len,
                     normalized_fingerprint,
+                    normalized_backend,
                     session_id,
                 ),
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -630,6 +630,12 @@ class AIAgent:
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
+        # Native OpenAI Responses threading state. We keep the prior response id
+        # plus a fingerprinted history boundary so resumed turns can safely send
+        # only the new delta instead of replaying the full conversation.
+        self._codex_previous_response_id = None
+        self._codex_previous_response_history_len = 0
+        self._codex_previous_response_history_fingerprint = None
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
@@ -3539,6 +3545,114 @@ class AIAgent:
 
         return items
 
+    def _responses_history_fingerprint(self, messages: List[Dict[str, Any]]) -> str:
+        """Return a stable fingerprint for Responses-threading history matching."""
+        try:
+            payload = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except TypeError:
+            payload = json.dumps(messages, ensure_ascii=False, default=str, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+    def _history_messages_from_responses_payload(
+        self,
+        payload_messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Strip ephemeral Responses-only prefixes (for example prefill messages)."""
+        prefill_count = len(self.prefill_messages or [])
+        if prefill_count <= 0:
+            return payload_messages
+        return payload_messages[prefill_count:]
+
+    @staticmethod
+    def _normalize_messages_for_responses_threading(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Match the durable history shape used just before _build_api_kwargs()."""
+        normalized: List[Dict[str, Any]] = []
+        strip_keys = {"reasoning", "finish_reason", "_flush_sentinel", "_thinking_prefill"}
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            normalized.append({k: v for k, v in msg.items() if k not in strip_keys})
+        return normalized
+
+    def _build_codex_responses_turn_input(self, payload_messages: List[Dict[str, Any]]) -> tuple[Optional[str], List[Dict[str, Any]]]:
+        """Return (previous_response_id, input_items) for the next Codex request.
+
+        Native Responses threading is only used when the current history still
+        matches the prefix that produced the stored previous_response_id.
+        Otherwise we safely fall back to full replay.
+        """
+        history_messages = self._normalize_messages_for_responses_threading(
+            self._history_messages_from_responses_payload(payload_messages)
+        )
+        previous_response_id = getattr(self, "_codex_previous_response_id", None)
+        history_len = getattr(self, "_codex_previous_response_history_len", None)
+        history_fingerprint = getattr(self, "_codex_previous_response_history_fingerprint", None)
+
+        can_thread = (
+            isinstance(previous_response_id, str)
+            and previous_response_id.strip()
+            and isinstance(history_len, int)
+            and history_len >= 0
+            and isinstance(history_fingerprint, str)
+            and history_len <= len(history_messages)
+            and self._responses_history_fingerprint(history_messages[:history_len]) == history_fingerprint
+        )
+        if not can_thread:
+            return None, self._chat_messages_to_responses_input(payload_messages)
+
+        delta_messages = history_messages[history_len:]
+        return previous_response_id.strip(), self._chat_messages_to_responses_input(delta_messages)
+
+    def _persist_codex_previous_response_state(self) -> None:
+        """Write the current native Codex continuity boundary to the session store."""
+        if not self._session_db or not self.session_id:
+            return
+        try:
+            self._session_db.update_codex_previous_response(
+                self.session_id,
+                getattr(self, "_codex_previous_response_id", None),
+                history_len=getattr(self, "_codex_previous_response_history_len", 0),
+                history_fingerprint=getattr(self, "_codex_previous_response_history_fingerprint", None),
+            )
+        except Exception as e:
+            logger.debug("Session DB update_codex_previous_response failed: %s", e)
+
+    def _hydrate_codex_previous_response_state(self, session_row: Optional[Dict[str, Any]]) -> None:
+        """Restore native Codex continuity boundary from persisted session metadata."""
+        if self.api_mode != "codex_responses" or not isinstance(session_row, dict):
+            return
+
+        response_id = session_row.get("codex_previous_response_id")
+        history_len = session_row.get("codex_previous_response_history_len")
+        history_fingerprint = session_row.get("codex_previous_response_history_fingerprint")
+
+        self._codex_previous_response_id = (
+            response_id.strip() if isinstance(response_id, str) and response_id.strip() else None
+        )
+        self._codex_previous_response_history_len = history_len if isinstance(history_len, int) and history_len >= 0 else 0
+        self._codex_previous_response_history_fingerprint = (
+            history_fingerprint if isinstance(history_fingerprint, str) and history_fingerprint else None
+        )
+
+    def _remember_codex_previous_response(self, response: Any, history_messages: List[Dict[str, Any]]) -> None:
+        """Persist the last successful Responses id plus its history boundary."""
+        response_id = getattr(response, "id", None)
+        if not isinstance(response_id, str) or not response_id.strip():
+            return
+
+        stored_history = history_messages
+        if stored_history and stored_history[0].get("role") == "system":
+            stored_history = stored_history[1:]
+        stored_history = self._normalize_messages_for_responses_threading(
+            self._history_messages_from_responses_payload(stored_history)
+        )
+
+        self._codex_previous_response_id = response_id.strip()
+        self._codex_previous_response_history_len = len(stored_history)
+        # Fingerprint only the durable conversation history, not ephemeral API-only prefixes.
+        self._codex_previous_response_history_fingerprint = self._responses_history_fingerprint(stored_history)
+        self._persist_codex_previous_response_state()
+
     def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
         if not isinstance(raw_items, list):
             raise ValueError("Codex Responses input must be a list of input items.")
@@ -3705,6 +3819,7 @@ class AIAgent:
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
+            "previous_response_id",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3734,8 +3849,8 @@ class AIAgent:
         if isinstance(temperature, (int, float)):
             normalized["temperature"] = float(temperature)
 
-        # Pass through tool_choice, parallel_tool_calls, prompt_cache_key
-        for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key"):
+        # Pass through tool_choice, parallel_tool_calls, prompt_cache_key, previous_response_id
+        for passthrough_key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "previous_response_id"):
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
@@ -5946,15 +6061,22 @@ class AIAgent:
                 elif self.reasoning_config.get("effort"):
                     reasoning_effort = self.reasoning_config["effort"]
 
+            previous_response_id = None
+            input_items = self._chat_messages_to_responses_input(payload_messages)
+            if not is_github_responses:
+                previous_response_id, input_items = self._build_codex_responses_turn_input(payload_messages)
+
             kwargs = {
                 "model": self.model,
                 "instructions": instructions,
-                "input": self._chat_messages_to_responses_input(payload_messages),
+                "input": input_items,
                 "tools": self._responses_tools(),
                 "tool_choice": "auto",
                 "parallel_tool_calls": True,
                 "store": False,
             }
+            if previous_response_id:
+                kwargs["previous_response_id"] = previous_response_id
 
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
@@ -7654,11 +7776,13 @@ class AIAgent:
         # prefix cache.
         if self._cached_system_prompt is None:
             stored_prompt = None
+            session_row = None
             if conversation_history and self._session_db:
                 try:
                     session_row = self._session_db.get_session(self.session_id)
                     if session_row:
                         stored_prompt = session_row.get("system_prompt") or None
+                        self._hydrate_codex_previous_response_state(session_row)
                 except Exception:
                     pass  # Fall through to build fresh
 
@@ -9464,7 +9588,8 @@ class AIAgent:
                         if not duplicate_interim:
                             messages.append(interim_msg)
                             self._emit_interim_assistant_message(interim_msg)
-
+                        self._remember_codex_previous_response(response, messages)
+ 
                     if self._codex_incomplete_retries < 3:
                         if not self.quiet_mode:
                             self._vprint(f"{self.log_prefix}↻ Codex response incomplete; continuing turn ({self._codex_incomplete_retries}/3)")
@@ -9531,6 +9656,8 @@ class AIAgent:
 
                         assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         messages.append(assistant_msg)
+                        if self.api_mode == "codex_responses":
+                            self._remember_codex_previous_response(response, messages)
                         for tc in assistant_message.tool_calls:
                             if tc.function.name not in self.valid_tool_names:
                                 content = f"Tool '{tc.function.name}' does not exist. Available tools: {available}"
@@ -9614,6 +9741,8 @@ class AIAgent:
                             # Append the assistant message with its (broken) tool_calls
                             recovery_assistant = self._build_assistant_message(assistant_message, finish_reason)
                             messages.append(recovery_assistant)
+                            if self.api_mode == "codex_responses":
+                                self._remember_codex_previous_response(response, messages)
                             
                             # Respond with tool error results for each tool call
                             invalid_names = {name for name, _ in invalid_json_args}
@@ -9684,6 +9813,8 @@ class AIAgent:
 
                     messages.append(assistant_msg)
                     self._emit_interim_assistant_message(assistant_msg)
+                    if self.api_mode == "codex_responses":
+                        self._remember_codex_previous_response(response, messages)
 
                     # Close any open streaming display (response box, reasoning
                     # box) before tool execution begins.  Intermediate turns may
@@ -9852,6 +9983,8 @@ class AIAgent:
                             )
                             interim_msg["_thinking_prefill"] = True
                             messages.append(interim_msg)
+                            if self.api_mode == "codex_responses":
+                                self._remember_codex_previous_response(response, messages)
                             self._session_messages = messages
                             self._save_session_log(messages)
                             continue
@@ -9963,6 +10096,7 @@ class AIAgent:
                         interim_msg = self._build_assistant_message(assistant_message, "incomplete")
                         messages.append(interim_msg)
                         self._emit_interim_assistant_message(interim_msg)
+                        self._remember_codex_previous_response(response, messages)
 
                         continue_msg = {
                             "role": "user",
@@ -10000,6 +10134,8 @@ class AIAgent:
                         messages.pop()
 
                     messages.append(final_msg)
+                    if self.api_mode == "codex_responses":
+                        self._remember_codex_previous_response(response, messages)
                     
                     _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                     if not self.quiet_mode:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1809,6 +1809,15 @@ class AIAgent:
         """Return True when the base URL targets OpenRouter."""
         return "openrouter" in self._base_url_lower
 
+    def _supports_previous_response_id(self, base_url: str = None) -> bool:
+        """Return True when the active Responses backend supports previous_response_id threading."""
+        url = (base_url or self.base_url or "").lower()
+        if "models.github.ai" in url or "api.githubcopilot.com" in url:
+            return False
+        if "chatgpt.com/backend-api/codex" in url:
+            return False
+        return self._is_direct_openai_url(url) or is_local_endpoint(url)
+
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
         """Return True for models that require the Responses API path.
@@ -6063,7 +6072,7 @@ class AIAgent:
 
             previous_response_id = None
             input_items = self._chat_messages_to_responses_input(payload_messages)
-            if not is_github_responses:
+            if self._supports_previous_response_id():
                 previous_response_id, input_items = self._build_codex_responses_turn_input(payload_messages)
 
             kwargs = {

--- a/run_agent.py
+++ b/run_agent.py
@@ -38,6 +38,7 @@ import threading
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlsplit
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -636,6 +637,7 @@ class AIAgent:
         self._codex_previous_response_id = None
         self._codex_previous_response_history_len = 0
         self._codex_previous_response_history_fingerprint = None
+        self._codex_previous_response_backend = None
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
@@ -1817,6 +1819,32 @@ class AIAgent:
         if "chatgpt.com/backend-api/codex" in url:
             return False
         return self._is_direct_openai_url(url) or is_local_endpoint(url)
+
+    def _previous_response_backend_key(self, base_url: str = None) -> Optional[str]:
+        """Return a narrow, stable identity for the backend minting Responses ids."""
+        raw_url = (base_url or self.base_url or "").strip()
+        if not raw_url:
+            return None
+        normalized_url = raw_url.lower()
+
+        if "chatgpt.com/backend-api/codex" in normalized_url:
+            return "chatgpt.com/backend-api/codex"
+        if "models.github.ai" in normalized_url:
+            return "models.github.ai"
+        if "api.githubcopilot.com" in normalized_url:
+            return "api.githubcopilot.com"
+        if self._is_direct_openai_url(normalized_url):
+            return "api.openai.com"
+        if is_local_endpoint(normalized_url):
+            parsed = urlsplit(raw_url)
+            scheme = (parsed.scheme or "http").lower()
+            hostname = (parsed.hostname or "").lower()
+            if not hostname:
+                return None
+            port = f":{parsed.port}" if parsed.port else ""
+            path = (parsed.path or "").rstrip("/")
+            return f"{scheme}://{hostname}{port}{path}"
+        return None
 
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
@@ -3596,6 +3624,8 @@ class AIAgent:
         previous_response_id = getattr(self, "_codex_previous_response_id", None)
         history_len = getattr(self, "_codex_previous_response_history_len", None)
         history_fingerprint = getattr(self, "_codex_previous_response_history_fingerprint", None)
+        persisted_backend = getattr(self, "_codex_previous_response_backend", None)
+        current_backend = self._previous_response_backend_key()
 
         can_thread = (
             isinstance(previous_response_id, str)
@@ -3603,6 +3633,8 @@ class AIAgent:
             and isinstance(history_len, int)
             and history_len >= 0
             and isinstance(history_fingerprint, str)
+            and isinstance(persisted_backend, str)
+            and persisted_backend == current_backend
             and history_len <= len(history_messages)
             and self._responses_history_fingerprint(history_messages[:history_len]) == history_fingerprint
         )
@@ -3622,6 +3654,7 @@ class AIAgent:
                 getattr(self, "_codex_previous_response_id", None),
                 history_len=getattr(self, "_codex_previous_response_history_len", 0),
                 history_fingerprint=getattr(self, "_codex_previous_response_history_fingerprint", None),
+                backend=getattr(self, "_codex_previous_response_backend", None),
             )
         except Exception as e:
             logger.debug("Session DB update_codex_previous_response failed: %s", e)
@@ -3634,6 +3667,7 @@ class AIAgent:
         response_id = session_row.get("codex_previous_response_id")
         history_len = session_row.get("codex_previous_response_history_len")
         history_fingerprint = session_row.get("codex_previous_response_history_fingerprint")
+        backend = session_row.get("codex_previous_response_backend")
 
         self._codex_previous_response_id = (
             response_id.strip() if isinstance(response_id, str) and response_id.strip() else None
@@ -3641,6 +3675,9 @@ class AIAgent:
         self._codex_previous_response_history_len = history_len if isinstance(history_len, int) and history_len >= 0 else 0
         self._codex_previous_response_history_fingerprint = (
             history_fingerprint if isinstance(history_fingerprint, str) and history_fingerprint else None
+        )
+        self._codex_previous_response_backend = (
+            backend.strip() if isinstance(backend, str) and backend.strip() else None
         )
 
     def _remember_codex_previous_response(self, response: Any, history_messages: List[Dict[str, Any]]) -> None:
@@ -3660,6 +3697,7 @@ class AIAgent:
         self._codex_previous_response_history_len = len(stored_history)
         # Fingerprint only the durable conversation history, not ephemeral API-only prefixes.
         self._codex_previous_response_history_fingerprint = self._responses_history_fingerprint(stored_history)
+        self._codex_previous_response_backend = self._previous_response_backend_key()
         self._persist_codex_previous_response_state()
 
     def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -17,6 +17,7 @@ sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
 sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -415,6 +416,165 @@ class TestBuildApiKwargsCodex:
 
 
 # ── Message conversion tests ────────────────────────────────────────────────
+
+class TestCodexPreviousResponseIdThreading:
+    def _make_codex_agent(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "openai-codex",
+            api_mode="codex_responses",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        monkeypatch.setattr(agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(agent, "_save_session_log", lambda *a, **k: None)
+        monkeypatch.setattr(agent, "_persist_session", lambda *a, **k: None)
+        agent.model = "codex-mini-latest"
+        agent.client = MagicMock()
+        return agent
+
+    @staticmethod
+    def _codex_response(response_id, text):
+        return SimpleNamespace(
+            id=response_id,
+            model="codex-mini-latest",
+            status="completed",
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    phase="final_answer",
+                    content=[SimpleNamespace(type="output_text", text=text)],
+                )
+            ],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+
+    def test_first_turn_does_not_send_previous_response_id(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        kwargs_seen = []
+
+        def fake_api(kwargs):
+            kwargs_seen.append(kwargs)
+            return self._codex_response("resp_1", "First reply")
+
+        monkeypatch.setattr(agent, "_interruptible_api_call", fake_api)
+
+        result = agent.run_conversation("hello", conversation_history=[])
+
+        assert result["final_response"] == "First reply"
+        assert len(kwargs_seen) == 1
+        assert "previous_response_id" not in kwargs_seen[0]
+        assert kwargs_seen[0]["input"] == [{"role": "user", "content": "hello"}]
+
+    def test_follow_up_turn_threads_previous_response_id_with_only_new_input(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        kwargs_seen = []
+        responses = iter(
+            [
+                self._codex_response("resp_1", "First reply"),
+                self._codex_response("resp_2", "Second reply"),
+            ]
+        )
+
+        def fake_api(kwargs):
+            kwargs_seen.append(kwargs)
+            return next(responses)
+
+        monkeypatch.setattr(agent, "_interruptible_api_call", fake_api)
+
+        first = agent.run_conversation("hello", conversation_history=[])
+        second = agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert first["final_response"] == "First reply"
+        assert second["final_response"] == "Second reply"
+        assert len(kwargs_seen) == 2
+        assert "previous_response_id" not in kwargs_seen[0]
+        assert kwargs_seen[1]["previous_response_id"] == "resp_1"
+        assert kwargs_seen[1]["input"] == [{"role": "user", "content": "follow up"}]
+
+    def test_falls_back_to_full_replay_when_no_previous_response_id_is_stored(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "First reply", "finish_reason": "stop"},
+            {"role": "user", "content": "follow up"},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert "previous_response_id" not in kwargs
+        assert kwargs["input"] == agent._chat_messages_to_responses_input(messages)
+
+    def test_resumed_agent_restores_persisted_previous_response_id(self, monkeypatch, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "resume-codex"
+        db.create_session(session_id=session_id, source="cli", model="codex-mini-latest")
+
+        first_agent = AIAgent(
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider="openai-codex",
+            api_mode="codex_responses",
+            max_iterations=4,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id=session_id,
+            session_db=db,
+            persist_session=True,
+        )
+        monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
+        monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+        monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+        monkeypatch.setattr(first_agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(first_agent, "_save_session_log", lambda *a, **k: None)
+        first_agent.model = "codex-mini-latest"
+        first_seen = []
+
+        def first_fake_api(kwargs):
+            first_seen.append(kwargs)
+            return self._codex_response("resp_1", "First reply")
+
+        monkeypatch.setattr(first_agent, "_interruptible_api_call", first_fake_api)
+        first = first_agent.run_conversation("hello", conversation_history=[])
+
+        session = db.get_session(session_id)
+        assert session["codex_previous_response_id"] == "resp_1"
+        assert session["codex_previous_response_history_len"] == 2
+        assert isinstance(session["codex_previous_response_history_fingerprint"], str)
+        assert "previous_response_id" not in first_seen[0]
+
+        resumed_agent = AIAgent(
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider="openai-codex",
+            api_mode="codex_responses",
+            max_iterations=4,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id=session_id,
+            session_db=db,
+            persist_session=True,
+        )
+        monkeypatch.setattr(resumed_agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(resumed_agent, "_save_session_log", lambda *a, **k: None)
+        resumed_agent.model = "codex-mini-latest"
+        resumed_seen = []
+
+        def resumed_fake_api(kwargs):
+            resumed_seen.append(kwargs)
+            return self._codex_response("resp_2", "Second reply")
+
+        monkeypatch.setattr(resumed_agent, "_interruptible_api_call", resumed_fake_api)
+        second = resumed_agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert second["final_response"] == "Second reply"
+        assert resumed_seen[0]["previous_response_id"] == "resp_1"
+        assert resumed_seen[0]["input"] == [{"role": "user", "content": "follow up"}]
+        db.close()
+
 
 class TestChatMessagesToResponsesInput:
     """Verify _chat_messages_to_responses_input for Codex mode."""

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -467,7 +467,7 @@ class TestCodexPreviousResponseIdThreading:
         assert "previous_response_id" not in kwargs_seen[0]
         assert kwargs_seen[0]["input"] == [{"role": "user", "content": "hello"}]
 
-    def test_follow_up_turn_threads_previous_response_id_with_only_new_input(self, monkeypatch):
+    def test_follow_up_turn_omits_previous_response_id_for_chatgpt_codex_backend(self, monkeypatch):
         agent = self._make_codex_agent(monkeypatch)
         kwargs_seen = []
         responses = iter(
@@ -490,8 +490,8 @@ class TestCodexPreviousResponseIdThreading:
         assert second["final_response"] == "Second reply"
         assert len(kwargs_seen) == 2
         assert "previous_response_id" not in kwargs_seen[0]
-        assert kwargs_seen[1]["previous_response_id"] == "resp_1"
-        assert kwargs_seen[1]["input"] == [{"role": "user", "content": "follow up"}]
+        assert "previous_response_id" not in kwargs_seen[1]
+        assert kwargs_seen[1]["input"] == agent._chat_messages_to_responses_input(first["messages"] + [{"role": "user", "content": "follow up"}])
 
     def test_falls_back_to_full_replay_when_no_previous_response_id_is_stored(self, monkeypatch):
         agent = self._make_codex_agent(monkeypatch)
@@ -571,9 +571,69 @@ class TestCodexPreviousResponseIdThreading:
         second = resumed_agent.run_conversation("follow up", conversation_history=first["messages"])
 
         assert second["final_response"] == "Second reply"
-        assert resumed_seen[0]["previous_response_id"] == "resp_1"
-        assert resumed_seen[0]["input"] == [{"role": "user", "content": "follow up"}]
+        assert "previous_response_id" not in resumed_seen[0]
+        assert resumed_seen[0]["input"] == resumed_agent._chat_messages_to_responses_input(first["messages"] + [{"role": "user", "content": "follow up"}])
         db.close()
+
+
+class TestLocalResponsesPreviousResponseIdThreading:
+    def _make_local_responses_agent(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="codex_responses",
+            base_url="http://localhost:1234/v1",
+        )
+        monkeypatch.setattr(agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(agent, "_save_session_log", lambda *a, **k: None)
+        monkeypatch.setattr(agent, "_persist_session", lambda *a, **k: None)
+        agent.model = "gpt-5"
+        agent.client = MagicMock()
+        return agent
+
+    @staticmethod
+    def _responses_response(response_id, text):
+        return SimpleNamespace(
+            id=response_id,
+            model="gpt-5",
+            status="completed",
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    phase="final_answer",
+                    content=[SimpleNamespace(type="output_text", text=text)],
+                )
+            ],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+
+    def test_follow_up_turn_threads_previous_response_id_for_local_responses_backend(self, monkeypatch):
+        agent = self._make_local_responses_agent(monkeypatch)
+        kwargs_seen = []
+        responses = iter(
+            [
+                self._responses_response("resp_local_1", "First reply"),
+                self._responses_response("resp_local_2", "Second reply"),
+            ]
+        )
+
+        def fake_api(kwargs):
+            kwargs_seen.append(kwargs)
+            return next(responses)
+
+        monkeypatch.setattr(agent, "_interruptible_api_call", fake_api)
+
+        first = agent.run_conversation("hello", conversation_history=[])
+        second = agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert first["final_response"] == "First reply"
+        assert second["final_response"] == "Second reply"
+        assert len(kwargs_seen) == 2
+        assert "previous_response_id" not in kwargs_seen[0]
+        assert kwargs_seen[1]["previous_response_id"] == "resp_local_1"
+        assert kwargs_seen[1]["input"] == [{"role": "user", "content": "follow up"}]
 
 
 class TestChatMessagesToResponsesInput:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -591,6 +591,29 @@ class TestLocalResponsesPreviousResponseIdThreading:
         agent.client = MagicMock()
         return agent
 
+    def _make_persisted_responses_agent(self, monkeypatch, db, session_id, *, base_url):
+        provider = "openai-codex" if "api.openai.com" in base_url else "custom"
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=base_url,
+            provider=provider,
+            api_mode="codex_responses",
+            max_iterations=4,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id=session_id,
+            session_db=db,
+            persist_session=True,
+        )
+        monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
+        monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+        monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+        monkeypatch.setattr(agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(agent, "_save_session_log", lambda *a, **k: None)
+        agent.model = "gpt-5"
+        return agent
+
     @staticmethod
     def _responses_response(response_id, text):
         return SimpleNamespace(
@@ -634,6 +657,81 @@ class TestLocalResponsesPreviousResponseIdThreading:
         assert "previous_response_id" not in kwargs_seen[0]
         assert kwargs_seen[1]["previous_response_id"] == "resp_local_1"
         assert kwargs_seen[1]["input"] == [{"role": "user", "content": "follow up"}]
+
+    def test_resumed_session_does_not_reuse_previous_response_id_across_supported_backends(self, monkeypatch, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "resume-cross-backend"
+        db.create_session(session_id=session_id, source="cli", model="gpt-5")
+
+        first_agent = self._make_persisted_responses_agent(
+            monkeypatch, db, session_id, base_url="http://localhost:1234/v1"
+        )
+        first_seen = []
+
+        def first_fake_api(kwargs):
+            first_seen.append(kwargs)
+            return self._responses_response("resp_local_1", "First reply")
+
+        monkeypatch.setattr(first_agent, "_interruptible_api_call", first_fake_api)
+        first = first_agent.run_conversation("hello", conversation_history=[])
+
+        session = db.get_session(session_id)
+        assert session["codex_previous_response_id"] == "resp_local_1"
+        assert "codex_previous_response_backend" in session
+        assert session["codex_previous_response_backend"] is not None
+        assert "previous_response_id" not in first_seen[0]
+
+        resumed_agent = self._make_persisted_responses_agent(
+            monkeypatch, db, session_id, base_url="https://api.openai.com/v1"
+        )
+        resumed_seen = []
+
+        def resumed_fake_api(kwargs):
+            resumed_seen.append(kwargs)
+            return self._responses_response("resp_openai_2", "Second reply")
+
+        monkeypatch.setattr(resumed_agent, "_interruptible_api_call", resumed_fake_api)
+        second = resumed_agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert second["final_response"] == "Second reply"
+        assert "previous_response_id" not in resumed_seen[0]
+        assert resumed_seen[0]["input"] == resumed_agent._chat_messages_to_responses_input(
+            first["messages"] + [{"role": "user", "content": "follow up"}]
+        )
+        db.close()
+
+    def test_resumed_session_reuses_previous_response_id_on_same_supported_backend(self, monkeypatch, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "resume-same-backend"
+        db.create_session(session_id=session_id, source="cli", model="gpt-5")
+
+        first_agent = self._make_persisted_responses_agent(
+            monkeypatch, db, session_id, base_url="http://localhost:1234/v1"
+        )
+
+        monkeypatch.setattr(
+            first_agent,
+            "_interruptible_api_call",
+            lambda kwargs: self._responses_response("resp_local_1", "First reply"),
+        )
+        first = first_agent.run_conversation("hello", conversation_history=[])
+
+        resumed_agent = self._make_persisted_responses_agent(
+            monkeypatch, db, session_id, base_url="http://localhost:1234/v1"
+        )
+        resumed_seen = []
+
+        def resumed_fake_api(kwargs):
+            resumed_seen.append(kwargs)
+            return self._responses_response("resp_local_2", "Second reply")
+
+        monkeypatch.setattr(resumed_agent, "_interruptible_api_call", resumed_fake_api)
+        second = resumed_agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert second["final_response"] == "Second reply"
+        assert resumed_seen[0]["previous_response_id"] == "resp_local_1"
+        assert resumed_seen[0]["input"] == [{"role": "user", "content": "follow up"}]
+        db.close()
 
 
 class TestChatMessagesToResponsesInput:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -53,6 +53,40 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["system_prompt"] == "You are a helpful assistant."
 
+    def test_update_codex_previous_response(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_codex_previous_response(
+            "s1",
+            response_id="resp_123",
+            history_len=4,
+            history_fingerprint="abc123",
+        )
+
+        session = db.get_session("s1")
+        assert session["codex_previous_response_id"] == "resp_123"
+        assert session["codex_previous_response_history_len"] == 4
+        assert session["codex_previous_response_history_fingerprint"] == "abc123"
+
+    def test_update_codex_previous_response_clears_invalid_values(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.update_codex_previous_response(
+            "s1",
+            response_id="resp_123",
+            history_len=4,
+            history_fingerprint="abc123",
+        )
+        db.update_codex_previous_response(
+            "s1",
+            response_id="   ",
+            history_len=-1,
+            history_fingerprint="",
+        )
+
+        session = db.get_session("s1")
+        assert session["codex_previous_response_id"] is None
+        assert session["codex_previous_response_history_len"] == 0
+        assert session["codex_previous_response_history_fingerprint"] is None
+
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_token_counts("s1", input_tokens=200, output_tokens=100)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -60,12 +60,14 @@ class TestSessionLifecycle:
             response_id="resp_123",
             history_len=4,
             history_fingerprint="abc123",
+            backend="responses:http://localhost:1234/v1",
         )
 
         session = db.get_session("s1")
         assert session["codex_previous_response_id"] == "resp_123"
         assert session["codex_previous_response_history_len"] == 4
         assert session["codex_previous_response_history_fingerprint"] == "abc123"
+        assert session["codex_previous_response_backend"] == "responses:http://localhost:1234/v1"
 
     def test_update_codex_previous_response_clears_invalid_values(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -74,18 +76,21 @@ class TestSessionLifecycle:
             response_id="resp_123",
             history_len=4,
             history_fingerprint="abc123",
+            backend="responses:http://localhost:1234/v1",
         )
         db.update_codex_previous_response(
             "s1",
             response_id="   ",
             history_len=-1,
             history_fingerprint="",
+            backend="",
         )
 
         session = db.get_session("s1")
         assert session["codex_previous_response_id"] is None
         assert session["codex_previous_response_history_len"] == 0
         assert session["codex_previous_response_history_fingerprint"] is None
+        assert session["codex_previous_response_backend"] is None
 
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -969,7 +974,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 8
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1025,17 +1030,18 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to the latest schema.
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 8
 
-        # Verify title column exists and is NULL for existing sessions
+        # Verify new session metadata columns exist and are NULL for existing sessions.
         session = migrated_db.get_session("existing")
         assert session is not None
         assert session["title"] is None
+        assert session["codex_previous_response_backend"] is None
 
         # Verify we can set title on migrated session
         assert migrated_db.set_session_title("existing", "Migrated Title") is True


### PR DESCRIPTION
What does this PR do?

Fixes a real Codex continuity regression in Hermes without overgeneralizing `previous_response_id` across incompatible backends.

Root cause

`https://chatgpt.com/backend-api/codex` rejects `previous_response_id` with `HTTP 400 Unsupported parameter: previous_response_id`.

The original continuity work in this PR correctly targeted resumed-session continuity, but the backend contract was too broad: the ChatGPT Codex backend does not support native `previous_response_id` threading even though other Responses-compatible backends may.

Final behavior in this PR

- persists Codex continuity state for resumed sessions
- only sends `previous_response_id` to backends that actually support it
- explicitly omits `previous_response_id` for `https://chatgpt.com/backend-api/codex`
- falls back to full replay input for ChatGPT Codex follow-up/resume turns
- scopes persisted continuity state to the backend that minted it so a stored response id is not reused across backend boundaries
- preserves native threading for supported OpenAI-compatible/local Responses backends

Related Issue

No existing issue. This PR addresses a scoped Codex continuity bug affecting resumed Hermes sessions.

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- added Codex continuity fields to the sessions schema in `hermes_state.py`
  - `codex_previous_response_id`
  - `codex_previous_response_history_len`
  - `codex_previous_response_history_fingerprint`
  - `codex_previous_response_backend`
- added/updated `SessionDB.update_codex_previous_response(...)`
- persisted remembered Codex response boundaries from `run_agent.py`
- hydrated persisted boundaries during resumed-session startup
- gated native `previous_response_id` threading by backend capability instead of assuming all Codex/Responses lanes support it
- kept `https://chatgpt.com/backend-api/codex` on safe replay behavior
- prevented reuse of persisted response ids across backend boundaries
- added focused regression coverage in:
  - `tests/run_agent/test_provider_parity.py`
  - `tests/test_hermes_state.py`

How to Test

1. Run the focused backend/state regression lane:
   `uv run pytest tests/run_agent/test_provider_parity.py tests/test_hermes_state.py -k 'previous_response_id or update_codex_previous_response or schema_version or migration_from_v2' -q`

2. Run the additional Codex responses sanity lane:
   `uv run pytest tests/run_agent/test_run_agent_codex_responses.py -k 'build_api_kwargs_codex or copilot_responses' -q`

3. Confirm results:
   - ChatGPT Codex backend follow-up/resume turns do not send `previous_response_id`
   - supported local/OpenAI-compatible Responses backends still thread `previous_response_id`
   - resumed sessions only reuse persisted continuity when the backend identity still matches
   - Hermes falls back to full replay when the stored boundary is absent, mismatched, or backend-incompatible

Checklist

Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Screenshots / Logs

Focused verification run in a clean worktree for this PR:

- `uv run pytest tests/run_agent/test_provider_parity.py tests/test_hermes_state.py -k 'previous_response_id or update_codex_previous_response or schema_version or migration_from_v2' -q`
  - Result: 11 passed

- `uv run pytest tests/run_agent/test_run_agent_codex_responses.py -k 'build_api_kwargs_codex or copilot_responses' -q`
  - Result: 3 passed