### PR TITLE
fix(paths): honor HERMES_HOME fallback in mcp serve

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -65,7 +65,10 @@ def _get_sessions_dir() -> Path:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / "sessions"
     except ImportError:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
+        hermes_home = os.environ.get("HERMES_HOME")
+        if hermes_home:
+            return Path(hermes_home) / "sessions"
+        return Path.home() / ".hermes" / "sessions"
 
 
 def _get_session_db():
@@ -101,9 +104,9 @@ def _load_channel_directory() -> dict:
         from hermes_constants import get_hermes_home
         directory_file = get_hermes_home() / "channel_directory.json"
     except ImportError:
-        directory_file = Path(
-            os.environ.get("HERMES_HOME", Path.home() / ".hermes")
-        ) / "channel_directory.json"
+        hermes_home = os.environ.get("HERMES_HOME")
+        base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
+        directory_file = base_dir / "channel_directory.json"
 
     if not directory_file.exists():
         return {}
@@ -346,7 +349,9 @@ class EventBridge:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"
         except ImportError:
-            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
+            hermes_home = os.environ.get("HERMES_HOME")
+            base_dir = Path(hermes_home) if hermes_home else Path.home() / ".hermes"
+            db_file = base_dir / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -19,8 +19,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
-ENV_FILE = HERMES_HOME / ".env"
+from hermes_constants import get_config_path, get_env_path, get_hermes_home
+
+HERMES_HOME = get_hermes_home()
+ENV_FILE = get_env_path()
+CONFIG_PATH = get_config_path()
 
 OK = "\033[92m\u2713\033[0m"
 FAIL = "\033[91m\u2717\033[0m"
@@ -151,7 +154,7 @@ def check_system_tools():
             if opus_loaded:
                 check("Opus codec", True)
             else:
-                check("Opus codec", False, "brew install opus / apt install libopus0")
+                check("Opus codec", False, "brew install opus")
                 ok = False
         except Exception as e:
             check("Opus codec", False, str(e))
@@ -164,7 +167,7 @@ def check_system_tools():
     if ffmpeg_path:
         check("ffmpeg", True, ffmpeg_path)
     else:
-        check("ffmpeg", False, "brew install ffmpeg / apt install ffmpeg")
+        check("ffmpeg", False, "brew install ffmpeg")
         ok = False
 
     return ok
@@ -235,11 +238,10 @@ def check_config(groq_key, eleven_key):
     """Check hermes config.yaml."""
     section("Configuration")
 
-    config_path = HERMES_HOME / "config.yaml"
-    if config_path.exists():
+    if CONFIG_PATH.exists():
         try:
             import yaml
-            with open(config_path) as f:
+            with open(CONFIG_PATH) as f:
                 cfg = yaml.safe_load(f) or {}
 
             stt_provider = cfg.get("stt", {}).get("provider", "local")

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -229,6 +229,24 @@ class TestHelpers:
         result = _get_sessions_dir()
         assert result == tmp_path / "sessions"
 
+    def test_get_sessions_dir_importerror_prefers_env_over_default(self, tmp_path, monkeypatch):
+        import builtins
+        import mcp_serve
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_constants":
+                raise ImportError("boom")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            result = mcp_serve._get_sessions_dir()
+
+        assert result == tmp_path / "profile-home" / "sessions"
+
     def test_load_sessions_index_empty(self, sessions_dir, monkeypatch):
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
@@ -245,6 +263,28 @@ class TestHelpers:
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
         assert mcp_serve._load_sessions_index() == {}
+
+    def test_load_channel_directory_importerror_prefers_env_over_default(self, tmp_path, monkeypatch):
+        import builtins
+        import mcp_serve
+
+        hermes_home = tmp_path / "profile-home"
+        hermes_home.mkdir()
+        directory_file = hermes_home / "channel_directory.json"
+        directory_file.write_text(json.dumps({"telegram": {"targets": []}}))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_constants":
+                raise ImportError("boom")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            result = mcp_serve._load_channel_directory()
+
+        assert result == {"telegram": {"targets": []}}
 
 
 class TestContentExtraction:
@@ -1040,6 +1080,60 @@ class TestEventBridgePollE2E:
         bridge._poll_once(db)
         assert db.call_count == first_calls, \
             "Second poll should skip DB queries when files unchanged"
+
+    def test_poll_once_importerror_prefers_env_state_db_path(self, tmp_path, monkeypatch):
+        import builtins
+        import mcp_serve
+
+        hermes_home = tmp_path / "profile-home"
+        sessions_dir = hermes_home / "sessions"
+        sessions_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        session_id = "20260329_150000_importerror"
+        sessions_data = {
+            "agent:main:telegram:dm:importerror": {
+                "session_key": "agent:main:telegram:dm:importerror",
+                "session_id": session_id,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": "importerror"},
+            }
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+
+        db_path = hermes_home / "state.db"
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "Hello", "timestamp": "2026-03-29T15:00:01"},
+        ])
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        bridge = mcp_serve.EventBridge()
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_constants":
+                raise ImportError("boom")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            bridge._poll_once(TestDB())
+
+        result = bridge.poll_events(after_cursor=0)
+        assert len(result["events"]) == 1
+        assert result["events"][0]["content"] == "Hello"
 
     def test_poll_detects_new_message_after_db_write(self, tmp_path, monkeypatch):
         """Write a new message to the DB after first poll, verify it's detected."""


### PR DESCRIPTION
## Summary
- fix `mcp_serve.py` fallback paths so they honor `HERMES_HOME` before falling back to `~/.hermes`
- add regression coverage for the `ImportError` fallback paths used by sessions, channel directory, and state DB discovery
- update `scripts/discord-voice-doctor.py` to use shared Hermes path helpers and macOS-native install hints

## Testing
- `source venv/bin/activate && python -m pytest tests/test_mcp_serve.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q` *(fails on pre-existing unrelated suite failures in the current branch, including many gateway/run_agent/plugin tests plus `OSError: [Errno 24] Too many open files`; the targeted regression suite for this patch passes)*
