### PR TITLE
[codex] Fix Telegram daily report callbacks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -109,6 +109,328 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH = os.getenv(
+    "DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH",
+    str(_Path.home() / ".openclaw" / "workspace" / "reports" / "daily-crypto" / "latest.digest.json"),
+).strip()
+DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH = os.getenv(
+    "DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH",
+    str(_Path.home() / ".openclaw" / "workspace" / "reports" / "daily-crypto" / "latest.digest.txt"),
+).strip()
+DAILY_REPORT_CALLBACK_PREFIX = "daily-report:"
+_DAILY_REPORT_LABELS = {
+    "markdown": "长版报告",
+    "full": "晨报摘要",
+    "binance": "币安异动",
+    "github": "GitHub 热门",
+    "x": "X 情报",
+    "sentiment": "市场情绪",
+}
+
+
+def _split_telegram_text(text: str, limit: int = 3600) -> List[str]:
+    cleaned = text.strip()
+    if not cleaned:
+        return []
+    if len(cleaned) <= limit:
+        return [cleaned]
+
+    parts: List[str] = []
+    chunk = ""
+    for paragraph in cleaned.split("\n\n"):
+        paragraph = paragraph.strip()
+        if not paragraph:
+            continue
+        candidate = paragraph if not chunk else f"{chunk}\n\n{paragraph}"
+        if len(candidate) <= limit:
+            chunk = candidate
+            continue
+        if chunk:
+            parts.append(chunk)
+            chunk = ""
+        if len(paragraph) <= limit:
+            chunk = paragraph
+            continue
+        lines = paragraph.splitlines()
+        line_chunk = ""
+        for line in lines:
+            candidate_line = line if not line_chunk else f"{line_chunk}\n{line}"
+            if len(candidate_line) <= limit:
+                line_chunk = candidate_line
+                continue
+            if line_chunk:
+                parts.append(line_chunk)
+            if len(line) <= limit:
+                line_chunk = line
+                continue
+            for index in range(0, len(line), limit):
+                parts.append(line[index : index + limit])
+            line_chunk = ""
+        if line_chunk:
+            chunk = line_chunk
+    if chunk:
+        parts.append(chunk)
+    return parts
+
+
+def _add_telegram_part_numbers(parts: List[str]) -> List[str]:
+    if len(parts) <= 1:
+        return parts
+    total = len(parts)
+    return [f"({index}/{total})\n{part}" for index, part in enumerate(parts, start=1)]
+
+
+def _summarize_text(text: str, limit: int = 120) -> str:
+    clean = text.replace("\n", " ").strip()
+    if len(clean) <= limit:
+        return clean
+    return f"{clean[:limit]}..."
+
+
+def _contains_cjk(text: str) -> bool:
+    return any("\u4e00" <= char <= "\u9fff" for char in text or "")
+
+
+def _choose_localized_text(*values: Any, fallback: str = "") -> str:
+    normalized: List[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            normalized.append(text)
+    for candidate in normalized:
+        if _contains_cjk(candidate):
+            return candidate
+    return normalized[0] if normalized else fallback
+
+
+def _translate_sentiment_label(label: str) -> str:
+    lowered = (label or "").strip().lower()
+    mapping = {
+        "extreme fear": "极度恐慌",
+        "fear": "恐慌",
+        "neutral": "中性",
+        "greed": "贪婪",
+        "extreme greed": "极度贪婪",
+    }
+    return mapping.get(lowered, label or "-")
+
+
+def _format_daily_digest_binance(items: List[Dict[str, Any]]) -> str:
+    if not items:
+        return "今天的币安异动摘要还没生成。"
+    lines = ["今日币安异动"]
+    for item in items[:5]:
+        symbol = str(item.get("symbol", "-"))
+        move = item.get("price_change_percent")
+        quote_volume = item.get("quote_volume")
+        move_text = f"{float(move):+.2f}%" if isinstance(move, (int, float)) else str(move or "-")
+        volume_text = (
+            f"{float(quote_volume) / 1_000_000:.2f}M"
+            if isinstance(quote_volume, (int, float))
+            else "-"
+        )
+        lines.append(f"- {symbol} | {move_text} | 成交额 {volume_text} USDT")
+    return "\n".join(lines)
+
+
+def _format_daily_digest_github(items: List[Dict[str, Any]]) -> str:
+    if not items:
+        return "今天的 GitHub 热门摘要还没生成。"
+    lines = ["今日 GitHub 热门"]
+    for item in items[:5]:
+        repo = str(item.get("repo", "-"))
+        language = str(item.get("language", "") or "未知")
+        stars_today = item.get("stars_today")
+        desc = _choose_localized_text(
+            item.get("description_zh"),
+            item.get("description"),
+            fallback="查看仓库说明",
+        )
+        if not _contains_cjk(desc):
+            desc = "查看仓库说明"
+        desc = _summarize_text(desc, limit=72)
+        star_text = f"+{int(stars_today)}" if isinstance(stars_today, (int, float)) else "-"
+        lines.append(f"- {repo} | {language} | 今日星标 {star_text} | {desc}")
+    return "\n".join(lines)
+
+
+def _format_daily_digest_x(items: List[Dict[str, Any]]) -> str:
+    if not items:
+        return "今天的 X 情报摘要还没生成。"
+    lines = ["今日 X 情报"]
+    for item in items[:5]:
+        account = str(item.get("account", "-"))
+        title = _choose_localized_text(
+            item.get("summary_zh"),
+            item.get("title_zh"),
+            item.get("summary"),
+            item.get("title"),
+            fallback="该条情报已收录，详见长版报告。",
+        )
+        if not _contains_cjk(title):
+            title = "该条情报已收录，详见长版报告。"
+        title = _summarize_text(title, limit=96)
+        lines.append(f"- @{account} {title}")
+    return "\n".join(lines)
+
+
+def _format_daily_digest_sentiment(sentiment: Dict[str, Any]) -> str:
+    if not sentiment:
+        return "今天的市场情绪摘要还没生成。"
+    value = str(sentiment.get("value", "-"))
+    classification = _choose_localized_text(
+        sentiment.get("classification_zh"),
+        sentiment.get("value_classification_zh"),
+        sentiment.get("classification"),
+        sentiment.get("value_classification"),
+        fallback="-",
+    )
+    classification = _translate_sentiment_label(classification)
+    return f"今日市场情绪\n- 恐慌与贪婪指数：{value}\n- 分类：{classification}"
+
+
+def _build_localized_daily_digest_from_payload(payload: Dict[str, Any]) -> str:
+    report_date = str(payload.get("report_date", "")).strip() or "今日"
+    sentiment = payload.get("market_sentiment") or payload.get("fng_index") or {}
+    sentiment_value = str(sentiment.get("value", "-"))
+    sentiment_label = _choose_localized_text(
+        sentiment.get("classification_zh"),
+        sentiment.get("value_classification_zh"),
+        sentiment.get("classification"),
+        sentiment.get("value_classification"),
+        fallback="-",
+    )
+    sentiment_label = _translate_sentiment_label(sentiment_label)
+
+    binance_items = payload.get("top_binance_movers") or (payload.get("binance_movers") or {}).get("items") or []
+    contract_items = payload.get("top_contract_movers") or (payload.get("contract_movers") or {}).get("items") or []
+    github_items = payload.get("top_github_repos") or (payload.get("github_trending") or {}).get("items") or []
+    x_items = payload.get("top_x_posts") or (payload.get("x_watchlist") or {}).get("items") or []
+    potential_raw = payload.get("top_potential_picks") or payload.get("potential_picks") or []
+    if isinstance(potential_raw, dict):
+        potential_items = potential_raw.get("items") or []
+    elif isinstance(potential_raw, list):
+        potential_items = potential_raw
+    else:
+        potential_items = []
+
+    def _format_movers(items: List[Dict[str, Any]]) -> str:
+        if not items:
+            return "暂无"
+        parts: List[str] = []
+        for item in items[:3]:
+            symbol = str(item.get("symbol", "-"))
+            move = item.get("price_change_percent")
+            move_text = f"{float(move):+.2f}%" if isinstance(move, (int, float)) else str(move or "-")
+            parts.append(f"{symbol} {move_text}")
+        return "，".join(parts) if parts else "暂无"
+
+    def _format_github(items: List[Dict[str, Any]]) -> str:
+        if not items:
+            return "暂无"
+        repos = [str(item.get("repo", "-")).strip() for item in items[:3] if str(item.get("repo", "")).strip()]
+        return "，".join(repos) if repos else "暂无"
+
+    def _format_x_focus(items: List[Dict[str, Any]]) -> str:
+        if not items:
+            return "暂无"
+        accounts = [
+            f"@{str(item.get('account', '-')).strip()}"
+            for item in items[:3]
+            if str(item.get("account", "")).strip()
+        ]
+        return "、".join(accounts) + "（详见长版）" if accounts else "暂无"
+
+    def _format_picks(items: List[Dict[str, Any]]) -> str:
+        if not items:
+            return "暂无"
+        picks: List[str] = []
+        for item in items[:3]:
+            symbol = str(item.get("symbol", "-"))
+            confidence = item.get("confidence")
+            if isinstance(confidence, (int, float)):
+                picks.append(f"{symbol}({int(confidence)})")
+            else:
+                picks.append(symbol)
+        return "，".join(picks) if picks else "暂无"
+
+    lines = [
+        f"每日加密晨报 | {report_date}",
+        f"情绪：{sentiment_value} | {sentiment_label}",
+        f"异动：{_format_movers(binance_items)}",
+        f"合约：{_format_movers(contract_items)}",
+        f"GitHub：{_format_github(github_items)}",
+        f"焦点：{_format_x_focus(x_items)}",
+        f"潜力币：{_format_picks(potential_items)}",
+    ]
+    return "\n".join(lines)
+
+
+def _build_daily_report_messages_for_callback(query_type: str) -> tuple[List[str], str]:
+    digest_json_path = _Path(DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH)
+    digest_text_path = _Path(DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH)
+
+    if digest_json_path.exists():
+        payload = json.loads(digest_json_path.read_text())
+        markdown_path = str((payload.get("paths") or {}).get("markdown", "")).strip()
+
+        if query_type == "markdown":
+            markdown_text = ""
+            if markdown_path and _Path(markdown_path).exists():
+                markdown_text = _Path(markdown_path).read_text().strip()
+            else:
+                latest_md = digest_json_path.with_name("latest.md")
+                if latest_md.exists():
+                    markdown_text = latest_md.read_text().strip()
+                    markdown_path = str(latest_md)
+            if markdown_text:
+                messages = _split_telegram_text(markdown_text)
+                footer = f"长版报告路径：{markdown_path}" if markdown_path else ""
+                if footer:
+                    if messages and len(messages[-1]) + len(footer) + 2 <= 3600:
+                        messages[-1] = f"{messages[-1]}\n\n{footer}"
+                    else:
+                        messages.append(footer)
+                messages = _add_telegram_part_numbers(messages)
+                return messages, f"已发送长版报告（共 {len(messages)} 段）"
+
+        if query_type == "binance":
+            reply = _format_daily_digest_binance(payload.get("top_binance_movers") or [])
+        elif query_type == "github":
+            reply = _format_daily_digest_github(payload.get("top_github_repos") or [])
+        elif query_type == "x":
+            reply = _format_daily_digest_x(payload.get("top_x_posts") or [])
+        elif query_type == "sentiment":
+            reply = _format_daily_digest_sentiment(payload.get("market_sentiment") or {})
+        else:
+            reply = _build_localized_daily_digest_from_payload(payload)
+            if not reply.strip():
+                reply = str(payload.get("digest_text", "")).strip()
+
+        if reply:
+            if markdown_path:
+                reply = f"{reply}\n\n长版报告：{markdown_path}"
+            return [reply], reply
+
+    if digest_text_path.exists():
+        digest_text = digest_text_path.read_text().strip()
+        if digest_text:
+            return [digest_text], digest_text
+
+    raise FileNotFoundError("daily crypto digest not found")
+
+
+def _normalize_int_string(value: Any) -> Optional[str]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped.isdigit() else None
+    return None
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -1506,6 +1828,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
             return
 
+        if data.startswith(DAILY_REPORT_CALLBACK_PREFIX):
+            query_type = data[len(DAILY_REPORT_CALLBACK_PREFIX) :].strip()
+            if query_type not in _DAILY_REPORT_LABELS:
+                await query.answer(text="暂不支持这个晨报按钮。")
+                return
+            await self._handle_daily_report_callback(query, query_type)
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -1533,6 +1863,53 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    async def _handle_daily_report_callback(self, query: Any, query_type: str) -> None:
+        """Send the requested daily report section back to the chat."""
+        label = _DAILY_REPORT_LABELS.get(query_type, "晨报")
+        await query.answer(text=f"正在发送{label}...")
+
+        try:
+            messages, summary = _build_daily_report_messages_for_callback(query_type)
+        except FileNotFoundError:
+            messages = ["今天的晨报摘要还没生成，先稍后再问我一次。"]
+            summary = messages[0]
+        except Exception as exc:
+            logger.error("Failed to build daily report callback payload: %s", exc)
+            messages = ["晨报展开失败了，我稍后再帮你重试一次。"]
+            summary = messages[0]
+
+        if not query.message:
+            return
+
+        chat_id = str(query.message.chat_id)
+        reply_to = _normalize_int_string(getattr(query.message, "message_id", None))
+        thread_id = _normalize_int_string(getattr(query.message, "message_thread_id", None))
+        metadata = {"thread_id": thread_id} if thread_id else None
+
+        for index, message in enumerate(messages):
+            result = await self.send(
+                chat_id=chat_id,
+                content=message,
+                reply_to=reply_to if index == 0 else None,
+                metadata=metadata,
+            )
+            if not result.success:
+                logger.warning(
+                    "[%s] Failed sending daily report callback chunk %d/%d: %s",
+                    self.name,
+                    index + 1,
+                    len(messages),
+                    result.error,
+                )
+
+        logger.info(
+            "[%s] Served daily report callback type=%s chat_id=%s summary=%s",
+            self.name,
+            query_type,
+            chat_id,
+            _summarize_text(summary, limit=160),
+        )
 
     async def send_voice(
         self,

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -14,9 +14,16 @@ import ipaddress
 import logging
 import os
 import socket
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import httpx
+import httpcore
+from httpcore._backends.auto import AutoBackend
+from httpcore._backends.base import SOCKET_OPTION, AsyncNetworkBackend, AsyncNetworkStream
+from httpx._config import DEFAULT_LIMITS, Limits, Proxy, create_ssl_context
+from httpx._models import Request, Response
+from httpx._transports.default import AsyncResponseStream, map_httpcore_exceptions
+from httpx._types import AsyncByteStream
 
 logger = logging.getLogger(__name__)
 
@@ -64,9 +71,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         proxy_url = _resolve_proxy_url()
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
-        self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
+        self._primary = _build_async_http_transport(**transport_kwargs)
         self._fallbacks = {
-            ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
+            ip: _build_async_http_transport_for_ip(ip, **transport_kwargs)
+            for ip in self._fallback_ips
         }
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()
@@ -83,10 +91,9 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
         last_error: Exception | None = None
         for ip in attempt_order:
-            candidate = request if ip is None else _rewrite_request_for_ip(request, ip)
             transport = self._primary if ip is None else self._fallbacks[ip]
             try:
-                response = await transport.handle_async_request(candidate)
+                response = await transport.handle_async_request(request)
                 if ip is not None and self._sticky_ip != ip:
                     async with self._sticky_lock:
                         if self._sticky_ip != ip:
@@ -245,3 +252,164 @@ def _rewrite_request_for_ip(request: httpx.Request, ip: str) -> httpx.Request:
 
 def _is_retryable_connect_error(exc: Exception) -> bool:
     return isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError))
