### PR TITLE
fix(gateway): propagate chat_type through session context to prevent stale dm entries

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6760,6 +6760,7 @@ class GatewayRunner:
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
+            chat_type=context.source.chat_type or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
@@ -6975,6 +6976,7 @@ class GatewayRunner:
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        chat_type = watcher.get("chat_type", "")
         thread_id = watcher.get("thread_id", "")
         user_id = watcher.get("user_id", "")
         user_name = watcher.get("user_name", "")
@@ -7034,6 +7036,7 @@ class GatewayRunner:
                             _source = SessionSource(
                                 platform=_platform_enum,
                                 chat_id=chat_id,
+                                chat_type=chat_type or "dm",
                                 thread_id=thread_id or None,
                                 user_id=user_id or None,
                                 user_name=user_name or None,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -45,6 +45,7 @@ from contextvars import ContextVar
 _SESSION_PLATFORM: ContextVar[str] = ContextVar("HERMES_SESSION_PLATFORM", default="")
 _SESSION_CHAT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_ID", default="")
 _SESSION_CHAT_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_NAME", default="")
+_SESSION_CHAT_TYPE: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_TYPE", default="")
 _SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", default="")
 _SESSION_USER_ID: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID", default="")
 _SESSION_USER_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_USER_NAME", default="")
@@ -54,6 +55,7 @@ _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
@@ -65,6 +67,7 @@ def set_session_vars(
     platform: str = "",
     chat_id: str = "",
     chat_name: str = "",
+    chat_type: str = "",
     thread_id: str = "",
     user_id: str = "",
     user_name: str = "",
@@ -82,6 +85,7 @@ def set_session_vars(
         _SESSION_PLATFORM.set(platform),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
@@ -98,6 +102,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_PLATFORM,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -231,6 +231,35 @@ async def test_notify_on_complete_preserves_user_identity(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_notify_on_complete_preserves_chat_type(monkeypatch, tmp_path):
+    """Synthetic completion event should keep group chats as group, not dm."""
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="done\n", exited=True, exit_code=0, command="echo test"
+        ),
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path)
+    adapter = runner.adapters[Platform.DISCORD]
+
+    watcher = _watcher_dict_with_notify()
+    watcher["chat_type"] = "group"
+
+    await runner._run_process_watcher(watcher)
+
+    assert adapter.handle_message.await_count == 1
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
 async def test_none_user_id_skips_pairing(monkeypatch, tmp_path):
     """A non-internal event with user_id=None should be silently dropped."""
     import gateway.run as gateway_run

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -14,6 +14,7 @@ from gateway.session_context import (
 def test_set_session_env_sets_contextvars(monkeypatch):
     """_set_session_env should populate contextvars, not os.environ."""
     runner = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     source = SessionSource(
         platform=Platform.TELEGRAM,
         chat_id="-1001",
@@ -31,6 +32,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
 
     tokens = runner._set_session_env(context)
 
@@ -38,6 +40,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == "Group"
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
@@ -60,6 +63,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
 
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -82,6 +86,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
     assert get_session_env("HERMES_SESSION_CHAT_ID") == ""
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == ""
     assert get_session_env("HERMES_SESSION_USER_ID") == ""
     assert get_session_env("HERMES_SESSION_USER_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
@@ -111,9 +116,10 @@ def test_get_session_env_default_when_nothing_set(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
 
 
-def test_set_session_env_handles_missing_optional_fields():
+def test_set_session_env_handles_missing_optional_fields(monkeypatch):
     """_set_session_env should handle None chat_name and thread_id gracefully."""
     runner = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     source = SessionSource(
         platform=Platform.TELEGRAM,
         chat_id="-1001",
@@ -128,6 +134,7 @@ def test_set_session_env_handles_missing_optional_fields():
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "private"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
 
     runner._clear_session_env(tokens)
@@ -169,9 +176,10 @@ def test_session_key_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
 
 
-def test_set_session_env_includes_session_key():
+def test_set_session_env_includes_session_key(monkeypatch):
     """_set_session_env should propagate session_key from SessionContext."""
     runner = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     source = SessionSource(
         platform=Platform.TELEGRAM,
         chat_id="-1001",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1424,11 +1424,13 @@ def terminal_tool(
                     _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
                     if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
+                        _gw_chat_type = _gse("HERMES_SESSION_CHAT_TYPE", "")
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
                         _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                         _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                         proc_session.watcher_platform = _gw_platform
                         proc_session.watcher_chat_id = _gw_chat_id
+                        proc_session.watcher_chat_type = _gw_chat_type
                         proc_session.watcher_user_id = _gw_user_id
                         proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_thread_id = _gw_thread_id
@@ -1439,6 +1441,7 @@ def terminal_tool(
                             "session_key": session_key,
                             "platform": _gw_platform,
                             "chat_id": _gw_chat_id,
+                            "chat_type": _gw_chat_type,
                             "user_id": _gw_user_id,
                             "user_name": _gw_user_name,
                             "thread_id": _gw_thread_id,


### PR DESCRIPTION
## Summary

- Background process completion notifications (`_run_process_watcher`) create synthetic `MessageEvent`s to re-inject results into the conversation pipeline
- `HERMES_SESSION_CHAT_TYPE` was not propagated through the session context variable chain, so `SessionSource.chat_type` defaulted to `"dm"` for all synthetic events — even when the originating chat was a group
- This caused supergroup `chat_id`s (e.g. `-1003853515602`) to be recorded as dm sessions in `sessions.json`, which then polluted `channel_directory.json` during rebuilds: the stale dm entry (with null name) shadowed the correct group entry via `seen_ids` dedup

## Root cause

The watcher path was designed with a "minimum info for routing" mindset — `platform`, `chat_id`, `thread_id`, `user_id`, `user_name` were enough to *send* a message back. But this path also creates a `SessionSource` that flows into session creation, `sessions.json` origin storage, and `channel_directory` discovery. Since `SessionSource` defaults `chat_type="dm"`, the omission was silent — no error, just quietly wrong metadata.

## Changes

- **`gateway/session_context.py`**: Add `_SESSION_CHAT_TYPE` context var to the var map, `set_session_vars`, and `clear_session_vars`
- **`gateway/run.py`**: Pass `chat_type` in `_set_session_env`; extract and use `chat_type` from watcher dict in `_run_process_watcher`
- **`tools/terminal_tool.py`**: Read `HERMES_SESSION_CHAT_TYPE` and include it in watcher registration dict

## Why chat_type matters on this path

- Session key generation uses `chat_type` (`agent:main:telegram:{chat_type}:{chat_id}`)
- `sessions.json` origin records feed `channel_directory` rebuilds
- DM vs group branching affects pairing, authorization, and routing policy
- Platforms like Discord, Slack, and Feishu have different handling for dm/group/channel types

This is not just routing info — it's session semantics that must be preserved when re-injecting internal events.

## Test plan

- [x] `test_notify_on_complete_preserves_chat_type` — verifies group `chat_type` survives synthetic event creation
- [x] `test_set_session_env_sets_contextvars` — verifies `HERMES_SESSION_CHAT_TYPE` is set correctly
- [x] `test_clear_session_env_restores_previous_state` — verifies chat_type is restored after handler exit
- [x] All 17 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)