### PR TITLE
fix(install): bootstrap pip when missing from venv on Ubuntu 25.10+

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -775,6 +775,25 @@ setup_venv() {
 
         "$PYTHON_PATH" -m venv venv
         log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+
+        # On some systems (Ubuntu 25.10+, Debian trixie) python3 -m venv
+        # creates a venv without pip.  Bootstrap it via ensurepip if missing.
+        if ! ./venv/bin/python -m pip --version >/dev/null 2>&1; then
+            log_info "pip not found in venv — bootstrapping via ensurepip..."
+            if ./venv/bin/python -m ensurepip --upgrade >/dev/null 2>&1; then
+                log_success "pip bootstrapped successfully"
+            else
+                log_warn "ensurepip failed — trying get-pip.py fallback..."
+                if command -v curl >/dev/null 2>&1; then
+                    curl -fsSL https://bootstrap.pypa.io/get-pip.py | ./venv/bin/python
+                elif command -v wget >/dev/null 2>&1; then
+                    wget -qO- https://bootstrap.pypa.io/get-pip.py | ./venv/bin/python
+                else
+                    log_error "Cannot bootstrap pip: neither ensurepip nor curl/wget available."
+                    exit 1
+                fi
+            fi
+        fi
         return 0
     fi
 
@@ -789,6 +808,26 @@ setup_venv() {
     $UV_CMD venv venv --python "$PYTHON_VERSION"
 
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+
+    # On some systems (Ubuntu 25.10+, Debian trixie) the venv may be created
+    # without pip even when using uv.  Bootstrap it via ensurepip if missing
+    # so subsequent pip-based steps do not fail with "No module named pip".
+    if ! ./venv/bin/python -m pip --version >/dev/null 2>&1; then
+        log_info "pip not found in venv — bootstrapping via ensurepip..."
+        if ./venv/bin/python -m ensurepip --upgrade >/dev/null 2>&1; then
+            log_success "pip bootstrapped successfully"
+        else
+            log_warn "ensurepip failed — trying get-pip.py fallback..."
+            if command -v curl >/dev/null 2>&1; then
+                curl -fsSL https://bootstrap.pypa.io/get-pip.py | ./venv/bin/python
+            elif command -v wget >/dev/null 2>&1; then
+                wget -qO- https://bootstrap.pypa.io/get-pip.py | ./venv/bin/python
+            else
+                log_error "Cannot bootstrap pip: neither ensurepip nor curl/wget available."
+                exit 1
+            fi
+        fi
+    fi
 }
 
 install_deps() {


### PR DESCRIPTION
## Problem

Closes #3002

On Ubuntu 25.10, Debian trixie and similar systems, python3 -m venv and uv venv may create a virtual environment without pip, causing the installer to fail with No module named pip.

## Fix

After venv creation in both the Termux and uv paths, check if pip is available. If not, bootstrap it in order:
1. ensurepip --upgrade (stdlib, preferred)
2. get-pip.py via curl
3. get-pip.py via wget
4. Fatal error if none available

This matches the workaround documented by users in the issue thread, but automated and integrated into the install flow.