### PR TITLE
fix(registry): unwrap double-wrapped OpenAI tool schemas from plugins

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5846,6 +5846,86 @@ class AIAgent:
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
 
+    def _is_google_api(self) -> bool:
+        """Return True when the base URL targets Google's Gemini API."""
+        return "generativelanguage.googleapis.com" in self._base_url_lower
+
+    @staticmethod
+    def _sanitize_google_schema(schema: dict) -> dict:
+        """Recursively sanitize a JSON Schema dict for Google compatibility.
+
+        Google's Gemini API rejects several JSON Schema features that are
+        valid in OpenAI's tool format:
+          - ``additionalProperties``
+          - ``anyOf`` / ``oneOf`` / ``allOf`` / ``$ref``
+          - ``default`` values on properties
+          - top-level schemas without ``type``
+
+        This method returns a *new* dict with unsupported keys removed and
+        ``type``/``properties`` guaranteed on object schemas.
+        """
+        if not isinstance(schema, dict):
+            return schema
+
+        # Keys that Google's FunctionDeclaration parameters reject.
+        _UNSUPPORTED = {
+            "additionalProperties", "anyOf", "oneOf", "allOf",
+            "$ref", "$schema", "default", "title",
+        }
+
+        cleaned: dict = {}
+        for key, value in schema.items():
+            if key in _UNSUPPORTED:
+                continue
+            if key == "properties" and isinstance(value, dict):
+                cleaned[key] = {
+                    k: AIAgent._sanitize_google_schema(v)
+                    for k, v in value.items()
+                }
+            elif key == "items" and isinstance(value, dict):
+                cleaned[key] = AIAgent._sanitize_google_schema(value)
+            else:
+                cleaned[key] = value
+
+        # Ensure object schemas always have type + properties.
+        if cleaned.get("properties") and "type" not in cleaned:
+            cleaned["type"] = "object"
+        if cleaned.get("type") == "object" and "properties" not in cleaned:
+            cleaned["properties"] = {}
+
+        return cleaned
+
+    def _convert_tools_for_google(self, tools: list) -> list:
+        """Convert OpenAI-format tools to Google-native function declarations.
+
+        Google's ``/v1beta/openai`` endpoint and native API both expect::
+
+            [{"function_declarations": [
+                {"name": "...", "description": "...", "parameters": {...}},
+            ]}]
+
+        The OpenAI wrapper (``{"type": "function", "function": {...}}``) is
+        NOT accepted by Google's protobuf validator — it rejects ``type``
+        and ``function`` as unknown fields on the ``Tool`` message.
+
+        Returns a list suitable for passing via ``extra_body["tools"]``.
+        """
+        if not tools:
+            return []
+        declarations = []
+        for tool in tools:
+            fn = tool.get("function", tool) if isinstance(tool, dict) else {}
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            params = fn.get("parameters", {"type": "object", "properties": {}})
+            declarations.append({
+                "name": name,
+                "description": fn.get("description", ""),
+                "parameters": self._sanitize_google_schema(params),
+            })
+        return [{"function_declarations": declarations}] if declarations else []
+
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""
         return "portal.qwen.ai" in self._base_url_lower
@@ -6086,7 +6166,12 @@ class AIAgent:
                 "sessionId": self.session_id or "hermes",
                 "promptId": str(uuid.uuid4()),
             }
-        if self.tools:
+        # Google's Gemini API rejects OpenAI-format tool wrappers
+        # ({"type": "function", "function": {...}}).  Convert to native
+        # function_declarations and pass via extra_body so the OpenAI SDK
+        # doesn't re-validate the schema.
+        _is_google = self._is_google_api()
+        if self.tools and not _is_google:
             api_kwargs["tools"] = self.tools
 
         if self.max_tokens is not None:
@@ -6166,6 +6251,10 @@ class AIAgent:
 
         if self._is_qwen_portal():
             extra_body["vl_high_resolution_images"] = True
+
+        # Google: pass tools as native function_declarations via extra_body.
+        if _is_google and self.tools:
+            extra_body["tools"] = self._convert_tools_for_google(self.tools)
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body

--- a/run_agent.py
+++ b/run_agent.py
@@ -5846,86 +5846,6 @@ class AIAgent:
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
 
