### PR TITLE
feat: add GBrain skill support and bird-smart X capture flow

### DIFF
--- a/skills/note-taking/gbrain/SKILL.md
+++ b/skills/note-taking/gbrain/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: gbrain
+description: Install, operate, and query GBrain as a markdown-first personal knowledge brain for Hermes.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [gbrain, knowledge-base, markdown, postgres, pglite, second-brain, personal-crm]
+    category: note-taking
+    related_skills: [obsidian, llm-wiki, autonomous-second-brain-backend]
+---
+
+# GBrain
+
+Use this skill when the user wants a persistent personal knowledge brain backed by
+markdown plus structured retrieval.
+
+GBrain is best when the user wants:
+- a searchable brain of people, companies, meetings, deals, ideas, and projects
+- markdown files as the human-editable system of record
+- better retrieval than raw grep over notes
+- an agent workflow that reads the brain before answering and syncs after writing
+
+## What GBrain Is
+
+GBrain combines:
+1. a markdown repository that humans and agents can read/edit directly
+2. a local or remote Postgres index for hybrid retrieval
+3. an agent workflow where the model reads the brain before answering and writes back after learning
+
+Default setup is local PGLite, so the user can start without Docker or a hosted DB.
+For larger or multi-device setups, migrate to Supabase later.
+
+## When This Skill Activates
+
+Use this skill when the user asks to:
+- install or set up GBrain
+- import markdown notes into a personal knowledge system
+- query their existing brain
+- wire Hermes into a brain-first workflow
+- maintain or troubleshoot a GBrain installation
+
+## References
+
+Read these linked files when needed:
+- `references/quickstart.md` — install, init, import, query, sync, verify
+- `templates/agents-brain-first-snippet.md` — AGENTS.md snippet for brain-first behavior
+
+## Core Operating Rules
+
+1. Prefer `gbrain search` for exact names and terms.
+2. Prefer `gbrain query` for semantic or synthesized questions.
+3. Use `gbrain get <slug>` only after search/query identifies the relevant page.
+4. After changing brain markdown, run `gbrain sync --no-pull --no-embed`.
+5. If any command fails, run `gbrain doctor --json` before guessing.
+6. Use Hermes memory/session search for agent behavior and prior chats; use GBrain for world knowledge.
+
+## Setup Workflow
+
+### 1. Install
+
+Check whether `bun` and `gbrain` already exist before installing.
+
+If GBrain is missing:
+```bash
+curl -fsSL https://bun.sh/install | bash
+source ~/.bashrc 2>/dev/null || true
+bun add -g github:garrytan/gbrain
+```
+
+Verify:
+```bash
+gbrain --version
+```
+
+### 2. Initialize the brain
+
+Default local setup:
+```bash
+gbrain init
+```
+
+Verify health:
+```bash
+gbrain doctor --json
+gbrain stats
+```
+
+Use Supabase when the user explicitly wants remote access, multi-device use, or a
+large brain from day one:
+```bash
+gbrain init --supabase
+```
+
+### 3. Create or inspect the markdown brain repo
+
+If the user already has a brain repo, inspect its structure before importing or editing:
+- read the top-level resolver/schema/index files first
+- inspect the main entity directories
+- avoid creating duplicate pages before searching existing content
+
+If starting fresh, follow the upstream schema pattern:
+- `people/`
+- `companies/`
+- `deals/`
+- `projects/`
+- `concepts/`
+- `meetings/`
+- `ideas/` or `originals/`
+- `inbox/` for unresolved items
+
+Every directory should have a resolver README describing what belongs there.
+
+### 4. Import content
+
+Find promising markdown sources first, then tell the user what was found.
+For imports, prefer a first pass without embeddings:
+```bash
+gbrain import /path/to/repo --no-embed
+```
+
+Then verify:
+```bash
+gbrain stats
+```
+
+### 5. Query for the first magic moment
+
+Run both an exact and a semantic query:
+```bash
+gbrain search "specific person, term, or company"
+gbrain query "what are the key themes across these notes?"
+```
+
+If embeddings are stale or missing:
+```bash
+gbrain embed --stale
+```
+
+## Brain-First Lookup Protocol
+
+When a user asks about a person, company, meeting, idea, or project in their known world:
+
+1. search the brain first
+2. read the most relevant page(s)
+3. answer with brain-grounded context
+4. if the interaction created new durable world knowledge, update the brain
+5. sync after the write
+
+Lookup order:
+```bash
+gbrain search "name"
+gbrain query "what do we know about name"
+gbrain get <resolved-slug>
+```
+
+Only fall back to raw file search or external web/API lookups if the brain does not
+contain the needed information.
+
+## Write-Back Protocol
+
+When the user shares durable information about their world:
+- identify the primary entity page
+- update the compiled truth section with the current best synthesis
+- append new evidence/timeline entries rather than rewriting history
+- cross-link related entities
+- sync immediately after edits
+
+Sync command:
+```bash
+gbrain sync --no-pull --no-embed
+```
+
+Refresh embeddings later in batch:
+```bash
+gbrain embed --stale
+```
+
+## Troubleshooting
+
+Always start with:
+```bash
+gbrain doctor --json
+```
+
+Common fixes:
+- no pages found → import content first, then re-check `gbrain stats`
+- poor semantic results → run `gbrain embed --stale`
+- connection issues on Supabase → use the pooled Postgres connection string, not a REST URL
+- stale search results after edits → run `gbrain sync --no-pull --no-embed`
+
+## Hermes-Specific Guidance
+
+- Use terminal for `gbrain` commands.
+- Use file tools to inspect and edit markdown brain files safely.
+- Use session/memory search for prior conversations or user preferences.
+- Use GBrain for the user's externalized world knowledge.
+- If the user wants an always-on personal CRM or second brain, recommend pairing GBrain with deterministic collectors and native cron/systemd jobs.
+
+## Good Outcome
+
+A successful setup ends with all of these true:
+- `gbrain --version` works
+- `gbrain doctor --json` is healthy
+- `gbrain stats` shows imported pages
+- `gbrain search` returns exact matches
+- `gbrain query` returns useful semantic matches
+- Hermes follows a brain-first lookup pattern for relevant questions

