### PR TITLE
fix(cli): check /browser status against configured CDP host

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,33 @@ def _get_chrome_debug_candidates(system: str) -> list[str]:
         )
 
     return candidates
+
+
+def _get_cdp_socket_target(cdp_url: str, default_port: int = 9222) -> tuple[str, int]:
+    """Extract the socket host/port from a CDP URL for reachability checks."""
+    raw = (cdp_url or "").strip()
+    if not raw:
+        return "127.0.0.1", default_port
+
+    # Accept full URLs like http://host:9222, ws://host:9222/devtools/browser/...,
+    # and bare host:port values.
+    parsed = urlparse(raw if "://" in raw else f"//{raw}", scheme="http")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or default_port
+    return host, port
+
+
+def _is_cdp_endpoint_reachable(cdp_url: str, timeout: float = 1.0) -> bool:
+    """Return True if the configured CDP endpoint accepts TCP connections."""
+    import socket
+
+    host, port = _get_cdp_socket_target(cdp_url)
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.close()
+        return True
+    except OSError:
+        return False
 
 
 def load_cli_config() -> Dict[str, Any]:
@@ -5471,24 +5499,9 @@ class HermesCLI:
 
             print()
 
-            # Extract port for connectivity checks
-            _port = 9222
-            try:
-                _port = int(cdp_url.rsplit(":", 1)[-1].split("/")[0])
-            except (ValueError, IndexError):
-                pass
-
-            # Check if Chrome is already listening on the debug port
-            import socket
-            _already_open = False
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.settimeout(1)
-                s.connect(("127.0.0.1", _port))
-                s.close()
-                _already_open = True
-            except (OSError, socket.timeout):
-                pass
+            # Extract host/port for connectivity checks.
+            _host, _port = _get_cdp_socket_target(cdp_url)
+            _already_open = _is_cdp_endpoint_reachable(cdp_url)
 
             if _already_open:
                 print(f"   ✓ Chrome is already listening on port {_port}")
@@ -5500,15 +5513,10 @@ class HermesCLI:
                     # Wait for the port to come up
                     import time as _time
                     for _wait in range(10):
-                        try:
-                            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                            s.settimeout(1)
-                            s.connect(("127.0.0.1", _port))
-                            s.close()
+                        if _is_cdp_endpoint_reachable(cdp_url):
                             _already_open = True
                             break
-                        except (OSError, socket.timeout):
-                            _time.sleep(0.5)
+                        _time.sleep(0.5)
                     if _already_open:
                         print(f"   ✓ Chrome launched and listening on port {_port}")
                     else:
@@ -5589,20 +5597,9 @@ class HermesCLI:
             if current:
                 print("🌐 Browser: connected to live Chrome via CDP")
                 print(f"   Endpoint: {current}")
-
-                _port = 9222
-                try:
-                    _port = int(current.rsplit(":", 1)[-1].split("/")[0])
-                except (ValueError, IndexError):
-                    pass
-                try:
-                    import socket
-                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    s.settimeout(1)
-                    s.connect(("127.0.0.1", _port))
-                    s.close()
+                if _is_cdp_endpoint_reachable(current):
                     print("   Status: ✓ reachable")
-                except (OSError, Exception):
+                else:
                     print("   Status: ⚠ not reachable (Chrome may not be running)")
             else:
                 try:

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -55,3 +55,23 @@ class TestChromeDebugLaunch:
             assert HermesCLI._try_launch_chrome_debug(9222, "Windows") is True
 
         _assert_chrome_debug_cmd(captured["cmd"], installed, 9222)
