### PR TITLE
fix(gateway): import RedactingFormatter for stderr handler

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,6 +8470,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
+
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)


### PR DESCRIPTION
## Bug Description

Starting the gateway crashes immediately with a NameError when stderr logging is enabled.

## Root Cause

A logging refactor removed the local `from agent.redact import RedactingFormatter` import from `gateway/run.py`, but the stderr handler setup still calls `RedactingFormatter(...)`.

## Fix

- reintroduce a local `from agent.redact import RedactingFormatter` import in the stderr handler block inside `start_gateway()`

## How to Verify

1. Run `hermes gateway run` or `python -m hermes_cli.main gateway run --replace`
2. Confirm the gateway no longer crashes with `NameError: name 'RedactingFormatter' is not defined`
3. Confirm `hermes gateway status` reports the service as running

## Test Plan

- [ ] Added regression test for this bug
- [ ] Existing tests still pass
- [x] Manual verification of the fix

Manual verification performed locally:
- reproduced the crash before the patch
- applied the import fix
- confirmed `hermes-gateway.service` became `active (running)`
- confirmed Telegram pending updates dropped to 0

## Risk Assessment

Low — this restores an import for an already-used formatter in a narrow gateway startup code path without changing runtime behavior elsewhere.
