### PR TITLE
fix(gateway): add inactivity timeout for /background tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20097,6 +20097,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
+            agent_holder: list = [None]
+            _executor_task = None
+
+            def _finalize_executor_task() -> None:
+                """Best-effort: consume the worker future's eventual result.
+
+                The gateway-owned worker thread can't be force-killed, so on
+                inactivity-timeout or cancellation we interrupt the agent
+                (signalling it to unwind) and attach this so the late
+                result/exception is retrieved rather than surfacing as a
+                "Future exception was never retrieved" warning once the
+                interrupted worker finally returns.
+                """
+                task = _executor_task
+                if task is None:
+                    return
+
+                def _swallow(_t) -> None:
+                    if _t.cancelled():
+                        return
+                    try:
+                        _exc = _t.exception()
+                    except Exception:
+                        return
+                    if _exc is not None:
+                        logger.debug(
+                            "Background task %s executor unwound after "
+                            "timeout/cancellation: %s", task_id, _exc,
+                        )
+
+                if task.done():
+                    _swallow(task)
+                else:
+                    task.add_done_callback(_swallow)
+
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
             enriched_prompt = prompt
@@ -20146,6 +20181,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                agent_holder[0] = agent
+
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -20154,7 +20191,99 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 finally:
                     self._cleanup_agent_resources(agent)
 
