### PR TITLE
fix(routing): pass api_mode from cheap_model config in smart routing

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -172,13 +172,20 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             ),
         }
 
+    # Prefer api_mode from route config (cheap_model.api_mode) over the
+    # runtime-resolved value.  resolve_runtime_provider does not accept
+    # api_mode, so custom endpoints that require a specific mode (e.g.
+    # anthropic_messages for local servers with KV cache) would otherwise
+    # fall back to the default chat_completions.
+    effective_api_mode = route.get("api_mode") or runtime.get("api_mode")
+
     return {
         "model": route.get("model"),
         "runtime": {
             "api_key": runtime.get("api_key"),
             "base_url": runtime.get("base_url"),
             "provider": runtime.get("provider"),
-            "api_mode": runtime.get("api_mode"),
+            "api_mode": effective_api_mode,
             "command": runtime.get("command"),
             "args": list(runtime.get("args") or []),
             "credential_pool": runtime.get("credential_pool"),
@@ -188,7 +195,7 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             route.get("model"),
             runtime.get("provider"),
             runtime.get("base_url"),
-            runtime.get("api_mode"),
+            effective_api_mode,
             runtime.get("command"),
             tuple(runtime.get("args") or ()),
         ),

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -59,3 +59,95 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+# -- api_mode passthrough tests -----------------------------------------------
+
+
+def test_resolve_turn_route_prefers_route_api_mode(monkeypatch):
+    """api_mode from cheap_model config takes priority over runtime default."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-local",
+            "base_url": "http://127.0.0.1:8000",
+            "provider": "custom",
+            "api_mode": "chat_completions",  # runtime default
+        },
+    )
+    cfg = {
+        **_BASE_CONFIG,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "local-9b",
+            "base_url": "http://127.0.0.1:8000",
+            "api_mode": "anthropic_messages",  # explicit config
+        },
+    }
+    result = resolve_turn_route(
+        "hello",
+        cfg,
+        {"model": "strong-model", "provider": "openrouter"},
+    )
+    assert result["runtime"]["api_mode"] == "anthropic_messages"
+
+
+def test_resolve_turn_route_falls_back_to_runtime_api_mode(monkeypatch):
+    """When cheap_model has no api_mode, fall back to runtime-resolved value."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-local",
+            "base_url": "http://127.0.0.1:8000",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+        },
+    )
+    cfg = {
+        **_BASE_CONFIG,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "local-9b",
+            # no api_mode — should fall back to runtime
+        },
+    }
+    result = resolve_turn_route(
+        "hello",
+        cfg,
+        {"model": "strong-model", "provider": "openrouter"},
+    )
+    assert result["runtime"]["api_mode"] == "chat_completions"
+
+
+def test_api_mode_reflected_in_signature(monkeypatch):
+    """api_mode should be included in the routing signature for cache keying."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-local",
+            "base_url": "http://127.0.0.1:8000",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+        },
+    )
+    cfg = {
+        **_BASE_CONFIG,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "local-9b",
+            "api_mode": "anthropic_messages",
+        },
+    }
+    result = resolve_turn_route(
+        "hi",
+        cfg,
+        {"model": "strong-model", "provider": "openrouter"},
+    )
+    # Signature tuple should contain effective api_mode
+    assert "anthropic_messages" in result["signature"]


### PR DESCRIPTION
## What does this PR do?

`resolve_runtime_provider` does not accept an `api_mode` parameter. When smart model routing routes a message to the `cheap_model`, the configured `api_mode` (e.g. `anthropic_messages`) is silently dropped, and the runtime defaults to `chat_completions`.

This breaks local inference servers that require a specific API format, particularly when using Anthropic-format endpoints with SSD KV caching where api_mode determines cache hit behavior.

Fix: prefer `route.get("api_mode")` over `runtime.get("api_mode")` in the cheap model return path.

## Related Issue

Fixes #8515

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/smart_model_routing.py`: Added `effective_api_mode` that prefers route config over runtime, used in both `runtime` dict and `signature` tuple
- `tests/agent/test_smart_model_routing.py`: Added 3 tests for api_mode priority, fallback, and signature inclusion

## How to Test

1. Configure `cheap_model.api_mode: anthropic_messages` in smart routing config
2. Send a simple message that routes to cheap model
3. Verify the API call uses `anthropic_messages` format (not `chat_completions`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Sequoia), Apple Silicon

### Documentation & Housekeeping

- [x] N/A - no config keys added, existing `cheap_model.api_mode` now works as expected
- [x] Cross-platform: all platforms affected equally, fix is platform-independent