### PR TITLE
feat(cli): show reasoning and fast mode in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1885,11 +1885,13 @@ class HermesCLI:
             model_short = model_short[:-5]
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
+        model_display = self._get_status_model_display(model_short)
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "model_display": model_display,
             "duration": format_duration_compact(elapsed_seconds),
             "context_tokens": 0,
             "context_length": None,
@@ -1928,6 +1930,37 @@ class HermesCLI:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
         return snapshot
+
+    def _get_status_model_display(self, model_short: str) -> str:
+        """Return the status-bar model label including reasoning/fast markers."""
+        labels: list[str] = []
+
+        reasoning_config = None
+        agent = getattr(self, "agent", None)
+        if agent is not None:
+            reasoning_config = getattr(agent, "reasoning_config", None)
+        if not isinstance(reasoning_config, dict):
+            reasoning_config = getattr(self, "reasoning_config", None)
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                labels.append("none")
+            else:
+                effort = reasoning_config.get("effort")
+                if isinstance(effort, str) and effort.strip():
+                    labels.append(effort.strip())
+
+        service_tier = None
+        if agent is not None:
+            service_tier = getattr(agent, "service_tier", None)
+        if not service_tier:
+            service_tier = getattr(self, "service_tier", None)
+        if isinstance(service_tier, str) and service_tier.strip():
+            normalized_tier = service_tier.strip()
+            labels.append("fast" if normalized_tier == "priority" else normalized_tier)
+
+        if not labels:
+            return model_short
+        return f"{model_short} [{' '.join(labels)}]"
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -2041,10 +2074,10 @@ class HermesCLI:
             duration_label = snapshot["duration"]
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {snapshot['model_display']} · {duration_label}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot['model_display']}", percent_label]
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -2055,7 +2088,7 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {snapshot['model_display']}", context_label, percent_label]
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -2077,7 +2110,7 @@ class HermesCLI:
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                    ("class:status-bar-strong", snapshot["model_display"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                     ("class:status-bar", " "),
@@ -2088,7 +2121,7 @@ class HermesCLI:
                 if width < 76:
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", snapshot["model_display"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                         ("class:status-bar-dim", " · "),
@@ -2106,7 +2139,7 @@ class HermesCLI:
                     bar_style = self._status_bar_context_style(percent)
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", snapshot["model_display"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -8,6 +8,8 @@ from cli import HermesCLI
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.model = model
+    cli_obj.reasoning_config = None
+    cli_obj.service_tier = None
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
@@ -79,6 +81,32 @@ class TestCLIStatusBar:
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_build_status_bar_text_includes_reasoning_and_fast_markers(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+        cli_obj.service_tier = "priority"
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.4 [high fast]" in text
+        assert "12.4K/200K" in text
+
+    def test_build_status_bar_text_includes_reasoning_disabled_marker(self):
+        cli_obj = _make_cli(model="gpt-5.4")
+        cli_obj.reasoning_config = {"enabled": False}
+
+        text = cli_obj._build_status_bar_text(width=100)
+
+        assert "gpt-5.4 [none]" in text
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()


### PR DESCRIPTION
## Summary
- show the active reasoning mode and fast mode in the interactive status bar model label
- keep the existing compact footer layout while surfacing runtime model settings
- add CLI status bar coverage for enabled reasoning, disabled reasoning, and fast mode markers

## Why
The status bar already shows the active model, but it does not expose two runtime settings that materially change behavior and cost: reasoning effort and fast mode. This makes it harder to confirm at a glance that the current session is using the intended runtime configuration.

## Validation
- `pytest tests/cli/test_cli_status_bar.py -q`
