### PR TITLE
fix(routing): add CJK substring matching for smart model routing

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -45,6 +45,41 @@ _COMPLEX_KEYWORDS = {
     "kubernetes",
 }
 
+# CJK keywords matched via jieba segmentation (word-level, not substring).
+# Chinese/Japanese/Korean text has no word-separating spaces, so the
+# space-based split() above never matches individual CJK keywords.
+_CJK_COMPLEX_KEYWORDS = {
+    # Task/action verbs
+    "帮忙", "帮我", "研究", "分析", "调查", "排查", "检查", "诊断",
+    "实现", "开发", "修复", "修改", "优化", "重构", "设计",
+    # Memory/knowledge
+    "记住", "记得", "记忆", "记录",
+    # Search/lookup
+    "查", "查询", "搜索", "搜一下", "查一下", "看看", "找找", "查查", "找",
+    # Tool-invoking
+    "设置", "配置", "安装", "部署", "定时", "提醒", "闹钟",
+    "下单", "点餐", "外卖", "奶茶",
+    # Technical
+    "终端", "命令", "脚本", "代码", "接口", "api", "API",
+}
+
+# Lazy-init jieba to avoid import cost on every message
+_jieba_loaded = False
+
+
+def _segment_cjk(text: str) -> set:
+    """Segment CJK text into words using jieba, with graceful fallback."""
+    global _jieba_loaded
+    try:
+        import jieba
+        if not _jieba_loaded:
+            jieba.setLogLevel(20)  # suppress "Building prefix dict" noise
+            _jieba_loaded = True
+        return set(jieba.cut(text))
+    except ImportError:
+        # jieba not installed — fall back to empty set (caller uses substring)
+        return set()
+
 _URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
 
 
@@ -96,8 +131,17 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
         return None
 
     lowered = text.lower()
+    # Word-level match for space-delimited languages (English, etc.)
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
     if words & _COMPLEX_KEYWORDS:
+        return None
+    # CJK segmentation-based match — jieba splits Chinese into real words,
+    # so "你研究下" → {"你", "研究", "下"} which matches "研究".
+    cjk_words = _segment_cjk(lowered)
+    if cjk_words and cjk_words & _CJK_COMPLEX_KEYWORDS:
+        return None
+    # Fallback substring match when jieba is not installed
+    if not cjk_words and any(kw in lowered for kw in _CJK_COMPLEX_KEYWORDS):
         return None
 
     route = dict(cheap_model)

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -59,3 +59,50 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+# -- CJK keyword matching tests -----------------------------------------------
+
+
+def test_chinese_simple_greeting_routes_to_cheap():
+    """Simple Chinese greetings should route to the cheap model."""
+    assert choose_cheap_model_route("你好", _BASE_CONFIG) is not None
+    assert choose_cheap_model_route("晚安", _BASE_CONFIG) is not None
+    assert choose_cheap_model_route("谢谢", _BASE_CONFIG) is not None
+
+
+def test_chinese_task_keywords_route_to_strong():
+    """Chinese messages with task/action keywords should route to strong model."""
+    # 帮我 (help me) — task delegation
+    assert choose_cheap_model_route("帮我查一下附近的奶茶店", _BASE_CONFIG) is None
+    # 记住 (remember) — memory operation
+    assert choose_cheap_model_route("记住我喜欢喝红茶玛奇朵", _BASE_CONFIG) is None
+    # 设置 (configure) — tool invocation
+    assert choose_cheap_model_route("帮我设置一个提醒", _BASE_CONFIG) is None
+
+
+def test_chinese_search_keywords_route_to_strong():
+    """Chinese search/lookup keywords should route to strong model."""
+    assert choose_cheap_model_route("搜索最近的天气预报", _BASE_CONFIG) is None
+    assert choose_cheap_model_route("查一下明天的航班", _BASE_CONFIG) is None
+
+
+def test_chinese_technical_keywords_route_to_strong():
+    """Chinese technical keywords should route to strong model."""
+    assert choose_cheap_model_route("分析这个问题的原因", _BASE_CONFIG) is None
+    assert choose_cheap_model_route("研究下这个方案", _BASE_CONFIG) is None
+
+
+def test_english_behavior_unchanged():
+    """English routing should not be affected by CJK additions."""
+    # Simple English still routes cheap
+    assert choose_cheap_model_route("hello", _BASE_CONFIG) is not None
+    assert choose_cheap_model_route("good morning", _BASE_CONFIG) is not None
+    # Complex English still routes strong
+    assert choose_cheap_model_route("debug this error", _BASE_CONFIG) is None
+    assert choose_cheap_model_route("implement a feature", _BASE_CONFIG) is None
+
+
+def test_mixed_cjk_english_with_keyword():
+    """Mixed CJK+English with a complex keyword routes to strong."""
+    assert choose_cheap_model_route("帮我debug这个bug", _BASE_CONFIG) is None


### PR DESCRIPTION
## What does this PR do?

Smart model routing's keyword-based complexity check uses `text.split()` to tokenize messages, then checks for set intersection with `_COMPLEX_KEYWORDS`. This works for English but fails entirely for CJK languages — Chinese, Japanese, and Korean have no word-separating spaces, so `split()` returns the entire message as a single token that never matches individual keywords.

**Result:** All CJK messages are classified as "simple" and always routed to the cheap model, even when they contain task/action keywords like "帮我", "记住", "搜索".

Fix: add a CJK keyword set (`_CJK_COMPLEX_KEYWORDS`) matched via jieba segmentation (with substring fallback when jieba is not installed).

See also: #5714 (complementary — narrows English keyword false positives, while this PR adds CJK support)

## Related Issue

Fixes #8516

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/smart_model_routing.py`:
  - Added `_CJK_COMPLEX_KEYWORDS` set with Chinese task/action/search/tool keywords
  - Added `_segment_cjk()` with lazy-loaded jieba and graceful fallback
  - Added dual matching: jieba word-level for CJK, substring fallback without jieba
- `tests/agent/test_smart_model_routing.py`: Added 6 tests for Chinese greetings, task keywords, search keywords, technical keywords, unchanged English behavior, and mixed CJK+English

## How to Test

| Message | Expected Route |
|---------|---------------|
| 你好 (hello) | cheap |
| 晚安 (good night) | cheap |
| 帮我查一下附近的奶茶店 | strong |
| 记住我喜欢喝红茶玛奇朵 | strong |
| debug this error | strong (unchanged) |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Sequoia), Apple Silicon

### Documentation & Housekeeping

- [x] N/A - no config keys added, existing keyword mechanism extended
- [x] Cross-platform: all platforms affected equally. jieba is optional (substring fallback works without it)