+
+
+def test_cdp_socket_target_uses_configured_host():
+    from cli import _get_cdp_socket_target
+
+    assert _get_cdp_socket_target("http://172.18.144.1:9222") == ("172.18.144.1", 9222)
+    assert _get_cdp_socket_target("ws://172.18.144.1:9222/devtools/browser/abc") == ("172.18.144.1", 9222)
+
+
+def test_browser_status_checks_remote_cdp_endpoint(monkeypatch, capsys):
+    cli = HermesCLI.__new__(HermesCLI)
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://172.18.144.1:9222")
+
+    with patch("cli._is_cdp_endpoint_reachable", return_value=True) as reachable:
+        cli._handle_browser_command("/browser status")
+
+    out = capsys.readouterr().out
+    assert "Endpoint: http://172.18.144.1:9222" in out
+    assert "Status: ✓ reachable" in out
+    reachable.assert_called_once_with("http://172.18.144.1:9222")

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -60,18 +60,18 @@ class TestChromeDebugLaunch:
 def test_cdp_socket_target_uses_configured_host():
     from cli import _get_cdp_socket_target
 
-    assert _get_cdp_socket_target("http://172.18.144.1:9222") == ("172.18.144.1", 9222)
-    assert _get_cdp_socket_target("ws://172.18.144.1:9222/devtools/browser/abc") == ("172.18.144.1", 9222)
+    assert _get_cdp_socket_target("http://192.0.2.10:9222") == ("192.0.2.10", 9222)
+    assert _get_cdp_socket_target("ws://192.0.2.10:9222/devtools/browser/abc") == ("192.0.2.10", 9222)
 
 
 def test_browser_status_checks_remote_cdp_endpoint(monkeypatch, capsys):
     cli = HermesCLI.__new__(HermesCLI)
-    monkeypatch.setenv("BROWSER_CDP_URL", "http://172.18.144.1:9222")
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://192.0.2.10:9222")
 
     with patch("cli._is_cdp_endpoint_reachable", return_value=True) as reachable:
         cli._handle_browser_command("/browser status")
 
     out = capsys.readouterr().out
-    assert "Endpoint: http://172.18.144.1:9222" in out
+    assert "Endpoint: http://192.0.2.10:9222" in out
     assert "Status: ✓ reachable" in out
-    reachable.assert_called_once_with("http://172.18.144.1:9222")
+    reachable.assert_called_once_with("http://192.0.2.10:9222")


### PR DESCRIPTION
## What does this PR do?

This fixes `/browser status` and the `/browser connect` reachability check when Hermes is connected to a non-local CDP endpoint.

Previously, the CLI always checked `127.0.0.1:<port>` even when `BROWSER_CDP_URL` or `/browser connect` pointed at a different host, such as a Windows host IP from WSL2. That caused false `not reachable` warnings even when the configured remote CDP endpoint was the correct one.

This change makes Hermes parse the configured CDP URL and check the actual host/port from that endpoint instead of hardcoding localhost.

## Related Issue

No existing issue or PR found for this specific `/browser status` remote-host false-negative bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Added `_get_cdp_socket_target()` to extract host/port from configured CDP URLs
  - Added `_is_cdp_endpoint_reachable()` so reachability checks use the configured endpoint host instead of always probing `127.0.0.1`
  - Updated `/browser connect` and `/browser status` to use the configured CDP host/port
- `tests/cli/test_cli_browser_connect.py`
  - Added coverage for remote-host CDP URL parsing
  - Added coverage that `/browser status` checks the configured endpoint value
  - Uses documentation-safe example IPs instead of environment-specific private addresses

## How to Test

1. Start Hermes from WSL2 and connect browser tools to a Windows-hosted CDP endpoint such as:
   `/browser connect http://<windows-host-ip>:9222`
2. Run `/browser status`
3. Confirm Hermes reports reachability based on the configured host instead of incorrectly probing `127.0.0.1:9222`

Static validation run in this environment:

```bash
python3 -m py_compile cli.py tests/cli/test_cli_browser_connect.py
```

I could not run the targeted pytest file in this environment because `pytest` is not installed in the local WSL runtime used for validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 22H2 + WSL2 Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix, `/browser status` could show:

```text
Browser: connected to live Chrome via CDP
Endpoint: http://<windows-host-ip>:9222
Status: not reachable
```

because the code probed `127.0.0.1:9222` instead of the configured endpoint host.