### PR TITLE
feat: support document/archive extensions in MEDIA: tag extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1160,7 +1160,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Problem

The `extract_media()` regex in `gateway/platforms/base.py` only matched audio/video/image extensions (`png|jpe?g|gif|webp|mp4|...|m4a`). Document formats like `.epub`, `.pdf`, `.zip` etc. were not explicitly matched, causing `MEDIA:/path/to/file.epub` to fall through to the generic `\S+` branch which can fail silently depending on the path format.

The send routing (line 1705) already has an `else` branch that calls `send_document()` for non-audio/video/image files — so the infrastructure was there, just the extraction regex was too narrow.

## Fix

Add common document and archive extensions to the extraction regex:
`epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa`

## Testing

Verified the updated regex compiles and correctly matches:
- `MEDIA:/path/to/book.epub` ✓
- `MEDIA:/tmp/report.pdf` ✓  
- Existing image/video/audio paths ✓
- Non-MEDIA text (no false positives) ✓