### PR TITLE
fix: add git to Dockerfile apt dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 python3-pip ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/hermes


### PR DESCRIPTION
## What does this PR do?

Docker build fails at `npm install` step because a dependency requires `git clone`, but `git` is not installed in the container image.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `git` to the `apt-get install` list in `Dockerfile` (line 9)

## How to Test

1. `docker build -t hermes-agent .`
2. Build should complete without `npm ERR! enoent spawn git` error

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on my platform: Windows 11 (Docker Desktop)

### Documentation & Housekeeping

- [x] N/A for all documentation items

## Screenshots / Logs

Error before fix:
npm ERR! code ENOENT
npm ERR! syscall spawn git
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent An unknown git error occurred