+
+
+class _TelegramIPOverrideBackend(AsyncNetworkBackend):
+    """Route TCP connects for api.telegram.org to a chosen fallback IP.
+
+    Request URL, Host header, and TLS server hostname remain unchanged, so
+    certificate validation still happens against api.telegram.org.
+    """
+
+    def __init__(self, override_ip: str, backend: AsyncNetworkBackend | None = None):
+        self._override_ip = override_ip
+        self._backend = AutoBackend() if backend is None else backend
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> AsyncNetworkStream:
+        target_host = self._override_ip if host == _TELEGRAM_API_HOST else host
+        return await self._backend.connect_tcp(
+            target_host,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> AsyncNetworkStream:  # pragma: nocover
+        return await self._backend.connect_unix_socket(
+            path,
+            timeout=timeout,
+            socket_options=socket_options,
+        )
+
+    async def sleep(self, seconds: float) -> None:  # pragma: nocover
+        await self._backend.sleep(seconds)
+
+
+class _TelegramIPOverrideTransport(httpx.AsyncBaseTransport):
+    """Async transport that preserves request host while overriding TCP target."""
+
+    def __init__(
+        self,
+        override_ip: str,
+        verify: Any = True,
+        cert: Any = None,
+        trust_env: bool = True,
+        http1: bool = True,
+        http2: bool = False,
+        limits: Limits = DEFAULT_LIMITS,
+        proxy: Any = None,
+        uds: str | None = None,
+        local_address: str | None = None,
+        retries: int = 0,
+        socket_options: Iterable[SOCKET_OPTION] | None = None,
+    ) -> None:
+        proxy = Proxy(url=proxy) if isinstance(proxy, (str, httpx.URL)) else proxy
+        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
+        network_backend = _TelegramIPOverrideBackend(override_ip)
+
+        if proxy is None:
+            self._pool = httpcore.AsyncConnectionPool(
+                ssl_context=ssl_context,
+                max_connections=limits.max_connections,
+                max_keepalive_connections=limits.max_keepalive_connections,
+                keepalive_expiry=limits.keepalive_expiry,
+                http1=http1,
+                http2=http2,
+                uds=uds,
+                local_address=local_address,
+                retries=retries,
+                socket_options=socket_options,
+                network_backend=network_backend,
+            )
+        elif proxy.url.scheme in ("http", "https"):
+            self._pool = httpcore.AsyncHTTPProxy(
+                proxy_url=httpcore.URL(
+                    scheme=proxy.url.raw_scheme,
+                    host=proxy.url.raw_host,
+                    port=proxy.url.port,
+                    target=proxy.url.raw_path,
+                ),
+                proxy_auth=proxy.raw_auth,
+                proxy_headers=proxy.headers.raw,
+                proxy_ssl_context=proxy.ssl_context,
+                ssl_context=ssl_context,
+                max_connections=limits.max_connections,
+                max_keepalive_connections=limits.max_keepalive_connections,
+                keepalive_expiry=limits.keepalive_expiry,
+                http1=http1,
+                http2=http2,
+                socket_options=socket_options,
+                network_backend=network_backend,
+            )
+        elif proxy.url.scheme in ("socks5", "socks5h"):
+            self._pool = httpcore.AsyncSOCKSProxy(
+                proxy_url=httpcore.URL(
+                    scheme=proxy.url.raw_scheme,
+                    host=proxy.url.raw_host,
+                    port=proxy.url.port,
+                    target=proxy.url.raw_path,
+                ),
+                proxy_auth=proxy.raw_auth,
+                ssl_context=ssl_context,
+                max_connections=limits.max_connections,
+                max_keepalive_connections=limits.max_keepalive_connections,
+                keepalive_expiry=limits.keepalive_expiry,
+                http1=http1,
+                http2=http2,
+                network_backend=network_backend,
+            )
+        else:  # pragma: no cover
+            raise ValueError(
+                "Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h',"
+                f" but got {proxy.url.scheme!r}."
+            )
+
+    async def handle_async_request(self, request: Request) -> Response:
+        assert isinstance(request.stream, AsyncByteStream)
+        req = httpcore.Request(
+            method=request.method,
+            url=httpcore.URL(
+                scheme=request.url.raw_scheme,
+                host=request.url.raw_host,
+                port=request.url.port,
+                target=request.url.raw_path,
+            ),
+            headers=request.headers.raw,
+            content=request.stream,
+            extensions=request.extensions,
+        )
+        with map_httpcore_exceptions():
+            resp = await self._pool.handle_async_request(req)
+
+        return Response(
+            status_code=resp.status,
+            headers=resp.headers,
+            stream=AsyncResponseStream(resp.stream),
+            extensions=resp.extensions,
+        )
+
+    async def aclose(self) -> None:
+        await self._pool.aclose()
+
+
+def _build_async_http_transport(**transport_kwargs) -> httpx.AsyncBaseTransport:
+    return httpx.AsyncHTTPTransport(**transport_kwargs)
+
+
+def _build_async_http_transport_for_ip(
+    ip: str, **transport_kwargs
+) -> httpx.AsyncBaseTransport:
+    return _TelegramIPOverrideTransport(ip, **transport_kwargs)

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -1,6 +1,7 @@
 """Tests for Telegram inline keyboard approval buttons."""
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -46,6 +47,8 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
+import gateway.platforms.telegram as telegram_module
+from gateway.platforms.base import SendResult
 from gateway.platforms.telegram import TelegramAdapter
 from gateway.config import Platform, PlatformConfig
 
@@ -289,3 +292,162 @@ class TestTelegramApprovalCallback:
 
         # Should NOT have triggered approval resolution
         mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_daily_report_callback_sends_full_digest(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="10"))
