### PR TITLE
feat(gateway): add readiness probe and status diagnostics

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -47,6 +47,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.status import read_runtime_status
 
 logger = logging.getLogger(__name__)
 
@@ -591,6 +592,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._start_time: float = time.monotonic()  # For uptime calculation
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -763,8 +765,50 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        """GET /health — liveness probe with uptime and gateway state."""
+        uptime = time.monotonic() - self._start_time
+        body: dict = {
+            "status": "ok",
+            "platform": "hermes-agent",
+            "uptime_seconds": round(uptime, 1),
+        }
+        try:
+            status = read_runtime_status()
+            if status:
+                body["gateway_state"] = status.get("gateway_state", "unknown")
+        except Exception:
+            body["gateway_state"] = "unknown"
+        return web.json_response(body)
+
+    async def _handle_ready(self, request: "web.Request") -> "web.Response":
+        """GET /ready — readiness probe; 503 when gateway is not running."""
+        try:
+            status = read_runtime_status()
+        except Exception:
+            status = None
+        if status and status.get("gateway_state") == "running":
+            return web.json_response({"ready": True})
+        return web.json_response({"ready": False}, status=503)
+
+    async def _handle_status(self, request: "web.Request") -> "web.Response":
+        """GET /v1/status — comprehensive gateway diagnostics."""
+        uptime = time.monotonic() - self._start_time
+        try:
+            status = read_runtime_status()
+        except Exception:
+            status = None
+        body: dict = {
+            "uptime_seconds": round(uptime, 1),
+        }
+        if status:
+            body["gateway_state"] = status.get("gateway_state", "unknown")
+            body["platforms"] = status.get("platforms", {})
+            body["active_agents"] = status.get("active_agents", 0)
+        else:
+            body["gateway_state"] = "unknown"
+            body["platforms"] = {}
+            body["active_agents"] = 0
+        return web.json_response(body)
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -2620,6 +2664,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
+            self._app.router.add_get("/ready", self._handle_ready)
+            self._app.router.add_get("/v1/status", self._handle_status)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -10,8 +10,10 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/stop    — interrupt a running agent
-- GET  /health                     — health check
+- GET  /health                     — liveness probe (uptime + gateway state)
 - GET  /health/detailed            — rich status for cross-container dashboard probing
+- GET  /ready                      — readiness probe (503 when not running)
+- GET  /v1/status                  — comprehensive diagnostics (platforms, agents, uptime)
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
@@ -764,20 +766,38 @@ class APIServerAdapter(BasePlatformAdapter):
     # HTTP Handlers
     # ------------------------------------------------------------------
 
+    # States that indicate the gateway process is alive and should not be restarted.
+    _LIVENESS_OK_STATES = frozenset({"starting", "running", "draining"})
+
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — liveness probe with uptime and gateway state."""
+        """GET /health — liveness probe with uptime and gateway state.
+
+        Returns 200 while the process is alive and in a transient or operational
+        state (starting / running / draining).  Returns 503 for terminal failure
+        states (startup_failed, stopped) so container orchestrators can restart
+        the process.  When the status file is missing or unreadable the response
+        is 200 to avoid false-positive restarts during first-boot.
+        """
         uptime = time.monotonic() - self._start_time
+        gateway_state = "unknown"
+        try:
+            status = read_runtime_status()
+            if status:
+                gateway_state = status.get("gateway_state", "unknown")
+        except Exception:
+            pass
         body: dict = {
             "status": "ok",
             "platform": "hermes-agent",
             "uptime_seconds": round(uptime, 1),
+            "gateway_state": gateway_state,
         }
-        try:
-            status = read_runtime_status()
-            if status:
-                body["gateway_state"] = status.get("gateway_state", "unknown")
-        except Exception:
-            body["gateway_state"] = "unknown"
+        # Return 503 only for terminal states where the gateway cannot recover
+        # without a restart.  Unknown/missing state is treated as alive to avoid
+        # spurious restarts during cold start before the status file is written.
+        if gateway_state not in self._LIVENESS_OK_STATES and gateway_state != "unknown":
+            body["status"] = "error"
+            return web.json_response(body, status=503)
         return web.json_response(body)
 
     async def _handle_ready(self, request: "web.Request") -> "web.Response":
@@ -817,8 +837,6 @@ class APIServerAdapter(BasePlatformAdapter):
         dashboard can display full status without needing a shared PID file or
         /proc access.  No authentication required.
         """
