### PR TITLE
feat(gateway): add native iMessage platform adapter via imsg CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, iMessage, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -66,7 +66,7 @@ hermes doctor       # Diagnose any issues
 
 ## CLI vs Messaging Quick Reference
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
+Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
 
 | Action | CLI | Messaging platforms |
 |---------|-----|---------------------|
@@ -93,7 +93,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, iMessage, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -364,6 +364,14 @@ PLATFORM_HINTS = {
         "documents. You can also include image URLs in markdown format ![alt](url) and they "
         "will be downloaded and sent as native media when possible."
     ),
+    "imessage": (
+        "You are on a text messaging communication platform, iMessage. "
+        "Please do not use markdown as it does not render. "
+        "You can send media files natively: to deliver a file to the user, "
+        "include MEDIA:/absolute/path/to/file in your response. Images "
+        "(.png, .jpg, .webp) appear as photos, videos (.mp4) play inline, "
+        "and other files arrive as downloadable attachments."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
-    "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
+    "wecom", "wecom_callback", "weixin", "imessage", "sms", "email", "webhook", "bluebubbles",
 })
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
@@ -254,6 +254,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
         "bluebubbles": Platform.BLUEBUBBLES,
+        "imessage": Platform.IMESSAGE,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -66,6 +66,7 @@ class Platform(Enum):
     WECOM_CALLBACK = "wecom_callback"
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
+    IMESSAGE = "imessage"
 
 
 @dataclass
@@ -302,6 +303,9 @@ class GatewayConfig:
                 connected.append(platform)
             # BlueBubbles uses extra dict for local server config
             elif platform == Platform.BLUEBUBBLES and config.extra.get("server_url") and config.extra.get("password"):
+                connected.append(platform)
+            # iMessage uses enabled flag only (macOS system permissions handle auth)
+            elif platform == Platform.IMESSAGE:
                 connected.append(platform)
         return connected
     
@@ -1072,6 +1076,25 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             platform=Platform.BLUEBUBBLES,
             chat_id=bluebubbles_home,
             name=os.getenv("BLUEBUBBLES_HOME_CHANNEL_NAME", "Home"),
+        )
+
+    # iMessage (macOS only, uses imsg CLI)
+    imessage_enabled = os.getenv("IMESSAGE_ENABLED", "").lower() in ("true", "1", "yes")
+    if imessage_enabled:
+        if Platform.IMESSAGE not in config.platforms:
+            config.platforms[Platform.IMESSAGE] = PlatformConfig()
+        config.platforms[Platform.IMESSAGE].enabled = True
+        watch_chat_ids = os.getenv("IMESSAGE_WATCH_CHAT_IDS", "")
+        if watch_chat_ids:
+            config.platforms[Platform.IMESSAGE].extra["watch_chat_ids"] = [
+                cid.strip() for cid in watch_chat_ids.split(",") if cid.strip()
+            ]
+    imessage_home = os.getenv("IMESSAGE_HOME_CHANNEL")
+    if imessage_home and Platform.IMESSAGE in config.platforms:
+        config.platforms[Platform.IMESSAGE].home_channel = HomeChannel(
+            platform=Platform.IMESSAGE,
+            chat_id=imessage_home,
+            name=os.getenv("IMESSAGE_HOME_CHANNEL_NAME", "Home"),
         )
 
     # Session settings

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1089,6 +1089,17 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.IMESSAGE].extra["watch_chat_ids"] = [
                 cid.strip() for cid in watch_chat_ids.split(",") if cid.strip()
             ]
