### PR TITLE
fix: resolve openai-codex context-length mapping to models.dev

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -143,6 +143,9 @@ class ProviderInfo:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
+    "openai": "openai",
+    # Hermes "openai-codex" provider uses OpenAI's model catalog.
+    "openai-codex": "openai",
     "anthropic": "anthropic",
     "zai": "zai",
     "kimi-coding": "kimi-for-coding",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -208,6 +208,17 @@ class TestGetModelContextLength:
         assert get_model_context_length("test/model") == 32000
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.models_dev.lookup_models_dev_context")
+    def test_openai_codex_provider_uses_models_dev_context(self, mock_lookup, mock_fetch):
+        mock_fetch.return_value = {}
+        mock_lookup.return_value = 400000
+
+        result = get_model_context_length("gpt-5.4-mini", provider="openai-codex")
+
+        assert result == 400000
+        mock_lookup.assert_called_once_with("openai-codex", "gpt-5.4-mini")
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_fallback_to_defaults(self, mock_fetch):
         mock_fetch.return_value = {}
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -80,13 +80,14 @@ class TestProviderMapping:
 
     def test_known_providers_mapped(self):
         assert PROVIDER_TO_MODELS_DEV["anthropic"] == "anthropic"
+        assert PROVIDER_TO_MODELS_DEV["openai"] == "openai"
+        assert PROVIDER_TO_MODELS_DEV["openai-codex"] == "openai"
         assert PROVIDER_TO_MODELS_DEV["copilot"] == "github-copilot"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"
 
     def test_unmapped_provider_not_in_dict(self):
         assert "nous" not in PROVIDER_TO_MODELS_DEV
-        assert "openai-codex" not in PROVIDER_TO_MODELS_DEV
 
 
 class TestExtractContext:


### PR DESCRIPTION
## What changed
- map `openai-codex` to models.dev `openai` provider in `PROVIDER_TO_MODELS_DEV`
- add explicit `openai -> openai` mapping
- add regression tests for provider mapping and context-length resolution path

## Why
When Hermes runs with `provider: openai-codex`, provider-aware models.dev lookup could miss and fall back to `128000` context for models like `gpt-5.4-mini`. That causes premature compaction thresholds (e.g., `64k` at 50%).

Closes #8161

## How to test
- Focused regression tests:
  - `source venv/bin/activate && pytest tests/agent/test_models_dev.py tests/agent/test_model_metadata.py -q`
  - Result on my branch: `97 passed`
- Manual path check:
  - `python - <<'PY'\nfrom agent.model_metadata import get_model_context_length\nprint(get_model_context_length('gpt-5.4-mini', provider='openai-codex'))\nPY`
  - Result on my branch: `400000`

## Platforms tested
- Linux (local dev environment)
