### PR TITLE
fix(gateway): detect systemd in /restart to avoid killing service permanently

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4071,7 +4071,13 @@ class GatewayRunner:
             return "⏳ Gateway restart already in progress..."
 
         active_agents = self._running_agent_count()
-        self.request_restart(detached=True, via_service=False)
+        # When running under systemd (INVOCATION_ID is set), exit with the
+        # service restart code so systemd restarts us cleanly.  Otherwise
+        # fall back to detached self-restart for standalone / launchd setups.
+        if os.environ.get("INVOCATION_ID"):
+            self.request_restart(detached=False, via_service=True)
+        else:
+            self.request_restart(detached=True, via_service=False)
         if active_agents:
             return f"⏳ Draining {active_agents} active agent(s) before restart..."
         return "♻ Restarting gateway..."


### PR DESCRIPTION
## Summary

Fixes #8104 — `/restart` slash command hardcodes `detached=True, via_service=False`, which causes systemd-managed gateways to die permanently instead of restarting.

**Root cause:** When `via_service=False`, the gateway exits with code 0 instead of 75 (`GATEWAY_SERVICE_RESTART_EXIT_CODE`). systemd sees a clean exit, not a restart request. The detached child process then tries to regenerate the service file and `systemctl restart`, but by then systemd may have hit `StartLimitBurst` or the service file regeneration strips custom environment overrides.

**Fix:** Check `INVOCATION_ID` environment variable (set by systemd for all managed units) to auto-detect service management:
- **systemd detected** → `request_restart(detached=False, via_service=True)` — exits with code 75, systemd restarts cleanly
- **standalone/launchd** → `request_restart(detached=True, via_service=False)` — existing detached self-restart behavior preserved

This matches the pattern already used by the SIGUSR1 restart handler at `start_gateway()`.

## Changes

- `gateway/run.py`: `_handle_restart_command()` — 7 lines added, 1 removed

## Test plan

- [ ] `hermes gateway` under systemd → `/restart` → gateway exits with code 75, systemd restarts it
- [ ] `hermes gateway` standalone → `/restart` → detached self-restart (no behavior change)
- [ ] `hermes gateway` under launchd → `/restart` → detached self-restart (no behavior change)