### PR TITLE
fix(gateway): regression causing display.streaming to override root gateway streaming config 

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -9,6 +9,10 @@ Resolution order (first non-None wins):
     3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
     4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
+Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
+top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
+sets an explicit per-platform override.
+
 Backward compatibility: ``display.tool_progress_overrides`` is still read as a
 fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
 config migration (version bump) automatically moves the old format into the new
@@ -143,10 +147,13 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>)
-    val = display_cfg.get(setting)
-    if val is not None:
-        return _normalise(setting, val)
+    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # that key controls only CLI terminal streaming; gateway token streaming is
+    # governed by the top-level streaming config plus per-platform overrides.
+    if setting != "streaming":
+        val = display_cfg.get(setting)
+        if val is not None:
+            return _normalise(setting, val)
 
     # 3. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -332,6 +332,15 @@ class TestStreamingPerPlatform:
         result = resolve_display_setting(config, "telegram", "streaming")
         assert result is None  # caller should check global StreamingConfig
 
+    def test_global_display_streaming_is_cli_only(self):
+        """display.streaming must not act as a gateway streaming override."""
+        from gateway.display_config import resolve_display_setting
+
+        for value in (True, False):
+            config = {"display": {"streaming": value}}
+            assert resolve_display_setting(config, "telegram", "streaming") is None
+            assert resolve_display_setting(config, "discord", "streaming") is None
+
     def test_explicit_false_disables(self):
         """Explicit False disables streaming for that platform."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -527,6 +527,27 @@ async def test_run_agent_streaming_does_not_enable_completed_interim_commentary(
 
 
 @pytest.mark.asyncio
+async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-display-streaming-cli-only",
+        config_data={
+            "display": {
+                "streaming": True,
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+    assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_interim_commentary_works_with_tool_progress_off(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where gateway token streaming could be enabled by the CLI-only `display.streaming` config key.

`display.streaming` is documented as controlling CLI streaming, while gateway streaming should be controlled by the top-level `streaming` config. After the per-platform display resolver was added, global `display.streaming` was treated as a gateway display override, so a config like this could still stream/edit messages in Discord:

```yaml
display:
  streaming: true
streaming:
  enabled: false
```

This PR updates gateway display resolution so:

  - global `display.streaming` is ignored for gateway streaming decisions
  - root `streaming.enabled` / `streaming.transport` remains the gateway default
  - explicit per-platform overrides like `display.platforms.discord.streaming` still work

## Testing

Passed:

`python -m pytest tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer.py -q`

71 passed

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #8338

Note: this is also the reason why so many issues related to streaming are now being opened. Because streaming suddenly got enabled for a lot of people.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Updated `gateway/display_config.py` so global `display.streaming` is treated as CLI-only and no longer overrides the gateway’s top-level `streaming` config.
- Preserved explicit per-platform gateway overrides via `display.platforms.<platform>.streaming`.
- Added resolver coverage in `tests/gateway/test_display_config.py` for ignoring global `display.streaming` in gateway streaming resolution.
- Added gateway behavior coverage in `tests/gateway/test_run_progress_topics.py` for `display.streaming: true` plus `streaming.enabled: false`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

With root gateway streaming disabled:

```yaml
streaming:
  enabled: false
```

Messaging platforms no longer receive progressively edited streamed messages unless they have platform specific overrides. This aligns with the documentation and fixes the regression and the unintended behavior.

Root `display.streaming: true` should only affect the CLI terminal streaming display as per the docs.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

