### PR TITLE
fix: make skill loading instructions more aggressive in system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -726,8 +726,13 @@ def build_skills_system_prompt(
 
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If one clearly matches your task, "
-            "load it with skill_view(name) and follow its instructions. "
+            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+            "Err on the side of loading — it is always better to have context you don't need "
+            "than to miss critical steps, pitfalls, or established workflows. "
+            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+            "and proven workflows that outperform general-purpose approaches. Load the skill "
+            "even if you think you could handle the task with basic tools like web_search or terminal.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
@@ -737,7 +742,7 @@ def build_skills_system_prompt(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "If none match, proceed normally without loading a skill."
+            "Only proceed without loading a skill if genuinely none are relevant to the task."
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The system prompt's skill loading instructions were too permissive, causing models to skip loading relevant skills unless explicitly forced.

### Changes (3 key shifts)

**1. Lowered threshold** — `clearly matches` → `matches or is even partially relevant` + `you MUST load it`

**2. Added bias-toward-loading** — "Err on the side of loading — it is always better to have context you don't need than to miss critical steps, pitfalls, or established workflows."

**3. Specialized knowledge callout** (v2) — "Skills contain specialized knowledge — API endpoints, tool-specific commands, and proven workflows that outperform general-purpose approaches. Load the skill even if you think you could handle the task with basic tools like web_search or terminal."

This addresses the specific failure mode where models bypass skills because they can accomplish the task with general tools (e.g., using `web_search` for arxiv instead of loading the arxiv skill with the proper API endpoint format).

**4. Inverted escape hatch** — `If none match, proceed normally` → `Only proceed without loading a skill if genuinely none are relevant`

### Live benchmark (sonnet-4, 20 test cases: 5 direct + 10 indirect + 5 negative)

|  | OLD | v1 | v2 (final) |
|--|-----|-----|-----|
| Direct match (5) | 4/5 | 4/5 | **5/5** |
| Indirect match (10) | 7/10 | 9/10 | **9/10** |
| Negative / no skill (5) | 5/5 | 5/5 | **5/5** |
| **TOTAL** | **16/20 (80%)** | **18/20 (90%)** | **19/20 (95%)** |

The single remaining `miss` (I4) is a prompt without an actionable YouTube URL — model correctly asks for it first. When a URL is provided, the skill loads immediately.

## Files changed
- `agent/prompt_builder.py` — skill loading instructions (8 insertions, 3 deletions)

## Test plan
- `python3 -m pytest tests/agent/test_prompt_builder.py` — 108 passed
- Live benchmark: 20 prompts × 3 variants (old/v1/v2) on sonnet-4