### PR TITLE
fix(gateway): suppress partial streaming on non-editable platforms

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from gateway.platforms.base import BasePlatformAdapter
+
 logger = logging.getLogger("gateway.stream_consumer")
 
 # Sentinel to signal the stream is complete
@@ -87,6 +89,22 @@ class GatewayStreamConsumer:
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
+        self._platform_supports_editing = self._detect_platform_edit_support()
+
+    def _detect_platform_edit_support(self) -> bool:
+        """Return True when the adapter implements real message editing."""
+        edit_attr = getattr(self.adapter, "edit_message", None)
+        if edit_attr is None:
+            return False
+
+        adapter_edit = getattr(type(self.adapter), "edit_message", None)
+        if adapter_edit is BasePlatformAdapter.edit_message:
+            return False
+
+        if adapter_edit is None and isinstance(self.adapter, BasePlatformAdapter):
+            return False
+
+        return True
 
     @property
     def already_sent(self) -> bool:
@@ -174,63 +192,75 @@ class GatewayStreamConsumer:
 
                 current_update_visible = False
                 if should_edit and self._accumulated:
-                    # Split overflow: if accumulated text exceeds the platform
-                    # limit, split into properly sized chunks.
+                    # Platforms without real edit support (e.g. Weixin) should
+                    # not expose partial streamed text. Wait for the final
+                    # response instead of sending a half-finished message plus a
+                    # continuation tail.
                     if (
-                        len(self._accumulated) > _safe_limit
-                        and self._message_id is None
+                        not self._platform_supports_editing
+                        and commentary_text is None
+                        and not got_done
+                        and not got_segment_break
                     ):
-                        # No existing message to edit (first message or after a
-                        # segment break).  Use truncate_message — the same
-                        # helper the non-streaming path uses — to split with
-                        # proper word/code-fence boundaries and chunk
-                        # indicators like "(1/2)".
-                        chunks = self.adapter.truncate_message(
-                            self._accumulated, _safe_limit
-                        )
-                        for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
-                        self._accumulated = ""
-                        self._last_sent_text = ""
-                        self._last_edit_time = time.monotonic()
-                        if got_done:
-                            self._final_response_sent = self._already_sent
-                            return
-                        if got_segment_break:
+                        current_update_visible = False
+                    else:
+                        # Split overflow: if accumulated text exceeds the platform
+                        # limit, split into properly sized chunks.
+                        if (
+                            len(self._accumulated) > _safe_limit
+                            and self._message_id is None
+                        ):
+                            # No existing message to edit (first message or after a
+                            # segment break).  Use truncate_message — the same
+                            # helper the non-streaming path uses — to split with
+                            # proper word/code-fence boundaries and chunk
+                            # indicators like "(1/2)".
+                            chunks = self.adapter.truncate_message(
+                                self._accumulated, _safe_limit
+                            )
+                            for chunk in chunks:
+                                await self._send_new_chunk(chunk, self._message_id)
+                            self._accumulated = ""
+                            self._last_sent_text = ""
+                            self._last_edit_time = time.monotonic()
+                            if got_done:
+                                self._final_response_sent = self._already_sent
+                                return
+                            if got_segment_break:
+                                self._message_id = None
+                                self._fallback_final_send = False
+                                self._fallback_prefix = ""
+                            continue
+
+                        # Existing message: edit it with the first chunk, then
+                        # start a new message for the overflow remainder.
+                        while (
+                            len(self._accumulated) > _safe_limit
+                            and self._message_id is not None
+                            and self._edit_supported
+                        ):
+                            split_at = self._accumulated.rfind("\n", 0, _safe_limit)
+                            if split_at < _safe_limit // 2:
+                                split_at = _safe_limit
+                            chunk = self._accumulated[:split_at]
+                            ok = await self._send_or_edit(chunk)
+                            if self._fallback_final_send or not ok:
+                                # Edit failed (or backed off due to flood control)
+                                # while attempting to split an oversized message.
+                                # Keep the full accumulated text intact so the
+                                # fallback final-send path can deliver the remaining
+                                # continuation without dropping content.
+                                break
+                            self._accumulated = self._accumulated[split_at:].lstrip("\n")
                             self._message_id = None
