### PR TITLE
fix(cli): decode arrow keys in curses model menus

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2830,10 +2830,9 @@ def _prompt_model_selection(
     # Build a pricing header hint for the menu title
     menu_title = "Select default model:"
     if has_pricing:
-        # Align the header with the model column.
-        # Each choice is "  {label}" (2 spaces) and simple_term_menu prepends
-        # a 3-char cursor region ("-> " or "   "), so content starts at col 5.
-        pad = " " * 5
+        # Align the header with the model column. curses_single_select renders
+        # each row as " {arrow} {label}", so the label starts at column 3.
+        pad = " " * 3
         header = f"\n{pad}{'':>{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}"
         if has_cache:
             header += f"  {'Cache':>{cache_col}}"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2850,16 +2850,21 @@ def _prompt_model_selection(
         choices = [_label(mid) for mid in ordered]
         choices.append("Enter custom model name")
 
+        footer_lines: list[str] | None = None
         if _unavailable:
-            effective_title = "Select default model (free models):"
-        else:
-            effective_title = menu_title
+            _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+            footer_lines = [
+                f"── Unavailable models (requires paid tier — upgrade at {_upgrade_url}) ──",
+            ]
+            for mid in _unavailable:
+                footer_lines.append(f"  {_label(mid)}")
 
         idx = curses_single_select(
-            effective_title,
+            menu_title,
             choices,
             default_index=default_idx,
             cancel_label="Skip (keep current)",
+            footer_lines=footer_lines,
         )
         if idx is None:
             return None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2845,52 +2845,30 @@ def _prompt_model_selection(
 
     # Try arrow-key menu first, fall back to number input
     try:
-        from simple_term_menu import TerminalMenu
+        from hermes_cli.curses_ui import curses_single_select
 
-        choices = [f"  {_label(mid)}" for mid in ordered]
-        choices.append("  Enter custom model name")
-        choices.append("  Skip (keep current)")
+        choices = [_label(mid) for mid in ordered]
+        choices.append("Enter custom model name")
 
-        # Print the unavailable block BEFORE the menu via regular print().
-        # simple_term_menu pads title lines to terminal width (causes wrapping),
-        # so we keep the title minimal and use stdout for the static block.
-        # clear_screen=False means our printed output stays visible above.
-        _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         if _unavailable:
-            print(menu_title)
-            print()
-            for mid in _unavailable:
-                print(f"{_DIM}     {_label(mid)}{_RESET}")
-            print()
-            print(f"{_DIM}  ── Upgrade at {_upgrade_url} for paid models ──{_RESET}")
-            print()
-            effective_title = "Available free models:"
+            effective_title = "Select default model (free models):"
         else:
             effective_title = menu_title
 
-        menu = TerminalMenu(
+        idx = curses_single_select(
+            effective_title,
             choices,
-            cursor_index=default_idx,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_green", "bold"),
-            menu_highlight_style=("fg_green",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title=effective_title,
+            default_index=default_idx,
+            cancel_label="Skip (keep current)",
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-        flush_stdin()
         if idx is None:
             return None
         print()
         if idx < len(ordered):
             return ordered[idx]
-        elif idx == len(ordered):
-            custom = input("Enter model name: ").strip()
-            return custom if custom else None
-        return None
-    except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+        custom = input("Enter model name: ").strip()
+        return custom if custom else None
+    except Exception:
         pass
 
     # Fallback: numbered list

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2870,7 +2870,10 @@ def _prompt_model_selection(
         print()
         if idx < len(ordered):
             return ordered[idx]
-        custom = input("Enter model name: ").strip()
+        try:
+            custom = input("Enter model name: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
         return custom if custom else None
     except Exception:
         pass

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -76,8 +76,12 @@ def read_curses_key(stdscr, curses_mod=None) -> int:
     if key != 27:
         return key
 
+    # Use a short blocking timeout rather than nodelay so we tolerate
+    # terminals (slow SSH/tmux PTYs) that deliver ESC, [, A across
+    # separate reads — a naive non-blocking poll would misread those
+    # as a bare Escape/cancel.
     try:
-        stdscr.nodelay(True)
+        stdscr.timeout(50)
     except Exception:
         pass
 
@@ -129,7 +133,7 @@ def read_curses_key(stdscr, curses_mod=None) -> int:
         return 0
     finally:
         try:
-            stdscr.nodelay(False)
+            stdscr.timeout(-1)
         except Exception:
             pass
 
@@ -436,9 +440,10 @@ def curses_single_select(
     title_lines = title.splitlines() or [""]
 
     if not sys.stdin.isatty():
-        return _numbered_single_fallback(
-            title, all_items, cancel_idx, footer_lines=footer
-        )
+        # Headless invocation (piped stdin, CI). Matches curses_checklist's
+        # behavior: return cancel rather than block on input() and silently
+        # consume piped bytes.
+        return None
 
     try:
         import curses

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -89,18 +89,29 @@ def read_curses_key(stdscr, curses_mod=None) -> int:
             _queue_pending_keys(stdscr, second)
             return key
 
+        # CSI/SS3 sequence. Read until we hit a terminator so function keys
+        # like Home/End/Delete (ESC [ H, ESC [ F, ESC [ 3 ~) don't leak their
+        # tail bytes back into the caller's input buffer where they would be
+        # injected as printable characters.
         sequence: list[int] = []
         while True:
             part = stdscr.getch()
             if part == -1:
-                _queue_pending_keys(stdscr, second, *sequence)
-                return key
+                break
             sequence.append(part)
-            if 65 <= part <= 68:
+            if second == 79:  # SS3: single-byte function identifier
+                break
+            # CSI final byte is in range 0x40–0x7E.
+            if 0x40 <= part <= 0x7E:
                 break
             if len(sequence) >= 8:
-                _queue_pending_keys(stdscr, second, *sequence)
-                return key
+                break
+
+        if not sequence:
+            # Incomplete escape (e.g. Alt-[ / Alt-O). Preserve the lead byte
+            # so Alt-key semantics still work and return the bare ESC.
+            _queue_pending_keys(stdscr, second)
+            return key
 
         last = sequence[-1]
         mapping = {
@@ -110,10 +121,12 @@ def read_curses_key(stdscr, curses_mod=None) -> int:
             68: curses_mod.KEY_LEFT,
         }
         mapped = mapping.get(last)
-        if mapped is None:
-            _queue_pending_keys(stdscr, second, *sequence)
-            return key
-        return mapped
+        if mapped is not None:
+            return mapped
+        # Unknown function key — swallow the whole sequence rather than
+        # replaying it as input; returning 0 is a harmless no-op for the
+        # menu/filter loops (not ESC, not printable, not an arrow).
+        return 0
     finally:
         try:
             stdscr.nodelay(False)
@@ -466,8 +479,14 @@ def curses_single_select(
                 except curses.error:
                     pass
 
-                reserved = items_start + len(footer) + 1  # +1 for trailing row
-                visible_rows = max(1, max_y - reserved)
+                # Cap footer at one-third of the rows below the hint so a long
+                # unavailable-model block can't crush the selectable list on a
+                # standard 24-row terminal. The remaining footer lines are
+                # dropped (users can still see them in the numbered fallback).
+                available = max(1, max_y - items_start - 1)
+                footer_cap = max(0, available // 3)
+                footer_shown = min(len(footer), footer_cap)
+                visible_rows = max(1, available - footer_shown)
                 if cursor < scroll_offset:
                     scroll_offset = cursor
                 elif cursor >= scroll_offset + visible_rows:
@@ -493,12 +512,15 @@ def curses_single_select(
                         pass
                     last_item_row = y
 
-                if footer:
+                if footer_shown:
                     footer_start = last_item_row + 2
-                    for i, fline in enumerate(footer):
+                    for i in range(footer_shown):
                         y = footer_start + i
                         if y >= max_y - 1:
                             break
+                        fline = footer[i]
+                        if i == footer_shown - 1 and footer_shown < len(footer):
+                            fline = f"{fline}  (+{len(footer) - footer_shown} more)"
                         try:
                             stdscr.addnstr(y, 0, fline, max_x - 1, curses.A_DIM)
                         except curses.error:

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -492,10 +492,15 @@ def curses_single_select(
                 # unavailable-model block can't crush the selectable list on a
                 # standard 24-row terminal. The remaining footer lines are
                 # dropped (users can still see them in the numbered fallback).
+                # The footer is rendered after a blank separator row, so budget
+                # for that separator too — otherwise a 6–8 row tmux split would
+                # reserve space for a footer that never actually fits, hiding
+                # selectable rows for no visible gain.
                 available = max(1, max_y - items_start - 1)
-                footer_cap = max(0, available // 3)
+                footer_cap = max(0, (available - 1) // 3) if footer else 0
                 footer_shown = min(len(footer), footer_cap)
-                visible_rows = max(1, available - footer_shown)
+                separator_row = 1 if footer_shown else 0
+                visible_rows = max(1, available - footer_shown - separator_row)
                 if cursor < scroll_offset:
                     scroll_offset = cursor
                 elif cursor >= scroll_offset + visible_rows:

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -10,6 +10,9 @@ from typing import Callable, List, Optional, Set
 from hermes_cli.colors import Colors, color
 
 
+_PENDING_KEYS: dict[int, list[int]] = {}
+
+
 def flush_stdin() -> None:
     """Flush any stray bytes from the stdin input buffer.
 
@@ -30,6 +33,92 @@ def flush_stdin() -> None:
         termios.tcflush(sys.stdin, termios.TCIFLUSH)
     except Exception:
         pass
+
+
+def _enable_keypad(stdscr) -> None:
+    """Ask curses to translate escape sequences into KEY_* constants when possible."""
+    try:
+        stdscr.keypad(True)
+    except Exception:
+        pass
+
+
+def _queue_pending_keys(stdscr, *keys: int) -> None:
+    """Push keys back so the next ``read_curses_key`` call can consume them."""
+    values = [key for key in keys if key != -1]
+    if not values:
+        return
+
+    ident = id(stdscr)
+    existing = _PENDING_KEYS.get(ident, [])
+    _PENDING_KEYS[ident] = values + existing
+
+
+def read_curses_key(stdscr, curses_mod=None) -> int:
+    """Read one logical key from curses, decoding raw arrow escape sequences.
+
+    Some terminals still deliver arrows as ``ESC [ A/B`` or ``ESC O A/B`` when
+    ``keypad(True)`` does not take effect. Treat those sequences as arrow keys
+    instead of misreading the leading ``ESC`` as a cancel action.
+    """
+    ident = id(stdscr)
+    pending = _PENDING_KEYS.get(ident)
+    if pending:
+        key = pending.pop(0)
+        if not pending:
+            _PENDING_KEYS.pop(ident, None)
+        return key
+
+    if curses_mod is None:
+        import curses as curses_mod
+
+    key = stdscr.getch()
+    if key != 27:
+        return key
+
+    try:
+        stdscr.nodelay(True)
+    except Exception:
+        pass
+
+    try:
+        second = stdscr.getch()
+        if second == -1:
+            return key
+        if second not in (91, 79):  # CSI or SS3
+            _queue_pending_keys(stdscr, second)
+            return key
+
+        sequence: list[int] = []
+        while True:
+            part = stdscr.getch()
+            if part == -1:
+                _queue_pending_keys(stdscr, second, *sequence)
+                return key
+            sequence.append(part)
+            if 65 <= part <= 68:
+                break
+            if len(sequence) >= 8:
+                _queue_pending_keys(stdscr, second, *sequence)
+                return key
+
+        last = sequence[-1]
+        mapping = {
+            65: curses_mod.KEY_UP,
+            66: curses_mod.KEY_DOWN,
+            67: curses_mod.KEY_RIGHT,
+            68: curses_mod.KEY_LEFT,
+        }
+        mapped = mapping.get(last)
+        if mapped is None:
+            _queue_pending_keys(stdscr, second, *sequence)
+            return key
+        return mapped
+    finally:
+        try:
+            stdscr.nodelay(False)
+        except Exception:
+            pass
 
 
 def curses_checklist(
@@ -65,6 +154,7 @@ def curses_checklist(
         result_holder: list = [None]
 
         def _draw(stdscr):
+            _enable_keypad(stdscr)
             curses.curs_set(0)
             if curses.has_colors():
                 curses.start_color()
@@ -137,7 +227,7 @@ def curses_checklist(
                         pass
 
                 stdscr.refresh()
-                key = stdscr.getch()
+                key = read_curses_key(stdscr, curses)
 
                 if key in (curses.KEY_UP, ord("k")):
                     cursor = (cursor - 1) % len(items)
@@ -194,6 +284,7 @@ def curses_radiolist(
         result_holder: list = [None]
 
         def _draw(stdscr):
+            _enable_keypad(stdscr)
             curses.curs_set(0)
             if curses.has_colors():
                 curses.start_color()
@@ -261,7 +352,7 @@ def curses_radiolist(
                         pass
 
                 stdscr.refresh()
-                key = stdscr.getch()
+                key = read_curses_key(stdscr, curses)
 
                 if key in (curses.KEY_UP, ord("k")):
                     cursor = (cursor - 1) % len(items)
@@ -331,6 +422,7 @@ def curses_single_select(
         cancel_idx = len(items)
 
         def _draw(stdscr):
+            _enable_keypad(stdscr)
             curses.curs_set(0)
             if curses.has_colors():
                 curses.start_color()
@@ -382,7 +474,7 @@ def curses_single_select(
                         pass
 
                 stdscr.refresh()
-                key = stdscr.getch()
+                key = read_curses_key(stdscr, curses)
 
                 if key in (curses.KEY_UP, ord("k")):
                     cursor = (cursor - 1) % len(all_items)

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -440,10 +440,14 @@ def curses_single_select(
     title_lines = title.splitlines() or [""]
 
     if not sys.stdin.isatty():
-        # Headless invocation (piped stdin, CI). Matches curses_checklist's
-        # behavior: return cancel rather than block on input() and silently
-        # consume piped bytes.
-        return None
+        # Headless invocation (piped stdin, scripted tests). Fall back to the
+        # numbered prompt so callers that feed a numeric choice through stdin
+        # keep working; _numbered_single_fallback catches EOFError and returns
+        # None when there is nothing to read, so truly detached contexts still
+        # cancel cleanly without blocking.
+        return _numbered_single_fallback(
+            title, all_items, cancel_idx, footer_lines=footer
+        )
 
     try:
         import curses

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -405,17 +405,27 @@ def curses_single_select(
     default_index: int = 0,
     *,
     cancel_label: str = "Cancel",
+    footer_lines: List[str] | None = None,
 ) -> int | None:
     """Curses single-select menu. Returns selected index or None on cancel.
 
     Works inside prompt_toolkit because curses.wrapper() restores the terminal
     safely, unlike simple_term_menu which conflicts with /dev/tty.
+
+    ``title`` may contain newlines — each line is rendered on its own row so
+    callers can supply a multi-line header (e.g. a pricing column legend).
+    ``footer_lines`` is rendered dimly below the items and is useful for
+    supplementary information such as unavailable-model hints.
     """
     all_items = list(items) + [cancel_label]
     cancel_idx = len(items)
+    footer = list(footer_lines or [])
+    title_lines = title.splitlines() or [""]
 
     if not sys.stdin.isatty():
-        return _numbered_single_fallback(title, all_items, cancel_idx)
+        return _numbered_single_fallback(
+            title, all_items, cancel_idx, footer_lines=footer
+        )
 
     try:
         import curses
@@ -431,6 +441,8 @@ def curses_single_select(
                 curses.init_pair(2, curses.COLOR_YELLOW, -1)
             cursor = min(default_index, len(all_items) - 1)
             scroll_offset = 0
+            title_rows = len(title_lines)
+            items_start = title_rows + 1  # +1 for the hint row
 
             while True:
                 stdscr.clear()
@@ -440,25 +452,32 @@ def curses_single_select(
                     hattr = curses.A_BOLD
                     if curses.has_colors():
                         hattr |= curses.color_pair(2)
-                    stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-                    stdscr.addnstr(
-                        1, 0,
-                        "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
+                    for row, line in enumerate(title_lines):
+                        if row >= max_y:
+                            break
+                        attr = hattr if row == 0 else curses.A_NORMAL
+                        stdscr.addnstr(row, 0, line, max_x - 1, attr)
+                    if title_rows < max_y:
+                        stdscr.addnstr(
+                            title_rows, 0,
+                            "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
+                            max_x - 1, curses.A_DIM,
+                        )
                 except curses.error:
                     pass
 
-                visible_rows = max_y - 3
+                reserved = items_start + len(footer) + 1  # +1 for trailing row
+                visible_rows = max(1, max_y - reserved)
                 if cursor < scroll_offset:
                     scroll_offset = cursor
                 elif cursor >= scroll_offset + visible_rows:
                     scroll_offset = cursor - visible_rows + 1
 
+                last_item_row = items_start
                 for draw_i, i in enumerate(
                     range(scroll_offset, min(len(all_items), scroll_offset + visible_rows))
                 ):
-                    y = draw_i + 3
+                    y = draw_i + items_start
                     if y >= max_y - 1:
                         break
                     arrow = "→" if i == cursor else " "
@@ -472,6 +491,18 @@ def curses_single_select(
                         stdscr.addnstr(y, 0, line, max_x - 1, attr)
                     except curses.error:
                         pass
+                    last_item_row = y
+
+                if footer:
+                    footer_start = last_item_row + 2
+                    for i, fline in enumerate(footer):
+                        y = footer_start + i
+                        if y >= max_y - 1:
+                            break
+                        try:
+                            stdscr.addnstr(y, 0, fline, max_x - 1, curses.A_DIM)
+                        except curses.error:
+                            pass
 
                 stdscr.refresh()
                 key = read_curses_key(stdscr, curses)
@@ -494,20 +525,26 @@ def curses_single_select(
         return result_holder[0]
 
     except Exception:
-        all_items = list(items) + [cancel_label]
-        cancel_idx = len(items)
-        return _numbered_single_fallback(title, all_items, cancel_idx)
+        return _numbered_single_fallback(
+            title, list(items) + [cancel_label], len(items), footer_lines=footer
+        )
 
 
 def _numbered_single_fallback(
     title: str,
     items: List[str],
     cancel_idx: int,
+    *,
+    footer_lines: List[str] | None = None,
 ) -> int | None:
     """Text-based numbered fallback for single-select."""
     print(f"\n  {title}\n")
     for i, label in enumerate(items, 1):
         print(f"  {i}. {label}")
+    if footer_lines:
+        print()
+        for line in footer_lines:
+            print(f"  {line}")
     print()
     try:
         val = input(f"  Choice [1-{len(items)}]: ").strip()

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -411,15 +411,15 @@ def curses_single_select(
     Works inside prompt_toolkit because curses.wrapper() restores the terminal
     safely, unlike simple_term_menu which conflicts with /dev/tty.
     """
+    all_items = list(items) + [cancel_label]
+    cancel_idx = len(items)
+
     if not sys.stdin.isatty():
-        return None
+        return _numbered_single_fallback(title, all_items, cancel_idx)
 
     try:
         import curses
         result_holder: list = [None]
-
-        all_items = list(items) + [cancel_label]
-        cancel_idx = len(items)
 
         def _draw(stdscr):
             _enable_keypad(stdscr)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -367,6 +367,9 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
             )
 
         def _curses_browse(stdscr):
+            from hermes_cli.curses_ui import _enable_keypad, read_curses_key
+
+            _enable_keypad(stdscr)
             curses.curs_set(0)
             if curses.has_colors():
                 curses.start_color()
@@ -486,7 +489,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                     pass
 
                 stdscr.refresh()
-                key = stdscr.getch()
+                key = read_curses_key(stdscr, curses)
 
                 if key in (curses.KEY_UP,):
                     if filtered:
@@ -2663,24 +2666,15 @@ def _remove_custom_provider(config):
     choices.append("Cancel")
 
     try:
-        from simple_term_menu import TerminalMenu
-
-        menu = TerminalMenu(
-            [f"  {c}" for c in choices],
-            cursor_index=0,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_red", "bold"),
-            menu_highlight_style=("fg_red",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title="Select provider to remove:",
+        from hermes_cli.curses_ui import curses_single_select
+        idx = curses_single_select(
+            "Select provider to remove:",
+            choices[:-1],
+            default_index=0,
+            cancel_label="Cancel",
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-
-        flush_stdin()
         print()
-    except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+    except Exception:
         for i, c in enumerate(choices, 1):
             print(f"  {i}. {c}")
         print()
@@ -2737,31 +2731,23 @@ def _model_flow_named_custom(config, provider_info):
 
         print(f"Found {len(models)} model(s):\n")
         try:
-            from simple_term_menu import TerminalMenu
-
+            from hermes_cli.curses_ui import curses_single_select
             menu_items = [
-                f"  {m} (current)" if m == saved_model else f"  {m}" for m in models
-            ] + ["  Cancel"]
-            menu = TerminalMenu(
+                f"{m} (current)" if m == saved_model else m
+                for m in models
+            ]
+            idx = curses_single_select(
+                f"Select model from {name}:",
                 menu_items,
-                cursor_index=default_idx,
-                menu_cursor="-> ",
-                menu_cursor_style=("fg_green", "bold"),
-                menu_highlight_style=("fg_green",),
-                cycle_cursor=True,
-                clear_screen=False,
-                title=f"Select model from {name}:",
+                default_index=default_idx,
+                cancel_label="Cancel",
             )
-            idx = menu.show()
-            from hermes_cli.curses_ui import flush_stdin
-
-            flush_stdin()
             print()
-            if idx is None or idx >= len(models):
+            if idx is None:
                 print("Cancelled.")
                 return
             model_name = models[idx]
-        except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+        except Exception:
             for i, m in enumerate(models, 1):
                 suffix = " (current)" if m == saved_model else ""
                 print(f"  {i}. {m}{suffix}")
@@ -2896,34 +2882,23 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         default_idx = 0
 
     try:
-        from simple_term_menu import TerminalMenu
+        from hermes_cli.curses_ui import curses_single_select
 
-        choices = [f"  {_label(effort)}" for effort in ordered]
-        choices.append(f"  {disable_label}")
-        choices.append(f"  {skip_label}")
-        menu = TerminalMenu(
+        choices = [_label(effort) for effort in ordered]
+        choices.append(disable_label)
+        idx = curses_single_select(
+            "Select reasoning effort:",
             choices,
-            cursor_index=default_idx,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_green", "bold"),
-            menu_highlight_style=("fg_green",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title="Select reasoning effort:",
+            default_index=default_idx,
+            cancel_label=skip_label,
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-
-        flush_stdin()
         if idx is None:
             return None
         print()
         if idx < len(ordered):
             return ordered[idx]
-        if idx == len(ordered):
-            return "none"
-        return None
-    except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
+        return "none"
+    except Exception:
         pass
 
     print("Select reasoning effort:")

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -825,6 +825,9 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
     result_holder = {"plugins_changed": False, "providers_changed": False}
 
     def _draw(stdscr):
+        from hermes_cli.curses_ui import _enable_keypad, read_curses_key
+
+        _enable_keypad(stdscr)
         curses.curs_set(0)
         if curses.has_colors():
             curses.start_color()
@@ -939,7 +942,7 @@ def _run_composite_ui(curses, plugin_names, plugin_labels, plugin_selected,
                     y += 1
 
             stdscr.refresh()
-            key = stdscr.getch()
+            key = read_curses_key(stdscr, curses)
 
             if key in (curses.KEY_UP, ord("k")):
                 if total_items > 0:

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -91,3 +91,63 @@ def test_curses_single_select_renders_footer_lines_dim_below_items():
     last_item_row = max(item_rows)
     assert all(args[0] > last_item_row for args in footer_calls)
     assert all(args[4] == curses.A_DIM for args in footer_calls)
+
+
+def test_curses_single_select_long_footer_does_not_crush_items():
+    """A long footer must not shrink the selectable list to a single row on a
+    24-row terminal — items should always win most of the screen."""
+    from hermes_cli.curses_ui import curses_single_select
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getmaxyx.return_value = (24, 80)
+    mock_stdscr.getch.side_effect = [10]
+
+    items = [f"model-{i}" for i in range(15)]
+    footer = [f"footer-{i}" for i in range(40)]
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("curses.wrapper") as mock_wrapper, \
+         patch("curses.curs_set"), \
+         patch("curses.has_colors", return_value=False):
+        mock_stdin.isatty.return_value = True
+        mock_wrapper.side_effect = lambda func: func(mock_stdscr)
+        curses_single_select(
+            "Select default model:", items, default_index=0, footer_lines=footer
+        )
+
+    rendered = [call.args for call in mock_stdscr.addnstr.call_args_list]
+    item_rows = [args[2] for args in rendered if args[2].startswith(" → ") or args[2].startswith("   ")]
+    # At least half of the screen should stay available for items, even with
+    # a 40-line footer. On a 24-row terminal that means well over a single row.
+    assert len(item_rows) >= 10, f"Only {len(item_rows)} items visible with long footer"
+
+
+def test_read_curses_key_swallows_non_arrow_csi_sequences():
+    """Delete/Home/End sequences (ESC [ 3 ~, ESC [ H, ESC [ F) must not leave
+    their tail bytes in the pending-key buffer — replaying them would inject
+    '[3~' into a filter input or cancel the picker unexpectedly."""
+    from hermes_cli.curses_ui import read_curses_key, _PENDING_KEYS
+
+    mock_stdscr = MagicMock()
+    # ESC [ 3 ~  (Delete)
+    mock_stdscr.getch.side_effect = [27, 91, 51, 126]
+
+    import curses as real_curses
+    key = read_curses_key(mock_stdscr, curses_mod=real_curses)
+
+    assert key != 27, "non-arrow escape should not surface as ESC (would cancel picker)"
+    assert 32 > key or key > 126, "non-arrow escape must not be a printable char"
+    # No leftover bytes injected into pending buffer.
+    assert _PENDING_KEYS.get(id(mock_stdscr)) in (None, [])
+
+
+def test_read_curses_key_still_decodes_arrow_after_cleanup():
+    """The cleanup for non-arrow sequences must not regress arrow decoding."""
+    from hermes_cli.curses_ui import read_curses_key
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getch.side_effect = [27, 91, 66]  # ESC [ B = down
+
+    import curses as real_curses
+    key = read_curses_key(mock_stdscr, curses_mod=real_curses)
+    assert key == real_curses.KEY_DOWN

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -151,3 +151,89 @@ def test_read_curses_key_still_decodes_arrow_after_cleanup():
     import curses as real_curses
     key = read_curses_key(mock_stdscr, curses_mod=real_curses)
     assert key == real_curses.KEY_DOWN
+
+
+def test_read_curses_key_uses_timeout_not_nodelay():
+    """Slow terminals (SSH/tmux) deliver ESC, [, A across separate reads. The
+    decoder must wait briefly for the continuation bytes instead of immediately
+    giving up on the sequence — so it must use timeout(), not nodelay(True)."""
+    from hermes_cli.curses_ui import read_curses_key
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getch.side_effect = [27, 91, 65]  # ESC [ A = up
+
+    import curses as real_curses
+    key = read_curses_key(mock_stdscr, curses_mod=real_curses)
+    assert key == real_curses.KEY_UP
+    assert mock_stdscr.timeout.called, "read_curses_key must set a blocking timeout"
+    # It should enter a bounded wait (positive ms) and restore afterwards.
+    delays = [c.args[0] for c in mock_stdscr.timeout.call_args_list]
+    assert any(d > 0 for d in delays), "expected a positive blocking timeout"
+    assert delays[-1] <= 0, "timeout must be restored to blocking after decode"
+
+
+def test_curses_single_select_returns_none_when_stdin_not_tty():
+    """Headless invocations (piped stdin, CI) must return cancel without
+    blocking on input() — matching curses_checklist's behavior."""
+    from hermes_cli.curses_ui import curses_single_select
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("builtins.input") as mock_input:
+        mock_stdin.isatty.return_value = False
+        result = curses_single_select(
+            "Pick one", ["a", "b", "c"], default_index=0
+        )
+
+    assert result is None
+    assert not mock_input.called, "curses_single_select must not read stdin when non-TTY"
+
+
+def test_prompt_model_selection_header_aligns_with_curses_rows():
+    """With the curses renderer each row starts at column 3 (' arrow label'),
+    so the header's 'In' column must align with the priced values in the item
+    rows. Previously pad=5 (simple_term_menu's layout) shifted 'In'/'Out' past
+    their values, making the table misleading."""
+    from hermes_cli import auth
+
+    captured: dict = {}
+
+    def _fake_select(title, items, default_index=0, *, cancel_label="Cancel", footer_lines=None):
+        captured["title"] = title
+        captured["items"] = items
+        return None  # cancel
+
+    pricing = {"m1": {"prompt": "0.001", "completion": "0.002"}}
+
+    with patch("hermes_cli.curses_ui.curses_single_select", _fake_select), \
+         patch("builtins.input", return_value=""):
+        auth._prompt_model_selection(
+            ["m1"],
+            current_model="",
+            pricing=pricing,
+            portal_url=None,
+            unavailable_models=None,
+        )
+
+    title = captured["title"]
+    items = captured["items"]
+    lines = title.split("\n")
+    assert len(lines) >= 2
+    header_line = lines[1]
+
+    # curses_single_select renders each row as " {arrow} {label}" (3-char
+    # prefix). Compare the right edge of "In" in the header against the right
+    # edge of the input-price value in the "m1" row prefixed with "   ".
+    rendered_m1_row = "   " + items[0]
+    in_column_right = header_line.rfind("In") + len("In")
+    # The input-price value "$0.001/Mtok" or similar lives after the name
+    # column; find the first non-space char after the model name in the row.
+    row_name_end = rendered_m1_row.index("m1") + len("m1")
+    tail = rendered_m1_row[row_name_end:]
+    # The first price token's right edge should line up with "In"'s right edge.
+    first_price_token = next(tok for tok in tail.split("  ") if tok.strip())
+    price_right = row_name_end + tail.index(first_price_token) + len(first_price_token)
+    assert in_column_right == price_right, (
+        f"Header 'In' must right-align with first price column; "
+        f"header={header_line!r}, row={rendered_m1_row!r}, "
+        f"in_right={in_column_right}, price_right={price_right}"
+    )

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -34,3 +34,60 @@ def test_curses_radiolist_decodes_ss3_arrow_sequences():
     result, _mock_stdscr = _run_radiolist_with_keys([27, 79, 65, 10], selected=1)
 
     assert result == 0
+
+
+def _run_single_select(title, items, *, footer_lines=None, key_sequence=(10,)):
+    from hermes_cli.curses_ui import curses_single_select
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getmaxyx.return_value = (30, 120)
+    mock_stdscr.getch.side_effect = list(key_sequence)
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("curses.wrapper") as mock_wrapper, \
+         patch("curses.curs_set"), \
+         patch("curses.has_colors", return_value=False):
+        mock_stdin.isatty.return_value = True
+        mock_wrapper.side_effect = lambda func: func(mock_stdscr)
+        result = curses_single_select(
+            title, items, default_index=0, footer_lines=footer_lines
+        )
+
+    rendered = [call.args for call in mock_stdscr.addnstr.call_args_list]
+    return result, rendered
+
+
+def test_curses_single_select_renders_multiline_title_without_overwrite():
+    """A title containing newlines must occupy successive rows so subsequent
+    hint/items never overwrite later title lines (priced model headers)."""
+    title = "Select default model:\n       In    Out  /Mtok"
+    result, rendered = _run_single_select(title, ["gpt-x", "gpt-y"])
+
+    assert result == 0
+    rows_by_text = {args[2]: args[0] for args in rendered}
+    assert rows_by_text["Select default model:"] == 0
+    assert rows_by_text["       In    Out  /Mtok"] == 1
+    hint_row = next(args[0] for args in rendered if "navigate" in args[2])
+    assert hint_row == 2
+
+
+def test_curses_single_select_renders_footer_lines_dim_below_items():
+    """Footer lines (e.g. unavailable-model disclosures) must render after the
+    items so callers can surface paid-tier info inside the curses menu."""
+    import curses
+
+    footer = [
+        "── Unavailable models (requires paid tier — upgrade at https://example.test) ──",
+        "  premium-model",
+    ]
+    result, rendered = _run_single_select(
+        "Select default model:", ["free-a", "free-b"], footer_lines=footer
+    )
+
+    assert result == 0
+    footer_calls = [args for args in rendered if args[2] in footer]
+    assert len(footer_calls) == 2
+    item_rows = [args[0] for args in rendered if args[2].startswith(" → ") or args[2].startswith("   ")]
+    last_item_row = max(item_rows)
+    assert all(args[0] > last_item_row for args in footer_calls)
+    assert all(args[4] == curses.A_DIM for args in footer_calls)

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -204,6 +204,69 @@ def test_curses_single_select_non_tty_returns_none_on_eof():
     assert result is None
 
 
+def test_prompt_model_selection_cancels_on_eof_from_custom_entry():
+    """Picking 'Enter custom model name' and then hitting Ctrl-D (or pipe
+    close) must return None immediately instead of falling through the broad
+    except-Exception and redrawing the numbered fallback menu."""
+    from hermes_cli import auth
+
+    call_count = {"n": 0}
+
+    def _fake_select(title, items, default_index=0, *, cancel_label="Cancel", footer_lines=None):
+        call_count["n"] += 1
+        # Index for "Enter custom model name" (last item before cancel).
+        return len(items) - 1
+
+    with patch("hermes_cli.curses_ui.curses_single_select", _fake_select), \
+         patch("builtins.input", side_effect=EOFError), \
+         patch("builtins.print"):
+        result = auth._prompt_model_selection(
+            ["m1"],
+            current_model="",
+            pricing=None,
+            portal_url=None,
+            unavailable_models=None,
+        )
+
+    assert result is None
+    assert call_count["n"] == 1, "EOF from custom-entry must not re-enter the picker"
+
+
+def test_curses_single_select_skips_footer_on_very_short_terminal():
+    """On a 6-row terminal the footer + separator cannot fit — the helper
+    must drop the footer entirely rather than reserve a row that never
+    renders, which would otherwise shrink the selectable list for no gain."""
+    from hermes_cli.curses_ui import curses_single_select
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getmaxyx.return_value = (6, 80)
+    mock_stdscr.getch.side_effect = [10]
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("curses.wrapper") as mock_wrapper, \
+         patch("curses.curs_set"), \
+         patch("curses.has_colors", return_value=False):
+        mock_stdin.isatty.return_value = True
+        mock_wrapper.side_effect = lambda func: func(mock_stdscr)
+        curses_single_select(
+            "Title",
+            ["a", "b", "c"],
+            default_index=0,
+            footer_lines=["footer-1", "footer-2"],
+        )
+
+    rendered = [call.args for call in mock_stdscr.addnstr.call_args_list]
+    item_texts = [args[2] for args in rendered if args[2].startswith(" → ") or args[2].startswith("   ")]
+    # With a 6-row terminal the 3 items should all be visible; footer is
+    # dropped, no row wasted on a phantom footer slot.
+    assert len(item_texts) >= 2, (
+        f"small terminal must not sacrifice item rows for a hidden footer: {rendered}"
+    )
+    assert not any("footer-" in args[2] for args in rendered), (
+        "footer should be skipped entirely when the terminal is too short"
+    )
+
+
 def test_prompt_model_selection_header_aligns_with_curses_rows():
     """With the curses renderer each row starts at column 3 (' arrow label'),
     so the header's 'In' column must align with the priced values in the item

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -172,20 +172,36 @@ def test_read_curses_key_uses_timeout_not_nodelay():
     assert delays[-1] <= 0, "timeout must be restored to blocking after decode"
 
 
-def test_curses_single_select_returns_none_when_stdin_not_tty():
-    """Headless invocations (piped stdin, CI) must return cancel without
-    blocking on input() — matching curses_checklist's behavior."""
+def test_curses_single_select_non_tty_honors_piped_numeric_choice():
+    """Scripted callers pipe a number into stdin (e.g. tests that exercise
+    _prompt_model_selection via echo "2\\n" | hermes model). The non-TTY path
+    must dispatch to the numbered fallback so those flows still resolve to a
+    concrete choice; collapsing straight to None was a P1 regression that
+    broke test_terminal_menu_fallbacks / test_custom_provider_model_switch."""
     from hermes_cli.curses_ui import curses_single_select
 
     with patch("sys.stdin") as mock_stdin, \
-         patch("builtins.input") as mock_input:
+         patch("builtins.input", return_value="2") as mock_input, \
+         patch("builtins.print"):
         mock_stdin.isatty.return_value = False
-        result = curses_single_select(
-            "Pick one", ["a", "b", "c"], default_index=0
-        )
+        result = curses_single_select("Pick one", ["a", "b", "c"], default_index=0)
+
+    assert result == 1, "piped '2' should select index 1 via numbered fallback"
+    assert mock_input.called
+
+
+def test_curses_single_select_non_tty_returns_none_on_eof():
+    """When piped stdin is exhausted, the numbered fallback raises EOFError,
+    which must surface as a clean cancel rather than propagating."""
+    from hermes_cli.curses_ui import curses_single_select
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("builtins.input", side_effect=EOFError), \
+         patch("builtins.print"):
+        mock_stdin.isatty.return_value = False
+        result = curses_single_select("Pick one", ["a", "b", "c"])
 
     assert result is None
-    assert not mock_input.called, "curses_single_select must not read stdin when non-TTY"
 
 
 def test_prompt_model_selection_header_aligns_with_curses_rows():

--- a/tests/hermes_cli/test_curses_ui_navigation.py
+++ b/tests/hermes_cli/test_curses_ui_navigation.py
@@ -1,0 +1,36 @@
+"""Regression tests for curses arrow-key navigation helpers."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _run_radiolist_with_keys(key_sequence, *, selected=0):
+    from hermes_cli.curses_ui import curses_radiolist
+
+    mock_stdscr = MagicMock()
+    mock_stdscr.getmaxyx.return_value = (20, 80)
+    mock_stdscr.getch.side_effect = key_sequence
+
+    with patch("sys.stdin") as mock_stdin, \
+         patch("curses.wrapper") as mock_wrapper, \
+         patch("curses.curs_set"), \
+         patch("curses.has_colors", return_value=False):
+        mock_stdin.isatty.return_value = True
+        mock_wrapper.side_effect = lambda func: func(mock_stdscr)
+        result = curses_radiolist("Pick provider", ["one", "two", "three"], selected=selected)
+
+    return result, mock_stdscr
+
+
+def test_curses_radiolist_decodes_csi_arrow_sequences():
+    """Raw ESC [ B should behave like down-arrow, not cancel the menu."""
+    result, mock_stdscr = _run_radiolist_with_keys([27, 91, 66, 10])
+
+    assert result == 1
+    mock_stdscr.keypad.assert_called_with(True)
+
+
+def test_curses_radiolist_decodes_ss3_arrow_sequences():
+    """Raw ESC O A should behave like up-arrow for terminals in application mode."""
+    result, _mock_stdscr = _run_radiolist_with_keys([27, 79, 65, 10], selected=1)
+
+    assert result == 0

--- a/tests/hermes_cli/test_reasoning_effort_menu.py
+++ b/tests/hermes_cli/test_reasoning_effort_menu.py
@@ -1,24 +1,17 @@
-import sys
-import types
-
-
 from hermes_cli.main import _prompt_reasoning_effort_selection
 
 
-class _FakeTerminalMenu:
-    last_choices = None
-
-    def __init__(self, choices, **kwargs):
-        _FakeTerminalMenu.last_choices = choices
-        self._cursor_index = kwargs.get("cursor_index")
-
-    def show(self):
-        return self._cursor_index
-
-
 def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
-    fake_module = types.SimpleNamespace(TerminalMenu=_FakeTerminalMenu)
-    monkeypatch.setitem(sys.modules, "simple_term_menu", fake_module)
+    captured = {}
+
+    def _fake_single_select(title, items, default_index=0, *, cancel_label="Cancel"):
+        captured["title"] = title
+        captured["items"] = items
+        captured["default_index"] = default_index
+        captured["cancel_label"] = cancel_label
+        return default_index
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_single_select", _fake_single_select)
 
     selected = _prompt_reasoning_effort_selection(
         ["low", "minimal", "medium", "high"],
@@ -26,9 +19,13 @@ def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
     )
 
     assert selected == "medium"
-    assert _FakeTerminalMenu.last_choices[:4] == [
-        "  minimal",
-        "  low",
-        "  medium  ← currently in use",
-        "  high",
+    assert captured["title"] == "Select reasoning effort:"
+    assert captured["items"] == [
+        "minimal",
+        "low",
+        "medium  ← currently in use",
+        "high",
+        "Disable reasoning",
     ]
+    assert captured["default_index"] == 2
+    assert captured["cancel_label"] == "Skip (keep current)"

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -281,6 +281,12 @@ class TestCursesBrowse:
         result = self._run_with_keys(sessions, [curses.KEY_DOWN, 10])
         assert result == sessions[1]["id"]
 
+    def test_raw_escape_down_sequence_selects_second(self):
+        """ESC [ B should navigate down instead of being treated as cancel."""
+        sessions = _make_sessions(3)
+        result = self._run_with_keys(sessions, [27, 91, 66, 10])
+        assert result == sessions[1]["id"]
+
     def test_down_down_enter_selects_third(self):
         import curses
         sessions = _make_sessions(5)


### PR DESCRIPTION
## What changed
- made curses menus translate raw arrow-key escape sequences in addition to `KEY_UP`/`KEY_DOWN`
- switched nested model-selection menus off `simple_term_menu` onto the shared curses menu helpers
- added regression coverage for raw arrow escape sequences and session-browser navigation

## Why
Some terminals were sending arrow keys as raw escape sequences such as `ESC [ B`, so the initial provider picker could appear to work while later model-selection menus treated navigation input incorrectly. This made `hermes model` and related setup flows unreliable.

## Impact
- provider and model selection menus now behave consistently across more terminals
- nested selection flows reuse one input stack instead of mixing curses and `simple_term_menu`
- users can navigate the affected menus with arrow keys without the input being misread as cancel or confirm

## Root cause
The shared menu code only handled `curses.KEY_*` values, and some later pickers still used `simple_term_menu`. In affected terminals that split arrows into escape sequences, the menus interpreted the input incorrectly.

## Validation
- `./.venv/bin/python -m pytest tests/hermes_cli/test_curses_ui_navigation.py tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_setup_prompt_menus.py tests/hermes_cli/test_plugins_cmd.py -q`
