### PR TITLE
fix(discord): mark ready before slash command sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -538,16 +538,27 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
-                # Resolve any usernames in the allowed list to numeric IDs
-                await adapter_self._resolve_allowed_usernames()
-
-                # Sync slash commands with Discord
-                try:
-                    synced = await adapter_self._client.tree.sync()
-                    logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
-                except Exception as e:  # pragma: no cover - defensive logging
-                    logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
+                # Mark the adapter ready as soon as Discord itself is ready.
+                # Slash-command sync can be slow or hang transiently, and should
+                # not block the bot from becoming usable for normal messaging.
                 adapter_self._ready_event.set()
+
+                # Resolve any usernames in the allowed list to numeric IDs.
+                try:
+                    await adapter_self._resolve_allowed_usernames()
+                except Exception as e:  # pragma: no cover - defensive logging
+                    logger.warning("[%s] Allowed-user resolution failed: %s", adapter_self.name, e, exc_info=True)
+
+                # Sync slash commands with Discord in the background so startup
+                # doesn't timeout while waiting for command registration.
+                async def _sync_tree_background():
+                    try:
+                        synced = await adapter_self._client.tree.sync()
+                        logger.info("[%s] Synced %d slash command(s)", adapter_self.name, len(synced))
+                    except Exception as e:  # pragma: no cover - defensive logging
+                        logger.warning("[%s] Slash command sync failed: %s", adapter_self.name, e, exc_info=True)
+
+                asyncio.create_task(_sync_tree_background())
 
             @self._client.event
             async def on_message(message: DiscordMessage):


### PR DESCRIPTION
## Summary
- mark the Discord adapter ready as soon as `on_ready()` fires
- move slash-command sync to a background task
- keep allowed-user resolution and sync failures non-blocking during startup

## Problem
Hermes could time out during Discord startup even when the bot token and network were valid. The adapter only set `_ready_event` after awaiting slash command sync, so a slow or hung `tree.sync()` made the gateway report `Timeout waiting for connection to Discord` and appear offline.

## Fix
Set `_ready_event` immediately when Discord itself is ready, then perform username resolution and slash-command sync without blocking startup.

## Validation
- confirmed Discord HTTP API auth succeeds with the configured bot token
- confirmed a minimal `discord.py` client reaches READY
- reproduced Hermes gateway timeout before the change
- after the patch, restarted the gateway and verified it stays active without the previous startup timeout
