### PR TITLE
feat(wecom): add image and voice message support for callback adapter

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -36,7 +36,10 @@ except ImportError:
     HTTPX_AVAILABLE = False
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter, MessageEvent, MessageType, SendResult,
+    cache_image_from_bytes, get_audio_cache_dir,
+)
 from gateway.platforms.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
 
 logger = logging.getLogger(__name__)
@@ -256,7 +259,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 decrypted = self._decrypt_request(
                     app, body, msg_signature, timestamp, nonce,
                 )
-                event = self._build_event(app, decrypted)
+                event = await self._build_event(app, decrypted)
                 if event is not None:
                     # Record which app this user belongs to.
                     if event.source and event.source.user_id:
@@ -299,7 +302,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
-    def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
+    async def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
         root = ET.fromstring(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
@@ -307,7 +310,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             event_name = (root.findtext("Event") or "").lower()
             if event_name in {"enter_agent", "subscribe"}:
                 return None
-        if msg_type not in {"text", "event"}:
+        if msg_type not in {"text", "event", "image", "voice"}:
             return None
 
         user_id = root.findtext("FromUserName", default="")
@@ -327,13 +330,126 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_id,
         )
+
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        message_type = MessageType.TEXT
+
+        if msg_type == "image":
+            message_type = MessageType.PHOTO
+            caption = root.findtext("Content", default="").strip()
+            content = caption or "[图片]"
+            media_id = root.findtext("MediaId", default="")
+            pic_url = root.findtext("PicUrl", default="")
+            cached_path = await self._download_image(app, media_id, pic_url)
+            if cached_path:
+                media_urls.append(cached_path)
+                media_types.append("image/jpeg")
+
+        if msg_type == "voice":
+            message_type = MessageType.VOICE
+            content = "[语音消息]"
+            media_id = root.findtext("MediaId", default="")
+            cached_path = await self._download_voice(app, media_id)
+            if cached_path:
+                media_urls.append(cached_path)
+                media_types.append("audio/amr")
+
         return MessageEvent(
             text=content,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             raw_message=xml_text,
             message_id=msg_id,
+            media_urls=media_urls,
+            media_types=media_types,
         )
