### PR TITLE
fix(feishu): issue where streaming edits in Feishu show extra leading…

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1390,6 +1390,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)


### PR DESCRIPTION

## What does this PR do?

Fixes extra leading blank lines appearing in Feishu streaming messages after they are edited.

When the LLM streams a response beginning with `\n\n` (which is common), the initial `send()` call correctly strips leading whitespace via `format_message()`. However, subsequent `edit_message()` calls — used for every streaming update — did not call `format_message()`, so the raw `\n\n` prefix was passed directly to the Feishu API. Feishu renders these as blank lines, causing messages to display with extra leading whitespace (marked "已编辑") for the duration of the stream.

The fix is a one-line change: apply `format_message()` in `edit_message()` before building the outbound payload, matching the existing behavior in `send()`.

## Related Issue

Fixes #8252

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Added `content = self.format_message(content)` at the top of `edit_message()`, before `_build_outbound_payload()` is called. This mirrors the existing call in `send()` and ensures leading/trailing whitespace is stripped from edited messages just as it is for newly sent ones.

## How to Test

1. Configure Hermes with a Feishu bot and trigger a prompt that causes streaming output (e.g. a long response or one that searches external resources).
2. Observe the message in the Feishu client while it is being streamed/edited.
3. **Before fix**: the message shows 1–2 blank lines above the text content (message is marked 已编辑).
4. **After fix**: the message text begins immediately with no extra leading blank lines throughout streaming.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before fix** — streaming edit shows extra blank lines:
```
(blank line)
(blank line)
Let me check the actual JIRA address...
```
*(message marked 已编辑 in Feishu client)*

**After fix** — text starts immediately:
```
Let me check the actual JIRA address...
```
