### PR TITLE
fix(matrix): restore verify_with_recovery_key after device key rotation

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -508,6 +508,19 @@ class MatrixAdapter(BasePlatformAdapter):
                     await api.session.close()
                     return False
 
+                # Import cross-signing private keys from SSSS and self-sign
+                # the current device. Required after any device-key rotation
+                # (fresh crypto.db, share_keys re-upload) — otherwise the
+                # device's self-signing signature is stale and peers refuse
+                # to share Megolm sessions with the rotated device.
+                recovery_key = os.getenv("MATRIX_RECOVERY_KEY", "").strip()
+                if recovery_key:
+                    try:
+                        await olm.verify_with_recovery_key(recovery_key)
+                        logger.info("Matrix: cross-signing verified via recovery key")
+                    except Exception as exc:
+                        logger.warning("Matrix: recovery key verification failed: %s", exc)
+
                 client.crypto = olm
                 logger.info(
                     "Matrix: E2EE enabled (store: %s%s)",


### PR DESCRIPTION
## Summary

After upgrading to v0.8.0, my Matrix gateway bot stopped decrypting messages. Root cause: v0.8.0's migration from `MemoryCryptoStore` to `PgCryptoStore` also removed the `verify_with_recovery_key()` bootstrap that used to run after `share_keys()` in `gateway/platforms/matrix.py`.

On any run where the bot's device keys get re-uploaded (fresh `crypto.db`, `_verify_device_keys_on_server` detecting stale server keys, etc.), the new device keys carry only the old self-signing signature — which no longer verifies. Peers like Element then refuse to share Megolm sessions with the rotated device, so the bot silently stops decrypting.

This restores the recovery-key bootstrap: on startup, if `MATRIX_RECOVERY_KEY` is set, import the cross-signing private keys from SSSS and call `sign_own_device()`, producing a valid signature server-side.

- Idempotent
- Gated on `MATRIX_RECOVERY_KEY` — zero behavior change for users who don't configure a recovery key
- 13 lines added, no other changes

## Test plan

- [x] Working Matrix E2EE setup with `MATRIX_RECOVERY_KEY` configured
- [x] Delete `crypto.db` and restart gateway to simulate a rotation
- [x] Confirm `Matrix: cross-signing verified via recovery key` appears in the logs
- [x] Send a message from a paired Element client to the bot
- [x] Bot decrypts and replies (with a fresh `device_id` — Element's own client cache is a separate, client-side issue when reusing a `device_id` across rotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)