### PR TITLE
fix(feishu): route Lark SDK logs to Hermes logging and improve error handling

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -987,8 +987,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("[Feishu] WS client start() exited with error: %s", exc, exc_info=True)
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
@@ -1202,6 +1202,16 @@ class FeishuAdapter(BasePlatformAdapter):
         if not FEISHU_AVAILABLE:
             logger.error("[Feishu] lark-oapi not installed")
             return False
+
+        # Route the Lark SDK's internal logger ("Lark") through the Hermes
+        # logging system so its messages appear in agent.log alongside
+        # gateway logs.  Without this, SDK-level errors/debug only go to
+        # stdout and are invisible to ``hermes logs -f``.
+        _lark_logger = logging.getLogger("Lark")
+        _lark_logger.propagate = True
+        for _h in list(_lark_logger.handlers):
+            _lark_logger.removeHandler(_h)
+
         if not self._app_id or not self._app_secret:
             logger.error("[Feishu] FEISHU_APP_ID or FEISHU_APP_SECRET not set")
             return False
@@ -3075,7 +3085,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             request = self._build_get_application_request(app_id=self._app_id, lang="en_us")
-            response = await asyncio.to_thread(self._client.application.v6.application.get, request)
+            response = await asyncio.wait_for(
+                asyncio.to_thread(self._client.application.v6.application.get, request),
+                timeout=15,
+            )
             if not response or not response.success():
                 code = getattr(response, "code", None)
                 if code == 99991672:
@@ -3089,6 +3102,8 @@ class FeishuAdapter(BasePlatformAdapter):
             app_name = (getattr(app, "app_name", None) or "").strip()
             if app_name:
                 self._bot_name = app_name
+        except asyncio.TimeoutError:
+            logger.warning("[Feishu] Hydrate bot identity timed out after 15s, skipping (non-critical)")
         except Exception:
             logger.debug("[Feishu] Failed to hydrate bot identity", exc_info=True)
 


### PR DESCRIPTION
## Summary

- **Route the Lark SDK internal logger to Hermes logging** — The Lark SDK uses its own logger (`"Lark"`) with a stdout-only handler. This means SDK-level messages (connection errors, event receipts, reconnection failures) are invisible to `hermes logs -f`. This PR redirects that logger through the Hermes logging system so all messages appear in `agent.log`.

- **Stop silently swallowing WS client exceptions** — The `_run_official_feishu_ws_client` function had `except Exception: pass`, which completely hid critical websocket connection failures. Replaced with `logger.warning()` so errors are visible.

- **Add explicit timeout to `_hydrate_bot_identity()`** — The `asyncio.to_thread()` call had no timeout, which could block gateway startup indefinitely when the Lark REST API is slow or unreachable (common on high-latency networks or with Lark international). Added a 15-second `asyncio.wait_for()` timeout with a proper `asyncio.TimeoutError` handler.

## Motivation

When using Lark (international Feishu) with websocket mode, the gateway reported `Connected in websocket mode (lark)` but silently failed to process inbound messages. Debugging was extremely difficult because:

1. The Lark SDK logger outputs only to stdout, invisible to `hermes logs -f`
2. `except Exception: pass` hid all WS client errors
3. `_hydrate_bot_identity()` could hang on slow networks with no timeout or warning

These three changes together make Feishu/Lark websocket issues diagnosable from the standard Hermes log output.

## Test plan

- [x] Verified Lark SDK logs now appear in `agent.log` via `hermes logs -f`
- [x] Verified websocket connection and message reception on Lark international
- [x] Verified gateway startup with slow API response (hydrate timeout fires correctly at 15s)
- [x] Confirmed no impact on Feishu China (domestic) websocket mode

Made with [Cursor](https://cursor.com)