### PR TITLE
fix: add missing RedactingFormatter import to prevent gateway crash on -v (closes #8090)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,6 +8470,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)


### PR DESCRIPTION
Closes #8090.

## Summary
The `--verbose` flag crashes the gateway at startup with `NameError: name 'RedactingFormatter' is not defined`.

The verbosity setup block uses `RedactingFormatter` but only imports it in the `else` branch (when `verbosity is None`). When `--verbose` is passed, the import is skipped but the class is still referenced.

## Fix
Added a lazy import `from agent.redact import RedactingFormatter` at the point of use inside the `if verbosity is not None:` block.

## Why This Matters
- Gateway crashes on startup when any verbosity flag is used
- Simple one-line fix, zero risk of regression
- Affects all users who run with `-v` or `-vv`