### PR TITLE
chore: add .gstack/ to .gitignore to prevent security reports from leaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ mini-swe-agent/
 # Nix
 .direnv/
 result
+.gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ mini-swe-agent/
 .direnv/
 .nix-stamps/
 result
+.gstack/
 website/static/api/skills-index.json
 # skills.json + skills-meta.json are build artifacts emitted by
 # website/scripts/extract-skills.py during prebuild — keep them out of


### PR DESCRIPTION
## What does this PR do?

The `.gstack/` directory is used by security scanning tools to store
detailed security reports including:

- Known vulnerability details
- CVSS scores and exploit scenarios
- Internal file paths and line numbers

This directory was not in `.gitignore`, meaning a `git add .` could
accidentally commit sensitive security findings to the repository's
public history.

## Fix

Added `.gstack/` to `.gitignore`:

echo ".gstack/" >> .gitignore

## Type of Change

- [x] 🔒 Security / chore (information disclosure prevention)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] One-line fix, no behavior change