### PR TITLE
fix(tools): enforce ACP transport overrides in delegate_task child agents

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -312,6 +312,12 @@ def _build_child_agent(
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
 
+    if override_acp_command:
+        # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
+        # so run_agent.py initializes the CopilotACPClient.
+        effective_provider = "copilot-acp"
+        effective_api_mode = "chat_completions"
+
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning


### PR DESCRIPTION
## Summary

- When `override_acp_command` is passed to `_build_child_agent`, the child agent's `effective_provider` and `effective_api_mode` are not overridden — they inherit the parent's native API config (e.g. Anthropic).
- This causes the child `AIAgent` to skip `CopilotACPClient` initialization entirely (`run_agent.py:4008` checks `self.provider == "copilot-acp"`), making real HTTP requests with the parent's API key instead of routing through the ACP subprocess.
- Result: HTTP 401 errors when delegating to profile-based persistent agents via ACP.
- Fix: if `override_acp_command` is provided, force `effective_provider = "copilot-acp"` and `effective_api_mode = "chat_completions"` before constructing the child agent.

Refs #2653

## Test plan

- [x] `pytest tests/ -v -k "delegat"` — 91 passed, 0 new failures
- [x] Full test suite — 2225 passed, 4 pre-existing failures unrelated to this change
- [ ] Manual: run parent agent (Anthropic native) → `delegate_task` with `acp_command` → verify child routes through CopilotACPClient
- Tested on: Linux 6.18.12+kali-amd64, Python 3.13.12