### PR TITLE
fix: add open.bigmodel.cn to zai provider URL mapping

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,6 +210,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
     "api.z.ai": "zai",
+    "open.bigmodel.cn": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.kimi.com": "kimi-coding",
     "api.minimax": "minimax",


### PR DESCRIPTION
## Summary

`open.bigmodel.cn` is the official API endpoint for ZhipuAI (智谱AI), but it is not recognized by Hermes' `_URL_TO_PROVIDER` mapping in `agent/model_metadata.py`.

This causes Hermes to treat it as an unknown custom endpoint and fall back to the default 128K context length for GLM-5-Turbo, even though the model actually supports **200K context**.

## Change

Add `"open.bigmodel.cn": "zai"` to `_URL_TO_PROVIDER` so that models like `glm-5-turbo` served via this endpoint are correctly resolved through models.dev with the proper 200K context length.

## Impact

- Fixes incorrect "compression model context is 128,000 tokens" warning when using ZhipuAI's official API endpoint
- No behavior change for existing configurations

## Reference

- GLM-5-Turbo context length: https://docs.bigmodel.cn/cn/guide/start/model-overview
