### PR TITLE
fix: preserve venv python symlink when remapping paths for system service

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -752,13 +752,18 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
       /root/.hermes/hermes-agent  -> /home/alice/.hermes/hermes-agent
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
-    current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    current_home = Path.home()
+    # Use normpath/abspath instead of resolve() so that symlinks are NOT
+    # followed.  venv/bin/python is typically a symlink to the real Python
+    # interpreter (e.g. /usr/bin/python3.11); resolve() would make the path
+    # appear to live outside the home directory and return the system Python
+    # instead of preserving the venv path.
+    normalized = Path(os.path.normpath(os.path.abspath(path)))
     try:
-        relative = resolved.relative_to(current_home)
+        relative = normalized.relative_to(current_home)
         return str(Path(target_home_dir) / relative)
     except ValueError:
-        return str(resolved)
+        return str(normalized)
 
 
 def _hermes_home_for_target_user(target_home_dir: str) -> str:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -968,6 +968,29 @@ class TestRemapPathForUser:
         result = gateway_cli._remap_path_for_user(original, str(tmp_path / "alice"))
         assert result == original
 
+    def test_does_not_follow_symlinks(self, monkeypatch, tmp_path):
+        """venv/bin/python is a symlink to the system Python; the symlink path
+        itself (which lives under the home dir) must be remapped, not the
+        symlink target (which lives under /usr/bin and would be kept as-is)."""
+        root_home = tmp_path / "root"
+        venv_bin = root_home / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        system_python = tmp_path / "usr" / "bin" / "python3"
+        system_python.parent.mkdir(parents=True)
+        system_python.write_text("")
+        # Simulate the venv python symlink pointing to system python
+        (venv_bin / "python").symlink_to(system_python)
+
+        monkeypatch.setattr(Path, "home", lambda: root_home)
+
+        result = gateway_cli._remap_path_for_user(
+            str(venv_bin / "python"),
+            str(tmp_path / "alice"),
+        )
+        # Should remap the symlink path to alice's home, NOT follow to system python
+        assert result == str(tmp_path / "alice" / ".venv" / "bin" / "python")
+        assert str(system_python) != result
+
 
 class TestSystemUnitPathRemapping:
     """System units must remap ALL paths from the caller's home to the target user."""


### PR DESCRIPTION
## Problem

When installing a system-scoped systemd service that runs as a specific user
(`hermes gateway install --system --run-as-user alice`), the generated unit's
`ExecStart` ends up pointing at the **system Python** instead of the
virtualenv Python. The service therefore cannot import any packages installed
in the venv and fails at runtime.

The bug was introduced in commit 8dd738c, which added `_remap_path_for_user()`
and called it from `generate_systemd_unit()` when `system=True`:

```python
# system=True branch
python_path = _remap_path_for_user(python_path, home_dir)
```

`home_dir` here is the **target user's** home directory resolved by
`_system_service_identity(run_as_user)` — e.g. `/home/alice` when the caller
is root. The intent is correct: remap venv/project paths that currently point
into root's home so the generated unit uses equivalent paths under alice's home.
The implementation, however, has a subtle flaw with symlinks.

## Root cause

`_remap_path_for_user()` calls `Path.resolve()` to normalise the path before
checking whether it lives under the current user's home:

```python
current_home = Path.home().resolve()
resolved = Path(path).resolve()   # ← follows symlinks
try:
    relative = resolved.relative_to(current_home)
    return str(Path(target_home_dir) / relative)
except ValueError:
    return str(resolved)          # ← returns symlink target unchanged
```

In every standard virtualenv, `venv/bin/python` is a **symlink** to the real
interpreter (e.g. `/usr/bin/python3.11`). `.resolve()` silently dereferences it:

```
/root/.venv/bin/python  →(resolve)→  /usr/bin/python3.11
```

`/usr/bin/python3.11` is not under `/root`, so `relative_to()` raises
`ValueError` and the function returns the resolved system-Python path as-is.

The generated unit becomes:

```ini
; wrong — system Python, not the venv
ExecStart=/usr/bin/python3.11 -m hermes_cli.main gateway run --replace
```

instead of:

```ini
; correct — alice's venv Python
ExecStart=/home/alice/.venv/bin/python -m hermes_cli.main gateway run --replace
```

The existing test in `TestSystemUnitPathRemapping` missed this because it
creates the venv python with `.write_text("")` (a real file, not a symlink),
so `.resolve()` was a no-op in that test.

## Fix

Replace `Path.resolve()` with `os.path.normpath(os.path.abspath())`, which
normalises the path (collapses `..`, makes it absolute) **without following
symlinks**. Also align `current_home` to use `Path.home()` without `.resolve()`
so both sides of `relative_to()` are consistently non-dereferenced:

```python
current_home = Path.home()
# normpath/abspath normalises without following symlinks.
# venv/bin/python is a symlink to the real interpreter; resolve() would make
# it appear to live outside the home dir and return the system Python instead.
normalized = Path(os.path.normpath(os.path.abspath(path)))
try:
    relative = normalized.relative_to(current_home)
    return str(Path(target_home_dir) / relative)
except ValueError:
    return str(normalized)
```

## Test

Added `TestRemapPathForUser::test_does_not_follow_symlinks`: creates a real
symlink (`venv/bin/python → <tmp>/usr/bin/python3`) and asserts that the
remapped result is the target user's venv path, not the symlink target.

## Checklist

- [x] Root cause identified
- [x] Minimal fix (2 lines changed in `_remap_path_for_user`)
- [x] Regression test added with an actual symlink
- [x] All 63 existing `test_gateway_service` tests still pass