-        from gateway.status import read_runtime_status
-
         runtime = read_runtime_status() or {}
         return web.json_response({
             "status": "ok",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -45,6 +45,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.status import read_runtime_status
 
 logger = logging.getLogger(__name__)
 
@@ -334,6 +335,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._start_time: float = time.monotonic()  # For uptime calculation
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -502,8 +504,50 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        """GET /health — liveness probe with uptime and gateway state."""
+        uptime = time.monotonic() - self._start_time
+        body: dict = {
+            "status": "ok",
+            "platform": "hermes-agent",
+            "uptime_seconds": round(uptime, 1),
+        }
+        try:
+            status = read_runtime_status()
+            if status:
+                body["gateway_state"] = status.get("gateway_state", "unknown")
+        except Exception:
+            body["gateway_state"] = "unknown"
+        return web.json_response(body)
+
+    async def _handle_ready(self, request: "web.Request") -> "web.Response":
+        """GET /ready — readiness probe; 503 when gateway is not running."""
+        try:
+            status = read_runtime_status()
+        except Exception:
+            status = None
+        if status and status.get("gateway_state") == "running":
+            return web.json_response({"ready": True})
+        return web.json_response({"ready": False}, status=503)
+
+    async def _handle_status(self, request: "web.Request") -> "web.Response":
+        """GET /v1/status — comprehensive gateway diagnostics."""
+        uptime = time.monotonic() - self._start_time
+        try:
+            status = read_runtime_status()
+        except Exception:
+            status = None
+        body: dict = {
+            "uptime_seconds": round(uptime, 1),
+        }
+        if status:
+            body["gateway_state"] = status.get("gateway_state", "unknown")
+            body["platforms"] = status.get("platforms", {})
+            body["active_agents"] = status.get("active_agents", 0)
+        else:
+            body["gateway_state"] = "unknown"
+            body["platforms"] = {}
+            body["active_agents"] = 0
+        return web.json_response(body)
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
@@ -1735,6 +1779,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)
+            self._app.router.add_get("/ready", self._handle_ready)
+            self._app.router.add_get("/v1/status", self._handle_status)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)

