### PR TITLE
fix(telegram): quote-reply to user message in streaming mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7647,6 +7647,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to_id=event_message_id,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -70,6 +70,7 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to_id: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -78,6 +79,7 @@ class GatewayStreamConsumer:
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
+        self._initial_reply_to: Optional[str] = reply_to_id
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -311,17 +313,23 @@ class GatewayStreamConsumer:
     async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
+        For the very first chunk (reply_to_id is None), uses the original
+        user message ID so the bot's reply appears as a quote-reply.
+        Subsequent chunks thread to the bot's own previous message.
+
         Returns the message_id so callers can thread subsequent chunks.
         """
         text = self._clean_for_display(text)
         if not text.strip():
             return reply_to_id
         try:
+            # First chunk: quote-reply to the user's original message
+            effective_reply_to = reply_to_id or self._initial_reply_to
             meta = dict(self.metadata) if self.metadata else {}
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                reply_to=reply_to_id,
+                reply_to=effective_reply_to,
                 metadata=meta,
             )
             if result.success and result.message_id:


### PR DESCRIPTION
## Problem

When streaming is enabled, the bot's responses never appear as quote-replies to the user's message on Telegram. This is because `GatewayStreamConsumer` sends messages with `reply_to=None` — it never receives the original message ID.

The non-streaming path (`_process_message_background` in `base.py`) correctly passes `reply_to=event.message_id`, but streaming bypasses this entirely.

## Fix

Two changes:

1. **`stream_consumer.py`**: Added `reply_to_id` parameter to `GatewayStreamConsumer.__init__()` and stored as `_initial_reply_to`. In `_send_new_chunk()`, when `reply_to_id` is `None` (first chunk), falls back to `_initial_reply_to` so the bot's first streamed message quote-replies to the user's original message. Subsequent chunks continue threading to the bot's own previous message.

2. **`run.py`**: Passes `event_message_id` to `GatewayStreamConsumer` constructor.

## Testing

All 28 existing `test_stream_consumer.py` tests pass. The `reply_to_id` parameter is optional (defaults to `None`), so no other call sites need updating.

## Behavior

- **First chunk**: `reply_to=effective_reply_to` → Telegram shows quote-reply to user's message
- **Subsequent chunks**: `reply_to=bot_message_id` → threads to bot's previous message
- **Segment breaks**: reset state, next segment uses `_initial_reply_to` again for its first chunk