+
+        digest_json = tmp_path / "latest.digest.json"
+        digest_json.write_text(
+            json.dumps(
+                {
+                    "report_date": "2026-04-12",
+                    "market_sentiment": {
+                        "value": "54",
+                        "classification_zh": "中性",
+                    },
+                    "top_binance_movers": [
+                        {
+                            "symbol": "BTCUSDT",
+                            "price_change_percent": 3.21,
+                            "quote_volume": 123000000,
+                        }
+                    ],
+                    "top_contract_movers": [],
+                    "top_github_repos": [
+                        {
+                            "repo": "foo/bar",
+                            "language": "Python",
+                            "stars_today": 123,
+                            "description_zh": "测试仓库",
+                        }
+                    ],
+                    "top_x_posts": [
+                        {
+                            "account": "alice",
+                            "summary_zh": "市场偏强",
+                        }
+                    ],
+                    "top_potential_picks": [
+                        {
+                            "symbol": "ETH",
+                            "confidence": 88,
+                        }
+                    ],
+                    "paths": {},
+                },
+                ensure_ascii=False,
+            )
+        )
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH",
+            str(digest_json),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH",
+            str(tmp_path / "latest.digest.txt"),
+            raising=False,
+        )
+
+        query = AsyncMock()
+        query.data = "daily-report:full"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 77
+        query.message.message_thread_id = 456
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        adapter.send.assert_called_once()
+        kwargs = adapter.send.call_args.kwargs
+        assert kwargs["chat_id"] == "12345"
+        assert kwargs["reply_to"] == "77"
+        assert kwargs["metadata"] == {"thread_id": "456"}
+        assert "每日加密晨报" in kwargs["content"]
+        assert "BTCUSDT" in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_daily_report_callback_sends_markdown_in_parts(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="11"))
+
+        markdown_path = tmp_path / "latest.md"
+        markdown_path.write_text("\n\n".join(["A" * 2100, "B" * 2100, "C" * 2100]))
+
+        digest_json = tmp_path / "latest.digest.json"
+        digest_json.write_text(
+            json.dumps({"paths": {"markdown": str(markdown_path)}}, ensure_ascii=False)
+        )
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH",
+            str(digest_json),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH",
+            str(tmp_path / "latest.digest.txt"),
+            raising=False,
+        )
+
+        query = AsyncMock()
+        query.data = "daily-report:markdown"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 78
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        assert adapter.send.call_count >= 2
+        first_kwargs = adapter.send.call_args_list[0].kwargs
+        assert first_kwargs["chat_id"] == "12345"
+        assert first_kwargs["reply_to"] == "78"
+
+    @pytest.mark.asyncio
+    async def test_daily_report_callback_handles_missing_files(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="12"))
+
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_JSON_PATH",
+            str(tmp_path / "missing.digest.json"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            telegram_module,
+            "DAILY_CRYPTO_LATEST_DIGEST_TEXT_PATH",
+            str(tmp_path / "missing.digest.txt"),
+            raising=False,
+        )
+
+        query = AsyncMock()
+        query.data = "daily-report:github"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 79
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        adapter.send.assert_called_once()
+        assert "还没生成" in adapter.send.call_args.kwargs["content"]

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -28,21 +28,23 @@ from gateway.platforms import telegram_network as tnet
 class FakeTransport(httpx.AsyncBaseTransport):
     """Records calls and raises / returns based on a host→action mapping."""
 
