### PR TITLE
feat(api): add native audio transcription and speech endpoints

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -103,10 +103,10 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 _AUDIO_STREAM_CHUNK_BYTES = 64 * 1024
 _AUDIO_SPEECH_FORMATS = {
-    "mp3": (".mp3", "audio/mpeg"),
-    "wav": (".wav", "audio/wav"),
-    "opus": (".ogg", "audio/ogg"),
-    "ogg": (".ogg", "audio/ogg"),
+    "mp3": ".mp3",
+    "wav": ".wav",
+    "opus": ".ogg",
+    "ogg": ".ogg",
 }
 _AUDIO_TRANSCRIPTION_FORMATS = {"json", "text", "verbose_json"}
 
@@ -681,7 +681,7 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
-        """Reject overly large request bodies early based on Content-Length."""
+        """Apply route-specific limits to sized and chunked request bodies."""
         if request.method in {"POST", "PUT", "PATCH"}:
             limit = AUDIO_MAX_REQUEST_BYTES if request.path.startswith("/v1/audio/") else MAX_REQUEST_BYTES
             cl = request.headers.get("Content-Length")
@@ -691,6 +691,10 @@ if AIOHTTP_AVAILABLE:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
+            # The application's client_max_size is the largest limit needed by
+            # any route. Clone the request with its actual route limit so
+            # Request.read()/json() also enforce it for chunked bodies.
+            request = request.clone(client_max_size=limit)
         try:
             return await handler(request)
         except web.HTTPRequestEntityTooLarge:
@@ -1134,6 +1138,25 @@ class APIServerAdapter(BasePlatformAdapter):
             if guessed:
                 return guessed
         return ".webm"
+
+    @staticmethod
+    def _detect_audio_media_type(file_path: str) -> str:
+        """Detect an audio MIME type from the generated artifact's signature."""
+        with open(file_path, "rb") as handle:
+            header = handle.read(12)
+        if header.startswith(b"OggS"):
+            return "audio/ogg"
+        if len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WAVE":
+            return "audio/wav"
+        if header.startswith(b"fLaC"):
+            return "audio/flac"
+        if header.startswith(b"ID3") or (
+            len(header) >= 2 and header[0] == 0xFF and (header[1] & 0xE0) == 0xE0
+        ):
+            return "audio/mpeg"
+        if len(header) >= 8 and header[4:8] == b"ftyp":
+            return "audio/mp4"
+        return "application/octet-stream"
 
     async def _stream_file_response(
         self,
@@ -1589,6 +1612,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         form_fields: Dict[str, str] = {}
         temp_path: Optional[str] = None
+        uploaded_bytes = 0
         try:
             while True:
                 part = await reader.next()
@@ -1602,9 +1626,22 @@ class APIServerAdapter(BasePlatformAdapter):
                             chunk = await part.read_chunk()
                             if not chunk:
                                 break
+                            uploaded_bytes += len(chunk)
+                            if uploaded_bytes > AUDIO_MAX_REQUEST_BYTES:
+                                return web.json_response(
+                                    _openai_error("Request body too large.", code="body_too_large"),
+                                    status=413,
+                                )
                             handle.write(chunk)
                 elif part.name:
-                    form_fields[part.name] = await part.text()
+                    value = await part.read()
+                    uploaded_bytes += len(value)
+                    if uploaded_bytes > AUDIO_MAX_REQUEST_BYTES:
+                        return web.json_response(
+                            _openai_error("Request body too large.", code="body_too_large"),
+                            status=413,
+                        )
+                    form_fields[part.name] = value.decode(part.get_charset(default="utf-8"))
 
             if temp_path is None:
                 return web.json_response(_openai_error("Missing 'file' field"), status=400)
@@ -1689,7 +1726,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
-        suffix, media_type = audio_format
+        suffix = audio_format
         fd, output_path = tempfile.mkstemp(prefix="hermes_api_tts_", suffix=suffix)
         os.close(fd)
 
@@ -1737,6 +1774,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
             if actual_path != output_path:
                 _cleanup_output_path()
+
+            media_type = self._detect_audio_media_type(actual_path)
 
             return await self._stream_file_response(
                 request,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4,6 +4,8 @@ OpenAI-compatible API server platform adapter.
 Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
+- POST /v1/audio/transcriptions    — OpenAI-style audio transcription endpoint
+- POST /v1/audio/speech            — OpenAI-style speech synthesis endpoint
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
@@ -36,10 +38,12 @@ import hashlib
 import hmac
 import json
 import logging
+import mimetypes
 import os
 import socket as _socket
 import re
 import sqlite3
+import tempfile
 import time
 import uuid
 from pathlib import Path
@@ -93,9 +97,18 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+AUDIO_MAX_REQUEST_BYTES = 100_000_000  # 100 MB for uploaded audio files
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+_AUDIO_STREAM_CHUNK_BYTES = 64 * 1024
+_AUDIO_SPEECH_FORMATS = {
+    "mp3": (".mp3", "audio/mpeg"),
+    "wav": (".wav", "audio/wav"),
+    "opus": (".ogg", "audio/ogg"),
+    "ogg": (".ogg", "audio/ogg"),
+}
+_AUDIO_TRANSCRIPTION_FORMATS = {"json", "text", "verbose_json"}
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -546,7 +559,14 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, "
+        "X-Hermes-Session-Id, X-Hermes-Session-Key"
+    ),
+    "Access-Control-Expose-Headers": (
+        "X-Hermes-Session-Id, X-Hermes-STT-Provider, X-Hermes-TTS-Provider, "
+        "X-Hermes-Transcript-Filtered, X-Hermes-Voice-Compatible"
+    ),
 }
 
 
