### PR TITLE
feat(cli): support models list in user-defined providers for /model picker

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -304,7 +304,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -407,7 +407,7 @@ def get_running_pid() -> Optional[int]:
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
         remove_pid_file()
         return None
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -917,9 +917,9 @@ def list_authenticated_providers(
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
 
-            models_list = []
-            if default_model:
-                models_list.append(default_model)
+            models_list = list(ep_cfg.get("models", []))
+            if default_model and default_model not in models_list:
+                models_list.insert(0, default_model)
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config
@@ -928,7 +928,7 @@ def list_authenticated_providers(
                 "name": display_name,
                 "is_current": ep_name == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": models_list[:max_models],
                 "total_models": len(models_list) if models_list else 0,
                 "source": "user-config",
                 "api_url": api_url,
@@ -954,17 +954,17 @@ def list_authenticated_providers(
             if slug in seen_slugs:
                 continue
 
-            models_list = []
+            models_list = list(entry.get("models", []))
             default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
+            if default_model and default_model not in models_list:
+                models_list.insert(0, default_model)
 
             results.append({
                 "slug": slug,
                 "name": display_name,
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": models_list[:max_models],
                 "total_models": len(models_list),
                 "source": "user-config",
                 "api_url": api_url,


### PR DESCRIPTION
## What

Support a `models` list field in user-defined providers (`providers:` and `custom_providers:` in config.yaml) so the `/model` interactive picker displays all available models — not just a single `default_model`.

Also fixes a Windows compatibility issue in `gateway/status.py` where `os.kill(pid, 0)` raises `OSError` instead of `ProcessLookupError`, preventing the gateway from starting.

## Why

Users with custom OpenAI-compatible endpoints (self-hosted proxies, LM Studio, Ollama, etc.) that serve multiple models had no way to list them in the `/model` picker. The picker only showed the single `default_model` field, forcing users to remember and type model names manually.

## Changes

**`hermes_cli/model_switch.py`** — `list_authenticated_providers()`:
- Read `models` list from `providers:` entries (section 3) and `custom_providers:` entries (section 4)
- Prepend `default_model`/`model` to the list if not already present (backward compatible)
- Apply `max_models` limit to the displayed list

**`gateway/status.py`** — `acquire_scoped_lock()` and `get_running_pid()`:
- Add `OSError` to the exception tuple for `os.kill(pid, 0)` calls
- On Windows, `os.kill(pid, 0)` raises `OSError: [WinError 87]` instead of `ProcessLookupError`

## Config example

```yaml
providers:
  my-proxy:
    name: "My LLM Proxy"
    api: "http://localhost:8000/v1"
    key_env: "MY_PROXY_KEY"
    default_model: "model-a"
    models:          # NEW — all show up in /model picker
      - model-a
      - model-b
      - model-c
```

## Backward compatibility

Fully backward compatible. Without the `models` field, behavior is identical to before (only `default_model` is shown).

## How to test

1. Add a `providers:` entry in `~/.hermes/config.yaml` with a `models` list
2. Run `hermes` or start the gateway (`hermes gateway run`)
3. Use `/model` — the picker should display all listed models under the provider
4. Select a model — verify the switch works correctly

**Windows gateway fix:**
1. On Windows, start `hermes gateway run`
2. Verify it starts without `OSError: [WinError 87]` on PID file checks

## Platforms tested

- Windows 11 (PowerShell + Git Bash)
- Telegram gateway (interactive model picker verified)