-    def __init__(self, calls, behavior):
+    def __init__(self, calls, behavior, label="primary"):
         self.calls = calls
         self.behavior = behavior
+        self.label = label
         self.closed = False
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.calls.append(
             {
+                "transport_label": self.label,
                 "url_host": request.url.host,
                 "host_header": request.headers.get("host"),
                 "sni_hostname": request.extensions.get("sni_hostname"),
                 "path": request.url.path,
             }
         )
-        action = self.behavior.get(request.url.host, "ok")
+        action = self.behavior.get(self.label, self.behavior.get(request.url.host, "ok"))
         if action == "timeout":
             raise httpx.ConnectTimeout("timed out")
         if action == "connect_error":
@@ -66,6 +68,24 @@ def _fake_transport_factory(calls, behavior):
 
     factory.instances = instances
     return factory
+
+
+def _fake_transport_builders(calls, behavior):
+    instances = []
+
+    def primary(**kwargs):
+        t = FakeTransport(calls, behavior, label="primary")
+        instances.append(t)
+        return t
+
+    def fallback(ip, **kwargs):
+        t = FakeTransport(calls, behavior, label=ip)
+        instances.append(t)
+        return t
+
+    primary.instances = instances
+    fallback.instances = instances
+    return primary, fallback
 
 
 def _telegram_request(path="/botTOKEN/getMe"):