--- a/skills/note-taking/gbrain/SKILL.md
+++ b/skills/note-taking/gbrain/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   hermes:
     tags: [gbrain, knowledge-base, markdown, postgres, pglite, second-brain, personal-crm]
     category: note-taking
-    related_skills: [obsidian, llm-wiki, autonomous-second-brain-backend]
+    related_skills: [obsidian, llm-wiki, autonomous-second-brain-backend, bird-smart-capture]
 ---
 
 # GBrain
@@ -45,6 +45,7 @@ Use this skill when the user asks to:
 
 Read these linked files when needed:
 - `references/quickstart.md` — install, init, import, query, sync, verify
+- `references/x-bird-smart-integration.md` — use bird-smart instead of the X API for X/Twitter ingestion on this machine
 - `templates/agents-brain-first-snippet.md` — AGENTS.md snippet for brain-first behavior
 
 ## Core Operating Rules
@@ -55,6 +56,7 @@ Read these linked files when needed:
 4. After changing brain markdown, run `gbrain sync --no-pull --no-embed`.
 5. If any command fails, run `gbrain doctor --json` before guessing.
 6. Use Hermes memory/session search for agent behavior and prior chats; use GBrain for world knowledge.
+7. For X/Twitter ingestion on this machine, prefer `/home/sparta/.local/bin/bird-smart` over the official X API unless the user explicitly requests the API path.
 
 ## Setup Workflow
 