-            result = await self._run_in_executor_with_context(run_sync)
+            # _float_env falls back to the default on a malformed/empty value
+            # instead of raising and failing the whole background run.
+            _bg_timeout_raw = _float_env("HERMES_AGENT_TIMEOUT", 1800)
+            _bg_timeout = _bg_timeout_raw if _bg_timeout_raw > 0 else None
+            _bg_warning_raw = _float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
+            _bg_warning = _bg_warning_raw if _bg_warning_raw > 0 else None
+            _bg_warning_fired = False
+            _POLL_INTERVAL = _float_env("HERMES_BG_POLL_INTERVAL", 5.0)
+
+            # Poll the gateway-owned executor with session contextvars preserved
+            # (via _run_in_executor_with_context) instead of the default loop
+            # executor — matches the non-background path. Wrap in a Task so we
+            # can watch it for inactivity without blocking.
+            _executor_task = asyncio.ensure_future(
+                self._run_in_executor_with_context(run_sync)
+            )
+
+            _inactivity_timeout = False
+            result = None
+            while True:
+                done, _ = await asyncio.wait(
+                    {_executor_task}, timeout=_POLL_INTERVAL
+                )
+                if done:
+                    result = _executor_task.result()
+                    break
+                if _bg_timeout is None:
+                    continue
+                _bg_agent = agent_holder[0]
+                _idle_secs = 0.0
+                if _bg_agent and hasattr(_bg_agent, "get_activity_summary"):
+                    try:
+                        _act = _bg_agent.get_activity_summary()
+                        _idle_secs = _act.get("seconds_since_activity", 0.0)
+                    except Exception:
+                        pass
+                if (not _bg_warning_fired and _bg_warning is not None
+                        and _idle_secs >= _bg_warning):
+                    _bg_warning_fired = True
+                    _elapsed_warn = int(_bg_warning // 60) or 1
+                    try:
+                        await adapter.send(
+                            source.chat_id,
+                            f"⚠️ Background task {task_id}: no activity for "
+                            f"{_elapsed_warn} min. Will time out soon if it "
+                            f"remains idle.",
+                            metadata=_thread_metadata,
+                        )
+                    except Exception:
+                        pass
+                if _idle_secs >= _bg_timeout:
+                    _inactivity_timeout = True
+                    break
+
+            if _inactivity_timeout:
+                _timed_out_agent = agent_holder[0]
+                _activity = {}
+                if _timed_out_agent and hasattr(_timed_out_agent, "get_activity_summary"):
+                    try:
+                        _activity = _timed_out_agent.get_activity_summary()
+                    except Exception:
+                        pass
+                _cur_tool = _activity.get("current_tool")
+                _secs_ago = _activity.get("seconds_since_activity", 0)
+                _timeout_mins = int(_bg_timeout // 60) or 1
+
+                logger.error(
+                    "Background task %s idle for %.0fs (timeout %.0fs) | tool=%s",
+                    task_id, _secs_ago, _bg_timeout, _cur_tool or "none",
+                )
+
+                if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
+                    _timed_out_agent.interrupt("Execution timed out (inactivity)")
+
+                # Detach and consume the still-running worker future so the
+                # interrupted agent's eventual return isn't reported as an
+                # unretrieved exception (thread can't be force-killed).
+                _finalize_executor_task()
+
+                _diag_parts = [
+                    f"⏱️ Background task {task_id} timed out — no activity "
+                    f"for {_timeout_mins} min.",
+                ]
+                if _cur_tool:
+                    _diag_parts.append(f"Last active tool: `{_cur_tool}`.")
+                _diag_parts.append("Use /background to retry with a different prompt.")
+
+                await adapter.send(
+                    source.chat_id,
+                    "\n".join(_diag_parts),
+                    metadata=_thread_metadata,
+                )
+                return
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -20240,6 +20369,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata=_thread_metadata,
                 )
 
+        except asyncio.CancelledError:
+            logger.warning("Background task %s cancelled (gateway shutdown?)", task_id)
+            # Best-effort: interrupt the in-flight agent so provider/tool work
+            # stops instead of running on past the cancelled awaiter, then
+            # consume the worker future so its late return isn't reported as an
+            # unretrieved exception during shutdown.
+            _bg_agent = agent_holder[0]
+            if _bg_agent is not None and hasattr(_bg_agent, "interrupt"):
+                try:
+                    _bg_agent.interrupt("Background task cancelled (gateway shutdown)")
+                except Exception:
+                    pass
+            _finalize_executor_task()
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"⚠️ Background task {task_id} was cancelled (gateway restart or shutdown).",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
         except Exception as e:
             logger.exception("Background task %s failed", task_id)
             try:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -168,6 +168,188 @@ class TestRunBackgroundTask:
 
 
 # ---------------------------------------------------------------------------
+# _run_background_task inactivity watchdog + cancellation (PR #8298)
+# ---------------------------------------------------------------------------
+
+
+def _sent_contents(mock_adapter):
+    """Collect the text content of every adapter.send() call (positional or kw)."""
+    out = []
+    for call in mock_adapter.send.call_args_list:
+        content = call.kwargs.get("content")
+        if content is None and len(call.args) > 1:
+            content = call.args[1]
+        out.append(content or "")
+    return out
+
+
+def _prime_worker_runner(runner, monkeypatch):
+    """Wire the resolve helpers so _run_background_task reaches run_sync (which
+    builds the real agent via the patched AIAgent and populates agent_holder)."""
+    from gateway import run as gateway_run
+
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("test-model", {"api_key": "test-key"})
+    )
+    runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+    runner._load_service_tier = MagicMock(return_value=None)
+    runner._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "model": "test-model",
+            "runtime": {"api_key": "test-key"},
+            "request_overrides": None,
+        }
+    )
+    runner._refresh_fallback_model = MagicMock(return_value=None)
+    runner._cleanup_agent_resources = MagicMock()
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+
+class TestBackgroundWatchdog:
+    """The /background inactivity watchdog + cancellation handling."""
+
+    @pytest.mark.asyncio
+    async def test_inactivity_warning_fires_once(self, monkeypatch):
+        """A single idle-warning message is sent while the agent stays idle,
+        even though the poller ticks several times before the run completes."""
+        import time as _time
+
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "9999")   # never time out
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0.01")
+        monkeypatch.setenv("HERMES_BG_POLL_INTERVAL", "0.02")
+
+        runner = _make_runner()
+        _prime_worker_runner(runner, monkeypatch)
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done late"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done late"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, user_id="12345", chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_agent = MagicMock()
+        mock_agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 999.0, "current_tool": "shell",
+        }
+        mock_agent.run_conversation.side_effect = lambda **kw: (
+            _time.sleep(0.12) or {"final_response": "done late", "messages": []}
+        )
+        mock_agent.shutdown_memory_provider = MagicMock()
+        mock_agent.close = MagicMock()
+
+        with patch("run_agent.AIAgent", return_value=mock_agent):
+            await runner._run_background_task("do slow thing", source, "bg_test")
+
+        contents = _sent_contents(mock_adapter)
+        warnings = [c for c in contents if "no activity for" in c and "time out soon" in c]
+        completions = [c for c in contents if "Background task complete" in c]
+        assert len(warnings) == 1, f"expected exactly one idle warning, got {contents}"
+        assert len(completions) == 1, f"expected the result to still be delivered, got {contents}"
+
+    @pytest.mark.asyncio
+    async def test_inactivity_timeout_interrupts_and_notifies(self, monkeypatch):
+        """When idle exceeds the timeout, the agent is interrupted and a
+        timeout diagnostic is delivered (instead of hanging forever)."""
+        import threading
+
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0.05")
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0.01")
+        monkeypatch.setenv("HERMES_BG_POLL_INTERVAL", "0.02")
+
+        runner = _make_runner()
+        _prime_worker_runner(runner, monkeypatch)
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, user_id="12345", chat_id="67890",
+            user_name="testuser",
+        )
+
+        released = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 999.0, "current_tool": "shell",
+        }
+        # Block until interrupt() releases us (or a safety timeout), mimicking a
+        # wedged worker thread that only unwinds once interrupted.
+        mock_agent.run_conversation.side_effect = lambda **kw: (
+            released.wait(timeout=5.0) and None
+            or {"final_response": "late", "messages": []}
+        )
+        mock_agent.interrupt.side_effect = lambda *a, **k: released.set()
+        mock_agent.shutdown_memory_provider = MagicMock()
+        mock_agent.close = MagicMock()
+
+        with patch("run_agent.AIAgent", return_value=mock_agent):
+            await runner._run_background_task("wedge please", source, "bg_test")
+
+        mock_agent.interrupt.assert_called()
+        contents = _sent_contents(mock_adapter)
+        assert any("timed out" in c for c in contents), contents
+        assert any("`shell`" in c for c in contents), contents
+        # Let the released worker thread unwind so its future is consumed cleanly.
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_interrupts_and_notifies(self, monkeypatch):
+        """Cancelling the background task (gateway shutdown) interrupts the
+        in-flight agent and notifies the user rather than dying silently."""
+        import threading
+
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "9999")   # not a timeout test
+        monkeypatch.setenv("HERMES_BG_POLL_INTERVAL", "0.02")
+
+        runner = _make_runner()
+        _prime_worker_runner(runner, monkeypatch)
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, user_id="12345", chat_id="67890",
+            user_name="testuser",
+        )
+
+        started = threading.Event()
+        released = threading.Event()
+        mock_agent = MagicMock()
+        mock_agent.get_activity_summary.return_value = {"seconds_since_activity": 0.0}
+        mock_agent.run_conversation.side_effect = lambda **kw: (
+            started.set() or released.wait(timeout=5.0)
+            or {"final_response": "late", "messages": []}
+        )
+        mock_agent.interrupt.side_effect = lambda *a, **k: released.set()
+        mock_agent.shutdown_memory_provider = MagicMock()
+        mock_agent.close = MagicMock()
+
+        with patch("run_agent.AIAgent", return_value=mock_agent):
+            task = asyncio.ensure_future(
+                runner._run_background_task("long job", source, "bg_test")
+            )
+            # Wait until the worker is actually running (agent_holder populated).
+            for _ in range(200):
+                if started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert started.is_set(), "worker never started"
+            task.cancel()
+            await task  # handler swallows CancelledError after notifying
+
+        mock_agent.interrupt.assert_called()
+        contents = _sent_contents(mock_adapter)
+        assert any("was cancelled" in c for c in contents), contents
+
+
+# ---------------------------------------------------------------------------
 # /background in help and known_commands
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Background tasks spawned by `/background` had two ways to silently drop results:

