### PR TITLE
fix(weixin,wecom,matrix): respect system proxy via aiohttp trust_env

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -768,7 +768,7 @@ class MatrixAdapter(BasePlatformAdapter):
             # Try aiohttp first (always available), fall back to httpx
             try:
                 import aiohttp as _aiohttp
-                async with _aiohttp.ClientSession() as http:
+                async with _aiohttp.ClientSession(trust_env=True) as http:
                     async with http.get(image_url, timeout=_aiohttp.ClientTimeout(total=30)) as resp:
                         resp.raise_for_status()
                         data = await resp.read()

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -266,7 +266,7 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession(trust_env=True)
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -929,7 +929,7 @@ async def qr_login(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError("aiohttp is required for Weixin QR login")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         try:
             qr_resp = await _api_get(
                 session,
@@ -1124,7 +1124,7 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession(trust_env=True)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -1731,7 +1731,7 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         adapter = WeixinAdapter(
             PlatformConfig(
                 enabled=True,


### PR DESCRIPTION
## Problem

`aiohttp.ClientSession` defaults to `trust_env=False`, which means it ignores `HTTP_PROXY` / `HTTPS_PROXY` environment variables. For users behind a proxy (e.g. Clash in fake-ip mode — common in China), DNS resolves to fake IPs that only work when traffic is routed through the proxy. Since aiohttp bypasses the proxy entirely, QR login and all subsequent API calls silently fail.

This is especially impactful for **Weixin** and **WeCom**, which are Chinese services almost exclusively accessed through a proxy in practice.

## Fix

Added `trust_env=True` to all `aiohttp.ClientSession` instantiations that connect to external hosts:

| File | Locations | Connects to |
|------|-----------|-------------|
| `gateway/platforms/weixin.py` | 3 places | Tencent iLink API |
| `gateway/platforms/wecom.py` | 1 place | WeCom WebSocket API |
| `gateway/platforms/matrix.py` | 1 place | External image URLs |

**WhatsApp sessions are intentionally excluded** — they only connect to `127.0.0.1` (local bridge), where proxy routing is not needed.

**httpx-based adapters** (`dingtalk`, `signal`, `wecom_callback`) are unaffected — httpx already defaults to `trust_env=True`.

## Impact

- No behaviour change for users not using a proxy (`trust_env=True` is a no-op when no proxy env vars are set)
- Fixes Weixin QR login and runtime API calls for proxy users
- Consistent with how most HTTP clients (curl, requests, httpx) handle proxy settings by default