### PR TITLE
fix(stream-consumer): preserve accumulated text on chunk send failure

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -360,7 +360,17 @@ class GatewayStreamConsumer:
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            self._final_response_sent = self._already_sent
+                            # If some chunks failed, _accumulated holds the
+                            # unsent remainder.  Attempt to deliver it now so
+                            # it is not silently dropped.  Only mark the
+                            # response as fully sent when _accumulated is empty
+                            # (all chunks delivered) or when the fallback send
+                            # succeeds; otherwise leave _final_response_sent
+                            # False so the gateway's own fallback path retries.
+                            if self._accumulated:
+                                await self._send_fallback_final(self._accumulated)
+                            else:
+                                self._final_response_sent = self._already_sent
                             return
                         if got_segment_break:
                             self._message_id = None

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -343,9 +343,20 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
+                        sent_length = 0
                         for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
-                        self._accumulated = ""
+                            if not self._clean_for_display(chunk).strip():
+                                # Chunk is empty after removing media/whitespace
+                                # markers — advance past it
+                                sent_length += len(chunk)
+                                continue
+                            reply_id = self._message_id
+                            new_id = await self._send_new_chunk(chunk, reply_id)
+                            if new_id is not None and new_id != reply_id:
+                                sent_length += len(chunk)
+                            else:
+                                break
+                        self._accumulated = self._accumulated[sent_length:]
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -188,9 +188,20 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
+                        sent_length = 0
                         for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
-                        self._accumulated = ""
+                            if not self._clean_for_display(chunk).strip():
+                                # Chunk is empty after removing media/whitespace
+                                # markers — advance past it
+                                sent_length += len(chunk)
+                                continue
+                            reply_id = self._message_id
+                            new_id = await self._send_new_chunk(chunk, reply_id)
+                            if new_id is not None and new_id != reply_id:
+                                sent_length += len(chunk)
+                            else:
+                                break
+                        self._accumulated = self._accumulated[sent_length:]
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:

--- a/tests/gateway/test_stream_consumer_text_loss.py
+++ b/tests/gateway/test_stream_consumer_text_loss.py
@@ -98,3 +98,49 @@ class TestAccumulatedTextPreservation:
         assert consumer._accumulated != "", (
             "Unsent text should be preserved when a chunk fails"
         )
+
+    @pytest.mark.asyncio
+    async def test_partial_chunk_failure_does_not_suppress_gateway_fallback(self):
+        """When the first chunk is delivered but subsequent chunks fail,
+        _final_response_sent must NOT be True while unsent text remains.
+
+        If _final_response_sent were set True here, the gateway would mark
+        the response as already_sent and skip its own fallback delivery,
+        permanently losing the unsent remainder."""
+        call_count = 0
+        sent_contents = []
+
+        async def partial_fail_send(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            content = kwargs.get("content", "")
+            if call_count == 1:
+                sent_contents.append(content)
+                return SimpleNamespace(success=True, message_id="msg_1")
+            raise Exception("network error on second chunk")
+
+        adapter = _make_adapter(
+            max_len=4096,
+            send_fn=partial_fail_send,
+            truncate_fn=lambda text, limit: [text[:limit], text[limit:]],
+        )
+
+        cfg = StreamConsumerConfig(buffer_threshold=10)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config=cfg)
+
+        long_text = "A" * 4000
+        consumer._queue.put(long_text)
+        consumer._queue.put(_DONE)
+
+        await consumer.run()
+
+        # The gateway uses final_response_sent to decide whether to skip
+        # its own delivery.  When text remains unsent, it must be False so
+        # the gateway can retry delivery of the full response.
+        # (The fallback send attempt inside run() also fails because the
+        # mock raises on every call after the first, so the unsent tail
+        # never reaches the user via the consumer — the gateway must do it.)
+        assert not consumer._final_response_sent, (
+            "_final_response_sent must be False when unsent text remains, "
+            "so the gateway's fallback send path is not suppressed"
+        )

