### PR TITLE
fix: honor configured context length in compression feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1696,6 +1696,74 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
 
+    @staticmethod
+    def _parse_positive_int(value: object) -> Optional[int]:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    def _resolve_auxiliary_context_override(
+        self,
+        *,
+        aux_model: str,
+        aux_base_url: str,
+    ) -> Optional[int]:
+        """Return a config-driven context override for an auxiliary model.
+
+        The main model's global ``model.context_length`` override should only be
+        reused when the auxiliary compression client resolves to the exact same
+        runtime model+endpoint. For different auxiliary models, only honor an
+        exact ``custom_providers[].models[model].context_length`` match.
+        """
+        aux_model_norm = str(aux_model or "").strip()
+        aux_base_url_norm = str(aux_base_url or "").strip().rstrip("/")
+        main_model_norm = str(getattr(self, "model", "") or "").strip()
+        main_base_url_norm = str(getattr(self, "base_url", "") or "").strip().rstrip("/")
+
+        main_override = self._parse_positive_int(
+            getattr(self, "_config_context_length", None)
+        )
+        if (
+            main_override is not None
+            and aux_model_norm
+            and aux_model_norm == main_model_norm
+            and aux_base_url_norm
+            and aux_base_url_norm == main_base_url_norm
+        ):
+            return main_override
+
+        try:
+            from hermes_cli.config import load_config as _load_agent_config
+
+            _cfg = _load_agent_config()
+        except Exception:
+            return None
+
+        if not isinstance(_cfg, dict) or not aux_model_norm or not aux_base_url_norm:
+            return None
+
+        custom_providers = _cfg.get("custom_providers")
+        if not isinstance(custom_providers, list):
+            return None
+
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
+            if not entry_url or entry_url != aux_base_url_norm:
+                continue
+            models = entry.get("models")
+            if not isinstance(models, dict):
+                return None
+            model_cfg = models.get(aux_model_norm)
+            if not isinstance(model_cfg, dict):
+                return None
+            return self._parse_positive_int(model_cfg.get("context_length"))
+
+        return None
+
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
         window is smaller than the main model's compression threshold.
@@ -1733,10 +1801,15 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            aux_context_override = self._resolve_auxiliary_context_override(
+                aux_model=aux_model,
+                aux_base_url=aux_base_url,
+            )
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
+                config_context_length=aux_context_override,
             )
 
             threshold = self.context_compressor.threshold_tokens

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -19,6 +19,7 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    config_context_length: int | None = None,
 ) -> AIAgent:
     """Build a minimal AIAgent with a compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
@@ -29,6 +30,7 @@ def _make_agent(
     agent.quiet_mode = True
     agent.log_prefix = ""
     agent.compression_enabled = compression_enabled
+    agent._config_context_length = config_context_length
     agent._print_fn = None
     agent.suppress_status_output = False
     agent._stream_consumers = []
@@ -179,6 +181,33 @@ def test_just_below_threshold_warns(mock_get_client, mock_ctx_len):
 
     assert len(messages) == 1
     assert "small-model" in messages[0]
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=272_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_uses_main_context_override_when_runtime_matches(mock_get_client, mock_ctx_len):
+    """Matching main-model auxiliary clients should reuse model.context_length."""
+    agent = _make_agent(
+        main_context=272_000,
+        threshold_percent=0.50,
+        config_context_length=272_000,
+    )
+    agent.provider = "custom"
+    agent.base_url = "https://right.codes/codex/v1"
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://right.codes/codex/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "test-main-model")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once()
+    assert mock_ctx_len.call_args.kwargs.get("config_context_length") == 272_000
+    assert messages == []
 
 
 # ── Two-phase: __init__ + run_conversation replay ───────────────────


### PR DESCRIPTION
## Summary
- reuse `model.context_length` when the compression auxiliary client resolves to the same runtime model and endpoint
- avoid the false 128K warning for the 272K custom-endpoint setup
- add a regression test covering the 272K custom-endpoint case

## Test Plan
- `source venv/bin/activate && python -m pytest -o addopts='' tests/run_agent/test_compression_feasibility.py tests/run_agent/test_switch_model_context.py -q`