### PR TITLE
fix: prevent tool name duplication with Fireworks/Kimi streaming (closes #8089)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5004,7 +5004,15 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                new_name = tc_delta.function.name
+                                existing = entry["function"]["name"]
+                                # Some providers (Fireworks, Kimi) send the full tool name
+                                # in each chunk rather than a delta.  Only append if this is
+                                # truly a new fragment (not a repeat of the full name).
+                                if not existing or (new_name and not existing.endswith(new_name)):
+                                    entry["function"]["name"] += new_name
+                                elif not existing and new_name:
+                                    entry["function"]["name"] = new_name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)


### PR DESCRIPTION
Closes #8089.

## Summary
When using Fireworks or Kimi providers, tool names get duplicated during streaming (e.g., `browser_navigatebrowser_navigatebrowser_navigate`).

These providers send the **complete** tool name in every streaming chunk, not incremental deltas. The unconditional `+=` appended the full name repeatedly.

## Fix
Check if the existing accumulated name already ends with the incoming fragment before appending. This prevents duplicates while still supporting true delta-based providers (Anthropic, OpenAI).

## Why This Matters
- Breaks tool routing when names are corrupted
- Affects any user of Fireworks or Kimi providers
- Simple defensive check, no risk for existing providers