### PR TITLE
fix(gateway): add missing RedactingFormatter import (salvage #8046)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8560,6 +8560,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # verbosity=1    (-v):         INFO and above
     # verbosity=2+   (-vv/-vvv):   DEBUG
     if verbosity is not None:
+        from agent.redact import RedactingFormatter
+
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
         _stderr_handler.setLevel(_stderr_level)

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -133,6 +133,39 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, tmp_path):
+    """Verbosity != None must not crash with NameError on RedactingFormatter (#8044)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    class _CleanExitRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.adapters = {}
+
+        async def start(self):
+            return True
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _CleanExitRunner)
+
+    from gateway.run import start_gateway
+
+    # verbosity=1 triggers the code path that uses RedactingFormatter.
+    # Before the fix this raised NameError.
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
+
+    assert ok is True
+
+
+@pytest.mark.asyncio
 async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 


### PR DESCRIPTION
## Summary

Fixes #8044. Gateway crashes with `NameError: name 'RedactingFormatter' is not defined` on startup when `verbosity is not None` (launchd with `--replace`, or any `-v` flag).

Regression introduced in fd73937e (PR #7991, component-separated logging) which reorganized logging handlers but dropped the import.

## Changes

- Add lazy import `from agent.redact import RedactingFormatter` inside the `if verbosity is not None:` block in `gateway/run.py`
- Add test exercising the verbosity code path

## Attribution

Cherry-picked from PR #8046 by @tomqiaozc (first submitter, included test). Conflict resolved (test insertion point) — kept both the new test from #8046 and the existing test from main.

Closes #8044. Supersedes #8046, #8047, #8058, #8092, #8099.