### PR TITLE
fix(windows): cross-platform compatibility for cli, gateway, and memory_tool

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1065,8 +1065,18 @@ def _cprint(text: str):
     Raw ANSI escapes written via print() are swallowed by patch_stdout's
     StdoutProxy.  Routing through print_formatted_text(ANSI(...)) lets
     prompt_toolkit parse the escapes and render real colors.
+
+    Falls back to plain print() on Windows non-native consoles (e.g. Git Bash /
+    mintty) where Win32 console APIs are unavailable.
     """
-    _pt_print(_PT_ANSI(text))
+    try:
+        _pt_print(_PT_ANSI(text))
+    except Exception:
+        # Git Bash / mintty on Windows: no Win32 console screen buffer.
+        # Strip ANSI escapes for clean output, or keep them if terminal supports it.
+        import re as _re
+        plain = _re.sub(r'\x1b\[[0-9;]*m', '', text)
+        print(plain)
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -306,6 +306,9 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 os.kill(existing_pid, 0)
             except (ProcessLookupError, PermissionError):
                 stale = True
+            except OSError:
+                # Windows: os.kill(pid, 0) raises OSError for non-existent PIDs
+                stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
                 if (
@@ -408,6 +411,10 @@ def get_running_pid() -> Optional[int]:
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
     except (ProcessLookupError, PermissionError):
+        remove_pid_file()
+        return None
+    except OSError:
+        # Windows: os.kill(pid, 0) raises OSError for non-existent PIDs
         remove_pid_file()
         return None
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
+import sys
 import json
 import logging
 import os
@@ -146,10 +146,23 @@ class MemoryStore:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = open(lock_path, "w")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if sys.platform == "win32":
+                import msvcrt
+                msvcrt.locking(fd.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_EX)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if sys.platform == "win32":
+                try:
+                    import msvcrt
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_UN)
             fd.close()
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

Fixes three Windows-specific failures that prevent Hermes from running on Windows 11 (Git Bash / native CMD / PowerShell). Each fix is minimal and non-breaking on Linux/macOS.

## Related Issue

Fixes #<!-- windows compat tracking issue if any -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`cli.py`** — `_cprint()`: wraps `_pt_print(_PT_ANSI(...))` in a try/except; on Git Bash / mintty where Win32 console screen buffer APIs are unavailable, falls back to `print()` with ANSI escapes stripped
- **`gateway/status.py`** — `acquire_scoped_lock()` and `get_running_pid()`: `os.kill(pid, 0)` raises `OSError` (not `ProcessLookupError`) on Windows for non-existent PIDs; adds `except OSError: stale = True` in both callsites so stale lock files are cleaned up instead of blocking gateway startup
- **`tools/memory_tool.py`** — `MemoryStore._lock()`: replaces Unix-only `fcntl.flock()` with cross-platform logic — `msvcrt.locking()` on `sys.platform == "win32"`, `fcntl.flock()` everywhere else; `import fcntl` moved inside the else-branch so it no longer raises `ModuleNotFoundError` on import

## How to Test

1. Run Hermes on Windows 11 (Git Bash or native CMD):
   ```
   hermes -q "hello"
   ```
   - Before: crash on `_cprint` / `fcntl` import / gateway stale-lock handling
   - After: clean startup and response

2. Kill a Hermes process mid-session, restart — gateway should detect stale PID and recover instead of refusing to start.

3. `pytest tests/ -q --ignore=tests/hermes_cli/test_gateway_service.py` — all pass (test_gateway_service.py has a pre-existing Unix-only `pwd` import unrelated to this PR)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` (excluding pre-existing broken test) — all pass
- [x] Tested on: **Windows 11 Pro (Git Bash + native CMD)**

### Documentation & Housekeeping

- [x] N/A — no config keys or architecture changes
- [x] Cross-platform impact considered ✓ (this PR IS the cross-platform fix)

## Screenshots / Logs

Tested locally on Windows 11 Pro 10.0.26220. The three fixes together allow `hermes -q "hello"` to complete a full turn without crashing.