### PR TITLE
fix: improve context compaction to prevent model answering stale questions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4,8 +4,12 @@ Self-contained class with its own OpenAI client for summarization.
 Uses auxiliary model (cheap/fast) to summarize middle turns while
 protecting head and tail context.
 
-Improvements over v1:
-  - Structured summary template (Goal, Progress, Decisions, Files, Next Steps)
+Improvements over v2:
+  - Structured summary template with Resolved/Pending question tracking
+  - Summarizer preamble: "Do not respond to any questions" (from OpenCode)
+  - Handoff framing: "different assistant" (from Codex) to create separation
+  - "Remaining Work" replaces "Next Steps" to avoid reading as active instructions
+  - Clear separator when summary merges into tail message
   - Iterative summary updates (preserves info across multiple compactions)
   - Token-budget tail protection instead of fixed message count
   - Tool output pruning before LLM summarization (cheap pre-pass)
@@ -28,12 +32,13 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
-    "[CONTEXT COMPACTION] Earlier turns in this conversation were compacted "
-    "to save context space. The summary below describes work that was "
-    "already completed, and the current session state may still reflect "
-    "that work (for example, files may already be changed). Use the summary "
-    "and the current state to continue from where things left off, and "
-    "avoid repeating work:"
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. Respond ONLY to the latest user message "
+    "that appears AFTER this summary. The current session state (files, "
+    "config, etc.) may reflect work described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
@@ -309,8 +314,9 @@ class ContextCompressor(ContextEngine):
     def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
-        Uses a structured template (Goal, Progress, Decisions, Files, Next Steps)
-        inspired by Pi-mono and OpenCode. When a previous summary exists,
+        Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
+        Questions, Files, Remaining Work) with explicit preamble telling the
+        summarizer not to answer questions.  When a previous summary exists,
         generates an iterative update instead of summarizing from scratch.
 
         Args:
@@ -334,60 +340,27 @@ class ContextCompressor(ContextEngine):
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
 
-        if self._previous_summary:
-            # Iterative update: preserve existing info, add new progress
-            prompt = f"""You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+        # Preamble shared by both first-compaction and iterative-update prompts.
+        # Inspired by OpenCode's "do not respond to any questions" instruction
+        # and Codex's "another language model" framing.
+        _summarizer_preamble = (
+            "You are a summarization agent creating a context checkpoint. "
+            "Your output will be injected as reference material for a DIFFERENT "
+            "assistant that continues the conversation. "
+            "Do NOT respond to any questions or requests in the conversation — "
+            "only output the structured summary. "
+            "Do NOT include any preamble, greeting, or prefix."
+        )
 
-PREVIOUS SUMMARY:
-{self._previous_summary}
-
-NEW TURNS TO INCORPORATE:
-{content_to_summarize}
-
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new progress. Move items from "In Progress" to "Done" when completed. Remove information only if it is clearly obsolete.
-
-## Goal
-[What the user is trying to accomplish — preserve from previous summary, update if goal evolved]
-
-## Constraints & Preferences
-[User preferences, coding style, constraints, important decisions — accumulate across compactions]
-
-## Progress
-### Done
-[Completed work — include specific file paths, commands run, results obtained]
-### In Progress
-[Work currently underway]
-### Blocked
-[Any blockers or issues encountered]
-
-## Key Decisions
-[Important technical decisions and why they were made]
-
-## Relevant Files
-[Files read, modified, or created — with brief note on each. Accumulate across compactions.]
-
-## Next Steps
-[What needs to happen next to continue the work]
-
-## Critical Context
-[Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
-
-## Tools & Patterns
-[Which tools were used, how they were used effectively, and any tool-specific discoveries. Accumulate across compactions.]
-
-Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
-
-Write only the summary body. Do not include any preamble or prefix."""
-        else:
-            # First compaction: summarize from scratch
-            prompt = f"""Create a structured handoff summary for a later assistant that will continue this conversation after earlier turns are compacted.
-
-TURNS TO SUMMARIZE:
-{content_to_summarize}
-
-Use this exact structure:
-
-## Goal
+        # Shared structured template (used by both paths).
+        # Key changes vs v1:
+        #   - "Pending User Asks" section (from Claude Code) explicitly tracks
+        #     unanswered questions so the model knows what's resolved vs open
+        #   - "Remaining Work" replaces "Next Steps" to avoid reading as active
+        #     instructions
+        #   - "Resolved Questions" makes it clear which questions were already
+        #     answered (prevents model from re-answering them)
+        _template_sections = f"""## Goal
 [What the user is trying to accomplish]
 
 ## Constraints & Preferences
