### PR TITLE
fix(signal): strip streaming cursor glyphs from outbound messages

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -108,7 +108,7 @@ def _ext_to_mime(ext: str) -> str:
 
 
 def _render_mentions(text: str, mentions: list) -> str:
-    """Replace Signal mention placeholders (\\uFFFC) with readable @identifiers.
+    """Replace Signal mention placeholders (\uFFFC) with readable @identifiers.
 
     Signal encodes @mentions as the Unicode object replacement character
     with out-of-band metadata containing the mentioned user's UUID/number.
@@ -126,6 +126,21 @@ def _render_mentions(text: str, mentions: list) -> str:
         replacement = f"@{identifier}"
         text = text[:start] + replacement + text[start + length:]
     return text
+
+
+def _sanitize_outbound_text(text: str) -> str:
+    """Remove known problematic control glyphs before sending to Signal.
+
+    Some Signal clients render unsupported Unicode as tofu squares. In practice,
+    the streaming cursor block (▉) and occasional object replacement character
+    (U+FFFC) can leak into outgoing text when an edit cleanup race occurs.
+    Strip these plus non-printable ASCII control chars.
+    """
+    if not text:
+        return ""
+    cleaned = text.replace("\uFFFC", "").replace("▉", "")
+    cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', cleaned)
+    return cleaned
 
 
 def check_signal_requirements() -> bool:
@@ -600,7 +615,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         params: Dict[str, Any] = {
             "account": self.account,
-            "message": content,
+            "message": _sanitize_outbound_text(content),
         }
 
         if chat_id.startswith("group:"):
@@ -671,7 +686,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         params: Dict[str, Any] = {
             "account": self.account,
-            "message": caption or "",
+            "message": _sanitize_outbound_text(caption or ""),
             "attachments": [file_path],
         }
 
@@ -710,7 +725,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         params: Dict[str, Any] = {
             "account": self.account,
-            "message": caption or "",
+            "message": _sanitize_outbound_text(caption or ""),
             "attachments": [file_path],
         }
 

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -194,6 +194,11 @@ class TestSignalHelpers:
         monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
         assert check_signal_requirements() is False
 
+    def test_sanitize_outbound_text_strips_cursor_and_object_replacement(self):
+        from gateway.platforms.signal import _sanitize_outbound_text
+        text = "hello ▉ world\uFFFC"
+        assert _sanitize_outbound_text(text) == "hello  world"
+
 
 # ---------------------------------------------------------------------------
 # SSE URL Encoding (Bug Fix: phone numbers with + must be URL-encoded)
@@ -728,6 +733,18 @@ class TestSignalSendReturnsMessageId:
 
         assert result.success is True
         assert result.message_id == "1712345678000"
+
+    @pytest.mark.asyncio
+    async def test_send_strips_streaming_cursor_glyph(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1712345678000})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        result = await adapter.send(chat_id="+155****4567", content="hello ▉")
+
+        assert result.success is True
+        assert captured[0]["params"]["message"] == "hello "
 
     @pytest.mark.asyncio
     async def test_send_returns_none_message_id_when_no_timestamp(self, monkeypatch):


### PR DESCRIPTION
**Summary**
- strip problematic outbound glyphs in Signal adapter to prevent visible tofu squares in clients
- add _sanitize_outbound_text and apply it to text sends and attachment captions
- add regression tests for sanitizer and send path

**Context**
Signal users can occasionally see a lingering square/block character at message end when the streaming cursor glyph leaks through (for example when final cursor cleanup edit races or fails).

**Changes**
- gateway/platforms/signal.py
-- add _sanitize_outbound_text(text)
-- remove U+FFFC and streaming cursor block glyph
-- strip non printable ASCII control chars
-- sanitize outbound send() content and media captions
- tests/gateway/test_signal.py
-- add sanitizer unit test
-- add send() regression test that verifies cursor glyph is stripped

**Validation**
- pytest -q tests/gateway/test_signal.py::TestSignalHelpers::test_sanitize_outbound_text_strips_cursor_and_object_replacement tests/gateway/test_signal.py::TestSignalSendReturnsMessageId::test_send_strips_streaming_cursor_glyph
- both tests pass

**Notes**
- this is intentionally narrow to Signal outbound text path
- no behavior change for other platforms