### PR TITLE
feat(cli): add cron model override flags

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -90,6 +90,9 @@ def cron_list(show_all: bool = False):
         print(f"    Deliver:   {deliver_str}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
+        model = job.get("model")
+        if model:
+            print(f"    Model:     {model}")
         script = job.get("script")
         if script:
             print(f"    Script:    {script}")
@@ -168,6 +171,7 @@ def cron_create(args):
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         script=getattr(args, "script", None),
+        model=getattr(args, "model", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -178,6 +182,8 @@ def cron_create(args):
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
     job_data = result.get("job", {})
+    if job_data.get("model"):
+        print(f"  Model: {job_data['model']}")
     if job_data.get("script"):
         print(f"  Script: {job_data['script']}")
     print(f"  Next run: {result['next_run_at']}")
@@ -218,6 +224,7 @@ def cron_edit(args):
         repeat=getattr(args, "repeat", None),
         skills=final_skills,
         script=getattr(args, "script", None),
+        model=getattr(args, "model", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -231,6 +238,8 @@ def cron_edit(args):
         print(f"  Skills: {', '.join(updated['skills'])}")
     else:
         print("  Skills: none")
+    if updated.get("model"):
+        print(f"  Model: {updated['model']}")
     if updated.get("script"):
         print(f"  Script: {updated['script']}")
     return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4831,6 +4831,7 @@ For more help on a command:
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument("--skill", dest="skills", action="append", help="Attach a skill. Repeat to add multiple skills.")
     cron_create.add_argument("--script", help="Path to a Python script whose stdout is injected into the prompt each run")
+    cron_create.add_argument("--model", help="Optional per-job model override")
 
     # cron edit
     cron_edit = cron_subparsers.add_parser("edit", help="Edit an existing scheduled job")
@@ -4845,6 +4846,7 @@ For more help on a command:
     cron_edit.add_argument("--remove-skill", dest="remove_skills", action="append", help="Remove a specific attached skill. Repeatable.")
     cron_edit.add_argument("--clear-skills", action="store_true", help="Remove all attached skills from the job")
     cron_edit.add_argument("--script", help="Path to a Python script whose stdout is injected into the prompt each run. Pass empty string to clear.")
+    cron_edit.add_argument("--model", help="Optional per-job model override. Pass empty string to clear.")
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -56,6 +56,7 @@ class TestCronCommandLifecycle:
                 skill=None,
                 skills=["find-nearby", "blogwatcher"],
                 clear_skills=False,
+                model="anthropic/claude-sonnet-4.6",
             )
         )
         updated = get_job(job["id"])
@@ -63,6 +64,7 @@ class TestCronCommandLifecycle:
         assert updated["name"] == "Edited Job"
         assert updated["prompt"] == "Revised prompt"
         assert updated["schedule_display"] == "every 120m"
+        assert updated["model"] == "anthropic/claude-sonnet-4.6"
 
         cron_command(
             Namespace(
@@ -76,11 +78,13 @@ class TestCronCommandLifecycle:
                 skill=None,
                 skills=None,
                 clear_skills=True,
+                model="",
             )
         )
         cleared = get_job(job["id"])
         assert cleared["skills"] == []
         assert cleared["skill"] is None
+        assert cleared["model"] is None
 
         out = capsys.readouterr().out
         assert "Updated job" in out
@@ -96,12 +100,24 @@ class TestCronCommandLifecycle:
                 repeat=None,
                 skill=None,
                 skills=["blogwatcher", "find-nearby"],
+                model="openai/gpt-5.4-mini",
             )
         )
         out = capsys.readouterr().out
         assert "Created job" in out
+        assert "Model: openai/gpt-5.4-mini" in out
 
         jobs = list_jobs()
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "find-nearby"]
         assert jobs[0]["name"] == "Skill combo"
+        assert jobs[0]["model"] == "openai/gpt-5.4-mini"
+
+    def test_list_shows_job_model(self, tmp_cron_dir, capsys):
+        create_job(prompt="Check status", schedule="every 1h", model="openai/gpt-5.4-mini")
+
+        cron_command(Namespace(cron_command="list", all=False))
+
+        out = capsys.readouterr().out
+        assert "Model:" in out
+        assert "openai/gpt-5.4-mini" in out

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -38,6 +38,7 @@ Cron-run sessions cannot recursively create more cron jobs. Hermes disables cron
 ```bash
 hermes cron create "every 2h" "Check server status"
 hermes cron create "every 1h" "Summarize new feed items" --skill blogwatcher
+hermes cron create "every 1h" "Run with a pinned model" --model openai/gpt-5.4-mini
 hermes cron create "every 1h" "Use both skills and combine the result" \
   --skill blogwatcher \
   --skill find-nearby \
@@ -105,6 +106,7 @@ You do not need to delete and recreate jobs just to change them.
 ```bash
 hermes cron edit <job_id> --schedule "every 4h"
 hermes cron edit <job_id> --prompt "Use the revised task"
+hermes cron edit <job_id> --model anthropic/claude-sonnet-4.6
 hermes cron edit <job_id> --skill blogwatcher --skill find-nearby
 hermes cron edit <job_id> --add-skill find-nearby
 hermes cron edit <job_id> --remove-skill blogwatcher


### PR DESCRIPTION
## What does this PR do?

Adds `--model` support to `hermes cron create` and `hermes cron edit`, and surfaces the configured model in CLI output.

The cronjob tool already supports per-job model overrides, but the standalone CLI subcommands did not expose that capability.

## Related Issue

Fixes #8207

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- `hermes_cli/main.py`
  - added `--model` to `hermes cron create`
  - added `--model` to `hermes cron edit`
- `hermes_cli/cron.py`
  - pass `model` through to the cronjob tool on create/update
  - show `Model:` in create/edit/list output when a per-job override exists
- `tests/hermes_cli/test_cron.py`
  - added coverage for creating jobs with a model override
  - added coverage for editing/clearing a job model override
  - added coverage for list output including the model
- `website/docs/user-guide/features/cron.md`
  - documented `--model` examples for create/edit

## How to Test

1. Create a cron job with a pinned model:
   ```bash
   hermes cron create "every 1h" "Run a task" --model openai/gpt-5.4-mini
   ```
2. Edit an existing job to change the model:
   ```bash
   hermes cron edit <job_id> --model anthropic/claude-sonnet-4.6
   ```
3. Run `hermes cron list` and verify the model is shown for jobs that have an override.

Or run:
```bash
python -m pytest tests/hermes_cli/test_cron.py -q -n0
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run relevant pytest coverage locally
- [x] I've added tests for my changes
- [x] I've tested on my platform:
  - macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation
- [x] N/A — no config schema changes
- [x] I've considered cross-platform impact
- [x] N/A — no tool schema changes
