### PR TITLE
fix: use POST for weixin upload_full_url CDN uploads

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1560,7 +1560,7 @@ class WeixinAdapter(BasePlatformAdapter):
             )
         elif upload_full_url:
             timeout = aiohttp.ClientTimeout(total=120)
-            async with self._session.put(
+            async with self._session.post(
                 upload_full_url,
                 data=ciphertext,
                 headers={"Content-Type": "application/octet-stream"},


### PR DESCRIPTION
Problem
- Hermes personal Weixin text delivery worked, but file/image uploads failed with 404 at the CDN upload step.
- The failure happened when getUploadUrl returned upload_full_url.

Root cause
- The upload_full_url branch in gateway/platforms/weixin.py used HTTP PUT.
- The current Weixin CDN upload endpoint expects POST.

Fix
- Change the upload_full_url branch from self._session.put(...) to self._session.post(...).

Validation
- Text send through personal Weixin: success
- DOCX send through personal Weixin: success
- Online image send through personal Weixin: success