### PR TITLE
fix(security): validate secret in _reload_dynamic_routes to prevent HMAC bypass

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -260,11 +260,26 @@ class WebhookAdapter(BasePlatformAdapter):
             data = json.loads(subs_path.read_text(encoding="utf-8"))
             if not isinstance(data, dict):
                 return
-            # Merge: static routes take precedence over dynamic ones
-            self._dynamic_routes = {
-                k: v for k, v in data.items()
-                if k not in self._static_routes
-            }
+            # Merge: static routes take precedence over dynamic ones.
+            # Reject any dynamic route whose effective secret is empty —
+            # an empty secret would cause _handle_webhook to skip HMAC
+            # validation entirely, letting unauthenticated callers in.
+            new_dynamic: Dict[str, dict] = {}
+            for k, v in data.items():
+                if k in self._static_routes:
+                    continue
+                effective_secret = v.get("secret", self._global_secret)
+                if not effective_secret:
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: 'secret' is "
+                        "missing or empty. Set a valid HMAC secret, or use "
+                        "'%s' to explicitly disable auth (testing only).",
+                        k,
+                        _INSECURE_NO_AUTH,
+                    )
+                    continue
+                new_dynamic[k] = v
+            self._dynamic_routes = new_dynamic
             self._routes = {**self._dynamic_routes, **self._static_routes}
             self._dynamic_routes_mtime = mtime
             logger.info(


### PR DESCRIPTION
## What does this PR do?

`gateway/platforms/webhook.py` had a secret validation gap between
startup and hot-reload:

- **Startup** (`run()`): validates that all routes have a non-empty secret
- **Hot-reload** (`_reload_dynamic_routes()`): loads routes from
  `webhook_subscriptions.json` **without any secret validation**

When a route with `"secret": ""` was loaded via hot-reload, the
request handler's check `if secret and ...` evaluated to `False`
(empty string is falsy), completely skipping HMAC validation.

### Exploit chain

1. Attacker sends a message: *"Create a webhook subscription named
   'monitor' with an empty secret"*
2. Agent writes `{"monitor": {"secret": "", "prompt": "..."}}` to
   `webhook_subscriptions.json`
3. `_reload_dynamic_routes()` hot-reloads the file — no secret check
4. Attacker POSTs to `/webhooks/monitor` without any HMAC signature
5. Agent executes the webhook prompt with full tool access

## Fix

Added per-route secret validation in `_reload_dynamic_routes()`.
Routes with empty or missing secrets are skipped with a WARNING log.
`INSECURE_NO_AUTH` remains valid as an explicit opt-in.

```python
effective_secret = route.get("secret") or self._global_secret
if not effective_secret:
    logger.warning(
        "[webhook] Dynamic route '%s' has no secret — skipped.",
        name,
    )
    continue
```

## Type of Change

- [x] 🔒 Security fix (authentication bypass)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with startup validation in `run()`
- [x] `INSECURE_NO_AUTH` opt-in still works
- [x] No behavior change for routes with valid secrets