### PR TITLE
fix(weixin): update parameter names for image and document senders

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1490,24 +1490,24 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,
         chat_id: str,
-        path: str,
+        file_path: str,
         caption: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         if not self._session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, path, caption)
+            message_id = await self._send_file(chat_id, file_path, caption)
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)


### PR DESCRIPTION
Here is the English version for your PR description, tailored for a technical repository like `hermes-agent`.

---

## What does this PR do?

This PR fixes a parameter mismatch in the `weixin` adapter. The caller (e.g., `run.py`) passes arguments using keywords `image_path` and `file_path`, but the function definitions in `weixin.py` were using a generic `path` parameter. This caused a `TypeError: got an unexpected keyword argument` during execution.

Aligning these parameter names ensures the adapter correctly handles asynchronous media uploads as intended by the orchestration layer.

## Related Issue

Fixes # ## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`adapter/weixin.py`**:
    - Renamed parameter `path` to `image_path` in `send_image_file` to match caller arguments.
    - Renamed parameter `path` to `file_path` in `send_document` for semantic clarity and caller alignment.
- **`run.py`**:
    - Verified keyword arguments used in `adapter.send_image_file` and `adapter.send_document` calls match the updated definitions.

## How to Test

1. Launch the agent with the WeChat adapter enabled.
2. Trigger a flow that generates an image (e.g., a chart or a generated asset).
3. Trigger a flow that sends a document (e.g., a KML file or log).
4. **Expected Result**: Files are uploaded and sent to the chat successfully without `TypeError`.

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(weixin): align parameter names with caller`)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've considered cross-platform impact — N/A

## Screenshots / Logs

**Before Fix:**
```text
WARNING gateway.platforms.base: [Weixin] Error sending media: WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
```

**After Fix:**
The media message is successfully delivered to the WeChat client.