### PR TITLE
feat(model_tools): validate tool args against JSON Schema

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -491,6 +491,98 @@ def _coerce_boolean(value: str):
     return value
 
 
+def validate_tool_args(args: Dict[str, Any], schema: dict) -> List[str]:
+    """Validate tool call arguments against their JSON Schema.
+
+    Checks required fields, type mismatches (after coercion), enum
+    constraints, and numeric/string range constraints (minimum/maximum,
+    minLength/maxLength).  Returns a list of human-readable error strings —
+    empty when arguments are valid.
+    """
+    errors: List[str] = []
+    parameters = schema.get("parameters", {})
+    properties = parameters.get("properties", {})
+    required = parameters.get("required", [])
+
+    # 1. Required fields
+    for field in required:
+        if field not in args:
+            errors.append(f"Missing required argument: {field}")
+
+    # 2. Per-property checks (only for arguments that are present)
+    type_map = {
+        "string": str,
+        "integer": int,
+        "number": (int, float),
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+    for key, value in args.items():
+        prop_schema = properties.get(key)
+        if not prop_schema:
+            continue
+
+        # Type check
+        expected_type = prop_schema.get("type")
+        if expected_type:
+            # Normalise union types to a list
+            types_to_check = expected_type if isinstance(expected_type, list) else [expected_type]
+            matched = False
+            for t in types_to_check:
+                python_type = type_map.get(t)
+                if python_type and isinstance(value, python_type):
+                    matched = True
+                    break
+                # In JSON, booleans are also int instances in Python — skip
+                # the int check for booleans and vice versa.
+                if t == "integer" and isinstance(value, bool):
+                    continue
+                if t == "boolean" and isinstance(value, int):
+                    continue
+            if not matched and types_to_check:
+                errors.append(
+                    f"Argument '{key}' has wrong type: expected "
+                    f"{'/'.join(types_to_check)}, got {type(value).__name__}"
+                )
+
+        # Enum constraint
+        enum_values = prop_schema.get("enum")
+        if enum_values is not None and value not in enum_values:
+            errors.append(
+                f"Argument '{key}' value '{value}' not in enum: {enum_values}"
+            )
+
+        # Numeric constraints
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            minimum = prop_schema.get("minimum")
+            if minimum is not None and value < minimum:
+                errors.append(
+                    f"Argument '{key}' value {value} is below minimum {minimum}"
+                )
+            maximum = prop_schema.get("maximum")
+            if maximum is not None and value > maximum:
+                errors.append(
+                    f"Argument '{key}' value {value} exceeds maximum {maximum}"
+                )
+
+        # String constraints
+        if isinstance(value, str):
+            min_length = prop_schema.get("minLength")
+            if min_length is not None and len(value) < min_length:
+                errors.append(
+                    f"Argument '{key}' length {len(value)} is below minLength {min_length}"
+                )
+            max_length = prop_schema.get("maxLength")
+            if max_length is not None and len(value) > max_length:
+                errors.append(
+                    f"Argument '{key}' length {len(value)} exceeds maxLength {max_length}"
+                )
+
+    return errors
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -519,6 +611,16 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # Validate arguments against JSON Schema before dispatch
+    tool_schema = registry.get_schema(function_name)
+    if tool_schema:
+        validation_errors = validate_tool_args(function_args, tool_schema)
+        if validation_errors:
+            return json.dumps(
+                {"error": f"Invalid arguments: {'; '.join(validation_errors)}"},
+                ensure_ascii=False,
+            )
 
     try:
         if function_name in _AGENT_LOOP_TOOLS:

--- a/model_tools.py
+++ b/model_tools.py
@@ -510,6 +510,9 @@ def validate_tool_args(args: Dict[str, Any], schema: dict) -> List[str]:
             errors.append(f"Missing required argument: {field}")
 
     # 2. Per-property checks (only for arguments that are present)
+    #
+    # JSON Schema type → Python type mapping.  "null" maps to NoneType so that
+    # nullable union types such as ["string", "null"] validate correctly.
     type_map = {
         "string": str,
         "integer": int,
@@ -517,6 +520,7 @@ def validate_tool_args(args: Dict[str, Any], schema: dict) -> List[str]:
         "boolean": bool,
         "array": list,
         "object": dict,
+        "null": type(None),
     }
 
     for key, value in args.items():
@@ -525,34 +529,40 @@ def validate_tool_args(args: Dict[str, Any], schema: dict) -> List[str]:
             continue
 
         # Type check
+        type_error = False
         expected_type = prop_schema.get("type")
         if expected_type:
             # Normalise union types to a list
             types_to_check = expected_type if isinstance(expected_type, list) else [expected_type]
             matched = False
             for t in types_to_check:
+                # In JSON Schema, booleans and integers are distinct even though
+                # Python's bool is a subclass of int.  Apply the bool guard
+                # BEFORE the isinstance check so that True/False never match
+                # "integer" and non-bool ints never match "boolean".
+                if t == "integer" and isinstance(value, bool):
+                    continue
+                if t == "boolean" and not isinstance(value, bool) and isinstance(value, int):
+                    continue
                 python_type = type_map.get(t)
                 if python_type and isinstance(value, python_type):
                     matched = True
                     break
-                # In JSON, booleans are also int instances in Python — skip
-                # the int check for booleans and vice versa.
-                if t == "integer" and isinstance(value, bool):
-                    continue
-                if t == "boolean" and isinstance(value, int):
-                    continue
             if not matched and types_to_check:
+                type_error = True
                 errors.append(
                     f"Argument '{key}' has wrong type: expected "
                     f"{'/'.join(types_to_check)}, got {type(value).__name__}"
                 )
 
-        # Enum constraint
-        enum_values = prop_schema.get("enum")
-        if enum_values is not None and value not in enum_values:
-            errors.append(
-                f"Argument '{key}' value '{value}' not in enum: {enum_values}"
-            )
+        # Enum constraint — skip when a type error was already recorded for
+        # this argument to avoid confusing double-error output.
+        if not type_error:
+            enum_values = prop_schema.get("enum")
+            if enum_values is not None and value not in enum_values:
+                errors.append(
+                    f"Argument '{key}' value '{value}' not in enum: {enum_values}"
+                )
 
         # Numeric constraints
         if isinstance(value, (int, float)) and not isinstance(value, bool):

--- a/model_tools.py
+++ b/model_tools.py
@@ -456,6 +456,98 @@ def _coerce_boolean(value: str):
     return value
 
 
+def validate_tool_args(args: Dict[str, Any], schema: dict) -> List[str]:
+    """Validate tool call arguments against their JSON Schema.
+
+    Checks required fields, type mismatches (after coercion), enum
+    constraints, and numeric/string range constraints (minimum/maximum,
+    minLength/maxLength).  Returns a list of human-readable error strings —
+    empty when arguments are valid.
+    """
+    errors: List[str] = []
+    parameters = schema.get("parameters", {})
+    properties = parameters.get("properties", {})
+    required = parameters.get("required", [])
+
+    # 1. Required fields
+    for field in required:
+        if field not in args:
+            errors.append(f"Missing required argument: {field}")
+
+    # 2. Per-property checks (only for arguments that are present)
+    type_map = {
+        "string": str,
+        "integer": int,
+        "number": (int, float),
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+    for key, value in args.items():
+        prop_schema = properties.get(key)
+        if not prop_schema:
+            continue
+
+        # Type check
+        expected_type = prop_schema.get("type")
+        if expected_type:
+            # Normalise union types to a list
+            types_to_check = expected_type if isinstance(expected_type, list) else [expected_type]
+            matched = False
+            for t in types_to_check:
+                python_type = type_map.get(t)
+                if python_type and isinstance(value, python_type):
+                    matched = True
+                    break
+                # In JSON, booleans are also int instances in Python — skip
+                # the int check for booleans and vice versa.
+                if t == "integer" and isinstance(value, bool):
+                    continue
+                if t == "boolean" and isinstance(value, int):
+                    continue
+            if not matched and types_to_check:
+                errors.append(
+                    f"Argument '{key}' has wrong type: expected "
+                    f"{'/'.join(types_to_check)}, got {type(value).__name__}"
+                )
+
+        # Enum constraint
+        enum_values = prop_schema.get("enum")
+        if enum_values is not None and value not in enum_values:
+            errors.append(
+                f"Argument '{key}' value '{value}' not in enum: {enum_values}"
+            )
+
+        # Numeric constraints
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            minimum = prop_schema.get("minimum")
+            if minimum is not None and value < minimum:
+                errors.append(
+                    f"Argument '{key}' value {value} is below minimum {minimum}"
+                )
+            maximum = prop_schema.get("maximum")
+            if maximum is not None and value > maximum:
+                errors.append(
+                    f"Argument '{key}' value {value} exceeds maximum {maximum}"
+                )
+
+        # String constraints
+        if isinstance(value, str):
+            min_length = prop_schema.get("minLength")
+            if min_length is not None and len(value) < min_length:
+                errors.append(
+                    f"Argument '{key}' length {len(value)} is below minLength {min_length}"
+                )
+            max_length = prop_schema.get("maxLength")
+            if max_length is not None and len(value) > max_length:
+                errors.append(
+                    f"Argument '{key}' length {len(value)} exceeds maxLength {max_length}"
+                )
+
+    return errors
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -483,6 +575,16 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # Validate arguments against JSON Schema before dispatch
+    tool_schema = registry.get_schema(function_name)
+    if tool_schema:
+        validation_errors = validate_tool_args(function_args, tool_schema)
+        if validation_errors:
+            return json.dumps(
+                {"error": f"Invalid arguments: {'; '.join(validation_errors)}"},
+                ensure_ascii=False,
+            )
 
     # Notify the read-loop tracker when a non-read/search tool runs,
     # so the *consecutive* counter resets (reads after other work are fine).

--- a/tests/run_agent/test_tool_arg_schema_validation.py
+++ b/tests/run_agent/test_tool_arg_schema_validation.py
@@ -1,0 +1,253 @@
+"""Tests for tool argument schema validation.
+
+validate_tool_args() checks tool call arguments against their JSON Schema
+before dispatch, catching missing required fields, type mismatches, and
+constraint violations (enum, minimum/maximum, minLength/maxLength) that
+coerce_tool_args() does not cover.
+"""
+
+import json
+
+import pytest
+
+from model_tools import validate_tool_args, handle_function_call
+from tools.registry import ToolRegistry
+
+
+# ── Unit tests for validate_tool_args ──────────────────────────────────────
+
+
+class TestValidateToolArgsRequiredFields:
+    """Required field validation."""
+
+    def test_missing_required_field(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "mode": {"type": "string"},
+                },
+                "required": ["path"],
+            }
+        }
+        errors = validate_tool_args({"mode": "read"}, schema)
+        assert any("path" in e for e in errors)
+
+    def test_all_required_present(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+                "required": ["path"],
+            }
+        }
+        errors = validate_tool_args({"path": "/tmp/file.txt"}, schema)
+        assert errors == []
+
+    def test_no_required_in_schema(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+            }
+        }
+        errors = validate_tool_args({}, schema)
+        assert errors == []
+
+
+class TestValidateToolArgsTypeCheck:
+    """Type mismatch detection after coercion."""
+
+    def test_wrong_type_integer(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                },
+            }
+        }
+        errors = validate_tool_args({"count": "not_a_number"}, schema)
+        assert any("count" in e and "integer" in e for e in errors)
+
+    def test_wrong_type_boolean(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "verbose": {"type": "boolean"},
+                },
+            }
+        }
+        errors = validate_tool_args({"verbose": 42}, schema)
+        assert any("verbose" in e and "boolean" in e for e in errors)
+
+    def test_correct_type_passes(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "count": {"type": "integer"},
+                    "rate": {"type": "number"},
+                    "flag": {"type": "boolean"},
+                },
+            }
+        }
+        args = {"name": "test", "count": 5, "rate": 3.14, "flag": True}
+        errors = validate_tool_args(args, schema)
+        assert errors == []
+
+
+class TestValidateToolArgsEnum:
+    """Enum constraint validation."""
+
+    def test_value_not_in_enum(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["read", "write"]},
+                },
+            }
+        }
+        errors = validate_tool_args({"mode": "delete"}, schema)
+        assert any("mode" in e and "enum" in e for e in errors)
+
+    def test_value_in_enum_passes(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["read", "write"]},
+                },
+            }
+        }
+        errors = validate_tool_args({"mode": "read"}, schema)
+        assert errors == []
+
+
+class TestValidateToolArgsNumericConstraints:
+    """minimum/maximum constraint validation."""
+
+    def test_below_minimum(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "minimum": 1},
+                },
+            }
+        }
+        errors = validate_tool_args({"limit": 0}, schema)
+        assert any("limit" in e and "minimum" in e for e in errors)
+
+    def test_above_maximum(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "maximum": 100},
+                },
+            }
+        }
+        errors = validate_tool_args({"limit": 200}, schema)
+        assert any("limit" in e and "maximum" in e for e in errors)
+
+    def test_within_range_passes(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100},
+                },
+            }
+        }
+        errors = validate_tool_args({"limit": 50}, schema)
+        assert errors == []
+
+
+class TestValidateToolArgsStringConstraints:
+    """minLength/maxLength constraint validation."""
+
+    def test_below_min_length(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                },
+            }
+        }
+        errors = validate_tool_args({"name": ""}, schema)
+        assert any("name" in e and "minLength" in e for e in errors)
+
+    def test_above_max_length(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "string", "maxLength": 10},
+                },
+            }
+        }
+        errors = validate_tool_args({"code": "a" * 11}, schema)
+        assert any("code" in e and "maxLength" in e for e in errors)
+
+    def test_within_length_passes(self):
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1, "maxLength": 100},
+                },
+            }
+        }
+        errors = validate_tool_args({"name": "hello"}, schema)
+        assert errors == []
+
+
+class TestValidateToolArgsIntegration:
+    """Integration: validation is wired into handle_function_call."""
+
+    def test_validation_error_returned_for_invalid_args(self):
+        """When args fail validation, handle_function_call returns a JSON
+        error without dispatching to the tool handler."""
+        # Register a test tool with strict schema
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_validate_tool",
+            toolset="test",
+            schema={
+                "name": "_test_validate_tool",
+                "description": "Test tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                    },
+                    "required": ["path"],
+                },
+            },
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+        )
+
+        # Temporarily patch the global registry
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_validate_tool"] = reg._tools["_test_validate_tool"]
+
+        try:
+            result = handle_function_call(
+                "_test_validate_tool",
+                {},  # missing required "path"
+            )
+            parsed = json.loads(result)
+            assert "error" in parsed
+            assert "path" in parsed["error"]
+        finally:
+            global_registry._tools.pop("_test_validate_tool", None)

