### PR TITLE
fix(mcp): avoid UNC cwd warnings for Windows stdio servers on WSL

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tools.mcp_tool import MCPServerTask, _format_connect_error, _resolve_stdio_command, _MCP_AVAILABLE
+from tools.mcp_tool import (
+    MCPServerTask,
+    _MCP_AVAILABLE,
+    _format_connect_error,
+    _resolve_stdio_command,
+    _resolve_stdio_cwd,
+)
 
 # Ensure the mcp module symbols exist for patching even when the SDK isn't installed
 if not _MCP_AVAILABLE:
@@ -47,6 +53,29 @@ def test_resolve_stdio_command_respects_explicit_empty_path():
     assert command == "python"
     assert env["PATH"] == ""
     assert seen_paths == [""]
+
+
+def test_resolve_stdio_cwd_uses_windows_mount_for_wsl_windows_exe():
+    with patch("tools.mcp_tool.is_wsl", return_value=True), \
+         patch.dict("os.environ", {"USERNAME": "Administrator"}, clear=False), \
+         patch("tools.mcp_tool.Path.is_dir", autospec=True, side_effect=lambda self: str(self) == "/mnt/c/Users/Administrator"):
+        cwd = _resolve_stdio_cwd("cmd.exe", None)
+
+    assert cwd == "/mnt/c/Users/Administrator"
+
+
+def test_resolve_stdio_cwd_respects_explicit_config():
+    with patch("tools.mcp_tool.is_wsl", return_value=True):
+        cwd = _resolve_stdio_cwd("cmd.exe", "/mnt/c/workspace")
+
+    assert cwd == "/mnt/c/workspace"
+
+
+def test_resolve_stdio_cwd_skips_non_windows_commands():
+    with patch("tools.mcp_tool.is_wsl", return_value=True):
+        cwd = _resolve_stdio_cwd("npx", None)
+
+    assert cwd is None
 
 
 def test_format_connect_error_unwraps_exception_group():
@@ -91,6 +120,38 @@ def test_run_stdio_uses_resolved_command_and_prepended_path(tmp_path):
             call_kwargs = mock_params.call_args.kwargs
             assert call_kwargs["command"] == str(npx_path)
             assert call_kwargs["env"]["PATH"].split(os.pathsep)[0] == str(node_bin)
+            assert call_kwargs["cwd"] is None
+
+            await server.shutdown()
+
+    asyncio.run(_test())
+
+
+def test_run_stdio_uses_safe_windows_cwd_on_wsl(tmp_path):
+    mock_session = MagicMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+    mock_stdio_cm = MagicMock()
+    mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))
+    mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    async def _test():
+        with patch("tools.mcp_tool.is_wsl", return_value=True), \
+             patch("tools.mcp_tool._resolve_stdio_cwd", return_value="/mnt/c/Users/Administrator"), \
+             patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+             patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm), \
+             patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm):
+            server = MCPServerTask("srv")
+            await server.start({"command": "cmd.exe", "args": ["/c", "echo", "ok"]})
+
+            call_kwargs = mock_params.call_args.kwargs
+            assert call_kwargs["command"].endswith("cmd.exe")
+            assert call_kwargs["cwd"] == "/mnt/c/Users/Administrator"
 
             await server.shutdown()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -79,7 +79,10 @@ import re
 import shutil
 import threading
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from hermes_constants import is_wsl
 
 logger = logging.getLogger(__name__)
 
@@ -265,6 +268,45 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         resolved_env = _prepend_path(resolved_env, command_dir)
 
     return resolved_command, resolved_env
+
+
+def _looks_like_windows_executable(command: str) -> bool:
+    """Return True when *command* appears to be a Windows executable name/path."""
+    lowered = os.path.basename(str(command).strip()).lower()
+    return lowered.endswith((".exe", ".cmd", ".bat", ".com"))
+
+
+def _resolve_stdio_cwd(command: str, config_cwd: Optional[str]) -> Optional[str]:
+    """Resolve a safe working directory for stdio MCP subprocesses.
+
+    On WSL, launching ``cmd.exe`` (or another Windows executable) from a Linux
+    cwd like ``/root`` makes Windows emit a UNC-path warning on stdout. That
+    corrupts stdio-based MCP traffic. When no explicit cwd is configured, route
+    Windows executables through a Windows-mounted path instead.
+    """
+    if config_cwd:
+        return os.path.expanduser(str(config_cwd))
+
+    if not is_wsl() or not _looks_like_windows_executable(command):
+        return None
+
+    candidates = []
+    for username in (
+        os.environ.get("USERNAME"),
+        os.environ.get("WIN_USERNAME"),
+    ):
+        if username:
+            candidates.append(Path("/mnt/c/Users") / username)
+
+    candidates.extend([
+        Path("/mnt/c/Users/Administrator"),
+        Path("/mnt/c/Users"),
+        Path("/mnt/c"),
+    ])
+    for candidate in candidates:
+        if candidate.is_dir():
+            return str(candidate)
+    return None
 
 
 def _format_connect_error(exc: BaseException) -> str:
@@ -825,6 +867,7 @@ class MCPServerTask:
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
+        config_cwd = config.get("cwd")
 
         if not command:
             raise ValueError(
@@ -833,6 +876,7 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+        resolved_cwd = _resolve_stdio_cwd(command, config_cwd)
 
         # Check package against OSV malware database before spawning
         from tools.osv_check import check_package_for_malware
@@ -846,6 +890,7 @@ class MCPServerTask:
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            cwd=resolved_cwd,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -100,6 +100,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `command` | string | Executable for a stdio MCP server |
 | `args` | list | Arguments for the stdio server |
 | `env` | mapping | Environment variables passed to the stdio server |
+| `cwd` | string | Working directory for stdio server subprocesses |
 | `url` | string | HTTP MCP endpoint |
 | `headers` | mapping | HTTP headers for remote servers |
 | `timeout` | number | Tool call timeout |
@@ -310,6 +311,43 @@ That makes MCP servers easier to reason about at the toolset level.
 For stdio servers, Hermes does not blindly pass your full shell environment.
 
 Only explicitly configured `env` plus a safe baseline are passed through. This reduces accidental secret leakage.
+
+### Stdio cwd control
+
+For stdio servers, you can also set an explicit working directory:
+
+```yaml
+mcp_servers:
+  chrome_devtools:
+    command: "cmd.exe"
+    args: ["/c", "npx -y chrome-devtools-mcp@latest --autoConnect"]
+    cwd: "/mnt/c/Users/Administrator"
+```
+
+This is especially useful on WSL when the stdio server command is a Windows executable such as `cmd.exe` or `powershell.exe`.
+
+If Hermes is launched from a Linux-only WSL path like `/root` or `/home/user`, Windows may treat that launch directory as a `\\wsl.localhost\...` UNC path and print a warning before the MCP server starts. That extra stdout text corrupts the stdio MCP protocol stream and makes the server appear to fail immediately.
+
+Hermes now automatically picks a Windows-mounted working directory for Windows stdio executables on WSL when `cwd` is not set, but you can still override it explicitly if needed.
+
+### WSL troubleshooting for Windows-backed stdio servers
+
+If an MCP server works in `hermes mcp test` but shows as failed when Hermes starts on WSL, check where you launched Hermes from.
+
+Avoid launching Hermes from Linux-only WSL directories when the MCP command is a Windows executable:
+
+- bad: `/root`, `/home/...`
+- good: `/mnt/c/Users/<you>`, `/mnt/c/workspace/...`
+
+Typical failure symptom:
+
+```text
+'\\wsl.localhost\Ubuntu\root'
+CMD.EXE was started with the above path as the current directory.
+UNC paths are not supported. Defaulting to Windows directory.
+```
+
+That message comes from `cmd.exe`, not from the MCP server itself.
 
 ### Config-level exposure control
 


### PR DESCRIPTION
## Summary
- avoid WSL `UNC` cwd warnings corrupting stdio MCP traffic when Hermes launches Windows executables like `cmd.exe`
- auto-select a Windows-mounted fallback cwd for WSL stdio MCP servers when no explicit `mcp_servers.<name>.cwd` is configured
- document the new `cwd` option and the WSL `/root` startup failure mode for Windows-backed MCP servers

## Problem
When Hermes runs inside WSL and an MCP stdio server is configured with a Windows executable such as `cmd.exe`, launching Hermes from a Linux-only WSL path like `/root` can break the MCP connection before the server even starts.

In the reproduced setup:
- Hermes ran inside WSL Ubuntu as `root`
- browser automation used `chrome-devtools-mcp` via `cmd.exe /c npx ...`
- Hermes was started from `/root`

That caused Windows interop to emit this warning on stdout:

```text
'\\wsl.localhost\Ubuntu\root'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported. Defaulting to Windows directory.
```

Because stdio MCP requires stdout to be protocol-only, those extra lines corrupted the transport and Hermes showed the MCP server as failed at startup.

## Design
I fixed this in the stdio MCP launch layer rather than in a one-off browser integration because the failure is generic to any WSL -> Windows executable stdio server.

Implementation details:
- keep honoring explicit `mcp_servers.<name>.cwd` if the user sets one
- detect WSL with the existing shared `hermes_constants.is_wsl()` helper
- detect Windows executables (`.exe`, `.cmd`, `.bat`, `.com`)
- when Hermes is on WSL and the stdio command is a Windows executable, pick a safe Windows-mounted cwd automatically if none was configured
- candidate fallbacks are:
  - `/mnt/c/Users/$USERNAME`
  - `/mnt/c/Users/$WIN_USERNAME`
  - `/mnt/c/Users/Administrator`
  - `/mnt/c/Users`
  - `/mnt/c`

This keeps normal Linux stdio servers unchanged and avoids touching command strings or wrapping processes in shell glue.

## Verification
Targeted tests:
- `uv run python -m pytest tests/tools/test_mcp_tool_issue_948.py -q`

Manual repro / regression checks:
- from `/root`, `hermes_cli/main.py mcp test chrome-devtools-win` now connects successfully
- from `/root`, `hermes_cli/main.py chat ... mcp_chrome_devtools_win_list_pages` now succeeds instead of failing at startup due to the `UNC` warning

## Notes
This came from a real WSL + Windows Chrome bridge setup where Hermes in WSL was driving a live Windows Chrome session via `chrome-devtools-mcp`.
