### PR TITLE
fix(weixin): Stop auto-splitting messages by newlines; match Telegram behavior

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -696,42 +696,14 @@ def _split_markdown_blocks(content: str) -> List[str]:
 
 
 def _split_delivery_units_for_weixin(content: str) -> List[str]:
-    """Split formatted content into chat-friendly delivery units.
+    """Return content as a single unit.
 
-    Weixin can render Markdown, but chat readability is better when top-level
-    line breaks become separate messages. Keep fenced code blocks intact and
-    attach indented continuation lines to the previous top-level line so
-    transformed tables/lists do not get torn apart.
+    Splitting is handled by ``_split_text_for_weixin_delivery`` based on
+    ``max_length`` only.  Keeping messages intact (instead of splitting by
+    newlines) matches the behavior of the Telegram adapter and prevents
+    flooding the user's chat with many small messages.
     """
-    units: List[str] = []
-
-    for block in _split_markdown_blocks(content):
-        if _FENCE_RE.match(block.splitlines()[0].strip()):
-            units.append(block)
-            continue
-
-        current: List[str] = []
-        for raw_line in block.splitlines():
-            line = raw_line.rstrip()
-            if not line.strip():
-                if current:
-                    units.append("\n".join(current).strip())
-                    current = []
-                continue
-
-            is_continuation = bool(current) and raw_line.startswith((" ", "\t"))
-            if is_continuation:
-                current.append(line)
-                continue
-
-            if current:
-                units.append("\n".join(current).strip())
-            current = [line]
-
-        if current:
-            units.append("\n".join(current).strip())
-
-    return [unit for unit in units if unit]
+    return [content] if content.strip() else []
 
 
 def _looks_like_chatty_line_for_weixin(line: str) -> bool:
@@ -761,13 +733,16 @@ def _looks_like_heading_line_for_weixin(line: str) -> bool:
 
 
 def _should_split_short_chat_block_for_weixin(block: str) -> bool:
-    """Split only chat-like multiline blocks into separate bubbles."""
-    lines = [line for line in block.splitlines() if line.strip()]
-    if not 2 <= len(lines) <= 6:
-        return False
-    if _looks_like_heading_line_for_weixin(lines[0]):
-        return False
-    return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
+    """Return False to keep short chat messages as a single unit.
+
+    Splitting short chat-like blocks into separate bubbles was originally
+    intended to create a more natural feel, but in practice it floods the
+    user's WeChat with many small messages.  Returning ``False`` keeps
+    the default compact behavior consistent with Telegram and other platforms.
+    Users who prefer per-line splitting can still enable it via
+    ``WEIXIN_SPLIT_MULTILINE_MESSAGES=true``.
+    """
+    return False
 
 
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:


### PR DESCRIPTION
## Problem

The WeChat adapter splits every paragraph/line-break into a separate message, flooding users' chat interfaces. This behavior is unique to WeChat — the Telegram adapter keeps messages intact and only splits when exceeding the max length limit.

Users consistently reported this as a major UX pain point, especially for longer AI replies that get broken into 5-10 separate WeChat messages.

## Solution

Two targeted changes to `gateway/platforms/weixin.py`:

1. **`_split_delivery_units_for_weixin`** — Simplified to return content as a single unit. Splitting is now handled by `_split_text_for_weixin_delivery` based on `max_length` (4000 chars) only.

2. **`_should_split_short_chat_block_for_weixin`** — Changed to return `False`. Previously, even with `split_multiline_messages=false` (the default), short 2-6 line messages would still be split into separate bubbles. This made the chat feel fragmented.

## Impact

| | Before | After |
|---|---|---|
| 3-paragraph reply | 3 separate WeChat messages | 1 WeChat message |
| Short 4-line reply | 4 bubbles | 1 bubble |
| Long reply (>4000 chars) | Split by newlines + length | Split by length only (code blocks still intact) |

Users who prefer the old per-line splitting behavior can still enable it via `WEIXIN_SPLIT_MULTILINE_MESSAGES=true` in their config.

## Discovered by

This issue was discovered while building [HermesClaw](https://github.com/AaronWong1999/hermesclaw), a dual-proxy router that runs Hermes Agent and OpenClaw on the same WeChat account. The newline-splitting behavior was the #1 reported UX complaint from HermesClaw users.

## Credit

- Discovered and fixed by **Aaron Wong** ([@AaronWong1999](https://github.com/AaronWong1999))
- X/Twitter: [@AaronYonW](https://x.com/AaronYonW)

Feel free to credit this contribution in the release notes or changelog. Happy to help the Hermes community! 🦞