-    def _is_google_api(self) -> bool:
-        """Return True when the base URL targets Google's Gemini API."""
-        return "generativelanguage.googleapis.com" in self._base_url_lower
-
-    @staticmethod
-    def _sanitize_google_schema(schema: dict) -> dict:
-        """Recursively sanitize a JSON Schema dict for Google compatibility.
-
-        Google's Gemini API rejects several JSON Schema features that are
-        valid in OpenAI's tool format:
-          - ``additionalProperties``
-          - ``anyOf`` / ``oneOf`` / ``allOf`` / ``$ref``
-          - ``default`` values on properties
-          - top-level schemas without ``type``
-
-        This method returns a *new* dict with unsupported keys removed and
-        ``type``/``properties`` guaranteed on object schemas.
-        """
-        if not isinstance(schema, dict):
-            return schema
-
-        # Keys that Google's FunctionDeclaration parameters reject.
-        _UNSUPPORTED = {
-            "additionalProperties", "anyOf", "oneOf", "allOf",
-            "$ref", "$schema", "default", "title",
-        }
-
-        cleaned: dict = {}
-        for key, value in schema.items():
-            if key in _UNSUPPORTED:
-                continue
-            if key == "properties" and isinstance(value, dict):
-                cleaned[key] = {
-                    k: AIAgent._sanitize_google_schema(v)
-                    for k, v in value.items()
-                }
-            elif key == "items" and isinstance(value, dict):
-                cleaned[key] = AIAgent._sanitize_google_schema(value)
-            else:
-                cleaned[key] = value
-
-        # Ensure object schemas always have type + properties.
-        if cleaned.get("properties") and "type" not in cleaned:
-            cleaned["type"] = "object"
-        if cleaned.get("type") == "object" and "properties" not in cleaned:
-            cleaned["properties"] = {}
-
-        return cleaned
-
-    def _convert_tools_for_google(self, tools: list) -> list:
-        """Convert OpenAI-format tools to Google-native function declarations.
-
-        Google's ``/v1beta/openai`` endpoint and native API both expect::
-
-            [{"function_declarations": [
-                {"name": "...", "description": "...", "parameters": {...}},
-            ]}]
-
-        The OpenAI wrapper (``{"type": "function", "function": {...}}``) is
-        NOT accepted by Google's protobuf validator — it rejects ``type``
-        and ``function`` as unknown fields on the ``Tool`` message.
-
-        Returns a list suitable for passing via ``extra_body["tools"]``.
-        """
-        if not tools:
-            return []
-        declarations = []
-        for tool in tools:
-            fn = tool.get("function", tool) if isinstance(tool, dict) else {}
-            name = fn.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            params = fn.get("parameters", {"type": "object", "properties": {}})
-            declarations.append({
-                "name": name,
-                "description": fn.get("description", ""),
-                "parameters": self._sanitize_google_schema(params),
-            })
-        return [{"function_declarations": declarations}] if declarations else []
-
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""
         return "portal.qwen.ai" in self._base_url_lower
@@ -6166,12 +6086,7 @@ class AIAgent:
                 "sessionId": self.session_id or "hermes",
                 "promptId": str(uuid.uuid4()),
             }
-        # Google's Gemini API rejects OpenAI-format tool wrappers
-        # ({"type": "function", "function": {...}}).  Convert to native
-        # function_declarations and pass via extra_body so the OpenAI SDK
-        # doesn't re-validate the schema.
-        _is_google = self._is_google_api()
-        if self.tools and not _is_google:
+        if self.tools:
             api_kwargs["tools"] = self.tools
 
         if self.max_tokens is not None:
@@ -6251,10 +6166,6 @@ class AIAgent:
 
         if self._is_qwen_portal():
             extra_body["vl_high_resolution_images"] = True
-
-        # Google: pass tools as native function_declarations via extra_body.
-        if _is_google and self.tools:
-            extra_body["tools"] = self._convert_tools_for_google(self.tools)
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -212,6 +212,168 @@ class TestGeminiAgentInit:
             assert agent.provider == "gemini"
 
 
