### PR TITLE
fix: store custom provider API keys in .env instead of config.yaml

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -276,7 +276,8 @@ def prefetch_update_check():
 
 def get_update_result(timeout: float = 0.5) -> Optional[int]:
     """Get result of prefetched check. Returns None if not ready."""
-    _update_check_done.wait(timeout=timeout)
+    if not _update_check_done.wait(timeout=timeout):
+        return None
     return _update_result
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2427,7 +2427,10 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 new_entry = {"api": old_url}
                 if old_name:
                     new_entry["name"] = old_name
-                if old_key and old_key not in ("no-key", "no-key-required", ""):
+                old_key_env = entry.get("api_key_env", "")
+                if old_key_env:
+                    new_entry["api_key_env"] = old_key_env
+                elif old_key and old_key not in ("no-key", "no-key-required", ""):
                     new_entry["api_key"] = old_key
 
                 # Carry over model and api_mode if present

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -306,7 +306,8 @@ def _has_any_provider_configured() -> bool:
         cfg_provider = (model_cfg.get("provider") or "").strip()
         cfg_base_url = (model_cfg.get("base_url") or "").strip()
         cfg_api_key = (model_cfg.get("api_key") or "").strip()
-        if cfg_provider or cfg_base_url or cfg_api_key:
+        cfg_api_key_env = (model_cfg.get("api_key_env") or "").strip()
+        if cfg_provider or cfg_base_url or cfg_api_key or cfg_api_key_env:
             return True
 
     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
@@ -1478,6 +1479,7 @@ def select_provider_and_model(args=None):
                 "base_url": base_url,
                 "api_key": entry.get("api_key", ""),
                 "key_env": entry.get("key_env", ""),
+                "api_key_env": entry.get("api_key_env", ""),
                 "model": entry.get("model", ""),
                 "api_mode": entry.get("api_mode", ""),
                 "provider_key": provider_key,
@@ -2466,7 +2468,7 @@ def _model_flow_custom(config):
     so it appears in the provider menu on subsequent runs.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import get_env_value, load_config, save_config
+    from hermes_cli.config import get_env_value, load_config, save_config, save_env_value
 
     current_url = get_env_value("OPENAI_BASE_URL") or ""
     current_key = get_env_value("OPENAI_API_KEY") or ""
@@ -2619,7 +2621,10 @@ def _model_flow_custom(config):
         model["provider"] = "custom"
         model["base_url"] = effective_url
         if effective_key:
-            model["api_key"] = effective_key
+            env_var = _custom_provider_env_var(effective_url)
+            save_env_value(env_var, effective_key)
+            model["api_key_env"] = env_var
+            model.pop("api_key", None)
         model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()
@@ -2642,7 +2647,10 @@ def _model_flow_custom(config):
         _caller_model["provider"] = "custom"
         _caller_model["base_url"] = effective_url
         if effective_key:
-            _caller_model["api_key"] = effective_key
+            env_var = _custom_provider_env_var(effective_url)
+            save_env_value(env_var, effective_key)
+            _caller_model["api_key_env"] = env_var
+            _caller_model.pop("api_key", None)
         _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
@@ -2678,6 +2686,19 @@ def _auto_provider_name(base_url: str) -> str:
     return name
 
 
+def _custom_provider_env_var(base_url: str) -> str:
+    """Derive a deterministic env-var name from a custom provider URL."""
+    import re
+
+    clean = base_url.replace("https://", "").replace("http://", "").rstrip("/")
+    clean = re.sub(r"/v1/?$", "", clean)
+    hostname = clean.split("/")[0].split(":")[0]
+    sanitized = re.sub(r"[^A-Za-z0-9]", "_", hostname).strip("_").upper()
+    if not sanitized:
+        sanitized = "ENDPOINT"
+    return f"CUSTOM_{sanitized}_API_KEY"
+
+
 def _save_custom_provider(
     base_url, api_key="", model="", context_length=None, name=None
 ):
