### PR TITLE
fix(delegate): bypass parent toolset intersection when acp_command is set

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -444,9 +444,20 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
+        # Allow callers (e.g. delegate_task spawning `hermes acp` subprocesses)
+        # to widen or narrow the toolset via HERMES_ACP_TOOLSETS env var.
+        # Format: comma-separated toolset names, e.g. "terminal,file,web".
+        # Default is "hermes-acp" (the coding-focused editor preset).
+        import os as _os
+        _env_toolsets = _os.environ.get("HERMES_ACP_TOOLSETS", "").strip()
+        if _env_toolsets:
+            _acp_toolsets = [t.strip() for t in _env_toolsets.split(",") if t.strip()]
+        else:
+            _acp_toolsets = ["hermes-acp"]
+
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": ["hermes-acp"],
+            "enabled_toolsets": _acp_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "model": model or default_model,

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -54,6 +54,26 @@ class TestCreateSession:
     def test_get_nonexistent_session_returns_none(self, manager):
         assert manager.get_session("does-not-exist") is None
 
+    def test_create_session_defaults_to_hermes_acp_toolset(self):
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock(name="MockAIAgent")
+            manager = SessionManager()
+            manager.create_session(cwd="/tmp/work")
+
+        call_kwargs = MockAgent.call_args.kwargs
+        assert call_kwargs["enabled_toolsets"] == ["hermes-acp"]
+
+    def test_create_session_honors_hermes_acp_toolsets_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_TOOLSETS", "browser, skills, session_search")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock(name="MockAIAgent")
+            manager = SessionManager()
+            manager.create_session(cwd="/tmp/work")
+
+        call_kwargs = MockAgent.call_args.kwargs
+        assert call_kwargs["enabled_toolsets"] == ["browser", "skills", "session_search"]
+
 
 # ---------------------------------------------------------------------------
 # fork

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -219,6 +219,55 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(goal="Test depth", parent_agent=parent)
             self.assertEqual(mock_child._delegate_depth, 1)
 
+    def test_acp_override_bypasses_parent_toolset_intersection(self):
+        """ACP child agents should use requested toolsets directly."""
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use browser tools",
+                context=None,
+                toolsets=["browser", "skills", "session_search", "delegation"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                override_acp_command="hermes",
+                override_acp_args=["acp"],
+            )
+
+        call_kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(
+            call_kwargs["enabled_toolsets"],
+            ["browser", "skills", "session_search"],
+        )
+
+    def test_parent_acp_command_uses_hermes_acp_default_without_intersection(self):
+        """If parent already uses ACP transport, child defaults to hermes-acp."""
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+        parent.acp_command = "hermes"
+        parent.acp_args = ["acp"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use native ACP tools",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+        call_kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(call_kwargs["enabled_toolsets"], ["hermes-acp"])
+
     def test_active_children_tracking(self):
         """Verify children are registered/unregistered for interrupt propagation."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -280,7 +280,19 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    # When an ACP command override is set, the child is a different agent
+    # binary (e.g. `hermes acp`) with its own native tool registry.
+    # Parent toolset intersection doesn't apply — the child resolves its own
+    # tools from its own registry.  Use requested toolsets directly, or fall
+    # back to "hermes-acp" which is the full Hermes ACP toolset.
+    _has_acp_override = bool(override_acp_command or (
+        parent_agent and getattr(parent_agent, "acp_command", None)))
+    if _has_acp_override:
+        if toolsets:
+            child_toolsets = _strip_blocked_tools(list(toolsets))
+        else:
+            child_toolsets = _strip_blocked_tools(["hermes-acp"])
+    elif toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks
         child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
     elif parent_agent and parent_enabled is not None:


### PR DESCRIPTION
## Problem

When `delegate_task` spawns a child agent with `acp_command` set (e.g. `acp_command='hermes'`, `acp_args=['acp']`), the child's toolsets are intersected with the parent's advertised toolsets (line 271 of `tools/delegate_tool.py`).

When the parent is an MCP host like Claude Code that only exposes a small subset of tools (~6 MCP tools), the intersection strips the child down to: `patch, process, read_file, search_files, terminal, write_file` — losing browser automation, skills, vision, session search, and all MCP server tools.

This makes delegated subagents essentially blind — unable to do web research, load skills, search sessions, or interact with any MCP servers.

## Solution

When `override_acp_command` (or the parent's `acp_command` attribute) is set, the child is intended to use a different agent binary's native tool registry. The parent toolset intersection doesn't apply in this case.

### Changes

**`tools/delegate_tool.py`** (the critical fix):
- Added a bypass path before the existing intersection logic
- When an ACP command override is detected, the child uses the requested toolsets directly (defaulting to `hermes-acp`) without parent intersection

**`acp_adapter/session.py`** (complementary):
- Added `HERMES_ACP_TOOLSETS` env var support so the ACP server's default toolset (`hermes-acp`) can be overridden at runtime
- Default behavior unchanged when env var is not set

## Result

| | Before | After |
|--|--------|-------|
| Tools available to child | 6 | 68 |
| Browser tools | ❌ | ✅ (10 tools) |
| Skills tools | ❌ | ✅ (3 tools) |
| Session search | ❌ | ✅ |
| Vision | ❌ | ✅ |
| MCP servers | ❌ | ✅ (44 tools) |

## Testing

Functional test: delegated a web research task to a subagent with `acp_command='hermes'`. The child successfully:
- Made 13 browser tool calls across 3 different pages
- Navigated, clicked, expanded FAQ sections, read GitHub repos
- Extracted and reported structured findings in 76 seconds
- Even caught a factual error in the parent agent's prior research

## Backward Compatibility

- When `acp_command` is **not** set: behavior is identical to before (parent intersection applies)
- When `HERMES_ACP_TOOLSETS` is **not** set: ACP server uses `hermes-acp` as before
- No changes to the default delegation path or toolset definitions