-                            self._fallback_final_send = False
-                            self._fallback_prefix = ""
-                        continue
+                            self._last_sent_text = ""
 
-                    # Existing message: edit it with the first chunk, then
-                    # start a new message for the overflow remainder.
-                    while (
-                        len(self._accumulated) > _safe_limit
-                        and self._message_id is not None
-                        and self._edit_supported
-                    ):
-                        split_at = self._accumulated.rfind("\n", 0, _safe_limit)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
-                        chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
-                        if self._fallback_final_send or not ok:
-                            # Edit failed (or backed off due to flood control)
-                            # while attempting to split an oversized message.
-                            # Keep the full accumulated text intact so the
-                            # fallback final-send path can deliver the remaining
-                            # continuation without dropping content.
-                            break
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
-                        self._message_id = None
-                        self._last_sent_text = ""
+                        display_text = self._accumulated
+                        if not got_done and not got_segment_break and commentary_text is None:
+                            display_text += self.cfg.cursor
 
-                    display_text = self._accumulated
-                    if not got_done and not got_segment_break and commentary_text is None:
-                        display_text += self.cfg.cursor
-
-                    current_update_visible = await self._send_or_edit(display_text)
-                    self._last_edit_time = time.monotonic()
+                        current_update_visible = await self._send_or_edit(display_text)
+                        self._last_edit_time = time.monotonic()
 
                 if got_done:
                     # Final edit without cursor. If progressive editing failed

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.config import PlatformConfig
+from gateway.platforms.weixin import WeixinAdapter
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
@@ -180,6 +182,68 @@ class TestStreamRunMediaStripping:
 
 
 # ── Segment break (tool boundary) tests ──────────────────────────────────
+
+
+class TestNonEditablePlatforms:
+    """Platforms without edit_message support should skip visible partials."""
+
+    @staticmethod
+    def _make_weixin_adapter():
+        adapter = WeixinAdapter(
+            PlatformConfig(enabled=True, token="token", extra={"account_id": "acct"})
+        )
+        adapter.send = AsyncMock(
+            side_effect=[
+                SimpleNamespace(success=True, message_id="msg_1"),
+                SimpleNamespace(success=True, message_id="msg_2"),
+            ]
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_non_editable_platform_sends_only_final_message(self):
+        adapter = self._make_weixin_adapter()
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉"),
+        )
+
+        consumer.on_delta("我是 Hermes")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta("，你可以把我当成一个助手。")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs["content"] for call in adapter.send.call_args_list]
+        assert sent_texts == ["我是 Hermes，你可以把我当成一个助手。"]
+
+    @pytest.mark.asyncio
+    async def test_non_editable_platform_segment_break_preserves_prior_segment(self):
+        adapter = self._make_weixin_adapter()
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉"),
+        )
+
+        consumer.on_delta("第一段")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(None)
+        await asyncio.sleep(0.08)
+        consumer.on_delta("第二段")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs["content"] for call in adapter.send.call_args_list]
+        assert sent_texts == ["第一段", "第二段"]
 
 
 class TestSegmentBreakOnToolBoundary:


### PR DESCRIPTION
## Summary

This fixes a streaming UX bug on platforms that do not support message editing, especially Weixin.

Previously, `GatewayStreamConsumer` could send:

- a partial message with the streaming cursor (`▉`)
- followed by a continuation message starting with punctuation

Now, for adapters without real `edit_message()` support, partial streamed text is not exposed. The final completed response is sent as a single clean message instead.

Closes #8307

## Root cause

`GatewayStreamConsumer` treated all platforms as if progressive message editing were available.

`WeixinAdapter` inherits the default `BasePlatformAdapter.edit_message()` implementation, which returns `Not supported`, so partial streaming degraded into a stuck cursor plus continuation tail.

## Changes

- detect whether the adapter implements real message editing
- suppress visible partial streaming on non-editable platforms
- preserve final response delivery semantics
- add a regression test covering the Weixin case

## Test plan

- [x] `pytest -q tests/gateway/test_stream_consumer.py tests/gateway/test_weixin.py`
