### PR TITLE
fix(bluebubbles): skip updated-message events to prevent duplicate replies

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -793,8 +793,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.json_response({"error": "invalid payload"}, status=400)
 
         event_type = self._value(payload.get("type"), payload.get("event")) or ""
-        # Only process message events; silently acknowledge everything else
-        if event_type and event_type not in _MESSAGE_EVENTS:
+        # Only process genuinely new messages.  BlueBubbles also fires
+        # "updated-message" for delivery receipts, read receipts, and
+        # other status changes — processing those as new messages causes
+        # duplicate replies.
+        if event_type != "new-message":
             return web.Response(text="ok")
 
         record = self._extract_payload_record(payload) or {}


### PR DESCRIPTION
## Summary

- BlueBubbles fires `updated-message` webhook events for delivery receipts, read receipts, and status changes
- The handler processed these as new inbound messages, causing duplicate agent replies for every message
- Fix: only process `new-message` events; silently ACK everything else

**Gateway log showing the duplicate:**
```
16:30:52,926 INFO Sending response (120 chars) to +601****6188
16:30:53,983 INFO Sending response (120 chars) to +601****6188  ← duplicate
```

## Trade-off

This also skips genuine iMessage edits (`updated-message` with changed text). A future enhancement could compare old vs new text to forward edits to the agent while filtering out status-only updates.

## Test plan

- [ ] Send iMessage to Hermes → confirm exactly one reply (no duplicate)
- [ ] Verify delivery/read receipt webhooks are acknowledged but not processed