### PR TITLE
fix: suppress stale response when session interrupted by new message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1619,7 +1619,25 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
-            
+
+            # Suppress stale responses from interrupted sessions.  If a new
+            # message arrived while the handler was running (or during
+            # post-processing) AND the handler did not consume it, the
+            # response we hold is for the OLD turn.  Sending it would cause
+            # the user to see a duplicate/stale reply followed by the real
+            # reply for the newer message.  (#8221)
+            if (
+                response
+                and interrupt_event.is_set()
+                and session_key in self._pending_messages
+            ):
+                logger.info(
+                    "[%s] Suppressing stale response for interrupted session %s",
+                    self.name,
+                    session_key,
+                )
+                response = None
+
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
             # when the message was queued behind an active agent.  Log at

--- a/tests/gateway/test_interrupt_stale_suppression.py
+++ b/tests/gateway/test_interrupt_stale_suppression.py
@@ -122,21 +122,29 @@ class TestStaleResponseSuppression:
         session_key = "telegram:user:789"
         event = _make_event("describe this", chat_id="789")
 
+        call_count = 0
+
         async def handler(ev):
-            # Photo burst queued (no interrupt set)
-            photo_event = MessageEvent(
-                text="",
-                message_type=MessageType.PHOTO,
-                source=MagicMock(
-                    chat_id="789",
-                    platform=Platform.TELEGRAM,
-                    thread_id=None,
-                ),
-                message_id="p1",
-            )
-            adapter._pending_messages[session_key] = photo_event
-            # interrupt_event is NOT set (photo bursts don't interrupt)
-            return "here is the description"
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Photo burst queued (no interrupt set)
+                photo_event = MessageEvent(
+                    text="",
+                    message_type=MessageType.PHOTO,
+                    source=MagicMock(
+                        chat_id="789",
+                        platform=Platform.TELEGRAM,
+                        thread_id=None,
+                        user_id="u1",
+                    ),
+                    message_id="p1",
+                )
+                adapter._pending_messages[session_key] = photo_event
+                # interrupt_event is NOT set (photo bursts don't interrupt)
+                return "here is the description"
+            # Recursive call for the queued photo — just return None
+            return None
 
         adapter.set_message_handler(handler)
         adapter._active_sessions[session_key] = asyncio.Event()

