### PR TITLE
fix(bluebubbles): extract chatGuid from chats array in webhook payload

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -857,13 +857,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             text = "(attachment)"
         # --- End attachment handling ---
 
+        # Extract chatGuid — try direct fields first, then fall back to
+        # the chats array (BB webhook payloads often only populate chats[]).
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
             record.get("chat_guid"),
             payload.get("chat_guid"),
-            payload.get("guid"),
         )
+        if not chat_guid:
+            _chats = record.get("chats") or payload.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -195,6 +195,88 @@ class TestBlueBubblesWebhookParsing:
         assert record["text"] == "hello"
 
 
+class TestBlueBubblesChatGuidFromChatsArray:
+    """chatGuid is often null in BB webhook payloads; extract from chats[]."""
+
+    def test_chat_guid_from_chats_array_dm(self, monkeypatch):
+        """DM: chats[0].guid provides the correct chat GUID."""
+        adapter = _make_adapter(monkeypatch)
+        record = {
+            "chatGuid": None,
+            "chatIdentifier": None,
+            "chats": [{"guid": "iMessage;-;+601234567890"}],
+        }
+        payload = {"data": record}
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            payload.get("chatGuid"),
+            record.get("chat_guid"),
+            payload.get("chat_guid"),
+        )
+        if not chat_guid:
+            _chats = record.get("chats") or payload.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        assert chat_guid == "iMessage;-;+601234567890"
+
+    def test_chat_guid_from_chats_array_group(self, monkeypatch):
+        """Group: chats[0].guid provides the group GUID."""
+        adapter = _make_adapter(monkeypatch)
+        record = {
+            "chatGuid": None,
+            "chatIdentifier": None,
+            "chats": [{"guid": "iMessage;+;chat17d58a0bf2"}],
+        }
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            record.get("chat_guid"),
+        )
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        assert chat_guid == "iMessage;+;chat17d58a0bf2"
+
+    def test_direct_chat_guid_still_preferred(self, monkeypatch):
+        """When chatGuid is populated, it takes priority over chats[]."""
+        adapter = _make_adapter(monkeypatch)
+        record = {
+            "chatGuid": "iMessage;-;direct@example.com",
+            "chats": [{"guid": "iMessage;-;different@example.com"}],
+        }
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            record.get("chat_guid"),
+        )
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid")
+        assert chat_guid == "iMessage;-;direct@example.com"
+
+    def test_empty_chats_array_falls_through(self, monkeypatch):
+        """Empty chats array → chat_guid stays None."""
+        adapter = _make_adapter(monkeypatch)
+        record = {"chatGuid": None, "chats": []}
+        chat_guid = adapter._value(record.get("chatGuid"))
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid")
+        assert chat_guid is None
+
+    def test_no_chats_key_falls_through(self, monkeypatch):
+        """Missing chats key entirely → chat_guid stays None."""
+        adapter = _make_adapter(monkeypatch)
+        record = {"chatGuid": None}
+        chat_guid = adapter._value(record.get("chatGuid"))
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid")
+        assert chat_guid is None
+
+
 class TestBlueBubblesGuidResolution:
     def test_raw_guid_returned_as_is(self, monkeypatch):
         """If target already contains ';' it's a raw GUID — return unchanged."""


### PR DESCRIPTION
## What does this PR do?

BlueBubbles webhook payloads do not populate the top-level `chatGuid` or `chatIdentifier` fields on message records. The chat GUID is only available inside the `chats` array. Without the correct chatGuid, the adapter falls back to the sender's phone number, and `_resolve_chat_guid` may resolve it to a group chat where the contact is a participant — causing DM replies to go to the wrong chat.

This PR falls back to `record["chats"][0]["guid"]` when direct `chatGuid` fields are empty, and removes the stale `payload.get("guid")` fallback that incorrectly matched the message GUID.

## Related Issue

Fixes #8514

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: Added `chats[0].guid` fallback, removed incorrect `payload.get("guid")` fallback
- `tests/gateway/test_bluebubbles.py`: Added `TestBlueBubblesChatGuidFromChatsArray` (5 tests)

## How to Test

1. Send a DM - verify reply goes to DM (not group)
2. Send in group chat - verify reply goes to group
3. Message with no chats array - verify fallback to chat_identifier

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Sequoia), Apple Silicon

### Documentation & Housekeeping

- [x] N/A - BlueBubbles-specific fix, no config or doc changes needed
- [x] Cross-platform: BlueBubbles is macOS-only, no impact on other platforms