### PR TITLE
feat(cron): wake ticker immediately on trigger_job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -550,11 +550,11 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Schedule a job to run on the next scheduler tick."""
+    """Schedule a job to run immediately by waking the ticker."""
     job = get_job(job_id)
     if not job:
         return None
-    return update_job(
+    result = update_job(
         job_id,
         {
             "enabled": True,
@@ -564,6 +564,13 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "next_run_at": _hermes_now().isoformat(),
         },
     )
+    if result:
+        try:
+            from cron.scheduler import wake
+            wake()
+        except Exception:
+            pass
+    return result
 
 
 def remove_job(job_id: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -38,6 +39,14 @@ from hermes_cli.config import load_config
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+_wake_event = threading.Event()
+
+
+def wake():
+    """Signal the background ticker to process due jobs immediately."""
+    _wake_event.set()
+
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8534,7 +8534,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     Also refreshes the channel directory every 5 minutes and prunes the
     image/audio/document cache once per hour.
     """
-    from cron.scheduler import tick as cron_tick
+    from cron.scheduler import tick as cron_tick, _wake_event
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -8571,7 +8571,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
 
-        stop_event.wait(timeout=interval)
+        for _ in range(interval):
+            if stop_event.is_set():
+                break
+            if _wake_event.wait(timeout=1):
+                _wake_event.clear()
+                break
     logger.info("Cron ticker stopped")
 
 


### PR DESCRIPTION
## Summary

- Add a `threading.Event` wake mechanism to the cron scheduler so that `trigger_job()` (the "Run Now" API) wakes the ticker thread immediately instead of waiting up to 60 seconds for the next polling cycle.
- `scheduler.py`: new module-level `_wake_event` and `wake()` function
- `jobs.py`: `trigger_job()` calls `wake()` after updating `next_run_at`
- `run.py`: ticker sleep changed from `stop_event.wait(60)` to a 1-second polling loop that checks both `stop_event` and `_wake_event`

Normal scheduled job behavior is unaffected. The file lock in `tick()` still prevents concurrent execution.

## Test plan

- [ ] Create a cron job via API, call `POST /api/jobs/{id}/run`, verify the job executes within ~1 second (previously up to 60s)
- [ ] Verify normal interval/cron jobs still fire on schedule
- [ ] Verify gateway shutdown (`stop_event.set()`) still stops the ticker cleanly
- [ ] Verify concurrent `trigger_job()` calls don't cause duplicate execution (file lock)


Made with [Cursor](https://cursor.com)