### PR TITLE
fix: Fix the error of message segmentation when replying in WeChat, a…

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -734,6 +734,42 @@ def _split_delivery_units_for_weixin(content: str) -> List[str]:
     return [unit for unit in units if unit]
 
 
+def _pack_units_for_weixin(units: List[str], max_length: int) -> List[str]:
+    """Merge adjacent small units back together to reduce message count.
+    
+    Combines units with double-newline separators as long as the combined text
+    stays within max_length. This preserves logical splitting for readability
+    while drastically reducing the number of outbound messages.
+    """
+    if not units:
+        return []
+    
+    combined_messages: List[str] = []
+    current_batch = ""
+    
+    for unit in units:
+        # Calculate what the batch would be if we add this unit
+        if current_batch:
+            candidate = current_batch + "\n\n" + unit
+        else:
+            candidate = unit
+        
+        # If it fits, add to current batch
+        if len(candidate) <= max_length:
+            current_batch = candidate
+        else:
+            # Batch is full, save it and start a new one
+            if current_batch:
+                combined_messages.append(current_batch)
+            current_batch = unit
+    
+    # Don't forget the last batch
+    if current_batch:
+        combined_messages.append(current_batch)
+    
+    return combined_messages
+
+
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:
     if len(content) <= max_length:
         return [content]
@@ -769,23 +805,27 @@ def _split_text_for_weixin_delivery(
 
     *per_line* (``split_per_line=True``): Legacy behavior — top-level line
     breaks become separate chat messages; oversized units still use
-    block-aware packing.
+    block-aware packing. Adjacent small units are automatically combined
+    to respect platform rate limits and avoid flooding the chat.
 
     The active mode is controlled via ``config.yaml`` ->
     ``platforms.weixin.extra.split_multiline_messages`` (``true`` / ``false``)
     or the env var ``WEIXIN_SPLIT_MULTILINE_MESSAGES``.
     """
     if split_per_line:
-        # Legacy: one message per top-level delivery unit.
+        # Legacy: one message per top-level delivery unit, but combine small units
+        # to avoid flooding the chat with too many rapid messages.
         if len(content) <= max_length and "\n" not in content:
             return [content]
-        chunks: List[str] = []
+        units: List[str] = []
         for unit in _split_delivery_units_for_weixin(content):
             if len(unit) <= max_length:
-                chunks.append(unit)
-                continue
-            chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
-        return chunks or [content]
+                units.append(unit)
+            else:
+                # Oversized unit: pack it into chunks before adding to units
+                units.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
+        # Now combine small units to reduce message count
+        return _pack_units_for_weixin(units, max_length) or [content]
 
     # Compact (default): single message when under the limit.
     if len(content) <= max_length:


### PR DESCRIPTION
…nd resolve the issue of 10 messages losing connection.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

