### PR TITLE
feat(models): add glm-5.1 to zai provider model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -130,6 +130,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemma-4-26b-it",
     ],
     "zai": [
+        "glm-5.1",
         "glm-5",
         "glm-5-turbo",
         "glm-4.7",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -104,7 +104,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
         "gemma-4-31b-it", "gemma-4-26b-it",
     ],
-    "zai": ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],


### PR DESCRIPTION
## Summary
- Adds `glm-5.1` to `_PROVIDER_MODELS` in `hermes_cli/models.py` and `_DEFAULT_PROVIDER_MODELS` in `hermes_cli/setup.py`
- `glm-5.1` is already available on the Z.AI API and listed in `OPENROUTER_MODELS`, but was missing from the direct `zai` provider curated lists, so it didn't appear in the model selector when using `zai` directly

## Test plan
- [ ] Run `hermes model` with `ZAI_API_KEY` set and verify `glm-5.1` appears in the model list
- [ ] Run `/model zai:glm-5.1` and confirm it resolves correctly