### PR TITLE
fix: rotate credential pool on 403 (Forbidden) responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4623,7 +4623,7 @@ class AIAgent:
                 effective_reason = FailoverReason.billing
             elif status_code == 429:
                 effective_reason = FailoverReason.rate_limit
-            elif status_code == 401:
+            elif status_code in (401, 403):
                 effective_reason = FailoverReason.auth
 
         if effective_reason == FailoverReason.billing:


### PR DESCRIPTION
## Summary

- `_handle_credential_pool_error` handled 401, 402, and 429 but **silently ignored 403**
- When a provider returns 403 for a revoked credential (e.g. a Nous `agent_key` invalidated by a newer login), the pool was never rotated — every subsequent request kept hitting the same failing credential
- Treat 403 like 402: immediately mark the current entry exhausted and rotate to the next pool entry, since a Forbidden response won't resolve with a retry

## Root cause

Nous (and other OAuth providers) invalidate older agent keys when new ones are minted. If a user has multiple credential pool entries (accumulated via repeated `hermes auth add nous`), the oldest entry (lowest priority, selected first by `fill_first`) may be revoked. Without 403 rotation, the pool is stuck on that entry indefinitely.

## Test plan

- [ ] Verify that a 403 response from the inference API causes the pool to rotate to the next available credential
- [ ] Verify that when all pool entries are exhausted after 403s, the error surfaces correctly to the user
- [ ] Existing 401/402/429 rotation behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)