### PR TITLE
fix(cli): show full messaging platform list in config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2795,11 +2795,25 @@ def show_config():
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
     
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
+    platforms = {
+        "Telegram": "TELEGRAM_BOT_TOKEN",
+        "Discord": "DISCORD_BOT_TOKEN",
+        "WhatsApp": "WHATSAPP_ENABLED",
+        "Signal": "SIGNAL_HTTP_URL",
+        "Slack": "SLACK_BOT_TOKEN",
+        "Email": "EMAIL_ADDRESS",
+        "SMS": "TWILIO_ACCOUNT_SID",
+        "DingTalk": "DINGTALK_CLIENT_ID",
+        "Feishu": "FEISHU_APP_ID",
+        "WeCom": "WECOM_BOT_ID",
+        "WeCom Callback": "WECOM_CALLBACK_CORP_ID",
+        "Weixin": "WEIXIN_ACCOUNT_ID",
+        "BlueBubbles": "BLUEBUBBLES_SERVER_URL",
+    }
+
+    for name, env_var in platforms.items():
+        configured = get_env_value(env_var)
+        print(f"  {name:16s} {'configured' if configured else color('not configured', Colors.DIM)}")
     
     # Skill config
     try:

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -46,3 +46,19 @@ def test_setup_summary_marks_placeholders(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "hermes config set <key> <value>" in out
+
+
+
+def test_show_config_lists_extended_messaging_platforms(tmp_path, capsys):
+    env = {
+        "HERMES_HOME": str(tmp_path),
+        "FEISHU_APP_ID": "app-id",
+        "SLACK_BOT_TOKEN": "xoxb-test",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "Feishu" in out
+    assert "Slack" in out
+    assert "WhatsApp" in out


### PR DESCRIPTION
## What does this PR do?

Makes `hermes config` show the same messaging platform list as `hermes status` instead of only Telegram and Discord.

Previously the config view omitted platforms like Feishu, Slack, Signal, WeCom, and others, which could make configured gateways appear missing.

## Related Issue

Fixes #8175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py`
  - expanded the `Messaging Platforms` section to include the broader platform set already surfaced by `hermes status`
- `tests/hermes_cli/test_placeholder_usage.py`
  - added coverage that `show_config()` now includes extended gateway platforms such as Feishu, Slack, and WhatsApp

## How to Test

1. Run `hermes config`.
2. Verify the `Messaging Platforms` section now includes the broader set of platforms instead of only Telegram and Discord.

Or run:
```bash
python -m pytest tests/hermes_cli/test_placeholder_usage.py -q -n0
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run relevant pytest coverage locally
- [x] I've added tests for my changes
- [x] I've tested on my platform:
  - macOS

### Documentation & Housekeeping
- [x] I've considered cross-platform impact (output-only Python change)
- [x] N/A — no docs/config schema changes
- [x] N/A — no tool schema changes
