### PR TITLE
fix(gateway): import RedactingFormatter missing after logging refactor

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8462,6 +8462,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # and gateway.log (INFO+, gateway-component records only).
     # Idempotent, so repeated calls from AIAgent.__init__ won't duplicate.
     from hermes_logging import setup_logging
+    from agent.redact import RedactingFormatter
     setup_logging(hermes_home=_hermes_home, mode="gateway")
 
     # Optional stderr handler — level driven by -v/-q flags on the CLI.


### PR DESCRIPTION
## Bug

Commit fd73937e refactored the logging setup but accidentally removed the `from agent.redact import RedactingFormatter` import that was inside the `if verbosity is not None:` block.

Since `verbosity` defaults to `0` (not `None`) — see `gateway.py:1537`: `verbosity = None if quiet else verbose` — this block is always entered on a normal gateway start, causing an immediate `NameError` that prevents the gateway from running at all.

```
NameError: name 'RedactingFormatter' is not defined
  File ".../gateway/run.py", line 8476, in start_gateway
    _stderr_handler.setFormatter(RedactingFormatter('%(levelname)s %(name)s: %(message)s'))
```

## Fix

Move `from agent.redact import RedactingFormatter` to the top of `start_gateway()`, alongside the other logging imports, so it is always available regardless of verbosity.

## Steps to reproduce

Install hermes after fd73937e and run `hermes gateway run` — the gateway crashes immediately on startup.