### PR TITLE
fix: send WhatsApp audio via native bridge media path

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -704,6 +704,23 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file natively via the WhatsApp bridge.
+
+        OGG/Opus files are treated by the Node bridge as PTT voice notes
+        (ptt=true); MP3/WAV/M4A are sent as normal audio attachments.
+        """
+        del reply_to, metadata, kwargs
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -211,6 +211,24 @@ class TestFileHandleClosedOnError:
         assert adapter._bridge_log_fh is None
 
 
+class TestSendVoice:
+    """Regression tests for native WhatsApp audio sending."""
+
+    @pytest.mark.asyncio
+    async def test_send_voice_routes_to_bridge_audio_media(self):
+        adapter = _make_adapter()
+        adapter._send_media_to_bridge = AsyncMock(
+            return_value=MagicMock(success=True, message_id="wa-audio-1")
+        )
+
+        result = await adapter.send_voice("chat-123", "/tmp/voice.ogg", caption="hello")
+
+        assert result.success is True
+        adapter._send_media_to_bridge.assert_awaited_once_with(
+            "chat-123", "/tmp/voice.ogg", "audio", "hello"
+        )
+
+
 class TestBridgeRuntimeFailure:
     """Verify runtime bridge death is surfaced as a fatal adapter error."""
 


### PR DESCRIPTION
## Summary
- add `WhatsAppAdapter.send_voice()`
- route WhatsApp audio through the existing bridge `/send-media` path
- add a regression test covering audio routing

## Problem
WhatsApp outbound audio attachments were falling back to the base adapter's text behavior because `gateway/run.py` already routes audio media to `adapter.send_voice()`, but `WhatsAppAdapter` did not implement `send_voice()`.

## Test Plan
- [x] local end-to-end manual test in WhatsApp chat confirmed audio attachment delivery after the fix
- [x] `pytest -q tests/gateway/test_whatsapp_connect.py -k send_voice_routes_to_bridge_audio_media`
- [ ] full gateway test suite
