### PR TITLE
Hard block manual background gateway restarts

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -521,13 +521,13 @@ class TestForkBombDetection:
 
 
 class TestGatewayProtection:
-    """Prevent agents from starting the gateway outside systemd management."""
+    """Prevent agents from starting the gateway outside service management."""
 
     def test_gateway_run_with_disown_detected(self):
         cmd = "kill 1605 && cd ~/.hermes/hermes-agent && source venv/bin/activate && python -m hermes_cli.main gateway run --replace &disown; echo done"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
-        assert "systemctl" in desc
+        assert "hermes gateway restart" in desc
 
     def test_gateway_run_with_ampersand_detected(self):
         cmd = "python -m hermes_cli.main gateway run --replace &"
@@ -540,7 +540,7 @@ class TestGatewayProtection:
         assert dangerous is True
 
     def test_gateway_run_with_setsid_detected(self):
-        cmd = "hermes_cli.main gateway run --replace &disown"
+        cmd = "setsid python -m hermes_cli.main gateway run --replace >/tmp/gw.log 2>&1"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
 
@@ -819,4 +819,17 @@ class TestChmodExecuteCombo:
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
 
+
+class TestGatewayManualRunDetection:
+    def test_nohup_gateway_run_detected(self):
+        cmd = "nohup python -m hermes_cli.main gateway run --replace > ~/.hermes/gateway.log 2>&1 &"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "gateway" in desc.lower()
+
+    def test_gateway_run_with_setsid_detected(self):
+        cmd = "setsid python -m hermes_cli.main gateway run --replace >/tmp/gw.log 2>&1"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "gateway" in desc.lower()
 

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -270,6 +270,43 @@ class TestAlwaysVisibility:
         assert cb.call_args[1]["allow_permanent"] is True
 
 
+class TestGatewayManualRunHardBlock:
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_nohup_is_hard_blocked_in_cli(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="once")
+        result = check_all_command_guards(
+            "nohup python -m hermes_cli.main gateway run --replace > ~/.hermes/gateway.log 2>&1 &",
+            "local",
+            approval_callback=cb,
+        )
+        assert result["approved"] is False
+        assert "hermes gateway restart" in result["message"]
+        cb.assert_not_called()
+        mock_tirith.assert_not_called()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_gateway_nohup_is_hard_blocked_in_gateway_mode(self, mock_tirith):
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        result = check_all_command_guards(
+            "nohup python -m hermes_cli.main gateway run --replace > ~/.hermes/gateway.log 2>&1 &",
+            "local",
+        )
+        assert result["approved"] is False
+        assert result.get("status") != "approval_required"
+        assert "hermes gateway restart" in result["message"]
+        mock_tirith.assert_not_called()
+
+    def test_gateway_nohup_is_hard_blocked_even_in_yolo(self):
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        result = check_all_command_guards(
+            "nohup python -m hermes_cli.main gateway run --replace > ~/.hermes/gateway.log 2>&1 &",
+            "local",
+        )
+        assert result["approved"] is False
+        assert "launchd/systemd" in result["message"]
+
+
 # ---------------------------------------------------------------------------
 # tirith ImportError → treated as allow
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -100,6 +100,21 @@ class TestYoloMode:
         assert result["message"] is None
         assert called["value"] is False
 
