### PR TITLE
fix(cli): apply api_mode when switching to named custom provider

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1955,6 +1955,14 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    # Apply api_mode from the custom provider entry so switching between
+    # providers with different protocols (e.g. openai ↔ anthropic_messages)
+    # uses the correct request format.
+    api_mode = provider_info.get("api_mode")
+    if api_mode:
+        model["api_mode"] = api_mode
+    else:
+        model.pop("api_mode", None)  # let runtime auto-detect
     save_config(cfg)
     deactivate_provider()
 

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -122,3 +122,96 @@ class TestCustomProviderModelSwitch:
         model = config.get("model")
         assert isinstance(model, dict)
         assert model["default"] == "model-X"
+
+    def test_api_mode_applied_from_provider_info(self, config_home):
+        """When a custom provider defines api_mode, it must be written to config."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "Claude Proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "sk-test",
+            "api_mode": "anthropic_messages",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3-opus"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("api_mode") == "anthropic_messages"
+
+    def test_api_mode_cleared_when_not_in_provider_info(self, config_home):
+        """Switching to a provider without api_mode should remove stale api_mode."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        # Pre-set api_mode in config (from a previous provider switch)
+        config_yaml = config_home / "config.yaml"
+        config_yaml.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom\n"
+            "  api_mode: anthropic_messages\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "Local Ollama",
+            "base_url": "http://localhost:11434/v1",
+            # no api_key, no api_mode — auto-detect
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["llama3"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert "api_mode" not in model, "stale api_mode should be removed"
+
+    def test_api_mode_switches_between_providers(self, config_home):
+        """Switching from anthropic_messages to openai should update api_mode."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        # First switch: set anthropic_messages
+        provider_a = {
+            "name": "Claude Proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "sk-a",
+            "api_mode": "anthropic_messages",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_a)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["model"]["api_mode"] == "anthropic_messages"
+
+        # Second switch: set openai (chat_completions)
+        provider_b = {
+            "name": "Local Ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_mode": "chat_completions",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["llama3"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_b)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["model"]["api_mode"] == "chat_completions"


### PR DESCRIPTION
## Problem

When switching between custom providers via `hermes model`, `_model_flow_named_custom()` sets `provider`, `base_url`, and `api_key` in config but **omits the `api_mode` field** from the provider entry. 

This causes API calls to use the wrong protocol when switching between providers with different API modes (e.g. `openai` ↔ `anthropic_messages`).

### Steps to reproduce

1. Configure two custom providers:
   - Provider A: `api_mode: anthropic_messages` (Claude-compatible endpoint)
   - Provider B: `api_mode: chat_completions` (local Ollama)
2. Switch to Provider A via `hermes model` → works
3. Switch to Provider B → **`api_mode` stays `anthropic_messages`** → requests fail or use wrong protocol

## Fix

Apply `api_mode` from `provider_info` when present, or remove stale `api_mode` via `model.pop('api_mode', None)` to let runtime auto-detect — matching the pattern already used by `_model_flow_custom()` and `_model_flow_copilot()`.

```python
api_mode = provider_info.get('api_mode')
if api_mode:
    model['api_mode'] = api_mode
else:
    model.pop('api_mode', None)  # let runtime auto-detect
```

## Tests

3 regression tests added to `test_custom_provider_model_switch.py`:
- `test_api_mode_applied_from_provider_info` — verifies api_mode is written to config
- `test_api_mode_cleared_when_not_in_provider_info` — verifies stale api_mode is removed
- `test_api_mode_switches_between_providers` — verifies bidirectional switching works

Fixes #8181