@@ -148,31 +168,34 @@ class TestFallbackTransport:
     @pytest.mark.asyncio
     async def test_falls_back_on_connect_timeout_and_becomes_sticky(self, monkeypatch):
         calls = []
-        behavior = {"api.telegram.org": "timeout", "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        behavior = {"primary": "timeout", "149.154.167.220": "ok"}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
         resp = await transport.handle_async_request(_telegram_request())
 
         assert resp.status_code == 200
         assert transport._sticky_ip == "149.154.167.220"
-        # First attempt was primary (api.telegram.org), second was fallback
-        assert calls[0]["url_host"] == "api.telegram.org"
-        assert calls[1]["url_host"] == "149.154.167.220"
-        assert calls[1]["host_header"] == "api.telegram.org"
-        assert calls[1]["sni_hostname"] == "api.telegram.org"
+        # First attempt was primary, second was fallback transport for .220
+        assert calls[0]["transport_label"] == "primary"
+        assert calls[1]["transport_label"] == "149.154.167.220"
+        assert calls[1]["url_host"] == "api.telegram.org"
 
         # Second request goes straight to sticky IP
         calls.clear()
         resp2 = await transport.handle_async_request(_telegram_request())
         assert resp2.status_code == 200
-        assert calls[0]["url_host"] == "149.154.167.220"
+        assert calls[0]["transport_label"] == "149.154.167.220"
 
     @pytest.mark.asyncio
     async def test_falls_back_on_connect_error(self, monkeypatch):
         calls = []
-        behavior = {"api.telegram.org": "connect_error", "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        behavior = {"primary": "connect_error", "149.154.167.220": "ok"}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
         resp = await transport.handle_async_request(_telegram_request())
@@ -184,47 +207,53 @@ class TestFallbackTransport:
     async def test_does_not_fallback_on_non_connect_error(self, monkeypatch):
         """Errors like ReadTimeout are not connection issues — don't retry."""
         calls = []
-        behavior = {"api.telegram.org": httpx.ReadTimeout("read timeout"), "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        behavior = {"primary": httpx.ReadTimeout("read timeout"), "149.154.167.220": "ok"}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
 
         with pytest.raises(httpx.ReadTimeout):
             await transport.handle_async_request(_telegram_request())
 
-        assert [c["url_host"] for c in calls] == ["api.telegram.org"]
+        assert [c["transport_label"] for c in calls] == ["primary"]
 
     @pytest.mark.asyncio
     async def test_all_ips_fail_raises_last_error(self, monkeypatch):
         calls = []
-        behavior = {"api.telegram.org": "timeout", "149.154.167.220": "timeout"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        behavior = {"primary": "timeout", "149.154.167.220": "timeout"}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
 
         with pytest.raises(httpx.ConnectTimeout):
             await transport.handle_async_request(_telegram_request())
 
-        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+        assert [c["transport_label"] for c in calls] == ["primary", "149.154.167.220"]
         assert transport._sticky_ip is None
 
     @pytest.mark.asyncio
     async def test_multiple_fallback_ips_tried_in_order(self, monkeypatch):
         calls = []
         behavior = {
-            "api.telegram.org": "timeout",
+            "primary": "timeout",
             "149.154.167.220": "timeout",
             "149.154.167.221": "ok",
         }
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "149.154.167.221"])
         resp = await transport.handle_async_request(_telegram_request())
 
         assert resp.status_code == 200
         assert transport._sticky_ip == "149.154.167.221"
-        assert [c["url_host"] for c in calls] == [
-            "api.telegram.org",
+        assert [c["transport_label"] for c in calls] == [
+            "primary",
             "149.154.167.220",
             "149.154.167.221",
         ]
@@ -234,11 +263,13 @@ class TestFallbackTransport:
         """If the sticky IP stops working, the transport retries others."""
         calls = []
         behavior = {
-            "api.telegram.org": "timeout",
+            "primary": "timeout",
             "149.154.167.220": "ok",
             "149.154.167.221": "ok",
         }
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "149.154.167.221"])
 
@@ -253,7 +284,7 @@ class TestFallbackTransport:
         resp = await transport.handle_async_request(_telegram_request())
         assert resp.status_code == 200
         # Tried sticky (.220) first, then fell through to .221
-        assert [c["url_host"] for c in calls] == ["149.154.167.220", "149.154.167.221"]
+        assert [c["transport_label"] for c in calls] == ["149.154.167.220", "149.154.167.221"]
         assert transport._sticky_ip == "149.154.167.221"
 
 
@@ -264,7 +295,9 @@ class TestFallbackTransportPassthrough:
     async def test_non_telegram_host_bypasses_fallback(self, monkeypatch):
         calls = []
         behavior = {}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
         request = httpx.Request("GET", "https://example.com/path")
@@ -278,7 +311,9 @@ class TestFallbackTransportPassthrough:
     async def test_empty_fallback_list_uses_primary_only(self, monkeypatch):
         calls = []
         behavior = {}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport([])
         resp = await transport.handle_async_request(_telegram_request())
@@ -289,8 +324,10 @@ class TestFallbackTransportPassthrough:
     @pytest.mark.asyncio
     async def test_primary_succeeds_no_fallback_needed(self, monkeypatch):
         calls = []
-        behavior = {"api.telegram.org": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+        behavior = {"primary": "ok"}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
         resp = await transport.handle_async_request(_telegram_request())
@@ -302,30 +339,33 @@ class TestFallbackTransportPassthrough:
 
 class TestFallbackTransportInit:
     def test_deduplicates_fallback_ips(self, monkeypatch):
-        monkeypatch.setattr(
-            tnet.httpx, "AsyncHTTPTransport", lambda **kw: FakeTransport([], {})
-        )
+        monkeypatch.setattr(tnet, "_build_async_http_transport", lambda **kw: FakeTransport([], {}))
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", lambda ip, **kw: FakeTransport([], {}, label=ip))
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "149.154.167.220"])
         assert transport._fallback_ips == ["149.154.167.220"]
 
     def test_filters_invalid_ips_at_init(self, monkeypatch):
