### PR TITLE
fix(gateway): resolve TypeError in suspend_recently_active on startup

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -807,9 +807,7 @@ class SessionStore:
         to avoid resetting long-idle sessions that are harmless to resume.
         Returns the number of sessions that were suspended.
         """
-        import time as _time
-
-        cutoff = _time.time() - max_age_seconds
+        cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
         with self._lock:
             self._ensure_loaded_locked()


### PR DESCRIPTION
## Problem

The `suspend_recently_active()` method in `gateway/session.py` fails on gateway startup with:

```
TypeError: '>=' not supported between instances of 'datetime.datetime' and 'float'
```

This error appears in logs as:
```
WARNING gateway.run: Session suspension on startup failed: '>=' not supported between instances of 'datetime.datetime' and 'float'
```

## Root Cause

Introduced in commit `2d328d5c` (PR #7536). The method calculates `cutoff` using `time.time()` which returns a float, then compares it with `entry.updated_at` which is a `datetime` object:

```python
cutoff = _time.time() - max_age_seconds  # → float
if not entry.suspended and entry.updated_at >= cutoff:  # datetime >= float → TypeError
```

## Fix

Changed the cutoff calculation to use `_now()` and `timedelta`, matching the pattern used elsewhere in the file (e.g., `list_sessions()`):

```python
cutoff = _now() - timedelta(seconds=max_age_seconds)
```

## Verification

- The fix ensures type consistency (both are `datetime` objects)
- Matches the pattern in `list_sessions()` method (line 928)
- Tested locally - no TypeError on gateway restart
- No other similar issues found in the codebase