--- a/tests/run_agent/test_tool_arg_schema_validation.py
+++ b/tests/run_agent/test_tool_arg_schema_validation.py
@@ -87,6 +87,53 @@ class TestValidateToolArgsTypeCheck:
         errors = validate_tool_args({"verbose": 42}, schema)
         assert any("verbose" in e and "boolean" in e for e in errors)
 
+    def test_bool_rejected_for_integer_field(self):
+        """Python bool is a subclass of int; JSON Schema treats them as distinct.
+        True/False must not pass an 'integer' type check."""
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                },
+            }
+        }
+        errors = validate_tool_args({"count": True}, schema)
+        assert any("count" in e for e in errors), (
+            "bool True should fail integer type check but got no errors"
+        )
+
+    def test_none_valid_for_nullable_union(self):
+        """JSON Schema allows 'null' as a type; None must pass ['string', 'null']."""
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tag": {"type": ["string", "null"]},
+                },
+            }
+        }
+        errors = validate_tool_args({"tag": None}, schema)
+        assert errors == [], f"None should be valid for ['string', 'null'] but got: {errors}"
+
+    def test_type_error_suppresses_enum_error(self):
+        """When a value has the wrong type, the enum check should be skipped
+        to avoid emitting two confusing errors for a single argument."""
+        schema = {
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["read", "write"]},
+                },
+            }
+        }
+        # Pass an integer — wrong type AND not in enum
+        errors = validate_tool_args({"mode": 42}, schema)
+        assert len(errors) == 1, (
+            f"Expected exactly one error (type mismatch), got {len(errors)}: {errors}"
+        )
+        assert "type" in errors[0].lower() or "wrong" in errors[0].lower()
+
     def test_correct_type_passes(self):
         schema = {
             "parameters": {


### PR DESCRIPTION
## Summary

- Add `validate_tool_args(args, schema)` that checks required fields, type mismatches (after coercion), enum constraints, and numeric/string range constraints (minimum/maximum, minLength/maxLength) against a tool's JSON Schema
- Wire validation into `handle_function_call()` after `coerce_tool_args()` — invalid arguments now return a clear JSON error instead of falling through to the tool handler
- 15 tests covering all validation categories plus integration with `handle_function_call`

## Problem

`coerce_tool_args()` only performs type coercion (e.g. `"42"` → `42`) but never validates that:
- Required fields are present
- Types actually match after coercion (a string `"hello"` for an integer field stays as-is)
- Constraints like `enum`, `minimum`/`maximum`, `minLength`/`maxLength` are satisfied

Invalid arguments previously fell through to tool handlers, causing cryptic errors or silent misbehavior.

## Test plan

- [x] `pytest tests/run_agent/test_tool_arg_schema_validation.py -v -o addopts=""` — 15/15 passed
- [x] Required field validation (missing, present, no required in schema)
- [x] Type mismatch detection (wrong integer, wrong boolean, correct types pass)
- [x] Enum constraint validation
- [x] Numeric range constraints (minimum, maximum, within range)
- [x] String length constraints (minLength, maxLength, within range)
- [x] Integration: `handle_function_call` returns error for invalid args without dispatching