### PR TITLE
fix: list all available toolsets in delegate_task schema description

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -25,6 +25,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
+from toolsets import TOOLSETS
+
 
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([
@@ -34,6 +36,18 @@ DELEGATE_BLOCKED_TOOLS = frozenset([
     "send_message",    # no cross-platform side effects
     "execute_code",    # children should reason step-by-step, not write scripts
 ])
+
+# Build a description fragment listing toolsets available for subagents.
+# Excludes toolsets where ALL tools are blocked, composite/platform toolsets
+# (hermes-* prefixed), and scenario toolsets.
+_EXCLUDED_TOOLSET_NAMES = frozenset({"debugging", "safe", "delegation"})
+_SUBAGENT_TOOLSETS = sorted(
+    name for name, defn in TOOLSETS.items()
+    if name not in _EXCLUDED_TOOLSET_NAMES
+    and not name.startswith("hermes-")
+    and not all(t in DELEGATE_BLOCKED_TOOLS for t in defn.get("tools", []))
+)
+_TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
@@ -999,9 +1013,10 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Toolsets to enable for this subagent. "
                     "Default: inherits your enabled toolsets. "
+                    f"Available toolsets: {_TOOLSET_LIST_STR}. "
                     "Common patterns: ['terminal', 'file'] for code work, "
-                    "['web'] for research, ['terminal', 'file', 'web'] for "
-                    "full-stack tasks."
+                    "['web'] for research, ['browser'] for web interaction, "
+                    "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
             "tasks": {
@@ -1014,7 +1029,7 @@ DELEGATE_TASK_SCHEMA = {
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Toolsets for this specific task. Use 'web' for network access, 'terminal' for shell.",
+                            "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
                         "acp_command": {
                             "type": "string",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -40,7 +40,7 @@ DELEGATE_BLOCKED_TOOLS = frozenset([
 # Build a description fragment listing toolsets available for subagents.
 # Excludes toolsets where ALL tools are blocked, composite/platform toolsets
 # (hermes-* prefixed), and scenario toolsets.
-_EXCLUDED_TOOLSET_NAMES = frozenset({"debugging", "safe", "delegation"})
+_EXCLUDED_TOOLSET_NAMES = frozenset({"debugging", "safe", "delegation", "moa", "rl"})
 _SUBAGENT_TOOLSETS = sorted(
     name for name, defn in TOOLSETS.items()
     if name not in _EXCLUDED_TOOLSET_NAMES


### PR DESCRIPTION
## Summary

The `delegate_task` tool's `toolsets` parameter description only mentioned `terminal`, `file`, and `web` as examples. Models (especially smaller ones like Gemma) would substitute `web` for `browser` because they didn't know `browser` was a valid toolset option — even when explicitly instructed to use the browser toolset.

**Root cause:** [jeffutter pointed out](https://github.com/NousResearch/hermes-agent/blob/992422910cc743fea9371480a1bce47230c6f25f/tools/delegate_tool.py#L981-L985) that the schema had no information about the browser toolset (or any toolset besides terminal/file/web).

## Changes

- Dynamically builds the available toolset list from the `TOOLSETS` dict at import time
- Filters out blocked toolsets (clarify, memory, messaging, code_execution), composite/platform toolsets (hermes-*), and scenario toolsets (debugging, safe, delegation)
- Updates both the top-level `toolsets` parameter description and the per-task `toolsets` description
- Adds `['browser'] for web interaction` to the common patterns examples

**The model now sees:**
```
Available toolsets: 'browser', 'cronjob', 'file', 'homeassistant', 'image_gen', 'moa', 'rl',
'search', 'session_search', 'skills', 'terminal', 'todo', 'tts', 'vision', 'web'.
```

Auto-updates when new toolsets are added to `toolsets.py`.

## Test plan

- `pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py` — 72 passed
- `pytest tests/test_model_tools.py tests/test_toolsets.py` — 32 passed
- Verified import + schema generation works correctly

Reported by jeffutter on Discord.