+    def test_gateway_manual_background_run_still_blocked_in_yolo_mode(self, monkeypatch):
+        """Service-manager bypasses stay blocked even when YOLO is enabled."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        cmd = "nohup python -m hermes_cli.main gateway run --replace > ~/.hermes/gateway.log 2>&1 &"
+
+        result = check_dangerous_command(cmd, "local")
+        assert result["approved"] is False
+        assert "hermes gateway restart" in result["message"]
+
+        combined = check_all_command_guards(cmd, "local")
+        assert combined["approved"] is False
+        assert "launchd/systemd" in combined["message"]
+
     def test_yolo_mode_not_set_by_default(self):
         """HERMES_YOLO_MODE should not be set by default."""
         # Clean env check — if it happens to be set in test env, that's fine,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -72,6 +72,15 @@ _SENSITIVE_WRITE_TARGET = (
 # Dangerous command patterns
 # =========================================================================
 
+_GATEWAY_SERVICE_MANAGER_DESC = (
+    "start gateway outside service manager "
+    "(use 'hermes gateway restart' or 'hermes gateway start')"
+)
+
+_NON_OVERRIDABLE_PATTERN_KEYS = {
+    _GATEWAY_SERVICE_MANAGER_DESC,
+}
+
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
@@ -101,9 +110,14 @@ DANGEROUS_PATTERNS = [
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     (r'\bfind\b.*-exec\s+(/\S*/)?rm\b', "find -exec rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),
-    # Gateway protection: never start gateway outside systemd management
-    (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
-    (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
+    # Gateway protection: manual background starts leave orphaned shells and
+    # bypass launchd/systemd supervision. These must stay hard-blocked.
+    (
+        r'(?:\bsetsid\b.*gateway\s+run\b|'
+        r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b))',
+        _GATEWAY_SERVICE_MANAGER_DESC,
+    ),
+    (r'\bnohup\b.*gateway\s+run\b', _GATEWAY_SERVICE_MANAGER_DESC),
     # Self-termination protection: prevent agent from killing its own process
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
     # Self-termination via kill + command substitution (pgrep/pidof).
@@ -190,6 +204,27 @@ def detect_dangerous_command(command: str) -> tuple:
             pattern_key = description
             return (True, pattern_key, description)
     return (False, None, None)
+
+
+def _hard_block_response(pattern_key: str, description: str) -> dict:
+    """Return a non-overridable block for structurally unsafe commands."""
+    if pattern_key == _GATEWAY_SERVICE_MANAGER_DESC:
+        return {
+            "approved": False,
+            "message": (
+                "BLOCKED: Do not start Hermes gateway with nohup, &, disown, or setsid. "
+                "Use 'hermes gateway restart' to replace the running gateway, or "
+                "'hermes gateway start' to let launchd/systemd manage it."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+        }
+    return {
+        "approved": False,
+        "message": f"BLOCKED: {description}.",
+        "pattern_key": pattern_key,
+        "description": description,
+    }
 
 
 # =========================================================================
@@ -598,12 +633,15 @@ def check_dangerous_command(command: str, env_type: str,
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
 
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if is_dangerous and pattern_key in _NON_OVERRIDABLE_PATTERN_KEYS:
+        return _hard_block_response(pattern_key, description)
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}
 
@@ -700,6 +738,10 @@ def check_all_command_guards(command: str, env_type: str,
     if env_type in ("docker", "singularity", "modal", "daytona"):
         return {"approved": True, "message": None}
 
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if is_dangerous and pattern_key in _NON_OVERRIDABLE_PATTERN_KEYS:
+        return _hard_block_response(pattern_key, description)
+
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
@@ -725,9 +767,6 @@ def check_all_command_guards(command: str, env_type: str,
         tirith_result = check_command_security(command)
     except ImportError:
         pass  # tirith module not installed — allow
-
-    # Dangerous command check (detection only, no approval)
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
 
     # --- Phase 2: Decide ---
 


### PR DESCRIPTION
## Summary
- hard block manual `nohup`/`&`/`disown`/`setsid` gateway background starts instead of sending them through the normal approval flow
- update the guidance to point users at `hermes gateway restart` / `hermes gateway start`
- add regression coverage for direct detection, combined command guards, and YOLO bypass behavior

## Why
A manual background `gateway run --replace` restart can leave an orphaned parent shell waiting forever while the gateway itself is already back online. That makes Hermes look hung even though the service recovered. This patch keeps those structurally unsafe restart patterns non-overridable and steers the agent back to the service-managed restart path.

## Testing
- `python -m py_compile tools/approval.py`
- `python -m pytest tests/tools/test_approval.py tests/tools/test_command_guards.py tests/tools/test_yolo_mode.py -q`

## Notes
- I also attempted `python -m pytest tests/ -q` before pushing.
- In this environment, the full suite reports many failures even on a fresh clone of upstream `main`, so I did not treat that as a regression introduced by this patch.
