### PR TITLE
fix(cli): sync api_mode when switching custom providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1955,6 +1955,11 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    api_mode = (provider_info.get("api_mode") or "").strip()
+    if api_mode:
+        model["api_mode"] = api_mode
+    else:
+        model.pop("api_mode", None)
     save_config(cfg)
     deactivate_provider()
 

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -122,3 +122,60 @@ class TestCustomProviderModelSwitch:
         model = config.get("model")
         assert isinstance(model, dict)
         assert model["default"] == "model-X"
+
+
+    def test_named_custom_provider_applies_api_mode(self, config_home):
+        """Selecting a named custom provider should copy its api_mode into model config."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        provider_info = {
+            "name": "Anthropic-compatible Gateway",
+            "base_url": "https://claude.example.com/v1",
+            "api_key": "sk-test",
+            "api_mode": "anthropic_messages",
+            "model": "claude-sonnet",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["claude-sonnet"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model["api_mode"] == "anthropic_messages"
+
+    def test_named_custom_provider_without_api_mode_clears_stale_value(self, config_home):
+        """Switching providers without api_mode should remove any stale model.api_mode."""
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        (config_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom\n"
+            "  base_url: https://old.example.com/v1\n"
+            "  api_mode: anthropic_messages\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "OpenAI-compatible Gateway",
+            "base_url": "https://openai.example.com/v1",
+            "api_key": "sk-test",
+            "model": "model-a",
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["model-a"]), \
+             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert "api_mode" not in model


### PR DESCRIPTION
## What does this PR do?

Fixes named custom provider switching so `model.api_mode` in `config.yaml` is updated to match the selected `custom_providers` entry.

Previously `_model_flow_named_custom()` wrote `provider`, `base_url`, and `api_key`, but ignored `custom_providers[].api_mode`. This left stale values behind when switching between custom endpoints with different protocols.

## Related Issue

Fixes #8181

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py`
  - copy `provider_info["api_mode"]` into `model["api_mode"]` when present
  - clear stale `model["api_mode"]` when the selected custom provider has no explicit `api_mode`
- `tests/hermes_cli/test_custom_provider_model_switch.py`
  - added regression test for applying `anthropic_messages`
  - added regression test for clearing a stale `api_mode`

## How to Test

1. Configure two custom providers with different API modes.
2. Run `hermes model` and switch between them.
3. Verify `~/.hermes/config.yaml` updates `model.api_mode` to match the selected provider, or removes it when the provider does not specify one.

Or run:
```bash
python -m pytest tests/hermes_cli/test_custom_provider_model_switch.py -q -n0
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run relevant pytest coverage locally
- [x] I've added tests for my changes
- [x] I've tested on my platform:
  - macOS

### Documentation & Housekeeping
- [x] I've considered cross-platform impact (logic-only Python change)
- [x] N/A — no docs/config schema changes
- [x] N/A — no tool schema changes
