### PR TITLE
fix: resolve Feishu gateway startup and config status regressions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,6 +77,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
 from utils import atomic_yaml_write, is_truthy_value
+from agent.redact import RedactingFormatter
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2787,11 +2787,32 @@ def show_config():
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
     
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
+    platforms = {
+        "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
+        "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
+        "WhatsApp": ("WHATSAPP_ENABLED", None),
+        "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
+        "Slack": ("SLACK_BOT_TOKEN", None),
+        "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
+        "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
+        "DingTalk": ("DINGTALK_CLIENT_ID", None),
+        "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
+        "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+        "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
+        "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
+        "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
+    }
+
+    for name, (token_var, home_var) in platforms.items():
+        token = get_env_value(token_var)
+        has_token = bool(token)
+
+        home_channel = get_env_value(home_var) if home_var else ""
+        status = "configured" if has_token else color("not configured", Colors.DIM)
+        if has_token and home_channel:
+            status += color(f" (home: {home_channel})", Colors.DIM)
+
+        print(f"  {name:15s} {status}")
     
     # Skill config
     try:

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -40,6 +40,21 @@ def test_show_config_marks_placeholders(tmp_path, capsys):
     assert "hermes config set <key> <value>" in out
 
 
+def test_show_config_lists_feishu_platform_status(tmp_path, capsys):
+    env = {
+        "HERMES_HOME": str(tmp_path),
+        "FEISHU_APP_ID": "cli_test_app",
+        "FEISHU_HOME_CHANNEL": "oc_test_home",
+    }
+    with patch.dict(os.environ, env):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "Feishu" in out
+    assert "configured" in out
+    assert "oc_test_home" in out
+
+
 def test_setup_summary_marks_placeholders(tmp_path, capsys):
     with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
         _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)


### PR DESCRIPTION
## Summary
- import `RedactingFormatter` in `gateway/run.py` so gateway startup does not crash
- expand `hermes config` messaging platform output to include Feishu and the same broader platform set shown in `hermes status`
- add a regression test for Feishu visibility in `show_config`

## Problem
This addresses two related issues reported upstream:
- Closes #8173
- Closes #8175

## Verification
- `python -m py_compile gateway/run.py hermes_cli/config.py hermes_cli/status.py`
- `python -m py_compile tests/hermes_cli/test_placeholder_usage.py`
- manual behavior check script confirmed:
  - `show_config()` displays Feishu as configured with home channel
  - `show_status()` still displays Feishu with home channel
  - `import gateway.run` succeeds

## Notes
- `package-lock.json` had unrelated local changes and was intentionally excluded from this PR.