+
+    async def _download_image(
+        self, app: Dict[str, Any], media_id: str, pic_url: str,
+    ) -> Optional[str]:
+        """Download a WeCom image to local cache. Returns cached file path or None."""
+        if media_id and self._http_client:
+            try:
+                token = await self._get_access_token(app)
+                resp = await self._http_client.get(
+                    "https://qyapi.weixin.qq.com/cgi-bin/media/get",
+                    params={"access_token": token, "media_id": media_id},
+                )
+                content_type = resp.headers.get("content-type", "")
+                if resp.status_code == 200 and "json" not in content_type:
+                    data = resp.content
+                    if len(data) > 0:
+                        ext = self._detect_image_ext(data)
+                        cached = cache_image_from_bytes(data, ext=ext)
+                        logger.info("[WecomCallback] Cached image (media_id) at %s", cached)
+                        return cached
+                else:
+                    logger.debug(
+                        "[WecomCallback] media/get returned %s: %s",
+                        resp.status_code, resp.text[:200],
+                    )
+            except Exception as exc:
+                logger.warning("[WecomCallback] media/get failed: %s", exc)
+
+        if pic_url and self._http_client:
+            try:
+                resp = await self._http_client.get(pic_url)
+                if resp.status_code == 200:
+                    data = resp.content
+                    if len(data) > 0:
+                        ext = self._detect_image_ext(data)
+                        cached = cache_image_from_bytes(data, ext=ext)
+                        logger.info("[WecomCallback] Cached image (pic_url) at %s", cached)
+                        return cached
+            except Exception as exc:
+                logger.warning("[WecomCallback] PicUrl download failed: %s", exc)
+
+        logger.warning("[WecomCallback] Could not download image (media_id=%s, pic_url=%s)", media_id, pic_url)
+        return None
+
+    @staticmethod
+    def _detect_image_ext(data: bytes) -> str:
+        """Detect image format from magic bytes."""
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            return ".png"
+        if data[:3] == b"\xff\xd8\xff":
+            return ".jpg"
+        if data[:4] == b"RIFF" and b"WEBP" in data[:12]:
+            return ".webp"
+        return ".jpg"
+
+    async def _download_voice(
+        self, app: Dict[str, Any], media_id: str,
+    ) -> Optional[str]:
+        """Download a WeCom voice message to local cache. Returns cached file path or None."""
+        if not media_id or not self._http_client:
+            return None
+        try:
+            token = await self._get_access_token(app)
+            resp = await self._http_client.get(
+                "https://qyapi.weixin.qq.com/cgi-bin/media/get",
+                params={"access_token": token, "media_id": media_id},
+            )
+            content_type = resp.headers.get("content-type", "")
+            if resp.status_code == 200 and "json" not in content_type:
+                data = resp.content
+                if len(data) > 0:
+                    import uuid as _uuid
+                    cache_dir = get_audio_cache_dir()
+                    filename = f"wecom_voice_{_uuid.uuid4().hex[:12]}.amr"
+                    filepath = cache_dir / filename
+                    filepath.write_bytes(data)
+                    logger.info("[WecomCallback] Cached voice at %s", filepath)
+                    return str(filepath)
+            else:
+                logger.debug(
+                    "[WecomCallback] media/get (voice) returned %s: %s",
+                    resp.status_code, resp.text[:200],
+                )
+        except Exception as exc:
+            logger.warning("[WecomCallback] Voice download failed: %s", exc)
+        return None
 
     def _crypt_for_app(self, app: Dict[str, Any]) -> WXBizMsgCrypt:
         return WXBizMsgCrypt(

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -55,7 +55,8 @@ class TestWecomCrypto:
 
 
 class TestWecomCallbackEventConstruction:
-    def test_build_event_extracts_text_message(self):
+    @pytest.mark.asyncio
+    async def test_build_event_extracts_text_message(self):
         adapter = WecomCallbackAdapter(_config())
         xml_text = """
         <xml>
@@ -67,7 +68,7 @@ class TestWecomCallbackEventConstruction:
           <MsgId>123456789</MsgId>
         </xml>
         """
-        event = adapter._build_event(_app(), xml_text)
+        event = await adapter._build_event(_app(), xml_text)
         assert event is not None
         assert event.source is not None
         assert event.source.user_id == "zhangsan"
@@ -75,7 +76,8 @@ class TestWecomCallbackEventConstruction:
         assert event.message_id == "123456789"
         assert event.text == "\u4f60\u597d"
 
-    def test_build_event_returns_none_for_subscribe(self):
+    @pytest.mark.asyncio
+    async def test_build_event_returns_none_for_subscribe(self):
         adapter = WecomCallbackAdapter(_config())
         xml_text = """
         <xml>
@@ -86,7 +88,7 @@ class TestWecomCallbackEventConstruction:
           <Event>subscribe</Event>
         </xml>
         """
-        event = adapter._build_event(_app(), xml_text)
+        event = await adapter._build_event(_app(), xml_text)
         assert event is None
 
 
@@ -163,7 +165,7 @@ class TestWecomCallbackPollLoop:
             calls.append(event.text)
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        event = adapter._build_event(
+        event = await adapter._build_event(
             _app(),
             """
             <xml>

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -76,7 +76,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac", ".amr", ".silk"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 
@@ -628,18 +628,38 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     if provider == "local":
         local_cfg = stt_config.get("local", {})
         model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
-        return _transcribe_local(file_path, model_name)
+        result = _transcribe_local(file_path, model_name)
+        if not result["success"] and os.getenv("GROQ_API_KEY") and _HAS_OPENAI:
+            logger.info("Local STT failed (%s), falling back to Groq", result.get("error", ""))
+            result = _transcribe_groq(file_path, model or DEFAULT_GROQ_STT_MODEL)
+            if result["success"]:
+                result["provider"] = "groq (fallback)"
+        return result
 
     if provider == "local_command":
         local_cfg = stt_config.get("local", {})
         model_name = _normalize_local_command_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
-        return _transcribe_local_command(file_path, model_name)
+        result = _transcribe_local_command(file_path, model_name)
+        if not result["success"] and os.getenv("GROQ_API_KEY") and _HAS_OPENAI:
+            logger.info("Local command STT failed, falling back to Groq")
+            result = _transcribe_groq(file_path, model or DEFAULT_GROQ_STT_MODEL)
+            if result["success"]:
+                result["provider"] = "groq (fallback)"
+        return result
 
     if provider == "groq":
         model_name = model or DEFAULT_GROQ_STT_MODEL
-        return _transcribe_groq(file_path, model_name)
+        result = _transcribe_groq(file_path, model_name)
+        if not result["success"] and _HAS_FASTER_WHISPER:
+            logger.info("Groq STT failed (%s), falling back to local", result.get("error", ""))
+            local_cfg = stt_config.get("local", {})
+            local_model = local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            result = _transcribe_local(file_path, local_model)
+            if result["success"]:
+                result["provider"] = "local (fallback)"
+        return result
 
     if provider == "openai":
         openai_cfg = stt_config.get("openai", {})


### PR DESCRIPTION
## Changes

### wecom_callback.py
- **Image support**: Download images via media/get API with PicUrl fallback, auto-detect format (PNG/JPG/WebP)
- **Voice support**: Download AMR audio via media/get API, cache locally for STT processing
- **_build_event**: Converted from sync to async to support media downloads
- **msg_type whitelist**: Expanded from {text, event} to {text, event, image, voice}
- Added  helper for magic-byte format detection

### transcription_tools.py
- Added  and  to SUPPORTED_FORMATS (WeChat native audio formats)
- Added bidirectional STT fallback: local → Groq when primary fails, Groq → local when primary fails
- Fallback is automatic and transparent — logs provider as e.g. `groq (fallback)`

## Motivation
WeCom callback adapter currently only handles text messages. Users sending images or voice messages get silently ignored. This adds full media support with automatic STT transcription for voice.