--- a/tests/gateway/test_interrupt_stale_suppression.py
+++ b/tests/gateway/test_interrupt_stale_suppression.py
@@ -1,0 +1,170 @@
+"""Tests for stale response suppression when a session is interrupted.
+
+When a new message arrives while the agent is processing (or just finished
+processing) a previous message, the old response should be suppressed so
+the user doesn't see a duplicate/stale reply.  (#8221)
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    PlatformConfig,
+    Platform,
+    SendResult,
+)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal adapter wired for interrupt-suppression tests."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent_messages: list[str] = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent_messages.append(content)
+        return SendResult(success=True, message_id="msg-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _make_event(text: str, chat_id: str = "123") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=MagicMock(
+            chat_id=chat_id,
+            platform=Platform.TELEGRAM,
+            thread_id=None,
+            user_id="u1",
+        ),
+        message_id="m1",
+    )
+
+
+class TestStaleResponseSuppression:
+    """Verify _process_message_background suppresses stale responses."""
+
+    @pytest.mark.asyncio
+    async def test_stale_response_suppressed_when_interrupt_pending(self):
+        """If the handler returns a response but the interrupt event is set
+        and a pending message exists, the response must be suppressed."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:123"
+        event_a = _make_event("message A")
+
+        async def fake_handler(event):
+            # Simulate interrupt arriving during handler execution:
+            # store a pending message and set the interrupt event.
+            adapter._pending_messages[session_key] = _make_event("message B")
+            adapter._active_sessions[session_key].set()
+            return "stale response for A"
+
+        adapter.set_message_handler(fake_handler)
+
+        # _process_message_background will process the pending message
+        # recursively, so we also need a handler for that round.
+        call_count = 0
+        original_handler = fake_handler
+
+        async def counting_handler(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return await original_handler(event)
+            # Second call (pending message) — return a normal response
+            return "response for B"
+
+        adapter.set_message_handler(counting_handler)
+
+        await adapter._process_message_background(event_a, session_key)
+
+        # The stale "response for A" must NOT have been sent.
+        assert "stale response for A" not in adapter.sent_messages
+        # The response for B should have been sent.
+        assert "response for B" in adapter.sent_messages
+
+    @pytest.mark.asyncio
+    async def test_response_sent_when_no_interrupt(self):
+        """Normal case: no interrupt → response is sent."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:456"
+        event = _make_event("hello", chat_id="456")
+
+        async def handler(ev):
+            return "normal response"
+
+        adapter.set_message_handler(handler)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter._process_message_background(event, session_key)
+
+        assert "normal response" in adapter.sent_messages
+
+    @pytest.mark.asyncio
+    async def test_response_sent_when_photo_burst_queued(self):
+        """Photo bursts queue without setting interrupt — response must
+        still be sent."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:789"
+        event = _make_event("describe this", chat_id="789")
+
+        async def handler(ev):
+            # Photo burst queued (no interrupt set)
+            photo_event = MessageEvent(
+                text="",
+                message_type=MessageType.PHOTO,
+                source=MagicMock(
+                    chat_id="789",
+                    platform=Platform.TELEGRAM,
+                    thread_id=None,
+                ),
+                message_id="p1",
+            )
+            adapter._pending_messages[session_key] = photo_event
+            # interrupt_event is NOT set (photo bursts don't interrupt)
+            return "here is the description"
+
+        adapter.set_message_handler(handler)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter._process_message_background(event, session_key)
+
+        assert "here is the description" in adapter.sent_messages
+
+    @pytest.mark.asyncio
+    async def test_interrupt_event_set_but_no_pending_sends_response(self):
+        """If the interrupt event is set but _run_agent already consumed
+        the pending message, the response should still be sent (it's the
+        response for the NEW message from the recursive call)."""
+        adapter = _StubAdapter()
+        session_key = "telegram:user:111"
+        event = _make_event("message A", chat_id="111")
+
+        async def handler(ev):
+            # Simulate _run_agent handling the interrupt: it sets the
+            # interrupt event during processing but consumes the pending
+            # message.  The response returned is for the NEW message.
+            adapter._active_sessions[session_key].set()
+            # No pending message left — _run_agent consumed it
+            return "response for new message"
+
+        adapter.set_message_handler(handler)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        await adapter._process_message_background(event, session_key)
+
+        assert "response for new message" in adapter.sent_messages

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -4,6 +4,15 @@ import json
 import os
 import pytest
 
+_ANTHROPIC_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+
+
+@pytest.fixture(autouse=True)
+def _clean_anthropic_env(monkeypatch):
+    """Prevent CI env vars from leaking into provider-detection tests."""
+    for var in _ANTHROPIC_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 def _write_config(tmp_path, config: dict) -> None:
     hermes_home = tmp_path / "hermes"

--- a/tests/run_agent/test_dict_tool_call_args.py
+++ b/tests/run_agent/test_dict_tool_call_args.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 
 def _tool_call(name: str, arguments):
@@ -20,13 +21,14 @@ def _response_with_tool_call(arguments):
     return SimpleNamespace(choices=[choice], usage=None)
 
 
-class _FakeChatCompletions:
-    def __init__(self):
-        self.calls = 0
+_shared_calls = 0
 
+
+class _FakeChatCompletions:
     def create(self, **kwargs):
-        self.calls += 1
-        if self.calls == 1:
+        global _shared_calls
+        _shared_calls += 1
+        if _shared_calls == 1:
             return _response_with_tool_call({"path": "README.md"})
         return SimpleNamespace(
             choices=[
@@ -39,15 +41,19 @@ class _FakeChatCompletions:
         )
 
 
-class _FakeClient:
-    def __init__(self):
+class _FakeClient(Mock):
+    def __init__(self, **kwargs):
+        super().__init__()
         self.chat = SimpleNamespace(completions=_FakeChatCompletions())
 
 
 def test_tool_call_validation_accepts_dict_arguments(monkeypatch):
+    global _shared_calls
+    _shared_calls = 0
+
     from run_agent import AIAgent
 
-    monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: _FakeClient())
+    monkeypatch.setattr("run_agent.OpenAI", _FakeClient)
     monkeypatch.setattr(
         "run_agent.get_tool_definitions",
         lambda *args, **kwargs: [{"function": {"name": "read_file"}}],

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -35,6 +35,13 @@ def _reset_logging_state():
             h.close()
         else:
             pre_existing.append(h)
+    # Reset child logger levels that other test modules in the same xdist
+    # worker may have changed (e.g. cli.py sets "tools" to ERROR).  Without
+    # this, propagated records can be silently dropped.
+    _LOGGERS_TO_RESET = ("tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli")
+    saved_levels = {name: logging.getLogger(name).level for name in _LOGGERS_TO_RESET}
+    for name in _LOGGERS_TO_RESET:
+        logging.getLogger(name).setLevel(logging.NOTSET)
     # Ensure the record factory is installed (it's idempotent).
     hermes_logging._install_session_record_factory()
     yield
@@ -43,6 +50,8 @@ def _reset_logging_state():
         if h not in pre_existing:
             root.removeHandler(h)
             h.close()
+    for name, lvl in saved_levels.items():
+        logging.getLogger(name).setLevel(lvl)
     hermes_logging._logging_initialized = False
     hermes_logging.clear_session_context()
 


### PR DESCRIPTION
## Summary

- Fixes duplicate/stale replies on Telegram when a new message arrives while the previous response is about to be sent
- Adds an interrupt check in `_process_message_background` after the message handler returns and before sending: if `interrupt_event.is_set()` **and** a pending message exists in `_pending_messages`, the old response is suppressed
- Photo bursts (which queue without setting the interrupt event) are unaffected

Closes #8221

## Test plan

- [x] New test: stale response suppressed when interrupt + pending message present
- [x] New test: normal response sent when no interrupt
- [x] New test: response sent when photo burst queued (no interrupt)
- [x] New test: response sent when interrupt set but pending already consumed
- [x] Existing `test_queue_consumption.py` tests still pass