### PR TITLE
fix: remove early return in custom endpoint context length resolution

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -979,13 +979,8 @@ def get_model_context_length(
                 if local_ctx and local_ctx > 0:
                     save_context_length(model, base_url, local_ctx)
                     return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
-            )
-            return DEFAULT_FALLBACK_CONTEXT
+            # Don't early-return the fallback here — continue to steps 4-8
+            # so hardcoded defaults and models.dev can still match.
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (


### PR DESCRIPTION
## Problem

When using a custom provider (e.g. a private OpenAI-compatible API) whose `/models` endpoint is unavailable, `get_model_context_length()` short-circuits at step 2 and returns the 128K fallback. This skips steps 4–8 entirely, including:

- Step 5: `models.dev` registry lookup (provider-aware)
- Step 6: OpenRouter live API metadata
- Step 8: Hardcoded `DEFAULT_CONTEXT_LENGTHS` (e.g. `"glm": 202752`)

As a result, models like `glm-5.1` served via a custom endpoint always resolve to 128,000 tokens instead of 202,752 (from the hardcoded defaults), triggering a false compression warning:

> ⚠ Compression model (glm-5.1) context is 128,000 tokens, but the main model's compression threshold is 180,000 tokens. Context compression will not be possible.

## Root Cause

In `get_model_context_length()`, when `_is_custom_endpoint(base_url)` is `True` and the `/models` endpoint returns no metadata, the function hits this early return (line 988):

```python
return DEFAULT_FALLBACK_CONTEXT  # 128_000
```

This prevents the resolution chain from reaching step 8 where `"glm" in "glm-5.1"` would match and return 202,752.

## Fix

Remove the early `return DEFAULT_FALLBACK_CONTEXT` so the function falls through to steps 4–8 before reaching the final fallback at step 10.

**Change**: 5 lines removed, 2 lines added (comment explaining the fallthrough).

## Before / After

| Scenario | Before | After |
|---|---|---|
| `glm-5.1` via custom endpoint (no `/models`) | 128,000 (early return) | 202,752 (hardcoded default match) |
| Local endpoint (Ollama, LM Studio, etc.) | Unaffected (still returns at step 3) | Unaffected |
| Known provider (OpenRouter, Anthropic, etc.) | Unaffected (never enters this branch) | Unaffected |
| Explicit `config_context_length` | Unaffected (step 0, highest priority) | Unaffected |

## Testing

```python
from agent.model_metadata import get_model_context_length

# Custom endpoint without /models — now reaches hardcoded defaults
get_model_context_length("glm-5.1", base_url="https://ai.leihuo.netease.com/v1/")
# Before: 128000  |  After: 202752

# Explicit config override still has highest priority
get_model_context_length("glm-5.1", base_url="https://ai.leihuo.netease.com/v1/", config_context_length=200000)
# Returns: 200000 (unchanged)

# Known providers unaffected
get_model_context_length("gpt-4", base_url="https://api.openai.com/v1")
# Unaffected — never enters the custom endpoint branch
```