-        monkeypatch.setattr(
-            tnet.httpx, "AsyncHTTPTransport", lambda **kw: FakeTransport([], {})
-        )
+        monkeypatch.setattr(tnet, "_build_async_http_transport", lambda **kw: FakeTransport([], {}))
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", lambda ip, **kw: FakeTransport([], {}, label=ip))
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "not-an-ip"])
         assert transport._fallback_ips == ["149.154.167.220"]
 
     def test_uses_proxy_env_for_primary_and_fallback_transports(self, monkeypatch):
         seen_kwargs = []
 
-        def factory(**kwargs):
+        def primary_factory(**kwargs):
             seen_kwargs.append(kwargs.copy())
             return FakeTransport([], {})
+
+        def fallback_factory(ip, **kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {}, label=ip)
 
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy"):
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_factory)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_factory)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
 
@@ -337,15 +377,18 @@ class TestFallbackTransportInit:
 class TestFallbackTransportClose:
     @pytest.mark.asyncio
     async def test_aclose_closes_all_transports(self, monkeypatch):
-        factory = _fake_transport_factory([], {})
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+        calls = []
+        behavior = {}
+        primary_builder, fallback_builder = _fake_transport_builders(calls, behavior)
+        monkeypatch.setattr(tnet, "_build_async_http_transport", primary_builder)
+        monkeypatch.setattr(tnet, "_build_async_http_transport_for_ip", fallback_builder)
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "149.154.167.221"])
         await transport.aclose()
 
         # 1 primary + 2 fallback transports