@@ -138,6 +140,27 @@ If embeddings are stale or missing:
 gbrain embed --stale
 ```
 
+### 6. X/Twitter ingestion for this machine: bird-smart, not X API
+
+For this user's environment, do not default to the official X API recipe. Prefer the
+local adaptive bird wrapper:
+
+```bash
+/home/sparta/.local/bin/bird-smart <x-url>
+```
+
+Why:
+- avoids X API setup/cost for common capture workflows
+- preserves full threads/articles better than shallow single-post extraction
+- can include useful replies when they add signal
+- matches the user's established bird-based workflow and credentials setup
+
+Recommended policy:
+- use `bird-smart` for single-link capture and selective enrichment
+- use backup credentials by default on this machine
+- include replies only when they add clarifications, counterarguments, or implementation detail
+- only use the official X API if the user explicitly wants account-wide monitoring features that bird cannot provide
+
 ## Brain-First Lookup Protocol
 
 When a user asks about a person, company, meeting, idea, or project in their known world:
@@ -196,6 +219,7 @@ Common fixes:
 - Use file tools to inspect and edit markdown brain files safely.
 - Use session/memory search for prior conversations or user preferences.
 - Use GBrain for the user's externalized world knowledge.
+- For X/Twitter capture on this machine, prefer `bird-smart` plus a local markdown/raw export into the brain repo over direct X API ingestion.
 - If the user wants an always-on personal CRM or second brain, recommend pairing GBrain with deterministic collectors and native cron/systemd jobs.
 
 ## Good Outcome

--- a/skills/note-taking/gbrain/references/quickstart.md
+++ b/skills/note-taking/gbrain/references/quickstart.md
@@ -1,0 +1,63 @@
+# GBrain Quickstart for Hermes
+
+## Install
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+source ~/.bashrc 2>/dev/null || true
+bun add -g github:garrytan/gbrain
+gbrain --version
+```
+
+## Initialize
+
+Local embedded brain:
+```bash
+gbrain init
+gbrain doctor --json
+gbrain stats
+```
+
+Remote / larger setup:
+```bash
+gbrain init --supabase
+```
+
+## Import
+
+```bash
+gbrain import /path/to/markdown-repo --no-embed
+gbrain stats
+```
+
+## Search and query
+
+```bash
+gbrain search "Pedro"
+gbrain query "what are the most important themes across these notes?"
+```
+
+## Keep retrieval current
+
+After editing brain markdown:
+```bash
+gbrain sync --no-pull --no-embed
+```
+
+When semantic retrieval needs refreshing:
+```bash
+gbrain embed --stale
+```
+
+## Health check
+
+```bash
+gbrain doctor --json
+```
+
+## Upstream docs worth reading
+
+- README: https://github.com/garrytan/gbrain
+- Skillpack: https://github.com/garrytan/gbrain/blob/master/docs/GBRAIN_SKILLPACK.md
+- Recommended schema: https://github.com/garrytan/gbrain/blob/master/docs/GBRAIN_RECOMMENDED_SCHEMA.md
+- Verification runbook: https://github.com/garrytan/gbrain/blob/master/docs/GBRAIN_VERIFY.md

