### PR TITLE
fix(gateway): guard request_overrides None crash in message flow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6971,7 +6971,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides")
+            agent.request_overrides = dict(turn_route.get("request_overrides") or {})
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5519,7 +5519,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=self.request_overrides.get("speed") == "fast",
+                fast_mode=(getattr(self, "request_overrides", None) or {}).get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":
@@ -7623,6 +7623,7 @@ class AIAgent:
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
+            api_kwargs = None  # Guard if _build_api_kwargs fails before assignment
 
             while retry_count < max_retries:
                 try:
@@ -8744,9 +8745,10 @@ class AIAgent:
                             self.log_prefix, max_retries, _final_summary,
                             _provider, _model, len(api_messages), f"{approx_tokens:,}",
                         )
-                        self._dump_api_request_debug(
-                            api_kwargs, reason="max_retries_exhausted", error=api_error,
-                        )
+                        if api_kwargs is not None:
+                            self._dump_api_request_debug(
+                                api_kwargs, reason="max_retries_exhausted", error=api_error,
+                            )
                         self._persist_session(messages, conversation_history)
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
                         if _is_stream_drop:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -225,6 +225,30 @@ class TestDeveloperRoleSwap:
         assert kwargs["messages"][0]["role"] == "developer"
 
 
+class TestBuildApiKwargsAnthropicMessages:
+    def test_handles_none_request_overrides(self, monkeypatch):
+        captured = {}
+
+        def _fake_build_anthropic_kwargs(**kwargs):
+            captured.update(kwargs)
+            return kwargs
+
+        monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_kwargs", _fake_build_anthropic_kwargs)
+        agent = _make_agent(
+            monkeypatch,
+            "anthropic",
+            api_mode="anthropic_messages",
+            base_url="https://api.anthropic.com",
+        )
+        agent.model = "claude-opus-4-6"
+        agent.request_overrides = None
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["fast_mode"] is False
+        assert captured["fast_mode"] is False
+
+
 class TestBuildApiKwargsChatCompletionsServiceTier:
     """service_tier via request_overrides works on the chat_completions path."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway crash path where `turn_route.get("request_overrides")` can be `None`, but downstream agent code assumes a dict and calls `.get("speed")`. In messaging flows this breaks request construction before the provider call and can also trigger a secondary `api_kwargs` error while handling the failure.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- In `gateway/run.py`, normalize `turn_route.get("request_overrides")` to an empty dict before assigning it to the cached agent.
- In `run_agent.py`, guard the Anthropic `fast_mode` lookup with an empty-dict fallback.
- In `run_agent.py`, initialize `api_kwargs = None` before the retry loop and only dump API request debug data when it exists, preventing a secondary `UnboundLocalError` from masking the original failure.

## How to Test

1. Configure a gateway flow where `turn_route` omits `request_overrides` or returns `None`.
2. Send a Telegram or gateway message that reaches `GatewayRunner._run_agent()`.
3. Confirm the agent no longer crashes with `NoneType object has no attribute get` in `_build_api_kwargs` and does not emit the secondary `UnboundLocalError` for `api_kwargs`.
4. Manual validation performed on Ubuntu 24.04 against a live Telegram-backed Hermes gateway instance.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation update not needed
- [x] Config example update not needed
- [x] CONTRIBUTING or AGENTS update not needed
- [x] Cross-platform impact considered
- [x] Tool descriptions or schemas update not needed

## Screenshots / Logs

Observed failure before the fix in a live gateway session:

- `AttributeError: NoneType object has no attribute get` at `run_agent.py` while building API kwargs
- Followed by a secondary `UnboundLocalError` for `api_kwargs` during error handling
