### PR TITLE
fix(bluebubbles): use 127.0.0.1 instead of localhost for webhook URL

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -221,7 +221,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
         if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     async def _find_registered_webhooks(self, url: str) -> list:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -367,19 +367,23 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises local hosts to '127.0.0.1' (IPv4).
+
+    BlueBubbles (Node.js) resolves 'localhost' to IPv6 '::1' on macOS,
+    but aiohttp binds IPv4 only → webhook delivery fails with ECONNREFUSED.
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
-    def test_local_hosts_normalized(self, monkeypatch, host):
+    def test_local_hosts_normalized_to_ipv4(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## What does this PR do?

On macOS, Node.js (BlueBubbles server) resolves `localhost` to IPv6 `::1` by default. The Hermes gateway (aiohttp) binds to IPv4 `127.0.0.1` only. When the webhook URL uses `localhost`, all webhook deliveries fail silently with `ECONNREFUSED ::1:<port>`, so no inbound iMessages are ever received.

This PR normalizes loopback webhook hosts to `127.0.0.1` (explicit IPv4) instead of `localhost`, ensuring BlueBubbles connects to the correct address.

## Related Issue

Fixes #8512

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/bluebubbles.py`: Changed `_webhook_url` property to normalize local hosts to `127.0.0.1` instead of `localhost`
- `tests/gateway/test_bluebubbles.py`: Updated `TestBlueBubblesWebhookUrl` tests to verify IPv4 normalization

## How to Test

1. Start Hermes gateway with BlueBubbles platform on macOS
2. Verify webhook registers with `http://127.0.0.1:...` instead of `http://localhost:...`
3. Send an iMessage → confirm webhook delivery succeeds and gateway processes the message

**BlueBubbles server log (before fix):**
```
[WebhookService] Failed to dispatch "new-message" event to webhook: http://localhost:8645/...
  -> Error: connect ECONNREFUSED ::1:8645
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (Sequoia), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

**Cross-platform note:** This fix only affects macOS where Node.js prefers IPv6. On Linux, `localhost` typically resolves to IPv4 first, so the fix is a no-op. On Windows, the same IPv6 preference can occur with newer Node.js versions — this fix prevents the issue proactively.