### PR TITLE
feat: add Brave Search as web search backend

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -208,6 +208,14 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Brave Search",
+                "tag": "Privacy-focused search with independent index (extraction falls back to Firecrawl)",
+                "web_backend": "brave",
+                "env_vars": [
+                    {"key": "BRAVE_API_KEY", "prompt": "Brave Search API key", "url": "https://brave.com/search/api/"},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "tag": "Free - run your own instance",
                 "web_backend": "firecrawl",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- Brave Search: https://brave.com/search/api/ (search only — extraction falls back to Firecrawl)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "brave"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -98,6 +99,7 @@ def _get_backend() -> str:
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
+        ("brave", _has_env("BRAVE_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
     )
     for backend, available in backend_candidates:
@@ -117,6 +119,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "brave":
+        return _has_env("BRAVE_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -187,6 +191,7 @@ def _web_requires_env() -> list[str]:
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
+        "BRAVE_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
     ]
@@ -278,6 +283,63 @@ def _get_async_parallel_client():
             )
         _async_parallel_client = AsyncParallel(api_key=api_key)
     return _async_parallel_client
+
+# ─── Brave Search Client ─────────────────────────────────────────────────────
+
+_BRAVE_BASE_URL = os.getenv("BRAVE_API_URL") or "https://api.search.brave.com/res/v1"
+
+
+def _brave_request(endpoint: str, payload: dict) -> dict:
+    """Send a GET request to the Brave Search API.
+
+    Brave Search uses header-based auth (X-Subscription-Token header).
+    Raises ``ValueError`` if ``BRAVE_API_KEY`` is not set.
+    """
+    api_key = os.getenv("BRAVE_API_KEY", "")
+    if not api_key:
+        raise ValueError(
+            "BRAVE_API_KEY environment variable not set. "
+            "Get your API key at https://brave.com/search/api/"
+        )
+    url = f"{_BRAVE_BASE_URL}/{endpoint.lstrip('/')}"
+    headers = {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "X-Subscription-Token": api_key,
+    }
+    logger.info("Brave Search %s request to %s", endpoint, url)
+    response = httpx.get(url, headers=headers, params=payload, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def _normalize_brave_search_results(response: dict) -> dict:
+    """Normalize Brave Search /web/search response to the standard web search format.
+
+    Brave returns results in the ``web`` key with ``results`` array containing:
+    ``{title, url, description, extra_snippets, etc.}``
+    We map to ``{success, data: {web: [{title, url, description, position}]}}``.
+    """
+    web_results = []
+    web_data = response.get("web", {})
+    results = web_data.get("results", [])
+
+    for i, result in enumerate(results):
+        # Brave may provide extra_snippets as additional descriptions
+        description = result.get("description", "")
+        extra_snippets = result.get("extra_snippets", [])
+        if extra_snippets:
+            description = description + " " + " ".join(extra_snippets[:2]) if description else " ".join(extra_snippets[:2])
+
+        web_results.append({
+            "title": result.get("title", ""),
+            "url": result.get("url", ""),
+            "description": description,
+            "position": i + 1,
+        })
+
+    return {"success": True, "data": {"web": web_results}}
+
 
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
@@ -1117,6 +1179,21 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "brave":
+            logger.info("Brave Search: '%s' (limit: %d)", query, limit)
+            raw = _brave_request("web/search", {
+                "q": query,
+                "count": min(limit, 20),
+                "search_lang": "en",
+            })
+            response_data = _normalize_brave_search_results(raw)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
 
         response = _get_firecrawl_client().search(
@@ -1251,7 +1328,14 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
-            else:
+            elif backend == "brave":
+                # Brave Search doesn't have an extract endpoint; fall back to Firecrawl
+                logger.info("Brave backend selected for extraction - falling back to Firecrawl (%d URL(s))", len(safe_urls))
+                # Fall through to Firecrawl extraction below
+                backend = "firecrawl"
+
+            # Firecrawl extraction (for brave fallback, firecrawl, or unrecognized backends)
+            if backend in ("firecrawl", "brave") or backend not in ("parallel", "exa", "tavily"):
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
                 formats: List[str] = []


### PR DESCRIPTION
## Summary

Adds Brave Search as a new web search backend option for Hermes Agent.

## Why?

- **Privacy-focused**: Brave uses its own independent index, not Google or Bing
- **Free tier available**: 2,000 queries/month for free
- **Alternative to paid services**: Users can choose Brave instead of Tavily/Exa/Firecrawl/Parallel
- **Simple auth**: Uses X-Subscription-Token header (no OAuth complexity)

## Features

- **Search**: Uses Brave's `/web/search` endpoint
- **Extract**: Falls back to Firecrawl (Brave doesn't have an extract API)
- **Configuration**: `BRAVE_API_KEY` environment variable, or via `hermes tools` setup

## Configuration

```yaml
# ~/.hermes/config.yaml
web:
  backend: brave
```

```bash
# ~/.hermes/.env
BRAVE_API_KEY=***
```

Get an API key from https://brave.com/search/api/

## Backend Priority

The fallback order when no backend is explicitly configured:
`firecrawl > parallel > tavily > brave > exa`

## Related

- Closes #6106
- Alternative implementation to #4372 with cleaner extraction fallback logic