### PR TITLE
feat(plugins): add on_approval_request and on_task_complete hooks with sound_alerts plugin

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -63,6 +63,8 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "on_approval_request",
+    "on_task_complete",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/plugins/sound_alerts/__init__.py
+++ b/plugins/sound_alerts/__init__.py
@@ -1,0 +1,151 @@
+"""
+Sound Alerts Plugin
+
+Plays TTS audio notifications when:
+1. An approval request is triggered (dangerous command)
+2. A task completes
+
+Uses Edge TTS for audio generation and system audio players for playback.
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default voice — can be overridden via HERMES_SOUND_ALERTS_VOICE env var
+DEFAULT_VOICE = "zh-CN-XiaoyiNeural"
+DEFAULT_APPROVAL_TEXT = "注意！有一个操作需要你的审批。"
+DEFAULT_COMPLETE_TEXT = "任务已完成。"
+
+# Lock to prevent overlapping audio playback
+_play_lock = threading.Lock()
+
+
+def _get_voice() -> str:
+    """Get the TTS voice from config or environment."""
+    return os.environ.get("HERMES_SOUND_ALERTS_VOICE", DEFAULT_VOICE)
+
+
+def _get_approval_text() -> str:
+    """Get the approval alert text."""
+    return os.environ.get("HERMES_SOUND_ALERTS_APPROVAL_TEXT", DEFAULT_APPROVAL_TEXT)
+
+
+def _get_complete_text() -> str:
+    """Get the task complete alert text."""
+    return os.environ.get("HERMES_SOUND_ALERTS_COMPLETE_TEXT", DEFAULT_COMPLETE_TEXT)
+
+
+def _get_audio_player() -> list[str] | None:
+    """Detect the system audio player command."""
+    system = platform.system()
+    if system == "Darwin":
+        if shutil.which("afplay"):
+            return ["afplay"]
+    elif system == "Linux":
+        # Try common Linux audio players
+        for player in ["ffplay", "paplay", "aplay", "mpv", "cvlc"]:
+            if shutil.which(player):
+                if player == "ffplay":
+                    return ["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet"]
+                elif player == "mpv":
+                    return ["mpv", "--no-video", "--really-quiet"]
+                elif player == "cvlc":
+                    return ["cvlc", "--play-and-exit", "--quiet"]
+                return [player]
+    elif system == "Windows":
+        # PowerShell can play audio
+        return ["powershell", "-c", "(New-Object Media.SoundPlayer '{}').PlaySync()"]
+    return None
+
+
+def _generate_tts(text: str, voice: str) -> str | None:
+    """Generate TTS audio using edge-tts. Returns path to audio file or None."""
+    try:
+        import edge_tts
+        import asyncio
+
+        output_path = os.path.join(
+            tempfile.gettempdir(),
+            f"hermes_sound_alert_{os.getpid()}_{threading.get_ident()}.mp3",
+        )
+
+        async def _generate():
+            communicate = edge_tts.Communicate(text, voice)
+            await communicate.save(output_path)
+
+        asyncio.run(_generate())
+
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+            return output_path
+    except Exception as e:
+        logger.debug("TTS generation failed: %s", e)
+    return None
+
+
+def _play_audio(file_path: str) -> None:
+    """Play an audio file using the system audio player."""
+    player_cmd = _get_audio_player()
+    if player_cmd is None:
+        logger.debug("No audio player found on this system")
+        return
+
+    try:
+        if platform.system() == "Windows":
+            # Windows: replace placeholder with actual path
+            cmd = [part.format(file_path) if '{}' in part else part for part in player_cmd]
+        else:
+            cmd = player_cmd + [file_path]
+
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=10,
+        )
+    except Exception as e:
+        logger.debug("Audio playback failed: %s", e)
+    finally:
+        # Clean up temp file
+        try:
+            os.unlink(file_path)
+        except OSError:
+            pass
+
+
+def _play_alert(text: str) -> None:
+    """Generate TTS and play audio alert in a background thread."""
+
+    def _worker():
+        with _play_lock:
+            voice = _get_voice()
+            audio_path = _generate_tts(text, voice)
+            if audio_path:
+                _play_audio(audio_path)
+
+    # Run in background so we don't block the hook caller
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+
+
+def on_approval_request(**kwargs: Any) -> None:
+    """Hook callback: play alert sound when approval is requested."""
+    _play_alert(_get_approval_text())
+
+
+def on_task_complete(**kwargs: Any) -> None:
+    """Hook callback: play alert sound when a task completes."""
+    _play_alert(_get_complete_text())
+
+
+def register(ctx) -> None:
+    """Plugin entry point — register hooks."""
+    ctx.register_hook("on_approval_request", on_approval_request)
+    ctx.register_hook("on_task_complete", on_task_complete)
+    logger.info("sound_alerts plugin registered")

--- a/plugins/sound_alerts/__init__.py
+++ b/plugins/sound_alerts/__init__.py
@@ -15,7 +15,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
-from typing import Any
+from typing import Any, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def _get_complete_text() -> str:
     return os.environ.get("HERMES_SOUND_ALERTS_COMPLETE_TEXT", DEFAULT_COMPLETE_TEXT)
 
 
-def _get_audio_player() -> list[str] | None:
+def _get_audio_player() -> Optional[List[str]]:
     """Detect the system audio player command."""
     system = platform.system()
     if system == "Darwin":
@@ -66,7 +66,7 @@ def _get_audio_player() -> list[str] | None:
     return None
 
 
-def _generate_tts(text: str, voice: str) -> str | None:
+def _generate_tts(text: str, voice: str) -> Optional[str]:
     """Generate TTS audio using edge-tts. Returns path to audio file or None."""
     try:
         import edge_tts
@@ -106,7 +106,9 @@ def _play_audio(file_path: str) -> None:
 
         subprocess.run(
             cmd,
-            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             timeout=10,
         )
     except Exception as e:

--- a/plugins/sound_alerts/plugin.yaml
+++ b/plugins/sound_alerts/plugin.yaml
@@ -1,0 +1,7 @@
+name: sound_alerts
+version: 1.0.0
+description: "TTS sound alerts for approval requests and task completion. Plays audio notifications when the agent needs permission or finishes a task."
+requires_env: []
+hooks:
+  - on_approval_request
+  - on_task_complete

--- a/run_agent.py
+++ b/run_agent.py
@@ -10191,6 +10191,23 @@ class AIAgent:
             except Exception as exc:
                 logger.warning("post_llm_call hook failed: %s", exc)
 
+        # Plugin hook: on_task_complete
+        # Fired when the agent finishes a task (completed normally).
+        # Plugins can use this to notify the user (e.g. play a sound).
+        if completed and final_response:
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_task_complete",
+                    session_id=self.session_id,
+                    user_message=original_user_message,
+                    assistant_response=final_response,
+                    api_calls=api_call_count,
+                    platform=getattr(self, "platform", None) or "",
+                )
+            except Exception as exc:
+                logger.warning("on_task_complete hook failed: %s", exc)
+
         # Extract reasoning from the last assistant message (if any)
         last_reasoning = None
         for msg in reversed(messages):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -815,6 +815,19 @@ def check_all_command_guards(command: str, env_type: str,
 
             # Notify the user (bridges sync agent thread → async gateway)
             try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_approval_request",
+                    command=command,
+                    description=combined_desc,
+                    pattern_key=primary_key,
+                    pattern_keys=all_keys,
+                    platform="gateway",
+                    session_key=session_key,
+                )
+            except Exception:
+                pass
+            try:
                 notify_cb(approval_data)
             except Exception as exc:
                 logger.warning("Gateway approval notify failed: %s", exc)
@@ -892,6 +905,19 @@ def check_all_command_guards(command: str, env_type: str,
 
     # CLI interactive: single combined prompt
     # Hide [a]lways when any tirith warning is present
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_approval_request",
+            command=command,
+            description=combined_desc,
+            pattern_key=primary_key,
+            pattern_keys=all_keys,
+            platform="cli",
+            session_key=session_key,
+        )
+    except Exception:
+        pass
     choice = prompt_dangerous_approval(command, combined_desc,
                                        allow_permanent=not has_tirith,
                                        approval_callback=approval_callback)


### PR DESCRIPTION
## Summary

Add two new lifecycle hooks to the plugin system and a built-in `sound_alerts` plugin that plays TTS audio notifications.

### New Hooks

| Hook | When Fired | Key Params |
|------|-----------|------------|
| `on_approval_request` | Dangerous command triggers approval (CLI + gateway) | `command`, `description`, `platform` |
| `on_task_complete` | Agent finishes a task (completed normally) | `session_id`, `assistant_response`, `api_calls` |

### sound_alerts Plugin

Plays TTS audio when these hooks fire:
- **Approval alert**: 注意！有一个操作需要你的审批。 
- **Task complete alert**: 任务已完成。

Features:
- Uses Edge TTS (free, no API key needed)
- Cross-platform audio playback: macOS (afplay), Linux (ffplay/paplay/aplay), Windows (PowerShell)
- Non-blocking (background thread)
- Thread-safe (lock prevents overlapping playback)
- Configurable via env vars:
  - `HERMES_SOUND_ALERTS_VOICE` — TTS voice (default: zh-CN-XiaoyiNeural)
  - `HERMES_SOUND_ALERTS_APPROVAL_TEXT` — custom approval text
  - `HERMES_SOUND_ALERTS_COMPLETE_TEXT` — custom completion text

### Files Changed

| File | Change |
|------|--------|
| `hermes_cli/plugins.py` | +2 — add hooks to `VALID_HOOKS` |
| `tools/approval.py` | +26 — invoke `on_approval_request` in CLI + gateway paths |
| `run_agent.py` | +17 — invoke `on_task_complete` after `post_llm_call` |
| `plugins/sound_alerts/plugin.yaml` | new — plugin manifest |
| `plugins/sound_alerts/__init__.py` | new — plugin implementation |

### Why Built-in Plugin?

Since edge-tts is already a dependency of Hermes, the plugin has zero additional dependencies. Users just need to drop it in `~/.hermes/plugins/sound_alerts/` to enable it, or we could consider making it an opt-in default.