-        assert len(factory.instances) == 3
-        assert all(t.closed for t in factory.instances)
+        assert len(primary_builder.instances) == 3
+        assert all(t.closed for t in primary_builder.instances)
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add Hermes Telegram callback handling for `daily-report:*` buttons so the daily crypto report can expand inline from existing report messages
- fix Telegram fallback transport to preserve the logical `api.telegram.org` host and TLS target while dialing fallback IPs, which resolves the callback reply path
- add regression coverage for both the callback flow and the fallback transport behavior

## Root Cause
The daily report buttons were wired into report messages, but the running Hermes `tg-data` gateway did not handle the `daily-report:*` callback payloads. After adding that handler, the live callback path still failed because the fallback transport rewrote the request host to a raw Telegram IP, which broke TLS verification in the current httpx/httpcore stack and prevented callback replies from being delivered.

## Impact
This restores the `uk数据` daily report buttons such as long report, summary, Binance movers, GitHub trending, X intel, and sentiment, and keeps Telegram callback replies working even when the gateway has to fall back to a Telegram IP.

## Validation
- `/Users/ukgorclawbot/.hermes/hermes-agent/venv/bin/python -m pytest /Users/ukgorclawbot/.hermes/hermes-agent/tests/gateway/test_telegram_approval_buttons.py /Users/ukgorclawbot/.hermes/hermes-agent/tests/gateway/test_telegram_network.py -q -o addopts=''`
- `/Users/ukgorclawbot/.hermes/hermes-agent/venv/bin/python -m py_compile /Users/ukgorclawbot/.hermes/hermes-agent/gateway/platforms/telegram.py /Users/ukgorclawbot/.hermes/hermes-agent/gateway/platforms/telegram_network.py`
