### PR TITLE
[codex] Add Chinese CLI and TUI language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,33 @@ hermes tools        # Configure which tools are enabled
 hermes config set   # Set individual config values
 hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
 hermes setup        # Run the full setup wizard (configures everything at once)
+hermes lang zh      # Switch CLI/TUI helper text to Chinese
+hermes zh           # Built-in Chinese quickstart / command guide
 hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
 hermes update       # Update to the latest version
 hermes doctor       # Diagnose any issues
 ```
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
+
+## Chinese Guide
+
+Hermes now ships with a built-in offline Chinese guide for users who prefer to learn setup steps and commands in Chinese:
+
+```bash
+hermes lang zh
+hermes zh
+hermes zh setup
+hermes zh commands
+```
+
+Inside the interactive CLI or a messaging conversation, you can also use:
+
+```text
+/zh
+/zh config
+/zh gateway
+```
 
 ## CLI vs Messaging Quick Reference
 

--- a/cli.py
+++ b/cli.py
@@ -1395,13 +1395,18 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 
 
 
-def _build_compact_banner() -> str:
+def _build_compact_banner(language: str = "en") -> str:
     """Build a compact banner that fits the current terminal width."""
     try:
         from hermes_cli.skin_engine import get_active_skin
         _skin = get_active_skin()
     except Exception:
         _skin = None
+    try:
+        from hermes_cli.ui_language import is_chinese_display
+        _zh = is_chinese_display(language)
+    except Exception:
+        _zh = False
 
     skin_name = getattr(_skin, "name", "default") if _skin else "default"
     border_color = _skin.get_color("banner_border", "#FFD700") if _skin else "#FFD700"
@@ -1409,11 +1414,11 @@ def _build_compact_banner() -> str:
     dim_color = _skin.get_color("banner_dim", "#B8860B") if _skin else "#B8860B"
 
     if skin_name == "default":
-        line1 = "⚕ NOUS HERMES - AI Agent Framework"
+        line1 = "⚕ NOUS HERMES - AI Agent Framework" if not _zh else "⚕ NOUS HERMES - AI 智能体框架"
         tiny_line = "⚕ NOUS HERMES"
     else:
         agent_name = _skin.get_branding("agent_name", "Hermes Agent") if _skin else "Hermes Agent"
-        line1 = f"{agent_name} - AI Agent Framework"
+        line1 = f"{agent_name} - AI Agent Framework" if not _zh else f"{agent_name} - AI 智能体框架"
         tiny_line = agent_name
 
     version_line = format_banner_version_label()
@@ -1612,6 +1617,11 @@ class HermesCLI:
         self.console = Console()
         self.config = CLI_CONFIG
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
+        try:
+            from hermes_cli.ui_language import normalize_display_language
+            self.display_language = normalize_display_language(CLI_CONFIG["display"].get("language", "en"))
+        except Exception:
+            self.display_language = "en"
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
@@ -2016,17 +2026,17 @@ class HermesCLI:
         compact = self._use_minimal_tui_chrome(width=width)
         if self._voice_recording:
             if compact:
-                return [("class:voice-status-recording", " ● REC ")]
-            return [("class:voice-status-recording", " ● REC  Ctrl+B to stop ")]
+                return [("class:voice-status-recording", self._ui_text("voice_rec_compact"))]
+            return [("class:voice-status-recording", self._ui_text("voice_rec_full"))]
         if self._voice_processing:
             if compact:
-                return [("class:voice-status", " ◉ STT ")]
-            return [("class:voice-status", " ◉ Transcribing... ")]
+                return [("class:voice-status", self._ui_text("voice_stt_compact"))]
+            return [("class:voice-status", self._ui_text("voice_stt_full"))]
         if compact:
-            return [("class:voice-status", " 🎤 Ctrl+B ")]
-        tts = " | TTS on" if self._voice_tts else ""
-        cont = " | Continuous" if self._voice_continuous else ""
-        return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ")]
+            return [("class:voice-status", self._ui_text("voice_ready_compact"))]
+        tts = self._ui_text("voice_tts_on") if self._voice_tts else ""
+        cont = self._ui_text("voice_continuous") if self._voice_continuous else ""
+        return [("class:voice-status", self._ui_text("voice_ready_full", tts=tts, cont=cont))]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
@@ -2933,7 +2943,7 @@ class HermesCLI:
         use_compact = self.compact or term_width < 80
         
         if use_compact:
-            self.console.print(_build_compact_banner())
+            self.console.print(_build_compact_banner(language=self._ui_language()))
             self._show_status()
         else:
             # Get tools for display
@@ -2951,6 +2961,7 @@ class HermesCLI:
                 enabled_toolsets=self.enabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
+                language=self._ui_language(),
             )
         
         # Show tool availability warnings if any tools are disabled
@@ -2960,24 +2971,23 @@ class HermesCLI:
         if ctx_len and ctx_len <= 8192:
             self.console.print()
             self.console.print(
-                f"[yellow]⚠️  Context length is only {ctx_len:,} tokens — "
-                f"this is likely too low for agent use with tools.[/]"
+                f"[yellow]{self._ui_text('context_warning', count=f'{ctx_len:,}')}[/]"
             )
             self.console.print(
-                "[dim]   Hermes needs 16k–32k minimum. Tool schemas + system prompt alone use ~4k–8k.[/]"
+                f"[dim]   {self._ui_text('context_warning_detail')}[/]"
             )
             base_url = getattr(self, "base_url", "") or ""
             if "11434" in base_url or "ollama" in base_url.lower():
                 self.console.print(
-                    "[dim]   Ollama fix: OLLAMA_CONTEXT_LENGTH=32768 ollama serve[/]"
+                    f"[dim]   {self._ui_text('context_warning_ollama')}[/]"
                 )
             elif "1234" in base_url:
                 self.console.print(
-                    "[dim]   LM Studio fix: Set context length in model settings → reload model[/]"
+                    f"[dim]   {self._ui_text('context_warning_lmstudio')}[/]"
                 )
             else:
                 self.console.print(
-                    "[dim]   Fix: Set model.context_length in config.yaml, or increase your server's context setting[/]"
+                    f"[dim]   {self._ui_text('context_warning_generic')}[/]"
                 )
 
         # Warn if the configured model is a Nous Hermes LLM (not agentic)
@@ -2985,12 +2995,10 @@ class HermesCLI:
         if "hermes" in model_name.lower():
             self.console.print()
             self.console.print(
-                "[bold yellow]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
-                "designed for use with Hermes Agent.[/]"
+                f"[bold yellow]{self._ui_text('hermes_model_warning')}[/]"
             )
             self.console.print(
-                "[dim]   They lack tool-calling capabilities required for agent workflows. "
-                "Consider using an agentic model (Claude, GPT, Gemini, DeepSeek, etc.).[/]"
+                f"[dim]   {self._ui_text('hermes_model_warning_detail')}[/]"
             )
             self.console.print(
                 "[dim]   Switch with: /model sonnet  or  /model gpt5[/]"
@@ -3483,13 +3491,13 @@ class HermesCLI:
             
             if api_key_missing:
                 self.console.print()
-                self.console.print("[yellow]⚠️  Some tools disabled (missing API keys):[/]")
+                self.console.print(f"[yellow]{self._ui_text('tools_disabled_missing_keys')}[/]")
                 for item in api_key_missing:
                     tools_str = ", ".join(item["tools"][:2])  # Show first 2 tools
                     if len(item["tools"]) > 2:
                         tools_str += f", +{len(item['tools'])-2} more"
                     self.console.print(f"   [dim]• {item['name']}[/] [dim italic]({', '.join(item['missing_vars'])})[/]")
-                self.console.print("[dim]   Run 'hermes setup' to configure[/]")
+                self.console.print(f"[dim]   {self._ui_text('run_setup_to_configure')}[/]")
         except Exception:
             pass  # Don't crash on import errors
     
@@ -3520,16 +3528,19 @@ class HermesCLI:
         except Exception:
             separator_color, accent_color, label_color = "#B8860B", "#FFBF00", "cyan"
         toolsets_info = ""
+        toolset_label = "toolsets" if self._ui_language() == "en" else "工具集"
+        provider_label = "provider" if self._ui_language() == "en" else "提供方"
+        auth_label = "auth" if self._ui_language() == "en" else "认证"
         if self.enabled_toolsets and "all" not in self.enabled_toolsets:
-            toolsets_info = f" [dim {separator_color}]·[/] [{label_color}]toolsets: {', '.join(self.enabled_toolsets)}[/]"
+            toolsets_info = f" [dim {separator_color}]·[/] [{label_color}]{toolset_label}: {', '.join(self.enabled_toolsets)}[/]"
 
-        provider_info = f" [dim {separator_color}]·[/] [dim]provider: {self.provider}[/]"
+        provider_info = f" [dim {separator_color}]·[/] [dim]{provider_label}: {self.provider}[/]"
         if self._provider_source:
-            provider_info += f" [dim {separator_color}]·[/] [dim]auth: {self._provider_source}[/]"
+            provider_info += f" [dim {separator_color}]·[/] [dim]{auth_label}: {self._provider_source}[/]"
 
         self.console.print(
             f"  {api_indicator} [{accent_color}]{model_short}[/] "
-            f"[dim {separator_color}]·[/] [bold {label_color}]{tool_count} tools[/]"
+            f"[dim {separator_color}]·[/] [bold {label_color}]{tool_count} {'tools' if self._ui_language() == 'en' else '个工具'}[/]"
             f"{toolsets_info}{provider_info}"
         )
 
@@ -3570,19 +3581,19 @@ class HermesCLI:
         is_running = bool(getattr(self, "_agent_running", False))
 
         lines = [
-            "Hermes CLI Status",
+            self._ui_text("status_title"),
             "",
-            f"Session ID: {self.session_id}",
-            f"Path: {display_hermes_home()}",
+            f"{self._ui_text('status_session_id')}: {self.session_id}",
+            f"{self._ui_text('status_path')}: {display_hermes_home()}",
         ]
         if title:
-            lines.append(f"Title: {title}")
+            lines.append(f"{self._ui_text('status_title_field')}: {title}")
         lines.extend([
-            f"Model: {model} ({provider})",
-            f"Created: {created_at.strftime('%Y-%m-%d %H:%M')}",
-            f"Last Activity: {updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"Tokens: {total_tokens:,}",
-            f"Agent Running: {'Yes' if is_running else 'No'}",
+            f"{self._ui_text('status_model')}: {model} ({provider})",
+            f"{self._ui_text('status_created')}: {created_at.strftime('%Y-%m-%d %H:%M')}",
+            f"{self._ui_text('status_last_activity')}: {updated_at.strftime('%Y-%m-%d %H:%M')}",
+            f"{self._ui_text('status_tokens')}: {total_tokens:,}",
+            f"{self._ui_text('status_agent_running')}: {self._ui_text('yes' if is_running else 'no')}",
         ])
         self.console.print("\n".join(lines), highlight=False, markup=False)
     
@@ -3595,6 +3606,36 @@ class HermesCLI:
         model = getattr(agent, "model", None) or getattr(self, "model", None)
         return model_supports_fast_mode(model)
 
+    def _ui_language(self) -> str:
+        """Return the active CLI/TUI display language."""
+        try:
+            from hermes_cli.ui_language import normalize_display_language
+            value = getattr(self, "display_language", None)
+            if value:
+                return normalize_display_language(value)
+            config = getattr(self, "config", {}) or {}
+            display = config.get("display", {}) if isinstance(config, dict) else {}
+            return normalize_display_language(display.get("language", "en"))
+        except Exception:
+            return "en"
+
+    def _ui_text(self, key: str, **kwargs) -> str:
+        """Translate a fixed CLI/TUI label."""
+        from hermes_cli.ui_language import ui_text
+        return ui_text(key, self._ui_language(), **kwargs)
+
+    def _set_display_language(self, language: str) -> None:
+        """Persist the active language in the current CLI object."""
+        from hermes_cli.ui_language import normalize_display_language
+        normalized = normalize_display_language(language)
+        self.display_language = normalized
+        if isinstance(getattr(self, "config", None), dict):
+            self.config.setdefault("display", {})["language"] = normalized
+        try:
+            CLI_CONFIG.setdefault("display", {})["language"] = normalized
+        except Exception:
+            pass
+
     def _command_available(self, slash_command: str) -> bool:
         if slash_command == "/fast":
             return self._fast_command_available()
@@ -3602,14 +3643,17 @@ class HermesCLI:
 
     def show_help(self):
         """Display help information with categorized commands."""
-        from hermes_cli.commands import COMMANDS_BY_CATEGORY
+        from hermes_cli.commands import COMMAND_REGISTRY
+        from hermes_cli.ui_language import alias_description, category_label, command_help_description
 
-        try:
-            from hermes_cli.skin_engine import get_active_help_header
-            header = get_active_help_header("(^_^)? Available Commands")
-        except Exception:
-            header = "(^_^)? Available Commands"
-        header = (header or "").strip() or "(^_^)? Available Commands"
+        if self._ui_language() == "en":
+            try:
+                from hermes_cli.skin_engine import get_active_help_header
+                header = get_active_help_header(self._ui_text("help_header"))
+            except Exception:
+                header = self._ui_text("help_header")
+        else:
+            header = self._ui_text("help_header")
         inner_width = 55
         if len(header) > inner_width:
             header = header[:inner_width]
@@ -3617,38 +3661,91 @@ class HermesCLI:
         _cprint(f"{_BOLD}|{header:^{inner_width}}|{_RST}")
         _cprint(f"{_BOLD}+{'-' * inner_width}+{_RST}")
 
-        for category, commands in COMMANDS_BY_CATEGORY.items():
-            _cprint(f"\n  {_BOLD}── {category} ──{_RST}")
-            for cmd, desc in commands.items():
+        categories: list[str] = []
+        for command_def in COMMAND_REGISTRY:
+            if command_def.gateway_only or command_def.category in categories:
+                continue
+            categories.append(command_def.category)
+
+        for category in categories:
+            _cprint(f"\n  {_BOLD}── {category_label(category, self._ui_language())} ──{_RST}")
+            for command_def in COMMAND_REGISTRY:
+                if command_def.gateway_only or command_def.category != category:
+                    continue
+                cmd = f"/{command_def.name}"
                 if not self._command_available(cmd):
                     continue
+                desc = command_help_description(
+                    command_def.name,
+                    command_def.description,
+                    command_def.args_hint,
+                    self._ui_language(),
+                )
                 ChatConsole().print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
+                for alias in command_def.aliases:
+                    alias_cmd = f"/{alias}"
+                    if not self._command_available(alias_cmd):
+                        continue
+                    alias_desc = alias_description(desc, command_def.name, self._ui_language())
+                    ChatConsole().print(f"    [bold {_accent_hex()}]{alias_cmd:<15}[/] [dim]-[/] {_escape(alias_desc)}")
 
         if _skill_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed):")
+            _cprint(
+                f"\n  ⚡ {_BOLD}{self._ui_text('skill_commands')}{_RST} "
+                f"({self._ui_text('installed_count', count=len(_skill_commands))}):"
+            )
             for cmd, info in sorted(_skill_commands.items()):
                 ChatConsole().print(
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
-        _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"\n  {_DIM}{self._ui_text('help_tip_chat')}{_RST}")
+        _cprint(f"  {_DIM}{self._ui_text('help_tip_multiline')}{_RST}")
         if _is_termux_environment():
-            _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
+            _cprint(
+                f"  {_DIM}{self._ui_text('help_tip_attach_image', path=_termux_example_image_path())}{_RST}\n"
+            )
         else:
-            _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+            _cprint(f"  {_DIM}{self._ui_text('help_tip_paste_image')}{_RST}\n")
+
+    def _show_chinese_guide(self, cmd: str):
+        """Display the built-in Chinese guide for Hermes."""
+        parts = cmd.split(maxsplit=1)
+        topic = parts[1].strip() if len(parts) > 1 else None
+        from hermes_cli.chinese_guide import render_topic
+        self.console.print(render_topic(topic, markdown=False), highlight=False, markup=False)
+
+    def _handle_lang_command(self, cmd: str):
+        """Handle /lang [en|zh|status] for CLI/TUI language switching."""
+        from hermes_cli.ui_language import display_language_name, parse_display_language
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            _cprint(f"  {_ACCENT}{self._ui_text('lang_status', label=display_language_name(self._ui_language()))}{_RST}")
+            _cprint(f"  {_DIM}{self._ui_text('lang_usage')}{_RST}")
+            return
+
+        parsed = parse_display_language(parts[1].strip())
+        if not parsed:
+            _cprint(f"  {_DIM}{self._ui_text('lang_unknown', value=parts[1].strip())}{_RST}")
+            return
+
+        self._set_display_language(parsed)
+        saved = save_config_value("display.language", parsed)
+        key = "lang_changed_saved" if saved else "lang_changed_session"
+        _cprint(f"  {_ACCENT}{self._ui_text(key, label=display_language_name(parsed))}{_RST}")
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
         tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
         
         if not tools:
-            print("(;_;) No tools available")
+            print(self._ui_text("no_tools_available"))
             return
         
         # Header
         print()
-        title = "(^_^)/ Available Tools"
+        title = self._ui_text("available_tools_title")
         width = 78
         pad = width - len(title)
         print("+" + "-" * width + "+")
@@ -3677,7 +3774,7 @@ class HermesCLI:
                 print(f"    * {name:<20} - {desc}")
             print()
         
-        print(f"  Total: {len(tools)} tools  ヽ(^o^)ノ")
+        print(f"  {self._ui_text('tools_total', count=len(tools))}")
         print()
 
     def _handle_tools_command(self, cmd: str):
@@ -3738,7 +3835,7 @@ class HermesCLI:
         
         # Header
         print()
-        title = "(^_^)b Available Toolsets"
+        title = self._ui_text("available_toolsets_title")
         width = 58
         pad = width - len(title)
         print("+" + "-" * width + "+")
@@ -3757,10 +3854,10 @@ class HermesCLI:
                 print(f"  {marker} {name:<18} [{tool_count:>2} tools] - {desc}")
         
         print()
-        print("  (*) = currently enabled")
+        print(f"  {self._ui_text('toolsets_currently_enabled')}")
         print()
-        print("  Tip: Use 'all' or '*' to enable all toolsets")
-        print("  Example: python cli.py --toolsets web,terminal")
+        print(f"  {self._ui_text('toolsets_tip_enable_all')}")
+        print(f"  {self._ui_text('toolsets_example')}")
         print()
     
     def _handle_profile_command(self):
@@ -5121,14 +5218,17 @@ class HermesCLI:
         
         print()
         print("+" + "-" * 60 + "+")
-        print("|" + " " * 15 + "(✿◠‿◠) Gateway Status" + " " * 17 + "|")
+        _gateway_title = self._ui_text("gateway_status_title")
+        _gateway_title = _gateway_title[:58]
+        _gateway_pad = 60 - len(_gateway_title)
+        print("|" + " " * (_gateway_pad // 2) + _gateway_title + " " * (_gateway_pad - _gateway_pad // 2) + "|")
         print("+" + "-" * 60 + "+")
         print()
         
         try:
             config = load_gateway_config()
             
-            print("  Messaging Platform Configuration:")
+            print(f"  {self._ui_text('gateway_platform_config')}")
             print("  " + "-" * 55)
             
             platform_status = {
@@ -5142,33 +5242,33 @@ class HermesCLI:
                 if pconfig and pconfig.enabled:
                     home = config.get_home_channel(platform)
                     home_str = f" → {home.name}" if home else ""
-                    print(f"    ✓ {name:<12} Enabled{home_str}")
+                    print(f"    ✓ {name:<12} {self._ui_text('gateway_enabled')}{home_str}")
                 else:
-                    print(f"    ○ {name:<12} Not configured ({env_var})")
+                    print(f"    ○ {name:<12} {self._ui_text('gateway_not_configured')} ({env_var})")
             
             print()
-            print("  Session Reset Policy:")
+            print(f"  {self._ui_text('gateway_reset_policy')}")
             print("  " + "-" * 55)
             policy = config.default_reset_policy
-            print(f"    Mode: {policy.mode}")
-            print(f"    Daily reset at: {policy.at_hour}:00")
-            print(f"    Idle timeout: {policy.idle_minutes} minutes")
+            print(f"    {self._ui_text('gateway_mode')}: {policy.mode}")
+            print(f"    {self._ui_text('gateway_daily_reset')}: {policy.at_hour}:00")
+            print(f"    {self._ui_text('gateway_idle_timeout')}: {policy.idle_minutes} {self._ui_text('gateway_minutes')}")
             
             print()
-            print("  To start the gateway:")
+            print(f"  {self._ui_text('gateway_start_label')}")
             print("    python cli.py --gateway")
             print()
-            print(f"  Configuration file: {display_hermes_home()}/config.yaml")
+            print(f"  {self._ui_text('gateway_config_file')}: {display_hermes_home()}/config.yaml")
             print()
             
         except Exception as e:
             print(f"  Error loading gateway config: {e}")
             print()
-            print("  To configure the gateway:")
-            print("    1. Set environment variables:")
+            print(f"  {self._ui_text('gateway_configure_label')}")
+            print(f"    1. {self._ui_text('gateway_set_env')}")
             print("       TELEGRAM_BOT_TOKEN=your_token")
             print("       DISCORD_BOT_TOKEN=your_token")
-            print(f"    2. Or configure settings in {display_hermes_home()}/config.yaml")
+            print(f"    2. {self._ui_text('gateway_or_config')} {display_hermes_home()}/config.yaml")
             print()
     
     def process_command(self, command: str) -> bool:
@@ -5196,6 +5296,10 @@ class HermesCLI:
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "lang":
+            self._handle_lang_command(cmd_original)
+        elif canonical == "zh":
+            self._show_chinese_guide(cmd_original)
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":
@@ -5225,7 +5329,7 @@ class HermesCLI:
                 cc = ChatConsole()
                 term_w = shutil.get_terminal_size().columns
                 if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
+                    cc.print(_build_compact_banner(language=self._ui_language()))
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
@@ -5240,11 +5344,12 @@ class HermesCLI:
                         enabled_toolsets=self.enabled_toolsets,
                         session_id=self.session_id,
                         context_length=ctx_len,
+                        language=self._ui_language(),
                     )
-                _cprint("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
+                _cprint(self._ui_text("fresh_start"))
             else:
                 self.show_banner()
-                print("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
+                print(self._ui_text("fresh_start"))
         elif canonical == "history":
             self.show_history()
         elif canonical == "title":
@@ -5333,8 +5438,9 @@ class HermesCLI:
             self._show_session_status()
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
-            state = "visible" if self._status_bar_visible else "hidden"
-            self.console.print(f"  Status bar {state}")
+            self.console.print(
+                self._ui_text("statusbar_visible" if self._status_bar_visible else "statusbar_hidden")
+            )
         elif canonical == "verbose":
             self._toggle_verbose()
         elif canonical == "yolo":
@@ -6072,10 +6178,10 @@ class HermesCLI:
         # into garbled sequences like '?[33mTool progress: NEW?[0m' (#2262).
         from hermes_cli.colors import Colors as _Colors
         labels = {
-            "off": f"{_Colors.DIM}Tool progress: OFF{_Colors.RESET} — silent mode, just the final response.",
-            "new": f"{_Colors.YELLOW}Tool progress: NEW{_Colors.RESET} — show each new tool (skip repeats).",
-            "all": f"{_Colors.GREEN}Tool progress: ALL{_Colors.RESET} — show every tool call.",
-            "verbose": f"{_Colors.BOLD}{_Colors.GREEN}Tool progress: VERBOSE{_Colors.RESET} — full args, results, think blocks, and debug logs.",
+            "off": f"{_Colors.DIM}{self._ui_text('tool_progress_off')}{_Colors.RESET}",
+            "new": f"{_Colors.YELLOW}{self._ui_text('tool_progress_new')}{_Colors.RESET}",
+            "all": f"{_Colors.GREEN}{self._ui_text('tool_progress_all')}{_Colors.RESET}",
+            "verbose": f"{_Colors.BOLD}{_Colors.GREEN}{self._ui_text('tool_progress_verbose')}{_Colors.RESET}",
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
 
@@ -6085,10 +6191,10 @@ class HermesCLI:
         current = bool(os.environ.get("HERMES_YOLO_MODE"))
         if current:
             os.environ.pop("HERMES_YOLO_MODE", None)
-            self.console.print("  ⚠ YOLO mode [bold red]OFF[/] — dangerous commands will require approval.")
+            self.console.print(self._ui_text("yolo_off"))
         else:
             os.environ["HERMES_YOLO_MODE"] = "1"
-            self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
+            self.console.print(self._ui_text("yolo_on"))
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
@@ -6111,9 +6217,9 @@ class HermesCLI:
             else:
                 level = rc.get("effort", "medium")
             display_state = "on ✓" if self.show_reasoning else "off"
-            _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
-            _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_effort', level=level)}{_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_display', state=display_state)}{_RST}")
+            _cprint(f"  {_DIM}{self._ui_text('reasoning_usage')}{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -6124,32 +6230,32 @@ class HermesCLI:
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
             save_config_value("display.show_reasoning", True)
-            _cprint(f"  {_ACCENT}✓ Reasoning display: ON (saved){_RST}")
-            _cprint(f"  {_DIM}  Model thinking will be shown during and after each response.{_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_display_on')}{_RST}")
+            _cprint(f"  {_DIM}  {self._ui_text('reasoning_display_on_detail')}{_RST}")
             return
         if arg in ("hide", "off"):
             self.show_reasoning = False
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
             save_config_value("display.show_reasoning", False)
-            _cprint(f"  {_ACCENT}✓ Reasoning display: OFF (saved){_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_display_off')}{_RST}")
             return
 
         # Effort level change
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
-            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
-            _cprint(f"  {_DIM}Display:      show, hide{_RST}")
+            _cprint(f"  {_DIM}{self._ui_text('reasoning_unknown_arg', arg=arg)}{_RST}")
+            _cprint(f"  {_DIM}{self._ui_text('reasoning_valid_levels')}{_RST}")
+            _cprint(f"  {_DIM}{self._ui_text('reasoning_display_values')}{_RST}")
             return
 
         self.reasoning_config = parsed
         self.agent = None  # Force agent re-init with new reasoning config
 
         if save_config_value("agent.reasoning_effort", arg):
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_set_saved', arg=arg)}{_RST}")
         else:
-            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+            _cprint(f"  {_ACCENT}{self._ui_text('reasoning_set_session', arg=arg)}{_RST}")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
@@ -8016,19 +8122,27 @@ class HermesCLI:
             if self._preload_resumed_session():
                 self._display_resumed_history()
 
+        from hermes_cli.ui_language import localized_welcome
         try:
             from hermes_cli.skin_engine import get_active_skin
             _welcome_skin = get_active_skin()
-            _welcome_text = _welcome_skin.get_branding("welcome", "Welcome to Hermes Agent! Type your message or /help for commands.")
+            _agent_name = _welcome_skin.get_branding("agent_name", "Hermes Agent")
+            if self._ui_language() == "en":
+                _welcome_text = _welcome_skin.get_branding(
+                    "welcome",
+                    localized_welcome(_agent_name, self._ui_language()),
+                )
+            else:
+                _welcome_text = localized_welcome(_agent_name, self._ui_language())
             _welcome_color = _welcome_skin.get_color("banner_text", "#FFF8DC")
         except Exception:
-            _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
+            _welcome_text = localized_welcome("Hermes Agent", self._ui_language())
             _welcome_color = "#FFF8DC"
         self.console.print(f"[{_welcome_color}]{_welcome_text}[/]")
         if self.preloaded_skills and not self._startup_skills_line_shown:
             skills_label = ", ".join(self.preloaded_skills)
             self.console.print(
-                f"[bold {_accent_hex()}]Activated skills:[/] {skills_label}"
+                f"[bold {_accent_hex()}]{self._ui_text('activated_skills')}[/] {skills_label}"
             )
             self._startup_skills_line_shown = True
         self.console.print()
@@ -8604,6 +8718,7 @@ class HermesCLI:
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: _skill_commands,
             command_filter=cli_ref._command_available,
+            language_provider=cli_ref._ui_language,
         )
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,6 +76,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
+from agent.redact import RedactingFormatter
 from utils import atomic_yaml_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -2523,6 +2524,9 @@ class GatewayRunner:
         if canonical == "help":
             return await self._handle_help_command(event)
 
+        if canonical == "zh":
+            return await self._handle_zh_command(event)
+
         if canonical == "commands":
             return await self._handle_commands_command(event)
         
@@ -4018,6 +4022,12 @@ class GatewayRunner:
         except Exception:
             pass
         return "\n".join(lines)
+
+    async def _handle_zh_command(self, event: MessageEvent) -> str:
+        """Handle /zh [topic] - show the built-in Chinese guide."""
+        from hermes_cli.chinese_guide import render_topic
+        topic = event.get_command_args().strip() or None
+        return render_topic(topic, markdown=True)
 
     async def _handle_commands_command(self, event: MessageEvent) -> str:
         """Handle /commands [page] - paginated list of all commands and skills."""

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -318,7 +318,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                          enabled_toolsets: List[str] = None,
                          session_id: str = None,
                          get_toolset_for_tool=None,
-                         context_length: int = None):
+                         context_length: int = None,
+                         language: str = "en"):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -332,6 +333,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         context_length: Model's context window size in tokens.
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
+    from hermes_cli.ui_language import ui_text
     if get_toolset_for_tool is None:
         from model_tools import get_toolset_for_tool
 
@@ -384,7 +386,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")
     left_content = "\n".join(left_lines)
 
-    right_lines = [f"[bold {accent}]Available Tools[/]"]
+    right_lines = [f"[bold {accent}]{ui_text('banner_available_tools', language)}[/]"]
     toolsets_dict: Dict[str, list] = {}
 
     for tool in tools:
@@ -441,7 +443,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         right_lines.append(f"[dim {dim}]{toolset}:[/] {tools_str}")
 
     if remaining_toolsets > 0:
-        right_lines.append(f"[dim {dim}](and {remaining_toolsets} more toolsets...)[/]")
+        right_lines.append(f"[dim {dim}]{ui_text('banner_more_toolsets', language, count=remaining_toolsets)}[/]")
 
     # MCP Servers section (only if configured)
     try:
@@ -452,21 +454,21 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     if mcp_status:
         right_lines.append("")
-        right_lines.append(f"[bold {accent}]MCP Servers[/]")
+        right_lines.append(f"[bold {accent}]{ui_text('banner_mcp_servers', language)}[/]")
         for srv in mcp_status:
             if srv["connected"]:
                 right_lines.append(
                     f"[dim {dim}]{srv['name']}[/] [{text}]({srv['transport']})[/] "
-                    f"[dim {dim}]—[/] [{text}]{srv['tools']} tool(s)[/]"
+                    f"[dim {dim}]—[/] [{text}]{ui_text('banner_tool_count', language, count=srv['tools'])}[/]"
                 )
             else:
                 right_lines.append(
                     f"[red]{srv['name']}[/] [dim]({srv['transport']})[/] "
-                    f"[red]— failed[/]"
+                    f"[red]— {ui_text('banner_failed', language)}[/]"
                 )
 
     right_lines.append("")
-    right_lines.append(f"[bold {accent}]Available Skills[/]")
+    right_lines.append(f"[bold {accent}]{ui_text('banner_available_skills', language)}[/]")
     skills_by_category = get_available_skills()
     total_skills = sum(len(s) for s in skills_by_category.values())
 
@@ -475,27 +477,30 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             skill_names = sorted(skills_by_category[category])
             if len(skill_names) > 8:
                 display_names = skill_names[:8]
-                skills_str = ", ".join(display_names) + f" +{len(skill_names) - 8} more"
+                skills_str = ", ".join(display_names) + f" {ui_text('banner_more_skills', language, count=len(skill_names) - 8)}"
             else:
                 skills_str = ", ".join(skill_names)
             if len(skills_str) > 50:
                 skills_str = skills_str[:47] + "..."
             right_lines.append(f"[dim {dim}]{category}:[/] [{text}]{skills_str}[/]")
     else:
-        right_lines.append(f"[dim {dim}]No skills installed[/]")
+        right_lines.append(f"[dim {dim}]{ui_text('banner_no_skills', language)}[/]")
 
     right_lines.append("")
     mcp_connected = sum(1 for s in mcp_status if s["connected"]) if mcp_status else 0
-    summary_parts = [f"{len(tools)} tools", f"{total_skills} skills"]
+    summary_parts = [
+        ui_text('banner_summary_tools', language, count=len(tools)),
+        ui_text('banner_summary_skills', language, count=total_skills),
+    ]
     if mcp_connected:
-        summary_parts.append(f"{mcp_connected} MCP servers")
-    summary_parts.append("/help for commands")
+        summary_parts.append(ui_text('banner_summary_mcp', language, count=mcp_connected))
+    summary_parts.append(ui_text('banner_summary_help', language))
     # Show active profile name when not 'default'
     try:
         from hermes_cli.profiles import get_active_profile_name
         _profile_name = get_active_profile_name()
         if _profile_name and _profile_name != "default":
-            right_lines.append(f"[bold {accent}]Profile:[/] [{text}]{_profile_name}[/]")
+            right_lines.append(f"[bold {accent}]{ui_text('banner_profile', language)}[/] [{text}]{_profile_name}[/]")
     except Exception:
         pass  # Never break the banner over a profiles.py bug
 
@@ -506,10 +511,12 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         behind = get_update_result(timeout=0.5)
         if behind and behind > 0:
             from hermes_cli.config import recommended_update_command
-            commits_word = "commit" if behind == 1 else "commits"
+            commits_word = ui_text(
+                "banner_commit_word_singular" if behind == 1 else "banner_commit_word_plural",
+                language,
+            )
             right_lines.append(
-                f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
-                f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
+                f"[bold yellow]{ui_text('banner_update', language, count=behind, word=commits_word, command=recommended_update_command())}[/]"
             )
     except Exception:
         pass  # Never break the banner over an update check

--- a/hermes_cli/chinese_guide.py
+++ b/hermes_cli/chinese_guide.py
@@ -1,0 +1,250 @@
+"""Offline Chinese quickstart and command guide for Hermes Agent."""
+
+from __future__ import annotations
+
+from hermes_constants import display_hermes_home
+
+TOPIC_ALIASES = {
+    "quick": "quickstart",
+    "quickstart": "quickstart",
+    "install": "quickstart",
+    "intro": "quickstart",
+    "setup": "setup",
+    "config": "config",
+    "commands": "commands",
+    "command": "commands",
+    "cmd": "commands",
+    "gateway": "gateway",
+    "profile": "profiles",
+    "profiles": "profiles",
+    "topics": "topics",
+    "topic": "topics",
+    "list": "topics",
+}
+
+TOPIC_TITLES = {
+    "quickstart": "Hermes 中文快速上手",
+    "setup": "Hermes 中文配置流程",
+    "config": "Hermes 中文配置文件说明",
+    "commands": "Hermes 常用命令中文说明",
+    "gateway": "Hermes 消息网关中文说明",
+    "profiles": "Hermes Profiles 中文说明",
+    "topics": "Hermes 中文向导主题列表",
+}
+
+
+def available_topics() -> list[str]:
+    """Return user-facing topic names in display order."""
+    return ["quickstart", "setup", "config", "commands", "gateway", "profiles"]
+
+
+def normalize_topic(topic: str | None) -> str:
+    """Normalize a topic or fallback to the default quickstart guide."""
+    raw = (topic or "").strip().lower()
+    if not raw:
+        return "quickstart"
+    return TOPIC_ALIASES.get(raw, "")
+
+
+def render_topic(topic: str | None = None, *, markdown: bool = False) -> str:
+    """Render a Chinese guide topic for CLI or gateway output."""
+    normalized = normalize_topic(topic)
+    if not normalized:
+        topics = ", ".join(available_topics())
+        return (
+            "未找到这个主题。可用主题："
+            f"{topics}\n"
+            "你也可以使用 `hermes zh topics` 或 `/zh topics` 查看列表。"
+        )
+    if normalized == "topics":
+        return _render_topics(markdown=markdown)
+    if normalized == "quickstart":
+        return _render_quickstart(markdown=markdown)
+    if normalized == "setup":
+        return _render_setup(markdown=markdown)
+    if normalized == "config":
+        return _render_config(markdown=markdown)
+    if normalized == "commands":
+        return _render_commands(markdown=markdown)
+    if normalized == "gateway":
+        return _render_gateway(markdown=markdown)
+    if normalized == "profiles":
+        return _render_profiles(markdown=markdown)
+    return _render_topics(markdown=markdown)
+
+
+def _render_topics(*, markdown: bool) -> str:
+    body = [
+        "可用主题：",
+        "- `quickstart`：安装后 2 分钟快速上手",
+        "- `setup`：第一次配置 Hermes 的推荐流程",
+        "- `config`：`config.yaml`、`.env`、常见配置项说明",
+        "- `commands`：CLI / slash 常用命令中文解释",
+        "- `gateway`：Telegram / Discord / Slack 等网关接入思路",
+        "- `profiles`：多实例隔离配置的使用方式",
+        "",
+        "示例：`hermes zh commands` 或在会话里输入 `/zh config`。",
+    ]
+    return _render_document(TOPIC_TITLES["topics"], body, markdown=markdown)
+
+
+def _render_quickstart(*, markdown: bool) -> str:
+    body = [
+        "1. 安装 Hermes",
+        "- `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`",
+        "- 安装完成后重新加载 shell：`source ~/.bashrc` 或 `source ~/.zshrc`。",
+        "",
+        "2. 启动并进入交互界面",
+        "- 直接运行 `hermes` 就会进入交互式 CLI。",
+        "- 第一次使用建议先执行 `hermes setup`，它会带你完成模型和环境配置。",
+        "",
+        "3. 选择模型 / Provider",
+        "- `hermes model`：交互式选择模型。",
+        "- 如果你已经知道要用哪个模型，也可以直接在配置里设置：`hermes config set model.default openai/gpt-5`。",
+        "",
+        "4. 遇到不会配的地方",
+        "- `hermes zh setup`：看中文配置流程。",
+        "- `hermes zh commands`：看中文命令速查。",
+        "- `hermes doctor`：检查环境、依赖和常见错误。",
+        "",
+        "5. 会话里也能随时查中文帮助",
+        "- 输入 `/zh` 查看快速上手。",
+        "- 输入 `/zh config`、`/zh gateway`、`/zh profiles` 查看专题说明。",
+    ]
+    return _render_document(TOPIC_TITLES["quickstart"], body, markdown=markdown)
+
+
+def _render_setup(*, markdown: bool) -> str:
+    hermes_home = display_hermes_home()
+    body = [
+        "推荐给新用户的配置顺序：",
+        "1. 运行 `hermes setup`。",
+        "2. 先确定你要用的 Provider，例如 OpenAI、Anthropic、OpenRouter 或自建兼容接口。",
+        "3. 把 API Key 写进 `.env`，或者用 `hermes config set OPENAI_API_KEY <你的key>` 这类命令写入。",
+        "4. 再运行 `hermes model` 选择默认模型。",
+        "5. 如果你要让 Hermes 接入 Telegram / Discord / Slack，再运行 `hermes gateway setup`。",
+        "6. 最后执行 `hermes doctor`，确认依赖、配置和网络都正常。",
+        "",
+        "配置文件位置：",
+        f"- 主配置：`{hermes_home}/config.yaml`",
+        f"- 密钥环境变量：`{hermes_home}/.env`",
+        "",
+        "常见建议：",
+        "- 只想先在终端里用：完成 `setup`、`model` 就够了，网关可以以后再配。",
+        "- 想在手机聊天软件里用：除了 CLI 配置外，再补 `gateway setup` 和对应平台 token。",
+        "- 想多人或多场景隔离使用：从一开始就考虑 `hermes profile create <name>`。",
+    ]
+    return _render_document(TOPIC_TITLES["setup"], body, markdown=markdown)
+
+
+def _render_config(*, markdown: bool) -> str:
+    hermes_home = display_hermes_home()
+    body = [
+        "Hermes 的配置主要分两类：",
+        f"- `config.yaml`：普通配置，位置在 `{hermes_home}/config.yaml`",
+        f"- `.env`：API Key、token 等敏感信息，位置在 `{hermes_home}/.env`",
+        "",
+        "常用命令：",
+        "- `hermes config show`：查看当前配置。",
+        "- `hermes config path`：打印 `config.yaml` 路径。",
+        "- `hermes config env-path`：打印 `.env` 路径。",
+        "- `hermes config set model.default anthropic/claude-opus-4.6`：设置默认模型。",
+        "- `hermes config set OPENROUTER_API_KEY <key>`：写入 API Key；这类敏感项会自动进入 `.env`。",
+        "",
+        "你可以这样理解：",
+        "- 跟行为、显示、模型默认值有关的设置，通常放 `config.yaml`。",
+        "- 以 `_API_KEY`、`_TOKEN` 结尾，或类似平台密钥的设置，通常放 `.env`。",
+        "",
+        "排查建议：",
+        "- 改完配置后，如果行为不符合预期，先执行 `hermes config show` 看最终生效值。",
+        "- 如果是模型或 Provider 问题，结合 `hermes model`、`hermes doctor` 一起检查。",
+    ]
+    return _render_document(TOPIC_TITLES["config"], body, markdown=markdown)
+
+
+def _render_commands(*, markdown: bool) -> str:
+    body = [
+        "CLI 常用命令：",
+        "- `hermes`：进入交互式聊天界面。",
+        "- `hermes setup`：第一次安装后最推荐的配置入口。",
+        "- `hermes model`：切换默认模型或 Provider。",
+        "- `hermes tools`：查看或启用/禁用工具。",
+        "- `hermes gateway`：启动消息平台网关。",
+        "- `hermes doctor`：诊断环境和配置问题。",
+        "- `hermes zh <topic>`：查看内置中文指南。",
+        "",
+        "会话里的 slash 命令：",
+        "- `/help`：查看可用命令。",
+        "- `/new` 或 `/reset`：开启全新会话。",
+        "- `/model [provider:model]`：当前会话切模型。",
+        "- `/retry`：重试上一条消息。",
+        "- `/undo`：撤销上一轮用户/助手对话。",
+        "- `/compress`：手动压缩上下文，适合长会话。",
+        "- `/usage`：查看 token 使用情况。",
+        "- `/skills`：浏览或安装技能。",
+        "- `/lang [en|zh|status]`：切换或查看 TUI 界面语言。",
+        "- `/zh [topic]`：在会话里查看中文说明。",
+        "",
+        "推荐记住的两个排障命令：",
+        "- `hermes doctor`：偏向安装、依赖、配置检查。",
+        "- `/status`：偏向当前会话状态、模型、token 等信息。",
+    ]
+    return _render_document(TOPIC_TITLES["commands"], body, markdown=markdown)
+
+
+def _render_gateway(*, markdown: bool) -> str:
+    body = [
+        "Hermes Gateway 的作用：",
+        "- 让 Hermes 不只在本地终端里工作，还能接入 Telegram、Discord、Slack、WhatsApp、Signal 等平台。",
+        "",
+        "推荐流程：",
+        "1. 先把 CLI 用顺手，确认模型和 API Key 没问题。",
+        "2. 运行 `hermes gateway setup` 配置平台 token。",
+        "3. 用 `hermes gateway run` 前台启动，先验证是否正常。",
+        "4. 稳定后再按需要使用 `hermes gateway install` / `start` 作为后台服务。",
+        "",
+        "常用命令：",
+        "- `hermes gateway setup`：配置平台接入信息。",
+        "- `hermes gateway run`：前台运行，最适合调试。",
+        "- `hermes gateway status`：查看服务状态。",
+        "- `hermes gateway restart`：重启网关服务。",
+        "",
+        "使用建议：",
+        "- 调试阶段优先用 `run`，因为报错更直观。",
+        "- 生产环境再考虑后台服务和自动启动。",
+        "- 如果消息平台收不到回复，先检查对应平台 token、授权用户和日志。",
+    ]
+    return _render_document(TOPIC_TITLES["gateway"], body, markdown=markdown)
+
+
+def _render_profiles(*, markdown: bool) -> str:
+    hermes_home = display_hermes_home()
+    body = [
+        "Profiles 是 Hermes 的多实例隔离能力。",
+        "- 适合把“工作 / 个人 / 实验 / 不同客户项目”完全分开。",
+        "- 每个 profile 都有自己的配置、密钥、记忆、session、skills。",
+        "",
+        "常用命令：",
+        "- `hermes profile list`：查看所有 profile。",
+        "- `hermes profile create coder`：创建一个新 profile。",
+        "- `hermes -p coder`：直接以指定 profile 启动。",
+        "- `hermes profile use coder`：把某个 profile 设为默认。",
+        "- `hermes profile show coder`：看某个 profile 的详情。",
+        "",
+        "理解方式：",
+        f"- 默认实例通常在 `{hermes_home}`。",
+        "- 其他 profile 会使用独立目录，不共享 session 和配置。",
+        "",
+        "什么时候该用它：",
+        "- 你想把不同工作流彻底隔离。",
+        "- 你想给不同项目配不同模型、技能、API Key。",
+        "- 你需要演示环境和开发环境互不影响。",
+    ]
+    return _render_document(TOPIC_TITLES["profiles"], body, markdown=markdown)
+
+
+def _render_document(title: str, body: list[str], *, markdown: bool) -> str:
+    if markdown:
+        return "\n".join([f"## {title}", "", *body]).strip()
+    underline = "=" * len(title)
+    return "\n".join([title, underline, "", *body]).strip()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -116,6 +116,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("lang", "Switch the TUI display language", "Configuration",
+               cli_only=True, args_hint="[en|zh|status]", subcommands=("en", "zh", "status")),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",
@@ -140,6 +142,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),
     CommandDef("help", "Show available commands", "Info"),
+    CommandDef("zh", "Show the built-in Chinese quickstart and command guide", "Info",
+               aliases=("cn",), args_hint="[topic]",
+               subcommands=("quickstart", "setup", "config", "commands", "gateway", "profiles", "topics")),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
@@ -648,9 +653,19 @@ class SlashCommandCompleter(Completer):
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
         command_filter: Callable[[str], bool] | None = None,
+        language_provider: Callable[[], str] | None = None,
     ) -> None:
         self._skill_commands_provider = skill_commands_provider
         self._command_filter = command_filter
+        self._language_provider = language_provider
+
+    def _display_language(self) -> str:
+        if self._language_provider is None:
+            return "en"
+        try:
+            return str(self._language_provider() or "en")
+        except Exception:
+            return "en"
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -667,6 +682,20 @@ class SlashCommandCompleter(Completer):
             return self._skill_commands_provider() or {}
         except Exception:
             return {}
+
+    def _command_meta(self, command_def: CommandDef, alias: str | None = None) -> str:
+        from hermes_cli.ui_language import alias_description, command_help_description
+
+        language = self._display_language()
+        desc = command_help_description(
+            command_def.name,
+            command_def.description,
+            command_def.args_hint,
+            language,
+        )
+        if alias:
+            return alias_description(desc, command_def.name, language)
+        return desc
 
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
@@ -948,7 +977,10 @@ class SlashCommandCompleter(Completer):
 
         word = text[1:]
 
-        for cmd, desc in COMMANDS.items():
+        for command_def in COMMAND_REGISTRY:
+            if command_def.gateway_only:
+                continue
+            cmd = f"/{command_def.name}"
             if not self._command_allowed(cmd):
                 continue
             cmd_name = cmd[1:]
@@ -957,8 +989,19 @@ class SlashCommandCompleter(Completer):
                     self._completion_text(cmd_name, word),
                     start_position=-len(word),
                     display=cmd,
-                    display_meta=desc,
+                    display_meta=self._command_meta(command_def),
                 )
+            for alias in command_def.aliases:
+                alias_cmd = f"/{alias}"
+                if not self._command_allowed(alias_cmd):
+                    continue
+                if alias.startswith(word):
+                    yield Completion(
+                        self._completion_text(alias, word),
+                        start_position=-len(word),
+                        display=alias_cmd,
+                        display_meta=self._command_meta(command_def, alias=alias),
+                    )
 
         for cmd, info in self._iter_skill_commands().items():
             cmd_name = cmd[1:]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -506,6 +506,7 @@ DEFAULT_CONFIG = {
     
     "display": {
         "compact": False,
+        "language": "en",
         "personality": "kawaii",
         "resume_display": "full",
         "busy_input_mode": "interrupt",
@@ -707,7 +708,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 16,
+    "_config_version": 17,
 }
 
 # =============================================================================
@@ -1971,6 +1972,20 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 migrated = ", ".join(f"{p}={m}" for p, m in old_overrides.items())
                 print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
             results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
+
+    # ── Version 16 → 17: add explicit display.language default ──
+    if current_ver < 17:
+        config = read_raw_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        if "language" not in display:
+            display["language"] = "en"
+            config["display"] = display
+            results["config_added"].append("display.language=en (default)")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added display.language=en")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -18,6 +18,9 @@ Usage:
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
     hermes doctor              # Check configuration and dependencies
+    hermes lang zh             # Switch the CLI/TUI display language to Chinese
+    hermes zh                  # Show the built-in Chinese quickstart guide
+    hermes zh commands         # Show Chinese explanations for common commands
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
     hermes honcho sessions                 # List directory → session name mappings
@@ -2818,6 +2821,34 @@ def cmd_config(args):
     config_command(args)
 
 
+def cmd_lang(args):
+    """Show or change the CLI/TUI display language."""
+    from hermes_cli.config import load_config, set_config_value
+    from hermes_cli.ui_language import display_language_name, normalize_display_language, parse_display_language
+
+    requested = getattr(args, "language", None)
+    if not requested or str(requested).strip().lower() == "status":
+        current = normalize_display_language(load_config().get("display", {}).get("language", "en"))
+        print(f"CLI/TUI language: {display_language_name(current)} ({current})")
+        print("Usage: hermes lang [en|zh|status]")
+        return
+
+    parsed = parse_display_language(requested)
+    if not parsed:
+        print(f"Unsupported language: {requested}. Use en or zh.")
+        return
+
+    set_config_value("display.language", parsed)
+    print(f"CLI/TUI language set to {display_language_name(parsed)} ({parsed}).")
+
+
+def cmd_zh(args):
+    """Show the built-in Chinese guide."""
+    from hermes_cli.chinese_guide import render_topic
+    topic = "topics" if getattr(args, "list_topics", False) else getattr(args, "topic", None)
+    print(render_topic(topic, markdown=getattr(args, "markdown", False)))
+
+
 def cmd_version(args):
     """Show version."""
     print(f"Hermes Agent v{__version__} ({__release_date__})")
@@ -4904,7 +4935,58 @@ For more help on a command:
         help="Show redacted API key prefixes (first/last 4 chars) instead of just set/not set"
     )
     dump_parser.set_defaults(func=cmd_dump)
-    
+
+    # =========================================================================
+    # lang command
+    # =========================================================================
+    lang_parser = subparsers.add_parser(
+        "lang",
+        help="Show or change the CLI/TUI display language",
+        description="Switch visible CLI/TUI helper text between English and Chinese.",
+    )
+    lang_parser.add_argument(
+        "language",
+        nargs="?",
+        default="status",
+        help="Language: en, zh, or status",
+    )
+    lang_parser.set_defaults(func=cmd_lang)
+
+    # =========================================================================
+    # zh command
+    # =========================================================================
+    zh_parser = subparsers.add_parser(
+        "zh",
+        help="Show the built-in Chinese quickstart and command guide",
+        description="Offline Chinese guide for installation, setup, config, commands, gateway, and profiles.",
+        epilog=(
+            "Examples:\n"
+            "  hermes zh\n"
+            "  hermes zh setup\n"
+            "  hermes zh commands\n"
+            "  hermes zh --list\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    zh_parser.add_argument(
+        "topic",
+        nargs="?",
+        default="quickstart",
+        help="Topic: quickstart, setup, config, commands, gateway, profiles, topics",
+    )
+    zh_parser.add_argument(
+        "--list",
+        dest="list_topics",
+        action="store_true",
+        help="List all available Chinese guide topics",
+    )
+    zh_parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Render the guide as Markdown for sharing or copy/paste",
+    )
+    zh_parser.set_defaults(func=cmd_zh)
+
     # =========================================================================
     # config command
     # =========================================================================

--- a/hermes_cli/ui_language.py
+++ b/hermes_cli/ui_language.py
@@ -1,0 +1,330 @@
+"""Helpers for switching Hermes CLI/TUI user-facing text between English and Chinese."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+SUPPORTED_DISPLAY_LANGUAGES = {
+    "en": "en",
+    "en-us": "en",
+    "en_us": "en",
+    "english": "en",
+    "zh": "zh-CN",
+    "zh-cn": "zh-CN",
+    "zh_cn": "zh-CN",
+    "zh-hans": "zh-CN",
+    "cn": "zh-CN",
+    "chinese": "zh-CN",
+    "中文": "zh-CN",
+}
+
+
+_CATEGORY_ZH = {
+    "Session": "会话",
+    "Configuration": "配置",
+    "Tools & Skills": "工具与技能",
+    "Info": "信息",
+    "Exit": "退出",
+}
+
+
+_COMMAND_DESC_ZH = {
+    "new": "开始一个新会话（新的会话 ID 和历史）",
+    "clear": "清屏并开始一个新会话",
+    "history": "查看对话历史",
+    "save": "保存当前对话",
+    "retry": "重试上一条消息（重新发送给代理）",
+    "undo": "删除上一轮用户/助手对话",
+    "title": "为当前会话设置标题",
+    "branch": "为当前会话创建分支（探索不同路径）",
+    "compress": "手动压缩对话上下文",
+    "rollback": "列出或恢复文件系统检查点",
+    "stop": "停止所有后台进程",
+    "approve": "批准待处理的危险命令",
+    "deny": "拒绝待处理的危险命令",
+    "background": "在后台运行一个提示词",
+    "btw": "基于当前会话上下文的临时侧问（无工具、不持久化）",
+    "queue": "把提示排到下一轮（不打断当前运行）",
+    "status": "查看当前会话状态",
+    "profile": "查看当前激活的 profile 名称和 home 目录",
+    "sethome": "把当前聊天设置为 home 频道",
+    "resume": "恢复之前命名过的会话",
+    "config": "查看当前配置",
+    "model": "切换当前会话模型",
+    "provider": "查看可用 provider 和当前 provider",
+    "personality": "设置预定义人格",
+    "statusbar": "切换上下文/模型状态栏显示",
+    "verbose": "循环切换工具进度显示：off -> new -> all -> verbose",
+    "yolo": "切换 YOLO 模式（跳过所有危险命令审批）",
+    "reasoning": "管理 reasoning 强度和显示",
+    "fast": "切换快速模式（普通 / 快速）",
+    "skin": "查看或切换显示皮肤/主题",
+    "voice": "切换语音模式",
+    "lang": "切换 TUI 界面语言（英文 / 中文）",
+    "tools": "管理工具：/tools [list|disable|enable] [name...]",
+    "toolsets": "列出可用 toolset",
+    "skills": "搜索、安装、查看或管理技能",
+    "cron": "管理定时任务",
+    "reload-mcp": "从配置重新加载 MCP 服务器",
+    "browser": "通过 CDP 把浏览器工具连接到你的 Chrome",
+    "plugins": "列出已安装插件及其状态",
+    "commands": "分页浏览所有命令和技能",
+    "help": "显示可用命令",
+    "zh": "显示内置中文快速上手和命令向导",
+    "restart": "优雅重启网关，等待当前任务排空后执行",
+    "usage": "查看当前会话的 token 使用和速率限制",
+    "insights": "查看使用洞察和分析",
+    "platforms": "查看网关/消息平台状态",
+    "paste": "检查剪贴板里的图片并附加到下一条消息",
+    "image": "为下一条提示附加本地图片",
+    "update": "把 Hermes Agent 更新到最新版本",
+    "quit": "退出 CLI",
+}
+
+
+_TEXT = {
+    "help_header": {"en": "(^_^)? Available Commands", "zh-CN": "(^_^)? 可用命令"},
+    "skill_commands": {"en": "Skill Commands", "zh-CN": "技能命令"},
+    "installed_count": {"en": "{count} installed", "zh-CN": "已安装 {count} 个"},
+    "help_tip_chat": {
+        "en": "Tip: Just type your message to chat with Hermes!",
+        "zh-CN": "提示：直接输入消息就可以和 Hermes 对话！",
+    },
+    "help_tip_multiline": {
+        "en": "Multi-line: Alt+Enter for a new line",
+        "zh-CN": "多行输入：按 Alt+Enter 换行",
+    },
+    "help_tip_attach_image": {
+        "en": "Attach image: /image {path} or start your prompt with a local image path",
+        "zh-CN": "附加图片：/image {path}，或在提示词开头直接写本地图片路径",
+    },
+    "help_tip_paste_image": {
+        "en": "Paste image: Alt+V (or /paste)",
+        "zh-CN": "粘贴图片：Alt+V（或 /paste）",
+    },
+    "usage_label": {"en": "usage", "zh-CN": "用法"},
+    "status_title": {"en": "Hermes CLI Status", "zh-CN": "Hermes CLI 状态"},
+    "status_session_id": {"en": "Session ID", "zh-CN": "会话 ID"},
+    "status_path": {"en": "Path", "zh-CN": "路径"},
+    "status_title_field": {"en": "Title", "zh-CN": "标题"},
+    "status_model": {"en": "Model", "zh-CN": "模型"},
+    "status_created": {"en": "Created", "zh-CN": "创建时间"},
+    "status_last_activity": {"en": "Last Activity", "zh-CN": "最后活动"},
+    "status_tokens": {"en": "Tokens", "zh-CN": "Tokens"},
+    "status_agent_running": {"en": "Agent Running", "zh-CN": "代理运行中"},
+    "yes": {"en": "Yes", "zh-CN": "是"},
+    "no": {"en": "No", "zh-CN": "否"},
+    "no_tools_available": {"en": "(;_;) No tools available", "zh-CN": "(;_;) 当前没有可用工具"},
+    "available_tools_title": {"en": "(^_^)/ Available Tools", "zh-CN": "(^_^)/ 可用工具"},
+    "tools_total": {"en": "Total: {count} tools  ヽ(^o^)ノ", "zh-CN": "总计：{count} 个工具  ヽ(^o^)ノ"},
+    "available_toolsets_title": {"en": "(^_^)b Available Toolsets", "zh-CN": "(^_^)b 可用 Toolset"},
+    "toolsets_currently_enabled": {"en": "(*) = currently enabled", "zh-CN": "(*) = 当前已启用"},
+    "toolsets_tip_enable_all": {"en": "Tip: Use 'all' or '*' to enable all toolsets", "zh-CN": "提示：使用 'all' 或 '*' 启用全部 toolset"},
+    "toolsets_example": {"en": "Example: python cli.py --toolsets web,terminal", "zh-CN": "示例：python cli.py --toolsets web,terminal"},
+    "gateway_status_title": {"en": "(✿◠‿◠) Gateway Status", "zh-CN": "(✿◠‿◠) 网关状态"},
+    "gateway_platform_config": {"en": "Messaging Platform Configuration:", "zh-CN": "消息平台配置："},
+    "gateway_enabled": {"en": "Enabled", "zh-CN": "已启用"},
+    "gateway_not_configured": {"en": "Not configured", "zh-CN": "未配置"},
+    "gateway_reset_policy": {"en": "Session Reset Policy:", "zh-CN": "会话重置策略："},
+    "gateway_mode": {"en": "Mode", "zh-CN": "模式"},
+    "gateway_daily_reset": {"en": "Daily reset at", "zh-CN": "每日重置时间"},
+    "gateway_idle_timeout": {"en": "Idle timeout", "zh-CN": "空闲超时"},
+    "gateway_minutes": {"en": "minutes", "zh-CN": "分钟"},
+    "gateway_start_label": {"en": "To start the gateway:", "zh-CN": "启动网关："},
+    "gateway_config_file": {"en": "Configuration file", "zh-CN": "配置文件"},
+    "gateway_configure_label": {"en": "To configure the gateway:", "zh-CN": "配置网关："},
+    "gateway_set_env": {"en": "Set environment variables:", "zh-CN": "设置环境变量："},
+    "gateway_or_config": {"en": "Or configure settings in", "zh-CN": "或直接在这里配置："},
+    "fresh_start": {
+        "en": "  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n",
+        "zh-CN": "  ✨ (◕‿◕)✨ 全新开始！界面已清空，会话已重置。\n",
+    },
+    "statusbar_visible": {"en": "  Status bar visible", "zh-CN": "  状态栏已显示"},
+    "statusbar_hidden": {"en": "  Status bar hidden", "zh-CN": "  状态栏已隐藏"},
+    "welcome": {
+        "en": "Welcome to {agent_name}! Type your message or /help for commands.",
+        "zh-CN": "欢迎来到 {agent_name}！直接输入消息开始聊天，或输入 /help 查看命令。",
+    },
+    "activated_skills": {"en": "Activated skills:", "zh-CN": "已激活技能："},
+    "tool_progress_off": {"en": "Tool progress: OFF — silent mode, just the final response.", "zh-CN": "工具进度：关闭 — 静默模式，只显示最终回复。"},
+    "tool_progress_new": {"en": "Tool progress: NEW — show each new tool (skip repeats).", "zh-CN": "工具进度：NEW — 显示每个新工具调用（跳过重复项）。"},
+    "tool_progress_all": {"en": "Tool progress: ALL — show every tool call.", "zh-CN": "工具进度：ALL — 显示每一次工具调用。"},
+    "tool_progress_verbose": {"en": "Tool progress: VERBOSE — full args, results, think blocks, and debug logs.", "zh-CN": "工具进度：VERBOSE — 显示完整参数、结果、思考片段和调试日志。"},
+    "yolo_off": {"en": "  ⚠ YOLO mode OFF — dangerous commands will require approval.", "zh-CN": "  ⚠ YOLO 模式已关闭 — 危险命令仍需要审批。"},
+    "yolo_on": {"en": "  ⚡ YOLO mode ON — all commands auto-approved. Use with caution.", "zh-CN": "  ⚡ YOLO 模式已开启 — 所有命令自动批准，请谨慎使用。"},
+    "reasoning_effort": {"en": "  Reasoning effort:  {level}", "zh-CN": "  推理强度：{level}"},
+    "reasoning_display": {"en": "  Reasoning display: {state}", "zh-CN": "  推理显示：{state}"},
+    "reasoning_usage": {"en": "Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>", "zh-CN": "用法：/reasoning <none|minimal|low|medium|high|xhigh|show|hide>"},
+    "reasoning_display_on": {"en": "  ✓ Reasoning display: ON (saved)", "zh-CN": "  ✓ 推理显示：开启（已保存）"},
+    "reasoning_display_on_detail": {"en": "  Model thinking will be shown during and after each response.", "zh-CN": "  每次回复期间和结束后都会显示模型思考。"},
+    "reasoning_display_off": {"en": "  ✓ Reasoning display: OFF (saved)", "zh-CN": "  ✓ 推理显示：关闭（已保存）"},
+    "reasoning_unknown_arg": {"en": "(._.) Unknown argument: {arg}", "zh-CN": "(._.) 未知参数：{arg}"},
+    "reasoning_valid_levels": {"en": "Valid levels: none, minimal, low, medium, high, xhigh", "zh-CN": "可用级别：none、minimal、low、medium、high、xhigh"},
+    "reasoning_display_values": {"en": "Display:      show, hide", "zh-CN": "显示控制：show、hide"},
+    "reasoning_set_saved": {"en": "  ✓ Reasoning effort set to '{arg}' (saved to config)", "zh-CN": "  ✓ 推理强度已设置为 '{arg}'（已保存到配置）"},
+    "reasoning_set_session": {"en": "  ✓ Reasoning effort set to '{arg}' (session only)", "zh-CN": "  ✓ 推理强度已设置为 '{arg}'（仅当前会话）"},
+    "lang_status": {"en": "Current TUI language: {label}", "zh-CN": "当前 TUI 语言：{label}"},
+    "lang_usage": {"en": "Usage: /lang [en|zh|status]", "zh-CN": "用法：/lang [en|zh|status]"},
+    "lang_changed_saved": {"en": "TUI language set to {label} (saved to config).", "zh-CN": "TUI 语言已切换为 {label}（已保存到配置）。"},
+    "lang_changed_session": {"en": "TUI language set to {label} (session only).", "zh-CN": "TUI 语言已切换为 {label}（仅当前会话）。"},
+    "lang_unknown": {"en": "Unsupported language: {value}. Use en or zh.", "zh-CN": "不支持的语言：{value}。请使用 en 或 zh。"},
+    "banner_available_tools": {"en": "Available Tools", "zh-CN": "可用工具"},
+    "banner_more_toolsets": {"en": "(and {count} more toolsets...)", "zh-CN": "（以及另外 {count} 个 toolset...）"},
+    "banner_mcp_servers": {"en": "MCP Servers", "zh-CN": "MCP 服务器"},
+    "banner_tool_count": {"en": "{count} tool(s)", "zh-CN": "{count} 个工具"},
+    "banner_failed": {"en": "failed", "zh-CN": "连接失败"},
+    "banner_available_skills": {"en": "Available Skills", "zh-CN": "可用技能"},
+    "banner_more_skills": {"en": "+{count} more", "zh-CN": "+另外 {count} 个"},
+    "banner_no_skills": {"en": "No skills installed", "zh-CN": "当前没有安装技能"},
+    "banner_profile": {"en": "Profile:", "zh-CN": "Profile："},
+    "banner_summary_tools": {"en": "{count} tools", "zh-CN": "{count} 个工具"},
+    "banner_summary_skills": {"en": "{count} skills", "zh-CN": "{count} 个技能"},
+    "banner_summary_mcp": {"en": "{count} MCP servers", "zh-CN": "{count} 个 MCP 服务器"},
+    "banner_summary_help": {"en": "/help for commands", "zh-CN": "输入 /help 查看命令"},
+    "banner_update": {"en": "⚠ {count} {word} behind — run {command} to update", "zh-CN": "⚠ 落后 {count} 个{word} — 运行 {command} 更新"},
+    "banner_commit_word_singular": {"en": "commit", "zh-CN": "提交"},
+    "banner_commit_word_plural": {"en": "commits", "zh-CN": "提交"},
+    "tools_disabled_missing_keys": {"en": "⚠️  Some tools disabled (missing API keys):", "zh-CN": "⚠️  有些工具已禁用（缺少 API Key）："},
+    "run_setup_to_configure": {"en": "Run 'hermes setup' to configure", "zh-CN": "运行 'hermes setup' 完成配置"},
+    "context_warning": {
+        "en": "⚠️  Context length is only {count} tokens — this is likely too low for agent use with tools.",
+        "zh-CN": "⚠️  当前上下文长度只有 {count} tokens，这通常不足以支撑带工具的 agent 使用。",
+    },
+    "context_warning_detail": {
+        "en": "Hermes needs 16k–32k minimum. Tool schemas + system prompt alone use ~4k–8k.",
+        "zh-CN": "Hermes 至少需要 16k–32k。仅工具 schema 和 system prompt 就会占用约 4k–8k。",
+    },
+    "context_warning_ollama": {
+        "en": "Ollama fix: OLLAMA_CONTEXT_LENGTH=32768 ollama serve",
+        "zh-CN": "Ollama 修复方式：OLLAMA_CONTEXT_LENGTH=32768 ollama serve",
+    },
+    "context_warning_lmstudio": {
+        "en": "LM Studio fix: Set context length in model settings → reload model",
+        "zh-CN": "LM Studio 修复方式：在模型设置里提高上下文长度，然后重新加载模型",
+    },
+    "context_warning_generic": {
+        "en": "Fix: Set model.context_length in config.yaml, or increase your server's context setting",
+        "zh-CN": "修复方式：在 config.yaml 里设置 model.context_length，或提高你的服务端上下文长度设置",
+    },
+    "hermes_model_warning": {
+        "en": "⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not designed for use with Hermes Agent.",
+        "zh-CN": "⚠  Nous Research Hermes 3 和 4 模型不是 agentic 模型，不适合搭配 Hermes Agent 使用。",
+    },
+    "hermes_model_warning_detail": {
+        "en": "They lack tool-calling capabilities required for agent workflows. Consider using an agentic model (Claude, GPT, Gemini, DeepSeek, etc.).",
+        "zh-CN": "它们缺少 agent 工作流所需的工具调用能力。建议改用 Claude、GPT、Gemini、DeepSeek 等 agentic 模型。",
+    },
+    "voice_rec_compact": {"en": " ● REC ", "zh-CN": " ● 录音 "},
+    "voice_rec_full": {"en": " ● REC  Ctrl+B to stop ", "zh-CN": " ● 录音中  Ctrl+B 停止 "},
+    "voice_stt_compact": {"en": " ◉ STT ", "zh-CN": " ◉ 转写 "},
+    "voice_stt_full": {"en": " ◉ Transcribing... ", "zh-CN": " ◉ 转写中... "},
+    "voice_ready_compact": {"en": " 🎤 Ctrl+B ", "zh-CN": " 🎤 Ctrl+B "},
+    "voice_ready_full": {"en": " 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ", "zh-CN": " 🎤 语音模式{tts}{cont}  —  Ctrl+B 开始录音 "},
+    "voice_tts_on": {"en": " | TTS on", "zh-CN": " | TTS 开启"},
+    "voice_continuous": {"en": " | Continuous", "zh-CN": " | 连续模式"},
+}
+
+
+def normalize_display_language(value: str | None, *, default: str = "en") -> str:
+    """Normalize a display language value into a supported locale tag."""
+    raw = (value or "").strip()
+    if not raw:
+        return default
+    lowered = raw.lower()
+    if lowered in SUPPORTED_DISPLAY_LANGUAGES:
+        return SUPPORTED_DISPLAY_LANGUAGES[lowered]
+    if lowered.startswith("zh"):
+        return "zh-CN"
+    if lowered.startswith("en"):
+        return "en"
+    return default
+
+
+def parse_display_language(value: str | None) -> str | None:
+    """Parse a user-entered display language; return None when unsupported."""
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    if lowered in SUPPORTED_DISPLAY_LANGUAGES:
+        return SUPPORTED_DISPLAY_LANGUAGES[lowered]
+    if lowered.startswith("zh"):
+        return "zh-CN"
+    if lowered.startswith("en"):
+        return "en"
+    return None
+
+
+def is_chinese_display(language: str | None) -> bool:
+    """Return True when the language should show Chinese UI text."""
+    return normalize_display_language(language) == "zh-CN"
+
+
+def display_language_name(language: str | None) -> str:
+    """Return a human-readable language label."""
+    return "中文" if is_chinese_display(language) else "English"
+
+
+def ui_text(key: str, language: str | None = None, /, **kwargs) -> str:
+    """Return a localized UI string."""
+    lang = normalize_display_language(language)
+    entry = _TEXT[key]
+    template = entry["zh-CN"] if lang == "zh-CN" else entry["en"]
+    return template.format(**kwargs)
+
+
+def category_label(category: str, language: str | None = None) -> str:
+    """Return a localized CLI help category label."""
+    if is_chinese_display(language):
+        return _CATEGORY_ZH.get(category, category)
+    return category
+
+
+def command_description(command_name: str, fallback: str, language: str | None = None) -> str:
+    """Return a localized slash-command description for CLI help."""
+    if is_chinese_display(language):
+        return _COMMAND_DESC_ZH.get(command_name, fallback)
+    return fallback
+
+
+def command_help_description(
+    command_name: str,
+    fallback: str,
+    args_hint: str = "",
+    language: str | None = None,
+) -> str:
+    """Return a localized command description including usage when available."""
+    desc = command_description(command_name, fallback, language)
+    if not args_hint:
+        return desc
+    usage_label = ui_text("usage_label", language)
+    return f"{desc} ({usage_label}: /{command_name} {args_hint})"
+
+
+def alias_description(desc: str, canonical_name: str, language: str | None = None) -> str:
+    """Format an alias description in the current UI language."""
+    if is_chinese_display(language):
+        return f"{desc}（`/{canonical_name}` 的别名）"
+    return f"{desc} (alias for /{canonical_name})"
+
+
+def format_tool_progress(mode: str, language: str | None = None) -> str:
+    """Return a localized tool-progress label."""
+    key = {
+        "off": "tool_progress_off",
+        "new": "tool_progress_new",
+        "all": "tool_progress_all",
+        "verbose": "tool_progress_verbose",
+    }.get(mode, "tool_progress_all")
+    return ui_text(key, language)
+
+
+def localized_welcome(agent_name: str, language: str | None = None) -> str:
+    """Return the localized welcome line shown under the banner."""
+    return ui_text("welcome", language, agent_name=agent_name)
+
+
+def map_ui_text(keys: Mapping[str, str], language: str | None = None) -> dict[str, str]:
+    """Translate a fixed mapping of logical labels to localized strings."""
+    return {name: ui_text(key, language) for name, key in keys.items()}

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -219,6 +219,15 @@ class TestHistoryDisplay:
         assert "/resume" in output
         assert "Current preview" not in output
 
+    def test_zh_command_prints_chinese_guide(self, capsys):
+        cli = _make_cli()
+
+        cli.process_command("/zh setup")
+
+        rendered = capsys.readouterr().out
+        assert "中文配置流程" in rendered
+        assert "hermes setup" in rendered
+
     def test_resume_without_target_lists_recent_sessions(self, capsys):
         cli = _make_cli()
         cli.session_id = "current"
@@ -244,6 +253,38 @@ class TestHistoryDisplay:
         assert "Recent sessions" in output
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
+
+    def test_lang_command_switches_help_to_chinese(self):
+        cli = _make_cli()
+
+        with patch("cli.save_config_value", return_value=True):
+            cli.process_command("/lang zh")
+
+        from hermes_cli.ui_language import command_help_description
+
+        translated = command_help_description(
+            "skin",
+            "Show or change the display skin/theme",
+            "[name]",
+            cli.display_language,
+        )
+
+        assert "查看或切换显示皮肤/主题" in translated
+        assert "用法" in translated
+        assert cli.display_language == "zh-CN"
+
+    def test_session_status_localizes_labels_in_chinese(self, capsys):
+        cli = _make_cli()
+        cli.display_language = "zh-CN"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {"title": "中文会话"}
+
+        cli._show_session_status()
+
+        printed = capsys.readouterr().out
+        assert "Hermes CLI 状态" in printed
+        assert "会话 ID" in printed
+        assert "标题: 中文会话" in printed
 
 
 class TestRootLevelProviderOverride:

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -143,6 +143,18 @@ async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_zh_slash_command_returns_chinese_guide():
+    """The built-in /zh command should return the Chinese guide instead of leaking to the LLM."""
+    runner = _make_runner()
+
+    result = await runner._handle_message(_make_event("/zh config"))
+
+    assert result is not None
+    assert "中文配置文件说明" in result
+    assert "config.yaml" in result
+
+
+@pytest.mark.asyncio
 async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch):
     """Telegram autocomplete sends /reload_mcp for the /reload-mcp built-in.
     That must NOT be flagged as unknown."""

--- a/tests/hermes_cli/test_chinese_guide.py
+++ b/tests/hermes_cli/test_chinese_guide.py
@@ -1,0 +1,54 @@
+"""Tests for the built-in Chinese guide."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from unittest.mock import patch
+
+
+def test_render_topic_config_mentions_profile_aware_paths():
+    from hermes_cli.chinese_guide import render_topic
+
+    with patch.dict(os.environ, {"HERMES_HOME": "/tmp/hermes-zh-home"}):
+        text = render_topic("config")
+
+    assert "config.yaml" in text
+    assert ".env" in text
+    assert "/tmp/hermes-zh-home" in text
+
+
+def test_render_topic_accepts_aliases():
+    from hermes_cli.chinese_guide import render_topic
+
+    text = render_topic("install")
+    assert "中文快速上手" in text
+    assert "hermes setup" in text
+
+
+def test_render_topic_unknown_topic_shows_available_topics():
+    from hermes_cli.chinese_guide import render_topic
+
+    text = render_topic("bogus-topic")
+    assert "未找到这个主题" in text
+    assert "quickstart" in text
+    assert "hermes zh topics" in text
+
+
+def test_render_topic_markdown_mode_uses_heading():
+    from hermes_cli.chinese_guide import render_topic
+
+    text = render_topic("gateway", markdown=True)
+    assert text.startswith("## ")
+    assert "Gateway" in text
+
+
+def test_cmd_zh_prints_requested_topic(capsys):
+    from hermes_cli.main import cmd_zh
+
+    args = argparse.Namespace(topic="commands", list_topics=False, markdown=False)
+    cmd_zh(args)
+
+    output = capsys.readouterr().out
+    assert "常用命令中文说明" in output
+    assert "/zh [topic]" in output

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -99,6 +99,8 @@ class TestResolveCommand:
         assert resolve_command("reset").name == "new"
         assert resolve_command("q").name == "quit"
         assert resolve_command("exit").name == "quit"
+        assert resolve_command("lang").name == "lang"
+        assert resolve_command("cn").name == "zh"
         assert resolve_command("gateway").name == "platforms"
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
@@ -198,6 +200,12 @@ class TestGatewayHelpLines:
         bg_line = [l for l in lines if "/background" in l]
         assert len(bg_line) == 1
         assert "/bg" in bg_line[0]
+
+    def test_includes_chinese_guide_command(self):
+        lines = gateway_help_lines()
+        zh_line = [l for l in lines if "/zh [topic]" in l]
+        assert len(zh_line) == 1
+        assert "/cn" in zh_line[0]
 
 
 class TestTelegramBotCommands:
@@ -340,6 +348,15 @@ class TestSlashCommandCompleter:
         completions = _completions(SlashCommandCompleter(), "/help")
         assert len(completions) == 1
         assert completions[0].display_meta_text == "Show available commands"
+
+    def test_builtin_completion_display_meta_localizes_to_chinese(self):
+        completions = _completions(
+            SlashCommandCompleter(language_provider=lambda: "zh-CN"),
+            "/skin",
+        )
+        assert len(completions) == 1
+        assert "查看或切换显示皮肤/主题" in completions[0].display_meta_text
+        assert "用法" in completions[0].display_meta_text
 
     # -- exact-match trailing space --------------------------------------
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -429,6 +429,7 @@ class TestInterimAssistantMessageConfig:
 
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
+        assert DEFAULT_CONFIG["display"]["language"] == "en"
 
     def test_migrate_to_v15_adds_interim_assistant_message_gate(self, tmp_path):
         config_path = tmp_path / "config.yaml"
@@ -441,6 +442,7 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 16
+        assert raw["_config_version"] == 17
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
+        assert raw["display"]["language"] == "en"

--- a/tests/hermes_cli/test_ui_language.py
+++ b/tests/hermes_cli/test_ui_language.py
@@ -1,0 +1,48 @@
+"""Tests for CLI/TUI language helpers."""
+
+from hermes_cli.ui_language import (
+    alias_description,
+    command_description,
+    command_help_description,
+    display_language_name,
+    normalize_display_language,
+    parse_display_language,
+    ui_text,
+)
+
+
+def test_normalize_display_language_defaults_to_english():
+    assert normalize_display_language(None) == "en"
+    assert normalize_display_language("") == "en"
+
+
+def test_normalize_display_language_accepts_chinese_aliases():
+    assert normalize_display_language("zh") == "zh-CN"
+    assert normalize_display_language("中文") == "zh-CN"
+    assert parse_display_language("cn") == "zh-CN"
+
+
+def test_ui_text_returns_chinese_translation():
+    assert ui_text("help_header", "zh-CN") == "(^_^)? 可用命令"
+    assert "提示" in ui_text("help_tip_chat", "zh-CN")
+
+
+def test_command_description_translates_known_commands():
+    translated = command_description("lang", "Switch the TUI display language", "zh-CN")
+    assert "界面语言" in translated
+
+
+def test_command_help_description_localizes_usage_suffix():
+    translated = command_help_description("skin", "Show or change the display skin/theme", "[name]", "zh-CN")
+    assert "查看或切换显示皮肤/主题" in translated
+    assert "用法" in translated
+    assert "/skin [name]" in translated
+
+
+def test_alias_description_localizes_suffix():
+    assert "别名" in alias_description("显示可用命令", "help", "zh-CN")
+
+
+def test_display_language_name_is_human_readable():
+    assert display_language_name("en") == "English"
+    assert display_language_name("zh-CN") == "中文"

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 15
+        assert DEFAULT_CONFIG["_config_version"] == 17


### PR DESCRIPTION
## Summary

This PR adds first-class Chinese-language support for Hermes CLI/TUI helper text while preserving English as the default experience.

## What Changed

- added an offline Chinese quickstart and command guide via `hermes zh` and `/zh`
- added `display.language`, `hermes lang`, and `/lang` so the CLI/TUI language can switch between English and Chinese
- localized the main TUI surfaces users see most often:
  - `/help`
  - slash-command autocomplete descriptions
  - startup welcome copy and banner summaries
  - session status output
  - tool/toolset views
  - selected warnings and status messages
  - voice status bar labels
- added centralized UI language helpers to keep translations maintainable
- added regression coverage for config migration, command metadata, Chinese guide rendering, and localized command completions

## Why

Hermes already has a strong CLI/TUI experience, but new Chinese-speaking users still have to read setup guidance, command explanations, and helper text in English. This change lowers that onboarding barrier without removing the English-first workflow for existing users.

## Impact

- Chinese-speaking users can learn Hermes faster and use the interface with less translation overhead
- maintainers get a single translation layer instead of scattered string replacements
- English behavior remains the default unless users explicitly switch languages

## Validation

- `python -m pytest tests/hermes_cli/test_chinese_guide.py tests/hermes_cli/test_ui_language.py tests/hermes_cli/test_commands.py tests/hermes_cli/test_config.py tests/hermes_cli/test_banner.py tests/cli/test_cli_init.py tests/cli/test_cli_status_command.py tests/gateway/test_unknown_command.py tests/tools/test_browser_camofox_state.py -q`

## Notes

- this branch was pushed from a fork because the current GitHub account does not have direct push permission to the upstream repository
- local unrelated change in `package-lock.json` was intentionally excluded from this PR
