### PR TITLE
docs(gateway): add files:read to required Slack bot token scopes

### DIFF
--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -54,6 +54,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | `im:read` | View basic DM info |
 | `im:write` | Open and manage DMs |
 | `users:read` | Look up user information |
+| `files:read` | Read files (images, audio, documents) |
 | `files:write` | Upload files (images, audio, documents) |
 
 :::caution Missing scopes = missing features


### PR DESCRIPTION
## What does this PR do?

Adds `files:read` to the required bot token scopes table in the Slack setup guide.

Without this scope, Slack returns an HTML sign-in/redirect page instead of actual file bytes when the gateway attempts to download image attachments.

#7125 added magic-byte validation that catches this bad response before it reaches `vision_analyze`, but the underlying cause is still a missing scope. This PR updates the docs so new users include `files:read` from the start and avoid the failure entirely.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `website/docs/user-guide/messaging/slack.md` — added `files:read` to the Bot Token Scopes table in Step 2

## Checklist

<!-- Complete these before requesting review. -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A