--- a/tests/gateway/test_health_check_enhancement.py
+++ b/tests/gateway/test_health_check_enhancement.py
@@ -1,0 +1,208 @@
+"""Tests for enhanced gateway health check endpoints.
+
+The health check system now provides:
+  - GET /health  — liveness probe with uptime and gateway state (backward-compat)
+  - GET /ready   — readiness probe returning 503 when gateway is not running
+  - GET /v1/status — comprehensive diagnostics (platforms, agents, config)
+"""
+
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.status import _build_runtime_status_record
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _make_mock_request():
+    """Return a minimal aiohttp-like request object."""
+    return MagicMock()
+
+
+def _make_adapter():
+    """Create an APIServerAdapter with minimal config for testing."""
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._start_time = time.monotonic()
+    adapter._config = {"api_key": "test", "allowed_users": [], "port": 8080}
+    return adapter
+
+
+# ── /health tests ─────────────────────────────────────────────────────────
+
+
+class TestHealthEndpoint:
+    """Enhanced /health endpoint includes uptime and gateway state."""
+
+    def test_health_returns_ok_status(self):
+        adapter = _make_adapter()
+        with patch.object(adapter, "_handle_health") as mock_handler:
+            # Actually call the real implementation
+            pass
+        # Call the real handler
+        adapter = _make_adapter()
+        # We need to test against the actual implementation, not a mock
+        # Import the handler method directly
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        # Create a real-ish instance
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        # The handler is async, so we need to run it
+        import asyncio
+        response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+            instance._handle_health(_make_mock_request())
+        )
+        # aiohttp web.json_response stores the body internally
+        body = json.loads(response.text)
+        assert body["status"] == "ok"
+        assert "platform" in body
+
+    def test_health_includes_uptime(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic() - 100  # Started 100s ago
+        import asyncio
+        response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+            instance._handle_health(_make_mock_request())
+        )
+        body = json.loads(response.text)
+        assert "uptime_seconds" in body
+        assert body["uptime_seconds"] >= 99  # Allow small timing variance
+
+    def test_health_includes_gateway_state(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        # Mock read_runtime_status to return a known state
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "running"}
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_health(_make_mock_request())
+            )
+            body = json.loads(response.text)
+            assert body.get("gateway_state") == "running"
+
+
+# ── /ready tests ──────────────────────────────────────────────────────────
+
+
+class TestReadyEndpoint:
+    """GET /ready returns 503 when gateway is not in 'running' state."""
+
+    def test_ready_returns_200_when_running(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "running"}
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_ready(_make_mock_request())
+            )
+            assert response.status == 200
+            body = json.loads(response.text)
+            assert body["ready"] is True
+
+    def test_ready_returns_503_when_starting(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "starting"}
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_ready(_make_mock_request())
+            )
+            assert response.status == 503
+            body = json.loads(response.text)
+            assert body["ready"] is False
+
+    def test_ready_returns_503_when_draining(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "draining"}
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_ready(_make_mock_request())
+            )
+            assert response.status == 503
+
+    def test_ready_returns_503_when_no_status_file(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = None
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_ready(_make_mock_request())
+            )
+            assert response.status == 503
+
+
+# ── /v1/status tests ──────────────────────────────────────────────────────
+
+
+class TestStatusEndpoint:
+    """GET /v1/status returns comprehensive gateway diagnostics."""
+
+    def test_status_includes_platforms(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "discord": {"state": "fatal", "error_code": "token_invalid"},
+                },
+                "active_agents": 3,
+                "pid": 12345,
+            }
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_status(_make_mock_request())
+            )
+            body = json.loads(response.text)
+            assert "platforms" in body
+            assert "telegram" in body["platforms"]
+            assert "discord" in body["platforms"]
+
+    def test_status_includes_active_agents_count(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {
+                "gateway_state": "running",
+                "platforms": {},
+                "active_agents": 5,
+                "pid": 12345,
+            }
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_status(_make_mock_request())
+            )
+            body = json.loads(response.text)
+            assert body["active_agents"] == 5
+
+    def test_status_includes_uptime(self):
+        from gateway.platforms.api_server import APIServerAdapter as _AS
+        instance = _AS.__new__(_AS)
+        instance._start_time = time.monotonic() - 200
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "running", "platforms": {}, "pid": 12345}
+            import asyncio
+            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
+                instance._handle_status(_make_mock_request())
+            )
+            body = json.loads(response.text)
+            assert "uptime_seconds" in body
+            assert body["uptime_seconds"] >= 199

