### PR TITLE
feat(feishu): configurable ACK reaction lifecycle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -550,6 +550,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.FEISHU and "ack_reaction" in platform_cfg:
+                    bridged["ack_reaction"] = platform_cfg["ack_reaction"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -278,6 +278,8 @@ class FeishuAdapterSettings:
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    # ACK reaction lifecycle: "on_complete" (remove OK after agent finishes) or "off" (disabled)
+    ack_reaction: str = "on_complete"
 
 
 @dataclass
@@ -1049,6 +1051,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
+        self._ack_reactions: Dict[str, str] = {}  # message_id → reaction_id (pending ACK reactions)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
@@ -1144,6 +1147,7 @@ class FeishuAdapter(BasePlatformAdapter):
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
+            ack_reaction=str(extra.get("ack_reaction", "on_complete")).strip().lower(),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -2031,23 +2035,27 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _handle_message_with_guards(self, event: MessageEvent) -> None:
         """Dispatch a single event through the agent pipeline with per-chat serialization
-        and a persistent ACK emoji reaction before processing starts.
+        and a transient ACK (OK) emoji reaction.
 
         - Per-chat lock: ensures messages in the same chat are processed one at a time
           (matches openclaw's createChatQueue serial queue behaviour).
         - ACK indicator: adds a CHECK reaction to the triggering message before handing
-          off to the agent and leaves it in place as a receipt marker.
+          off to the agent. The reaction is removed in ``on_processing_complete`` after
+          the agent has fully responded (not when handle_message returns, since it
+          spawns a background task).
         """
         chat_id = getattr(event.source, "chat_id", "") or "" if event.source else ""
         chat_lock = self._get_chat_lock(chat_id)
         async with chat_lock:
             message_id = event.message_id
-            if message_id:
-                await self._add_ack_reaction(message_id)
+            if message_id and self._settings.ack_reaction == "on_complete":
+                reaction_id = await self._add_ack_reaction(message_id)
+                if reaction_id:
+                    self._ack_reactions[message_id] = reaction_id
             await self.handle_message(event)
 
     async def _add_ack_reaction(self, message_id: str) -> Optional[str]:
-        """Add a persistent ACK emoji reaction to signal the message was received."""
+        """Add an ACK (OK) emoji reaction to signal the message was received."""
         if not self._client or not message_id:
             return None
         try:
@@ -2079,6 +2087,29 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to add ack reaction to %s", message_id, exc_info=True)
         return None
+
+    async def _remove_ack_reaction(self, message_id: str, reaction_id: str) -> None:
+        """Remove the ACK (OK) emoji reaction after the agent finishes responding."""
+        if not self._client or not message_id or not reaction_id:
+            return
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageReactionRequest
+            request = (
+                DeleteMessageReactionRequest.builder()
+                .message_id(message_id)
+                .reaction_id(reaction_id)
+                .build()
+            )
+            await asyncio.to_thread(self._client.im.v1.message_reaction.delete, request)
+        except Exception:
+            logger.debug("[Feishu] Failed to remove ack reaction from %s", message_id, exc_info=True)
+
+    async def on_processing_complete(self, event: "MessageEvent", outcome: Any) -> None:
+        """Remove the ACK reaction after the agent has fully processed and responded."""
+        message_id = getattr(event, "message_id", "") or ""
+        reaction_id = self._ack_reactions.pop(message_id, None)
+        if message_id and reaction_id:
+            await self._remove_ack_reaction(message_id, reaction_id)
 
     # =========================================================================
     # Webhook server and security

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -660,6 +660,14 @@ DEFAULT_CONFIG = {
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
     },
 
+    # Feishu / Lark platform settings (gateway mode)
+    "feishu": {
+        # ACK reaction lifecycle:
+        #   "on_complete" — add OK reaction on receipt, remove after agent finishes responding (default)
+        #   "off"         — disable ACK (OK) reaction entirely
+        "ack_reaction": "on_complete",
+    },
+
     # Approval mode for dangerous commands:
     #   manual — always prompt the user (default)
     #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -231,6 +231,23 @@ Interactive cards require **three** configuration steps in the Feishu Developer 
 Without all three steps, Feishu will successfully *send* interactive cards (sending only requires `im:message:send` permission), but clicking any button will return error 200340. The card appears to work — the error only surfaces when a user interacts with it.
 :::
 
+## ACK Reaction
+
+When Hermes receives a message, it adds an 🆗 (OK) reaction to acknowledge receipt. By default, the reaction is removed after the agent finishes responding.
+
+You can control this behavior in `config.yaml`:
+
+```yaml
+feishu:
+  ack_reaction: "on_complete"  # default — remove OK reaction after agent finishes responding
+  # ack_reaction: "off"       # disable ACK reaction entirely
+```
+
+| Value | Behavior |
+|-------|----------|
+| `on_complete` | Add 🆗 on receipt, remove after agent finishes (default) |
+| `off` | No reaction added |
+
 ## Media Support
 
 ### Inbound (receiving)


### PR DESCRIPTION
## Summary

Changes the ACK ✅ reaction from permanent (fire-and-forget) to transient — it now persists only until the agent has fully responded, then is automatically removed.

### Problem

Previously, the ✅ reaction was added when a message was received and left in place forever. Since `handle_message()` spawns a background task and returns immediately, there was no way to remove it after the agent finished replying.

### Solution (+35/-4 lines, single file)

- Track pending reactions in `_ack_reactions` dict (`message_id → reaction_id`)
- Add `_remove_ack_reaction()` method to delete reactions via API
- Implement `on_processing_complete()` hook — fires after the agent has fully processed and responded, removes the ✅
- New `ack_reaction` config option in `gateway.platforms.feishu.extra`:

```yaml
ack_reaction: "on_complete"  # default — remove ✅ after agent finishes responding
ack_reaction: "off"          # disable ACK reaction entirely
```

### Notes

- When `ack_reaction` is `"off"`, no reaction is added at all (saves API calls)
- When `ack_reaction` is `"on_complete"` (default), behavior changes from permanent → transient
- The `on_processing_complete` hook is part of `BasePlatformAdapter` — no changes to base.py needed