+# ── Tool Schema Sanitization for Google ──
+
+class TestGeminiToolConversion:
+    """Verify OpenAI-format tools are converted to Google-native format."""
+
+    @pytest.fixture()
+    def agent(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        with patch("run_agent.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from run_agent import AIAgent
+            agent = AIAgent(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                api_key="test-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+        return agent
+
+    def test_is_google_api(self, agent):
+        assert agent._is_google_api()
+
+    def test_is_google_api_false_for_openai(self, agent):
+        agent.base_url = "https://api.openai.com/v1"
+        assert not agent._is_google_api()
+
+    def test_convert_tools_unwraps_openai_format(self, agent):
+        """OpenAI wrapper (type+function) should be stripped for Google."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "File path"},
+                        },
+                        "required": ["path"],
+                    },
+                },
+            }
+        ]
+        result = agent._convert_tools_for_google(tools)
+        assert len(result) == 1
+        assert "function_declarations" in result[0]
+        decls = result[0]["function_declarations"]
+        assert len(decls) == 1
+        assert decls[0]["name"] == "read_file"
+        assert decls[0]["description"] == "Read a file"
+        assert "type" not in result[0]  # no OpenAI wrapper
+        assert "function" not in result[0]  # no OpenAI wrapper
+
+    def test_convert_tools_multiple(self, agent):
+        tools = [
+            {"type": "function", "function": {"name": "tool_a", "description": "A", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "tool_b", "description": "B", "parameters": {"type": "object", "properties": {}}}},
+        ]
+        result = agent._convert_tools_for_google(tools)
+        decls = result[0]["function_declarations"]
+        assert len(decls) == 2
+        assert decls[0]["name"] == "tool_a"
+        assert decls[1]["name"] == "tool_b"
+
+    def test_convert_tools_empty(self, agent):
+        assert agent._convert_tools_for_google([]) == []
+        assert agent._convert_tools_for_google(None) == []
+
+    def test_sanitize_strips_additional_properties(self, agent):
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "additionalProperties": False,
+        }
+        result = agent._sanitize_google_schema(schema)
+        assert "additionalProperties" not in result
+        assert result["type"] == "object"
+        assert result["properties"]["x"]["type"] == "string"
+
+    def test_sanitize_strips_unsupported_keys(self, agent):
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string", "default": "hi", "title": "X"}},
+            "anyOf": [{"type": "string"}],
+            "$ref": "#/defs/Foo",
+        }
+        result = agent._sanitize_google_schema(schema)
+        assert "anyOf" not in result
+        assert "$ref" not in result
+        assert "default" not in result["properties"]["x"]
+        assert "title" not in result["properties"]["x"]
+
+    def test_sanitize_adds_missing_type(self, agent):
+        schema = {"properties": {"a": {"type": "integer"}}}
+        result = agent._sanitize_google_schema(schema)
+        assert result["type"] == "object"
+
+    def test_sanitize_nested_objects(self, agent):
+        schema = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "default": "test"},
+                    },
+                    "additionalProperties": True,
+                },
+            },
+        }
+        result = agent._sanitize_google_schema(schema)
+        nested = result["properties"]["config"]
+        assert "additionalProperties" not in nested
+        assert "default" not in nested["properties"]["name"]
+
+    def test_sanitize_array_items(self, agent):
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string", "default": ""},
+                },
+            },
+        }
+        result = agent._sanitize_google_schema(schema)
+        assert "default" not in result["properties"]["tags"]["items"]
+
+    def test_build_api_kwargs_google_uses_extra_body(self, agent):
+        """For Google endpoints, tools go in extra_body, not top-level tools."""
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run commands",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        agent.max_tokens = None
+        agent.reasoning_config = None
+        agent.request_overrides = None
+        agent.providers_allowed = None
+        agent.providers_ignored = None
+        agent.providers_order = None
+        agent.provider_sort = None
+        agent.provider_require_parameters = False
+        agent.provider_data_collection = None
+        agent._ollama_num_ctx = None
+        msgs = [{"role": "system", "content": "You are helpful."}]
+        kwargs = agent._build_api_kwargs(msgs)
+        # tools should NOT be in top-level kwargs (would fail Google validation)
+        assert "tools" not in kwargs
+        # tools should be in extra_body as Google-native format
+        assert "extra_body" in kwargs
+        google_tools = kwargs["extra_body"]["tools"]
+        assert "function_declarations" in google_tools[0]
+        assert google_tools[0]["function_declarations"][0]["name"] == "terminal"
+
+
 # ── models.dev Integration ──
 
 class TestGeminiModelsDev:

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -214,164 +214,62 @@ class TestGeminiAgentInit:
 
 # ── Tool Schema Sanitization for Google ──
 
-class TestGeminiToolConversion:
-    """Verify OpenAI-format tools are converted to Google-native format."""
+class TestRegistryUnwrapsDoubleWrappedSchemas:
+    """Verify the registry unwraps already-wrapped OpenAI tool schemas."""
 
-    @pytest.fixture()
-    def agent(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
-        with patch("run_agent.OpenAI") as mock_openai:
-            mock_openai.return_value = MagicMock()
-            from run_agent import AIAgent
-            agent = AIAgent(
-                model="gemini-2.5-flash",
-                provider="gemini",
-                api_key="test-key",
-                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
-            )
-        return agent
+    def test_double_wrapped_schema_unwrapped(self):
+        """Plugin schemas already in OpenAI format should not be double-wrapped."""
+        from tools.registry import ToolRegistry
 
-    def test_is_google_api(self, agent):
-        assert agent._is_google_api()
-
-    def test_is_google_api_false_for_openai(self, agent):
-        agent.base_url = "https://api.openai.com/v1"
-        assert not agent._is_google_api()
-
-    def test_convert_tools_unwraps_openai_format(self, agent):
-        """OpenAI wrapper (type+function) should be stripped for Google."""
-        tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "read_file",
-                    "description": "Read a file",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "path": {"type": "string", "description": "File path"},
-                        },
-                        "required": ["path"],
-                    },
-                },
-            }
-        ]
-        result = agent._convert_tools_for_google(tools)
-        assert len(result) == 1
-        assert "function_declarations" in result[0]
-        decls = result[0]["function_declarations"]
-        assert len(decls) == 1
-        assert decls[0]["name"] == "read_file"
-        assert decls[0]["description"] == "Read a file"
-        assert "type" not in result[0]  # no OpenAI wrapper
-        assert "function" not in result[0]  # no OpenAI wrapper
-
-    def test_convert_tools_multiple(self, agent):
-        tools = [
-            {"type": "function", "function": {"name": "tool_a", "description": "A", "parameters": {"type": "object", "properties": {}}}},
-            {"type": "function", "function": {"name": "tool_b", "description": "B", "parameters": {"type": "object", "properties": {}}}},
-        ]
-        result = agent._convert_tools_for_google(tools)
-        decls = result[0]["function_declarations"]
-        assert len(decls) == 2
-        assert decls[0]["name"] == "tool_a"
-        assert decls[1]["name"] == "tool_b"
-
-    def test_convert_tools_empty(self, agent):
-        assert agent._convert_tools_for_google([]) == []
-        assert agent._convert_tools_for_google(None) == []
-
-    def test_sanitize_strips_additional_properties(self, agent):
-        schema = {
-            "type": "object",
-            "properties": {"x": {"type": "string"}},
-            "additionalProperties": False,
-        }
-        result = agent._sanitize_google_schema(schema)
-        assert "additionalProperties" not in result
-        assert result["type"] == "object"
-        assert result["properties"]["x"]["type"] == "string"
-
-    def test_sanitize_strips_unsupported_keys(self, agent):
-        schema = {
-            "type": "object",
-            "properties": {"x": {"type": "string", "default": "hi", "title": "X"}},
-            "anyOf": [{"type": "string"}],
-            "$ref": "#/defs/Foo",
-        }
-        result = agent._sanitize_google_schema(schema)
-        assert "anyOf" not in result
-        assert "$ref" not in result
-        assert "default" not in result["properties"]["x"]
-        assert "title" not in result["properties"]["x"]
-
-    def test_sanitize_adds_missing_type(self, agent):
-        schema = {"properties": {"a": {"type": "integer"}}}
-        result = agent._sanitize_google_schema(schema)
-        assert result["type"] == "object"
-
-    def test_sanitize_nested_objects(self, agent):
-        schema = {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string", "default": "test"},
-                    },
-                    "additionalProperties": True,
-                },
+        reg = ToolRegistry()
+        # Simulate a plugin registering a schema already wrapped in OpenAI format
+        double_wrapped_schema = {
+            "type": "function",
+            "function": {
+                "name": "my_tool",
+                "description": "Does stuff",
+                "parameters": {"type": "object", "properties": {}},
             },
         }
-        result = agent._sanitize_google_schema(schema)
-        nested = result["properties"]["config"]
-        assert "additionalProperties" not in nested
-        assert "default" not in nested["properties"]["name"]
+        reg.register(
+            name="my_tool",
+            toolset="test",
+            schema=double_wrapped_schema,
+            handler=lambda **kw: "ok",
+        )
+        defs = reg.get_definitions(["my_tool"])
+        assert len(defs) == 1
+        tool = defs[0]
+        assert tool["type"] == "function"
+        fn = tool["function"]
+        # Should NOT be double-wrapped
+        assert "function" not in fn
+        assert fn["name"] == "my_tool"
+        assert fn["description"] == "Does stuff"
 
-    def test_sanitize_array_items(self, agent):
-        schema = {
-            "type": "object",
-            "properties": {
-                "tags": {
-                    "type": "array",
-                    "items": {"type": "string", "default": ""},
-                },
-            },
+    def test_raw_schema_still_works(self):
+        """Normal raw schemas should still be wrapped correctly."""
+        from tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        raw_schema = {
+            "name": "raw_tool",
+            "description": "Raw",
+            "parameters": {"type": "object", "properties": {}},
         }
-        result = agent._sanitize_google_schema(schema)
-        assert "default" not in result["properties"]["tags"]["items"]
-
-    def test_build_api_kwargs_google_uses_extra_body(self, agent):
-        """For Google endpoints, tools go in extra_body, not top-level tools."""
-        agent.tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "terminal",
-                    "description": "Run commands",
-                    "parameters": {"type": "object", "properties": {}},
-                },
-            }
-        ]
-        agent.max_tokens = None
-        agent.reasoning_config = None
-        agent.request_overrides = None
-        agent.providers_allowed = None
-        agent.providers_ignored = None
-        agent.providers_order = None
-        agent.provider_sort = None
-        agent.provider_require_parameters = False
-        agent.provider_data_collection = None
-        agent._ollama_num_ctx = None
-        msgs = [{"role": "system", "content": "You are helpful."}]
-        kwargs = agent._build_api_kwargs(msgs)
-        # tools should NOT be in top-level kwargs (would fail Google validation)
-        assert "tools" not in kwargs
-        # tools should be in extra_body as Google-native format
-        assert "extra_body" in kwargs
-        google_tools = kwargs["extra_body"]["tools"]
-        assert "function_declarations" in google_tools[0]
-        assert google_tools[0]["function_declarations"][0]["name"] == "terminal"
+        reg.register(
+            name="raw_tool",
+            toolset="test",
+            schema=raw_schema,
+            handler=lambda **kw: "ok",
+        )
+        defs = reg.get_definitions(["raw_tool"])
+        assert len(defs) == 1
+        tool = defs[0]
+        assert tool["type"] == "function"
+        fn = tool["function"]
+        assert fn["name"] == "raw_tool"
+        assert fn["description"] == "Raw"
 
 
 # ── models.dev Integration ──

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -137,8 +137,12 @@ class ToolRegistry:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue
-            # Ensure schema always has a "name" field — use entry.name as fallback
-            schema_with_name = {**entry.schema, "name": entry.name}
+            # Unwrap if the plugin already provided an OpenAI-wrapped schema
+            # ({"type": "function", "function": {...}}) to prevent double-wrapping.
+            raw = entry.schema
+            if raw.get("type") == "function" and "function" in raw:
+                raw = raw["function"]
+            schema_with_name = {**raw, "name": entry.name}
             result.append({"type": "function", "function": schema_with_name})
         return result
 


### PR DESCRIPTION
## Summary

Fixes the `400 INVALID_ARGUMENT` error when using Gemini models with tool-calling through Google's `/v1beta/openai` endpoint.

**Root cause**: Plugins (e.g. jarvis-bridge) that register tool schemas already in OpenAI format (`{"type": "function", "function": {...}}`) get wrapped **again** by `registry.get_definitions()`, producing double-wrapped tools:

```json
{"type": "function", "function": {"type": "function", "function": {"name": "jarvis_briefing", ...}}}
```

Google's protobuf validator sees `type` and `function` as unknown fields inside the `function` object and rejects them. This affects **any** provider, not just Gemini — but Google's strict validation surfaces the error first.

**Fix**: Detect and unwrap already-wrapped schemas in `registry.get_definitions()` before applying the standard OpenAI wrapper. This is a 4-line defensive fix in the registry that prevents double-wrapping regardless of how plugins format their schemas.

**Previous approach (removed)**: The initial commit added Google-specific tool conversion (`_convert_tools_for_google`, `_sanitize_google_schema`, `extra_body` routing) — this was treating the symptom rather than the cause. That code has been removed.

## Error reproduced

```
Error code: 400 - Invalid JSON payload received.
Unknown name "type" at 'tools[14].function': Cannot find field.
Unknown name "function" at 'tools[14].function': Cannot find field.
```

Tools[0]-[13] (built-in) worked fine. Tools[14]-[18] (from jarvis-bridge plugin) were double-wrapped.

Related: #3236, #4983

## Changes

| File | What changed |
|------|-------------|
| `tools/registry.py` | Unwrap pre-wrapped OpenAI schemas before wrapping (4 lines) |
| `run_agent.py` | Removed `_is_google_api()`, `_sanitize_google_schema()`, `_convert_tools_for_google()`, and `extra_body` tool routing |
| `tests/hermes_cli/test_gemini_provider.py` | Replaced 11 Google conversion tests with 2 registry unwrap tests |

## Test plan

- [x] All 44 tests pass (40 existing + 2 new + 2 agent init)
- [x] Manual test: `hermes chat --provider gemini --model gemini-2.5-flash` — no more 400 error
- [x] Existing tests unaffected — non-plugin tools still wrapped correctly