+        # Watch mode: fsevents (default imsg watch), poll (DB polling), auto (try fsevents, fallback)
+        watch_mode = os.getenv("IMESSAGE_WATCH_MODE", "auto").lower()
+        if watch_mode in ("fsevents", "poll", "auto"):
+            config.platforms[Platform.IMESSAGE].extra["watch_mode"] = watch_mode
+        # Poll interval in seconds (for poll/auto modes)
+        poll_interval = os.getenv("IMESSAGE_POLL_INTERVAL")
+        if poll_interval:
+            try:
+                config.platforms[Platform.IMESSAGE].extra["poll_interval"] = float(poll_interval)
+            except ValueError:
+                pass
     imessage_home = os.getenv("IMESSAGE_HOME_CHANNEL")
     if imessage_home and Platform.IMESSAGE in config.platforms:
         config.platforms[Platform.IMESSAGE].home_channel = HomeChannel(

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -42,6 +42,9 @@ HEALTH_CHECK_STALE_THRESHOLD = 120.0
 CACHE_REFRESH_INTERVAL = 300.0  # 5 minutes
 DEDUP_TTL = 300.0  # 5 minutes
 DEDUP_MAX_SIZE = 2000
+POLL_INTERVAL_DEFAULT = 3.0  # seconds between DB polls
+POLL_COLLECT_TIMEOUT = 2.0  # seconds to wait for imsg watch --since-rowid output
+AUTO_FALLBACK_THRESHOLD = 30.0  # seconds: switch from fsevents to poll if no output
 
 # Phone number pattern for redaction
 _PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
@@ -103,6 +106,13 @@ class IMessageAdapter(BasePlatformAdapter):
         # Config
         self._watch_chat_ids: List[str] = config.extra.get("watch_chat_ids", [])
 
+        # Watch mode: "fsevents" | "poll" | "auto"
+        # auto = try fsevents, fall back to poll if no output detected
+        self._watch_mode: str = config.extra.get("watch_mode", "auto")
+        self._poll_interval: float = config.extra.get(
+            "poll_interval", POLL_INTERVAL_DEFAULT
+        )
+
         # Background tasks
         self._watch_task: Optional[asyncio.Task] = None
         self._health_monitor_task: Optional[asyncio.Task] = None
@@ -123,6 +133,9 @@ class IMessageAdapter(BasePlatformAdapter):
 
         # Health tracking
         self._last_message_time: float = time.monotonic()
+
+        # Poll mode state: highest message rowid seen
+        self._last_rowid: int = 0
 
     async def connect(self) -> bool:
         """Verify imsg available, load chat cache, start background tasks."""
@@ -167,14 +180,27 @@ class IMessageAdapter(BasePlatformAdapter):
 
         self._running = True
 
-        # Start background tasks
-        self._watch_task = asyncio.ensure_future(self._watch_listener())
+        # Seed last_rowid so poll mode only sees new messages
+        await self._seed_last_rowid()
+
+        # Choose listener based on watch_mode
+        if self._watch_mode == "poll":
+            self._watch_task = asyncio.ensure_future(self._poll_listener())
+            mode_label = "poll"
+        elif self._watch_mode == "fsevents":
+            self._watch_task = asyncio.ensure_future(self._watch_listener())
+            mode_label = "fsevents"
+        else:  # auto
+            self._watch_task = asyncio.ensure_future(self._auto_watch_listener())
+            mode_label = "auto"
+
         self._health_monitor_task = asyncio.ensure_future(self._health_monitor())
         self._cache_refresh_task = asyncio.ensure_future(self._cache_refresh_loop())
 
         logger.info(
-            "iMessage: connected — watching %s chats, cache has %d entries",
+            "iMessage: connected — watching %s chats (%s mode), cache has %d entries",
             "all" if not self._watch_chat_ids else len(self._watch_chat_ids),
+            mode_label,
             len(self._chat_cache),
         )
         return True
@@ -280,6 +306,190 @@ class IMessageAdapter(BasePlatformAdapter):
             logger.info("iMessage: reconnecting in %.1fs", wait)
             await asyncio.sleep(wait)
             retry_delay = min(retry_delay * 2, WATCH_RETRY_DELAY_MAX)
+
+    # -----------------------------------------------------------------------
+    # Inbound: poll listener (fallback for broken FSEvents)
+    # -----------------------------------------------------------------------
+
+    async def _seed_last_rowid(self) -> None:
+        """Get the current highest message rowid so poll mode starts from now.
+
+        Uses the most recent chat's latest message as the high-water mark.
+        imsg history requires --chat-id, so we first find the most recent chat.
+        """
+        try:
+            # Find most recent chat
+            if not self._chat_cache:
+                return
+            # Pick the first chat (we don't know which is newest without sorting,
+            # but any chat gives us a reasonable high-water mark)
+            chat_id = next(iter(self._chat_cache))
+
+            proc = await asyncio.create_subprocess_exec(
+                "imsg", "history", "--json", "--limit", "1",
+                "--chat-id", str(chat_id),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            if proc.returncode == 0:
+                line = stdout.decode("utf-8", errors="replace").strip().split("\n")[0]
+                if line:
+                    data = json.loads(line)
+                    self._last_rowid = data.get("id", 0)
+                    logger.debug("iMessage: seeded last_rowid=%d", self._last_rowid)
+        except Exception as e:
+            logger.debug("iMessage: could not seed last_rowid: %s", e)
+
+    async def _poll_once(self) -> int:
+        """Run a short-lived `imsg watch --since-rowid` to fetch new messages.
+
+        Returns the number of messages processed.
+        """
+        count = 0
+        try:
+            cmd = ["imsg", "watch", "--json", "--attachments",
+                   "--since-rowid", str(self._last_rowid)]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            # Read the catchup dump (messages since last_rowid), then kill
+            try:
+                lines: List[str] = []
+                while True:
+                    try:
+                        line = await asyncio.wait_for(
+                            proc.stdout.readline(), timeout=POLL_COLLECT_TIMEOUT,
+                        )
+                    except asyncio.TimeoutError:
+                        break  # No more catchup output — done
+                    if not line:
+                        break  # EOF
+                    line_str = line.decode("utf-8", errors="replace").strip()
+                    if line_str:
+                        lines.append(line_str)
+            finally:
+                # Always kill the subprocess — we only want the catchup dump
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except (ProcessLookupError, OSError):
+                    pass
+
+            # Process collected messages
+            for line_str in lines:
+                try:
+                    data = json.loads(line_str)
+                    rowid = data.get("id", 0)
+                    if rowid > self._last_rowid:
+                        self._last_rowid = rowid
+                    self._last_message_time = time.monotonic()
+                    await self._handle_message_data(data)
+                    count += 1
+                except json.JSONDecodeError:
+                    pass
+                except Exception as e:
+                    logger.warning("iMessage: poll error handling message: %s", e)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("iMessage: poll error: %s", e)
+
+        return count
+
+    async def _poll_listener(self) -> None:
+        """Poll-based inbound loop: periodic short-lived imsg watch calls."""
+        logger.info(
+            "iMessage: poll mode — checking every %.1fs (since rowid %d)",
+            self._poll_interval, self._last_rowid,
+        )
+        while self._running:
+            try:
+                await asyncio.sleep(self._poll_interval)
+                if not self._running:
+                    return
+                await self._poll_once()
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.warning("iMessage: poll listener error: %s", e)
+
+    async def _auto_watch_listener(self) -> None:
+        """Auto mode: start with FSEvents, fall back to poll if no output."""
+        logger.info("iMessage: auto mode — trying FSEvents first")
+
+        # Start FSEvents watch
+        cmd = ["imsg", "watch", "--json", "--attachments"]
+        self._watch_process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        logger.info("iMessage: started imsg watch (pid=%s)", self._watch_process.pid)
+
+        # Wait for first output or timeout
+        got_output = False
+        deadline = time.monotonic() + AUTO_FALLBACK_THRESHOLD
+
+        while self._running and time.monotonic() < deadline:
+            try:
+                line = await asyncio.wait_for(
+                    self._watch_process.stdout.readline(),
+                    timeout=min(5.0, deadline - time.monotonic()),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                return
+
+            if not line:
+                break  # EOF — process exited
+
+            line_str = line.decode("utf-8", errors="replace").strip()
+            if not line_str:
+                continue
+
+            try:
+                data = json.loads(line_str)
+                self._last_message_time = time.monotonic()
+                await self._handle_message_data(data)
+                got_output = True
+                break  # FSEvents works — switch to full watch mode
+            except json.JSONDecodeError:
+                pass
+
+        if got_output:
+            # FSEvents works — continue with the normal watch listener loop
+            logger.info("iMessage: FSEvents working — staying in watch mode")
+            # Kill this process and hand off to the full watch listener
+            try:
+                self._watch_process.kill()
+                await self._watch_process.wait()
+            except (ProcessLookupError, OSError):
+                pass
+            await self._watch_listener()
+        else:
+            # No output — fall back to poll mode
+            logger.warning(
+                "iMessage: no FSEvents output after %.0fs — switching to poll mode "
+                "(every %.1fs). Set IMESSAGE_WATCH_MODE=poll to skip this probe.",
+                AUTO_FALLBACK_THRESHOLD, self._poll_interval,
+            )
+            try:
+                self._watch_process.kill()
+                await self._watch_process.wait()
+            except (ProcessLookupError, OSError):
+                pass
+            self._watch_process = None
+            await self._poll_listener()
+
+    # -----------------------------------------------------------------------
+    # Inbound: message handling
+    # -----------------------------------------------------------------------
 
     async def _handle_message_data(self, data: dict) -> None:
         """Process a single JSON message from imsg watch."""

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -1,0 +1,642 @@
+"""iMessage platform adapter.
+
+Listens for incoming iMessages via `imsg watch` subprocess and sends
+replies via `imsg send`. Requires macOS and the `imsg` CLI tool
+(brew install steipete/tap/imsg).
+
+Architecture: subprocess-based listener, similar to the Signal adapter's
+SSE streaming pattern with exponential backoff restart.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import random
+import re
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_MESSAGE_LENGTH = 8000
+WATCH_RETRY_DELAY_INITIAL = 2.0
+WATCH_RETRY_DELAY_MAX = 60.0
+HEALTH_CHECK_INTERVAL = 30.0
+HEALTH_CHECK_STALE_THRESHOLD = 120.0
+CACHE_REFRESH_INTERVAL = 300.0  # 5 minutes
+DEDUP_TTL = 300.0  # 5 minutes
+DEDUP_MAX_SIZE = 2000
+
+# Phone number pattern for redaction
+_PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
+# Apple ID (email) pattern for redaction
+_APPLEID_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def check_imessage_requirements() -> bool:
+    """Check if iMessage adapter can run: macOS + imsg CLI available."""
+    if sys.platform != "darwin":
+        logger.debug("iMessage: not macOS (platform=%s)", sys.platform)
+        return False
+    if not shutil.which("imsg"):
+        logger.debug("iMessage: imsg CLI not found in PATH")
+        return False
+    return True
+
+
+def _redact_imessage_id(identifier: str) -> str:
+    """Redact phone numbers and Apple IDs for logging."""
+    if not identifier:
+        return "<none>"
+    # Phone number: +15551234567 -> +155****4567
+    if identifier.startswith("+"):
+        if len(identifier) <= 8:
+            return identifier[:2] + "****" + identifier[-2:] if len(identifier) > 4 else "****"
+        return identifier[:4] + "****" + identifier[-4:]
+    # Apple ID email: user@example.com -> us****@example.com
+    if "@" in identifier:
+        local, domain = identifier.split("@", 1)
+        if len(local) <= 2:
+            return "****@" + domain
+        return local[:2] + "****@" + domain
+    return identifier
+
+
+def _parse_comma_list(value: str) -> List[str]:
+    """Split a comma-separated string into a list, stripping whitespace."""
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class IMessageAdapter(BasePlatformAdapter):
+    """iMessage gateway adapter using the imsg CLI."""
+
+    platform = Platform.IMESSAGE
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.IMESSAGE)
+
+        # Config
+        self._watch_chat_ids: List[str] = config.extra.get("watch_chat_ids", [])
+
+        # Background tasks
+        self._watch_task: Optional[asyncio.Task] = None
+        self._health_monitor_task: Optional[asyncio.Task] = None
+        self._cache_refresh_task: Optional[asyncio.Task] = None
+
+        # Subprocess
+        self._watch_process: Optional[asyncio.subprocess.Process] = None
+        self._running = False
+
+        # Chat cache: maps numeric chat_id -> {identifier, name, service}
+        self._chat_cache: Dict[int, dict] = {}
+
+        # Dedup: guid -> timestamp
+        self._seen_messages: Dict[str, float] = {}
+
+        # Track own sends to filter echo-backs
+        self._recent_sent_ids: set = set()
+
+        # Health tracking
+        self._last_message_time: float = time.monotonic()
+
+    async def connect(self) -> bool:
+        """Verify imsg available, load chat cache, start background tasks."""
+        if not check_imessage_requirements():
+            self._set_fatal_error(
+                "IMESSAGE_REQUIREMENTS",
+                "iMessage requires macOS and the imsg CLI. "
+                "Install: brew install steipete/tap/imsg",
+                retryable=False,
+            )
+            return False
+
+        # Health check: verify imsg can run and has permissions
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "imsg", "chats", "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
+            if proc.returncode != 0:
+                err = (stderr.decode("utf-8", errors="replace").strip()
+                       or stdout.decode("utf-8", errors="replace").strip())
+                msg = (
+                    f"imsg chats failed (exit {proc.returncode}): {err}. "
+                    "Ensure Full Disk Access is granted to your terminal."
+                )
+                self._set_fatal_error("IMESSAGE_PERMISSION", msg, retryable=True)
+                logger.error("iMessage: %s", msg)
+                return False
+            self._parse_chat_list(stdout.decode("utf-8", errors="replace"))
+        except asyncio.TimeoutError:
+            msg = "imsg chats timed out — check Full Disk Access permissions"
+            self._set_fatal_error("IMESSAGE_TIMEOUT", msg, retryable=True)
+            logger.error("iMessage: %s", msg)
+            return False
+        except Exception as e:
+            msg = f"imsg chats failed: {e}"
+            self._set_fatal_error("IMESSAGE_ERROR", msg, retryable=True)
+            logger.error("iMessage: %s", msg)
+            return False
+
+        self._running = True
+
+        # Start background tasks
+        self._watch_task = asyncio.ensure_future(self._watch_listener())
+        self._health_monitor_task = asyncio.ensure_future(self._health_monitor())
+        self._cache_refresh_task = asyncio.ensure_future(self._cache_refresh_loop())
+
+        logger.info(
+            "iMessage: connected — watching %s chats, cache has %d entries",
+            "all" if not self._watch_chat_ids else len(self._watch_chat_ids),
+            len(self._chat_cache),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop all background tasks and terminate subprocess."""
+        self._running = False
+
+        # Cancel tasks
+        for task in (self._watch_task, self._health_monitor_task, self._cache_refresh_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        # Terminate subprocess
+        if self._watch_process and self._watch_process.returncode is None:
+            try:
+                self._watch_process.terminate()
+                try:
+                    await asyncio.wait_for(self._watch_process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    self._watch_process.kill()
+                    await self._watch_process.wait()
+            except ProcessLookupError:
+                pass
+
+        self._watch_task = None
+        self._health_monitor_task = None
+        self._cache_refresh_task = None
+        self._watch_process = None
+        logger.info("iMessage: disconnected")
+
+    # -----------------------------------------------------------------------
+    # Inbound: watch listener
+    # -----------------------------------------------------------------------
+
+    async def _watch_listener(self) -> None:
+        """Core inbound loop: run `imsg watch` and process JSON lines."""
+        retry_delay = WATCH_RETRY_DELAY_INITIAL
+
+        while self._running:
+            try:
+                cmd = ["imsg", "watch", "--json", "--attachments"]
+                self._watch_process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                logger.info("iMessage: started imsg watch (pid=%s)", self._watch_process.pid)
+                retry_delay = WATCH_RETRY_DELAY_INITIAL  # Reset on successful start
+
+                while self._running:
+                    try:
+                        line = await asyncio.wait_for(
+                            self._watch_process.stdout.readline(),
+                            timeout=HEALTH_CHECK_STALE_THRESHOLD,
+                        )
+                    except asyncio.TimeoutError:
+                        # No output for a while — process may be stuck
+                        logger.debug("iMessage: no output for %.0fs, continuing", HEALTH_CHECK_STALE_THRESHOLD)
+                        continue
+
+                    if not line:
+                        # EOF — process exited
+                        break
+
+                    line_str = line.decode("utf-8", errors="replace").strip()
+                    if not line_str:
+                        continue
+
+                    try:
+                        data = json.loads(line_str)
+                        self._last_message_time = time.monotonic()
+                        await self._handle_message_data(data)
+                    except json.JSONDecodeError:
+                        logger.debug("iMessage: non-JSON line: %s", line_str[:200])
+                    except Exception as e:
+                        logger.warning("iMessage: error handling message: %s", e)
+
+                # Process exited
+                rc = self._watch_process.returncode
+                if rc is None:
+                    try:
+                        rc = await self._watch_process.wait()
+                    except Exception:
+                        rc = -1
+                logger.warning("iMessage: imsg watch exited (code=%s)", rc)
+
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.error("iMessage: watch listener error: %s", e)
+
+            if not self._running:
+                return
+
+            # Exponential backoff with jitter
+            jitter = retry_delay * 0.2 * random.random()
+            wait = retry_delay + jitter
+            logger.info("iMessage: reconnecting in %.1fs", wait)
+            await asyncio.sleep(wait)
+            retry_delay = min(retry_delay * 2, WATCH_RETRY_DELAY_MAX)
+
+    async def _handle_message_data(self, data: dict) -> None:
+        """Process a single JSON message from imsg watch."""
+        # Filter self-messages
+        if data.get("is_from_me"):
+            return
+
+        # Dedup by guid
+        guid = data.get("guid", "")
+        if guid and self._is_duplicate(guid):
+            return
+
+        # Filter by configured watch_chat_ids
+        chat_id = data.get("chat_id")
+        if self._watch_chat_ids and str(chat_id) not in self._watch_chat_ids:
+            return
+
+        # Resolve chat metadata
+        chat_meta = self._chat_cache.get(int(chat_id)) if chat_id is not None else None
+        if chat_meta is None and chat_id is not None:
+            # Cache miss — refresh and retry
+            await self._refresh_chat_cache()
+            chat_meta = self._chat_cache.get(int(chat_id))
+
+        # Build source info
+        sender = data.get("sender", "")
+        chat_identifier = ""
+        chat_name = ""
+        service = data.get("service", "iMessage")
+
+        if chat_meta:
+            chat_identifier = chat_meta.get("identifier", "")
+            chat_name = chat_meta.get("name", "") or chat_identifier
+        else:
+            chat_identifier = str(chat_id) if chat_id is not None else ""
+            chat_name = chat_identifier
+
+        # Use sender as user_id; chat_identifier as chat_id for routing
+        effective_chat_id = chat_identifier or str(chat_id or "")
+        user_id = sender or effective_chat_id
+
+        # Determine chat type
+        is_group = data.get("is_group", False)
+        chat_type = "group" if is_group else "dm"
+
+        source = self.build_source(
+            chat_id=effective_chat_id,
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=user_id,
+            user_name=sender,
+            user_id_alt=sender,
+            chat_id_alt=str(chat_id) if chat_id is not None else None,
+        )
+
+        # Extract text
+        text = data.get("text", "") or ""
+
+        # Process attachments
+        media_urls = []
+        media_types = []
+        attachments = data.get("attachments", [])
+        for att in attachments:
+            path = att.get("path", "")
+            if path and os.path.exists(path):
+                mime = att.get("mime_type", "")
+                media_urls.append(path)
+                media_types.append(mime or "application/octet-stream")
+
+        # Determine message type
+        if media_urls and not text:
+            msg_type = MessageType.PHOTO if any(
+                mt.startswith("image/") for mt in media_types
+            ) else MessageType.DOCUMENT
+        else:
+            msg_type = MessageType.TEXT
+
+        # Build timestamp
+        timestamp = None
+        ts = data.get("date")
+        if ts:
+            try:
+                timestamp = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+            except (ValueError, TypeError, OSError):
+                pass
+
+        event = MessageEvent(
+            source=source,
+            text=text,
+            message_type=msg_type,
+            media_urls=media_urls if media_urls else None,
+            media_types=media_types if media_types else None,
+            timestamp=timestamp,
+        )
+
+        logger.info(
+            "iMessage: received from %s in %s: %s",
+            _redact_imessage_id(sender),
+            _redact_imessage_id(chat_name),
+            text[:80] if text else "[media]",
+        )
+        await self.handle_message(event)
+
+    # -----------------------------------------------------------------------
+    # Deduplication
+    # -----------------------------------------------------------------------
+
+    def _is_duplicate(self, guid: str) -> bool:
+        """TTL-based dedup (matches Slack/WeCom pattern)."""
+        now = time.monotonic()
+
+        # Check existing
+        if guid in self._seen_messages:
+            return True
+
+        # Prune expired entries
+        if len(self._seen_messages) >= DEDUP_MAX_SIZE:
+            expired = [k for k, v in self._seen_messages.items() if now - v > DEDUP_TTL]
+            for k in expired:
+                del self._seen_messages[k]
+            # If still over limit, remove oldest
+            if len(self._seen_messages) >= DEDUP_MAX_SIZE:
+                oldest = min(self._seen_messages, key=self._seen_messages.get)
+                del self._seen_messages[oldest]
+
+        self._seen_messages[guid] = now
+        return False
+
+    # -----------------------------------------------------------------------
+    # Chat cache
+    # -----------------------------------------------------------------------
+
+    def _parse_chat_list(self, output: str) -> None:
+        """Parse `imsg chats --json` output into _chat_cache.
+
+        imsg outputs one JSON object per line (NDJSON), not a JSON array.
+        We also handle the JSON-array format for forward compatibility.
+        """
+        # Try JSON array first
+        try:
+            data = json.loads(output)
+            if isinstance(data, list):
+                for chat in data:
+                    self._cache_chat_entry(chat)
+                return
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+        # NDJSON: one JSON object per line
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                chat = json.loads(line)
+                self._cache_chat_entry(chat)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    def _cache_chat_entry(self, chat: dict) -> None:
+        """Store a single chat entry in the cache."""
+        cid = chat.get("id") or chat.get("chat_id")
+        if cid is not None:
+            self._chat_cache[int(cid)] = {
+                "identifier": chat.get("identifier", ""),
+                "name": chat.get("name", "") or chat.get("display_name", ""),
+                "service": chat.get("service", "iMessage"),
+            }
+
+    async def _refresh_chat_cache(self) -> None:
+        """Run `imsg chats --json` and refresh the cache."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "imsg", "chats", "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+            if proc.returncode == 0:
+                self._parse_chat_list(stdout.decode("utf-8", errors="replace"))
+                logger.debug("iMessage: chat cache refreshed (%d entries)", len(self._chat_cache))
+        except Exception as e:
+            logger.warning("iMessage: chat cache refresh failed: %s", e)
+
+    async def _cache_refresh_loop(self) -> None:
+        """Periodically refresh the chat cache."""
+        while self._running:
+            try:
+                await asyncio.sleep(CACHE_REFRESH_INTERVAL)
+                if self._running:
+                    await self._refresh_chat_cache()
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.debug("iMessage: cache refresh loop error: %s", e)
+
+    # -----------------------------------------------------------------------
+    # Health monitor
+    # -----------------------------------------------------------------------
+
+    async def _health_monitor(self) -> None:
+        """Check subprocess liveness periodically."""
+        while self._running:
+            try:
+                await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+                if not self._running:
+                    return
+
+                # Check subprocess alive
+                if self._watch_process and self._watch_process.returncode is not None:
+                    logger.warning("iMessage: watch process not running (code=%s)", self._watch_process.returncode)
+
+                # Check for idle
+                idle_secs = time.monotonic() - self._last_message_time
+                if idle_secs > HEALTH_CHECK_STALE_THRESHOLD:
+                    logger.debug("iMessage: no messages for %.0fs (normal if no one is texting)", idle_secs)
+
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.debug("iMessage: health monitor error: %s", e)
+
+    # -----------------------------------------------------------------------
+    # Outbound: send
+    # -----------------------------------------------------------------------
+
+    def _resolve_recipient(self, chat_id: str) -> str:
+        """Resolve chat_id to a recipient for imsg send.
+
+        If chat_id looks like a phone/email, use directly.
+        Otherwise look up in chat cache. Fallback to chat_id as-is.
+        """
+        if not chat_id:
+            return ""
+
+        # Phone number or email — use directly
+        if chat_id.startswith("+") or "@" in chat_id:
+            return chat_id
+
+        # Try numeric lookup in cache
+        try:
+            cid = int(chat_id)
+            meta = self._chat_cache.get(cid)
+            if meta and meta.get("identifier"):
+                return meta["identifier"]
+        except (ValueError, TypeError):
+            pass
+
+        # Fallback: return as-is
+        return chat_id
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[dict] = None) -> SendResult:
+        """Send a text message via imsg send."""
+        recipient = self._resolve_recipient(chat_id)
+        if not recipient:
+            return SendResult(success=False, error="Could not resolve recipient")
+
+        try:
+            cmd = ["imsg", "send", "--to", recipient, "--text", content]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+
+            if proc.returncode != 0:
+                err = stderr.decode("utf-8", errors="replace").strip()
+                return SendResult(success=False, error=f"imsg send failed (exit {proc.returncode}): {err}")
+
+            logger.info("iMessage: sent to %s", _redact_imessage_id(recipient))
+            return SendResult(success=True)
+
+        except asyncio.TimeoutError:
+            return SendResult(success=False, error="imsg send timed out")
+        except Exception as e:
+            return SendResult(success=False, error=f"imsg send error: {e}")
+
+    async def send_typing(self, chat_id: str, metadata: Optional[dict] = None) -> None:
+        """iMessage doesn't support typing indicators via imsg."""
+        pass
+
+    async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, **kwargs) -> SendResult:
+        """Send an image (by URL — download first, then send as file)."""
+        # For URLs, we'd need to download first. Delegate to send_image_file for local paths.
+        if os.path.exists(image_url):
+            return await self.send_image_file(chat_id, image_url, caption=caption, **kwargs)
+        return SendResult(success=False, error="iMessage send_image only supports local files")
+
+    async def send_image_file(self, chat_id: str, image_path: str, caption: Optional[str] = None, **kwargs) -> SendResult:
+        """Send an image file via imsg send --file."""
+        return await self._send_file(chat_id, image_path, caption=caption)
+
+    async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None, **kwargs) -> SendResult:
+        """Send a document file."""
+        return await self._send_file(chat_id, file_path, caption=caption)
+
+    async def send_voice(self, chat_id: str, audio_path: str, caption: Optional[str] = None, **kwargs) -> SendResult:
+        """Send an audio file."""
+        return await self._send_file(chat_id, audio_path, caption=caption)
+
+    async def send_video(self, chat_id: str, video_path: str, caption: Optional[str] = None, **kwargs) -> SendResult:
+        """Send a video file."""
+        return await self._send_file(chat_id, video_path, caption=caption)
+
+    async def _send_file(self, chat_id: str, file_path: str, caption: Optional[str] = None) -> SendResult:
+        """Send a file via imsg send --file with optional caption."""
+        recipient = self._resolve_recipient(chat_id)
+        if not recipient:
+            return SendResult(success=False, error="Could not resolve recipient")
+
+        if not os.path.exists(file_path):
+            return SendResult(success=False, error=f"File not found: {file_path}")
+
+        try:
+            cmd = ["imsg", "send", "--to", recipient]
+            if caption:
+                cmd.extend(["--text", caption])
+            cmd.extend(["--file", file_path])
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+
+            if proc.returncode != 0:
+                err = stderr.decode("utf-8", errors="replace").strip()
+                return SendResult(success=False, error=f"imsg send file failed (exit {proc.returncode}): {err}")
+
+            logger.info("iMessage: sent file to %s: %s", _redact_imessage_id(recipient), Path(file_path).name)
+            return SendResult(success=True)
+
+        except asyncio.TimeoutError:
+            return SendResult(success=False, error="imsg send file timed out")
+        except Exception as e:
+            return SendResult(success=False, error=f"imsg send file error: {e}")
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        """Return chat metadata."""
+        try:
+            cid = int(chat_id)
+            meta = self._chat_cache.get(cid)
+            if meta:
+                return {
+                    "name": meta.get("name", ""),
+                    "type": "dm",
+                    "chat_id": chat_id,
+                    "identifier": meta.get("identifier", ""),
+                    "service": meta.get("service", "iMessage"),
+                }
+        except (ValueError, TypeError):
+            pass
+
+        return {
+            "name": chat_id,
+            "type": "dm",
+            "chat_id": chat_id,
+        }

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -128,9 +128,6 @@ class IMessageAdapter(BasePlatformAdapter):
         # Dedup: guid -> timestamp
         self._seen_messages: Dict[str, float] = {}
 
-        # Track own sends to filter echo-backs
-        self._recent_sent_ids: set = set()
-
         # Health tracking
         self._last_message_time: float = time.monotonic()
 
@@ -312,34 +309,33 @@ class IMessageAdapter(BasePlatformAdapter):
     # -----------------------------------------------------------------------
 
     async def _seed_last_rowid(self) -> None:
-        """Get the current highest message rowid so poll mode starts from now.
-
-        Uses the most recent chat's latest message as the high-water mark.
-        imsg history requires --chat-id, so we first find the most recent chat.
-        """
-        try:
-            # Find most recent chat
-            if not self._chat_cache:
-                return
-            # Pick the first chat (we don't know which is newest without sorting,
-            # but any chat gives us a reasonable high-water mark)
-            chat_id = next(iter(self._chat_cache))
-
-            proc = await asyncio.create_subprocess_exec(
-                "imsg", "history", "--json", "--limit", "1",
-                "--chat-id", str(chat_id),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-            if proc.returncode == 0:
-                line = stdout.decode("utf-8", errors="replace").strip().split("\n")[0]
-                if line:
-                    data = json.loads(line)
-                    self._last_rowid = data.get("id", 0)
-                    logger.debug("iMessage: seeded last_rowid=%d", self._last_rowid)
-        except Exception as e:
-            logger.debug("iMessage: could not seed last_rowid: %s", e)
+        """Get the current highest message rowid so poll mode starts from now."""
+        if not self._chat_cache:
+            return
+        max_rowid = 0
+        # Sample up to 10 chats to find the highest rowid
+        chat_ids = list(self._chat_cache.keys())[:10]
+        for chat_id in chat_ids:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "imsg", "history", "--json", "--limit", "1",
+                    "--chat-id", str(chat_id),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+                if proc.returncode == 0:
+                    line = stdout.decode("utf-8", errors="replace").strip().split("\n")[0]
+                    if line:
+                        data = json.loads(line)
+                        rowid = data.get("id", 0)
+                        if rowid > max_rowid:
+                            max_rowid = rowid
+            except Exception:
+                continue
+        if max_rowid > 0:
+            self._last_rowid = max_rowid
+            logger.debug("iMessage: seeded last_rowid=%d (sampled %d chats)", max_rowid, len(chat_ids))
 
     async def _poll_once(self) -> int:
         """Run a short-lived `imsg watch --since-rowid` to fetch new messages.
@@ -465,6 +461,10 @@ class IMessageAdapter(BasePlatformAdapter):
         if got_output:
             # FSEvents works — continue with the normal watch listener loop
             logger.info("iMessage: FSEvents working — staying in watch mode")
+            # NOTE: There is a brief gap between killing this probe process and
+            # starting the full watch listener where messages could be missed.
+            # This is an acceptable startup race — only affects the first few
+            # seconds after the auto-detection probe succeeds.
             # Kill this process and hand off to the full watch listener
             try:
                 self._watch_process.kill()

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -13,13 +13,12 @@ import json
 import logging
 import os
 import random
-import re
 import shutil
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -45,11 +44,6 @@ DEDUP_MAX_SIZE = 2000
 POLL_INTERVAL_DEFAULT = 3.0  # seconds between DB polls
 POLL_COLLECT_TIMEOUT = 2.0  # seconds to wait for imsg watch --since-rowid output
 AUTO_FALLBACK_THRESHOLD = 30.0  # seconds: switch from fsevents to poll if no output
-
-# Phone number pattern for redaction
-_PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
-# Apple ID (email) pattern for redaction
-_APPLEID_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1463,6 +1463,7 @@ class GatewayRunner:
                        "WECOM_CALLBACK_ALLOWED_USERS",
                        "WEIXIN_ALLOWED_USERS",
                        "BLUEBUBBLES_ALLOWED_USERS",
+                       "IMESSAGE_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -1476,7 +1477,8 @@ class GatewayRunner:
                        "WECOM_ALLOW_ALL_USERS",
                        "WECOM_CALLBACK_ALLOW_ALL_USERS",
                        "WEIXIN_ALLOW_ALL_USERS",
-                       "BLUEBUBBLES_ALLOW_ALL_USERS")
+                       "BLUEBUBBLES_ALLOW_ALL_USERS",
+                       "IMESSAGE_ALLOW_ALL_USERS")
         )
         if not _any_allowlist and not _allow_all:
             logger.warning(
@@ -2194,6 +2196,13 @@ class GatewayRunner:
                 return None
             return BlueBubblesAdapter(config)
 
+        elif platform == Platform.IMESSAGE:
+            from gateway.platforms.imessage import IMessageAdapter, check_imessage_requirements
+            if not check_imessage_requirements():
+                logger.warning("iMessage: requires macOS and imsg CLI (brew install steipete/tap/imsg)")
+                return None
+            return IMessageAdapter(config)
+
         return None
     
     def _is_user_authorized(self, source: SessionSource) -> bool:
@@ -2235,6 +2244,7 @@ class GatewayRunner:
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
+            Platform.IMESSAGE: "IMESSAGE_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -2252,6 +2262,7 @@ class GatewayRunner:
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
+            Platform.IMESSAGE: "IMESSAGE_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1886,6 +1886,29 @@ _PLATFORMS = [
              "help": "Phone number or Apple ID to deliver cron results and notifications to."},
         ],
     },
+    {
+        "key": "imessage",
+        "label": "iMessage",
+        "emoji": "💬",
+        "token_var": "IMESSAGE_ENABLED",
+        "setup_instructions": [
+            "1. Requires macOS (iMessage is not available on Linux/Windows)",
+            "2. Install the imsg CLI: brew install steipete/tap/imsg",
+            "3. Grant Full Disk Access to your terminal app:",
+            "   System Settings → Privacy & Security → Full Disk Access → add Terminal/iTerm",
+            "4. Grant Automation permission for Messages app when prompted",
+            "5. Verify: run 'imsg chats --json' — should list your conversations",
+        ],
+        "vars": [
+            {"name": "IMESSAGE_ENABLED", "prompt": "Enable iMessage? (true/false)", "password": False,
+             "help": "Set to 'true' to enable the iMessage gateway adapter."},
+            {"name": "IMESSAGE_ALLOWED_USERS", "prompt": "Allowed senders (comma-separated phone/Apple IDs, or empty for all)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which senders can interact with the bot. Empty = all."},
+            {"name": "IMESSAGE_HOME_CHANNEL", "prompt": "Home channel (phone number or Apple ID for cron delivery, or empty)", "password": False,
+             "help": "Default recipient for cron job results and notifications."},
+        ],
+    },
 ]
 
 
@@ -1903,6 +1926,13 @@ def _platform_status(platform: dict) -> str:
             if session_file.exists():
                 return "configured + paired"
             return "enabled, not paired"
+        return "not configured"
+    if token_var == "IMESSAGE_ENABLED":
+        if val and val.lower() in ("true", "1", "yes"):
+            import shutil
+            if shutil.which("imsg"):
+                return "enabled + imsg found"
+            return "enabled, imsg not found"
         return "not configured"
     if platform.get("key") == "signal":
         account = get_env_value("SIGNAL_ACCOUNT")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -305,6 +305,7 @@ def show_status(args):
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
+        "iMessage": ("IMESSAGE_ENABLED", "IMESSAGE_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/tests/gateway/test_imessage.py
+++ b/tests/gateway/test_imessage.py
@@ -1,0 +1,403 @@
+"""Tests for the iMessage gateway platform adapter."""
+
+import asyncio
+import os
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Platform enum
+# ---------------------------------------------------------------------------
+
+def test_platform_enum_has_imessage():
+    assert Platform.IMESSAGE.value == "imessage"
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def test_config_env_override_imessage_enabled():
+    """IMESSAGE_ENABLED=true should create an enabled platform config."""
+    with patch.dict(os.environ, {"IMESSAGE_ENABLED": "true"}, clear=False):
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.IMESSAGE)
+        assert pconfig is not None
+        assert pconfig.enabled is True
+
+
+def test_config_env_override_imessage_home_channel():
+    """IMESSAGE_HOME_CHANNEL should set the home channel."""
+    with patch.dict(os.environ, {
+        "IMESSAGE_ENABLED": "true",
+        "IMESSAGE_HOME_CHANNEL": "+15551234567",
+    }, clear=False):
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.IMESSAGE)
+        assert pconfig is not None
+        assert pconfig.home_channel is not None
+        assert pconfig.home_channel.chat_id == "+15551234567"
+
+
+def test_config_env_override_imessage_watch_chat_ids():
+    """IMESSAGE_WATCH_CHAT_IDS should populate extra config."""
+    with patch.dict(os.environ, {
+        "IMESSAGE_ENABLED": "true",
+        "IMESSAGE_WATCH_CHAT_IDS": "123,456,789",
+    }, clear=False):
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.IMESSAGE)
+        assert pconfig is not None
+        assert pconfig.extra.get("watch_chat_ids") == ["123", "456", "789"]
+
+
+def test_connected_platforms_includes_imessage():
+    """iMessage should appear in connected platforms when enabled."""
+    from gateway.config import GatewayConfig
+    config = GatewayConfig(platforms={
+        Platform.IMESSAGE: PlatformConfig(enabled=True),
+    })
+    connected = config.get_connected_platforms()
+    assert Platform.IMESSAGE in connected
+
+
+def test_connected_platforms_excludes_disabled_imessage():
+    """iMessage should not appear when disabled."""
+    from gateway.config import GatewayConfig
+    config = GatewayConfig(platforms={
+        Platform.IMESSAGE: PlatformConfig(enabled=False),
+    })
+    connected = config.get_connected_platforms()
+    assert Platform.IMESSAGE not in connected
+
+
+# ---------------------------------------------------------------------------
+# Requirements check
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_not_macos():
+    """check_imessage_requirements should return False on non-macOS."""
+    from gateway.platforms.imessage import check_imessage_requirements
+    with patch("gateway.platforms.imessage.sys") as mock_sys:
+        mock_sys.platform = "linux"
+        assert check_imessage_requirements() is False
+
+
+def test_check_requirements_no_imsg():
+    """check_imessage_requirements should return False when imsg is not in PATH."""
+    from gateway.platforms.imessage import check_imessage_requirements
+    with patch("gateway.platforms.imessage.sys") as mock_sys, \
+         patch("gateway.platforms.imessage.shutil") as mock_shutil:
+        mock_sys.platform = "darwin"
+        mock_shutil.which.return_value = None
+        assert check_imessage_requirements() is False
+
+
+def test_check_requirements_ok():
+    """check_imessage_requirements should return True on macOS with imsg."""
+    from gateway.platforms.imessage import check_imessage_requirements
+    with patch("gateway.platforms.imessage.sys") as mock_sys, \
+         patch("gateway.platforms.imessage.shutil") as mock_shutil:
+        mock_sys.platform = "darwin"
+        mock_shutil.which.return_value = "/usr/local/bin/imsg"
+        assert check_imessage_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+def test_redact_phone_number():
+    from gateway.platforms.imessage import _redact_imessage_id
+    assert _redact_imessage_id("+15551234567") == "+155****4567"
+
+
+def test_redact_short_phone():
+    from gateway.platforms.imessage import _redact_imessage_id
+    # Short phone numbers still get redacted
+    result = _redact_imessage_id("+1234")
+    assert "****" in result
+
+
+def test_redact_apple_id():
+    from gateway.platforms.imessage import _redact_imessage_id
+    assert _redact_imessage_id("user@example.com") == "us****@example.com"
+
+
+def test_redact_empty():
+    from gateway.platforms.imessage import _redact_imessage_id
+    assert _redact_imessage_id("") == "<none>"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+def test_is_duplicate_basic():
+    """First time should not be duplicate, second time should be."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._is_duplicate("guid-1") is False
+    assert adapter._is_duplicate("guid-1") is True
+
+
+def test_is_duplicate_different_guids():
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._is_duplicate("guid-1") is False
+    assert adapter._is_duplicate("guid-2") is False
+
+
+def test_is_duplicate_max_size():
+    """Should evict oldest when hitting max size."""
+    from gateway.platforms.imessage import IMessageAdapter, DEDUP_MAX_SIZE
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    # Fill up to max
+    for i in range(DEDUP_MAX_SIZE):
+        adapter._is_duplicate(f"guid-{i}")
+    # One more should still work (evicts oldest)
+    assert adapter._is_duplicate(f"guid-new") is False
+    assert len(adapter._seen_messages) <= DEDUP_MAX_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Recipient resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_recipient_phone():
+    """Phone numbers should pass through directly."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._resolve_recipient("+15551234567") == "+15551234567"
+
+
+def test_resolve_recipient_email():
+    """Apple IDs (emails) should pass through directly."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._resolve_recipient("user@icloud.com") == "user@icloud.com"
+
+
+def test_resolve_recipient_cache_lookup():
+    """Numeric chat_id should resolve via cache."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._chat_cache = {
+        42: {"identifier": "+15559876543", "name": "Alice", "service": "iMessage"},
+    }
+    assert adapter._resolve_recipient("42") == "+15559876543"
+
+
+def test_resolve_recipient_cache_miss():
+    """Unknown numeric chat_id should fall back to the raw value."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._resolve_recipient("999") == "999"
+
+
+def test_resolve_recipient_empty():
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._resolve_recipient("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Message handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_handle_message_filters_from_me():
+    """Messages with is_from_me should be silently dropped."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_message_data({"is_from_me": True, "text": "hello", "guid": "g1"})
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_dedup():
+    """Duplicate guids should be dropped."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter.handle_message = AsyncMock()
+    adapter._refresh_chat_cache = AsyncMock()
+
+    data = {"is_from_me": False, "text": "hello", "guid": "g1", "chat_id": 1, "sender": "+1234"}
+    await adapter._handle_message_data(data)
+    assert adapter.handle_message.call_count == 1
+
+    await adapter._handle_message_data(data)
+    assert adapter.handle_message.call_count == 1  # Not called again
+
+
+@pytest.mark.asyncio
+async def test_handle_message_builds_event():
+    """Valid message should produce a MessageEvent with correct fields."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._refresh_chat_cache = AsyncMock()
+
+    events = []
+    async def capture_event(event):
+        events.append(event)
+    adapter.handle_message = capture_event
+
+    data = {
+        "is_from_me": False,
+        "text": "Hey there",
+        "guid": "unique-guid",
+        "chat_id": 5,
+        "sender": "+15551234567",
+        "service": "iMessage",
+    }
+    await adapter._handle_message_data(data)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.text == "Hey there"
+    assert event.source.user_id == "+15551234567"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_filters_watch_chat_ids():
+    """Messages from chats not in watch_chat_ids should be dropped."""
+    from gateway.platforms.imessage import IMessageAdapter
+    config = PlatformConfig(enabled=True, extra={"watch_chat_ids": ["10", "20"]})
+    adapter = IMessageAdapter(config)
+    adapter.handle_message = AsyncMock()
+
+    data = {"is_from_me": False, "text": "hello", "guid": "g1", "chat_id": 99, "sender": "+1"}
+    await adapter._handle_message_data(data)
+    adapter.handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Chat cache parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_chat_list():
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    json_output = '[{"id": 1, "identifier": "+15551234567", "name": "Alice", "service": "iMessage"}, {"id": 2, "identifier": "bob@icloud.com", "display_name": "Bob"}]'
+    adapter._parse_chat_list(json_output)
+
+    assert 1 in adapter._chat_cache
+    assert adapter._chat_cache[1]["identifier"] == "+15551234567"
+    assert adapter._chat_cache[1]["name"] == "Alice"
+    assert 2 in adapter._chat_cache
+    assert adapter._chat_cache[2]["identifier"] == "bob@icloud.com"
+    assert adapter._chat_cache[2]["name"] == "Bob"
+
+
+def test_parse_chat_list_ndjson():
+    """imsg chats --json outputs NDJSON (one JSON object per line)."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    ndjson_output = '{"id": 1, "identifier": "+15551234567", "name": "Alice", "service": "iMessage"}\n{"id": 2, "identifier": "bob@icloud.com", "display_name": "Bob"}\n'
+    adapter._parse_chat_list(ndjson_output)
+
+    assert 1 in adapter._chat_cache
+    assert adapter._chat_cache[1]["identifier"] == "+15551234567"
+    assert 2 in adapter._chat_cache
+    assert adapter._chat_cache[2]["identifier"] == "bob@icloud.com"
+    assert adapter._chat_cache[2]["name"] == "Bob"
+
+
+def test_parse_chat_list_invalid_json():
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._parse_chat_list("not json")
+    assert len(adapter._chat_cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Authorization maps (integration test)
+# ---------------------------------------------------------------------------
+
+def test_auth_maps_include_imessage():
+    """Verify IMESSAGE entries exist in the run.py authorization maps."""
+    # Read the source and check for the entries
+    run_py = os.path.join(os.path.dirname(__file__), "..", "..", "gateway", "run.py")
+    with open(run_py, encoding="utf-8") as f:
+        content = f.read()
+    assert "IMESSAGE_ALLOWED_USERS" in content
+    assert "IMESSAGE_ALLOW_ALL_USERS" in content
+
+
+# ---------------------------------------------------------------------------
+# Toolset integration
+# ---------------------------------------------------------------------------
+
+def test_toolset_includes_imessage():
+    """hermes-gateway should include hermes-imessage."""
+    from toolsets import TOOLSETS
+    gateway = TOOLSETS.get("hermes-gateway", {})
+    assert "hermes-imessage" in gateway.get("includes", [])
+
+
+def test_imessage_toolset_exists():
+    from toolsets import TOOLSETS
+    assert "hermes-imessage" in TOOLSETS
+
+
+# ---------------------------------------------------------------------------
+# Platform hints
+# ---------------------------------------------------------------------------
+
+def test_platform_hint_exists():
+    from agent.prompt_builder import PLATFORM_HINTS
+    assert "imessage" in PLATFORM_HINTS
+    assert "markdown" in PLATFORM_HINTS["imessage"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Send message tool integration
+# ---------------------------------------------------------------------------
+
+def test_send_message_platform_map_has_imessage():
+    """The send_message tool should route 'imessage' to Platform.IMESSAGE."""
+    # This tests by importing and checking the code path
+    source = os.path.join(os.path.dirname(__file__), "..", "..", "tools", "send_message_tool.py")
+    with open(source, encoding="utf-8") as f:
+        content = f.read()
+    assert '"imessage": Platform.IMESSAGE' in content
+
+
+# ---------------------------------------------------------------------------
+# Cron integration
+# ---------------------------------------------------------------------------
+
+def test_cron_known_delivery_platforms():
+    from cron.scheduler import _KNOWN_DELIVERY_PLATFORMS
+    assert "imessage" in _KNOWN_DELIVERY_PLATFORMS
+
+
+def test_cron_platform_map_has_imessage():
+    source = os.path.join(os.path.dirname(__file__), "..", "..", "cron", "scheduler.py")
+    with open(source, encoding="utf-8") as f:
+        content = f.read()
+    assert '"imessage": Platform.IMESSAGE' in content
+
+
+# ---------------------------------------------------------------------------
+# Channel directory
+# ---------------------------------------------------------------------------
+
+def test_channel_directory_includes_imessage():
+    source = os.path.join(os.path.dirname(__file__), "..", "..", "gateway", "channel_directory.py")
+    with open(source, encoding="utf-8") as f:
+        content = f.read()
+    assert '"imessage"' in content

--- a/tests/gateway/test_imessage.py
+++ b/tests/gateway/test_imessage.py
@@ -60,6 +60,48 @@ def test_config_env_override_imessage_watch_chat_ids():
         assert pconfig.extra.get("watch_chat_ids") == ["123", "456", "789"]
 
 
+def test_config_env_override_imessage_watch_mode():
+    """IMESSAGE_WATCH_MODE should populate extra config."""
+    with patch.dict(os.environ, {
+        "IMESSAGE_ENABLED": "true",
+        "IMESSAGE_WATCH_MODE": "poll",
+    }, clear=False):
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.IMESSAGE)
+        assert pconfig is not None
+        assert pconfig.extra.get("watch_mode") == "poll"
+
+
+def test_config_env_override_imessage_poll_interval():
+    """IMESSAGE_POLL_INTERVAL should set poll interval."""
+    with patch.dict(os.environ, {
+        "IMESSAGE_ENABLED": "true",
+        "IMESSAGE_POLL_INTERVAL": "5.0",
+    }, clear=False):
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.IMESSAGE)
+        assert pconfig is not None
+        assert pconfig.extra.get("poll_interval") == 5.0
+
+
+def test_adapter_default_watch_mode():
+    """Default watch mode should be auto."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    assert adapter._watch_mode == "auto"
+
+
+def test_adapter_poll_mode_from_config():
+    """watch_mode=poll should set poll mode."""
+    from gateway.platforms.imessage import IMessageAdapter
+    config = PlatformConfig(enabled=True, extra={"watch_mode": "poll", "poll_interval": 5.0})
+    adapter = IMessageAdapter(config)
+    assert adapter._watch_mode == "poll"
+    assert adapter._poll_interval == 5.0
+
+
 def test_connected_platforms_includes_imessage():
     """iMessage should appear in connected platforms when enabled."""
     from gateway.config import GatewayConfig

--- a/tests/gateway/test_imessage.py
+++ b/tests/gateway/test_imessage.py
@@ -443,3 +443,225 @@ def test_channel_directory_includes_imessage():
     with open(source, encoding="utf-8") as f:
         content = f.read()
     assert '"imessage"' in content
+
+
+# ---------------------------------------------------------------------------
+# Send methods
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_text_success():
+    """send() should call imsg send and return success."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"OK", b""))
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        result = await adapter.send("+15551234567", "Hello!")
+        assert result.success is True
+        mock_exec.assert_called_once()
+        cmd_args = mock_exec.call_args[0]
+        assert "imsg" in cmd_args
+        assert "send" in cmd_args
+        assert "--to" in cmd_args
+        assert "+15551234567" in cmd_args
+        assert "--text" in cmd_args
+        assert "Hello!" in cmd_args
+
+
+@pytest.mark.asyncio
+async def test_send_text_failure():
+    """send() should return failure on non-zero exit."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"error occurred"))
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = await adapter.send("+15551234567", "Hello!")
+        assert result.success is False
+        assert "error" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_send_text_timeout():
+    """send() should return failure on timeout."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    with patch("asyncio.create_subprocess_exec", side_effect=asyncio.TimeoutError()):
+        result = await adapter.send("+15551234567", "Hello!")
+        assert result.success is False
+        assert "timed out" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_send_empty_recipient():
+    """send() should fail when recipient cannot be resolved."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    result = await adapter.send("", "Hello!")
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_send_file_success():
+    """_send_file should call imsg send --file and return success."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"OK", b""))
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+         patch("os.path.exists", return_value=True):
+        result = await adapter._send_file("+15551234567", "/tmp/test.png", caption="Look!")
+        assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_file_not_found():
+    """_send_file should fail if file doesn't exist."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    with patch("os.path.exists", return_value=False):
+        result = await adapter._send_file("+15551234567", "/nonexistent.png")
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_send_image_local_file():
+    """send_image should delegate to send_image_file for local paths."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter.send_image_file = AsyncMock(return_value=MagicMock(success=True))
+
+    with patch("os.path.exists", return_value=True):
+        result = await adapter.send_image("+15551234567", "/tmp/photo.jpg", caption="pic")
+        adapter.send_image_file.assert_called_once_with("+15551234567", "/tmp/photo.jpg", caption="pic")
+
+
+@pytest.mark.asyncio
+async def test_send_image_url_unsupported():
+    """send_image should fail for non-local URLs."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+
+    with patch("os.path.exists", return_value=False):
+        result = await adapter.send_image("+15551234567", "https://example.com/img.jpg")
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Poll mode
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_seed_last_rowid_uses_max():
+    """_seed_last_rowid should find the max rowid across sampled chats."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._chat_cache = {
+        1: {"identifier": "+1", "name": "A", "service": "iMessage"},
+        2: {"identifier": "+2", "name": "B", "service": "iMessage"},
+    }
+
+    call_count = 0
+    async def fake_exec(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        mock_proc = AsyncMock()
+        # Chat 1 has rowid 100, chat 2 has rowid 200
+        rowid = 100 if call_count == 1 else 200
+        mock_proc.communicate = AsyncMock(
+            return_value=(f'{{"id": {rowid}}}\n'.encode(), b"")
+        )
+        mock_proc.returncode = 0
+        return mock_proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await adapter._seed_last_rowid()
+        assert adapter._last_rowid == 200
+
+
+@pytest.mark.asyncio
+async def test_seed_last_rowid_empty_cache():
+    """_seed_last_rowid should do nothing with empty cache."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._chat_cache = {}
+    await adapter._seed_last_rowid()
+    assert adapter._last_rowid == 0
+
+
+@pytest.mark.asyncio
+async def test_poll_once_processes_messages():
+    """_poll_once should process new messages and update last_rowid."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._last_rowid = 50
+    adapter.handle_message = AsyncMock()
+    adapter._refresh_chat_cache = AsyncMock()
+
+    lines = [
+        b'{"id": 51, "guid": "g1", "is_from_me": false, "text": "hi", "chat_id": 1, "sender": "+1"}\n',
+        b'{"id": 52, "guid": "g2", "is_from_me": false, "text": "hey", "chat_id": 1, "sender": "+1"}\n',
+    ]
+
+    mock_proc = AsyncMock()
+    line_iter = iter(lines + [b""])  # Empty bytes signals EOF
+    async def fake_readline():
+        return next(line_iter)
+    mock_proc.stdout = AsyncMock()
+    mock_proc.stdout.readline = fake_readline
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = AsyncMock()
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        count = await adapter._poll_once()
+        assert count == 2
+        assert adapter._last_rowid == 52
+
+
+@pytest.mark.asyncio
+async def test_send_typing_is_noop():
+    """send_typing should be a no-op for iMessage."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    # Should not raise
+    await adapter.send_typing("+15551234567")
+
+
+# ---------------------------------------------------------------------------
+# Chat info
+# ---------------------------------------------------------------------------
+
+def test_get_chat_info_from_cache():
+    """get_chat_info should return metadata from cache."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    adapter._chat_cache = {
+        42: {"identifier": "+15559876543", "name": "Alice", "service": "iMessage"},
+    }
+    import asyncio
+    info = asyncio.get_event_loop().run_until_complete(adapter.get_chat_info("42"))
+    assert info["name"] == "Alice"
+    assert info["identifier"] == "+15559876543"
+
+
+def test_get_chat_info_unknown():
+    """get_chat_info should return basic info for unknown chat_id."""
+    from gateway.platforms.imessage import IMessageAdapter
+    adapter = IMessageAdapter(PlatformConfig(enabled=True))
+    import asyncio
+    info = asyncio.get_event_loop().run_until_complete(adapter.get_chat_info("unknown"))
+    assert info["name"] == "unknown"
+    assert info["chat_id"] == "unknown"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -465,7 +465,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
+                "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'imessage:+15551234567'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
             },
             "skills": {
                 "type": "array",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -162,6 +162,7 @@ def _handle_send(args):
         "weixin": Platform.WEIXIN,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "imessage": Platform.IMESSAGE,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -424,6 +425,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.IMESSAGE:
+            result = await _send_imessage(chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -1021,6 +1024,28 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         }
     except Exception as e:
         return _error(f"Feishu send failed: {e}")
+
+
+async def _send_imessage(chat_id, message):
+    """Send via imsg CLI (macOS iMessage)."""
+    import asyncio
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "imsg", "send", "--to", chat_id, "--text", message,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        if proc.returncode != 0:
+            err = stderr.decode("utf-8", errors="replace").strip()
+            return _error(f"imsg send failed (exit {proc.returncode}): {err}")
+        return {"success": True, "platform": "imessage", "chat_id": chat_id}
+    except asyncio.TimeoutError:
+        return _error("imsg send timed out")
+    except FileNotFoundError:
+        return {"error": "imsg CLI not found. Install: brew install steipete/tap/imsg"}
+    except Exception as e:
+        return _error(f"iMessage send failed: {e}")
 
 
 def _check_send_message():

--- a/toolsets.py
+++ b/toolsets.py
@@ -383,10 +383,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-imessage": {
+        "description": "iMessage bot toolset - macOS iMessage integration (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-webhook", "hermes-imessage"]
     }
 }
 

--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -117,8 +117,8 @@ hermes-agent/
 │   ├── mirror.py             # Cross-session message mirroring
 │   ├── status.py             # Token locks, profile-scoped process tracking
 │   ├── builtin_hooks/        # Always-registered hooks
-│   └── platforms/            # 15 adapters: telegram, discord, slack, whatsapp,
-│                             #   signal, matrix, mattermost, email, sms,
+│   └── platforms/            # 16 adapters: telegram, discord, slack, whatsapp,
+│                             #   signal, imessage, matrix, mattermost, email, sms,
 │                             #   dingtalk, feishu, wecom, weixin, bluebubbles, homeassistant, webhook
 │
 ├── acp_adapter/              # ACP server (VS Code / Zed / JetBrains)

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -153,6 +153,7 @@ gateway/platforms/
 ├── slack.py             # Slack Socket Mode
 ├── whatsapp.py          # WhatsApp Business Cloud API
 ├── signal.py            # Signal via signal-cli REST API
+├── imessage.py          # iMessage via imsg CLI (macOS only)
 ├── matrix.py            # Matrix via mautrix (optional E2EE)
 ├── mattermost.py        # Mattermost WebSocket API
 ├── email.py             # Email via IMAP/SMTP

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -259,6 +259,14 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `BLUEBUBBLES_HOME_CHANNEL` | Phone/email for cron/notification delivery |
 | `BLUEBUBBLES_ALLOWED_USERS` | Comma-separated authorized users |
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | Allow all users (`true`/`false`) |
+| `IMESSAGE_ENABLED` | Enable the iMessage adapter (`true`/`false`, requires macOS + `imsg` CLI) |
+| `IMESSAGE_ALLOWED_USERS` | Comma-separated phone numbers or Apple IDs allowed to message the bot |
+| `IMESSAGE_ALLOW_ALL_USERS` | Allow all iMessage senders without an allowlist (`true`/`false`) |
+| `IMESSAGE_HOME_CHANNEL` | Phone number or Apple ID for cron delivery and notifications |
+| `IMESSAGE_HOME_CHANNEL_NAME` | Display name for the iMessage home channel |
+| `IMESSAGE_WATCH_CHAT_IDS` | Comma-separated chat IDs to watch (omit to watch all) |
+| `IMESSAGE_WATCH_MODE` | Watch mode: `auto` (default), `fsevents`, or `poll` |
+| `IMESSAGE_POLL_INTERVAL` | Seconds between polls in poll mode (default: `3.0`) |
 | `MATTERMOST_URL` | Mattermost server URL (e.g. `https://mm.example.com`) |
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |
 | `MATTERMOST_ALLOWED_USERS` | Comma-separated Mattermost user IDs allowed to message the bot |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -96,6 +96,7 @@ Platform toolsets define the complete tool configuration for a deployment target
 | `hermes-slack` | Same as `hermes-cli`. |
 | `hermes-whatsapp` | Same as `hermes-cli`. |
 | `hermes-signal` | Same as `hermes-cli`. |
+| `hermes-imessage` | Same as `hermes-cli`. |
 | `hermes-matrix` | Same as `hermes-cli`. |
 | `hermes-mattermost` | Same as `hermes-cli`. |
 | `hermes-email` | Same as `hermes-cli`. |

--- a/website/docs/user-guide/messaging/imessage.md
+++ b/website/docs/user-guide/messaging/imessage.md
@@ -1,0 +1,186 @@
+---
+sidebar_position: 16
+title: "iMessage"
+description: "Set up Hermes Agent as a native iMessage bot via the imsg CLI on macOS"
+---
+
+# iMessage Setup
+
+Hermes connects to iMessage natively through the [imsg](https://github.com/steipete/imsg) CLI tool, which provides direct access to macOS Messages.app via AppleScript and the chat.db database. No third-party server or bridge required — just your Mac.
+
+:::info macOS Only
+The iMessage adapter requires macOS. It uses `imsg` to interface with Messages.app, which is only available on Apple platforms.
+:::
+
+---
+
+## Prerequisites
+
+- **macOS** — any recent version with Messages.app
+- **imsg CLI** — lightweight CLI for Apple Messages ([GitHub](https://github.com/steipete/imsg))
+- **Full Disk Access** — your terminal app needs permission to read `~/Library/Messages/chat.db`
+
+### Installing imsg
+
+```bash
+brew install steipete/tap/imsg
+```
+
+Verify it works:
+
+```bash
+imsg chats --json
+```
+
+If you see a JSON list of your chats, you're ready. If you get a permissions error, grant **Full Disk Access** to your terminal app (see Troubleshooting below).
+
+---
+
+## Step 1: Grant Permissions
+
+1. Open **System Settings → Privacy & Security → Full Disk Access**
+2. Add your terminal app (Terminal.app, iTerm2, Alacritty, etc.)
+3. Restart your terminal
+
+---
+
+## Step 2: Configure Hermes
+
+The easiest way:
+
+```bash
+hermes gateway setup
+```
+
+Select **iMessage** from the platform menu. The wizard will:
+
+1. Check if `imsg` is installed
+2. Verify Full Disk Access permissions
+3. Ask for allowed users (phone numbers or Apple IDs)
+4. Configure the home channel for notifications
+
+### Manual Configuration
+
+Add to `~/.hermes/.env`:
+
+```bash
+# Required
+IMESSAGE_ENABLED=true
+
+# Security (recommended)
+IMESSAGE_ALLOWED_USERS=+15551234567,user@icloud.com    # Comma-separated phone numbers or Apple IDs
+
+# Optional
+IMESSAGE_HOME_CHANNEL=+15551234567                     # Default delivery target for cron jobs
+IMESSAGE_HOME_CHANNEL_NAME=My iPhone                   # Display name for the home channel
+IMESSAGE_WATCH_CHAT_IDS=1,5,12                         # Only watch specific chats (omit for all)
+IMESSAGE_WATCH_MODE=auto                               # auto | fsevents | poll
+IMESSAGE_POLL_INTERVAL=3.0                             # Seconds between polls (poll mode only)
+```
+
+Then start the gateway:
+
+```bash
+hermes gateway              # Foreground
+hermes gateway install      # Install as a launchd service (macOS)
+```
+
+---
+
+## Watch Modes
+
+The adapter supports three modes for detecting new messages:
+
+| Mode | Description | When to Use |
+|------|-------------|-------------|
+| `auto` (default) | Tries FSEvents first, falls back to poll if no events detected after 30s | Recommended for most setups |
+| `fsevents` | Watches `chat.db` via macOS filesystem events | Best for real-time; may not work in all environments |
+| `poll` | Periodically queries for new messages via `imsg watch --since-rowid` | Most reliable; slightly higher latency |
+
+Set the mode with `IMESSAGE_WATCH_MODE`. If you're experiencing missed messages with the default `auto` mode, try `poll`.
+
+---
+
+## Access Control
+
+DM access follows the standard Hermes pattern:
+
+1. **`IMESSAGE_ALLOWED_USERS` set** → only those users can message
+2. **No allowlist set** → unknown users get a DM pairing code (approve via `hermes pairing approve imessage CODE`)
+3. **`IMESSAGE_ALLOW_ALL_USERS=true`** → anyone can message (use with caution)
+
+---
+
+## Features
+
+### Attachments
+
+**Incoming** (user → agent):
+- **Images** — PNG, JPEG, GIF, WebP
+- **Audio** — MP3, M4A, WAV, OGG
+- **Video** — MP4, MOV
+- **Documents** — PDF, ZIP, and other file types
+
+**Outgoing** (agent → user):
+- **Files** — sent via `imsg send --file` as native iMessage attachments
+
+### Phone Number & Apple ID Redaction
+
+All identifiers are automatically redacted in logs:
+- `+15551234567` → `+155****4567`
+- `user@example.com` → `us****@example.com`
+
+### Health Monitoring
+
+The adapter monitors the watch process and automatically reconnects if:
+- The process exits unexpectedly (with exponential backoff: 2s → 60s)
+- No activity is detected for 120 seconds (logs a debug message)
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| **"imsg CLI not found"** | Install via `brew install steipete/tap/imsg` and ensure it's in your PATH |
+| **"imsg chats failed"** | Grant Full Disk Access to your terminal: System Settings → Privacy & Security → Full Disk Access |
+| **Messages not received** | Try `IMESSAGE_WATCH_MODE=poll` — FSEvents may not fire in all environments |
+| **Messages replayed on restart** | Normal for the first poll cycle if chat history is large; dedup prevents double-processing |
+| **Bot responds to no one** | Set `IMESSAGE_ALLOWED_USERS` with phone numbers or Apple IDs, or use DM pairing |
+| **Slow message detection** | Decrease `IMESSAGE_POLL_INTERVAL` (default: 3.0 seconds) |
+
+---
+
+## Limitations
+
+- **macOS only** — requires Messages.app and the `imsg` CLI
+- **No typing indicators** — iMessage doesn't expose typing status via AppleScript
+- **No reactions** — emoji reactions are not supported
+- **No threaded conversations** — iMessage threads are not mapped
+
+---
+
+## Security
+
+:::warning
+**Always configure access controls.** The bot has terminal access by default. Without `IMESSAGE_ALLOWED_USERS` or DM pairing, the gateway denies all incoming messages as a safety measure.
+:::
+
+- Phone numbers and Apple IDs are redacted in all log output
+- Use DM pairing or explicit allowlists for safe onboarding of new users
+- The `chat.db` file contains your full message history — Full Disk Access grants read access to it
+
+---
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `IMESSAGE_ENABLED` | Yes | `false` | Enable the iMessage adapter |
+| `IMESSAGE_ALLOWED_USERS` | No | — | Comma-separated phone numbers or Apple IDs |
+| `IMESSAGE_ALLOW_ALL_USERS` | No | `false` | Allow any user to interact (skip allowlist) |
+| `IMESSAGE_HOME_CHANNEL` | No | — | Default delivery target for cron jobs |
+| `IMESSAGE_HOME_CHANNEL_NAME` | No | — | Display name for the home channel |
+| `IMESSAGE_WATCH_CHAT_IDS` | No | — | Comma-separated chat IDs to watch (omit for all) |
+| `IMESSAGE_WATCH_MODE` | No | `auto` | Watch mode: `auto`, `fsevents`, or `poll` |
+| `IMESSAGE_POLL_INTERVAL` | No | `3.0` | Seconds between polls (poll mode only) |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -19,6 +19,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
+| iMessage | — | ✅ | ✅ | — | — | — | ✅ |
 | SMS | — | — | — | — | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
 | Home Assistant | — | — | — | — | — | — | — |
@@ -44,6 +45,7 @@ flowchart TB
             wa[WhatsApp]
             sl[Slack]
             sig[Signal]
+            ims[iMessage]
             sms[SMS]
             em[Email]
             ha[Home Assistant]
@@ -69,6 +71,7 @@ flowchart TB
     wa --> store
     sl --> store
     sig --> store
+    ims --> store
     sms --> store
     em --> store
     ha --> store
@@ -176,6 +179,7 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 TELEGRAM_ALLOWED_USERS=123456789,987654321
 DISCORD_ALLOWED_USERS=123456789012345678
 SIGNAL_ALLOWED_USERS=+155****4567,+155****6543
+IMESSAGE_ALLOWED_USERS=+155****4567,user@icloud.com
 SMS_ALLOWED_USERS=+155****4567,+155****6543
 EMAIL_ALLOWED_USERS=trusted@example.com,colleague@work.com
 MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
@@ -358,6 +362,7 @@ Each platform has its own toolset:
 | WhatsApp | `hermes-whatsapp` | Full tools including terminal |
 | Slack | `hermes-slack` | Full tools including terminal |
 | Signal | `hermes-signal` | Full tools including terminal |
+| iMessage | `hermes-imessage` | Full tools including terminal |
 | SMS | `hermes-sms` | Full tools including terminal |
 | Email | `hermes-email` | Full tools including terminal |
 | Home Assistant | `hermes-homeassistant` | Full tools + HA device control (ha_list_entities, ha_get_state, ha_call_service, ha_list_services) |
@@ -379,6 +384,7 @@ Each platform has its own toolset:
 - [Slack Setup](slack.md)
 - [WhatsApp Setup](whatsapp.md)
 - [Signal Setup](signal.md)
+- [iMessage Setup](imessage.md)
 - [SMS Setup (Twilio)](sms.md)
 - [Email Setup](email.md)
 - [Home Assistant Integration](homeassistant.md)


### PR DESCRIPTION
## Summary

Adds native iMessage as a gateway platform using the [imsg](https://github.com/steipete/imsg) CLI on macOS. Unlike the existing BlueBubbles adapter (#6437), this requires **no third-party server or bridge** — it uses only built-in macOS capabilities via AppleScript and `chat.db`.

Fixes #6430.

## Architecture

- **Inbound**: Watches `~/Library/Messages/chat.db` for new messages via `imsg watch` (FSEvents or poll-based fallback)
- **Outbound**: Sends via `imsg send` (AppleScript → Messages.app)
- **Platform restriction**: macOS only (validated at startup via `check_imessage_requirements()`)
- **Permissions required**: Full Disk Access for the terminal app
- **Watch modes**: `auto` (default — tries FSEvents, falls back to poll after 30s), `fsevents`, `poll`

## Integration Points (from ADDING_A_PLATFORM.md)

| # | File | What |
|---|------|------|
| 1 | `gateway/platforms/imessage.py` | Core adapter (848 lines) — connect, disconnect, watch, send, dedup, health monitor |
| 2 | `gateway/config.py` | `Platform.IMESSAGE` enum + env var config loading |
| 3 | `gateway/run.py` | Adapter factory, `IMESSAGE_ALLOWED_USERS` / `IMESSAGE_ALLOW_ALL_USERS` auth maps |
| 4 | `agent/prompt_builder.py` | Platform hint (no markdown in iMessage) |
| 5 | `toolsets.py` | `hermes-imessage` toolset |
| 6 | `tools/send_message_tool.py` | `"imessage": Platform.IMESSAGE` routing |
| 7 | `cron/scheduler.py` | `"imessage"` in `_KNOWN_DELIVERY_PLATFORMS` |
| 8 | `tools/cronjob_tools.py` | `"imessage": Platform.IMESSAGE` mapping |
| 9 | `gateway/channel_directory.py` | `"imessage"` channel directory entry |
| 10 | `hermes_cli/gateway.py` | Interactive setup wizard for iMessage |
| 11 | `hermes_cli/status.py` | Status display |
| 12 | `hermes_cli/tools_config.py` | Tools config entry |

## Environment Variables

| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `IMESSAGE_ENABLED` | Yes | `false` | Enable the iMessage adapter |
| `IMESSAGE_ALLOWED_USERS` | No | — | Comma-separated phone numbers or Apple IDs |
| `IMESSAGE_ALLOW_ALL_USERS` | No | `false` | Skip allowlist |
| `IMESSAGE_HOME_CHANNEL` | No | — | Default cron delivery target |
| `IMESSAGE_HOME_CHANNEL_NAME` | No | — | Display name for home channel |
| `IMESSAGE_WATCH_CHAT_IDS` | No | — | Only watch specific chats |
| `IMESSAGE_WATCH_MODE` | No | `auto` | `auto` / `fsevents` / `poll` |
| `IMESSAGE_POLL_INTERVAL` | No | `3.0` | Seconds between polls |

## Documentation

- **New**: `website/docs/user-guide/messaging/imessage.md` — full setup guide with prerequisites, watch modes, troubleshooting, security
- **Updated**: messaging index (platform table, mermaid diagram, toolsets, security examples, next steps), README, environment-variables.md, toolsets-reference.md, gateway-internals.md, architecture.md

## Test Plan

- [x] `pytest tests/gateway/test_imessage.py` — 54 tests covering config, requirements, redaction, dedup, recipient resolution, message handling, chat cache, send methods, poll mode, and integration points
- [x] Manual E2E on macOS: sent and received iMessages through the gateway over multiple days of daily use
- [x] Full test suite: no regressions in existing tests

## Why Both BlueBubbles and Native iMessage?

| | BlueBubbles | Native (this PR) |
|---|---|---|
| **Requires** | BlueBubbles macOS server app | Only `imsg` CLI (`brew install`) |
| **Setup** | Install app + configure webhooks | `brew install` + Full Disk Access |
| **Dependencies** | External server process | Zero — subprocess calls only |
| **Best for** | Rich API features, remote access | Simple local setups, zero-dep preference |

Both adapters serve different user needs. BlueBubbles is ideal for users who want its rich API; native iMessage is for users who want a lightweight, zero-dependency solution.