### PR TITLE
feat(status-bar): per-prompt elapsed stopwatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1876,47 +1876,16 @@ class HermesCLI:
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
-    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
+    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float) -> Optional[str]:
         """Format per-prompt elapsed time for the status bar.
 
-        Always returns a string (never None) — shows 0s on fresh start.
-        Keeps seconds visible at all scales so the user can see it ticking.
-        Prepends a visual indicator: ⏱️ (live/running) or 🕐 (frozen/done).
-
-        Examples:
-            🕐 0s         — fresh session, no turn yet
-            ⏱️ 44s        — 44 seconds into a live turn
-            🕐 3m 12s     — turn completed in 3 min 12 sec
-            ⏱️ 1h 23m 45s — live, 1 hour 23 minutes 45 seconds
-            🕐 2d 5h 13m  — frozen duration from a marathon session
+        Returns None when no turn is in progress and no duration is frozen
+        (i.e., before the first prompt of the session).
         """
         if prompt_start_time is None and prompt_duration == 0.0:
-            return "🕐 0s"
-
+            return None
         elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
-        elapsed = max(0.0, elapsed)
-
-        days = int(elapsed // 86400)
-        remaining = elapsed % 86400
-        hours = int(remaining // 3600)
-        remaining = remaining % 3600
-        minutes = int(remaining // 60)
-        seconds = int(remaining % 60)
-
-        if days > 0:
-            if hours or minutes:
-                time_str = f"{days}d {hours}h {minutes}m" if minutes else f"{days}d {hours}h"
-            else:
-                time_str = f"{days}d"
-        elif hours > 0:
-            time_str = f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m" if minutes else f"{hours}h"
-        elif minutes > 0:
-            time_str = f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
-        else:
-            time_str = f"{int(elapsed)}s"
-
-        emoji = "⏱️" if live else "🕐"
-        return f"{emoji} {time_str}"
+        return format_duration_compact(max(0.0, elapsed))
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
@@ -1939,7 +1908,6 @@ class HermesCLI:
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
                 getattr(self, "_prompt_duration", 0.0),
-                live=getattr(self, "_prompt_start_time", None) is not None,
             ),
             "context_tokens": 0,
             "context_length": None,
@@ -9303,7 +9271,6 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
-            refresh_interval=1,  # 1s tick so the per-prompt elapsed timer updates live
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback

--- a/cli.py
+++ b/cli.py
@@ -1908,7 +1908,7 @@ class HermesCLI:
         else:
             time_str = f"{int(elapsed)}s"
 
-        emoji = "⏱️" if live else "🕐"
+        emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:

--- a/cli.py
+++ b/cli.py
@@ -1775,6 +1775,10 @@ class HermesCLI:
         self.conversation_history: List[Dict[str, Any]] = []
         self.session_start = datetime.now()
         self._resumed = False
+        # Per-prompt elapsed timer — started at the beginning of each chat turn,
+        # frozen when the agent thread completes, displayed in the status bar.
+        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_duration: float = 0.0  # frozen duration of last completed turn
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
         try:
@@ -1871,6 +1875,49 @@ class HermesCLI:
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
+    @staticmethod
+    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
+        """Format per-prompt elapsed time for the status bar.
+
+        Always returns a string (never None) — shows 0s on fresh start.
+        Keeps seconds visible at all scales so the user can see it ticking.
+        Prepends a visual indicator: ⏱️ (live/running) or 🕐 (frozen/done).
+
+        Examples:
+            🕐 0s         — fresh session, no turn yet
+            ⏱️ 44s        — 44 seconds into a live turn
+            🕐 3m 12s     — turn completed in 3 min 12 sec
+            ⏱️ 1h 23m 45s — live, 1 hour 23 minutes 45 seconds
+            🕐 2d 5h 13m  — frozen duration from a marathon session
+        """
+        if prompt_start_time is None and prompt_duration == 0.0:
+            return "🕐 0s"
+
+        elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
+        elapsed = max(0.0, elapsed)
+
+        days = int(elapsed // 86400)
+        remaining = elapsed % 86400
+        hours = int(remaining // 3600)
+        remaining = remaining % 3600
+        minutes = int(remaining // 60)
+        seconds = int(remaining % 60)
+
+        if days > 0:
+            if hours or minutes:
+                time_str = f"{days}d {hours}h {minutes}m" if minutes else f"{days}d {hours}h"
+            else:
+                time_str = f"{days}d"
+        elif hours > 0:
+            time_str = f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m" if minutes else f"{hours}h"
+        elif minutes > 0:
+            time_str = f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
+        else:
+            time_str = f"{int(elapsed)}s"
+
+        emoji = "⏱️" if live else "🕐"
+        return f"{emoji} {time_str}"
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -1889,6 +1936,11 @@ class HermesCLI:
             "model_name": model_name,
             "model_short": model_short,
             "duration": format_duration_compact(elapsed_seconds),
+            "prompt_elapsed": self._format_prompt_elapsed(
+                getattr(self, "_prompt_start_time", None),
+                getattr(self, "_prompt_duration", 0.0),
+                live=getattr(self, "_prompt_start_time", None) is not None,
+            ),
             "context_tokens": 0,
             "context_length": None,
             "context_percent": None,
@@ -2055,6 +2107,9 @@ class HermesCLI:
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
+            prompt_elapsed = snapshot.get("prompt_elapsed")
+            if prompt_elapsed:
+                parts.append(prompt_elapsed)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -2113,8 +2168,13 @@ class HermesCLI:
                         (bar_style, percent_label),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ]
+                    # Position 7: per-prompt elapsed timer (live or frozen)
+                    prompt_elapsed = snapshot.get("prompt_elapsed")
+                    if prompt_elapsed:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", prompt_elapsed))
+                    frags.append(("class:status-bar", " "))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
@@ -7545,6 +7605,11 @@ class HermesCLI:
                         "error": _summary,
                     }
 
+            # Start per-prompt elapsed timer — freezes when agent_thread.join()
+            # completes; reset on the next turn.
+            self._prompt_start_time = time.time()
+            self._prompt_duration = 0.0
+
             # Start agent in background thread
             agent_thread = threading.Thread(target=run_agent)
             agent_thread.start()
@@ -7596,6 +7661,11 @@ class HermesCLI:
                     agent_thread.join(0.1)
 
             agent_thread.join()  # Ensure agent thread completes
+
+            # Freeze per-prompt elapsed timer
+            if self._prompt_start_time is not None:
+                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_start_time = None
 
             # Proactively clean up async clients whose event loop is dead.
             # The agent thread may have created AsyncOpenAI clients bound

--- a/cli.py
+++ b/cli.py
@@ -1876,7 +1876,7 @@ class HermesCLI:
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
-    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float) -> str:
+    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
         """Format per-prompt elapsed time for the status bar.
 
         Always returns a string — shows 0s on fresh start before first turn.
@@ -1884,9 +1884,11 @@ class HermesCLI:
             59s → 1m → 1m 1s → ... → 1m 59s → 2m → 2m 1s → ...
             59m 59s → 1h → 1h 0m 1s → ...
             23h 59m 59s → 1d → 1d 0h 1m → ...
+
+        Emoji prefix: ⏱️ when turn is live, 🕐 when frozen or fresh start.
         """
         if prompt_start_time is None and prompt_duration == 0.0:
-            return "0s"
+            return "🕐 0s"
         elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
         elapsed = max(0.0, elapsed)
 
@@ -1898,12 +1900,16 @@ class HermesCLI:
         seconds = int(remaining % 60)
 
         if days > 0:
-            return f"{days}d {hours}h {minutes}m"
-        if hours > 0:
-            return f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m"
-        if minutes > 0:
-            return f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
-        return f"{int(elapsed)}s"
+            time_str = f"{days}d {hours}h {minutes}m"
+        elif hours > 0:
+            time_str = f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m"
+        elif minutes > 0:
+            time_str = f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
+        else:
+            time_str = f"{int(elapsed)}s"
+
+        emoji = "⏱️" if live else "🕐"
+        return f"{emoji} {time_str}"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
@@ -1926,6 +1932,7 @@ class HermesCLI:
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
                 getattr(self, "_prompt_duration", 0.0),
+                live=getattr(self, "_prompt_start_time", None) is not None,
             ),
             "context_tokens": 0,
             "context_length": None,

--- a/cli.py
+++ b/cli.py
@@ -9303,6 +9303,7 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
+            refresh_interval=1,  # 1s tick so the per-prompt elapsed timer updates live
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback

--- a/cli.py
+++ b/cli.py
@@ -1876,14 +1876,13 @@ class HermesCLI:
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
-    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float) -> Optional[str]:
+    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float) -> str:
         """Format per-prompt elapsed time for the status bar.
 
-        Returns None when no turn is in progress and no duration is frozen
-        (i.e., before the first prompt of the session).
+        Always returns a string — shows 0s on fresh start before first turn.
         """
         if prompt_start_time is None and prompt_duration == 0.0:
-            return None
+            return "0s"
         elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
         return format_duration_compact(max(0.0, elapsed))
 

--- a/cli.py
+++ b/cli.py
@@ -1880,11 +1880,30 @@ class HermesCLI:
         """Format per-prompt elapsed time for the status bar.
 
         Always returns a string — shows 0s on fresh start before first turn.
+        Keeps seconds visible at all scales so it increments smoothly:
+            59s → 1m → 1m 1s → ... → 1m 59s → 2m → 2m 1s → ...
+            59m 59s → 1h → 1h 0m 1s → ...
+            23h 59m 59s → 1d → 1d 0h 1m → ...
         """
         if prompt_start_time is None and prompt_duration == 0.0:
             return "0s"
         elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
-        return format_duration_compact(max(0.0, elapsed))
+        elapsed = max(0.0, elapsed)
+
+        days = int(elapsed // 86400)
+        remaining = elapsed % 86400
+        hours = int(remaining // 3600)
+        remaining = remaining % 3600
+        minutes = int(remaining // 60)
+        seconds = int(remaining % 60)
+
+        if days > 0:
+            return f"{days}d {hours}h {minutes}m"
+        if hours > 0:
+            return f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m"
+        if minutes > 0:
+            return f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
+        return f"{int(elapsed)}s"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.


### PR DESCRIPTION
## Summary

Adds a per-prompt elapsed stopwatch to the TUI status bar, giving users real-time visibility into how long the current prompt has been running — displayed as position 7 after the session duration timer.

## Motivation

The current status bar shows **session elapsed time** (e.g. `10m`) — useful for overall session awareness, but it tells you nothing about how long an individual prompt/response cycle is taking.

Hermes already has a **spinner that shows elapsed time while the agent is working**, but it has a fundamental UX limitation: **it is only visible while the agent is actively processing tool calls or streaming tokens.** The moment the agent finishes (or when there is a gap between tool calls), the spinner disappears and the elapsed time is gone. Users who want to glance at the bottom of their terminal to see "how long has this prompt been going?" cannot do so reliably.

This per-prompt stopwatch solves that by being **always visible in the status bar**, independent of the spinner. It starts ticking when a prompt is submitted, updates live throughout the entire agent run, and persists as a frozen value after completion — so users always know how long the last turn took, even after the spinner is long gone.

## What this adds

- A **per-prompt elapsed timer** displayed in the status bar
- Starts when `chat()` begins (before the agent thread runs)
- Updates live while the agent processes (visible even between tool calls)
- Freezes when the turn completes (persists until the next prompt)
- Reset on the next prompt

## Example in the wild

```
⚕ MiniMax-M2.7 │ 125K/204.8K │ [██████░░░░] 61% │ 10m │ ⏱ 44s
                                                                    ↑ prompt
                                                               ↑ session
```

## Visual indicators

| State | Display |
|-------|---------|
| Fresh session (before first prompt) | `⏲ 0s` |
| Turn in progress | `⏱ 10s`, `⏱ 1m 1s`, `⏱ 1h 24m 5s` |
| Turn completed (frozen) | `⏲ 3m 12s`, `⏲ 2d 7h 33m` |

## Timer format

Seconds are always visible so the counter increments smoothly across all scales:

```
59s → 1m → 1m 1s → 1m 2s → ... → 1m 59s → 2m → 2m 1s → ...
59m 59s → 1h 0m → 1h 0m 1s → ...
```

Trailing zeros are hidden at exact boundaries (`1m` not `1m 0s`).

## Technical changes

| Change | File | Details |
|--------|------|---------|
| Instance vars | `cli.py` | `_prompt_start_time`, `_prompt_duration` |
| Timer start | `cli.py` | Set before `agent_thread.start()` in `chat()` |
| Timer freeze | `cli.py` | Set after `agent_thread.join()` in `chat()` |
| Formatter | `cli.py` | `_format_prompt_elapsed()` — compact with emoji |
| Status bar snapshot | `cli.py` | `prompt_elapsed` field added |
| Status bar fragments | `cli.py` | Position 7 after session duration |

## Why the status bar and not just the spinner?

The KawaiiSpinner shows elapsed time, but only while it is actively animating — which requires the agent to be mid-operation. In practice, the spinner is invisible:

- Before the agent starts (during initialization)
- Between tool calls (gaps in the API conversation)
- After the agent finishes (response is displayed)
- When the terminal is scrolled and the spinner is off-screen

The status bar is **always pinned at the bottom of the viewport** and always visible. A user glancing at their terminal can instantly see `⏱ 2m 30s` and know the current prompt has been running for 2.5 minutes — without needing to wait for the spinner to appear or scroll back to find it.

## Backward compatibility

Fully additive. The session duration timer (`10m`) is unchanged. The prompt timer only appears when active or just-completed — it does not add noise to idle sessions.