@@ -2686,8 +2707,9 @@ def _save_custom_provider(
     Deduplicates by base_url — if the URL already exists, updates the
     model name and context_length but doesn't add a duplicate entry.
     Uses *name* when provided, otherwise auto-generates from the URL.
+    API keys are stored in .env via an environment variable reference.
     """
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, save_config, save_env_value
 
     cfg = load_config()
     providers = cfg.get("custom_providers") or []
@@ -2710,6 +2732,12 @@ def _save_custom_provider(
                 models_cfg[model] = {"context_length": context_length}
                 entry["models"] = models_cfg
                 changed = True
+            # Migrate legacy api_key to api_key_env
+            if entry.get("api_key"):
+                env_var = _custom_provider_env_var(base_url)
+                save_env_value(env_var, entry.pop("api_key"))
+                entry["api_key_env"] = env_var
+                changed = True
             if changed:
                 cfg["custom_providers"] = providers
                 save_config(cfg)
@@ -2721,7 +2749,9 @@ def _save_custom_provider(
 
     entry = {"name": name, "base_url": base_url}
     if api_key:
-        entry["api_key"] = api_key
+        env_var = _custom_provider_env_var(base_url)
+        save_env_value(env_var, api_key)
+        entry["api_key_env"] = env_var
     if model:
         entry["model"] = model
     if model and context_length:
@@ -2805,13 +2835,14 @@ def _model_flow_named_custom(config, provider_info):
     Falls back to the saved model if probing fails.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import get_env_value, load_config, save_config
     from hermes_cli.models import fetch_api_models
 
     name = provider_info["name"]
     base_url = provider_info["base_url"]
-    api_key = provider_info.get("api_key", "")
+    api_key_env = provider_info.get("api_key_env", "")
     key_env = provider_info.get("key_env", "")
+    api_key = (get_env_value(api_key_env) if api_key_env else "") or (get_env_value(key_env) if key_env else "") or provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
 
@@ -2907,8 +2938,15 @@ def _model_flow_named_custom(config, provider_info):
     else:
         model["provider"] = "custom"
         model["base_url"] = base_url
-        if api_key:
-            model["api_key"] = api_key
+        if api_key_env:
+            model["api_key_env"] = api_key_env
+            model.pop("api_key", None)
+        elif api_key:
+            env_var = _custom_provider_env_var(base_url)
+            from hermes_cli.config import save_env_value
+            save_env_value(env_var, api_key)
+            model["api_key_env"] = env_var
+            model.pop("api_key", None)
     # Apply api_mode from custom_providers entry, or clear stale value
     custom_api_mode = provider_info.get("api_mode", "")
     if custom_api_mode:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -372,10 +372,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         provider_menu_key = f"custom:{provider_key_norm}" if provider_key_norm else ""
         if requested_norm not in {name_norm, menu_key, provider_key_norm, provider_menu_key}:
             continue
+        _env_ref = str(entry.get("api_key_env", "") or "").strip()
+        _resolved_key = os.getenv(_env_ref, "") if _env_ref else str(entry.get("api_key", "") or "").strip()
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": _resolved_key,
         }
         key_env = str(entry.get("key_env", "") or "").strip()
         if key_env:
@@ -420,9 +422,11 @@ def _resolve_named_custom_runtime(
             pool_result["model"] = model_name
         return pool_result
 
+    _cp_env_ref = str(custom_provider.get("api_key_env", "") or "").strip()
+    _cp_key = os.getenv(_cp_env_ref, "") if _cp_env_ref else str(custom_provider.get("api_key", "") or "").strip()
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        _cp_key,
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
@@ -455,11 +459,16 @@ def _resolve_openrouter_runtime(
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
     cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
     cfg_api_key = ""
-    for k in ("api_key", "api"):
-        v = model_cfg.get(k)
-        if isinstance(v, str) and v.strip():
-            cfg_api_key = v.strip()
-            break
+    # Prefer api_key_env (env-var reference) over inline api_key for security
+    _api_key_env = model_cfg.get("api_key_env")
+    if isinstance(_api_key_env, str) and _api_key_env.strip():
+        cfg_api_key = os.getenv(_api_key_env.strip(), "")
+    if not cfg_api_key:
+        for k in ("api_key", "api"):
+            v = model_cfg.get(k)
+            if isinstance(v, str) and v.strip():
+                cfg_api_key = v.strip()
+                break
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
 

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -341,6 +341,9 @@ class TestMinimaxSwitchModelCredentialGuard:
             agent._client_kwargs = {}
             agent.client = None
             agent._anthropic_client = MagicMock()
+            agent._fallback_chain = []
+            agent._fallback_activated = False
+            agent._fallback_index = 0
 
         with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build, \
              patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-leaked") as mock_resolve, \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,6 +274,22 @@ def _hermetic_environment(tmp_path, monkeypatch):
     except Exception:
         pass
 
+    # 6. Reset gateway session contextvars. Unsetting HERMES_SESSION_* env
+    #    vars (step 2) isn't enough — gateway.session_context holds per-task
+    #    ContextVars that override os.environ. Tests that call
+    #    set_session_vars() or clear_session_vars() leak state into later
+    #    tests on the same xdist worker (same thread/context), causing
+    #    get_session_env("HERMES_SESSION_PLATFORM") to return the stale
+    #    contextvar value even when the test sets HERMES_SESSION_PLATFORM
+    #    via monkeypatch.setenv. Reset to the _UNSET sentinel so subsequent
+    #    lookups fall through to os.environ.
+    try:
+        from gateway.session_context import _VAR_MAP, _UNSET
+        for _var in _VAR_MAP.values():
+            _var.set(_UNSET)
+    except Exception:
+        pass
+
 
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1237,9 +1237,10 @@ class TestMatrixUploadAndSend:
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            result = await adapter._upload_and_send(
+                "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
+            )
 
         assert result.success is True
         # Should have uploaded ciphertext, not plaintext

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -27,6 +27,8 @@ def _clean_anthropic_env(monkeypatch):
 
 def test_returns_false_when_no_config(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
     (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
 
     from hermes_cli.auth import is_provider_explicitly_configured
@@ -55,6 +57,8 @@ def test_returns_true_when_config_provider_matches(tmp_path, monkeypatch):
 
 def test_returns_false_when_config_provider_is_different(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
     _write_config(tmp_path, {"model": {"provider": "kimi-coding", "default": "kimi-k2"}})
     _write_auth_store(tmp_path, {
         "version": 1,
@@ -78,6 +82,8 @@ def test_returns_true_when_anthropic_env_var_set(tmp_path, monkeypatch):
 def test_claude_code_oauth_token_does_not_count_as_explicit(tmp_path, monkeypatch):
     """CLAUDE_CODE_OAUTH_TOKEN is set by Claude Code, not the user — must not gate."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-auto-token")
     (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
 

--- a/tests/run_agent/test_real_interrupt_subagent.py
+++ b/tests/run_agent/test_real_interrupt_subagent.py
@@ -85,102 +85,107 @@ class TestRealSubagentInterrupt(unittest.TestCase):
         result_holder = [None]
         error_holder = [None]
 
-        def run_delegate():
-            try:
-                # Patch the OpenAI client creation inside AIAgent.__init__
-                with patch('run_agent.OpenAI') as MockOpenAI:
-                    mock_client = MagicMock()
-                    # API call takes 5 seconds — should be interrupted before that
-                    mock_client.chat.completions.create = _make_slow_api_response(delay=5.0)
-                    mock_client.close = MagicMock()
-                    MockOpenAI.return_value = mock_client
+        # Manage patches on the main thread so daemon-thread termination
+        # cannot leak class-level mocks into subsequent test modules.
+        mock_openai_patcher = patch('run_agent.OpenAI')
+        mock_prompt_patcher = patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent")
+        original_run = AIAgent.run_conversation
 
-                    # Patch the instance method so it skips prompt assembly
-                    with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"):
-                        # Signal when child starts
-                        original_run = AIAgent.run_conversation
+        def patched_run(self_agent, *args, **kwargs):
+            child_started.set()
+            return original_run(self_agent, *args, **kwargs)
 
-                        def patched_run(self_agent, *args, **kwargs):
-                            child_started.set()
-                            return original_run(self_agent, *args, **kwargs)
+        mock_run_patcher = patch.object(AIAgent, 'run_conversation', patched_run)
 
-                        with patch.object(AIAgent, 'run_conversation', patched_run):
-                            # Build a real child agent (AIAgent is NOT patched here,
-                            # only run_conversation and _build_system_prompt are)
-                            child = AIAgent(
-                                base_url="http://localhost:1",
-                                api_key="test-key",
-                                model="test/model",
-                                provider="test",
-                                api_mode="chat_completions",
-                                max_iterations=5,
-                                enabled_toolsets=["terminal"],
-                                quiet_mode=True,
-                                skip_context_files=True,
-                                skip_memory=True,
-                                platform="cli",
-                            )
-                            child._delegate_depth = 1
-                            parent._active_children.append(child)
-                            result = _run_single_child(
-                                task_index=0,
-                                goal="Test task",
-                                child=child,
-                                parent_agent=parent,
-                            )
-                            result_holder[0] = result
-            except Exception as e:
-                import traceback
-                traceback.print_exc()
-                error_holder[0] = e
+        MockOpenAI = mock_openai_patcher.start()
+        mock_prompt_patcher.start()
+        mock_run_patcher.start()
+        try:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = _make_slow_api_response(delay=5.0)
+            mock_client.close = MagicMock()
+            MockOpenAI.return_value = mock_client
 
-        agent_thread = threading.Thread(target=run_delegate, daemon=True)
-        agent_thread.start()
+            def run_delegate():
+                try:
+                    child = AIAgent(
+                        base_url="http://localhost:1",
+                        api_key="test-key",
+                        model="test/model",
+                        provider="test",
+                        api_mode="chat_completions",
+                        max_iterations=5,
+                        enabled_toolsets=["terminal"],
+                        quiet_mode=True,
+                        skip_context_files=True,
+                        skip_memory=True,
+                        platform="cli",
+                    )
+                    child._delegate_depth = 1
+                    parent._active_children.append(child)
+                    result = _run_single_child(
+                        task_index=0,
+                        goal="Test task",
+                        child=child,
+                        parent_agent=parent,
+                    )
+                    result_holder[0] = result
+                except Exception as e:
+                    import traceback
+                    traceback.print_exc()
+                    error_holder[0] = e
 
-        # Wait for child to start run_conversation
-        started = child_started.wait(timeout=10)
-        if not started:
-            agent_thread.join(timeout=1)
+            agent_thread = threading.Thread(target=run_delegate, daemon=True)
+            agent_thread.start()
+
+            # Wait for child to start run_conversation
+            started = child_started.wait(timeout=10)
+            if not started:
+                agent_thread.join(timeout=1)
+                if error_holder[0]:
+                    raise error_holder[0]
+                self.fail("Child never started run_conversation")
+
+            # Give child time to enter main loop and start API call
+            time.sleep(0.5)
+
+            # Verify child is registered
+            print(f"Active children: {len(parent._active_children)}")
+            self.assertGreaterEqual(len(parent._active_children), 1,
+                                    "Child not registered in _active_children")
+
+            # Interrupt! (simulating what CLI does)
+            start = time.monotonic()
+            parent.interrupt("User typed a new message")
+
+            # Check propagation
+            child = parent._active_children[0] if parent._active_children else None
+            if child:
+                print(f"Child._interrupt_requested after parent.interrupt(): {child._interrupt_requested}")
+                self.assertTrue(child._interrupt_requested,
+                               "Interrupt did not propagate to child!")
+
+            # Wait for delegate to finish (should be fast since interrupted)
+            agent_thread.join(timeout=5)
+            elapsed = time.monotonic() - start
+
             if error_holder[0]:
                 raise error_holder[0]
-            self.fail("Child never started run_conversation")
 
-        # Give child time to enter main loop and start API call
-        time.sleep(0.5)
+            result = result_holder[0]
+            self.assertIsNotNone(result, "Delegate returned no result")
+            print(f"Result status: {result['status']}, elapsed: {elapsed:.2f}s")
+            print(f"Full result: {result}")
 
-        # Verify child is registered
-        print(f"Active children: {len(parent._active_children)}")
-        self.assertGreaterEqual(len(parent._active_children), 1,
-                                "Child not registered in _active_children")
-
-        # Interrupt! (simulating what CLI does)
-        start = time.monotonic()
-        parent.interrupt("User typed a new message")
-
-        # Check propagation
-        child = parent._active_children[0] if parent._active_children else None
-        if child:
-            print(f"Child._interrupt_requested after parent.interrupt(): {child._interrupt_requested}")
-            self.assertTrue(child._interrupt_requested,
-                           "Interrupt did not propagate to child!")
-
-        # Wait for delegate to finish (should be fast since interrupted)
-        agent_thread.join(timeout=5)
-        elapsed = time.monotonic() - start
-
-        if error_holder[0]:
-            raise error_holder[0]
-
-        result = result_holder[0]
-        self.assertIsNotNone(result, "Delegate returned no result")
-        print(f"Result status: {result['status']}, elapsed: {elapsed:.2f}s")
-        print(f"Full result: {result}")
-
-        # The child should have been interrupted, not completed the full 5s API call
-        self.assertLess(elapsed, 3.0,
-                       f"Took {elapsed:.2f}s — interrupt was not detected quickly enough")
-        self.assertEqual(result["status"], "interrupted",
-                        f"Expected 'interrupted', got '{result['status']}'")
+            # The child should have been interrupted, not completed the full 5s API call
+            self.assertLess(elapsed, 3.0,
+                           f"Took {elapsed:.2f}s — interrupt was not detected quickly enough")
+            self.assertEqual(result["status"], "interrupted",
+                            f"Expected 'interrupted', got '{result['status']}'")
+        finally:
+            mock_run_patcher.stop()
+            mock_prompt_patcher.stop()
+            mock_openai_patcher.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -35,6 +35,15 @@ def _reset_logging_state():
             h.close()
         else:
             pre_existing.append(h)
+    # Reset child logger levels that AIAgent(quiet_mode=True) or
+    # setup_logging() may have set in the same xdist worker process.
+    _LOGGERS_TO_RESET = (
+        *hermes_logging._NOISY_LOGGERS,
+        "tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli",
+    )
+    saved_levels = {name: logging.getLogger(name).level for name in _LOGGERS_TO_RESET}
+    for name in _LOGGERS_TO_RESET:
+        logging.getLogger(name).setLevel(logging.NOTSET)
     # Ensure the record factory is installed (it's idempotent).
     hermes_logging._install_session_record_factory()
     yield
@@ -43,6 +52,8 @@ def _reset_logging_state():
         if h not in pre_existing:
             root.removeHandler(h)
             h.close()
+    for name, lvl in saved_levels.items():
+        logging.getLogger(name).setLevel(lvl)
     hermes_logging._logging_initialized = False
     hermes_logging.clear_session_context()
 


### PR DESCRIPTION
## Summary

Fixes #8316 — custom providers stored API keys directly in `config.yaml`, unlike standard providers which use environment variables via `.env`.

- Adds `_custom_provider_env_var()` to derive a deterministic env var name from the provider URL (e.g. `CUSTOM_API_SILICONFLOW_CN_API_KEY`)
- `_save_custom_provider()` now stores an `api_key_env` reference in config.yaml and saves the actual key to `.env` via `save_env_value()`
- `_model_flow_custom()` and `_model_flow_named_custom()` updated to use `api_key_env` instead of inline `api_key`
- `runtime_provider.py` resolves `api_key_env` from environment at runtime
- Backward compatible: falls back to reading `api_key` if `api_key_env` is not present, and migrates legacy entries on next save

## Test plan

- Add a custom provider via `hermes model` and verify API key appears in `~/.hermes/.env` (not `config.yaml`)
- Verify `config.yaml` contains `api_key_env: CUSTOM_<HOST>_API_KEY` instead of `api_key: <raw_key>`
- Verify existing custom providers with inline `api_key` still work (backward compatibility)
- Verify existing custom providers get migrated to `api_key_env` on next save