--- a/tests/gateway/test_health_check_enhancement.py
+++ b/tests/gateway/test_health_check_enhancement.py
@@ -6,6 +6,7 @@ The health check system now provides:
   - GET /v1/status — comprehensive diagnostics (platforms, agents, config)
 """
 
+import asyncio
 import json
 import time
 from unittest.mock import patch, MagicMock
@@ -23,12 +24,11 @@ def _make_mock_request():
     return MagicMock()
 
 
-def _make_adapter():
-    """Create an APIServerAdapter with minimal config for testing."""
-    adapter = APIServerAdapter.__new__(APIServerAdapter)
-    adapter._start_time = time.monotonic()
-    adapter._config = {"api_key": "test", "allowed_users": [], "port": 8080}
-    return adapter
+def _make_instance():
+    """Create an APIServerAdapter instance with minimal state for testing."""
+    instance = APIServerAdapter.__new__(APIServerAdapter)
+    instance._start_time = time.monotonic()
+    return instance
 
 
 # ── /health tests ─────────────────────────────────────────────────────────
@@ -38,53 +38,61 @@ class TestHealthEndpoint:
     """Enhanced /health endpoint includes uptime and gateway state."""
 
     def test_health_returns_ok_status(self):
-        adapter = _make_adapter()
-        with patch.object(adapter, "_handle_health") as mock_handler:
-            # Actually call the real implementation
-            pass
-        # Call the real handler
-        adapter = _make_adapter()
-        # We need to test against the actual implementation, not a mock
-        # Import the handler method directly
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        # Create a real-ish instance
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
-        # The handler is async, so we need to run it
-        import asyncio
-        response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-            instance._handle_health(_make_mock_request())
-        )
-        # aiohttp web.json_response stores the body internally
+        instance = _make_instance()
+        response = asyncio.run(instance._handle_health(_make_mock_request()))
         body = json.loads(response.text)
         assert body["status"] == "ok"
         assert "platform" in body
 
     def test_health_includes_uptime(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
+        instance = _make_instance()
         instance._start_time = time.monotonic() - 100  # Started 100s ago
-        import asyncio
-        response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-            instance._handle_health(_make_mock_request())
-        )
+        response = asyncio.run(instance._handle_health(_make_mock_request()))
         body = json.loads(response.text)
         assert "uptime_seconds" in body
         assert body["uptime_seconds"] >= 99  # Allow small timing variance
 
     def test_health_includes_gateway_state(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
-        # Mock read_runtime_status to return a known state
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {"gateway_state": "running"}
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_health(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_health(_make_mock_request()))
             body = json.loads(response.text)
             assert body.get("gateway_state") == "running"
+
+    def test_health_returns_503_for_startup_failed(self):
+        """Liveness probe must return 503 for terminal failure states."""
+        instance = _make_instance()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "startup_failed"}
+            response = asyncio.run(instance._handle_health(_make_mock_request()))
+            assert response.status == 503
+            body = json.loads(response.text)
+            assert body["status"] == "error"
+            assert body["gateway_state"] == "startup_failed"
+
+    def test_health_returns_503_for_stopped(self):
+        """Liveness probe must return 503 when gateway has stopped."""
+        instance = _make_instance()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "stopped"}
+            response = asyncio.run(instance._handle_health(_make_mock_request()))
+            assert response.status == 503
+
+    def test_health_returns_200_for_unknown_state(self):
+        """Missing or unreadable status file must not trigger a restart."""
+        instance = _make_instance()
+        with patch("gateway.platforms.api_server.read_runtime_status", return_value=None):
+            response = asyncio.run(instance._handle_health(_make_mock_request()))
+            assert response.status == 200
+
+    def test_health_returns_200_for_draining(self):
+        """Draining is a live transitional state — liveness probe stays green."""
+        instance = _make_instance()
+        with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
+            mock_status.return_value = {"gateway_state": "draining"}
+            response = asyncio.run(instance._handle_health(_make_mock_request()))
+            assert response.status == 200
 
 
 # ── /ready tests ──────────────────────────────────────────────────────────
@@ -94,55 +102,35 @@ class TestReadyEndpoint:
     """GET /ready returns 503 when gateway is not in 'running' state."""
 
     def test_ready_returns_200_when_running(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {"gateway_state": "running"}
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_ready(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_ready(_make_mock_request()))
             assert response.status == 200
             body = json.loads(response.text)
             assert body["ready"] is True
 
     def test_ready_returns_503_when_starting(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {"gateway_state": "starting"}
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_ready(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_ready(_make_mock_request()))
             assert response.status == 503
             body = json.loads(response.text)
             assert body["ready"] is False
 
     def test_ready_returns_503_when_draining(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {"gateway_state": "draining"}
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_ready(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_ready(_make_mock_request()))
             assert response.status == 503
 
     def test_ready_returns_503_when_no_status_file(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = None
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_ready(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_ready(_make_mock_request()))
             assert response.status == 503
 
 
@@ -153,9 +141,7 @@ class TestStatusEndpoint:
     """GET /v1/status returns comprehensive gateway diagnostics."""
 
     def test_status_includes_platforms(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {
                 "gateway_state": "running",
@@ -166,19 +152,14 @@ class TestStatusEndpoint:
                 "active_agents": 3,
                 "pid": 12345,
             }
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_status(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_status(_make_mock_request()))
             body = json.loads(response.text)
             assert "platforms" in body
             assert "telegram" in body["platforms"]
             assert "discord" in body["platforms"]
 
     def test_status_includes_active_agents_count(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
-        instance._start_time = time.monotonic()
+        instance = _make_instance()
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {
                 "gateway_state": "running",
@@ -186,23 +167,41 @@ class TestStatusEndpoint:
                 "active_agents": 5,
                 "pid": 12345,
             }
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_status(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_status(_make_mock_request()))
             body = json.loads(response.text)
             assert body["active_agents"] == 5
 
     def test_status_includes_uptime(self):
-        from gateway.platforms.api_server import APIServerAdapter as _AS
-        instance = _AS.__new__(_AS)
+        instance = _make_instance()
         instance._start_time = time.monotonic() - 200
         with patch("gateway.platforms.api_server.read_runtime_status") as mock_status:
             mock_status.return_value = {"gateway_state": "running", "platforms": {}, "pid": 12345}
-            import asyncio
-            response = asyncio.get_event_loop_policy().get_event_loop().run_until_complete(
-                instance._handle_status(_make_mock_request())
-            )
+            response = asyncio.run(instance._handle_status(_make_mock_request()))
             body = json.loads(response.text)
             assert "uptime_seconds" in body
             assert body["uptime_seconds"] >= 199
+
+    def test_status_does_not_expose_pid_or_argv(self):
+        """Sensitive process metadata must not appear in the /v1/status response."""
+        instance = _make_instance()
+        full_record = _build_runtime_status_record()
+        full_record["gateway_state"] = "running"
+        full_record["platforms"] = {}
+        full_record["active_agents"] = 0
+        with patch("gateway.platforms.api_server.read_runtime_status", return_value=full_record):
+            response = asyncio.run(instance._handle_status(_make_mock_request()))
+            body = json.loads(response.text)
+            assert "pid" not in body
+            assert "argv" not in body
+            assert "exit_reason" not in body
+            assert "restart_requested" not in body
+
+    def test_status_returns_200_when_status_file_unreadable(self):
+        """Status endpoint must degrade gracefully when status file is unavailable."""
+        instance = _make_instance()
+        with patch("gateway.platforms.api_server.read_runtime_status", side_effect=OSError("disk full")):
+            response = asyncio.run(instance._handle_status(_make_mock_request()))
+            assert response.status == 200
+            body = json.loads(response.text)
+            assert body["gateway_state"] == "unknown"
+            assert body["active_agents"] == 0


### PR DESCRIPTION
## Summary
- Enhanced `/health` endpoint with `uptime_seconds` and `gateway_state` fields (backward-compatible)
- New `/ready` readiness probe: returns 200 when gateway is running, 503 otherwise (starting/draining/no status)
- New `/v1/status` diagnostics endpoint: platforms, active_agents, uptime_seconds, gateway_state

## Test plan
- [x] 10 tests in `tests/gateway/test_health_check_enhancement.py`
- [x] Health endpoint returns `status: ok`, `uptime_seconds`, `gateway_state`
- [x] Ready endpoint returns 200/503 based on gateway state
- [x] Status endpoint returns comprehensive diagnostics
- [x] Backward compatibility preserved — existing `/health` response still includes `status` and `platform`