### PR TITLE
fix: surface max-iterations summary failures at ERROR level (closes #8049)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7492,8 +7492,15 @@ class AIAgent:
                     final_response = "I reached the iteration limit and couldn't generate a summary."
 
         except Exception as e:
-            logging.warning(f"Failed to get summary response: {e}")
-            final_response = f"I reached the maximum iterations ({self.max_iterations}) but couldn't summarize. Error: {str(e)}"
+            logger.error(
+                "Failed to generate max-iterations summary: %s (api_calls=%d/%d, session=%s). "
+                "Model may have been interrupted mid-tool-call — check tool results for partial work.",
+                e, api_call_count, self.max_iterations, self.session_id or "none",
+            )
+            final_response = (
+                f"I reached the maximum iterations ({self.max_iterations}) "
+                f"but couldn'\''t generate a summary. Error: {e}"
+            )
 
         return final_response
 


### PR DESCRIPTION
Closes #8049.

## Summary
When the summary API call fails after hitting max_iterations, the error was logged at `logging.warning` level with no context about what happened. Users see a generic error but have no indication that the model may have been interrupted mid-tool-call.

## Changes
- Changed `logging.warning` to `logger.error` (matches severity of other persistence failures)
- Added context: api_call_count, max_iterations, session_id
- Message now advises checking tool results for partial work

## Why This Matters
- Users need to know when the summary fails vs the model simply running out of iterations
- The context helps debug whether the failure is transient (API timeout) or systemic (model config)
- Matches the logging severity pattern from #8038 flush fix