--- a/skills/note-taking/gbrain/references/quickstart.md
+++ b/skills/note-taking/gbrain/references/quickstart.md
@@ -55,6 +55,19 @@ gbrain embed --stale
 gbrain doctor --json
 ```
 
+## X/Twitter capture on this machine
+
+Prefer the local bird-smart flow over the official X API for common capture work:
+
+```bash
+python skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py \
+  --url "https://x.com/.../status/..." \
+  --brain-repo /path/to/brain
+```
+
+This writes a markdown source note under `sources/social/x/` and raw JSON under
+`.raw/social/x/`, ready for `gbrain sync --no-pull --no-embed`.
+
 ## Upstream docs worth reading
 
 - README: https://github.com/garrytan/gbrain

--- a/skills/note-taking/gbrain/references/x-bird-smart-integration.md
+++ b/skills/note-taking/gbrain/references/x-bird-smart-integration.md
@@ -1,0 +1,109 @@
+# X/Twitter into GBrain via bird-smart
+
+This machine should prefer `bird-smart` over the official X API for common GBrain
+capture flows.
+
+## Why use bird-smart here
+
+- Matches the user's existing X/Twitter workflow and credentials setup
+- Avoids the official X API cost/setup burden for single-link and selective capture
+- Preserves full threads and article-style posts better than naive single-post capture
+- Can selectively pull replies when they add value
+
+Installed paths on this machine:
+- Wrapper: `/home/sparta/.local/bin/bird-smart`
+- Script: `/home/sparta/.hermes/scripts/bird-smart.py`
+
+Credential policy on this machine:
+- default `bird` uses backup credentials
+- use main credentials only when required for main-account-only surfaces
+
+## Recommended architecture inside a private monorepo/workspace
+
+Keep the brain repo and collector logic in your real workspace, not under `~/.hermes`.
+
+Suggested layout:
+
+```text
+<workspace>/
+├── brain/                         # markdown brain repo
+│   ├── people/
+│   ├── companies/
+│   ├── concepts/
+│   ├── meetings/
+│   ├── ideas/
+│   ├── inbox/
+│   ├── sources/
+│   │   └── social/
+│   │       └── x/
+│   └── .raw/
+│       └── social/
+│           └── x/
+└── automation/
+    └── x/
+        ├── capture-x-to-gbrain.py
+        └── state/
+```
+
+## Operating modes
+
+### 1. Single-link capture
+
+Use for a tweet/thread/article URL the user sends directly.
+
+```bash
+python skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py \
+  --url "https://x.com/.../status/..." \
+  --brain-repo /path/to/brain
+```
+
+This should:
+- run `bird-smart`
+- store raw JSON under `.raw/social/x/`
+- write a markdown source note under `sources/social/x/`
+- optionally run `gbrain sync --no-pull --no-embed`
+
+### 2. Selective enrichment/backfill
+
+For account or search backfills:
+- collect broad batches first with bird/user-tweets or other deterministic collectors
+- only escalate individual high-value posts through `bird-smart`
+- materialize only worth-keeping captures into the brain repo
+
+### 3. Always-on pipeline
+
+If you want recurring ingestion:
+- use native cron/systemd, not Hermes cron, for deterministic polling
+- write captures into the brain repo
+- sync with `gbrain sync --no-pull --no-embed`
+- run `gbrain embed --stale` in batch on a slower cadence
+
+## Filing policy
+
+For raw social captures:
+- raw JSON goes under `.raw/social/x/`
+- human/agent-readable markdown source docs go under `sources/social/x/`
+- durable synthesis belongs on entity/concept pages, not only in the source note
+
+## What to write into the markdown source doc
+
+Minimum useful fields:
+- canonical URL
+- post ID
+- author handle/name
+- created timestamp
+- classification from `bird-smart`
+- fetched surfaces (`read`, `thread`, `replies`)
+- concise summary of the post/thread
+- notable replies only if they add signal
+- path to the raw JSON sidecar
+
+## When to use the official X API instead
+
+Use the official API only if you explicitly need features bird cannot provide well,
+for example:
+- broad account-wide monitoring at a scale your local bird flow cannot handle
+- specialized search windows / rate-limit semantics you specifically want
+- collector logic tied to official API metadata such as deletion/engagement tracking across many accounts
+
+For this user's default workflow, `bird-smart` should remain the first choice.

--- a/skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py
+++ b/skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Capture an X/Twitter URL via bird-smart and materialize it into a GBrain repo.
+
+Writes:
+- raw JSON sidecar under .raw/social/x/
+- markdown source note under sources/social/x/
+
+This is intentionally filesystem-first so the caller can run `gbrain sync` after the
+capture without needing any GBrain Python API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+BIRD_SMART = "/home/sparta/.local/bin/bird-smart"
+
+
+def _slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"https?://", "", value)
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"^-+|-+$", "", value)
+    return value or "x-capture"
+
+
+def _safe_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _truncate(text: str, limit: int = 280) -> str:
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _first_present(obj: Dict[str, Any], keys: Iterable[str], default: Any = "") -> Any:
+    for key in keys:
+        value = obj.get(key)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _parse_dt(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    for candidate in (value, value.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+    return None
+
+
+def _extract_author(root: Dict[str, Any]) -> Tuple[str, str]:
+    user = root.get("user") or root.get("author") or {}
+    handle = _safe_text(
+        _first_present(user, ["username", "screen_name", "handle"]) or _first_present(root, ["username", "screen_name", "handle"])
+    ).lstrip("@")
+    name = _safe_text(_first_present(user, ["name", "displayname", "displayName"]))
+    if not handle and name:
+        handle = _slugify(name)
+    if not name and handle:
+        name = handle
+    return handle or "unknown", name or handle or "unknown"
+
+
+def _collect_tweets(payload: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not payload:
+        return []
+    tweets = payload.get("tweets")
+    if isinstance(tweets, list):
+        return [t for t in tweets if isinstance(t, dict)]
+    if isinstance(payload, dict) and payload.get("id"):
+        return [payload]
+    return []
+
+
+def _summarize_reply(reply: Dict[str, Any]) -> str:
+    handle, _name = _extract_author(reply)
+    text = _truncate(_safe_text(reply.get("text", "")), 220)
+    likes = _first_present(reply, ["likeCount", "favoriteCount"], 0)
+    replies = _first_present(reply, ["replyCount"], 0)
+    return f"- @{handle}: {text} (likes={likes}, replies={replies})"
+
+
+def _write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def build_markdown(url: str, capture: Dict[str, Any], raw_path: Path) -> str:
+    root = capture.get("root") or {}
+    handle, author_name = _extract_author(root)
+    post_id = _safe_text(_first_present(root, ["id", "rest_id", "tweet_id"], "unknown"))
+    text = _safe_text(root.get("text", "")).strip()
+    title = _truncate(text, 90) or f"X capture {post_id}"
+    classification = capture.get("classification") or []
+    surfaces = capture.get("fetched_surfaces") or []
+    created_at = _safe_text(_first_present(root, ["createdAt", "created_at", "date"], ""))
+    stats = {
+        "likes": _first_present(root, ["likeCount", "favoriteCount"], 0),
+        "reposts": _first_present(root, ["retweetCount", "retweet_count"], 0),
+        "replies": _first_present(root, ["replyCount", "reply_count"], 0),
+        "quotes": _first_present(root, ["quoteCount", "quote_count"], 0),
+    }
+
+    thread_tweets = _collect_tweets(capture.get("thread"))
+    reply_tweets = _collect_tweets(capture.get("replies"))
+
+    summary_bits = []
+    if text:
+        summary_bits.append(_truncate(text, 500))
+    if len(thread_tweets) > 1:
+        summary_bits.append(f"Thread expansion recovered {len(thread_tweets)} tweets.")
+    if reply_tweets:
+        summary_bits.append(f"Reply expansion fetched {len(reply_tweets)} replies; only notable ones should be synthesized.")
+
+    notable_replies = sorted(
+        reply_tweets,
+        key=lambda r: (
+            int(_first_present(r, ["likeCount", "favoriteCount"], 0) or 0),
+            int(_first_present(r, ["replyCount"], 0) or 0),
+        ),
+        reverse=True,
+    )[:5]
+
+    body = [
+        "---",
+        f'title: "{title.replace(chr(34), chr(39))}"',
+        f'type: source',
+        f'created: {datetime.now(timezone.utc).date().isoformat()}',
+        f'updated: {datetime.now(timezone.utc).date().isoformat()}',
+        f'author_handle: "@{handle}"',
+        f'post_id: "{post_id}"',
+        f'source_url: "{url}"',
+        f'classification: [{", ".join(json.dumps(x) for x in classification)}]',
+        f'fetched_surfaces: [{", ".join(json.dumps(x) for x in surfaces)}]',
+        f'raw_capture: "{raw_path.as_posix()}"',
+        "tags: [social-media, x, source]",
+        "---",
+        "",
+        f"# X capture: @{handle} / {post_id}",
+        "",
+        "## Summary",
+        "",
+        " ".join(summary_bits).strip() or "Captured via bird-smart.",
+        "",
+        "## Source metadata",
+        "",
+        f"- Author: {author_name} (@{handle})",
+        f"- URL: {url}",
+        f"- Post ID: {post_id}",
+        f"- Created at: {created_at or 'unknown'}",
+        f"- Classification: {', '.join(classification) if classification else 'unknown'}",
+        f"- Fetched surfaces: {', '.join(surfaces) if surfaces else 'read'}",
+        f"- Engagement: likes={stats['likes']}, reposts={stats['reposts']}, replies={stats['replies']}, quotes={stats['quotes']}",
+        "",
+        "## Root post",
+        "",
+        text or "(no text returned)",
+    ]
+
+    if len(thread_tweets) > 1:
+        body.extend([
+            "",
+            "## Thread expansion",
+            "",
+            f"Recovered {len(thread_tweets)} tweets in the conversation.",
+        ])
+        for idx, tweet in enumerate(thread_tweets, start=1):
+            tweet_text = _truncate(_safe_text(tweet.get("text", "")), 400)
+            tweet_id = _safe_text(_first_present(tweet, ["id", "rest_id", "tweet_id"], ""))
+            body.extend(["", f"### Thread item {idx} ({tweet_id})", "", tweet_text or "(no text returned)"])
+
+    if notable_replies:
+        body.extend(["", "## Notable replies", "", "Only replies with some measurable engagement are summarized here."])
+        body.extend(["", *[_summarize_reply(reply) for reply in notable_replies]])
+
+    body.extend([
+        "",
+        "## Raw capture",
+        "",
+        f"- Raw JSON: `{raw_path.as_posix()}`",
+        "- After reviewing this source note, update the relevant entity/concept pages and run `gbrain sync --no-pull --no-embed`.",
+        "",
+    ])
+    return "\n".join(body)
+
+
+def run_capture(url: str, include_replies: str, reply_threshold: int, max_thread_pages: int, timeout: int, json_full: bool) -> Dict[str, Any]:
+    cmd = [
+        BIRD_SMART,
+        url,
+        "--include-replies",
+        include_replies,
+        "--reply-threshold",
+        str(reply_threshold),
+        "--max-thread-pages",
+        str(max_thread_pages),
+        "--timeout",
+        str(timeout),
+    ]
+    if json_full:
+        cmd.append("--json-full")
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture an X URL via bird-smart into a GBrain repo")
+    parser.add_argument("--url", required=True, help="X/Twitter status URL or ID")
+    parser.add_argument("--brain-repo", required=True, help="Path to the markdown brain repo")
+    parser.add_argument("--include-replies", choices=["auto", "yes", "no"], default="auto")
+    parser.add_argument("--reply-threshold", type=int, default=3)
+    parser.add_argument("--max-thread-pages", type=int, default=2)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--json-full", action="store_true")
+    parser.add_argument("--sync", action="store_true", help="Run gbrain sync --no-pull --no-embed after writing files")
+    args = parser.parse_args()
+
+    brain_repo = Path(args.brain_repo).expanduser().resolve()
+    capture = run_capture(
+        url=args.url,
+        include_replies=args.include_replies,
+        reply_threshold=args.reply_threshold,
+        max_thread_pages=args.max_thread_pages,
+        timeout=args.timeout,
+        json_full=args.json_full,
+    )
+
+    root = capture.get("root") or {}
+    handle, _author_name = _extract_author(root)
+    post_id = _safe_text(_first_present(root, ["id", "rest_id", "tweet_id"], "unknown"))
+    created_at = _parse_dt(_safe_text(_first_present(root, ["createdAt", "created_at", "date"], "")))
+    date_prefix = (created_at or datetime.now(timezone.utc)).strftime("%Y-%m-%d")
+    slug = f"x-{date_prefix}-{_slugify(handle)}-{_slugify(post_id)}"
+
+    raw_rel = Path(".raw") / "social" / "x" / f"{slug}.json"
+    md_rel = Path("sources") / "social" / "x" / f"{slug}.md"
+    raw_path = brain_repo / raw_rel
+    md_path = brain_repo / md_rel
+
+    _write_json(raw_path, capture)
+    markdown = build_markdown(args.url, capture, raw_rel)
+    _write_text(md_path, markdown)
+
+    if args.sync:
+        subprocess.run(["gbrain", "sync", "--no-pull", "--no-embed"], cwd=str(brain_repo), check=True)
+
+    print(json.dumps({
+        "success": True,
+        "url": args.url,
+        "brain_repo": str(brain_repo),
+        "markdown_path": str(md_path),
+        "raw_path": str(raw_path),
+        "classification": capture.get("classification") or [],
+        "fetched_surfaces": capture.get("fetched_surfaces") or [],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/note-taking/gbrain/templates/agents-brain-first-snippet.md
+++ b/skills/note-taking/gbrain/templates/agents-brain-first-snippet.md
@@ -1,0 +1,21 @@
+## GBrain brain-first lookup
+
+When answering questions about the user's world (people, companies, meetings, projects, ideas, deals), search GBrain before relying on model recall or external APIs.
+
+Lookup order:
+1. `gbrain search "name or exact term"`
+2. `gbrain query "what do we know about X"`
+3. `gbrain get <slug>` after resolving the relevant page
+
+After editing any brain markdown files, run:
+```bash
+gbrain sync --no-pull --no-embed
+```
+
+Use GBrain for world knowledge.
+Use Hermes memory/session search for user preferences and prior conversation state.
+
+If GBrain commands fail, run:
+```bash
+gbrain doctor --json
+```

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -103,6 +103,14 @@ class TestTrustLevelFor:
         assert result in ("trusted", "community")
 
 
+class TestGitHubSourceDefaultTaps:
+    def test_includes_gbrain_skills_directory(self):
+        auth = MagicMock(spec=GitHubAuth)
+        src = GitHubSource(auth=auth)
+
+        assert {"repo": "garrytan/gbrain", "path": "skills/"} in src.taps
+
+
 # ---------------------------------------------------------------------------
 # SkillsShSource
 # ---------------------------------------------------------------------------

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -289,6 +289,7 @@ class GitHubSource(SkillSource):
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
+        {"repo": "garrytan/gbrain", "path": "skills/"},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -348,6 +348,7 @@ Default taps (browsable without any setup):
 - [anthropics/skills](https://github.com/anthropics/skills)
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 - [garrytan/gstack](https://github.com/garrytan/gstack)
+- [garrytan/gbrain](https://github.com/garrytan/gbrain)
 
 - Example:
 


### PR DESCRIPTION
## Summary
- add `garrytan/gbrain` as a default GitHub skills tap so Hermes can discover/install upstream GBrain skills out of the box
- add a bundled `gbrain` skill under `skills/note-taking/` with setup, query, sync, and troubleshooting guidance for Hermes users
- add a bird-smart based X capture helper at `skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py`
- document the GBrain X ingestion flow and quickstart usage for single-URL capture into a brain repo

## Testing
- `python -m pytest tests/tools/test_skills_hub.py tests/tools/test_skills_sync.py tests/tools/test_skills_tool.py -q`
- verified `GitHubSource._list_skills_in_repo("garrytan/gbrain", "skills/")` returns upstream GBrain skills
- direct `bird-smart` run against `https://x.com/garrytan/status/2043022208512172263`
- end-to-end adapter test with `python skills/note-taking/gbrain/scripts/capture_x_to_gbrain.py --url ... --brain-repo /tmp/gbrain-bird-test-...`
- confirmed classification included thread + post-with-fetched-replies and fetched surfaces included replies
