### PR TITLE
fix(matrix): add cross-signing recovery key verification for E2EE migration

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -18,6 +18,7 @@ Environment variables:
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement
     MATRIX_AUTO_THREAD          Auto-create threads for room messages (default: true)
+    MATRIX_RECOVERY_KEY         Recovery key for cross-signing verification after device key rotation
     MATRIX_DM_MENTION_THREADS   Create a thread when bot is @mentioned in a DM (default: false)
 """
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -508,6 +508,19 @@ class MatrixAdapter(BasePlatformAdapter):
                     await api.session.close()
                     return False
 
+                # Import cross-signing private keys from SSSS and self-sign
+                # the current device. Required after any device-key rotation
+                # (fresh crypto.db, share_keys re-upload) — otherwise the
+                # device's self-signing signature is stale and peers refuse
+                # to share Megolm sessions with the rotated device.
+                recovery_key = os.getenv("MATRIX_RECOVERY_KEY", "").strip()
+                if recovery_key:
+                    try:
+                        await olm.verify_with_recovery_key(recovery_key)
+                        logger.info("Matrix: cross-signing verified via recovery key")
+                    except Exception as exc:
+                        logger.warning("Matrix: recovery key verification failed: %s", exc)
+
                 client.crypto = olm
                 logger.info(
                     "Matrix: E2EE enabled (store: %s%s)",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -50,6 +50,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD",
+    "MATRIX_RECOVERY_KEY",
 })
 import yaml
 
@@ -1290,6 +1291,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Matrix device ID (stable across restarts)",
         "url": None,
         "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_RECOVERY_KEY": {
+        "description": "Matrix recovery key for cross-signing verification after device key rotation (from Element: Settings → Security → Recovery Key)",
+        "prompt": "Matrix recovery key",
+        "url": None,
+        "password": True,
         "category": "messaging",
         "advanced": True,
     },

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -277,6 +277,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATRIX_FREE_RESPONSE_ROOMS` | Comma-separated room IDs where bot responds without `@mention` |
 | `MATRIX_AUTO_THREAD` | Auto-create threads for room messages (default: `true`) |
 | `MATRIX_DM_MENTION_THREADS` | Create a thread when bot is `@mentioned` in a DM (default: `false`) |
+| `MATRIX_RECOVERY_KEY` | Recovery key for cross-signing verification after device key rotation. Recommended for E2EE setups with cross-signing enabled. |
 | `HASS_TOKEN` | Home Assistant Long-Lived Access Token (enables HA platform + tools) |
 | `HASS_URL` | Home Assistant URL (default: `http://homeassistant.local:8123`) |
 | `WEBHOOK_ENABLED` | Enable the webhook platform adapter (`true`/`false`) |

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -272,6 +272,18 @@ When E2EE is enabled, Hermes:
 - Decrypts incoming messages and encrypts outgoing messages automatically
 - Auto-joins encrypted rooms when invited
 
+### Cross-Signing Verification (Recommended)
+
+If your Matrix account has cross-signing enabled (the default in Element), set the recovery key so the bot can self-sign its device on startup. Without this, other Matrix clients may refuse to share encryption sessions with the bot after a device key rotation.
+
+```bash
+MATRIX_RECOVERY_KEY=EsT... your recovery key here
+```
+
+**Where to find it:** In Element, go to **Settings** → **Security & Privacy** → **Encryption** → your recovery key (also called the "Security Key"). This is the key you were asked to save when you first set up cross-signing.
+
+On each startup, if `MATRIX_RECOVERY_KEY` is set, Hermes imports cross-signing keys from the homeserver's secure secret storage and signs the current device. This is idempotent and safe to leave enabled permanently.
+
 :::warning
 If you delete the `~/.hermes/platforms/matrix/store/` directory, the bot loses its encryption keys. You'll need to verify the device again in your Matrix client. Back up this directory if you want to preserve encrypted sessions.
 :::
@@ -374,7 +386,7 @@ changed identity keys for the same device as suspicious.
      -d '{
        "type": "m.login.password",
        "identifier": {"type": "m.id.user", "user": "@hermes:your-server.org"},
-       "password": "your-password",
+       "password": "***",
        "initial_device_display_name": "Hermes Agent"
      }'
    ```
@@ -388,17 +400,27 @@ changed identity keys for the same device as suspicious.
    rm -f ~/.hermes/platforms/matrix/store/crypto_store.*
    ```
 
-3. **Force your Matrix client to rotate the encryption session**. In Element,
+3. **Set your recovery key** (if you use cross-signing — most Element users do). Add to `~/.hermes/.env`:
+
+   ```bash
+   MATRIX_RECOVERY_KEY=EsT... your recovery key here
+   ```
+
+   This lets the bot self-sign with cross-signing keys on startup, so Element trusts the new device immediately. Without this, Element may see the new device as unverified and refuse to share encryption sessions. Find your recovery key in Element under **Settings** → **Security & Privacy** → **Encryption**.
+
+4. **Force your Matrix client to rotate the encryption session**. In Element,
    open the DM room with the bot and type `/discardsession`. This forces Element
    to create a new encryption session and share it with the bot's new device.
 
-4. **Restart the gateway**:
+5. **Restart the gateway**:
 
    ```bash
    hermes gateway run
    ```
 
-5. **Send a new message**. The bot should decrypt and respond normally.
+   If `MATRIX_RECOVERY_KEY` is set, you should see `Matrix: cross-signing verified via recovery key` in the logs.
+
+6. **Send a new message**. The bot should decrypt and respond normally.
 
 :::note
 After migration, messages sent *before* the upgrade cannot be decrypted -- the old


### PR DESCRIPTION
## Summary

Salvages PR #8272 by @elkimek — adds `verify_with_recovery_key()` on startup so the bot's device gets a valid cross-signing signature after device key rotation. This fixes E2EE decryption failures for users upgrading from the old matrix-nio adapter to the mautrix-based one.

**Cherry-picked commit:** elkimek's 13-line fix that calls `olm.verify_with_recovery_key(recovery_key)` after `_verify_device_keys_on_server()`, gated on `MATRIX_RECOVERY_KEY` env var.

**Follow-up additions:**
- Register `MATRIX_RECOVERY_KEY` in `OPTIONAL_ENV_VARS` (config.py) with `password=True`, `advanced=True`
- Add to `_NON_SETUP_ENV_VARS` set and module docstring header
- Document cross-signing verification in the E2EE setup section of matrix.md
- Add recovery key as step 3 in the migration guide (existing steps renumbered)
- Add to environment-variables.md reference page

## What this fixes

When users upgrade from the old `matrix-nio` or pickle-based `mautrix` setup to the current SQLite crypto store, their bot gets a fresh encryption identity. The existing migration docs cover generating a new access token and deleting old crypto state, but users with **cross-signing enabled** (the default in Element) still hit silent decryption failures because the fresh device doesn't have a valid cross-signing signature. `verify_with_recovery_key()` imports cross-signing keys from SSSS and calls `sign_own_device()`, making the device immediately trusted.

## Test plan

- 229 matrix + config tests pass
- 2584 gateway tests pass (23 pre-existing failures in unrelated areas)
- py_compile checks pass on both modified Python files

Closes #8272 — contributor credit preserved via cherry-pick.