### PR TITLE
fix(gateway): preserve venv python in systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -753,12 +753,13 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
     current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    raw_path = Path(path).expanduser()
+    absolute = raw_path if raw_path.is_absolute() else (Path.cwd() / raw_path)
     try:
-        relative = resolved.relative_to(current_home)
+        relative = absolute.relative_to(current_home)
         return str(Path(target_home_dir) / relative)
     except ValueError:
-        return str(resolved)
+        return str(absolute)
 
 
 def _hermes_home_for_target_user(target_home_dir: str) -> str:


### PR DESCRIPTION
## Summary
- preserve the project venv Python entrypoint when generating the systemd system service unit
- avoid resolving the venv interpreter symlink to the underlying base interpreter

## Problem
The generated system service unit could point at the underlying uv-managed interpreter instead of the project venv entrypoint. That can bypass the expected environment and break startup with missing dependencies.

## Testing
- generated the systemd unit locally and verified the Python path stays on the project venv entrypoint
- verified the existing home-prefix remapping behavior remains unchanged for other paths