### PR TITLE
fix(gateway): queue pending messages instead of dropping them

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -727,29 +727,31 @@ class SendResult:
 
 
 def merge_pending_message_event(
-    pending_messages: Dict[str, MessageEvent],
+    pending_messages: Dict[str, List[MessageEvent]],
     session_key: str,
     event: MessageEvent,
 ) -> None:
-    """Store or merge a pending event for a session.
+    """Append a pending event for a session.
 
     Photo bursts/albums often arrive as multiple near-simultaneous PHOTO
-    events. Merge those into the existing queued event so the next turn sees
-    the whole burst, while non-photo follow-ups still replace the pending
-    event normally.
+    events. Merge those into the last queued PHOTO event so the next turn
+    sees the whole burst.  Other message types are appended to the queue
+    so no messages are silently dropped.
     """
-    existing = pending_messages.get(session_key)
+    queue = pending_messages.get(session_key, [])
+    # Merge consecutive photo events into one (album grouping)
     if (
-        existing
-        and getattr(existing, "message_type", None) == MessageType.PHOTO
+        queue
+        and getattr(queue[-1], "message_type", None) == MessageType.PHOTO
         and event.message_type == MessageType.PHOTO
     ):
-        existing.media_urls.extend(event.media_urls)
-        existing.media_types.extend(event.media_types)
+        queue[-1].media_urls.extend(event.media_urls)
+        queue[-1].media_types.extend(event.media_types)
         if event.text:
-            existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
-        return
-    pending_messages[session_key] = event
+            queue[-1].text = BasePlatformAdapter._merge_caption(queue[-1].text, event.text)
+    else:
+        queue.append(event)
+    pending_messages[session_key] = queue
 
 
 # Error substrings that indicate a transient *connection* failure worth retrying.
@@ -800,7 +802,7 @@ class BasePlatformAdapter(ABC):
         # Track active message handlers per session for interrupt support
         # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
         self._active_sessions: Dict[str, asyncio.Event] = {}
-        self._pending_messages: Dict[str, MessageEvent] = {}
+        self._pending_messages: Dict[str, List[MessageEvent]] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -1545,7 +1547,7 @@ class BasePlatformAdapter(ABC):
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
             logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            self._pending_messages[session_key] = event
+            merge_pending_message_event(self._pending_messages, session_key, event)
             # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
             return  # Don't process now - will be handled after current task finishes
@@ -1803,9 +1805,12 @@ class BasePlatformAdapter(ABC):
             )
 
             # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
-                logger.debug("[%s] Processing queued message from interrupt", self.name)
+            if session_key in self._pending_messages and self._pending_messages[session_key]:
+                pending_queue = self._pending_messages[session_key]
+                pending_event = pending_queue.pop(0)
+                if not pending_queue:
+                    del self._pending_messages[session_key]
+                logger.debug("[%s] Processing queued message from interrupt (%d more pending)", self.name, len(pending_queue) if session_key in self._pending_messages else 0)
                 # Clean up current session before processing pending
                 if session_key in self._active_sessions:
                     del self._active_sessions[session_key]
@@ -1884,8 +1889,15 @@ class BasePlatformAdapter(ABC):
         return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
     
     def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
-        """Get and clear any pending message for a session."""
-        return self._pending_messages.pop(session_key, None)
+        """Get and remove the next pending message for a session."""
+        queue = self._pending_messages.get(session_key)
+        if not queue:
+            self._pending_messages.pop(session_key, None)
+            return None
+        event = queue.pop(0)
+        if not queue:
+            del self._pending_messages[session_key]
+        return event
     
     def build_source(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2596,7 +2596,8 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                     )
-                    adapter._pending_messages[_quick_key] = queued_event
+                    from gateway.platforms.base import merge_pending_message_event as _merge_pend
+                    _merge_pend(adapter._pending_messages, _quick_key, queued_event)
                 return "Queued for the next turn."
 
             # /model must not be used while the agent is running.
@@ -2637,7 +2638,8 @@ class GatewayRunner:
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
                 if adapter:
-                    adapter._pending_messages[_quick_key] = event
+                    from gateway.platforms.base import merge_pending_message_event as _merge_pend
+                    _merge_pend(adapter._pending_messages, _quick_key, event)
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():


### PR DESCRIPTION
## Summary

When a message arrives while the agent is processing a previous one, `BasePlatformAdapter` stores it in `_pending_messages` for processing after the current turn. The problem: `_pending_messages` was `Dict[str, MessageEvent]` — a single slot per session. If messages B and C both arrive while A is processing, C overwrites B and B is silently lost.

This affects **all** messaging platforms (Telegram, Discord, WhatsApp, Signal, SimpleX, Matrix, etc.) since the logic lives in `base.py`. It is most noticeable on platforms without built-in batching delays.

### Changes

- Change `_pending_messages` from `Dict[str, MessageEvent]` to `Dict[str, List[MessageEvent]]`
- `merge_pending_message_event()` appends to the queue instead of overwriting (photo album merging still works — consecutive PHOTO events are merged into the last queued photo)
- Pending consumption pops from the front of the queue and continues processing remaining items
- `get_pending_message()` returns the next queued event instead of the only one
- Interrupt queueing now uses `merge_pending_message_event()` consistently

## Test plan

- [ ] Send 3+ messages quickly while the agent is processing — all should get responses or be included in the next turn
- [ ] Send multiple photos in quick succession — should still be grouped as an album
- [ ] Verify interrupt behavior still works (new message interrupts current processing)
- [ ] Test across platforms (Telegram, Discord, SimpleX)