1. **No inactivity timeout**: Regular agent sessions have a configurable inactivity timeout (default 1800s) that kills stuck agents and notifies the user. Background tasks used a bare `await loop.run_in_executor(None, run_sync)` with no timeout — a hung API call or stuck tool would run forever with no user notification.

2. **CancelledError not caught**: On gateway restart/shutdown, background asyncio tasks are cancelled. `asyncio.CancelledError` inherits from `BaseException` (not `Exception`), so the existing error handler never fired and the task disappeared silently.

### Changes

- Add the same inactivity polling loop used by regular sessions, checking `agent.get_activity_summary()` every 5s against `HERMES_AGENT_TIMEOUT` (default 1800s)
- Fire a warning message at `HERMES_AGENT_TIMEOUT_WARNING` (default 900s)
- On timeout, interrupt the agent and send diagnostic info to the user (timeout duration, last active tool)
- Catch `asyncio.CancelledError` separately to send a best-effort notification on gateway shutdown

No behavioral change when background tasks complete normally.

## Test plan

- [ ] Run `/background` with a prompt that completes normally — verify result is still delivered
- [ ] Run `/background` with a task likely to hang — verify warning at 15 min and timeout at 30 min
- [ ] Restart the gateway while a `/background` task is running — verify cancellation message is sent
- [ ] Set `HERMES_AGENT_TIMEOUT=0` — verify background tasks run without timeout (unlimited mode)
