### PR TITLE
fix(ci): pin third-party GitHub Actions to SHA to prevent supply chain attacks

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,16 +28,16 @@ jobs:
           submodules: recursive
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Build amd64 only so we can `load` the image for smoke testing.
       # `load: true` cannot export a multi-arch manifest to the local daemon.
       # The multi-arch build follows on push to main / release.
       - name: Build image (amd64, smoke test)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -56,14 +56,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push multi-arch image (main branch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -75,7 +75,7 @@ jobs:
 
       - name: Push multi-arch image (release)
         if: github.event_name == 'release'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Set up Python 3.11
         run: uv python install 3.11
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Set up Python 3.11
         run: uv python install 3.11


### PR DESCRIPTION
## What does this PR do?

`.github/workflows/docker-publish.yml` and `tests.yml` used mutable
version tags for third-party GitHub Actions:

```yaml
# Before (vulnerable)
uses: docker/build-push-action@v6
uses: astral-sh/setup-uv@v5
```

Mutable tags can be silently redirected to malicious commits. If an
attacker compromises the `docker` or `astral-sh` GitHub organization,
they can push a backdoored commit to the same tag — and the next CI
run will execute it with access to `secrets.DOCKERHUB_TOKEN`.

### Attack scenario

1. Attacker compromises `docker/build-push-action` and redirects `@v6`
   to a malicious commit
2. `docker-publish.yml` runs and the malicious action has access to
   `${{ secrets.DOCKERHUB_TOKEN }}` and `${{ secrets.DOCKERHUB_USERNAME }}`
3. Attacker pushes a backdoored image as `nousresearch/hermes-agent:latest`
4. Hundreds of thousands of users pull the compromised image

## Fix

Pinned all third-party actions to their full commit SHA with a version
comment for readability:

| Action | Old | New |
|---|---|---|
| `docker/setup-qemu-action` | `@v3` | `@SHA # v3` |
| `docker/setup-buildx-action` | `@v3` | `@SHA # v3` |
| `docker/build-push-action` | `@v6` | `@SHA # v6` |
| `docker/login-action` | `@v3` | `@SHA # v3` |
| `astral-sh/setup-uv` | `@v5` | `@SHA # v5` |

`actions/checkout@v4` (first-party GitHub action) not changed —
first-party actions are trusted.

## Type of Change

- [x] 🔒 Security fix (supply chain attack prevention)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] SHA comments preserve version readability
- [x] No behavior change — same action versions, just pinned