### PR TITLE
fix/windows gateway encoding v2

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1541,9 +1541,9 @@ class GatewayRunner:
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    logger.info("[OK] %s connected", platform.value)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("[X] %s failed to connect", platform.value)
                     if adapter.has_fatal_error:
                         self._update_platform_runtime_status(
                             platform.value,
@@ -1583,13 +1583,13 @@ class GatewayRunner:
                             "next_retry": time.monotonic() + 30,
                         }
             except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
                 self._update_platform_runtime_status(
                     platform.value,
                     platform_state="retrying",
                     error_code=None,
                     error_message=str(e),
                 )
+                logger.error("[X] %s error: %s", platform.value, e)
                 startup_retryable_errors.append(f"{platform.value}: {e}")
                 # Unexpected exceptions are typically transient — queue for retry
                 self._failed_platforms[platform] = {
@@ -1874,7 +1874,7 @@ class GatewayRunner:
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        logger.info("[OK] %s reconnected successfully", platform.value)
 
                         # Rebuild channel directory with the new adapter
                         try:
@@ -1983,12 +1983,12 @@ class GatewayRunner:
                 try:
                     await adapter.cancel_background_tasks()
                 except Exception as e:
-                    logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
+                    logger.debug("[X] %s background-task cancel error: %s", platform.value, e)
                 try:
                     await adapter.disconnect()
-                    logger.info("✓ %s disconnected", platform.value)
+                    logger.info("[--] %s disconnected", platform.value)
                 except Exception as e:
-                    logger.error("✗ %s disconnect error: %s", platform.value, e)
+                    logger.error("[X] %s disconnect error: %s", platform.value, e)
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:
@@ -2386,7 +2386,7 @@ class GatewayRunner:
                     tmp.replace(response_path)
                 except OSError as e:
                     logger.warning("Failed to write update response: %s", e)
-                    return f"✗ Failed to send response to update process: {e}"
+                    return f"[X] Failed to send response to update process: {e}"
                 _update_prompts.pop(_quick_key, None)
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
                 return f"✓ Sent `{label}` to the update process."
@@ -6362,21 +6362,21 @@ class GatewayRunner:
         # Block non-messaging platforms (API server, webhooks, ACP)
         platform = event.source.platform
         if platform not in self._UPDATE_ALLOWED_PLATFORMS:
-            return "✗ /update is only available from messaging platforms. Run `hermes update` from the terminal."
+            return "[X] /update is only available from messaging platforms. Run `hermes update` from the terminal."
 
         if is_managed():
-            return f"✗ {format_managed_message('update Hermes Agent')}"
+            return f"[X] {format_managed_message('update Hermes Agent')}"
 
         project_root = Path(__file__).parent.parent.resolve()
         git_dir = project_root / '.git'
 
         if not git_dir.exists():
-            return "✗ Not a git repository — cannot update."
+            return "[X] Not a git repository — cannot update."
 
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:
             return (
-                "✗ Could not locate the `hermes` command. "
+                " [X] Could not locate the `hermes` command. "
                 "Hermes is running, but the update command could not find the "
                 "executable on PATH or via the current Python interpreter. "
                 "Try running `hermes update` manually in your terminal."
@@ -6433,7 +6433,7 @@ class GatewayRunner:
         except Exception as e:
             pending_path.unlink(missing_ok=True)
             exit_code_path.unlink(missing_ok=True)
-            return f"✗ Failed to start update: {e}"
+            return f"[X] Failed to start update: {e}"
 
         self._schedule_update_notification_watch()
         return "⚕ Starting Hermes update… I'll stream progress here."
@@ -8473,6 +8473,20 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    # ── Fix Windows cp950 logging encoding ─────────────────────────────
+    # Remove all existing handlers and replace with UTF-8 one.
+    # Must happen BEFORE any logging call to prevent default handler creation.
+    root_logger = logging.getLogger()
+    for h in root_logger.handlers[:]:
+        root_logger.removeHandler(h)
+    new_handler = logging.StreamHandler()
+    try:
+        new_handler.stream.reconfigure(encoding="utf-8")
+    except AttributeError:
+        pass
+    new_handler.setFormatter(logging.Formatter('%(levelname)s %(name)s: %(message)s'))
+    root_logger.addHandler(new_handler)
+
     # ── Duplicate-instance guard ──────────────────────────────────────
     # Prevent two gateways from running under the same HERMES_HOME.
     # The PID file is scoped to HERMES_HOME, so future multi-profile
@@ -8564,6 +8578,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
         _stderr_handler = logging.StreamHandler()
+        try:
+            _stderr_handler.stream.reconfigure(encoding="utf-8")
+        except AttributeError:
+            pass
         _stderr_handler.setLevel(_stderr_level)
         _stderr_handler.setFormatter(RedactingFormatter('%(levelname)s %(name)s: %(message)s'))
         logging.getLogger().addHandler(_stderr_handler)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -304,7 +304,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -407,7 +407,7 @@ def get_running_pid() -> Optional[int]:
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
         remove_pid_file()
         return None
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,9 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
+import sys
+if sys.platform != "win32":
+    import fcntl
 import json
 import logging
 import os
@@ -146,10 +148,23 @@ class MemoryStore:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            import msvcrt
+            # Windows: use msvcrt locking (LK_LOCK = 1, LK_UNLCK = 0)
+            # Retry locking for up to 10 seconds
+            for _ in range(100):
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except IOError:
+                    import time
+                    time.sleep(0.1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            try:
+                import msvcrt
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except (ImportError, OSError):
+                pass
             fd.close()
 
     @staticmethod


### PR DESCRIPTION
- **test(tools): add unit tests for tool_backend_helpers module**
- **test(tools): add unit tests for budget_config module**
- **docs: fix ASCII diagram width mismatch in architecture.md**
- **fix: enable Matrix Reactions in platform comparison table**
- **fix: add gpt-5.4 and gpt-5.4-mini to openai-codex curated model list (#7670)**
- **fix: honor session-scoped gateway model overrides**
- **feat: background process monitoring — watch_patterns for real-time output alerts**
- **fix(qwen): correct context lengths for qwen3-coder models and send max_tokens to portal**
- **fix(streaming): adaptive backoff + cursor strip to prevent message truncation (#7683)**
- **fix: unify openai-codex model list — derive from codex_models.py (#7844)**
- **fix(matrix): pass required args to MemoryCryptoStore for mautrix ≥0.21 (#7848)**
- **fix: resolve three high-impact community bugs (#5819, #6893, #3388) (#7881)**
- **fix(vision): auto-resize oversized images, increase default timeout, fix vision capability detection**
- **docs: add warning about summary model context length requirement (#7879)**
- **feat(xiaomi): add Xiaomi MiMo as first-class provider**
- **docs: add Xiaomi MiMo to all provider docs + fix MiMo-V2-Flash ctx len**
- **refactor(auxiliary): config.yaml takes priority over env vars for aux task settings (#7889)**
- **fix(migration): update OpenClaw migration for schema drift**
- **feat(migration): preview-then-confirm UX + docs updates**
- **fix(vision): preserve aspect ratio during auto-resize**
- **fix(weixin): keep multi-line messages in single bubble by default (#7903)**
- **feat: warn at session start when compression model context is too small (#7894)**
- **fix(gateway): propagate user identity through process watcher pipeline**
- **fix(api-server): keep chat-completions SSE alive**
- **fix: detect truncated tool_calls when finish_reason is not length**
- **fix(agent): prevent false thinking-exhaustion for non-reasoning models**
- **fix(gateway): break stuck session resume loops on restart (#7536)**
- **fix: update thinking-exhaustion test for think-tag gating**
- **fix(gateway/weixin): ensure atomic persistence for critical session state**
- **fix(wecom): handle appmsg attachments (PDF/Word/Excel) from WeCom AI Bot**
- **refactor: extract shared helpers to deduplicate repeated code patterns (#7917)**
- **fix(weixin): add per-chunk retry with backoff for text delivery**
- **fix: reap orphaned browser sessions on startup (#7931)**
- **fix: scope tool interrupt signal per-thread to prevent cross-session leaks (#7930)**
- **fix(whatsapp): pin Baileys to fix/abprops-abt-fetch for bad-request fix**
- **add basic twilio signature checking and tests**
- **handle port variants in Twilio signatures**
- **change Twilio signature verification from opt-in to opt-out**
- **update docks with changes made**
- **remove unused import and fix misleading log**
- **add new test covering edge case where both insecure_no_sig and _webhook_url are set**
- **fix: mock aiohttp server in startup guard tests to avoid port binding**
- **fix(custom-providers): propagate model field from config to runtime so API receives the correct model name**
- **fix: propagate model through credential pool path + add tests**
- **fix(tools): prevent command argument injection and path traversal in checkpoint manager**
- **fix(tools): neutralize shell injection in _write_to_sandbox via path quoting (#7940)**
- **fix(gateway): use source.thread_id instead of undefined event in queued response**
- **fix: deduplicate reasoning items in Responses API input**
- **test: add dedup coverage for reasoning item ID deduplication**
- **fix(gateway): preserve queued voice events for STT**
- **fix: scope gateway status to the active profile**
- **fix: add all_profiles param + narrow exception handling**
- **feat(gateway): add all missing platforms to interactive setup wizard (#7949)**
- **fix: is_local_endpoint misses Docker/Podman DNS names (#7950)**
- **fix(cron): pass skip_context_files=True to AIAgent in run_job (#7958)**
- **fix(claw): warn if gateway is running before migrating bot tokens**
- **fix: normalize checkpoint manager home-relative paths**
- **feat(gateway): add WeCom callback-mode adapter for self-built apps**
- **fix: reset compression_attempts and primary_recovery_attempted on fallback activation**
- **fix: remove dead hasattr checks for retry counters initialized in reset block**
- **feat: add --env and --preset support to hermes mcp add**
- **fix(gateway): add HERMES_SESSION_KEY to session_context contextvars**
- **fix(cli): add ChatConsole.status for /skills search**
- **docs: add platform adapter developer guide + WeCom Callback docs (#7969)**
- **fix: always log outer loop exception traceback at DEBUG level**
- **fix: prevent agent from stopping mid-task — compression floor, budget overhaul, activity tracking**
- **docs: expand tool-use enforcement documentation (#7984)**
- **feat(gateway): surface natural mid-turn assistant messages in chat platforms**
- **fix(tools): enforce ID uniqueness in TODO store during replace operations**
- **fix: use ceiling division for token estimation, deduplicate inline formula**
- **feat(nix): container-aware CLI — auto-route into managed container (#7543)**
- **feat: standardize message whitespace and JSON formatting**
- **refactor: remove budget warning injection system (dead code)**
- **feat(cli): add native /model picker modal for provider → model selection**
- **refactor(terminal): remove check_interval parameter (#8001)**
- **feat: per-platform display verbosity configuration (#8006)**
- **feat: component-separated logging with session context and filtering (#7991)**
- **perf(ssh,modal): bulk file sync via tar pipe and tar/base64 archive (#8014)**
- **fix(matrix): replace pickle crypto store with SQLite, fix E2EE decryption (#7981)**
- **feat: add hermes backup and hermes import commands (#7997)**
- **fix(discord): decouple readiness from slash sync**
- **feat: /compress <focus> — guided compression with focus topic (#8017)**
- **fix(gateway): add missing RedactingFormatter import**
- **fix: improve context compaction to prevent model answering stale questions (#8107)**
- **fix(gateway): Windows compatibility fixes**
