### PR TITLE
fix(gateway): restore lazy import of RedactingFormatter after #7991

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8470,6 +8470,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)


### PR DESCRIPTION
Add lazy `from agent.redact import RedactingFormatter` import back to the stderr handler setup block that was orphaned by the component-separated logging refactor.

Fixes #8090