--- a/tests/gateway/test_stream_consumer_text_loss.py
+++ b/tests/gateway/test_stream_consumer_text_loss.py
@@ -1,0 +1,100 @@
+"""Tests for GatewayStreamConsumer — accumulated text preservation on send failure.
+
+When _send_new_chunk fails during the chunk-splitting path (lines 188-193),
+_accumulated is cleared unconditionally even if sends failed, causing text
+loss.  The fix: only clear _accumulated after confirming all chunks were
+delivered.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig, _DONE
+
+
+def _make_adapter(max_len=4096, send_fn=None, truncate_fn=None):
+    """Create a mock adapter for stream consumer tests."""
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = max_len
+    if send_fn:
+        adapter.send = AsyncMock(side_effect=send_fn)
+    else:
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+    if truncate_fn:
+        adapter.truncate_message = truncate_fn
+    else:
+        adapter.truncate_message = lambda text, limit: [text]
+    return adapter
+
+
+class TestAccumulatedTextPreservation:
+    @pytest.mark.asyncio
+    async def test_chunk_send_failure_preserves_accumulated(self):
+        """When _send_new_chunk fails during the chunk-splitting path,
+        _accumulated must not be cleared — the text would be lost."""
+        call_count = 0
+
+        async def failing_send(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("network error")
+
+        adapter = _make_adapter(
+            max_len=4096,
+            send_fn=failing_send,
+            truncate_fn=lambda text, limit: [text[:limit], text[limit:]],
+        )
+
+        cfg = StreamConsumerConfig(buffer_threshold=10)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config=cfg)
+
+        # _safe_limit = max(500, 4096 - len(cursor) - 100) = 3991
+        # Text must exceed _safe_limit to trigger the chunk-splitting path
+        long_text = "A" * 4000
+        consumer._queue.put(long_text)
+        consumer._queue.put(_DONE)
+
+        await consumer.run()
+
+        # After the fix, _accumulated should be preserved when sends fail
+        assert consumer._accumulated != "" or call_count == 0, (
+            "_accumulated should not be cleared when all _send_new_chunk calls fail"
+        )
+
+    @pytest.mark.asyncio
+    async def test_partial_chunk_failure_preserves_unsent_text(self):
+        """If the first chunk succeeds but a later one fails, the unsent
+        portion should be preserved in _accumulated."""
+        call_count = 0
+
+        async def partial_fail_send(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return SimpleNamespace(success=True, message_id="msg_1")
+            raise Exception("network error on second chunk")
+
+        adapter = _make_adapter(
+            max_len=4096,
+            send_fn=partial_fail_send,
+            truncate_fn=lambda text, limit: [text[:limit], text[limit:]],
+        )
+
+        cfg = StreamConsumerConfig(buffer_threshold=10)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config=cfg)
+
+        long_text = "A" * 4000
+        consumer._queue.put(long_text)
+        consumer._queue.put(_DONE)
+
+        await consumer.run()
+
+        # After the fix, the unsent portion (second chunk) should remain
+        # in _accumulated — not silently lost
+        assert consumer._accumulated != "", (
+            "Unsent text should be preserved when a chunk fails"
+        )


### PR DESCRIPTION
## Summary
- When `_send_new_chunk` fails during the chunk-splitting path (network error, send returns `success=False`), `_accumulated` was cleared unconditionally at line 193, causing silent text loss
- The fix tracks how many bytes of `_accumulated` were successfully delivered and only trims that portion; unsent text is preserved for retry
- Consistent with the existing `_message_id is not None` overflow path (lines 207-226) which already checks `_send_or_edit` return before advancing `_accumulated`

## Test plan
- [x] `test_chunk_send_failure_preserves_accumulated` — all chunk sends fail → `_accumulated` retains full text
- [x] `test_partial_chunk_failure_preserves_unsent_text` — first chunk succeeds, second fails → unsent portion preserved
- [x] All 28 existing `test_stream_consumer.py` tests still pass