### PR TITLE
fix: close leaked cron and gateway resources

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -599,6 +599,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
 
+    agent = None
     try:
         # Inject origin context so the agent's send_message tool knows the chat.
         # Must be INSIDE the try block so the finally cleanup always runs.
@@ -873,6 +874,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
+        if agent is not None:
+            try:
+                agent.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to close agent: %s", job_id, e)
         # Clean up injected env vars so they don't leak to other jobs
         for key in (
             "HERMES_SESSION_PLATFORM",

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -599,6 +599,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
 
+    # Sentinel ensures finally cleanup can safely run even if AIAgent(**kwargs)
+    # fails before assigning a live instance.
     agent = None
     try:
         # Inject origin context so the agent's send_message tool knows the chat.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -791,11 +791,17 @@ class GatewayRunner:
                 "tools if needed, then stop.]"
             )
 
-            tmp_agent.run_conversation(
-                user_message=flush_prompt,
-                conversation_history=msgs,
-            )
-            logger.info("Pre-reset memory flush completed for session %s", old_session_id)
+            try:
+                tmp_agent.run_conversation(
+                    user_message=flush_prompt,
+                    conversation_history=msgs,
+                )
+                logger.info("Pre-reset memory flush completed for session %s", old_session_id)
+            finally:
+                try:
+                    tmp_agent.close()
+                except Exception:
+                    pass
         except Exception as e:
             logger.debug("Pre-reset memory flush failed for session %s: %s", old_session_id, e)
 
@@ -3410,13 +3416,19 @@ class GatewayRunner:
                                 _hyg_agent._print_fn = lambda *a, **kw: None
 
                                 loop = asyncio.get_event_loop()
-                                _compressed, _ = await loop.run_in_executor(
-                                    None,
-                                    lambda: _hyg_agent._compress_context(
-                                        _hyg_msgs, "",
-                                        approx_tokens=_approx_tokens,
-                                    ),
-                                )
+                                try:
+                                    _compressed, _ = await loop.run_in_executor(
+                                        None,
+                                        lambda: _hyg_agent._compress_context(
+                                            _hyg_msgs, "",
+                                            approx_tokens=_approx_tokens,
+                                        ),
+                                    )
+                                finally:
+                                    try:
+                                        _hyg_agent.close()
+                                    except Exception:
+                                        pass
 
                                 # _compress_context ends the old session and creates
                                 # a new session_id.  Write compressed messages into
@@ -5310,10 +5322,16 @@ class GatewayRunner:
                     fallback_model=self._fallback_model,
                 )
 
-                return agent.run_conversation(
-                    user_message=prompt,
-                    task_id=task_id,
-                )
+                try:
+                    return agent.run_conversation(
+                        user_message=prompt,
+                        task_id=task_id,
+                    )
+                finally:
+                    try:
+                        agent.close()
+                    except Exception:
+                        pass
 
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(None, run_sync)
@@ -5492,11 +5510,17 @@ class GatewayRunner:
                     skip_context_files=True,
                     persist_session=False,
                 )
-                return agent.run_conversation(
-                    user_message=btw_prompt,
-                    conversation_history=history_snapshot,
-                    task_id=task_id,
-                )
+                try:
+                    return agent.run_conversation(
+                        user_message=btw_prompt,
+                        conversation_history=history_snapshot,
+                        task_id=task_id,
+                    )
+                finally:
+                    try:
+                        agent.close()
+                    except Exception:
+                        pass
 
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(None, run_sync)
@@ -5835,10 +5859,16 @@ class GatewayRunner:
                 return "Nothing to compress yet (the transcript is still all protected context)."
 
             loop = asyncio.get_event_loop()
-            compressed, _ = await loop.run_in_executor(
-                None,
-                lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
-            )
+            try:
+                compressed, _ = await loop.run_in_executor(
+                    None,
+                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
+                )
+            finally:
+                try:
+                    tmp_agent.close()
+                except Exception:
+                    pass
 
             # _compress_context already calls end_session() on the old session
             # (preserving its full transcript in SQLite) and creates a new

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26,6 +26,7 @@ import threading
 import time
 from pathlib import Path
 from datetime import datetime
+from contextlib import suppress
 from typing import Dict, Optional, Any, List
 
 # ---------------------------------------------------------------------------
@@ -306,6 +307,19 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
     return resolved
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_close_agent(agent: Any) -> None:
+    """Best-effort close for short-lived agent instances.
+
+    Gateway code creates several transient AIAgent instances for one-off tasks
+    such as memory flushes, compression, and helper flows. Centralizing the
+    cleanup avoids copy-paste drift and makes future close-path changes easier.
+    """
+    if agent is None or not hasattr(agent, "close"):
+        return
+    with suppress(Exception):
+        agent.close()
 
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
@@ -798,10 +812,7 @@ class GatewayRunner:
                 )
                 logger.info("Pre-reset memory flush completed for session %s", old_session_id)
             finally:
-                try:
-                    tmp_agent.close()
-                except Exception:
-                    pass
+                _safe_close_agent(tmp_agent)
         except Exception as e:
             logger.debug("Pre-reset memory flush failed for session %s: %s", old_session_id, e)
 
@@ -1397,11 +1408,7 @@ class GatewayRunner:
             # Close tool resources (terminal sandboxes, browser daemons,
             # background processes, httpx clients) to prevent zombie
             # process accumulation.
-            try:
-                if hasattr(agent, 'close'):
-                    agent.close()
-            except Exception:
-                pass
+            _safe_close_agent(agent)
 
     async def _launch_detached_restart_command(self) -> None:
         import shutil
@@ -1793,11 +1800,7 @@ class GatewayRunner:
                                     _cached_agent.shutdown_memory_provider()
                             except Exception:
                                 pass
-                            try:
-                                if hasattr(_cached_agent, 'close'):
-                                    _cached_agent.close()
-                            except Exception:
-                                pass
+                            _safe_close_agent(_cached_agent)
                         # Mark as flushed and persist to disk so the flag
                         # survives gateway restarts.
                         with self.session_store._lock:
@@ -3425,10 +3428,7 @@ class GatewayRunner:
                                         ),
                                     )
                                 finally:
-                                    try:
-                                        _hyg_agent.close()
-                                    except Exception:
-                                        pass
+                                    _safe_close_agent(_hyg_agent)
 
                                 # _compress_context ends the old session and creates
                                 # a new session_id.  Write compressed messages into
@@ -3945,11 +3945,7 @@ class GatewayRunner:
                 _cached = self._agent_cache.get(session_key)
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
-                try:
-                    if hasattr(_old_agent, "close"):
-                        _old_agent.close()
-                except Exception:
-                    pass
+                _safe_close_agent(_old_agent)
         self._evict_cached_agent(session_key)
 
         try:
@@ -5328,10 +5324,7 @@ class GatewayRunner:
                         task_id=task_id,
                     )
                 finally:
-                    try:
-                        agent.close()
-                    except Exception:
-                        pass
+                    _safe_close_agent(agent)
 
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(None, run_sync)
@@ -5517,10 +5510,7 @@ class GatewayRunner:
                         task_id=task_id,
                     )
                 finally:
-                    try:
-                        agent.close()
-                    except Exception:
-                        pass
+                    _safe_close_agent(agent)
 
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(None, run_sync)
@@ -5865,10 +5855,7 @@ class GatewayRunner:
                     lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
                 )
             finally:
-                try:
-                    tmp_agent.close()
-                except Exception:
-                    pass
+                _safe_close_agent(tmp_agent)
 
             # _compress_context already calls end_session() on the old session
             # (preserving its full transcript in SQLite) and creates a new

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -664,6 +664,7 @@ class TestRunJobSessionPersistence:
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")
+        mock_agent.close.assert_called_once()
         fake_db.end_session.assert_called_once()
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -226,6 +226,7 @@ class TestRunBackgroundTask:
             await runner._run_background_task("say hello", source, "bg_test")
 
         # Should have sent the result
+        mock_agent_instance.close.assert_called_once()
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -83,6 +83,7 @@ async def test_compress_command_reports_noop_without_success_banner():
     assert "No changes from compression" in result
     assert "Compressed:" not in result
     assert "Rough transcript estimate: ~100 tokens (unchanged)" in result
+    agent_instance.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_flush_memory_stale_guard.py
+++ b/tests/gateway/test_flush_memory_stale_guard.py
@@ -100,6 +100,7 @@ class TestMemoryInjection:
             runner._flush_memories_for_session("session_123")
 
         tmp_agent.run_conversation.assert_called_once()
+        tmp_agent.close.assert_called_once()
         flush_prompt = tmp_agent.run_conversation.call_args.kwargs.get("user_message", "")
 
         assert "Agent knows Python" in flush_prompt

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -193,6 +193,31 @@ class TestStdinHelpers:
             registry.kill_process(session.id)
 
 
+class TestReaderCleanup:
+    def test_reader_loop_closes_process_pipes_when_process_exits(self, registry):
+        proc = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stdout.read.side_effect = ["hello", ""]
+        proc.stdin = MagicMock()
+        proc.stderr = proc.stdout
+        proc.wait = MagicMock()
+        proc.returncode = 0
+
+        session = _make_session()
+        session.process = proc
+        registry._running[session.id] = session
+
+        registry._reader_loop(session)
+
+        proc.wait.assert_called_once_with(timeout=5)
+        proc.stdout.close.assert_called_once()
+        proc.stdin.close.assert_called_once()
+        assert session.exited is True
+        assert session.exit_code == 0
+        assert session.id in registry._finished
+        assert session.output_buffer == "hello"
+
+
 # =========================================================================
 # List sessions
 # =========================================================================

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -193,6 +193,37 @@ class TestStdinHelpers:
             registry.kill_process(session.id)
 
 
