### PR TITLE
fix(gateway): peek at pending message during interrupt — fix race that loses user messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8046,8 +8046,16 @@ class GatewayRunner:
                     if hasattr(_adapter, 'has_pending_interrupt') and _adapter.has_pending_interrupt(session_key):
                         agent = agent_holder[0]
                         if agent:
-                            pending_event = _adapter.get_pending_message(session_key)
-                            pending_text = pending_event.text if pending_event else None
+                            # Peek at the pending message text WITHOUT consuming it.
+                            # The message must remain in _pending_messages so the
+                            # post-run dequeue at _dequeue_pending_event() can
+                            # retrieve the full MessageEvent (with media metadata).
+                            # If we pop here, a race exists: the agent may finish
+                            # before checking _interrupt_requested, and the message
+                            # is lost — neither the interrupt path nor the dequeue
+                            # path finds it.
+                            _peek_event = _adapter._pending_messages.get(session_key)
+                            pending_text = _peek_event.text if _peek_event else None
                             logger.debug("Interrupt detected from adapter, signaling agent...")
                             agent.interrupt(pending_text)
                             _interrupt_detected.set()
@@ -8138,7 +8146,7 @@ class GatewayRunner:
                         if (_backup_adapter and _backup_agent
                                 and hasattr(_backup_adapter, 'has_pending_interrupt')
                                 and _backup_adapter.has_pending_interrupt(session_key)):
-                            _bp_event = _backup_adapter.get_pending_message(session_key)
+                            _bp_event = _backup_adapter._pending_messages.get(session_key)
                             _bp_text = _bp_event.text if _bp_event else None
                             logger.info(
                                 "Backup interrupt detected for session %s "
@@ -8198,7 +8206,7 @@ class GatewayRunner:
                         if (_backup_adapter and _backup_agent
                                 and hasattr(_backup_adapter, 'has_pending_interrupt')
                                 and _backup_adapter.has_pending_interrupt(session_key)):
-                            _bp_event = _backup_adapter.get_pending_message(session_key)
+                            _bp_event = _backup_adapter._pending_messages.get(session_key)
                             _bp_text = _bp_event.text if _bp_event else None
                             logger.info(
                                 "Backup interrupt detected for session %s "


### PR DESCRIPTION
## Summary

Fixes intermittent message loss when a user sends a message while the agent is running long tasks (terminal commands, background process monitoring).

**Root cause:** `monitor_for_interrupt()` and the backup interrupt checks called `get_pending_message()` which **pops** the message from the adapter's queue. If the agent finished naturally before checking `_interrupt_requested`, the message was permanently lost — neither the interrupt path nor the post-run dequeue could find it.

**The race:**
1. Agent near completion, user sends "Are you there"
2. Level 1 guard stores message, sets interrupt event
3. Monitor detects event, **pops** message, calls `agent.interrupt(text)`
4. Agent's `run_conversation()` was already returning → `interrupted = False`
5. Post-run: `_dequeue_pending_event()` returns None (monitor already consumed it)
6. `result.get('interrupted')` is False → `interrupt_message` fallback not triggered
7. Message permanently lost

**Fix:** Change all three interrupt detection sites from `get_pending_message()` (pop) to `_pending_messages.get()` (peek). The message stays in the adapter's queue until `_dequeue_pending_event()` consumes it in the post-run handler, which runs regardless of whether the agent was interrupted or finished naturally.

## Test plan
- Gateway test suite: 2540 passed, 22 pre-existing failures (unrelated)
- No new test failures introduced

Reported by @_SushantSays (intermittent message loss during long terminal command execution, persisting after 73f970fa).