@@ -663,10 +683,11 @@ if AIOHTTP_AVAILABLE:
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
         if request.method in {"POST", "PUT", "PATCH"}:
+            limit = AUDIO_MAX_REQUEST_BYTES if request.path.startswith("/v1/audio/") else MAX_REQUEST_BYTES
             cl = request.headers.get("Content-Length")
             if cl is not None:
                 try:
-                    if int(cl) > MAX_REQUEST_BYTES:
+                    if int(cl) > limit:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
@@ -1101,6 +1122,64 @@ class APIServerAdapter(BasePlatformAdapter):
             status=401,
         )
 
+    @staticmethod
+    def _infer_upload_suffix(filename: Optional[str], content_type: Optional[str]) -> str:
+        """Infer a temporary file suffix from filename or content type."""
+        if filename:
+            suffix = Path(filename).suffix.lower()
+            if suffix:
+                return suffix
+        if content_type:
+            guessed = mimetypes.guess_extension(content_type.split(";", 1)[0].strip(), strict=False)
+            if guessed:
+                return guessed
+        return ".webm"
+
+    async def _stream_file_response(
+        self,
+        request: "web.Request",
+        file_path: str,
+        media_type: str,
+        *,
+        status: int = 200,
+        extra_headers: Optional[Dict[str, str]] = None,
+        cleanup: bool = False,
+    ) -> "web.StreamResponse":
+        """Stream a local file and optionally delete it once the response finishes."""
+        headers = {
+            "Content-Type": media_type,
+            "Content-Length": str(os.path.getsize(file_path)),
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            headers.update(cors)
+
+        response = web.StreamResponse(status=status, headers=headers)
+        await response.prepare(request)
+        try:
+            with open(file_path, "rb") as handle:
+                while True:
+                    chunk = handle.read(_AUDIO_STREAM_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    await response.write(chunk)
+            await response.write_eof()
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+            logger.info("[api_server] audio client disconnected while streaming %s", file_path)
+        finally:
+            if cleanup:
+                try:
+                    os.unlink(file_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.debug("[api_server] failed to clean up %s: %s", file_path, exc)
+
+        return response
+
     # ------------------------------------------------------------------
     # Session header helpers
     # ------------------------------------------------------------------
@@ -1494,6 +1573,189 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return web.json_response({"object": "list", "data": models})
 
+    async def _handle_audio_transcriptions(self, request: "web.Request") -> "web.Response":
+        """POST /v1/audio/transcriptions - OpenAI-style speech-to-text endpoint."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            reader = await request.multipart()
+        except Exception:
+            return web.json_response(
+                _openai_error("Expected multipart/form-data request body"),
+                status=400,
+            )
+
+        form_fields: Dict[str, str] = {}
+        temp_path: Optional[str] = None
+        try:
+            while True:
+                part = await reader.next()
+                if part is None:
+                    break
+                if part.name == "file":
+                    suffix = self._infer_upload_suffix(part.filename, part.headers.get("Content-Type"))
+                    fd, temp_path = tempfile.mkstemp(prefix="hermes_api_stt_", suffix=suffix)
+                    with os.fdopen(fd, "wb") as handle:
+                        while True:
+                            chunk = await part.read_chunk()
+                            if not chunk:
+                                break
+                            handle.write(chunk)
+                elif part.name:
+                    form_fields[part.name] = await part.text()
+
+            if temp_path is None:
+                return web.json_response(_openai_error("Missing 'file' field"), status=400)
+
+            response_format = (form_fields.get("response_format") or "json").strip().lower()
+            if response_format not in _AUDIO_TRANSCRIPTION_FORMATS:
+                return web.json_response(
+                    _openai_error(
+                        "Unsupported response_format. Expected one of: json, text, verbose_json",
+                        param="response_format",
+                    ),
+                    status=400,
+                )
+
+            model = (form_fields.get("model") or "").strip() or None
+
+            from tools.transcription_tools import transcribe_audio
+            from tools.voice_mode import is_whisper_hallucination
+
+            result = await asyncio.to_thread(transcribe_audio, temp_path, model=model)
+            if not result.get("success"):
+                return web.json_response(
+                    _openai_error(str(result.get("error", "Transcription failed"))),
+                    status=400,
+                )
+
+            transcript = str(result.get("transcript", "") or "")
+            filtered = bool(result.get("filtered", False))
+            if transcript and is_whisper_hallucination(transcript):
+                transcript = ""
+                filtered = True
+
+            headers = {}
+            provider = str(result.get("provider", "") or "")
+            if provider:
+                headers["X-Hermes-STT-Provider"] = provider
+            if filtered:
+                headers["X-Hermes-Transcript-Filtered"] = "true"
+
+            if response_format == "text":
+                return web.Response(text=transcript, content_type="text/plain", headers=headers)
+
+            payload: Dict[str, Any] = {"text": transcript}
+            if response_format == "verbose_json":
+                payload["task"] = "transcribe"
+                if provider:
+                    payload["provider"] = provider
+                payload["filtered"] = filtered
+            return web.json_response(payload, headers=headers)
+        finally:
+            if temp_path:
+                try:
+                    os.unlink(temp_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.debug("[api_server] failed to clean up temp upload %s: %s", temp_path, exc)
+
+    async def _handle_audio_speech(self, request: "web.Request") -> "web.StreamResponse":
+        """POST /v1/audio/speech - OpenAI-style text-to-speech endpoint."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        input_text = body.get("input")
+        if not isinstance(input_text, str) or not input_text.strip():
+            return web.json_response(_openai_error("Missing or invalid 'input' field"), status=400)
+
+        response_format = str(body.get("response_format", "mp3") or "mp3").strip().lower()
+        audio_format = _AUDIO_SPEECH_FORMATS.get(response_format)
+        if audio_format is None:
+            return web.json_response(
+                _openai_error(
+                    "Unsupported response_format. Expected one of: mp3, wav, opus, ogg",
+                    param="response_format",
+                ),
+                status=400,
+            )
+
+        suffix, media_type = audio_format
+        fd, output_path = tempfile.mkstemp(prefix="hermes_api_tts_", suffix=suffix)
+        os.close(fd)
+
+        def _cleanup_output_path() -> None:
+            try:
+                os.unlink(output_path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+        try:
+            from tools.tts_tool import text_to_speech_tool
+
+            raw = await asyncio.to_thread(text_to_speech_tool, text=input_text.strip(), output_path=output_path)
+            try:
+                result = json.loads(raw)
+            except json.JSONDecodeError:
+                _cleanup_output_path()
+                return web.json_response(
+                    _openai_error("TTS tool returned invalid JSON", err_type="server_error"),
+                    status=500,
+                )
+
+            if not result.get("success"):
+                _cleanup_output_path()
+                return web.json_response(
+                    _openai_error(str(result.get("error", "TTS generation failed"))),
+                    status=400,
+                )
+
+            actual_path = str(result.get("file_path") or output_path)
+            if not os.path.isfile(actual_path):
+                _cleanup_output_path()
+                return web.json_response(
+                    _openai_error("TTS output file is missing", err_type="server_error"),
+                    status=500,
+                )
+
+            headers = {}
+            provider = str(result.get("provider", "") or "")
+            if provider:
+                headers["X-Hermes-TTS-Provider"] = provider
+            headers["X-Hermes-Voice-Compatible"] = "true" if bool(result.get("voice_compatible", False)) else "false"
+
+            if actual_path != output_path:
+                _cleanup_output_path()
+
+            return await self._stream_file_response(
+                request,
+                actual_path,
+                media_type,
+                extra_headers=headers,
+                cleanup=True,
+            )
+        except ValueError as exc:
+            _cleanup_output_path()
+            return web.json_response(_openai_error(str(exc)), status=400)
+        except Exception as exc:
+            _cleanup_output_path()
+            logger.error("[api_server] TTS failed: %s", exc, exc_info=True)
+            return web.json_response(
+                _openai_error(f"TTS generation failed: {exc}", err_type="server_error"),
+                status=500,
+            )
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -1528,6 +1790,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "chat_completions_streaming": True,
                 "responses_api": True,
                 "responses_streaming": True,
+                "audio_transcriptions": True,
+                "audio_speech": True,
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
@@ -1555,6 +1819,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "models": {"method": "GET", "path": "/v1/models"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
+                "audio_transcriptions": {"method": "POST", "path": "/v1/audio/transcriptions"},
+                "audio_speech": {"method": "POST", "path": "/v1/audio/speech"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
@@ -4838,13 +5104,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
+            self._app = web.Application(middlewares=mws, client_max_size=AUDIO_MAX_REQUEST_BYTES)
             assert self._app is not None
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
+            self._app.router.add_post("/v1/audio/transcriptions", self._handle_audio_transcriptions)
+            self._app.router.add_post("/v1/audio/speech", self._handle_audio_speech)
             self._app.router.add_get("/v1/skills", self._handle_skills)
             self._app.router.add_get("/v1/toolsets", self._handle_toolsets)
             # Session/client control surface (thin wrappers over SessionDB + _run_agent)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4,6 +4,8 @@ OpenAI-compatible API server platform adapter.
 Exposes an HTTP server with endpoints:
 - POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header)
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id)
+- POST /v1/audio/transcriptions    — OpenAI-style audio transcription endpoint
+- POST /v1/audio/speech            — OpenAI-style speech synthesis endpoint
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
@@ -24,12 +26,15 @@ import hashlib
 import hmac
 import json
 import logging
+import mimetypes
 import os
 import socket as _socket
 import re
 import sqlite3
+import tempfile
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -54,6 +59,14 @@ DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
+_AUDIO_STREAM_CHUNK_BYTES = 64 * 1024
+_AUDIO_SPEECH_FORMATS = {
+    "mp3": (".mp3", "audio/mpeg"),
+    "wav": (".wav", "audio/wav"),
+    "opus": (".ogg", "audio/ogg"),
+    "ogg": (".ogg", "audio/ogg"),
+}
+_AUDIO_TRANSCRIPTION_FORMATS = {"json", "text", "verbose_json"}
 
 
 def check_api_server_requirements() -> bool:
@@ -174,7 +187,11 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Session-Id",
+    "Access-Control-Expose-Headers": (
+        "X-Hermes-Session-Id, X-Hermes-STT-Provider, X-Hermes-TTS-Provider, "
+        "X-Hermes-Transcript-Filtered, X-Hermes-Voice-Compatible"
+    ),
 }
 
 
@@ -219,6 +236,8 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
+        if request.path.startswith("/v1/audio/"):
+            return await handler(request)
         if request.method in ("POST", "PUT", "PATCH"):
             cl = request.headers.get("Content-Length")
             if cl is not None:
@@ -426,6 +445,64 @@ class APIServerAdapter(BasePlatformAdapter):
             status=401,
         )
 
+    @staticmethod
+    def _infer_upload_suffix(filename: Optional[str], content_type: Optional[str]) -> str:
+        """Infer a temporary file suffix from filename or content type."""
+        if filename:
+            suffix = Path(filename).suffix.lower()
+            if suffix:
+                return suffix
+        if content_type:
+            guessed = mimetypes.guess_extension(content_type.split(";", 1)[0].strip(), strict=False)
+            if guessed:
+                return guessed
+        return ".webm"
+
+    async def _stream_file_response(
+        self,
+        request: "web.Request",
+        file_path: str,
+        media_type: str,
+        *,
+        status: int = 200,
+        extra_headers: Optional[Dict[str, str]] = None,
+        cleanup: bool = False,
+    ) -> "web.StreamResponse":
+        """Stream a local file and optionally delete it once the response finishes."""
+        headers = {
+            "Content-Type": media_type,
+            "Content-Length": str(os.path.getsize(file_path)),
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            headers.update(cors)
+
+        response = web.StreamResponse(status=status, headers=headers)
+        await response.prepare(request)
+        try:
+            with open(file_path, "rb") as handle:
+                while True:
+                    chunk = handle.read(_AUDIO_STREAM_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    await response.write(chunk)
+            await response.write_eof()
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+            logger.info("[api_server] audio client disconnected while streaming %s", file_path)
+        finally:
+            if cleanup:
+                try:
+                    os.unlink(file_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.debug("[api_server] failed to clean up %s: %s", file_path, exc)
+
+        return response
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -525,6 +602,181 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
             ],
         })
+
+    async def _handle_audio_transcriptions(self, request: "web.Request") -> "web.Response":
+        """POST /v1/audio/transcriptions — OpenAI-style speech-to-text endpoint."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            reader = await request.multipart()
+        except Exception:
+            return web.json_response(
+                _openai_error("Expected multipart/form-data request body"),
+                status=400,
+            )
+
+        form_fields: Dict[str, str] = {}
+        temp_path: Optional[str] = None
+        try:
+            while True:
+                part = await reader.next()
+                if part is None:
+                    break
+                if part.name == "file":
+                    suffix = self._infer_upload_suffix(part.filename, part.headers.get("Content-Type"))
+                    fd, temp_path = tempfile.mkstemp(prefix="hermes_api_stt_", suffix=suffix)
+                    with os.fdopen(fd, "wb") as handle:
+                        while True:
+                            chunk = await part.read_chunk()
+                            if not chunk:
+                                break
+                            handle.write(chunk)
+                elif part.name:
+                    form_fields[part.name] = await part.text()
+
+            if temp_path is None:
+                return web.json_response(_openai_error("Missing 'file' field"), status=400)
+
+            response_format = (form_fields.get("response_format") or "json").strip().lower()
+            if response_format not in _AUDIO_TRANSCRIPTION_FORMATS:
+                return web.json_response(
+                    _openai_error(
+                        "Unsupported response_format. Expected one of: json, text, verbose_json",
+                        param="response_format",
+                    ),
+                    status=400,
+                )
+
+            model = (form_fields.get("model") or "").strip() or None
+
+            from tools.transcription_tools import transcribe_audio
+            from tools.voice_mode import is_whisper_hallucination
+
+            result = await asyncio.to_thread(transcribe_audio, temp_path, model=model)
+            if not result.get("success"):
+                return web.json_response(
+                    _openai_error(str(result.get("error", "Transcription failed"))),
+                    status=400,
+                )
+
+            transcript = str(result.get("transcript", "") or "")
+            filtered = bool(result.get("filtered", False))
+            if transcript and is_whisper_hallucination(transcript):
+                transcript = ""
+                filtered = True
+
+            headers = {}
+            provider = str(result.get("provider", "") or "")
+            if provider:
+                headers["X-Hermes-STT-Provider"] = provider
+            if filtered:
+                headers["X-Hermes-Transcript-Filtered"] = "true"
+
+            if response_format == "text":
+                return web.Response(text=transcript, content_type="text/plain", headers=headers)
+
+            payload: Dict[str, Any] = {"text": transcript}
+            if response_format == "verbose_json":
+                payload["task"] = "transcribe"
+                if provider:
+                    payload["provider"] = provider
+                payload["filtered"] = filtered
+            return web.json_response(payload, headers=headers)
+        finally:
+            if temp_path:
+                try:
+                    os.unlink(temp_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.debug("[api_server] failed to clean up temp upload %s: %s", temp_path, exc)
+
+    async def _handle_audio_speech(self, request: "web.Request") -> "web.StreamResponse":
+        """POST /v1/audio/speech — OpenAI-style text-to-speech endpoint."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        input_text = body.get("input")
+        if not isinstance(input_text, str) or not input_text.strip():
+            return web.json_response(_openai_error("Missing or invalid 'input' field"), status=400)
+
+        response_format = str(body.get("response_format", "mp3") or "mp3").strip().lower()
+        audio_format = _AUDIO_SPEECH_FORMATS.get(response_format)
+        if audio_format is None:
+            return web.json_response(
+                _openai_error(
+                    "Unsupported response_format. Expected one of: mp3, wav, opus, ogg",
+                    param="response_format",
+                ),
+                status=400,
+            )
+
+        suffix, media_type = audio_format
+        fd, output_path = tempfile.mkstemp(prefix="hermes_api_tts_", suffix=suffix)
+        os.close(fd)
+
+        try:
+            from tools.tts_tool import text_to_speech_tool
+
+            raw = await asyncio.to_thread(text_to_speech_tool, text=input_text.strip(), output_path=output_path)
+            try:
+                result = json.loads(raw)
+            except json.JSONDecodeError:
+                return web.json_response(
+                    _openai_error("TTS tool returned invalid JSON", err_type="server_error"),
+                    status=500,
+                )
+
+            if not result.get("success"):
+                return web.json_response(
+                    _openai_error(str(result.get("error", "TTS generation failed"))),
+                    status=400,
+                )
+
+            actual_path = str(result.get("file_path") or output_path)
+            if not os.path.isfile(actual_path):
+                return web.json_response(
+                    _openai_error("TTS output file is missing", err_type="server_error"),
+                    status=500,
+                )
+
+            headers = {}
+            provider = str(result.get("provider", "") or "")
+            if provider:
+                headers["X-Hermes-TTS-Provider"] = provider
+            headers["X-Hermes-Voice-Compatible"] = "true" if bool(result.get("voice_compatible", False)) else "false"
+
+            return await self._stream_file_response(
+                request,
+                actual_path,
+                media_type,
+                extra_headers=headers,
+                cleanup=True,
+            )
+        except ValueError as exc:
+            try:
+                os.unlink(output_path)
+            except OSError:
+                pass
+            return web.json_response(_openai_error(str(exc)), status=400)
+        except Exception as exc:
+            try:
+                os.unlink(output_path)
+            except OSError:
+                pass
+            logger.error("[api_server] TTS failed: %s", exc, exc_info=True)
+            return web.json_response(
+                _openai_error(f"TTS generation failed: {exc}", err_type="server_error"),
+                status=500,
+            )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -1736,6 +1988,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
+            self._app.router.add_post("/v1/audio/transcriptions", self._handle_audio_transcriptions)
+            self._app.router.add_post("/v1/audio/speech", self._handle_audio_speech)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -26,12 +26,15 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
+    AUDIO_MAX_REQUEST_BYTES,
+    MAX_REQUEST_BYTES,
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
     _redact_api_error_text,
     check_api_server_requirements,
+    body_limit_middleware,
     cors_middleware,
     security_headers_middleware,
 )
@@ -617,8 +620,8 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=AUDIO_MAX_REQUEST_BYTES)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
@@ -1167,7 +1170,7 @@ class TestAudioEndpoints:
 
         def fake_tts(*, text, output_path):
             with open(output_path, "wb") as handle:
-                handle.write(b"audio-bytes")
+                handle.write(b"ID3audio-bytes")
             return json.dumps({
                 "success": True,
                 "file_path": output_path,
@@ -1184,11 +1187,83 @@ class TestAudioEndpoints:
                 body = await resp.read()
 
         assert resp.status == 200
-        assert body == b"audio-bytes"
+        assert body == b"ID3audio-bytes"
         assert resp.headers.get("Content-Type") == "audio/mpeg"
         assert resp.headers.get("X-Hermes-TTS-Provider") == "piper"
         assert resp.headers.get("X-Hermes-Voice-Compatible") == "true"
         assert tts_mock.call_args.kwargs["text"] == "hello from Hermes"
+
+    @pytest.mark.asyncio
+    async def test_audio_speech_uses_generated_artifact_mime_type(self, adapter):
+        app = _create_app(adapter)
+
+        def fake_edge_tts(*, text, output_path):
+            # Edge TTS writes MP3 regardless of the caller-provided suffix.
+            with open(output_path, "wb") as handle:
+                handle.write(b"ID3edge-mp3")
+            return json.dumps({
+                "success": True,
+                "file_path": output_path,
+                "provider": "edge",
+                "voice_compatible": False,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_edge_tts):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/audio/speech",
+                    json={"input": "hello", "response_format": "wav"},
+                )
+                await resp.read()
+
+        assert resp.status == 200
+        assert resp.headers.get("Content-Type") == "audio/mpeg"
+
+    @pytest.mark.asyncio
+    async def test_chunked_non_audio_request_keeps_standard_body_limit(self, adapter):
+        async def read_body(request):
+            await request.read()
+            return web.Response(text="ok")
+
+        app = web.Application(
+            middlewares=[body_limit_middleware],
+            client_max_size=AUDIO_MAX_REQUEST_BYTES,
+        )
+        app.router.add_post("/non-audio", read_body)
+
+        async def oversized_chunks():
+            yield b"x" * (MAX_REQUEST_BYTES // 2)
+            yield b"x" * (MAX_REQUEST_BYTES // 2 + 1)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/non-audio", data=oversized_chunks())
+            await resp.read()
+
+        assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_chunked_audio_upload_enforces_audio_limit(self, adapter):
+        app = _create_app(adapter)
+        form = FormData()
+
+        async def audio_chunks():
+            yield b"x" * 5
+            yield b"x" * 5
+
+        form.add_field(
+            "file",
+            audio_chunks(),
+            filename="sample.webm",
+            content_type="audio/webm",
+        )
+
+        with patch("gateway.platforms.api_server.AUDIO_MAX_REQUEST_BYTES", 8):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/audio/transcriptions", data=form)
+                data = await resp.json()
+
+        assert resp.status == 413
+        assert data["error"]["code"] == "body_too_large"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -21,7 +21,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aiohttp import web
+from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -625,6 +625,8 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_post("/v1/audio/transcriptions", adapter._handle_audio_transcriptions)
+    app.router.add_post("/v1/audio/speech", adapter._handle_audio_speech)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
@@ -944,9 +946,13 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["audio_transcriptions"] is True
+            assert data["features"]["audio_speech"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
+            assert data["endpoints"]["audio_transcriptions"]["path"] == "/v1/audio/transcriptions"
+            assert data["endpoints"]["audio_speech"]["path"] == "/v1/audio/speech"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
@@ -1113,6 +1119,76 @@ class TestToolsetsEndpoint:
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 assert authed.status == 200
+
+
+# ---------------------------------------------------------------------------
+# /v1/audio endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestAudioEndpoints:
+    @pytest.mark.asyncio
+    async def test_audio_transcriptions_returns_verbose_json(self, adapter):
+        app = _create_app(adapter)
+        form = FormData()
+        form.add_field(
+            "file",
+            b"fake webm bytes",
+            filename="sample.webm",
+            content_type="audio/webm",
+        )
+        form.add_field("model", "whisper-1")
+        form.add_field("response_format", "verbose_json")
+
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "hello", "provider": "local", "filtered": False},
+        ) as transcribe_mock, patch(
+            "tools.voice_mode.is_whisper_hallucination",
+            return_value=False,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/audio/transcriptions", data=form)
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data == {
+            "text": "hello",
+            "task": "transcribe",
+            "provider": "local",
+            "filtered": False,
+        }
+        assert resp.headers.get("X-Hermes-STT-Provider") == "local"
+        assert transcribe_mock.call_args.kwargs["model"] == "whisper-1"
+
+    @pytest.mark.asyncio
+    async def test_audio_speech_streams_generated_file(self, adapter):
+        app = _create_app(adapter)
+
+        def fake_tts(*, text, output_path):
+            with open(output_path, "wb") as handle:
+                handle.write(b"audio-bytes")
+            return json.dumps({
+                "success": True,
+                "file_path": output_path,
+                "provider": "piper",
+                "voice_compatible": True,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts) as tts_mock:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/audio/speech",
+                    json={"input": "hello from Hermes", "response_format": "mp3"},
+                )
+                body = await resp.read()
+
+        assert resp.status == 200
+        assert body == b"audio-bytes"
+        assert resp.headers.get("Content-Type") == "audio/mpeg"
+        assert resp.headers.get("X-Hermes-TTS-Provider") == "piper"
+        assert resp.headers.get("X-Hermes-Voice-Compatible") == "true"
+        assert tts_mock.call_args.kwargs["text"] == "hello from Hermes"
 
 
 # ---------------------------------------------------------------------------
@@ -3859,8 +3935,6 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
-
-
 # ---------------------------------------------------------------------------
 # Per-client model routing (model_routes)
 # ---------------------------------------------------------------------------

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -88,6 +88,8 @@ Endpoints:
 ```
 POST /v1/chat/completions        OpenAI Chat Completions (streaming via SSE)
 POST /v1/responses               OpenAI Responses API (stateful)
+POST /v1/audio/transcriptions    OpenAI-style speech-to-text (multipart upload)
+POST /v1/audio/speech            OpenAI-style text-to-speech (streamed audio)
 POST /v1/runs                    Start a run, returns run_id (202)
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -194,6 +194,41 @@ Retrieve a previously stored response by ID.
 
 Delete a stored response.
 
+### POST /v1/audio/transcriptions
+
+Transcribe an uploaded audio file with Hermes' configured STT provider. Send a
+`multipart/form-data` body containing a `file` field. Optional `model` and
+`response_format` fields are supported; `response_format` may be `json`,
+`text`, or `verbose_json`.
+
+```bash
+curl http://localhost:8642/v1/audio/transcriptions \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -F "file=@sample.webm" \
+  -F "response_format=verbose_json"
+```
+
+Audio uploads are limited to 100 MB. The response may include
+`X-Hermes-STT-Provider` and `X-Hermes-Transcript-Filtered` metadata headers.
+
+### POST /v1/audio/speech
+
+Generate speech with Hermes' configured TTS provider. Send JSON with a required
+`input` string and an optional `response_format` of `mp3`, `wav`, `opus`, or
+`ogg`. The generated audio is streamed back using the MIME type detected from
+the provider's actual output.
+
+```bash
+curl http://localhost:8642/v1/audio/speech \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input":"hello from Hermes","response_format":"mp3"}' \
+  --output speech.mp3
+```
+
+The response includes `X-Hermes-TTS-Provider` and
+`X-Hermes-Voice-Compatible` metadata headers.
+
 ### GET /v1/models
 
 Lists the agent as an available model. The advertised model name defaults to the [profile](/user-guide/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
@@ -510,7 +545,7 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 ## Limitations
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
-- **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
+- **No general file upload** — `/v1/audio/transcriptions` accepts audio uploads, and inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but general uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the chat APIs.
 - **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
 
 ## Proxy Mode


### PR DESCRIPTION
## What does this PR do?

This exposes Hermes' existing voice capabilities through the API server by adding OpenAI-style audio endpoints for transcription and speech synthesis.

Today the API server already supports chat and responses, but third-party UIs still cannot use Hermes for voice because `/v1/audio/transcriptions` and `/v1/audio/speech` are missing. This change closes that gap by wiring the API surface to the existing STT/TTS helpers, streaming generated audio back to clients, and exposing the Hermes-specific metadata headers browser clients need.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `POST /v1/audio/transcriptions` with multipart upload handling, `json` / `text` / `verbose_json` responses, provider metadata headers, and transcript hallucination filtering
- add `POST /v1/audio/speech` with streamed audio responses for `mp3`, `wav`, `opus`, and `ogg`
- add reusable file-streaming and temp-file cleanup helpers for generated audio responses
- update API-server CORS headers so browser clients can send `X-Hermes-Session-Id` and read STT/TTS metadata headers
- bypass the generic 1 MB request-body limit for `/v1/audio/*` routes so uploaded audio can be processed
- register the new audio routes in `gateway/platforms/api_server.py`

## How to Test

1. Start the Hermes API server with an API key and working STT/TTS configuration.
2. Run `curl -X POST http://localhost:8642/v1/audio/transcriptions -H "Authorization: Bearer $API_SERVER_KEY" -F "file=@sample.webm" -F "model=whisper-1" -F "response_format=verbose_json"` and verify you get a transcript payload plus `X-Hermes-STT-Provider` / `X-Hermes-Transcript-Filtered` headers.
3. Run `curl -X POST http://localhost:8642/v1/audio/speech -H "Authorization: Bearer $API_SERVER_KEY" -H "Content-Type: application/json" -d '{"input":"hello from Hermes","response_format":"mp3"}' --output speech.mp3 -D headers.txt` and verify streamed audio plus `X-Hermes-TTS-Provider` / `X-Hermes-Voice-Compatible` headers.
4. Run `/mnt/samesung/ai/util/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_api_server.py -q` from the branch checkout and verify the API-server suite stays green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, using `/mnt/samesung/ai/util/hermes-agent/.venv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m py_compile gateway/platforms/api_server.py`
- `/mnt/samesung/ai/util/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_api_server.py -q` → `107 passed`
- attempted full suite with `/mnt/samesung/ai/util/hermes-agent/.venv/bin/python -m pytest tests/ -q`, but the repository is not currently full-suite green in this environment
