### PR TITLE
fix(migration): don't auto-archive OpenClaw source directory

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -87,8 +87,8 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
         print_info("Migration cancelled. Stop the gateway and try again.")
         sys.exit(0)
 
-# State files commonly found in OpenClaw workspace directories that cause
-# confusion after migration (the agent discovers them and writes to them)
+# State files commonly found in OpenClaw workspace directories — listed
+# during cleanup to help the user decide whether to archive
 _WORKSPACE_STATE_GLOBS = (
     "*/todo.json",
     "*/sessions/*",
@@ -133,7 +133,7 @@ def _find_openclaw_dirs() -> list[Path]:
 
 
 def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
-    """Scan an OpenClaw directory for workspace state files that cause confusion.
+    """Scan an OpenClaw directory for workspace state files.
 
     Returns a list of (path, description) tuples.
     """
@@ -384,65 +384,16 @@ def _cmd_migrate(args):
     # Print results
     _print_migration_report(report, dry_run=False)
 
-    # After successful migration, offer to archive the source directory
-    if report.get("summary", {}).get("migrated", 0) > 0:
-        _offer_source_archival(source_dir, auto_yes)
-
-
-def _offer_source_archival(source_dir: Path, auto_yes: bool = False):
-    """After migration, offer to rename the source directory to prevent state fragmentation.
-
-    OpenClaw workspace directories contain state files (todo.json, sessions, etc.)
-    that the agent may discover and write to, causing confusion. Renaming the
-    directory prevents this.
-    """
-    if not source_dir.is_dir():
-        return
-
-    # Scan for state files that could cause problems
-    state_files = _scan_workspace_state(source_dir)
-
-    print()
-    print_header("Post-Migration Cleanup")
-    print_info("The OpenClaw directory still exists and contains workspace state files")
-    print_info("that can confuse the agent (todo lists, sessions, logs).")
-    if state_files:
-        print()
-        print(color("  Found state files:", Colors.YELLOW))
-        # Show up to 10 most relevant findings
-        for path, desc in state_files[:10]:
-            print(f"      {desc}")
-        if len(state_files) > 10:
-            print(f"      ... and {len(state_files) - 10} more")
-    print()
-    print_info(f"Recommend: rename {source_dir.name}/ to {source_dir.name}.pre-migration/")
-    print_info("This prevents the agent from discovering old workspace directories.")
-    print_info("You can always rename it back if needed.")
-    print()
-
-    if not auto_yes and not sys.stdin.isatty():
-        print_info("Non-interactive session — skipping archival.")
-        print_info("Run later with: hermes claw cleanup")
-        return
-
-    if auto_yes or prompt_yes_no(f"Archive {source_dir} now?", default=True):
-        try:
-            archive_path = _archive_directory(source_dir)
-            print_success(f"Archived: {source_dir} → {archive_path}")
-            print_info("The original directory has been renamed, not deleted.")
-            print_info(f"To undo: mv {archive_path} {source_dir}")
-        except OSError as e:
-            print_error(f"Could not archive: {e}")
-            print_info(f"You can do it manually: mv {source_dir} {source_dir}.pre-migration")
-    else:
-        print_info("Skipped. You can archive later with: hermes claw cleanup")
+    # Source directory is left untouched — archiving is not the migration
+    # tool's responsibility.  Users who want to clean up can run
+    # 'hermes claw cleanup' separately.
 
 
 def _cmd_cleanup(args):
     """Archive leftover OpenClaw directories after migration.
 
     Scans for OpenClaw directories that still exist after migration and offers
-    to rename them to .pre-migration to prevent state fragmentation.
+    to rename them to .pre-migration to free disk space.
     """
     dry_run = getattr(args, "dry_run", False)
     auto_yes = getattr(args, "yes", False)
@@ -517,7 +468,7 @@ def _cmd_cleanup(args):
 
         if state_files:
             print()
-            print(color(f"  {len(state_files)} state file(s) that could cause confusion:", Colors.YELLOW))
+            print(color(f"  {len(state_files)} state file(s) found:", Colors.YELLOW))
             for path, desc in state_files[:8]:
                 print(f"      {desc}")
             if len(state_files) > 8:

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -997,7 +997,14 @@ class Migrator:
             .get("workspace")
         )
         if isinstance(workspace, str) and workspace.strip():
-            additions["MESSAGING_CWD"] = workspace.strip()
+            ws_path = workspace.strip()
+            # Skip if the workspace points inside the OpenClaw source directory —
+            # that path will be stale after migration and would cause the Hermes
+            # gateway to use the old OpenClaw workspace as its cwd, picking up
+            # OpenClaw's AGENTS.md, MEMORY.md, etc.
+            source_str = str(self.source_root)
+            if not ws_path.startswith(source_str):
+                additions["MESSAGING_CWD"] = ws_path
 
         allowlist_path = self.source_root / "credentials" / "telegram-default-allowFrom.json"
         if allowlist_path.exists():


### PR DESCRIPTION
## Summary

`hermes claw migrate` was automatically renaming `~/.openclaw/` to `~/.openclaw.pre-migration/` after migration, breaking users who want to run both agents side by side. The stated reason was "agent confusion", but investigation shows the actual root cause was `MESSAGING_CWD` being copied verbatim from OpenClaw config.

### Changes

- **Remove source directory archival from `hermes claw migrate`** — this is not the migration tool's job. Users who want to clean up can use `hermes claw cleanup` separately.
- **Skip `MESSAGING_CWD` when it points inside the OpenClaw source directory** — this was the actual root cause. The old workspace path (e.g. `~/.openclaw/workspace`) caused the Hermes gateway to use OpenClaw's workspace as cwd, picking up its `AGENTS.md`, `MEMORY.md`, etc. Now it falls back to `$HOME`.

### Root cause analysis

Hermes agent does not scan `~/.openclaw/` at runtime. All file loading is explicitly scoped to `~/.hermes/` or the current working directory. The "confusion" only happened because the migration copied `MESSAGING_CWD=~/.openclaw/workspace` into Hermes `.env`, making the gateway operate inside OpenClaw's workspace.

## Test plan

- [ ] `hermes claw migrate --yes` completes without touching `~/.openclaw/`
- [ ] `hermes claw cleanup` still works independently for users who want to archive
- [ ] Migration with OpenClaw workspace at `~/.openclaw/workspace` does NOT set `MESSAGING_CWD`
- [ ] Migration with external workspace path (e.g. `/home/user/projects`) still sets `MESSAGING_CWD`

Closes #8188

🤖 Generated with [Claude Code](https://claude.com/claude-code)