### PR TITLE
fix(weixin): restore native media delivery

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -319,6 +319,11 @@ def _parse_aes_key(aes_key_b64: str) -> bytes:
     raise ValueError(f"unexpected aes_key format ({len(decoded)} decoded bytes)")
 
 
+def _encode_cdn_aes_key(aes_key: bytes) -> str:
+    """Encode AES key using the hex-text base64 format expected by Weixin CDN media items."""
+    return base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii")
+
+
 def _guess_chat_type(message: Dict[str, Any], account_id: str) -> Tuple[str, str]:
     room_id = str(message.get("room_id") or message.get("chat_room_id") or "").strip()
     to_user_id = str(message.get("to_user_id") or "").strip()
@@ -1636,7 +1641,7 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = self._token_store.get(self._account_id, chat_id)
         media_item = item_builder(
             encrypt_query_param=encrypted_query_param,
-            aes_key_b64=base64.b64encode(aes_key).decode("ascii"),
+            aes_key_b64=_encode_cdn_aes_key(aes_key),
             ciphertext_size=len(ciphertext),
             plaintext_size=rawsize,
             filename=Path(path).name,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -517,6 +517,30 @@ async def _upload_ciphertext(
         raise RuntimeError(f"CDN upload HTTP {response.status}: {raw[:200]}")
 
 
+async def _upload_ciphertext_full_url(
+    session: "aiohttp.ClientSession",
+    *,
+    ciphertext: bytes,
+    upload_full_url: str,
+) -> str:
+    timeout = aiohttp.ClientTimeout(total=120)
+    async with session.post(
+        upload_full_url,
+        data=ciphertext,
+        headers={"Content-Type": "application/octet-stream"},
+        timeout=timeout,
+    ) as response:
+        if response.status == 200:
+            encrypted_param = response.headers.get("x-encrypted-param")
+            if encrypted_param:
+                await response.read()
+                return encrypted_param
+            raw = await response.text()
+            raise RuntimeError(f"CDN upload missing x-encrypted-param header: {raw[:200]}")
+        raw = await response.text()
+        raise RuntimeError(f"CDN upload HTTP {response.status}: {raw[:200]}")
+
+
 async def _download_bytes(
     session: "aiohttp.ClientSession",
     *,
@@ -1532,24 +1556,24 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,
         chat_id: str,
-        path: str,
+        file_path: str,
         caption: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         if not self._session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, path, caption)
+            message_id = await self._send_file(chat_id, file_path, caption)
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -1592,7 +1616,13 @@ class WeixinAdapter(BasePlatformAdapter):
         upload_param = str(upload_response.get("upload_param") or "")
         upload_full_url = str(upload_response.get("upload_full_url") or "")
         ciphertext = _aes128_ecb_encrypt(plaintext, aes_key)
-        if upload_param:
+        if upload_full_url:
+            encrypted_query_param = await _upload_ciphertext_full_url(
+                self._session,
+                ciphertext=ciphertext,
+                upload_full_url=upload_full_url,
+            )
+        elif upload_param:
             encrypted_query_param = await _upload_ciphertext(
                 self._session,
                 ciphertext=ciphertext,
@@ -1600,16 +1630,6 @@ class WeixinAdapter(BasePlatformAdapter):
                 upload_param=upload_param,
                 filekey=filekey,
             )
-        elif upload_full_url:
-            timeout = aiohttp.ClientTimeout(total=120)
-            async with self._session.put(
-                upload_full_url,
-                data=ciphertext,
-                headers={"Content-Type": "application/octet-stream"},
-                timeout=timeout,
-            ) as response:
-                response.raise_for_status()
-                encrypted_query_param = response.headers.get("x-encrypted-param") or filekey
         else:
             raise RuntimeError(f"getUploadUrl returned neither upload_param nor upload_full_url: {upload_response}")
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -8,7 +8,13 @@ from unittest.mock import AsyncMock, patch
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
 from gateway.platforms import weixin
-from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter, _upload_ciphertext_full_url
+from gateway.platforms.weixin import (
+    ContextTokenStore,
+    WeixinAdapter,
+    _encode_cdn_aes_key,
+    _parse_aes_key,
+    _upload_ciphertext_full_url,
+)
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -437,6 +443,14 @@ class _FakeUploadSession:
 
 
 class TestWeixinUploadHelpers:
+    def test_encode_cdn_aes_key_round_trips_via_parse_helper(self):
+        aes_key = bytes.fromhex("1738b18276339f628684646f190e96d7")
+
+        encoded = _encode_cdn_aes_key(aes_key)
+
+        assert encoded == "MTczOGIxODI3NjMzOWY2Mjg2ODQ2NDZmMTkwZTk2ZDc="
+        assert _parse_aes_key(encoded) == aes_key
+
     def test_upload_full_url_uses_post_and_returns_header(self):
         session = _FakeUploadSession(
             _FakeAsyncResponse(status=200, headers={"x-encrypted-param": "enc-param"})

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
 from gateway.platforms import weixin
-from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
+from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter, _upload_ciphertext_full_url
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -374,3 +374,109 @@ class TestWeixinRemoteMediaSafety:
                 assert "Blocked unsafe URL" in str(exc)
             else:
                 raise AssertionError("expected ValueError for unsafe URL")
+
+
+class TestWeixinMediaSendHelpers:
+    def test_send_image_file_accepts_keyword_image_path(self):
+        adapter = _make_adapter()
+        adapter.send_document = AsyncMock(return_value="ok")
+
+        asyncio.run(adapter.send_image_file(chat_id="wxid_test123", image_path="/tmp/demo.png"))
+
+        adapter.send_document.assert_awaited_once_with(
+            "wxid_test123",
+            "/tmp/demo.png",
+            caption="",
+            metadata=None,
+        )
+
+    def test_send_document_accepts_keyword_file_path(self):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+        adapter._send_file = AsyncMock(return_value="msg-123")
+
+        result = asyncio.run(adapter.send_document(chat_id="wxid_test123", file_path="/tmp/demo.pdf"))
+
+        assert result.success is True
+        assert result.message_id == "msg-123"
+        adapter._send_file.assert_awaited_once_with("wxid_test123", "/tmp/demo.pdf", "")
+
+
+class _FakeAsyncResponse:
+    def __init__(self, status=200, headers=None, body=""):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self):
+        return self._body.encode("utf-8")
+
+    async def text(self):
+        return self._body
+
+
+class _FakeUploadSession:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append(("post", url, kwargs))
+        return self.response
+
+    def put(self, url, **kwargs):
+        self.calls.append(("put", url, kwargs))
+        return self.response
+
+
+class TestWeixinUploadHelpers:
+    def test_upload_full_url_uses_post_and_returns_header(self):
+        session = _FakeUploadSession(
+            _FakeAsyncResponse(status=200, headers={"x-encrypted-param": "enc-param"})
+        )
+
+        result = asyncio.run(
+            _upload_ciphertext_full_url(
+                session,
+                ciphertext=b"abc",
+                upload_full_url="https://cdn.example.com/c2c/upload?token=1",
+            )
+        )
+
+        assert result == "enc-param"
+        assert session.calls[0][0] == "post"
+        assert session.calls[0][1] == "https://cdn.example.com/c2c/upload?token=1"
+
+    @patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._get_upload_url", new_callable=AsyncMock)
+    def test_send_file_prefers_upload_full_url_over_legacy_upload_param(self, get_upload_url_mock, api_post_mock, tmp_path):
+        image_path = tmp_path / "demo.jpg"
+        image_path.write_bytes(b"fake-image-bytes")
+
+        get_upload_url_mock.return_value = {
+            "upload_full_url": "https://cdn.example.com/c2c/upload?token=1",
+            "upload_param": "legacy-param",
+        }
+        api_post_mock.return_value = {}
+
+        adapter = _make_adapter()
+        adapter._session = _FakeUploadSession(
+            _FakeAsyncResponse(status=200, headers={"x-encrypted-param": "enc-param"})
+        )
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda *_args: None
+
+        message_id = asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
+
+        assert message_id.startswith("hermes-weixin-")
+        assert adapter._session.calls[0][0] == "post"
+        assert "cdn.example.com" in adapter._session.calls[0][1]
+        api_post_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- accept the keyword argument names used by the shared gateway media helpers
- use `POST` for `upload_full_url` uploads and prefer that path when available
- encode CDN media `aes_key` as base64 of the hex text so Weixin clients can decrypt images correctly
- add regression coverage for upload_full_url handling and CDN AES key encoding

## Validation
- `python -m pytest tests/gateway/test_weixin.py -q` on profile repo: `24 passed`
- sent a real verification image through Weixin from profile; user confirmed the image opens normally

## Notes
- local macOS environment here does not have `pytest` installed, so the authoritative test run was executed on the server environment where the bug reproduced
