### PR TITLE
fix(cli): include custom provider model maps in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -920,9 +920,25 @@ def list_authenticated_providers(
                 continue
 
             models_list = []
+            configured_models = entry.get("models")
+            if isinstance(configured_models, dict):
+                models_list.extend(
+                    model_id.strip()
+                    for model_id in configured_models.keys()
+                    if isinstance(model_id, str) and model_id.strip()
+                )
+            elif isinstance(configured_models, list):
+                for model_entry in configured_models:
+                    if isinstance(model_entry, str) and model_entry.strip():
+                        models_list.append(model_entry.strip())
+                    elif isinstance(model_entry, dict):
+                        model_name = (model_entry.get("name") or "").strip()
+                        if model_name:
+                            models_list.append(model_name)
+
             default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
+            if default_model and default_model not in models_list:
+                models_list.insert(0, default_model)
 
             results.append({
                 "slug": slug,

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -102,3 +102,33 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+
+def test_list_authenticated_providers_uses_custom_provider_models_dict(monkeypatch):
+    """Custom providers with a models: mapping should expose all configured model IDs."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Redacted Gateway",
+                "base_url": "https://redacted-gateway.example/v1",
+                "model": "model-a",
+                "models": {
+                    "model-a": {},
+                    "model-b": {},
+                    "model-c": {},
+                    "model-d": {},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    provider = next(p for p in providers if p["slug"] == "custom:redacted-gateway")
+    assert provider["models"] == ["model-a", "model-b", "model-c", "model-d"]
+    assert provider["total_models"] == 4


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` picker for `custom_providers` entries that define multiple models under `custom_providers[].models`.

Previously, `list_authenticated_providers()` only used `custom_providers[].model`, so the picker incorrectly showed `(1)` and only exposed the default model even when several configured models were available.

This PR teaches the picker to consume `custom_providers[].models` first and fall back to `custom_providers[].model` only when needed.

## Related Issue

Fixes #8216

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/model_switch.py`
  - read model IDs from `custom_providers[].models`
  - support `dict`, `list[str]`, and `list[dict{name}]` shapes
  - keep `custom_providers[].model` as fallback/default only
  - avoid duplicate default model entries
- `tests/hermes_cli/test_model_switch_custom_providers.py`
  - added regression coverage for `models` provided as a dict mapping

## How to Test

1. Configure a custom provider with:
   ```yaml
   custom_providers:
     - name: Redacted Gateway
       base_url: https://redacted-gateway.example/v1
       model: model-a
       models:
         model-a: {}
         model-b: {}
         model-c: {}
         model-d: {}
   ```
2. Open `/model` and select that custom provider.
3. Verify the picker now shows all configured models and reports the correct total.

Or run:
```bash
python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_custom_provider_model_switch.py -q -n0
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run relevant pytest coverage locally
- [x] I've added tests for my changes
- [x] I've tested on my platform:
  - macOS

### Documentation & Housekeeping
- [x] I've considered cross-platform impact (logic-only Python change)
- [x] N/A — no docs/config schema changes
- [x] N/A — no tool schema changes
