### PR TITLE
feat(tools): Add support for SearXNG web searches and ScraperMCP extraction

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -367,6 +367,12 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_searxng(self):
+        """web.backend=searxng in config → 'searxng'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            assert _get_backend() == "searxng"
+
     # ── Fallback (no web.backend in config) ───────────────────────────
 
     def test_fallback_parallel_only_key(self):
@@ -533,6 +539,8 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SEARXNG_API_URL",
+        "SCRAPERMCP_URL",
     )
 
     def setup_method(self):
@@ -567,6 +575,14 @@ class TestCheckWebApiKey:
 
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_searxng_and_scrapermcp_urls_only(self):
+        with patch.dict(os.environ, {
+            "SEARXNG_API_URL": "https://searxng.example.com",
+            "SCRAPERMCP_URL": "http://scraper.local/mcp",
+        }):
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
@@ -610,8 +626,88 @@ class TestCheckWebApiKey:
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is True
 
+    def test_configured_searxng_backend_requires_both_urls(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            with patch.dict(os.environ, {"SEARXNG_API_URL": "https://searxng.example.com"}, clear=False):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is False
+
+    def test_configured_searxng_backend_accepts_both_urls(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            with patch.dict(os.environ, {
+                "SEARXNG_API_URL": "https://searxng.example.com",
+                "SCRAPERMCP_URL": "http://scraper.local/mcp",
+            }, clear=False):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
+
 
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+    assert "SEARXNG_API_URL" in _web_requires_env()
+    assert "SCRAPERMCP_URL" in _web_requires_env()
+
+
+@pytest.mark.asyncio
+async def test_scrapermcp_extract_retries_empty_results_with_render_js():
+    from tools.web_tools import _scrapermcp_extract
+
+    first = {
+        "results": [
+            {
+                "url": "https://example.com",
+                "success": True,
+                "data": {"content": "", "metadata": {"page_metadata": {"title": "Example"}}},
+                "error": None,
+            }
+        ]
+    }
+    second = {
+        "results": [
+            {
+                "url": "https://example.com",
+                "success": True,
+                "data": {"content": "rendered content", "metadata": {"page_metadata": {"title": "Example"}}},
+                "error": None,
+            }
+        ]
+    }
+
+    with patch("tools.web_tools._get_scrapermcp_render_js", return_value=False), \
+         patch("tools.web_tools._call_scrapermcp", new=AsyncMock(side_effect=[first, second])) as mock_call:
+        docs = await _scrapermcp_extract(["https://example.com"])
+
+    assert docs[0]["content"] == "rendered content"
+    assert docs[0]["metadata"]["extraction_info"]["render_js_used"] is True
+    assert docs[0]["metadata"]["extraction_info"]["js_fallback_used"] is True
+    assert docs[0]["metadata"]["extraction_info"]["attempt"] == "fallback_js_retry"
+    assert mock_call.await_args_list[0].kwargs["render_js"] is False
+    assert mock_call.await_args_list[1].kwargs["render_js"] is True
+
+
+@pytest.mark.asyncio
+async def test_scrapermcp_extract_keeps_first_pass_when_retry_not_needed():
+    from tools.web_tools import _scrapermcp_extract
+
+    first = {
+        "results": [
+            {
+                "url": "https://example.com",
+                "success": True,
+                "data": {"content": "plain content", "metadata": {"page_metadata": {"title": "Example"}}},
+                "error": None,
+            }
+        ]
+    }
+
+    with patch("tools.web_tools._get_scrapermcp_render_js", return_value=False), \
+         patch("tools.web_tools._call_scrapermcp", new=AsyncMock(return_value=first)) as mock_call:
+        docs = await _scrapermcp_extract(["https://example.com"])
+
+    assert docs[0]["content"] == "plain content"
+    assert docs[0]["metadata"]["extraction_info"]["render_js_used"] is False
+    assert docs[0]["metadata"]["extraction_info"]["js_fallback_used"] is False
+    assert docs[0]["metadata"]["extraction_info"]["attempt"] == "initial"
+    assert mock_call.await_count == 1

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- SearXNG: self-hosted metasearch via HTTP JSON API (search only; extraction via ScraperMCP)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -45,6 +46,7 @@ import logging
 import os
 import re
 import asyncio
+from urllib.parse import urljoin
 from typing import List, Dict, Any, Optional
 import httpx
 from firecrawl import Firecrawl
@@ -88,7 +90,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -99,6 +101,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("searxng", bool((_load_web_config().get("searxng_url") or "").strip()) or _has_env("SEARXNG_API_URL")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -117,7 +120,39 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "searxng":
+        return _has_searxng_config() and _has_scrapermcp_config()
     return False
+
+
+def _get_searxng_url() -> str:
+    """Return configured SearXNG base URL."""
+    config_url = (_load_web_config().get("searxng_url") or "").strip()
+    env_url = os.getenv("SEARXNG_API_URL", "").strip()
+    return (config_url or env_url).rstrip("/")
+
+
+def _has_searxng_config() -> bool:
+    return bool(_get_searxng_url())
+
+
+def _get_scrapermcp_url() -> str:
+    """Return configured ScraperMCP streamable HTTP endpoint."""
+    config_url = (_load_web_config().get("scrapermcp_url") or "").strip()
+    env_url = os.getenv("SCRAPERMCP_URL", "").strip()
+    return config_url or env_url
+
+
+def _has_scrapermcp_config() -> bool:
+    return bool(_get_scrapermcp_url())
+
+
+def _get_scrapermcp_render_js() -> bool:
+    value = _load_web_config().get("scrapermcp_render_js")
+    if isinstance(value, bool):
+        return value
+    env_value = os.getenv("SCRAPERMCP_RENDER_JS", "").strip().lower()
+    return env_value in {"1", "true", "yes", "on"}
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -161,7 +196,8 @@ def _raise_web_backend_configuration_error() -> None:
     """Raise a clear error for unsupported web backend configuration."""
     message = (
         "Web tools are not configured. "
-        "Set FIRECRAWL_API_KEY for cloud Firecrawl or set FIRECRAWL_API_URL for a self-hosted Firecrawl instance."
+        "Set FIRECRAWL_API_KEY for cloud Firecrawl, FIRECRAWL_API_URL for a self-hosted Firecrawl instance, "
+        "or configure web.searxng_url + web.scrapermcp_url (or SEARXNG_API_URL + SCRAPERMCP_URL) for a SearXNG + ScraperMCP setup."
     )
     if managed_nous_tools_enabled():
         message += (
@@ -189,6 +225,9 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "SEARXNG_API_URL",
+        "SCRAPERMCP_URL",
+        "SCRAPERMCP_RENDER_JS",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -358,6 +397,187 @@ def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[
             "error": "extraction failed",
             "metadata": {"sourceURL": url_str},
         })
+    return documents
+
+
+def _normalize_searxng_search_results(response: dict, limit: int) -> dict:
+    """Normalize SearXNG JSON response into Hermes's standard search shape."""
+    web_results = []
+    for i, result in enumerate((response or {}).get("results", [])[:limit]):
+        web_results.append({
+            "title": result.get("title", "") or "",
+            "url": result.get("url", "") or "",
+            "description": result.get("content", "") or result.get("snippet", "") or "",
+            "position": i + 1,
+        })
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _searxng_search(query: str, limit: int) -> dict:
+    """Run a search against a SearXNG instance and normalize the result."""
+    base_url = _get_searxng_url()
+    if not base_url:
+        raise ValueError(
+            "SearXNG backend selected but no URL configured. "
+            "Set web.searxng_url in config.yaml or SEARXNG_API_URL."
+        )
+
+    endpoint = urljoin(f"{base_url}/", "search")
+    response = httpx.get(
+        endpoint,
+        params={"q": query, "format": "json"},
+        timeout=30,
+        headers={"Accept": "application/json"},
+        follow_redirects=True,
+    )
+    response.raise_for_status()
+    return _normalize_searxng_search_results(response.json(), limit)
+
+
+async def _call_scrapermcp(urls: List[str], render_js: bool = False) -> dict:
+    """Call the configured ScraperMCP endpoint and return structured JSON."""
+    mcp_url = _get_scrapermcp_url()
+    if not mcp_url:
+        raise ValueError(
+            "SearXNG backend extraction requires ScraperMCP. "
+            "Set web.scrapermcp_url in config.yaml or SCRAPERMCP_URL."
+        )
+
+    try:
+        from mcp.client.streamable_http import streamable_http_client
+        from mcp import ClientSession
+    except ImportError as exc:
+        raise ImportError(
+            "ScraperMCP extraction requires the optional 'mcp' Python package. "
+            "Install it in Hermes's environment (pip install 'mcp>=1.24.0')."
+        ) from exc
+
+    payload = {
+        "urls": urls,
+        "timeout": 30,
+        "max_retries": 3,
+        "include_headers": False,
+        "render_js": render_js,
+    }
+
+    async with streamable_http_client(mcp_url) as streams:
+        read_stream, write_stream, *_ = streams
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.call_tool("scrape_url", payload)
+
+    if getattr(result, "isError", False):
+        error_text = ""
+        for block in (getattr(result, "content", None) or []):
+            if hasattr(block, "text"):
+                error_text += block.text
+        raise RuntimeError(error_text or "ScraperMCP returned an error")
+
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+
+    text_blob = "\n".join(
+        block.text for block in (getattr(result, "content", None) or []) if hasattr(block, "text")
+    )
+    try:
+        return json.loads(text_blob) if text_blob else {}
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("ScraperMCP returned an unexpected response format") from exc
+
+
+def _normalize_scrapermcp_documents(structured: dict, render_js_used: bool = False) -> List[Dict[str, Any]]:
+    """Normalize ScraperMCP scrape output into Hermes document results."""
+    documents: List[Dict[str, Any]] = []
+    for item in structured.get("results", []) or []:
+        url = item.get("url", "")
+        success = bool(item.get("success"))
+        data = item.get("data") or {}
+        metadata = (data.get("metadata") or {}).copy() if isinstance(data.get("metadata"), dict) else {}
+        page_meta = metadata.get("page_metadata") or {}
+        title = page_meta.get("title", "") if isinstance(page_meta, dict) else ""
+        content = data.get("content", "") if isinstance(data, dict) else ""
+        extraction_info = {
+            "backend": "scrapermcp",
+            "render_js_used": render_js_used,
+            "js_fallback_used": False,
+            "attempt": "initial",
+        }
+
+        if success:
+            documents.append({
+                "url": url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "metadata": {
+                    "sourceURL": url,
+                    "title": title,
+                    "extraction_info": extraction_info,
+                    **metadata,
+                },
+            })
+        else:
+            documents.append({
+                "url": url,
+                "title": title,
+                "content": "",
+                "raw_content": "",
+                "error": item.get("error") or "extraction failed",
+                "metadata": {
+                    "sourceURL": url,
+                    "title": title,
+                    "extraction_info": extraction_info,
+                    **metadata,
+                },
+            })
+
+    return documents
+
+
+async def _scrapermcp_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract markdown content via ScraperMCP with JS-render retry fallback."""
+    initial_render_js = _get_scrapermcp_render_js()
+    first_pass = await _call_scrapermcp(urls, render_js=initial_render_js)
+    documents = _normalize_scrapermcp_documents(first_pass, render_js_used=initial_render_js)
+
+    retry_urls = []
+    for doc in documents:
+        has_content = bool((doc.get("content") or "").strip())
+        if (doc.get("error") or not has_content) and doc.get("url"):
+            retry_urls.append(doc["url"])
+
+    if retry_urls and not initial_render_js:
+        logger.info(
+            "ScraperMCP initial scrape failed/empty for %d URL(s); retrying with render_js=true: %s",
+            len(retry_urls),
+            ", ".join(retry_urls),
+        )
+        retry_structured = await _call_scrapermcp(retry_urls, render_js=True)
+        retry_docs = {
+            doc.get("url", ""): doc
+            for doc in _normalize_scrapermcp_documents(retry_structured, render_js_used=True)
+        }
+        merged = []
+        for doc in documents:
+            replacement = retry_docs.get(doc.get("url", ""))
+            if replacement:
+                replacement_has_content = bool((replacement.get("content") or "").strip())
+                if replacement_has_content or replacement.get("error") != doc.get("error"):
+                    metadata = replacement.setdefault("metadata", {})
+                    extraction_info = metadata.setdefault("extraction_info", {})
+                    extraction_info["js_fallback_used"] = True
+                    extraction_info["attempt"] = "fallback_js_retry"
+                    logger.info(
+                        "ScraperMCP JS fallback %s for %s",
+                        "succeeded" if replacement_has_content and not replacement.get("error") else "returned updated result",
+                        replacement.get("url", "unknown URL"),
+                    )
+                    merged.append(replacement)
+                    continue
+            merged.append(doc)
+        documents = merged
+
     return documents
 
 
@@ -1117,6 +1337,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "searxng":
+            logger.info("SearXNG search: '%s' (limit: %d)", query, limit)
+            response_data = _searxng_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
 
         response = _get_firecrawl_client().search(
@@ -1251,6 +1481,9 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "searxng":
+                logger.info("ScraperMCP extract: %d URL(s)", len(safe_urls))
+                results = await _scrapermcp_extract(safe_urls)
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1453,6 +1686,7 @@ async def web_extract_tool(
                 "title": r.get("title", ""),
                 "content": r.get("content", ""),
                 "error": r.get("error"),
+                **({"extraction_info": r.get("metadata", {}).get("extraction_info")} if r.get("metadata", {}).get("extraction_info") else {}),
                 **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
             }
             for r in response.get("results", [])
@@ -1541,6 +1775,12 @@ async def web_crawl_tool(
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
         backend = _get_backend()
+
+        if backend == "searxng":
+            return json.dumps({
+                "error": "web_crawl is not supported with the SearXNG backend. Use web_search to find pages and web_extract (via ScraperMCP) to fetch them.",
+                "success": False,
+            }, ensure_ascii=False)
 
         # Tavily supports crawl via its /crawl endpoint
         if backend == "tavily":
@@ -1921,9 +2161,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng"))
 
 
 def check_auxiliary_model() -> bool:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -800,7 +800,7 @@ You can also change the reasoning effort at runtime with the `/reasoning` comman
 
 ## Tool-Use Enforcement
 
-Some models occasionally describe intended actions as text instead of making tool calls ("I would run the tests..." instead of actually calling the terminal). Tool-use enforcement injects system prompt guidance that steers the model back to actually calling tools.
+Some models (especially GPT-family) occasionally describe intended actions as text instead of making tool calls. Tool-use enforcement injects guidance that steers the model back to actually calling tools.
 
 ```yaml
 agent:
@@ -809,31 +809,12 @@ agent:
 
 | Value | Behavior |
 |-------|----------|
-| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `gemini`, `gemma`, `grok`. Disabled for all others (Claude, DeepSeek, Qwen, etc.). |
-| `true` | Always enabled, regardless of model. Useful if you notice your current model describing actions instead of performing them. |
-| `false` | Always disabled, regardless of model. |
-| `["gpt", "codex", "qwen", "llama"]` | Enabled only when the model name contains one of the listed substrings (case-insensitive). |
+| `"auto"` (default) | Enabled for GPT models (`gpt-`, `openai/gpt-`) and disabled for all others. |
+| `true` | Always enabled for all models. |
+| `false` | Always disabled. |
+| `["gpt-", "o1-", "custom-model"]` | Enabled only for models whose name contains one of the listed substrings. |
 
-### What it injects
-
-When enabled, three layers of guidance may be added to the system prompt:
-
-1. **General tool-use enforcement** (all matched models) — instructs the model to make tool calls immediately instead of describing intentions, keep working until the task is complete, and never end a turn with a promise of future action.
-
-2. **OpenAI execution discipline** (GPT and Codex models only) — additional guidance addressing GPT-specific failure modes: abandoning work on partial results, skipping prerequisite lookups, hallucinating instead of using tools, and declaring "done" without verification.
-
-3. **Google operational guidance** (Gemini and Gemma models only) — conciseness, absolute paths, parallel tool calls, and verify-before-edit patterns.
-
-These are transparent to the user and only affect the system prompt. Models that already use tools reliably (like Claude) don't need this guidance, which is why `"auto"` excludes them.
-
-### When to turn it on
-
-If you're using a model not in the default auto list and notice it frequently describes what it *would* do instead of doing it, set `tool_use_enforcement: true` or add the model substring to the list:
-
-```yaml
-agent:
-  tool_use_enforcement: ["gpt", "codex", "gemini", "grok", "my-custom-model"]
-```
+When enabled, the system prompt includes guidance reminding the model to make actual tool calls rather than describing what it would do. This is transparent to the user and has no effect on models that already use tools reliably.
 
 ## TTS Configuration
 
@@ -865,7 +846,6 @@ display:
   tool_progress: all      # off | new | all | verbose
   tool_progress_command: false  # Enable /verbose slash command in messaging gateway
   tool_progress_overrides: {}  # Per-platform overrides (see below)
-  interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
@@ -900,8 +880,6 @@ display:
 ```
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`.
-
-`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
 ## Privacy
 
@@ -993,8 +971,6 @@ streaming:
 
 When enabled, the bot sends a message on the first token, then progressively edits it as more tokens arrive. Platforms that don't support message editing (Signal, Email, Home Assistant) are auto-detected on the first attempt — streaming is gracefully disabled for that session with no flood of messages.
 
-For separate natural mid-turn assistant updates without progressive token editing, set `display.interim_assistant_messages: true`.
-
 **Overflow handling:** If the streamed text exceeds the platform's message length limit (~4096 chars), the current message is finalized and a new one starts automatically.
 
 :::note
@@ -1082,23 +1058,37 @@ code_execution:
 
 ## Web Search Backends
 
-The `web_search`, `web_extract`, and `web_crawl` tools support four backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search`, `web_extract`, and `web_crawl` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | parallel | tavily | exa | searxng
 ```
 
-| Backend | Env Var | Search | Extract | Crawl |
-|---------|---------|--------|---------|-------|
+| Backend | Env Var / Config | Search | Extract | Crawl |
+|---------|-------------------|--------|---------|-------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
+| **SearXNG** | `web.searxng_url` + `web.scrapermcp_url` (or `SEARXNG_API_URL` + `SCRAPERMCP_URL`) | ✔ | ✔* | — |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+`*` SearXNG provides search only; Hermes uses the configured ScraperMCP server for `web_extract` when `backend: searxng`.
+
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default. SearXNG should usually be selected explicitly with `web.backend: searxng`.
 
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=false` on the server to disable auth).
+
+**SearXNG + ScraperMCP example:**
+```yaml
+web:
+  backend: searxng
+  searxng_url: https://search.example.com
+  scrapermcp_url: http://scraper.local/mcp
+  scrapermcp_render_js: false
+```
+
+When `backend: searxng` is active, Hermes first extracts through ScraperMCP with the configured `scrapermcp_render_js` setting. If a page comes back empty or fails and `scrapermcp_render_js` is `false`, Hermes automatically retries that URL with `render_js: true` as a browser-style fallback. Extract responses include an `extraction_info` object per result showing whether JS rendering or fallback retry was used.
 
 **Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).
 


### PR DESCRIPTION
Add support for SearXNG web searches and ScraperMCP extraction with fallback to ScraperMCP's JS-enable extraction.

## What does this PR do?

I kept running into API limits with Firecrawl, and I already had SearXNG and ScraperMCP setup in my environment.  This PR adds support for changing Hermes' web search to SearXNG, and extracting results with ScraperMCP.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

tests/tools/test_web_tools_config.py: Add tests for the integration

tools/web_tools.py: Add SearXNG as a valid search backend.  Hand link results off to ScraperMCP for extraction.

website/docs/user-guide/configuration.md: Documentation

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure the endpoints for ScraperMCP and SearXNG in config.yaml like so
```
web:
  backend: searxng
  searxng_url: <url for searxng>
  scrapermcp_url: <url for ScraperMCP mcp endpoint>
  scrapermcp_render_js: false
```
2. Restart hermes-gateway
3.  Send Hermes the following prompt
```
I understand you are now setup to use my SearXNG and ScraperMCP instances for web search.  Can you test this out for me by giving me a quick news summary about the Artemis II mission?
```
4. Monitor the ScraperMCP dashboard and see which websites are being scraped.  Hermes should return something similar to
```
Yep — it looks like your SearXNG + ScraperMCP setup is working.

What I verified:
- web_search returned current Artemis II results, including NASA and Space.com.
- web_extract successfully pulled content from NASA and Space.com using ScraperMCP.
- One source (U.S. News) failed even after JS-render fallback, which is actually useful confirmation that the fallback path is being exercised as configured.

Quick Artemis II news summary...
[...deleted for brevity...]
```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Debian Trixie

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
