### PR TITLE
feat(model_tools): add opt-in result memoization for idempotent tools

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -596,10 +596,13 @@ def handle_function_call(
     # session_id so cross-session data leakage cannot occur.  The cache is
     # cleared at the start of every agent turn (via clear_memo_cache) so
     # stale results from prior turns are never served.
+    # Memoization is skipped when session_id is None (e.g. unit tests or
+    # direct CLI invocations without a session) to prevent unrelated callers
+    # from sharing a single "" cache bucket and observing each other's results.
     entry = registry.get_entry(function_name)
-    if entry and entry.can_memoize:
+    if entry and entry.can_memoize and session_id is not None:
         cache_key = _memo_key(function_name, function_args)
-        cached = _memo_get(session_id or "", cache_key)
+        cached = _memo_get(session_id, cache_key)
         if cached is not None:
             return cached
 
@@ -719,7 +722,8 @@ def handle_function_call(
         # Cache result for memoizable tools (skip error results).
         # Runs after transform_tool_result so we cache the final value.
         # Uses _memo_set which is session-scoped and LRU-bounded.
-        if entry and entry.can_memoize:
+        # session_id=None callers are excluded (see cache-lookup guard above).
+        if entry and entry.can_memoize and session_id is not None:
             try:
                 parsed = json.loads(result)
                 # Treat the result as an error only when the top-level
@@ -732,7 +736,7 @@ def handle_function_call(
                 )
                 if not is_error:
                     cache_key = _memo_key(function_name, function_args)
-                    _memo_set(session_id or "", cache_key, result)
+                    _memo_set(session_id, cache_key, result)
             except (json.JSONDecodeError, TypeError):
                 pass
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -495,8 +495,23 @@ def _coerce_boolean(value: str):
 # ---------------------------------------------------------------------------
 # Tool result memoization cache
 # ---------------------------------------------------------------------------
+#
+# Design constraints:
+#   - Scoped per session_id so concurrent gateway sessions cannot observe each
+#     other's cached results (data confidentiality).
+#   - Bounded per session: at most _MEMO_MAX_ENTRIES_PER_SESSION entries are
+#     kept; oldest entries are evicted when the limit is reached.
+#   - Cleared at the start of every agent turn via clear_memo_cache(session_id)
+#     so stale file contents or web responses from a prior turn are never
+#     served in a later turn where the underlying resource may have changed.
+#
+# Structure: { session_id -> OrderedDict[cache_key, result_str] }
 
-_memo_cache: Dict[str, str] = {}
+from collections import OrderedDict
+
+_MEMO_MAX_ENTRIES_PER_SESSION = 128
+
+_memo_cache: Dict[str, "OrderedDict[str, str]"] = {}
 _memo_lock = threading.Lock()
 
 
@@ -508,10 +523,42 @@ def _memo_key(tool_name: str, args: Dict[str, Any]) -> str:
     return f"{tool_name}:{args_hash}"
 
 
-def clear_memo_cache() -> None:
-    """Invalidate all cached tool results."""
+def _memo_get(session_id: str, key: str) -> Optional[str]:
+    """Return a cached result for *key* within *session_id*, or None."""
     with _memo_lock:
-        _memo_cache.clear()
+        session_cache = _memo_cache.get(session_id)
+        if session_cache is None:
+            return None
+        result = session_cache.get(key)
+        if result is not None:
+            # Move to end (most-recently-used) to support LRU eviction.
+            session_cache.move_to_end(key)
+        return result
+
+
+def _memo_set(session_id: str, key: str, value: str) -> None:
+    """Store *value* under *key* for *session_id*, evicting oldest if full."""
+    with _memo_lock:
+        session_cache = _memo_cache.setdefault(session_id, OrderedDict())
+        if key in session_cache:
+            session_cache.move_to_end(key)
+        session_cache[key] = value
+        while len(session_cache) > _MEMO_MAX_ENTRIES_PER_SESSION:
+            session_cache.popitem(last=False)  # evict oldest
+
+
+def clear_memo_cache(session_id: Optional[str] = None) -> None:
+    """Invalidate cached tool results.
+
+    When *session_id* is provided only that session's cache is cleared
+    (called at the start of every agent turn).  When omitted, the entire
+    process-level cache is cleared (used in tests and on process shutdown).
+    """
+    with _memo_lock:
+        if session_id is not None:
+            _memo_cache.pop(session_id, None)
+        else:
+            _memo_cache.clear()
 
 
 def handle_function_call(
@@ -543,15 +590,18 @@ def handle_function_call(
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
 
-    # Check memoization cache for idempotent tools
+    # Check memoization cache for idempotent tools.
+    # NOTE: hooks (pre_tool_call, post_tool_call, transform_tool_result) are
+    # intentionally NOT fired on cache hits.  The cache is scoped to
+    # session_id so cross-session data leakage cannot occur.  The cache is
+    # cleared at the start of every agent turn (via clear_memo_cache) so
+    # stale results from prior turns are never served.
     entry = registry.get_entry(function_name)
     if entry and entry.can_memoize:
         cache_key = _memo_key(function_name, function_args)
-        with _memo_lock:
-            cached = _memo_cache.get(cache_key)
-            if cached is not None:
-                return cached
-
+        cached = _memo_get(session_id or "", cache_key)
+        if cached is not None:
+            return cached
 
     try:
         if function_name in _AGENT_LOOP_TOOLS:
@@ -668,13 +718,21 @@ def handle_function_call(
 
         # Cache result for memoizable tools (skip error results).
         # Runs after transform_tool_result so we cache the final value.
+        # Uses _memo_set which is session-scoped and LRU-bounded.
         if entry and entry.can_memoize:
             try:
                 parsed = json.loads(result)
-                if "error" not in parsed:
+                # Treat the result as an error only when the top-level
+                # "error" key is present AND truthy.  Tools like web_tools
+                # and vision_tools use {"error": None, ...} as their success
+                # envelope, so a None value must not suppress caching.
+                is_error = (
+                    isinstance(parsed, dict)
+                    and bool(parsed.get("error"))
+                )
+                if not is_error:
                     cache_key = _memo_key(function_name, function_args)
-                    with _memo_lock:
-                        _memo_cache[cache_key] = result
+                    _memo_set(session_id or "", cache_key, result)
             except (json.JSONDecodeError, TypeError):
                 pass
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,6 +22,7 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import json
 import asyncio
+import hashlib
 import logging
 import threading
 import time
@@ -491,6 +492,28 @@ def _coerce_boolean(value: str):
     return value
 
 
+# ---------------------------------------------------------------------------
+# Tool result memoization cache
+# ---------------------------------------------------------------------------
+
+_memo_cache: Dict[str, str] = {}
+_memo_lock = threading.Lock()
+
+
+def _memo_key(tool_name: str, args: Dict[str, Any]) -> str:
+    """Build a deterministic cache key from tool name and arguments."""
+    args_hash = hashlib.sha256(
+        json.dumps(args, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
+    return f"{tool_name}:{args_hash}"
+
+
+def clear_memo_cache() -> None:
+    """Invalidate all cached tool results."""
+    with _memo_lock:
+        _memo_cache.clear()
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -519,6 +542,16 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # Check memoization cache for idempotent tools
+    entry = registry.get_entry(function_name)
+    if entry and entry.can_memoize:
+        cache_key = _memo_key(function_name, function_args)
+        with _memo_lock:
+            cached = _memo_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
 
     try:
         if function_name in _AGENT_LOOP_TOOLS:
@@ -632,6 +665,18 @@ def handle_function_call(
                     break
         except Exception:
             pass
+
+        # Cache result for memoizable tools (skip error results).
+        # Runs after transform_tool_result so we cache the final value.
+        if entry and entry.can_memoize:
+            try:
+                parsed = json.loads(result)
+                if "error" not in parsed:
+                    cache_key = _memo_key(function_name, function_args)
+                    with _memo_lock:
+                        _memo_cache[cache_key] = result
+            except (json.JSONDecodeError, TypeError):
+                pass
 
         return result
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,6 +22,7 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import json
 import asyncio
+import hashlib
 import logging
 import threading
 from typing import Dict, Any, List, Optional, Tuple
@@ -456,6 +457,28 @@ def _coerce_boolean(value: str):
     return value
 
 
+# ---------------------------------------------------------------------------
+# Tool result memoization cache
+# ---------------------------------------------------------------------------
+
+_memo_cache: Dict[str, str] = {}
+_memo_lock = threading.Lock()
+
+
+def _memo_key(tool_name: str, args: Dict[str, Any]) -> str:
+    """Build a deterministic cache key from tool name and arguments."""
+    args_hash = hashlib.sha256(
+        json.dumps(args, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
+    return f"{tool_name}:{args_hash}"
+
+
+def clear_memo_cache() -> None:
+    """Invalidate all cached tool results."""
+    with _memo_lock:
+        _memo_cache.clear()
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -483,6 +506,15 @@ def handle_function_call(
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
+
+    # Check memoization cache for idempotent tools
+    entry = registry._tools.get(function_name)
+    if entry and entry.can_memoize:
+        cache_key = _memo_key(function_name, function_args)
+        with _memo_lock:
+            cached = _memo_cache.get(cache_key)
+            if cached is not None:
+                return cached
 
     # Notify the read-loop tracker when a non-read/search tool runs,
     # so the *consecutive* counter resets (reads after other work are fine).
@@ -539,6 +571,17 @@ def handle_function_call(
             )
         except Exception:
             pass
+
+        # Cache result for memoizable tools (skip error results)
+        if entry and entry.can_memoize:
+            try:
+                parsed = json.loads(result)
+                if "error" not in parsed:
+                    cache_key = _memo_key(function_name, function_args)
+                    with _memo_lock:
+                        _memo_cache[cache_key] = result
+            except (json.JSONDecodeError, TypeError):
+                pass
 
         return result
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9644,6 +9644,15 @@ class AIAgent:
         # child-launch time see the parent's real id, not None.
         self._current_task_id = effective_task_id
         
+        # Clear per-session memoization cache at the start of each turn so
+        # file reads, web fetches, and other idempotent tool results from a
+        # prior turn are never served stale in the current turn.
+        try:
+            from model_tools import clear_memo_cache
+            clear_memo_cache(self.session_id)
+        except Exception:
+            pass
+
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
         self._invalid_tool_retries = 0

--- a/tests/run_agent/test_tool_result_memoization.py
+++ b/tests/run_agent/test_tool_result_memoization.py
@@ -388,3 +388,43 @@ class TestErrorEnvelopeHandling:
         finally:
             global_registry._tools.pop("_test_memo_real_error", None)
             clear_memo_cache(_TEST_SESSION)
+
+
+class TestNoneSessionIdSkipsMemoization:
+    """Memoization is skipped when session_id is None to prevent cross-caller contamination."""
+
+    def test_none_session_id_never_caches(self):
+        """Calls with session_id=None always invoke the handler — no shared bucket."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_none_session",
+            toolset="test",
+            schema={"name": "_test_memo_none_session", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_none_session"] = reg._tools["_test_memo_none_session"]
+        clear_memo_cache()
+
+        try:
+            r1 = handle_function_call("_test_memo_none_session", {"x": 1}, session_id=None)
+            r2 = handle_function_call("_test_memo_none_session", {"x": 1}, session_id=None)
+            # session_id=None must bypass the cache — handler invoked both times
+            assert call_count == 2, (
+                f"Handler called {call_count} times; expected 2 (session_id=None must not cache). "
+                "Two unrelated callers with no session_id must not share a cache bucket."
+            )
+            assert json.loads(r1)["call"] == 1
+            assert json.loads(r2)["call"] == 2
+        finally:
+            global_registry._tools.pop("_test_memo_none_session", None)
+            clear_memo_cache()

--- a/tests/run_agent/test_tool_result_memoization.py
+++ b/tests/run_agent/test_tool_result_memoization.py
@@ -2,9 +2,17 @@
 
 Tools can opt in to result caching by setting ``can_memoize=True`` at
 registration.  When enabled, ``handle_function_call()`` caches the dispatch
-result keyed by ``(tool_name, args_hash)`` and returns the cached value on
-subsequent calls with identical arguments — saving the cost of re-executing
-idempotent handlers like file reads or web fetches.
+result keyed by ``(tool_name, args_hash)`` within the current agent session
+and turn, returning the cached value on subsequent calls with identical
+arguments — saving the cost of re-executing idempotent handlers like file
+reads or web fetches.
+
+Cache semantics:
+  - Scoped per session_id: two sessions with the same tool+args do NOT share
+    results (prevents cross-session data leakage in gateway mode).
+  - Bounded: at most _MEMO_MAX_ENTRIES_PER_SESSION entries per session (LRU).
+  - Per-turn: clear_memo_cache(session_id) must be called at turn start so
+    stale results from prior turns are not served in the current turn.
 """
 
 import json
@@ -67,6 +75,8 @@ class TestRegistryRegisterCanMemoize:
 
 # ── Integration tests for memoization in handle_function_call ──────────────
 
+_TEST_SESSION = "test-session-memo"
+
 
 class TestMemoCacheHitMiss:
     """Memoizable tools return cached results on repeat calls."""
@@ -93,11 +103,11 @@ class TestMemoCacheHitMiss:
         # Patch the global registry
         from model_tools import registry as global_registry
         global_registry._tools["_test_memo_hit"] = reg._tools["_test_memo_hit"]
-        clear_memo_cache()
+        clear_memo_cache(_TEST_SESSION)
 
         try:
-            r1 = handle_function_call("_test_memo_hit", {"x": 1})
-            r2 = handle_function_call("_test_memo_hit", {"x": 1})
+            r1 = handle_function_call("_test_memo_hit", {"x": 1}, session_id=_TEST_SESSION)
+            r2 = handle_function_call("_test_memo_hit", {"x": 1}, session_id=_TEST_SESSION)
             # Both calls should return the same (first) result
             assert r1 == r2
             assert json.loads(r1)["call"] == 1
@@ -105,7 +115,7 @@ class TestMemoCacheHitMiss:
             assert call_count == 1
         finally:
             global_registry._tools.pop("_test_memo_hit", None)
-            clear_memo_cache()
+            clear_memo_cache(_TEST_SESSION)
 
     def test_different_args_produces_cache_miss(self):
         """Different arguments bypass the cache and invoke the handler."""
@@ -127,18 +137,18 @@ class TestMemoCacheHitMiss:
 
         from model_tools import registry as global_registry
         global_registry._tools["_test_memo_miss"] = reg._tools["_test_memo_miss"]
-        clear_memo_cache()
+        clear_memo_cache(_TEST_SESSION)
 
         try:
-            r1 = handle_function_call("_test_memo_miss", {"x": 1})
-            r2 = handle_function_call("_test_memo_miss", {"x": 2})
+            r1 = handle_function_call("_test_memo_miss", {"x": 1}, session_id=_TEST_SESSION)
+            r2 = handle_function_call("_test_memo_miss", {"x": 2}, session_id=_TEST_SESSION)
             # Different results — handler called twice
             assert json.loads(r1)["call"] == 1
             assert json.loads(r2)["call"] == 2
             assert call_count == 2
         finally:
             global_registry._tools.pop("_test_memo_miss", None)
-            clear_memo_cache()
+            clear_memo_cache(_TEST_SESSION)
 
     def test_non_memoizable_tool_always_invokes_handler(self):
         """A tool with can_memoize=False always runs the handler."""
@@ -160,21 +170,22 @@ class TestMemoCacheHitMiss:
 
         from model_tools import registry as global_registry
         global_registry._tools["_test_no_memo_dispatch"] = reg._tools["_test_no_memo_dispatch"]
-        clear_memo_cache()
+        clear_memo_cache(_TEST_SESSION)
 
         try:
-            handle_function_call("_test_no_memo_dispatch", {"x": 1})
-            handle_function_call("_test_no_memo_dispatch", {"x": 1})
+            handle_function_call("_test_no_memo_dispatch", {"x": 1}, session_id=_TEST_SESSION)
+            handle_function_call("_test_no_memo_dispatch", {"x": 1}, session_id=_TEST_SESSION)
             assert call_count == 2
         finally:
             global_registry._tools.pop("_test_no_memo_dispatch", None)
-            clear_memo_cache()
+            clear_memo_cache(_TEST_SESSION)
 
 
 class TestClearMemoCache:
-    """clear_memo_cache() invalidates all cached results."""
+    """clear_memo_cache() invalidates cached results."""
 
-    def test_clear_forces_re_execution(self):
+    def test_clear_session_forces_re_execution(self):
+        """Clearing the session cache forces the handler to run again."""
         call_count = 0
 
         def counting_handler(args, **kw):
@@ -193,15 +204,187 @@ class TestClearMemoCache:
 
         from model_tools import registry as global_registry
         global_registry._tools["_test_memo_clear"] = reg._tools["_test_memo_clear"]
-        clear_memo_cache()
+        clear_memo_cache(_TEST_SESSION)
 
         try:
-            r1 = handle_function_call("_test_memo_clear", {"x": 1})
-            clear_memo_cache()
-            r2 = handle_function_call("_test_memo_clear", {"x": 1})
+            r1 = handle_function_call("_test_memo_clear", {"x": 1}, session_id=_TEST_SESSION)
+            clear_memo_cache(_TEST_SESSION)
+            r2 = handle_function_call("_test_memo_clear", {"x": 1}, session_id=_TEST_SESSION)
             # After clearing, handler runs again
             assert json.loads(r1)["call"] == 1
             assert json.loads(r2)["call"] == 2
         finally:
             global_registry._tools.pop("_test_memo_clear", None)
+            clear_memo_cache(_TEST_SESSION)
+
+    def test_clear_all_forces_re_execution(self):
+        """clear_memo_cache() with no args clears all sessions."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_clear_all",
+            toolset="test",
+            schema={"name": "_test_memo_clear_all", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_clear_all"] = reg._tools["_test_memo_clear_all"]
+        clear_memo_cache()
+
+        try:
+            r1 = handle_function_call("_test_memo_clear_all", {"x": 1}, session_id=_TEST_SESSION)
+            clear_memo_cache()  # no session_id — clears everything
+            r2 = handle_function_call("_test_memo_clear_all", {"x": 1}, session_id=_TEST_SESSION)
+            assert json.loads(r1)["call"] == 1
+            assert json.loads(r2)["call"] == 2
+        finally:
+            global_registry._tools.pop("_test_memo_clear_all", None)
             clear_memo_cache()
+
+
+class TestSessionIsolation:
+    """Cache is scoped per session_id — sessions cannot observe each other's results."""
+
+    def test_different_sessions_do_not_share_cache(self):
+        """Two sessions with the same tool+args each get their own handler call."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_session_iso",
+            toolset="test",
+            schema={"name": "_test_memo_session_iso", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_session_iso"] = reg._tools["_test_memo_session_iso"]
+        clear_memo_cache("session-A")
+        clear_memo_cache("session-B")
+
+        try:
+            r1 = handle_function_call("_test_memo_session_iso", {"x": 1}, session_id="session-A")
+            r2 = handle_function_call("_test_memo_session_iso", {"x": 1}, session_id="session-B")
+            # Each session invokes the handler independently
+            assert call_count == 2
+            assert json.loads(r1)["call"] == 1
+            assert json.loads(r2)["call"] == 2
+        finally:
+            global_registry._tools.pop("_test_memo_session_iso", None)
+            clear_memo_cache("session-A")
+            clear_memo_cache("session-B")
+
+    def test_same_session_second_call_is_cached(self):
+        """Within a session, a second call with the same args is served from cache."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_session_hit",
+            toolset="test",
+            schema={"name": "_test_memo_session_hit", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_session_hit"] = reg._tools["_test_memo_session_hit"]
+        clear_memo_cache("session-X")
+
+        try:
+            r1 = handle_function_call("_test_memo_session_hit", {"x": 1}, session_id="session-X")
+            r2 = handle_function_call("_test_memo_session_hit", {"x": 1}, session_id="session-X")
+            assert call_count == 1
+            assert r1 == r2
+        finally:
+            global_registry._tools.pop("_test_memo_session_hit", None)
+            clear_memo_cache("session-X")
+
+
+class TestErrorEnvelopeHandling:
+    """Results with {\"error\": None} (success envelope) are cached; truthy errors are not."""
+
+    def test_error_none_result_is_cached(self):
+        """A result with error=None is a success envelope and must be cached."""
+        call_count = 0
+
+        def handler_with_error_none(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"error": None, "data": "payload", "call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_error_none",
+            toolset="test",
+            schema={"name": "_test_memo_error_none", "description": "t"},
+            handler=handler_with_error_none,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_error_none"] = reg._tools["_test_memo_error_none"]
+        clear_memo_cache(_TEST_SESSION)
+
+        try:
+            r1 = handle_function_call("_test_memo_error_none", {"x": 1}, session_id=_TEST_SESSION)
+            r2 = handle_function_call("_test_memo_error_none", {"x": 1}, session_id=_TEST_SESSION)
+            # error=None is a success envelope — second call must be a cache hit
+            assert call_count == 1, (
+                f"Handler was called {call_count} times; expected 1 (second call should be cached). "
+                "This means results with {{\"error\": None}} are incorrectly treated as errors."
+            )
+            assert r1 == r2
+        finally:
+            global_registry._tools.pop("_test_memo_error_none", None)
+            clear_memo_cache(_TEST_SESSION)
+
+    def test_truthy_error_result_is_not_cached(self):
+        """A result with a truthy error value must not be cached."""
+        call_count = 0
+
+        def failing_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"error": "something went wrong", "call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_real_error",
+            toolset="test",
+            schema={"name": "_test_memo_real_error", "description": "t"},
+            handler=failing_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_real_error"] = reg._tools["_test_memo_real_error"]
+        clear_memo_cache(_TEST_SESSION)
+
+        try:
+            handle_function_call("_test_memo_real_error", {"x": 1}, session_id=_TEST_SESSION)
+            handle_function_call("_test_memo_real_error", {"x": 1}, session_id=_TEST_SESSION)
+            # Error results must not be cached — handler runs twice
+            assert call_count == 2
+        finally:
+            global_registry._tools.pop("_test_memo_real_error", None)
+            clear_memo_cache(_TEST_SESSION)

--- a/tests/run_agent/test_tool_result_memoization.py
+++ b/tests/run_agent/test_tool_result_memoization.py
@@ -1,0 +1,207 @@
+"""Tests for tool result memoization (caching of idempotent tool results).
+
+Tools can opt in to result caching by setting ``can_memoize=True`` at
+registration.  When enabled, ``handle_function_call()`` caches the dispatch
+result keyed by ``(tool_name, args_hash)`` and returns the cached value on
+subsequent calls with identical arguments — saving the cost of re-executing
+idempotent handlers like file reads or web fetches.
+"""
+
+import json
+
+import pytest
+
+from model_tools import handle_function_call, clear_memo_cache
+from tools.registry import ToolRegistry, ToolEntry
+
+
+# ── Unit tests for ToolEntry.can_memoize field ─────────────────────────────
+
+
+class TestToolEntryCanMemoize:
+    """ToolEntry stores per-tool memoization opt-in flag."""
+
+    def test_default_can_memoize_is_false(self):
+        entry = ToolEntry(
+            name="t", toolset="test", schema={}, handler=lambda: None,
+            check_fn=None, requires_env=[], is_async=False,
+            description="", emoji="", max_result_size_chars=None,
+            can_memoize=False,
+        )
+        assert entry.can_memoize is False
+
+    def test_can_memoize_set_true(self):
+        entry = ToolEntry(
+            name="t", toolset="test", schema={}, handler=lambda: None,
+            check_fn=None, requires_env=[], is_async=False,
+            description="", emoji="", max_result_size_chars=None,
+            can_memoize=True,
+        )
+        assert entry.can_memoize is True
+
+
+class TestRegistryRegisterCanMemoize:
+    """registry.register() passes can_memoize to ToolEntry."""
+
+    def test_register_with_can_memoize(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_tool",
+            toolset="test",
+            schema={"name": "_test_memo_tool", "description": "t"},
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            can_memoize=True,
+        )
+        assert reg._tools["_test_memo_tool"].can_memoize is True
+
+    def test_register_without_can_memoize_defaults_false(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_no_memo",
+            toolset="test",
+            schema={"name": "_test_no_memo", "description": "t"},
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+        )
+        assert reg._tools["_test_no_memo"].can_memoize is False
+
+
+# ── Integration tests for memoization in handle_function_call ──────────────
+
+
+class TestMemoCacheHitMiss:
+    """Memoizable tools return cached results on repeat calls."""
+
+    def test_memoizable_tool_returns_cached_result(self):
+        """Second call with same args returns the cached result without
+        re-invoking the handler."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_hit",
+            toolset="test",
+            schema={"name": "_test_memo_hit", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        # Patch the global registry
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_hit"] = reg._tools["_test_memo_hit"]
+        clear_memo_cache()
+
+        try:
+            r1 = handle_function_call("_test_memo_hit", {"x": 1})
+            r2 = handle_function_call("_test_memo_hit", {"x": 1})
+            # Both calls should return the same (first) result
+            assert r1 == r2
+            assert json.loads(r1)["call"] == 1
+            # Handler should only have been called once
+            assert call_count == 1
+        finally:
+            global_registry._tools.pop("_test_memo_hit", None)
+            clear_memo_cache()
+
+    def test_different_args_produces_cache_miss(self):
+        """Different arguments bypass the cache and invoke the handler."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count, "x": args.get("x")})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_miss",
+            toolset="test",
+            schema={"name": "_test_memo_miss", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_miss"] = reg._tools["_test_memo_miss"]
+        clear_memo_cache()
+
+        try:
+            r1 = handle_function_call("_test_memo_miss", {"x": 1})
+            r2 = handle_function_call("_test_memo_miss", {"x": 2})
+            # Different results — handler called twice
+            assert json.loads(r1)["call"] == 1
+            assert json.loads(r2)["call"] == 2
+            assert call_count == 2
+        finally:
+            global_registry._tools.pop("_test_memo_miss", None)
+            clear_memo_cache()
+
+    def test_non_memoizable_tool_always_invokes_handler(self):
+        """A tool with can_memoize=False always runs the handler."""
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_no_memo_dispatch",
+            toolset="test",
+            schema={"name": "_test_no_memo_dispatch", "description": "t"},
+            handler=counting_handler,
+            can_memoize=False,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_no_memo_dispatch"] = reg._tools["_test_no_memo_dispatch"]
+        clear_memo_cache()
+
+        try:
+            handle_function_call("_test_no_memo_dispatch", {"x": 1})
+            handle_function_call("_test_no_memo_dispatch", {"x": 1})
+            assert call_count == 2
+        finally:
+            global_registry._tools.pop("_test_no_memo_dispatch", None)
+            clear_memo_cache()
+
+
+class TestClearMemoCache:
+    """clear_memo_cache() invalidates all cached results."""
+
+    def test_clear_forces_re_execution(self):
+        call_count = 0
+
+        def counting_handler(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            return json.dumps({"call": call_count})
+
+        reg = ToolRegistry()
+        reg.register(
+            name="_test_memo_clear",
+            toolset="test",
+            schema={"name": "_test_memo_clear", "description": "t"},
+            handler=counting_handler,
+            can_memoize=True,
+        )
+
+        from model_tools import registry as global_registry
+        global_registry._tools["_test_memo_clear"] = reg._tools["_test_memo_clear"]
+        clear_memo_cache()
+
+        try:
+            r1 = handle_function_call("_test_memo_clear", {"x": 1})
+            clear_memo_cache()
+            r2 = handle_function_call("_test_memo_clear", {"x": 1})
+            # After clearing, handler runs again
+            assert json.loads(r1)["call"] == 1
+            assert json.loads(r2)["call"] == 2
+        finally:
+            global_registry._tools.pop("_test_memo_clear", None)
+            clear_memo_cache()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -188,7 +188,24 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         can_memoize: bool = False,
     ):
-        """Register a tool.  Called at module-import time by each tool file."""
+        """Register a tool.  Called at module-import time by each tool file.
+
+        Args:
+            can_memoize: When True, ``handle_function_call`` caches the tool's
+                result keyed by ``(tool_name, args_hash)`` within the current
+                agent session and turn.  The cache is cleared at the start of
+                every turn, so results never go stale across turns.
+
+                **Only set this for tools that are genuinely idempotent and
+                have no observable side effects.**  Tools that perform logging,
+                increment rate-limit counters, record metrics, or mutate any
+                external state must NOT set ``can_memoize=True``, even if their
+                primary purpose is to read data.  The plugin hooks
+                ``pre_tool_call``, ``post_tool_call``, and
+                ``transform_tool_result`` are bypassed on cache hits, so any
+                plugin relying on those hooks for audit or enforcement will not
+                fire for cached calls.
+        """
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -79,12 +79,12 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars",
+        "max_result_size_chars", "can_memoize",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None):
+                 max_result_size_chars=None, can_memoize=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -95,6 +95,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.can_memoize = can_memoize
 
 
 class ToolRegistry:
@@ -185,6 +186,7 @@ class ToolRegistry:
         description: str = "",
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
+        can_memoize: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         with self._lock:
@@ -222,6 +224,7 @@ class ToolRegistry:
                 description=description or schema.get("description", ""),
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
+                can_memoize=can_memoize,
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -27,12 +27,12 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars",
+        "max_result_size_chars", "can_memoize",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None):
+                 max_result_size_chars=None, can_memoize=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -43,6 +43,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.can_memoize = can_memoize
 
 
 class ToolRegistry:
@@ -68,6 +69,7 @@ class ToolRegistry:
         description: str = "",
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
+        can_memoize: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         existing = self._tools.get(name)
@@ -88,6 +90,7 @@ class ToolRegistry:
             description=description or schema.get("description", ""),
             emoji=emoji,
             max_result_size_chars=max_result_size_chars,
+            can_memoize=can_memoize,
         )
         if check_fn and toolset not in self._toolset_checks:
             self._toolset_checks[toolset] = check_fn


### PR DESCRIPTION
## Summary

- Add `can_memoize` flag to `ToolEntry` and `registry.register()` — tools opt in to result caching
- `handle_function_call()` caches successful dispatch results keyed by `(tool_name, sha256(args))` and returns cached values on repeat calls with identical arguments
- `clear_memo_cache()` invalidates all cached entries for session boundary or post-side-effect use
- 8 tests covering cache hit/miss, non-memoizable tools, and cache invalidation

## Problem

Idempotent tools like `read_file` or `web_search` are sometimes called with identical arguments multiple times in a session (e.g., the LLM re-reading a file it already read). Each redundant call wastes time and resources. There was no mechanism to cache and reuse results.

## Design decisions

- **Opt-in, not opt-out**: Only tools that explicitly set `can_memoize=True` are cached, preventing side-effectful tools from silently returning stale results
- **Skip error results**: Only successful results are cached — errors always re-execute the handler
- **Thread-safe**: Cache access is guarded by a `threading.Lock`
- **Deterministic key**: `sha256(json.dumps(args, sort_keys=True))` ensures consistent cache hits regardless of dict ordering

## Test plan

- [x] `pytest tests/run_agent/test_tool_result_memoization.py -v -o addopts=""` — 8/8 passed
- [x] `can_memoize` defaults to `False`, stores `True` when set
- [x] `register()` passes `can_memoize` to `ToolEntry`
- [x] Memoizable tool returns cached result on second call (handler invoked once)
- [x] Different arguments produce cache miss (handler invoked twice)
- [x] Non-memoizable tool always invokes handler
- [x] `clear_memo_cache()` forces re-execution on next call