+
+
+def test_close_process_pipes_dedupes_by_fileno(registry):
+    class Handle:
+        def __init__(self, fileno_value):
+            self._fileno_value = fileno_value
+            self.close_calls = 0
+
+        def fileno(self):
+            return self._fileno_value
+
+        def close(self):
+            self.close_calls += 1
+
+    stdin = Handle(10)
+    stdout = Handle(11)
+    stderr = Handle(11)
+    proc = MagicMock()
+    proc.stdin = stdin
+    proc.stdout = stdout
+    proc.stderr = stderr
+
+    session = _make_session()
+    session.process = proc
+
+    registry._close_process_pipes(session)
+
+    assert stdin.close_calls == 1
+    assert stdout.close_calls == 1
+    assert stderr.close_calls == 0
+
 class TestReaderCleanup:
     def test_reader_loop_closes_process_pipes_when_process_exits(self, registry):
         proc = MagicMock()

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -501,9 +501,31 @@ class ProcessRegistry:
                 session.process.wait(timeout=5)
             except Exception as e:
                 logger.debug("Process wait timed out or failed: %s", e)
+            self._close_process_pipes(session)
             session.exited = True
             session.exit_code = session.process.returncode
             self._move_to_finished(session)
+
+    def _close_process_pipes(self, session: ProcessSession) -> None:
+        """Close parent-side pipe handles for a local Popen session."""
+        proc = getattr(session, "process", None)
+        if not proc:
+            return
+
+        handles = []
+        for attr in ("stdin", "stdout", "stderr"):
+            handle = getattr(proc, attr, None)
+            if handle is None:
+                continue
+            if any(handle is existing for existing in handles):
+                continue
+            handles.append(handle)
+
+        for handle in handles:
+            try:
+                handle.close()
+            except Exception:
+                pass
 
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -513,12 +513,19 @@ class ProcessRegistry:
             return
 
         handles = []
+        seen_fds = set()
         for attr in ("stdin", "stdout", "stderr"):
             handle = getattr(proc, attr, None)
             if handle is None:
                 continue
-            if any(handle is existing for existing in handles):
+            try:
+                fileno = handle.fileno()
+            except Exception:
+                fileno = None
+            if fileno is not None and fileno in seen_fds:
                 continue
+            if fileno is not None:
+                seen_fds.add(fileno)
             handles.append(handle)
 
         for handle in handles:


### PR DESCRIPTION
## Bug Description

Hermes gateway could hit `OSError: [Errno 24] Too many open files` during long-lived cron/gateway operation on macOS launchd setups with a low `RLIMIT_NOFILE` (for example 256).

Observed symptoms included:
- cron jobs still running but failing to deliver to Feishu
- `tools.terminal_tool`, `tools.code_execution_tool`, and `write_file` failing with `Too many open files`
- cron state persistence failing after delivery attempts
- even opening `~/.hermes/.env` failing inside later cron runs

## Root Cause

There were two resource-lifecycle problems contributing to descriptor pressure inside the long-lived gateway process:

1. `tools/process_registry.py` kept parent-side `stdin/stdout/stderr` pipe handles open after local background processes exited. Finished sessions remain in the registry for inspection, so those pipe FDs could accumulate until the process hit the OS limit.
2. Several temporary `AIAgent` instances created in cron and gateway helper flows were never explicitly closed. That left provider/client resources and other agent-owned cleanup work dependent on process lifetime instead of request lifetime.

## Fix

This PR tightens cleanup in the affected paths:

- add explicit local pipe cleanup in `ProcessRegistry._reader_loop()` after the child process exits and has been reaped
- close temporary `AIAgent` instances in:
  - `cron.scheduler.run_job()`
  - gateway pre-reset memory flush flow
  - gateway session hygiene compression flow
  - `/background` task execution flow
  - `/btw` task execution flow
  - `/compress` flow
- add regression tests that assert cleanup happens for these paths

## How to Verify

1. Run the focused regression tests:
   `source venv/bin/activate && python -m pytest -o addopts='' tests/tools/test_process_registry.py tests/cron/test_scheduler.py tests/gateway/test_background_command.py tests/gateway/test_compress_command.py tests/gateway/test_flush_memory_stale_guard.py -q`
2. Confirm the suite passes and the new assertions verify `.close()` / pipe cleanup behavior.
3. In a long-lived gateway session, run cron/background workloads that previously reproduced fd exhaustion and confirm the process no longer accumulates stale pipe handles from completed local background processes.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [ ] Manual verification of the fix in a live long-running gateway session

Focused test command run for this PR:

`source venv/bin/activate && python -m pytest -o addopts='' tests/tools/test_process_registry.py tests/cron/test_scheduler.py tests/gateway/test_background_command.py tests/gateway/test_compress_command.py tests/gateway/test_flush_memory_stale_guard.py -q`

Result: `133 passed`

## Risk Assessment

Low / Medium — behavior changes are narrowly scoped to resource cleanup after helper-agent usage and after local background-process exit. The main risk is cleanup timing, but the change avoids closing pipes during `kill_process()` itself and keeps process-state transitions aligned with actual process exit.