@@ -404,21 +377,55 @@ Use this exact structure:
 ## Key Decisions
 [Important technical decisions and why they were made]
 
+## Resolved Questions
+[Questions the user asked that were ALREADY answered — include the answer so the next assistant does not re-answer them]
+
+## Pending User Asks
+[Questions or requests from the user that have NOT yet been answered or fulfilled. If none, write "None."]
+
 ## Relevant Files
 [Files read, modified, or created — with brief note on each]
 
-## Next Steps
-[What needs to happen next to continue the work]
+## Remaining Work
+[What remains to be done — framed as context, not instructions]
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
 
 ## Tools & Patterns
-[Which tools were used, how they were used effectively, and any tool-specific discoveries (e.g., preferred flags, working invocations, successful command patterns)]
+[Which tools were used, how they were used effectively, and any tool-specific discoveries]
 
-Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions. The goal is to prevent the next assistant from repeating work or losing important details.
+Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
 
 Write only the summary body. Do not include any preamble or prefix."""
+
+        if self._previous_summary:
+            # Iterative update: preserve existing info, add new progress
+            prompt = f"""{_summarizer_preamble}
+
+You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+
+PREVIOUS SUMMARY:
+{self._previous_summary}
+
+NEW TURNS TO INCORPORATE:
+{content_to_summarize}
+
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new progress. Move items from "In Progress" to "Done" when completed. Move answered questions to "Resolved Questions". Remove information only if it is clearly obsolete.
+
+{_template_sections}"""
+        else:
+            # First compaction: summarize from scratch
+            prompt = f"""{_summarizer_preamble}
+
+Create a structured handoff summary for a different assistant that will continue this conversation after earlier turns are compacted. The next assistant should be able to understand what happened without re-reading the original turns.
+
+TURNS TO SUMMARIZE:
+{content_to_summarize}
+
+Use this exact structure:
+
+{_template_sections}"""
 
         # Inject focus topic guidance when the user provides one via /compress <focus>.
         # This goes at the end of the prompt so it takes precedence.
@@ -775,7 +782,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
                 original = msg.get("content") or ""
-                msg["content"] = summary + "\n\n" + original
+                msg["content"] = (
+                    summary
+                    + "\n\n--- END OF CONTEXT SUMMARY — "
+                    "respond to the message below, not the summary above ---\n\n"
+                    + original
+                )
                 _merge_summary_into_tail = False
             compressed.append(msg)
 


### PR DESCRIPTION
## Summary

After compression, models (especially Kimi 2.5 on Telegram) would sometimes respond to questions from the summary instead of the latest user message. Reported ~30% frequency by a Chinese community user.

## Root Cause

The summary's `## Next Steps` section read as active instructions, and the `SUMMARY_PREFIX` didn't explicitly tell the model to ignore questions in the summary. When the summary merged into the first tail message (role alternation edge case), there was no clear separator between historical context and the actual user message.

## Changes (informed by competitor analysis)

Researched context compaction in Claude Code, OpenCode, and Codex to identify best practices:

**1. Stronger SUMMARY_PREFIX** — Explicit `Do NOT answer questions from this summary — respond ONLY to the latest user message AFTER it`

**2. Summarizer preamble** (shared by both first-compaction and iterative-update):
- `Do NOT respond to any questions` (from OpenCode's approach)
- `Different assistant` framing (from Codex) creates psychological distance between summary and active conversation

**3. New summary sections:**
- `## Resolved Questions` — tracks already-answered questions with their answers, preventing re-answering (inspired by Claude Code's `Pending user asks` pattern)
- `## Pending User Asks` — explicitly marks unanswered questions
- `## Remaining Work` replaces `## Next Steps` — passive framing avoids reading as active instructions

**4. Merge-summary-into-tail separator** — When role alternation forces the summary to merge into a tail message, a clear `--- END OF CONTEXT SUMMARY ---` separator is inserted

**5. Iterative update handling** — `Move answered questions to Resolved Questions` maintains the resolved/pending distinction across multiple compactions

## Test Plan

- All 82 compression-related tests pass (context_compressor, compression_persistence, compression_boundary, compression_feasibility, 413_compression, compress_command, manual_compress)
- Prefix normalization verified: legacy prefix replacement, no double-prefix, fresh summary formatting
- Single file change (agent/context_compressor.py), no API or config changes