### PR TITLE
fix(feishu): correct Feishu identity model and enable multi-account routing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -84,26 +84,25 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
 
     if deliver == "origin":
         if origin:
-            return {
+            target = {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
+            if origin.get("account_id"):
+                target["account_id"] = origin.get("account_id")
+            return target
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in ("matrix", "telegram", "discord", "slack", "bluebubbles"):
-            chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
-            if chat_id:
+        for platform_name in ("matrix", "telegram", "discord", "slack", "bluebubbles", "feishu"):
+            target = _resolve_home_delivery_target(platform_name, origin=None)
+            if target:
                 logger.info(
                     "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
                     job.get("name", job.get("id", "?")),
                     platform_name,
                 )
-                return {
-                    "platform": platform_name,
-                    "chat_id": chat_id,
-                    "thread_id": None,
-                }
+                return target
         return None
 
     if ":" in deliver:
@@ -131,31 +130,113 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         except Exception:
             pass
 
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
         }
+        if origin and origin.get("platform") == platform_name and origin.get("account_id"):
+            target["account_id"] = origin.get("account_id")
+        return target
 
     platform_name = deliver
     if origin and origin.get("platform") == platform_name:
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),
             "thread_id": origin.get("thread_id"),
         }
+        if origin.get("account_id"):
+            target["account_id"] = origin.get("account_id")
+        return target
 
     if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
         return None
-    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
-    if not chat_id:
-        return None
+    return _resolve_home_delivery_target(platform_name, origin=origin)
 
-    return {
-        "platform": platform_name,
-        "chat_id": chat_id,
-        "thread_id": None,
-    }
+
+def _resolve_home_delivery_target(platform_name: str, origin: dict | None) -> Optional[dict]:
+    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+    if chat_id:
+        return {
+            "platform": platform_name,
+            "chat_id": chat_id,
+            "thread_id": None,
+        }
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        platform_enum = Platform(platform_name.lower())
+        account_id = None
+        if origin and origin.get("platform") == platform_name and origin.get("account_id"):
+            account_id = origin.get("account_id")
+        home = _resolve_home_channel(config, platform_enum, account_id=account_id)
+        if home and getattr(home, "chat_id", None):
+            target = {
+                "platform": platform_name,
+                "chat_id": str(home.chat_id),
+                "thread_id": None,
+            }
+            resolved_account_id = getattr(home, "account_id", None) or account_id
+            if resolved_account_id:
+                target["account_id"] = resolved_account_id
+            return target
+    except Exception:
+        logger.debug("Failed to resolve config-backed home channel for deliver=%s", platform_name, exc_info=True)
+
+    return None
+
+
+def _get_config_callable(config, name):
+    """Return a real config helper method, ignoring MagicMock auto-attributes."""
+    try:
+        instance_attr = vars(config).get(name)
+    except Exception:
+        instance_attr = None
+    if callable(instance_attr):
+        return instance_attr
+
+    class_attr = getattr(type(config), name, None)
+    if callable(class_attr):
+        return getattr(config, name)
+    return None
+
+
+def _resolve_platform_config(config, platform, account_id=None):
+    """Support both GatewayConfig and lightweight test doubles."""
+    getter = _get_config_callable(config, "get_platform_config")
+    if getter:
+        try:
+            return getter(platform, account_id=account_id)
+        except TypeError:
+            return getter(platform)
+
+    platforms = getattr(config, "platforms", {}) or {}
+    return platforms.get(platform)
+
+
+def _resolve_home_channel(config, platform, account_id=None):
+    """Support both GatewayConfig and lightweight test doubles."""
+    getter = _get_config_callable(config, "get_home_channel")
+    if getter:
+        try:
+            return getter(platform, account_id=account_id)
+        except TypeError:
+            return getter(platform)
+    return None
+
+
+def _lookup_runtime_adapter(adapters, account_adapters, platform, account_id=None):
+    """Resolve the best live adapter for a delivery target."""
+    if account_id and account_adapters:
+        adapter = account_adapters.get((platform, account_id))
+        if adapter is not None:
+            return adapter
+    if adapters:
+        return adapters.get(platform)
+    return None
 
 
 # Media extension sets — keep in sync with gateway/platforms/base.py:_process_message_background
@@ -196,7 +277,7 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(job: dict, content: str, adapters=None, account_adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target (origin chat, specific platform, etc.).
 
@@ -218,6 +299,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     platform_name = target["platform"]
     chat_id = target["chat_id"]
     thread_id = target.get("thread_id")
+    account_id = target.get("account_id")
 
     # Diagnostic: log thread_id for topic-aware delivery debugging
     origin = job.get("origin") or {}
@@ -268,7 +350,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.error("Job '%s': %s", job["id"], msg)
         return msg
 
-    pconfig = config.platforms.get(platform)
+    pconfig = _resolve_platform_config(config, platform, account_id=account_id)
     if not pconfig or not pconfig.enabled:
         msg = f"platform '{platform_name}' not configured/enabled"
         logger.warning("Job '%s': %s", job["id"], msg)
@@ -301,7 +383,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Prefer the live adapter when the gateway is running — this supports E2EE
     # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
-    runtime_adapter = (adapters or {}).get(platform)
+    runtime_adapter = _lookup_runtime_adapter(adapters, account_adapters, platform, account_id=account_id)
     if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
         send_metadata = {"thread_id": thread_id} if thread_id else None
         try:
@@ -607,6 +689,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["HERMES_SESSION_CHAT_ID"] = str(origin["chat_id"])
             if origin.get("chat_name"):
                 os.environ["HERMES_SESSION_CHAT_NAME"] = origin["chat_name"]
+            if origin.get("account_id"):
+                os.environ["HERMES_SESSION_ACCOUNT_ID"] = str(origin["account_id"])
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
@@ -621,6 +705,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
             if delivery_target.get("thread_id") is not None:
                 os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+            if delivery_target.get("account_id"):
+                os.environ["HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID"] = str(delivery_target["account_id"])
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -878,9 +964,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "HERMES_SESSION_PLATFORM",
             "HERMES_SESSION_CHAT_ID",
             "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_ACCOUNT_ID",
             "HERMES_CRON_AUTO_DELIVER_PLATFORM",
             "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
             "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+            "HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID",
         ):
             os.environ.pop(key, None)
         if _session_db:
@@ -894,7 +982,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
 
 
-def tick(verbose: bool = True, adapters=None, loop=None) -> int:
+def tick(verbose: bool = True, adapters=None, account_adapters=None, loop=None) -> int:
     """
     Check and run all due jobs.
     
@@ -962,7 +1050,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 delivery_error = None
                 if should_deliver:
                     try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                        delivery_error = _deliver_result(
+                            job,
+                            deliver_content,
+                            adapters=adapters,
+                            account_adapters=account_adapters,
+                            loop=loop,
+                        )
                     except Exception as de:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -79,13 +79,17 @@ class HomeChannel:
     platform: Platform
     chat_id: str
     name: str  # Human-readable name for display
+    account_id: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        payload = {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
             "name": self.name,
         }
+        if self.account_id:
+            payload["account_id"] = self.account_id
+        return payload
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
@@ -93,6 +97,7 @@ class HomeChannel:
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
             name=data.get("name", "Home"),
+            account_id=str(data["account_id"]).strip() if data.get("account_id") else None,
         )
 
 
@@ -175,6 +180,16 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
+        extra = data.get("extra", {})
+        if not isinstance(extra, dict):
+            extra = {}
+        # Preserve unknown top-level keys inside ``extra`` so platform-specific
+        # schemas can evolve without forcing a core dataclass change first.
+        extra = dict(extra)
+        for key, value in data.items():
+            if key in {"enabled", "token", "api_key", "home_channel", "reply_to_mode", "extra"}:
+                continue
+            extra[key] = value
         
         return cls(
             enabled=data.get("enabled", False),
@@ -182,7 +197,7 @@ class PlatformConfig:
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 
@@ -261,7 +276,13 @@ class GatewayConfig:
         """Return list of platforms that are enabled and configured."""
         connected = []
         for platform, config in self.platforms.items():
-            if not config.enabled:
+            has_feishu_accounts = (
+                platform == Platform.FEISHU
+                and isinstance(config.extra, dict)
+                and isinstance(config.extra.get("accounts", {}), dict)
+                and bool(config.extra.get("accounts"))
+            )
+            if not config.enabled and not has_feishu_accounts:
                 continue
             # Weixin requires both a token and an account_id
             if platform == Platform.WEIXIN:
@@ -290,7 +311,13 @@ class GatewayConfig:
             elif platform == Platform.WEBHOOK:
                 connected.append(platform)
             # Feishu uses extra dict for app credentials
-            elif platform == Platform.FEISHU and config.extra.get("app_id"):
+            elif platform == Platform.FEISHU and (
+                config.extra.get("app_id")
+                or any(
+                    isinstance(account_cfg, dict) and account_cfg.get("app_id")
+                    for account_cfg in (config.extra.get("accounts", {}) or {}).values()
+                )
+            ):
                 connected.append(platform)
             # WeCom bot mode uses extra dict for bot credentials
             elif platform == Platform.WECOM and config.extra.get("bot_id"):
@@ -305,11 +332,129 @@ class GatewayConfig:
                 connected.append(platform)
         return connected
     
-    def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
+    def get_default_account_id(self, platform: Platform) -> Optional[str]:
+        """Return the configured default account ID for a multi-account platform."""
+        config = self.platforms.get(platform)
+        if not config:
+            return None
+        if config.home_channel and getattr(config.home_channel, "account_id", None):
+            return str(config.home_channel.account_id).strip() or None
+        if not isinstance(config.extra, dict):
+            return None
+        value = str(config.extra.get("default_account") or "").strip()
+        return value or None
+
+    def get_platform_config(
+        self,
+        platform: Platform,
+        account_id: Optional[str] = None,
+    ) -> Optional[PlatformConfig]:
+        """Return the effective platform config for a platform/account pair."""
+        config = self.platforms.get(platform)
+        if not config:
+            return None
+        if platform != Platform.FEISHU:
+            return config
+
+        accounts = self.iter_platform_account_configs(platform)
+        if not accounts:
+            return config
+
+        resolved_account_id = (account_id or self.get_default_account_id(platform) or "").strip()
+        if resolved_account_id and resolved_account_id in accounts:
+            return accounts[resolved_account_id]
+
+        if config.home_channel or config.extra.get("app_id"):
+            return config
+
+        return next(iter(accounts.values()), config)
+
+    def iter_platform_account_configs(self, platform: Platform) -> Dict[str, PlatformConfig]:
+        """Return per-account platform configs for multi-account platforms."""
+        config = self.platforms.get(platform)
+        if not config or platform != Platform.FEISHU:
+            return {}
+
+        raw_accounts = config.extra.get("accounts", {})
+        if not isinstance(raw_accounts, dict) or not raw_accounts:
+            return {}
+
+        accounts: Dict[str, PlatformConfig] = {}
+        for account_id, account_block in raw_accounts.items():
+            normalized_id = str(account_id or "").strip()
+            if not normalized_id or not isinstance(account_block, dict):
+                continue
+            accounts[normalized_id] = _merge_account_platform_config(
+                platform=platform,
+                base_config=config,
+                account_id=normalized_id,
+                account_block=account_block,
+            )
+        return accounts
+
+    def iter_enabled_platform_bindings(self) -> List[tuple[Platform, Optional[str], PlatformConfig]]:
+        """Expand configured platforms into concrete adapter bindings."""
+        bindings: List[tuple[Platform, Optional[str], PlatformConfig]] = []
+        for platform, config in self.platforms.items():
+            account_configs = self.iter_platform_account_configs(platform)
+            if not config.enabled and not account_configs:
+                continue
+            if account_configs:
+                for account_id, account_config in account_configs.items():
+                    if account_config.enabled:
+                        bindings.append((platform, account_id, account_config))
+                continue
+            bindings.append((platform, None, config))
+        return bindings
+
+    def get_home_channel(self, platform: Platform, account_id: Optional[str] = None) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
-        if config:
+        if not config:
+            return None
+        if platform != Platform.FEISHU:
             return config.home_channel
+
+        if config.home_channel:
+            home = config.home_channel
+            if home.account_id:
+                return home
+            resolved_account_id = account_id or self.get_default_account_id(platform)
+            if not resolved_account_id:
+                account_configs = self.iter_platform_account_configs(platform)
+                if len(account_configs) == 1:
+                    resolved_account_id = next(iter(account_configs.keys()))
+            if resolved_account_id:
+                return HomeChannel(
+                    platform=home.platform,
+                    chat_id=home.chat_id,
+                    name=home.name,
+                    account_id=resolved_account_id,
+                )
+            return home
+
+        account_configs = self.iter_platform_account_configs(platform)
+        if account_id:
+            account_config = account_configs.get(str(account_id).strip())
+            if account_config and account_config.home_channel:
+                return account_config.home_channel
+
+        if not account_configs:
+            return None
+
+        legacy_homes: Dict[str, HomeChannel] = {}
+        for legacy_account_id, account_config in account_configs.items():
+            home = account_config.home_channel
+            if not home or not getattr(home, "chat_id", None):
+                continue
+            legacy_homes[legacy_account_id] = home
+
+        if len(legacy_homes) == 1:
+            return next(iter(legacy_homes.values()))
+
+        default_account_id = self.get_default_account_id(platform)
+        if default_account_id and default_account_id in legacy_homes:
+            return legacy_homes[default_account_id]
         return None
     
     def get_reset_policy(
@@ -361,7 +506,14 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                normalized_platform_data = dict(platform_data)
+                raw_home = normalized_platform_data.get("home_channel")
+                if isinstance(raw_home, dict) and "platform" not in raw_home:
+                    normalized_platform_data["home_channel"] = {
+                        **raw_home,
+                        "platform": platform.value,
+                    }
+                platforms[platform] = PlatformConfig.from_dict(normalized_platform_data)
             except ValueError:
                 pass  # Skip unknown platforms
         
@@ -416,9 +568,27 @@ class GatewayConfig:
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
         )
 
-    def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
+    def get_unauthorized_dm_behavior(
+        self,
+        platform: Optional[Platform] = None,
+        account_id: Optional[str] = None,
+    ) -> str:
         """Return the effective unauthorized-DM behavior for a platform."""
         if platform:
+            if account_id:
+                account_cfg = self.get_platform_config(platform, account_id=account_id)
+                if account_cfg:
+                    extra = account_cfg.extra if isinstance(account_cfg.extra, dict) else {}
+                    if "unauthorized_dm_behavior" in extra:
+                        return _normalize_unauthorized_dm_behavior(
+                            extra.get("unauthorized_dm_behavior"),
+                            self.unauthorized_dm_behavior,
+                        )
+                    dm_policy = str(extra.get("dm_policy", "") or "").strip().lower()
+                    if dm_policy == "pairing":
+                        return "pair"
+                    if dm_policy in {"allowlist", "disabled"}:
+                        return "ignore"
             platform_cfg = self.platforms.get(platform)
             if platform_cfg and "unauthorized_dm_behavior" in platform_cfg.extra:
                 return _normalize_unauthorized_dm_behavior(
@@ -426,6 +596,68 @@ class GatewayConfig:
                     self.unauthorized_dm_behavior,
                 )
         return self.unauthorized_dm_behavior
+
+
+def _coerce_home_channel(
+    platform: Platform,
+    raw_home: Any,
+    *,
+    account_id: Optional[str] = None,
+) -> Optional[HomeChannel]:
+    """Build a HomeChannel from a dict that may omit the platform field."""
+    if not isinstance(raw_home, dict):
+        return None
+    payload = dict(raw_home)
+    platform_value = payload.get("platform")
+    if platform_value is None:
+        payload["platform"] = platform.value
+    if account_id and not payload.get("account_id"):
+        payload["account_id"] = account_id
+    if platform_value is None:
+        return HomeChannel.from_dict(payload)
+    return HomeChannel.from_dict(payload)
+
+
+def _merge_account_platform_config(
+    *,
+    platform: Platform,
+    base_config: PlatformConfig,
+    account_id: str,
+    account_block: Dict[str, Any],
+) -> PlatformConfig:
+    """Overlay an account block onto a base platform config."""
+    base_extra = dict(base_config.extra or {})
+    base_extra.pop("accounts", None)
+    base_extra.pop("default_account", None)
+
+    account_extra = account_block.get("extra", {})
+    if not isinstance(account_extra, dict):
+        account_extra = {}
+    account_extra = dict(account_extra)
+    for key, value in account_block.items():
+        if key in {"enabled", "token", "api_key", "home_channel", "reply_to_mode", "extra"}:
+            continue
+        account_extra[key] = value
+
+    merged_extra = {**base_extra, **account_extra}
+    merged_extra["account_id"] = account_id
+
+    home_channel = None
+    if isinstance(account_block.get("home_channel"), dict):
+        home_channel = _coerce_home_channel(
+            platform,
+            account_block.get("home_channel"),
+            account_id=account_id,
+        )
+
+    return PlatformConfig(
+        enabled=_coerce_bool(account_block.get("enabled"), base_config.enabled or True),
+        token=account_block.get("token", base_config.token),
+        api_key=account_block.get("api_key", base_config.api_key),
+        home_channel=home_channel,
+        reply_to_mode=account_block.get("reply_to_mode", base_config.reply_to_mode),
+        extra=merged_extra,
+    )
 
 
 def load_gateway_config() -> GatewayConfig:
@@ -980,9 +1212,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
 
     # Feishu / Lark
+    feishu_has_accounts = bool(
+        config.platforms.get(Platform.FEISHU)
+        and isinstance(config.platforms[Platform.FEISHU].extra, dict)
+        and config.platforms[Platform.FEISHU].extra.get("accounts")
+    )
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
-    if feishu_app_id and feishu_app_secret:
+    if feishu_app_id and feishu_app_secret and not feishu_has_accounts:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
         config.platforms[Platform.FEISHU].enabled = True
@@ -998,13 +1235,20 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
             config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
-        feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
-        if feishu_home:
-            config.platforms[Platform.FEISHU].home_channel = HomeChannel(
-                platform=Platform.FEISHU,
-                chat_id=feishu_home,
-                name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
-            )
+
+    feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
+    if feishu_home and Platform.FEISHU in config.platforms:
+        feishu_home_account_id = config.get_default_account_id(Platform.FEISHU)
+        if not feishu_home_account_id:
+            feishu_accounts = config.iter_platform_account_configs(Platform.FEISHU)
+            if len(feishu_accounts) == 1:
+                feishu_home_account_id = next(iter(feishu_accounts.keys()))
+        config.platforms[Platform.FEISHU].home_channel = HomeChannel(
+            platform=Platform.FEISHU,
+            chat_id=feishu_home,
+            name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
+            account_id=feishu_home_account_id,
+        )
 
     # WeCom (Enterprise WeChat)
     wecom_bot_id = os.getenv("WECOM_BOT_ID")

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -37,6 +37,7 @@ class DeliveryTarget:
     - "telegram:123456" → specific Telegram chat
     """
     platform: Platform
+    account_id: Optional[str] = None
     chat_id: Optional[str] = None  # None means use home channel
     thread_id: Optional[str] = None
     is_origin: bool = False
@@ -59,6 +60,7 @@ class DeliveryTarget:
             if origin:
                 return cls(
                     platform=origin.platform,
+                    account_id=origin.account_id,
                     chat_id=origin.chat_id,
                     thread_id=origin.thread_id,
                     is_origin=True,
@@ -122,6 +124,7 @@ class DeliveryRouter:
         """
         self.config = config
         self.adapters = adapters or {}
+        self.account_adapters: Dict[tuple[Platform, Optional[str]], Any] = {}
         self.output_dir = get_hermes_home() / "cron" / "output"
     
     async def deliver(
@@ -228,13 +231,28 @@ class DeliveryRouter:
         metadata: Optional[Dict[str, Any]]
     ) -> Dict[str, Any]:
         """Deliver content to a messaging platform."""
-        adapter = self.adapters.get(target.platform)
-        
+        if not target.chat_id:
+            home = self.config.get_home_channel(target.platform, account_id=target.account_id)
+            if home:
+                target = DeliveryTarget(
+                    platform=target.platform,
+                    account_id=getattr(home, "account_id", None) or target.account_id,
+                    chat_id=home.chat_id,
+                    thread_id=target.thread_id,
+                    is_origin=target.is_origin,
+                    is_explicit=target.is_explicit,
+                )
+            else:
+                raise ValueError(f"No chat ID for {target.platform.value} delivery")
+
+        adapter = None
+        if target.account_id:
+            adapter = self.account_adapters.get((target.platform, target.account_id))
+        if adapter is None:
+            adapter = self.adapters.get(target.platform)
+
         if not adapter:
             raise ValueError(f"No adapter configured for {target.platform.value}")
-        
-        if not target.chat_id:
-            raise ValueError(f"No chat ID for {target.platform.value} delivery")
         
         # Guard: truncate oversized cron output to stay within platform limits
         if len(content) > MAX_PLATFORM_OUTPUT:
@@ -250,7 +268,4 @@ class DeliveryRouter:
         if target.thread_id and "thread_id" not in send_metadata:
             send_metadata["thread_id"] = target.thread_id
         return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
-
-
-
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -790,6 +790,7 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
+        self.account_id = str((config.extra or {}).get("account_id") or "").strip() or None
         self._message_handler: Optional[MessageHandler] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
@@ -1509,7 +1510,7 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
+            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart", "sethome"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,
@@ -1906,6 +1907,7 @@ class BasePlatformAdapter(ABC):
         return SessionSource(
             platform=self.platform,
             chat_id=str(chat_id),
+            account_id=self.account_id,
             chat_name=chat_name,
             chat_type=chat_type,
             user_id=str(user_id) if user_id else None,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -71,7 +71,9 @@ try:
         UpdateMessageRequest,
         UpdateMessageRequestBody,
     )
+    from lark_oapi.core import AccessTokenType, HttpMethod
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+    from lark_oapi.core.model.base_request import BaseRequest
     from lark_oapi.event.callback.model.p2_card_action_trigger import P2CardActionTriggerResponse
     from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
     from lark_oapi.ws import Client as FeishuWSClient
@@ -85,6 +87,9 @@ except ImportError:
     FeishuWSClient = None  # type: ignore[assignment]
     FEISHU_DOMAIN = None  # type: ignore[assignment]
     LARK_DOMAIN = None  # type: ignore[assignment]
+    AccessTokenType = None  # type: ignore[assignment]
+    HttpMethod = None  # type: ignore[assignment]
+    BaseRequest = None  # type: ignore[assignment]
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
@@ -274,6 +279,7 @@ class FeishuAdapterSettings:
     encrypt_key: str
     verification_token: str
     group_policy: str
+    require_mention: bool
     allowed_group_users: frozenset[str]
     bot_open_id: str
     bot_user_id: str
@@ -301,6 +307,7 @@ class FeishuGroupRule:
     """Per-group policy rule for controlling which users may interact with the bot."""
 
     policy: str  # "open" | "allowlist" | "blacklist" | "admin_only" | "disabled"
+    require_mention: Optional[bool] = None
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
 
@@ -323,6 +330,15 @@ def _escape_markdown_text(text: str) -> str:
 
 def _to_boolean(value: Any) -> bool:
     return value is True or value == 1 or value == "true"
+
+
+def _resolve_env_reference(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if not text.startswith("env:"):
+        return text
+    return os.getenv(text[4:].strip(), "").strip()
 
 
 def _is_style_enabled(style: Dict[str, Any] | None, key: str) -> bool:
@@ -405,6 +421,23 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _coerce_optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+        return None
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -962,16 +995,78 @@ def _unique_lines(lines: List[str]) -> List[str]:
     return unique
 
 
+_FEISHU_WS_THREAD_STATE = threading.local()
+
+
+def _current_feishu_ws_loop() -> asyncio.AbstractEventLoop:
+    """Resolve the active loop for the current Feishu websocket thread."""
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    loop = getattr(_FEISHU_WS_THREAD_STATE, "loop", None)
+    if loop is None or bool(getattr(loop, "is_closed", lambda: False)()):
+        raise RuntimeError("Feishu websocket loop is not initialized for this thread")
+    return loop
+
+
+class _FeishuWSLoopProxy:
+    """Route the SDK's module-global loop calls to the current thread-local loop."""
+
+    def run_until_complete(self, awaitable: Any) -> Any:
+        loop = getattr(_FEISHU_WS_THREAD_STATE, "loop", None)
+        if loop is None or bool(getattr(loop, "is_closed", lambda: False)()):
+            raise RuntimeError("Feishu websocket thread loop is not available")
+        return loop.run_until_complete(awaitable)
+
+    def create_task(self, coro: Any) -> asyncio.Task[Any]:
+        return _current_feishu_ws_loop().create_task(coro)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(_current_feishu_ws_loop(), name)
+
+
+async def _feishu_ws_connect_proxy(*args: Any, **kwargs: Any) -> Any:
+    """Apply thread-local websocket connect overrides without global races."""
+    connect_impl = getattr(_FEISHU_WS_THREAD_STATE, "original_connect", None)
+    if connect_impl is None:
+        raise RuntimeError("Feishu websocket connect proxy is not initialized")
+    ping_interval = getattr(_FEISHU_WS_THREAD_STATE, "ping_interval", None)
+    ping_timeout = getattr(_FEISHU_WS_THREAD_STATE, "ping_timeout", None)
+    if ping_interval is not None and "ping_interval" not in kwargs:
+        kwargs["ping_interval"] = ping_interval
+    if ping_timeout is not None and "ping_timeout" not in kwargs:
+        kwargs["ping_timeout"] = ping_timeout
+    return await connect_impl(*args, **kwargs)
+
+
+def _install_feishu_ws_runtime_proxies(ws_client_module: Any) -> None:
+    """Install process-wide SDK proxies that dispatch via thread-local state."""
+    if not getattr(ws_client_module, "_hermes_ws_proxy_installed", False):
+        original_connect = ws_client_module.websockets.connect
+        setattr(ws_client_module, "_hermes_ws_original_connect", original_connect)
+        ws_client_module.websockets.connect = _feishu_ws_connect_proxy
+        ws_client_module.loop = _FeishuWSLoopProxy()
+        setattr(ws_client_module, "_hermes_ws_proxy_installed", True)
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    _install_feishu_ws_runtime_proxies(ws_client_module)
+    _FEISHU_WS_THREAD_STATE.loop = loop
+    _FEISHU_WS_THREAD_STATE.original_connect = getattr(
+        ws_client_module,
+        "_hermes_ws_original_connect",
+        ws_client_module.websockets.connect,
+    )
+    _FEISHU_WS_THREAD_STATE.ping_interval = adapter._ws_ping_interval
+    _FEISHU_WS_THREAD_STATE.ping_timeout = adapter._ws_ping_timeout
     adapter._ws_thread_loop = loop
 
-    original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
 
     def _apply_runtime_ws_overrides() -> None:
@@ -983,13 +1078,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    async def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
-        if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
-            kwargs["ping_interval"] = adapter._ws_ping_interval
-        if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
-            kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
-
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
             raise RuntimeError("Feishu _configure_with_overrides called but original_configure is None")
@@ -997,7 +1085,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
-    ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
@@ -1006,7 +1093,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     except Exception:
         pass
     finally:
-        ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
@@ -1023,6 +1109,9 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             pass
         adapter._ws_thread_loop = None
+        for attr in ("loop", "original_connect", "ping_interval", "ping_timeout"):
+            if hasattr(_FEISHU_WS_THREAD_STATE, attr):
+                delattr(_FEISHU_WS_THREAD_STATE, attr)
 
 
 def check_feishu_requirements() -> bool:
@@ -1084,6 +1173,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
+        account_scoped = bool(str(extra.get("account_id") or "").strip())
         # Parse per-group rules from config
         raw_group_rules = extra.get("group_rules", {})
         group_rules: Dict[str, FeishuGroupRule] = {}
@@ -1093,6 +1183,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     continue
                 group_rules[str(chat_id)] = FeishuGroupRule(
                     policy=str(rule_cfg.get("policy", "open")).strip().lower(),
+                    require_mention=_coerce_optional_bool(rule_cfg.get("require_mention")),
                     allowlist=set(str(u).strip() for u in rule_cfg.get("allowlist", []) if str(u).strip()),
                     blacklist=set(str(u).strip() for u in rule_cfg.get("blacklist", []) if str(u).strip()),
                 )
@@ -1103,25 +1194,55 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
+        require_mention = _coerce_optional_bool(extra.get("require_mention"))
+        if require_mention is None:
+            require_mention = True
+
+        if extra.get("bot_name") not in (None, ""):
+            logger.warning(
+                "[Feishu] Ignoring configured bot_name. Hermes no longer treats bot_name as canonical "
+                "Feishu config; use runtime app identity discovery instead."
+            )
+
+        raw_allowed_group_users = (
+            extra.get("allowed_group_users")
+            if extra.get("allowed_group_users") is not None
+            else ("" if account_scoped else os.getenv("FEISHU_ALLOWED_USERS", ""))
+        )
+        if isinstance(raw_allowed_group_users, (list, tuple, set, frozenset)):
+            allowed_group_users = frozenset(
+                str(item).strip() for item in raw_allowed_group_users if str(item).strip()
+            )
+        else:
+            allowed_group_users = frozenset(
+                item.strip() for item in str(raw_allowed_group_users).split(",") if item.strip()
+            )
 
         return FeishuAdapterSettings(
-            app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
-            app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
-            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
-            connection_mode=str(
-                extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
+            app_id=_resolve_env_reference(extra.get("app_id")) or str("" if account_scoped else os.getenv("FEISHU_APP_ID", "")).strip(),
+            app_secret=_resolve_env_reference(extra.get("app_secret")) or str("" if account_scoped else os.getenv("FEISHU_APP_SECRET", "")).strip(),
+            domain_name=(
+                _resolve_env_reference(extra.get("domain"))
+                or str("" if account_scoped else os.getenv("FEISHU_DOMAIN", "feishu"))
+                or "feishu"
             ).strip().lower(),
-            encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
-            verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
-            group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
-            allowed_group_users=frozenset(
-                item.strip()
-                for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
-                if item.strip()
-            ),
-            bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
-            bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
-            bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
+            connection_mode=str(
+                _resolve_env_reference(extra.get("connection_mode"))
+                or ("" if account_scoped else os.getenv("FEISHU_CONNECTION_MODE", "websocket"))
+                or "websocket"
+            ).strip().lower(),
+            encrypt_key=_resolve_env_reference(extra.get("encrypt_key")) or str("" if account_scoped else os.getenv("FEISHU_ENCRYPT_KEY", "")).strip(),
+            verification_token=_resolve_env_reference(extra.get("verification_token")) or str("" if account_scoped else os.getenv("FEISHU_VERIFICATION_TOKEN", "")).strip(),
+            group_policy=str(
+                _resolve_env_reference(extra.get("group_policy"))
+                or ("" if account_scoped else os.getenv("FEISHU_GROUP_POLICY", "allowlist"))
+                or "allowlist"
+            ).strip().lower(),
+            require_mention=require_mention,
+            allowed_group_users=allowed_group_users,
+            bot_open_id=_resolve_env_reference(extra.get("bot_open_id")) or str("" if account_scoped else os.getenv("FEISHU_BOT_OPEN_ID", "")).strip(),
+            bot_user_id=_resolve_env_reference(extra.get("bot_user_id")) or str("" if account_scoped else os.getenv("FEISHU_BOT_USER_ID", "")).strip(),
+            bot_name=str("" if account_scoped else os.getenv("FEISHU_BOT_NAME", "")).strip(),
             dedup_cache_size=max(
                 32,
                 int(os.getenv("HERMES_FEISHU_DEDUP_CACHE_SIZE", str(_DEFAULT_DEDUP_CACHE_SIZE))),
@@ -1170,6 +1291,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._encrypt_key = settings.encrypt_key
         self._verification_token = settings.verification_token
         self._group_policy = settings.group_policy
+        self._require_mention = settings.require_mention
         self._allowed_group_users = set(settings.allowed_group_users)
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
@@ -1784,6 +1906,16 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         if getattr(sender, "sender_type", "") == "bot":
             logger.debug("[Feishu] Dropping bot-originated event: %s", message_id)
+            return
+        header = getattr(data, "header", None)
+        event_app_id = str(getattr(header, "app_id", "") or "")
+        if event_app_id and self._app_id and event_app_id != self._app_id:
+            logger.warning(
+                "[Feishu] Dropping inbound message for unexpected app_id: expected=%s actual=%s message_id=%s",
+                self._app_id,
+                event_app_id,
+                message_id,
+            )
             return
 
         chat_type = getattr(message, "chat_type", "p2p")
@@ -3042,6 +3174,12 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        rule = self._group_rules.get(chat_id) if chat_id else None
+        require_mention = self._require_mention
+        if rule and rule.require_mention is not None:
+            require_mention = rule.require_mention
+        if not require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:
@@ -3064,11 +3202,14 @@ class FeishuAdapter(BasePlatformAdapter):
             mention_open_id = getattr(mention_id, "open_id", None)
             mention_user_id = getattr(mention_id, "user_id", None)
             mention_name = (getattr(mention, "name", None) or "").strip()
+            mention_has_id = bool(mention_open_id or mention_user_id)
 
             if self._bot_open_id and mention_open_id == self._bot_open_id:
                 return True
             if self._bot_user_id and mention_user_id == self._bot_user_id:
                 return True
+            if mention_has_id:
+                continue
             if self._bot_name and mention_name == self._bot_name:
                 return True
 
@@ -3087,8 +3228,27 @@ class FeishuAdapter(BasePlatformAdapter):
         """Best-effort discovery of bot identity for precise group mention gating."""
         if not self._client:
             return
-        if any((self._bot_open_id, self._bot_user_id, self._bot_name)):
+        if self._bot_open_id or self._bot_user_id:
             return
+        try:
+            request = self._build_get_bot_info_request()
+            response = await asyncio.to_thread(self._client.request, request)
+            if response and response.success():
+                bot_open_id, bot_name = self._parse_bot_info_response(response)
+                if bot_open_id:
+                    self._bot_open_id = bot_open_id
+                if bot_name:
+                    self._bot_name = bot_name
+                if self._bot_open_id or self._bot_name:
+                    return
+            elif response:
+                logger.debug(
+                    "[Feishu] bot/v3/info returned code=%s msg=%s",
+                    getattr(response, "code", None),
+                    getattr(response, "msg", None),
+                )
+        except Exception:
+            logger.debug("[Feishu] Failed to hydrate bot identity from bot/v3/info", exc_info=True)
         try:
             request = self._build_get_application_request(app_id=self._app_id, lang="en_us")
             response = await asyncio.to_thread(self._client.application.v6.application.get, request)
@@ -3491,6 +3651,67 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(app_id=app_id, lang=lang)
+
+    @staticmethod
+    def _build_get_bot_info_request() -> Any:
+        if BaseRequest is not None and HttpMethod is not None and AccessTokenType is not None:
+            return (
+                BaseRequest.builder()
+                .http_method(HttpMethod.GET)
+                .uri("/open-apis/bot/v3/info")
+                .token_types({AccessTokenType.TENANT})
+                .build()
+            )
+        return SimpleNamespace(
+            http_method="GET",
+            uri="/open-apis/bot/v3/info",
+            token_types={"tenant"},
+        )
+
+    @staticmethod
+    def _parse_bot_info_response(response: Any) -> tuple[Optional[str], Optional[str]]:
+        payload: Dict[str, Any] = {}
+        raw = getattr(response, "raw", None)
+        raw_content = getattr(raw, "content", None)
+        if isinstance(raw_content, (bytes, bytearray)):
+            try:
+                payload = json.loads(raw_content.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                payload = {}
+        elif isinstance(raw_content, str):
+            try:
+                payload = json.loads(raw_content)
+            except json.JSONDecodeError:
+                payload = {}
+
+        bot_payload: Any = None
+        if payload:
+            bot_payload = payload.get("bot")
+            if bot_payload is None:
+                data_payload = payload.get("data")
+                if isinstance(data_payload, dict):
+                    bot_payload = data_payload.get("bot")
+        if bot_payload is None:
+            bot_payload = getattr(response, "bot", None)
+        if bot_payload is None:
+            data_payload = getattr(response, "data", None)
+            if isinstance(data_payload, dict):
+                bot_payload = data_payload.get("bot")
+            elif data_payload is not None:
+                bot_payload = getattr(data_payload, "bot", None)
+
+        if isinstance(bot_payload, dict):
+            open_id = str(bot_payload.get("open_id") or "").strip()
+            bot_name = str(bot_payload.get("bot_name") or bot_payload.get("name") or "").strip()
+            return (open_id or None, bot_name or None)
+
+        open_id = str(getattr(bot_payload, "open_id", "") or "").strip()
+        bot_name = str(
+            getattr(bot_payload, "bot_name", None)
+            or getattr(bot_payload, "name", None)
+            or ""
+        ).strip()
+        return (open_id or None, bot_name or None)
 
     @staticmethod
     def _build_reply_message_body(*, content: str, msg_type: str, reply_in_thread: bool, uuid_value: str) -> Any:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -643,25 +643,44 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error=f"Unknown platform: {platform_name}"
             )
 
-        adapter = self.gateway_runner.adapters.get(target_platform)
-        if not adapter:
-            return SendResult(
-                success=False,
-                error=f"Platform {platform_name} not connected",
-            )
-
-        # Use home channel if no specific chat_id in deliver_extra
         extra = delivery.get("deliver_extra", {})
         chat_id = extra.get("chat_id", "")
+        account_id = str(extra.get("account_id", "") or "").strip() or None
         if not chat_id:
-            home = self.gateway_runner.config.get_home_channel(target_platform)
+            home = self.gateway_runner.config.get_home_channel(target_platform, account_id=account_id)
             if home:
                 chat_id = home.chat_id
+                account_id = getattr(home, "account_id", None) or account_id
             else:
                 return SendResult(
                     success=False,
                     error=f"No chat_id or home channel for {platform_name}",
                 )
+
+        adapter = None
+        get_adapter = None
+        try:
+            instance_attr = vars(self.gateway_runner).get("_get_adapter")
+        except Exception:
+            instance_attr = None
+        if callable(instance_attr):
+            get_adapter = instance_attr
+        else:
+            class_attr = getattr(type(self.gateway_runner), "_get_adapter", None)
+            if callable(class_attr):
+                get_adapter = getattr(self.gateway_runner, "_get_adapter")
+
+        if callable(get_adapter):
+            adapter = get_adapter(target_platform, account_id=account_id)
+        elif account_id:
+            adapter = getattr(self.gateway_runner, "_adapters_by_binding", {}).get((target_platform, account_id))
+        if not adapter:
+            adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            return SendResult(
+                success=False,
+                error=f"Platform {platform_name} not connected",
+            )
 
         # Pass thread_id from deliver_extra so Telegram forum topics work
         metadata = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3765,8 +3765,6 @@ class GatewayRunner:
         )
         if message_text is None:
             return
-        if _is_shared_thread and source.user_name:
-            message_text = f"[{source.user_name}] {message_text}"
 
         if event.media_urls:
             image_paths = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -241,6 +241,7 @@ if not _configured_cwd or _configured_cwd in (".", "auto", "cwd"):
 from gateway.config import (
     Platform,
     GatewayConfig,
+    HomeChannel,
     load_gateway_config,
 )
 from gateway.session import (
@@ -534,6 +535,7 @@ class GatewayRunner:
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self._adapters_by_binding: Dict[Any, BasePlatformAdapter] = {}
 
         # Load ephemeral config from config.yaml / env vars.
         # Both are injected at API-call time only and never persisted.
@@ -591,8 +593,8 @@ class GatewayRunner:
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
 
         # Track platforms that failed to connect for background reconnection.
-        # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
-        self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
+        # Key: (platform, account_id), Value: {"config": platform_config, "attempts": int, "next_retry": float}
+        self._failed_platforms: Dict[Any, Dict[str, Any]] = {}
 
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
@@ -632,6 +634,142 @@ class GatewayRunner:
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+
+    def _adapter_binding_key(
+        self,
+        platform: Platform,
+        account_id: Optional[str] = None,
+    ) -> Any:
+        normalized_account = str(account_id or "").strip() or None
+        if normalized_account is None:
+            return platform
+        return (platform, normalized_account)
+
+    def _binding_label(self, platform: Platform, account_id: Optional[str] = None) -> str:
+        if account_id:
+            return f"{platform.value}[{account_id}]"
+        return platform.value
+
+    def _normalize_binding_key(
+        self,
+        binding_key: Any,
+    ) -> tuple[Platform, Optional[str]]:
+        if isinstance(binding_key, tuple):
+            platform = binding_key[0]
+            account_id = binding_key[1] if len(binding_key) > 1 else None
+            return (platform, str(account_id or "").strip() or None)
+        return (binding_key, None)
+
+    def _account_id_for_adapter(self, adapter: BasePlatformAdapter) -> Optional[str]:
+        return str(getattr(adapter, "account_id", "") or "").strip() or None
+
+    def _ensure_adapter_registry(self) -> None:
+        if not hasattr(self, "_adapters_by_binding") or self._adapters_by_binding is None:
+            self._adapters_by_binding = {}
+        if not hasattr(self, "adapters") or self.adapters is None:
+            self.adapters = {}
+        for platform, adapter in list(self.adapters.items()):
+            binding_key = self._adapter_binding_key(
+                platform,
+                str(getattr(adapter, "account_id", "") or "").strip() or None,
+            )
+            self._adapters_by_binding.setdefault(binding_key, adapter)
+        if not hasattr(self, "delivery_router") or self.delivery_router is None:
+            return
+        if not hasattr(self.delivery_router, "account_adapters") or self.delivery_router.account_adapters is None:
+            self.delivery_router.account_adapters = {}
+        self.delivery_router.account_adapters = self._adapters_by_binding
+
+    def _register_adapter(self, platform: Platform, adapter: BasePlatformAdapter) -> None:
+        self._ensure_adapter_registry()
+        account_id = self._account_id_for_adapter(adapter)
+        binding_key = self._adapter_binding_key(platform, account_id)
+        self._adapters_by_binding[binding_key] = adapter
+        default_account_id = self.config.get_default_account_id(platform)
+        if (
+            platform not in self.adapters
+            or account_id is None
+            or (default_account_id and account_id == default_account_id)
+        ):
+            self.adapters[platform] = adapter
+
+        self.delivery_router.adapters = self.adapters
+        self.delivery_router.account_adapters = self._adapters_by_binding
+
+    def _unregister_adapter(self, adapter: BasePlatformAdapter) -> None:
+        self._ensure_adapter_registry()
+        platform = adapter.platform
+        account_id = self._account_id_for_adapter(adapter)
+        binding_key = self._adapter_binding_key(platform, account_id)
+        self._adapters_by_binding.pop(binding_key, None)
+
+        if self.adapters.get(platform) is adapter:
+            replacement = None
+            default_account_id = self.config.get_default_account_id(platform)
+            if default_account_id:
+                replacement = self._adapters_by_binding.get(
+                    self._adapter_binding_key(platform, default_account_id)
+                )
+            if replacement is None:
+                for raw_candidate_key, candidate in self._adapters_by_binding.items():
+                    candidate_platform, _candidate_account_id = self._normalize_binding_key(raw_candidate_key)
+                    if candidate_platform == platform:
+                        replacement = candidate
+                        break
+            if replacement is None:
+                self.adapters.pop(platform, None)
+            else:
+                self.adapters[platform] = replacement
+
+        self.delivery_router.adapters = self.adapters
+        self.delivery_router.account_adapters = self._adapters_by_binding
+
+    def _get_adapter(
+        self,
+        platform: Platform,
+        account_id: Optional[str] = None,
+    ) -> Optional[BasePlatformAdapter]:
+        self._ensure_adapter_registry()
+        if account_id:
+            adapter = self._adapters_by_binding.get(
+                self._adapter_binding_key(platform, account_id)
+            )
+            if adapter is not None:
+                return adapter
+            logger.warning(
+                "No adapter binding found for %s[%s]",
+                platform.value,
+                account_id,
+            )
+            return None
+        return self.adapters.get(platform)
+
+    def _get_adapter_for_source(self, source: Optional[SessionSource]) -> Optional[BasePlatformAdapter]:
+        if source is None:
+            return None
+        return self._get_adapter(source.platform, getattr(source, "account_id", None))
+
+    def _has_home_channel_for_source(self, source: Optional[SessionSource]) -> bool:
+        if source is None or source.platform is None:
+            return False
+        if getattr(self, "config", None):
+            home_channel = self.config.get_home_channel(
+                source.platform,
+                account_id=getattr(source, "account_id", None),
+            )
+            if home_channel and getattr(home_channel, "chat_id", None):
+                return True
+        if source.platform == Platform.FEISHU and getattr(source, "account_id", None):
+            return False
+        env_key = f"{source.platform.value.upper()}_HOME_CHANNEL"
+        return bool(os.getenv(env_key))
+
+    def _all_adapter_instances(self) -> List[tuple[Any, BasePlatformAdapter]]:
+        self._ensure_adapter_registry()
+        return list(self._adapters_by_binding.items())
+
+    def _iter_enabled_bindings(self) -> List[tuple[Platform, Optional[str], Any]]:
+        return self.config.iter_enabled_platform_bindings()
 
 
 
@@ -955,9 +1093,10 @@ class GatewayRunner:
         If the error is retryable (e.g. network blip, DNS failure), queue the
         platform for background reconnection instead of giving up permanently.
         """
+        self._ensure_adapter_registry()
         logger.error(
             "Fatal %s adapter error (%s): %s",
-            adapter.platform.value,
+            self._binding_label(adapter.platform, self._account_id_for_adapter(adapter)),
             adapter.fatal_error_code or "unknown",
             adapter.fatal_error_message or "unknown error",
         )
@@ -968,29 +1107,31 @@ class GatewayRunner:
             error_message=adapter.fatal_error_message,
         )
 
-        existing = self.adapters.get(adapter.platform)
+        binding_key = self._adapter_binding_key(
+            adapter.platform,
+            self._account_id_for_adapter(adapter),
+        )
+        existing = self._adapters_by_binding.get(binding_key)
         if existing is adapter:
             try:
                 await adapter.disconnect()
             finally:
-                self.adapters.pop(adapter.platform, None)
-                self.delivery_router.adapters = self.adapters
+                self._unregister_adapter(adapter)
 
         # Queue retryable failures for background reconnection
         if adapter.fatal_error_retryable:
-            platform_config = self.config.platforms.get(adapter.platform)
-            if platform_config and adapter.platform not in self._failed_platforms:
-                self._failed_platforms[adapter.platform] = {
-                    "config": platform_config,
+            if binding_key not in self._failed_platforms:
+                self._failed_platforms[binding_key] = {
+                    "config": adapter.config,
                     "attempts": 0,
                     "next_retry": time.monotonic() + 30,
                 }
                 logger.info(
                     "%s queued for background reconnection",
-                    adapter.platform.value,
+                    self._binding_label(*self._normalize_binding_key(binding_key)),
                 )
 
-        if not self.adapters and not self._failed_platforms:
+        if not self._adapters_by_binding and not self._failed_platforms:
             self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"
             if adapter.fatal_error_retryable:
                 self._exit_with_failure = True
@@ -998,7 +1139,7 @@ class GatewayRunner:
             else:
                 logger.error("No connected messaging platforms remain. Shutting down gateway cleanly.")
             await self.stop()
-        elif not self.adapters and self._failed_platforms:
+        elif not self._adapters_by_binding and self._failed_platforms:
             # All platforms are down and queued for background reconnection.
             # If the error is retryable, exit with failure so systemd Restart=on-failure
             # can restart the process. Otherwise stay alive and keep retrying in background.
@@ -1323,7 +1464,7 @@ class GatewayRunner:
         }
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._get_adapter_for_source(event.source)
         if not adapter:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
@@ -1332,7 +1473,7 @@ class GatewayRunner:
         if not self._draining:
             return False
 
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._get_adapter_for_source(event.source)
         if not adapter:
             return True
 
@@ -1563,14 +1704,15 @@ class GatewayRunner:
         startup_retryable_errors: list[str] = []
         
         # Initialize and connect each configured platform
-        for platform, platform_config in self.config.platforms.items():
+        for platform, account_id, platform_config in self._iter_enabled_bindings():
             if not platform_config.enabled:
                 continue
             enabled_platform_count += 1
+            binding_label = self._binding_label(platform, account_id)
             
             adapter = self._create_adapter(platform, platform_config)
             if not adapter:
-                logger.warning("No adapter available for %s", platform.value)
+                logger.warning("No adapter available for %s", binding_label)
                 continue
             
             # Set up message + fatal error handlers
@@ -1580,7 +1722,7 @@ class GatewayRunner:
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             
             # Try to connect
-            logger.info("Connecting to %s...", platform.value)
+            logger.info("Connecting to %s...", binding_label)
             self._update_platform_runtime_status(
                 platform.value,
                 platform_state="connecting",
@@ -1590,18 +1732,18 @@ class GatewayRunner:
             try:
                 success = await adapter.connect()
                 if success:
-                    self.adapters[platform] = adapter
+                    self._register_adapter(platform, adapter)
                     self._sync_voice_mode_state_to_adapter(adapter)
                     connected_count += 1
+                    logger.info("✓ %s connected", binding_label)
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="connected",
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("✗ %s failed to connect", binding_label)
                     if adapter.has_fatal_error:
                         self._update_platform_runtime_status(
                             platform.value,
@@ -1615,11 +1757,11 @@ class GatewayRunner:
                             else startup_nonretryable_errors
                         )
                         target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
+                            f"{binding_label}: {adapter.fatal_error_message}"
                         )
                         # Queue for reconnection if the error is retryable
                         if adapter.fatal_error_retryable:
-                            self._failed_platforms[platform] = {
+                            self._failed_platforms[self._adapter_binding_key(platform, account_id)] = {
                                 "config": platform_config,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
@@ -1632,25 +1774,25 @@ class GatewayRunner:
                             error_message="failed to connect",
                         )
                         startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
+                            f"{binding_label}: failed to connect"
                         )
                         # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
+                        self._failed_platforms[self._adapter_binding_key(platform, account_id)] = {
                             "config": platform_config,
                             "attempts": 1,
                             "next_retry": time.monotonic() + 30,
                         }
             except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
+                logger.error("✗ %s error: %s", binding_label, e)
                 self._update_platform_runtime_status(
                     platform.value,
                     platform_state="retrying",
                     error_code=None,
                     error_message=str(e),
                 )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
+                startup_retryable_errors.append(f"{binding_label}: {e}")
                 # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
+                self._failed_platforms[self._adapter_binding_key(platform, account_id)] = {
                     "config": platform_config,
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
@@ -1733,9 +1875,12 @@ class GatewayRunner:
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
             logger.info(
-                "Starting reconnection watcher for %d failed platform(s): %s",
+                "Starting reconnection watcher for %d failed adapter binding(s): %s",
                 len(self._failed_platforms),
-                ", ".join(p.value for p in self._failed_platforms),
+                ", ".join(
+                    self._binding_label(*self._normalize_binding_key(binding_key))
+                    for binding_key in self._failed_platforms
+                ),
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
@@ -1883,26 +2028,27 @@ class GatewayRunner:
                 continue
 
             now = time.monotonic()
-            for platform in list(self._failed_platforms.keys()):
+            for raw_binding_key in list(self._failed_platforms.keys()):
                 if not self._running:
                     return
-                info = self._failed_platforms[platform]
+                platform, account_id = self._normalize_binding_key(raw_binding_key)
+                info = self._failed_platforms[raw_binding_key]
                 if now < info["next_retry"]:
                     continue  # not time yet
 
                 if info["attempts"] >= _MAX_ATTEMPTS:
                     logger.warning(
                         "Giving up reconnecting %s after %d attempts",
-                        platform.value, info["attempts"],
+                        self._binding_label(platform, account_id), info["attempts"],
                     )
-                    del self._failed_platforms[platform]
+                    del self._failed_platforms[raw_binding_key]
                     continue
 
                 platform_config = info["config"]
                 attempt = info["attempts"] + 1
                 logger.info(
                     "Reconnecting %s (attempt %d/%d)...",
-                    platform.value, attempt, _MAX_ATTEMPTS,
+                    self._binding_label(platform, account_id), attempt, _MAX_ATTEMPTS,
                 )
 
                 try:
@@ -1910,9 +2056,9 @@ class GatewayRunner:
                     if not adapter:
                         logger.warning(
                             "Reconnect %s: adapter creation returned None, removing from retry queue",
-                            platform.value,
+                            self._binding_label(platform, account_id),
                         )
-                        del self._failed_platforms[platform]
+                        del self._failed_platforms[raw_binding_key]
                         continue
 
                     adapter.set_message_handler(self._handle_message)
@@ -1922,17 +2068,16 @@ class GatewayRunner:
 
                     success = await adapter.connect()
                     if success:
-                        self.adapters[platform] = adapter
+                        self._register_adapter(platform, adapter)
                         self._sync_voice_mode_state_to_adapter(adapter)
-                        self.delivery_router.adapters = self.adapters
-                        del self._failed_platforms[platform]
+                        del self._failed_platforms[raw_binding_key]
+                        logger.info("✓ %s reconnected successfully", self._binding_label(platform, account_id))
                         self._update_platform_runtime_status(
                             platform.value,
                             platform_state="connected",
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
 
                         # Rebuild channel directory with the new adapter
                         try:
@@ -1951,9 +2096,9 @@ class GatewayRunner:
                             )
                             logger.warning(
                                 "Reconnect %s: non-retryable error (%s), removing from retry queue",
-                                platform.value, adapter.fatal_error_message,
+                                self._binding_label(platform, account_id), adapter.fatal_error_message,
                             )
-                            del self._failed_platforms[platform]
+                            del self._failed_platforms[raw_binding_key]
                         else:
                             self._update_platform_runtime_status(
                                 platform.value,
@@ -1966,7 +2111,7 @@ class GatewayRunner:
                             info["next_retry"] = time.monotonic() + backoff
                             logger.info(
                                 "Reconnect %s failed, next retry in %ds",
-                                platform.value, backoff,
+                                self._binding_label(platform, account_id), backoff,
                             )
                 except Exception as e:
                     self._update_platform_runtime_status(
@@ -1980,7 +2125,7 @@ class GatewayRunner:
                     info["next_retry"] = time.monotonic() + backoff
                     logger.warning(
                         "Reconnect %s error: %s, next retry in %ds",
-                        platform.value, e, backoff,
+                        self._binding_label(platform, account_id), e, backoff,
                     )
 
             # Check every 10 seconds for platforms that need reconnection
@@ -2037,16 +2182,21 @@ class GatewayRunner:
 
             self._finalize_shutdown_agents(active_agents)
 
-            for platform, adapter in list(self.adapters.items()):
+            for raw_binding_key, adapter in self._all_adapter_instances():
+                platform, account_id = self._normalize_binding_key(raw_binding_key)
                 try:
                     await adapter.cancel_background_tasks()
                 except Exception as e:
-                    logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
+                    logger.debug(
+                        "✗ %s background-task cancel error: %s",
+                        self._binding_label(platform, account_id),
+                        e,
+                    )
                 try:
                     await adapter.disconnect()
-                    logger.info("✓ %s disconnected", platform.value)
+                    logger.info("✓ %s disconnected", self._binding_label(platform, account_id))
                 except Exception as e:
-                    logger.error("✗ %s disconnect error: %s", platform.value, e)
+                    logger.error("✗ %s disconnect error: %s", self._binding_label(platform, account_id), e)
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:
@@ -2055,6 +2205,7 @@ class GatewayRunner:
             self._background_tasks.clear()
 
             self.adapters.clear()
+            self._adapters_by_binding.clear()
             self._running_agents.clear()
             self._pending_messages.clear()
             self._pending_approvals.clear()
@@ -2277,6 +2428,10 @@ class GatewayRunner:
         if not user_id:
             return False
 
+        account_auth = self._get_account_scoped_authorization(source)
+        if account_auth is not None:
+            return account_auth
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",
@@ -2361,11 +2516,78 @@ class GatewayRunner:
 
         return bool(check_ids & allowed_ids)
 
-    def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
+    @staticmethod
+    def _parse_authorized_id_list(raw_value: Any) -> set[str]:
+        """Normalize a config allowlist value into a set of IDs."""
+        if isinstance(raw_value, (list, tuple, set, frozenset)):
+            values = raw_value
+        else:
+            values = str(raw_value or "").split(",")
+        return {str(item).strip() for item in values if str(item).strip()}
+
+    def _get_account_scoped_authorization(self, source: SessionSource) -> Optional[bool]:
+        """Return account-scoped authorization for multi-account platforms, if configured."""
+        config = getattr(self, "config", None)
+        if not config or not source.platform or not source.account_id:
+            return None
+        getter = getattr(config, "get_platform_config", None)
+        if not callable(getter):
+            return None
+        platform_cfg = getter(source.platform, account_id=source.account_id)
+        if platform_cfg is None:
+            return None
+        extra = platform_cfg.extra if isinstance(platform_cfg.extra, dict) else {}
+
+        if source.platform == Platform.FEISHU:
+            if source.chat_type != "dm":
+                if any(
+                    key in extra
+                    for key in (
+                        "app_id",
+                        "group_policy",
+                        "default_group_policy",
+                        "group_rules",
+                        "require_mention",
+                        "allowed_group_users",
+                        "admins",
+                    )
+                ):
+                    return True
+                return None
+
+            dm_policy = str(extra.get("dm_policy", "") or "").strip().lower()
+            if str(extra.get("allow_all_users", "")).strip().lower() in {"true", "1", "yes"}:
+                return True
+            if dm_policy == "open":
+                return True
+            if dm_policy == "disabled":
+                return False
+
+            check_ids = {str(value).strip() for value in (source.user_id, source.user_id_alt) if str(value or "").strip()}
+            allowed_ids = self._parse_authorized_id_list(extra.get("allowed_users"))
+
+            if dm_policy == "allowlist":
+                if "*" in allowed_ids:
+                    return True
+                return bool(check_ids & allowed_ids)
+            if dm_policy == "pairing":
+                return None
+            if allowed_ids:
+                if "*" in allowed_ids:
+                    return True
+                return bool(check_ids & allowed_ids)
+
+        return None
+
+    def _get_unauthorized_dm_behavior(
+        self,
+        platform: Optional[Platform],
+        account_id: Optional[str] = None,
+    ) -> str:
         """Return how unauthorized DMs should be handled for a platform."""
         config = getattr(self, "config", None)
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
-            return config.get_unauthorized_dm_behavior(platform)
+            return config.get_unauthorized_dm_behavior(platform, account_id=account_id)
         return "pair"
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
@@ -2397,7 +2619,10 @@ class GatewayRunner:
         elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
-            if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
+            if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(
+                source.platform,
+                account_id=source.account_id,
+            ) == "pair":
                 platform_name = source.platform.value if source.platform else "unknown"
                 # Rate-limit ALL pairing responses (code or rejection) to
                 # prevent spamming the user with repeated messages when
@@ -2408,7 +2633,7 @@ class GatewayRunner:
                     platform_name, source.user_id, source.user_name or ""
                 )
                 if code:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._get_adapter_for_source(source)
                     if adapter:
                         await adapter.send(
                             source.chat_id,
@@ -2418,7 +2643,7 @@ class GatewayRunner:
                             f"`hermes pairing approve {platform_name} {code}`"
                         )
                 else:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._get_adapter_for_source(source)
                     if adapter:
                         await adapter.send(
                             source.chat_id,
@@ -2537,7 +2762,7 @@ class GatewayRunner:
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Stop requested")
                 # Force-clean: remove the session lock regardless of agent state
-                adapter = self.adapters.get(source.platform)
+                adapter = self._get_adapter_for_source(source)
                 if adapter and hasattr(adapter, 'get_pending_message'):
                     adapter.get_pending_message(_quick_key)  # consume and discard
                 self._pending_messages.pop(_quick_key, None)
@@ -2561,7 +2786,7 @@ class GatewayRunner:
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Session reset requested")
                 # Clear any pending messages so the old text doesn't replay
-                adapter = self.adapters.get(source.platform)
+                adapter = self._get_adapter_for_source(source)
                 if adapter and hasattr(adapter, 'get_pending_message'):
                     adapter.get_pending_message(_quick_key)  # consume and discard
                 self._pending_messages.pop(_quick_key, None)
@@ -2576,7 +2801,7 @@ class GatewayRunner:
                 queued_text = event.get_command_args().strip()
                 if not queued_text:
                     return "Usage: /queue <prompt>"
-                adapter = self.adapters.get(source.platform)
+                adapter = self._get_adapter_for_source(source)
                 if adapter:
                     from gateway.platforms.base import MessageEvent as _ME, MessageType as _MT
                     queued_event = _ME(
@@ -2606,9 +2831,14 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # /sethome updates routing state immediately and must not be
+            # queued as plain text behind an active session.
+            if _cmd_def_inner and _cmd_def_inner.name == "sethome":
+                return await self._handle_set_home_command(event)
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
-                adapter = self.adapters.get(source.platform)
+                adapter = self._get_adapter_for_source(source)
                 if adapter:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
@@ -2624,7 +2854,7 @@ class GatewayRunner:
                     return "⚡ Force-stopped. The agent was still starting — session unlocked."
                 # Queue the message so it will be picked up after the
                 # agent starts.
-                adapter = self.adapters.get(source.platform)
+                adapter = self._get_adapter_for_source(source)
                 if adapter:
                     adapter._pending_messages[_quick_key] = event
                 return None
@@ -3167,7 +3397,7 @@ class GatewayRunner:
                     and platform_name not in policy.notify_exclude_platforms
                 )
                 if should_notify:
-                    adapter = self.adapters.get(source.platform)
+                    adapter = self._get_adapter_for_source(source)
                     if adapter:
                         if reset_reason == "suspended":
                             reason_text = "previous session was stopped or interrupted"
@@ -3491,9 +3721,8 @@ class GatewayRunner:
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
-            env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-            if not os.getenv(env_key):
-                adapter = self.adapters.get(source.platform)
+            if not self._has_home_channel_for_source(source):
+                adapter = self._get_adapter_for_source(source)
                 if adapter:
                     await adapter.send(
                         source.chat_id,
@@ -3536,6 +3765,134 @@ class GatewayRunner:
         )
         if message_text is None:
             return
+        if _is_shared_thread and source.user_name:
+            message_text = f"[{source.user_name}] {message_text}"
+
+        if event.media_urls:
+            image_paths = []
+            for i, path in enumerate(event.media_urls):
+                # Check media_types if available; otherwise infer from message type
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                is_image = (
+                    mtype.startswith("image/")
+                    or event.message_type == MessageType.PHOTO
+                )
+                if is_image:
+                    image_paths.append(path)
+            if image_paths:
+                message_text = await self._enrich_message_with_vision(
+                    message_text, image_paths
+                )
+        
+        # -----------------------------------------------------------------
+        # Auto-transcribe voice/audio messages sent by the user
+        # -----------------------------------------------------------------
+        if event.media_urls:
+            audio_paths = []
+            for i, path in enumerate(event.media_urls):
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                is_audio = (
+                    mtype.startswith("audio/")
+                    or event.message_type in (MessageType.VOICE, MessageType.AUDIO)
+                )
+                if is_audio:
+                    audio_paths.append(path)
+            if audio_paths:
+                message_text = await self._enrich_message_with_transcription(
+                    message_text, audio_paths
+                )
+                # If STT failed, send a direct message to the user so they
+                # know voice isn't configured — don't rely on the agent to
+                # relay the error clearly.
+                _stt_fail_markers = (
+                    "No STT provider",
+                    "STT is disabled",
+                    "can't listen",
+                    "VOICE_TOOLS_OPENAI_KEY",
+                )
+                if any(m in message_text for m in _stt_fail_markers):
+                    _stt_adapter = self._get_adapter_for_source(source)
+                    _stt_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    if _stt_adapter:
+                        try:
+                            _stt_msg = (
+                                "🎤 I received your voice message but can't transcribe it — "
+                                "no speech-to-text provider is configured.\n\n"
+                                "To enable voice: install faster-whisper "
+                                "(`pip install faster-whisper` in the Hermes venv) "
+                                "and set `stt.enabled: true` in config.yaml, "
+                                "then /restart the gateway."
+                            )
+                            # Point to setup skill if it's installed
+                            if self._has_setup_skill():
+                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
+                            await _stt_adapter.send(
+                                source.chat_id, _stt_msg,
+                                metadata=_stt_meta,
+                            )
+                        except Exception:
+                            pass
+
+        # -----------------------------------------------------------------
+        # Enrich document messages with context notes for the agent
+        # -----------------------------------------------------------------
+        if event.media_urls and event.message_type == MessageType.DOCUMENT:
+            import mimetypes as _mimetypes
+            _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+            for i, path in enumerate(event.media_urls):
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                # Fall back to extension-based detection when MIME type is unreliable.
+                if mtype in ("", "application/octet-stream"):
+                    import os as _os2
+                    _ext = _os2.path.splitext(path)[1].lower()
+                    if _ext in _TEXT_EXTENSIONS:
+                        mtype = "text/plain"
+                    else:
+                        guessed, _ = _mimetypes.guess_type(path)
+                        if guessed:
+                            mtype = guessed
+                if not mtype.startswith(("application/", "text/")):
+                    continue
+                # Extract display filename by stripping the doc_{uuid12}_ prefix
+                import os as _os
+                basename = _os.path.basename(path)
+                # Format: doc_<12hex>_<original_filename>
+                parts = basename.split("_", 2)
+                display_name = parts[2] if len(parts) >= 3 else basename
+                # Sanitize to prevent prompt injection via filenames
+                import re as _re
+                display_name = _re.sub(r'[^\w.\- ]', '_', display_name)
+
+                if mtype.startswith("text/"):
+                    context_note = (
+                        f"[The user sent a text document: '{display_name}'. "
+                        f"Its content has been included below. "
+                        f"The file is also saved at: {path}]"
+                    )
+                else:
+                    context_note = (
+                        f"[The user sent a document: '{display_name}'. "
+                        f"The file is saved at: {path}. "
+                        f"Ask the user what they'd like you to do with it.]"
+                    )
+                message_text = f"{context_note}\n\n{message_text}"
+
+        # -----------------------------------------------------------------
+        # Inject reply context when user replies to a message not in history.
+        # Telegram (and other platforms) let users reply to specific messages,
+        # but if the quoted message is from a previous session, cron delivery,
+        # or background task, the agent has no context about what's being
+        # referenced. Prepend the quoted text so the agent understands. (#1594)
+        # -----------------------------------------------------------------
+        if getattr(event, 'reply_to_text', None) and event.reply_to_message_id:
+            reply_snippet = event.reply_to_text[:500]
+            found_in_history = any(
+                reply_snippet[:200] in (msg.get("content") or "")
+                for msg in history
+                if msg.get("role") in ("assistant", "user", "tool")
+            )
+            if not found_in_history:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         try:
             # Emit agent:start hook
@@ -3547,6 +3904,29 @@ class GatewayRunner:
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
+            # Expand @ context references (@file:, @folder:, @diff, etc.)
+            if "@" in message_text:
+                try:
+                    from agent.context_references import preprocess_context_references_async
+                    from agent.model_metadata import get_model_context_length
+                    _msg_cwd = os.environ.get("MESSAGING_CWD", os.path.expanduser("~"))
+                    _msg_ctx_len = get_model_context_length(
+                        self._model, base_url=self._base_url or "")
+                    _ctx_result = await preprocess_context_references_async(
+                        message_text, cwd=_msg_cwd,
+                        context_length=_msg_ctx_len, allowed_root=_msg_cwd)
+                    if _ctx_result.blocked:
+                        _adapter = self._get_adapter_for_source(source)
+                        if _adapter:
+                            await _adapter.send(
+                                source.chat_id,
+                                "\n".join(_ctx_result.warnings) or "Context injection refused.",
+                            )
+                        return
+                    if _ctx_result.expanded:
+                        message_text = _ctx_result.message
+                except Exception as exc:
+                    logger.debug("@ context reference expansion failed: %s", exc)
             # Run the agent
             agent_result = await self._run_agent(
                 message=message_text,
@@ -3560,7 +3940,7 @@ class GatewayRunner:
 
             # Stop persistent typing indicator now that the agent is done
             try:
-                _typing_adapter = self.adapters.get(source.platform)
+                _typing_adapter = self._get_adapter_for_source(source)
                 if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
                     await _typing_adapter.stop_typing(source.chat_id)
             except Exception:
@@ -3780,7 +4160,7 @@ class GatewayRunner:
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
                 if response:
-                    _media_adapter = self.adapters.get(source.platform)
+                    _media_adapter = self._get_adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
@@ -3792,7 +4172,7 @@ class GatewayRunner:
         except Exception as e:
             # Stop typing indicator on error too
             try:
-                _err_adapter = self.adapters.get(source.platform)
+                _err_adapter = self._get_adapter_for_source(source)
                 if _err_adapter and hasattr(_err_adapter, "stop_typing"):
                     await _err_adapter.stop_typing(source.chat_id)
             except Exception:
@@ -4285,7 +4665,7 @@ class GatewayRunner:
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
             # Try interactive picker if the platform supports it
-            adapter = self.adapters.get(source.platform)
+            adapter = self._get_adapter_for_source(source)
             has_picker = (
                 adapter is not None
                 and getattr(type(adapter), "send_model_picker", None) is not None
@@ -4748,9 +5128,7 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
-        
-        env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-        
+
         # Save to config.yaml
         try:
             import yaml
@@ -4759,13 +5137,48 @@ class GatewayRunner:
             if config_path.exists():
                 with open(config_path, encoding="utf-8") as f:
                     user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
+            if source.platform == Platform.FEISHU:
+                platforms_cfg = user_config.setdefault("platforms", {})
+                if not isinstance(platforms_cfg, dict):
+                    platforms_cfg = {}
+                    user_config["platforms"] = platforms_cfg
+                feishu_cfg = platforms_cfg.setdefault("feishu", {})
+                if not isinstance(feishu_cfg, dict):
+                    feishu_cfg = {}
+                    platforms_cfg["feishu"] = feishu_cfg
+                feishu_cfg["home_channel"] = {
+                    "account_id": source.account_id,
+                    "chat_id": chat_id,
+                    "name": chat_name,
+                }
+                accounts_cfg = feishu_cfg.get("accounts", {})
+                if isinstance(accounts_cfg, dict):
+                    for account_cfg in accounts_cfg.values():
+                        if isinstance(account_cfg, dict):
+                            account_cfg.pop("home_channel", None)
+                if getattr(self, "config", None):
+                    base_platform_cfg = self.config.platforms.get(source.platform)
+                    if base_platform_cfg is not None:
+                        base_platform_cfg.home_channel = HomeChannel(
+                            platform=source.platform,
+                            chat_id=chat_id,
+                            name=chat_name,
+                            account_id=source.account_id,
+                        )
+                        raw_accounts = base_platform_cfg.extra.get("accounts", {})
+                        if isinstance(raw_accounts, dict):
+                            for raw_account_cfg in raw_accounts.values():
+                                if isinstance(raw_account_cfg, dict):
+                                    raw_account_cfg.pop("home_channel", None)
+            else:
+                env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+                user_config[env_key] = chat_id
+                # Also set in the current environment so it takes effect immediately
+                os.environ[env_key] = str(chat_id)
             atomic_yaml_write(config_path, user_config)
-            # Also set in the current environment so it takes effect immediately
-            os.environ[env_key] = str(chat_id)
         except Exception as e:
             return f"Failed to save home channel: {e}"
-        
+
         return (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
@@ -4790,7 +5203,7 @@ class GatewayRunner:
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
 
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._get_adapter_for_source(event.source)
 
         if args in ("on", "enable"):
             self._voice_mode[chat_id] = "voice_only"
@@ -4829,7 +5242,7 @@ class GatewayRunner:
                 "all": "TTS (voice reply to all messages)",
             }
             # Append voice channel info if connected
-            adapter = self.adapters.get(event.source.platform)
+            adapter = self._get_adapter_for_source(event.source)
             guild_id = self._get_guild_id(event)
             if guild_id and hasattr(adapter, "get_voice_channel_info"):
                 info = adapter.get_voice_channel_info(guild_id)
@@ -4862,7 +5275,7 @@ class GatewayRunner:
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._get_adapter_for_source(event.source)
         if not hasattr(adapter, "join_voice_channel"):
             return "Voice channels are not supported on this platform."
 
@@ -4912,7 +5325,7 @@ class GatewayRunner:
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._get_adapter_for_source(event.source)
         guild_id = self._get_guild_id(event)
 
         if not guild_id or not hasattr(adapter, "leave_voice_channel"):
@@ -5078,7 +5491,7 @@ class GatewayRunner:
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
 
-            adapter = self.adapters.get(event.source.platform)
+            adapter = self._get_adapter_for_source(event.source)
 
             # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
@@ -5275,7 +5688,7 @@ class GatewayRunner:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
 
-        adapter = self.adapters.get(source.platform)
+        adapter = self._get_adapter_for_source(source)
         if not adapter:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
@@ -5447,7 +5860,7 @@ class GatewayRunner:
         """Execute an ephemeral /btw side question and deliver the answer."""
         from run_agent import AIAgent
 
-        adapter = self.adapters.get(source.platform)
+        adapter = self._get_adapter_for_source(source)
         if not adapter:
             logger.warning("No adapter for platform %s in /btw task %s", source.platform, task_id)
             return
@@ -6377,7 +6790,7 @@ class GatewayRunner:
             return "No pending command to approve."
 
         # Resume typing indicator — agent is about to continue processing.
-        _adapter = self.adapters.get(source.platform)
+        _adapter = self._get_adapter_for_source(source)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
 
@@ -6414,7 +6827,7 @@ class GatewayRunner:
             return "No pending command to deny."
 
         # Resume typing indicator — agent continues (with BLOCKED result).
-        _adapter = self.adapters.get(source.platform)
+        _adapter = self._get_adapter_for_source(source)
         if _adapter:
             _adapter.resume_typing_for_chat(source.chat_id)
 
@@ -6892,10 +7305,12 @@ class GatewayRunner:
         from gateway.session_context import set_session_vars
         return set_session_vars(
             platform=context.source.platform.value,
+            account_id=context.source.account_id or "",
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
+            user_id_alt=context.source.user_id_alt or "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
         )
@@ -7469,7 +7884,7 @@ class GatewayRunner:
             if not progress_queue:
                 return
 
-            adapter = self.adapters.get(source.platform)
+            adapter = self._get_adapter_for_source(source)
             if not adapter:
                 return
 
@@ -7622,7 +8037,7 @@ class GatewayRunner:
                 logger.debug("agent:step hook error: %s", _e)
 
         # Bridge sync status_callback → async adapter.send for context pressure
-        _status_adapter = self.adapters.get(source.platform)
+        _status_adapter = self._get_adapter_for_source(source)
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
@@ -7723,7 +8138,7 @@ class GatewayRunner:
             if _want_stream_deltas or _want_interim_consumer:
                 try:
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
-                    _adapter = self.adapters.get(source.platform)
+                    _adapter = self._get_adapter_for_source(source)
                     if _adapter:
                         # Platforms that don't support editing sent messages
                         # (e.g. WeChat) must not show a cursor in intermediate
@@ -8176,7 +8591,8 @@ class GatewayRunner:
         _interrupt_detected = asyncio.Event()  # shared with backup check
 
         async def monitor_for_interrupt():
-            if not session_key:
+            adapter = self._get_adapter_for_source(source)
+            if not adapter or not session_key:
                 return
 
             while True:
@@ -8227,7 +8643,7 @@ class GatewayRunner:
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
                 return  # Notifications disabled (gateway_notify_interval: 0)
-            _notify_adapter = self.adapters.get(source.platform)
+            _notify_adapter = self._get_adapter_for_source(source)
             if not _notify_adapter:
                 return
             while True:
@@ -8335,7 +8751,7 @@ class GatewayRunner:
                     if (not _warning_fired and _agent_warning is not None
                             and _idle_secs >= _agent_warning):
                         _warning_fired = True
-                        _warn_adapter = self.adapters.get(source.platform)
+                        _warn_adapter = self._get_adapter_for_source(source)
                         if _warn_adapter:
                             _elapsed_warn = int(_agent_warning // 60) or 1
                             _remaining_mins = int((_agent_timeout - _agent_warning) // 60) or 1
@@ -8454,7 +8870,7 @@ class GatewayRunner:
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]
-            adapter = self.adapters.get(source.platform)
+            adapter = self._get_adapter_for_source(source)
             
             # Get pending message from adapter.
             # Use session_key (not source.chat_id) to match adapter's storage keys.
@@ -8516,8 +8932,8 @@ class GatewayRunner:
                         "queueing message instead of recursing.",
                         _interrupt_depth, session_key,
                     )
-                    adapter = self.adapters.get(source.platform)
-                    if adapter and pending_event:
+                    adapter = self._get_adapter_for_source(source)
+                    if adapter and pending_event and hasattr(adapter, "_pending_messages"):
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
@@ -8645,7 +9061,13 @@ class GatewayRunner:
         return response
 
 
-def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
+def _start_cron_ticker(
+    stop_event: threading.Event,
+    adapters=None,
+    account_adapters=None,
+    loop=None,
+    interval: int = 60,
+):
     """
     Background thread that ticks the cron scheduler at a regular interval.
     
@@ -8668,7 +9090,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     tick_count = 0
     while not stop_event.is_set():
         try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop)
+            cron_tick(
+                verbose=False,
+                adapters=adapters,
+                account_adapters=account_adapters,
+                loop=loop,
+            )
         except Exception as e:
             logger.debug("Cron tick error: %s", e)
 
@@ -8853,7 +9280,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     cron_thread = threading.Thread(
         target=_start_cron_ticker,
         args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
+        kwargs={
+            "adapters": runner.adapters,
+            "account_adapters": runner._adapters_by_binding,
+            "loop": asyncio.get_running_loop(),
+        },
         daemon=True,
         name="cron-ticker",
     )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -75,6 +75,7 @@ class SessionSource:
     """
     platform: Platform
     chat_id: str
+    account_id: Optional[str] = None
     chat_name: Optional[str] = None
     chat_type: str = "dm"  # "dm", "group", "channel", "thread"
     user_id: Optional[str] = None
@@ -108,6 +109,7 @@ class SessionSource:
     def to_dict(self) -> Dict[str, Any]:
         d = {
             "platform": self.platform.value,
+            "account_id": self.account_id,
             "chat_id": self.chat_id,
             "chat_name": self.chat_name,
             "chat_type": self.chat_type,
@@ -126,6 +128,7 @@ class SessionSource:
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
         return cls(
             platform=Platform(data["platform"]),
+            account_id=data.get("account_id"),
             chat_id=str(data["chat_id"]),
             chat_name=data.get("chat_name"),
             chat_type=data.get("chat_type", "dm"),
@@ -462,17 +465,20 @@ def build_session_key(
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
     platform = source.platform.value
+    platform_scope = platform
+    if source.account_id:
+        platform_scope = f"{platform}[{source.account_id}]"
     if source.chat_type == "dm":
         if source.chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{source.chat_id}"
+                return f"agent:main:{platform_scope}:dm:{source.chat_id}:{source.thread_id}"
+            return f"agent:main:{platform_scope}:dm:{source.chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"agent:main:{platform_scope}:dm:{source.thread_id}"
+        return f"agent:main:{platform_scope}:dm"
 
     participant_id = source.user_id_alt or source.user_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = ["agent:main", platform_scope, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -43,19 +43,23 @@ from contextvars import ContextVar
 # ---------------------------------------------------------------------------
 
 _SESSION_PLATFORM: ContextVar[str] = ContextVar("HERMES_SESSION_PLATFORM", default="")
+_SESSION_ACCOUNT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_ACCOUNT_ID", default="")
 _SESSION_CHAT_ID: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_ID", default="")
 _SESSION_CHAT_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_CHAT_NAME", default="")
 _SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", default="")
 _SESSION_USER_ID: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID", default="")
+_SESSION_USER_ID_ALT: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID_ALT", default="")
 _SESSION_USER_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_USER_NAME", default="")
 _SESSION_KEY: ContextVar[str] = ContextVar("HERMES_SESSION_KEY", default="")
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
+    "HERMES_SESSION_ACCOUNT_ID": _SESSION_ACCOUNT_ID,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
+    "HERMES_SESSION_USER_ID_ALT": _SESSION_USER_ID_ALT,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
 }
@@ -63,10 +67,12 @@ _VAR_MAP = {
 
 def set_session_vars(
     platform: str = "",
+    account_id: str = "",
     chat_id: str = "",
     chat_name: str = "",
     thread_id: str = "",
     user_id: str = "",
+    user_id_alt: str = "",
     user_name: str = "",
     session_key: str = "",
 ) -> list:
@@ -80,10 +86,12 @@ def set_session_vars(
     """
     tokens = [
         _SESSION_PLATFORM.set(platform),
+        _SESSION_ACCOUNT_ID.set(account_id),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
+        _SESSION_USER_ID_ALT.set(user_id_alt),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
     ]
@@ -96,10 +104,12 @@ def clear_session_vars(tokens: list) -> None:
         return
     vars_in_order = [
         _SESSION_PLATFORM,
+        _SESSION_ACCOUNT_ID,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
+        _SESSION_USER_ID_ALT,
         _SESSION_USER_NAME,
         _SESSION_KEY,
     ]

--- a/model_tools.py
+++ b/model_tools.py
@@ -156,6 +156,7 @@ def _discover_tools():
         "tools.delegate_tool",
         "tools.process_registry",
         "tools.send_message_tool",
+        "tools.feishu_id_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -60,6 +61,40 @@ class TestResolveDeliveryTarget:
             "platform": "telegram",
             "chat_id": "-1001",
             "thread_id": "17585",
+        }
+
+    def test_origin_delivery_preserves_account_id(self):
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_123",
+                "account_id": "corp_a",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "feishu",
+            "chat_id": "oc_123",
+            "thread_id": None,
+            "account_id": "corp_a",
+        }
+
+    def test_explicit_same_platform_target_inherits_origin_account_id(self):
+        job = {
+            "deliver": "feishu:oc_456",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_123",
+                "account_id": "corp_a",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "feishu",
+            "chat_id": "oc_456",
+            "thread_id": None,
+            "account_id": "corp_a",
         }
 
     def test_explicit_telegram_topic_target_with_thread_id(self):
@@ -172,6 +207,76 @@ class TestResolveDeliveryTarget:
             "chat_id": "-2002",
             "thread_id": None,
         }
+
+    def test_bare_feishu_platform_falls_back_to_config_home_channel(self, monkeypatch):
+        from gateway.config import Platform
+
+        config = MagicMock()
+        config.get_home_channel = lambda platform, account_id=None: (
+            SimpleNamespace(chat_id="oc_team_claire", name="Team CLAIRE", account_id="corp_a")
+            if platform == Platform.FEISHU
+            else None
+        )
+        monkeypatch.delenv("FEISHU_HOME_CHANNEL", raising=False)
+
+        job = {
+            "deliver": "feishu",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "abc",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            assert _resolve_delivery_target(job) == {
+                "platform": "feishu",
+                "account_id": "corp_a",
+                "chat_id": "oc_team_claire",
+                "thread_id": None,
+            }
+
+    def test_origin_delivery_without_origin_can_fall_back_to_feishu_home_channel(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("BLUEBUBBLES_HOME_CHANNEL", raising=False)
+        monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_fallback_home")
+
+        job = {
+            "deliver": "origin",
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "feishu",
+            "chat_id": "oc_fallback_home",
+            "thread_id": None,
+        }
+
+    def test_origin_delivery_without_origin_can_fall_back_to_config_backed_feishu_home_channel(self, monkeypatch):
+        from gateway.config import Platform
+
+        monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("BLUEBUBBLES_HOME_CHANNEL", raising=False)
+        monkeypatch.delenv("FEISHU_HOME_CHANNEL", raising=False)
+
+        config = MagicMock()
+        config.get_home_channel = lambda platform, account_id=None: (
+            SimpleNamespace(chat_id="oc_config_home", name="Config Home", account_id="corp_a")
+            if platform == Platform.FEISHU
+            else None
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            assert _resolve_delivery_target({"deliver": "origin"}) == {
+                "platform": "feishu",
+                "account_id": "corp_a",
+                "chat_id": "oc_config_home",
+                "thread_id": None,
+            }
 
     def test_explicit_discord_topic_target_with_thread_id(self):
         """deliver: 'discord:chat_id:thread_id' parses correctly."""
@@ -763,6 +868,59 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        fake_db.close.assert_called_once()
+
+    def test_run_job_sets_and_clears_account_scoped_env(self, tmp_path, monkeypatch):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_123",
+                "account_id": "corp_a",
+            },
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        monkeypatch.delenv("HERMES_SESSION_ACCOUNT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                seen["session_account_id"] = os.getenv("HERMES_SESSION_ACCOUNT_ID")
+                seen["deliver_account_id"] = os.getenv("HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID")
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {
+            "session_account_id": "corp_a",
+            "deliver_account_id": "corp_a",
+        }
+        assert os.getenv("HERMES_SESSION_ACCOUNT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID") is None
         fake_db.close.assert_called_once()
 
 

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -176,6 +176,18 @@ class TestCommandBypassActiveSession:
             "/background response was not sent back to the user"
         )
 
+    @pytest.mark.asyncio
+    async def test_sethome_bypasses_guard(self):
+        """/sethome must bypass so routing state updates immediately."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/sethome"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:sethome" in r for r in adapter.sent_responses)
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -16,13 +16,19 @@ from gateway.config import (
 
 class TestHomeChannelRoundtrip:
     def test_to_dict_from_dict(self):
-        hc = HomeChannel(platform=Platform.DISCORD, chat_id="999", name="general")
+        hc = HomeChannel(
+            platform=Platform.DISCORD,
+            chat_id="999",
+            name="general",
+            account_id="bot-1",
+        )
         d = hc.to_dict()
         restored = HomeChannel.from_dict(d)
 
         assert restored.platform == Platform.DISCORD
         assert restored.chat_id == "999"
         assert restored.name == "general"
+        assert restored.account_id == "bot-1"
 
 
 class TestPlatformConfigRoundtrip:
@@ -222,6 +228,123 @@ class TestLoadGatewayConfig:
 
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
+
+    def test_loads_feishu_multi_account_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  feishu:\n"
+            "    default_account: corp_a\n"
+            "    home_channel:\n"
+            "      account_id: corp_a\n"
+            "      chat_id: oc_alpha\n"
+            "      name: Alpha\n"
+            "    accounts:\n"
+            "      corp_a:\n"
+            "        app_id: cli_a\n"
+            "        app_secret: sec_a\n"
+            "      corp_b:\n"
+            "        app_id: cli_b\n"
+            "        app_secret: sec_b\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert Platform.FEISHU in config.get_connected_platforms()
+        assert config.get_default_account_id(Platform.FEISHU) == "corp_a"
+        assert config.get_home_channel(Platform.FEISHU).chat_id == "oc_alpha"
+        assert config.get_home_channel(Platform.FEISHU).account_id == "corp_a"
+        corp_b = config.get_platform_config(Platform.FEISHU, account_id="corp_b")
+        assert corp_b is not None
+        assert corp_b.extra["app_id"] == "cli_b"
+        assert corp_b.extra["account_id"] == "corp_b"
+        bindings = config.iter_enabled_platform_bindings()
+        feishu_bindings = [
+            (platform, account_id)
+            for platform, account_id, _ in bindings
+            if platform == Platform.FEISHU
+        ]
+        assert feishu_bindings == [
+            (Platform.FEISHU, "corp_a"),
+            (Platform.FEISHU, "corp_b"),
+        ]
+
+    def test_feishu_legacy_account_home_channel_falls_back_when_platform_home_missing(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  feishu:\n"
+            "    accounts:\n"
+            "      corp_a:\n"
+            "        app_id: cli_a\n"
+            "        app_secret: sec_a\n"
+            "        home_channel:\n"
+            "          chat_id: oc_alpha\n"
+            "          name: Alpha\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        home = config.get_home_channel(Platform.FEISHU)
+        assert home is not None
+        assert home.chat_id == "oc_alpha"
+        assert home.account_id == "corp_a"
+
+    def test_feishu_legacy_env_is_ignored_when_multi_account_yaml_present(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  feishu:\n"
+            "    default_account: corp_a\n"
+            "    accounts:\n"
+            "      corp_a:\n"
+            "        app_id: cli_yaml\n"
+            "        app_secret: sec_yaml\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "cli_env")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "sec_env")
+
+        config = load_gateway_config()
+
+        feishu = config.platforms[Platform.FEISHU]
+        assert "app_id" not in feishu.extra
+        assert config.get_platform_config(Platform.FEISHU, "corp_a").extra["app_id"] == "cli_yaml"
+
+    def test_feishu_account_dm_policy_controls_unauthorized_dm_behavior(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "accounts": {
+                            "corp_a": {
+                                "app_id": "cli_a",
+                                "app_secret": "sec_a",
+                                "dm_policy": "allowlist",
+                            },
+                            "corp_b": {
+                                "app_id": "cli_b",
+                                "app_secret": "sec_b",
+                                "dm_policy": "pairing",
+                            },
+                        },
+                    },
+                ),
+            },
+            unauthorized_dm_behavior="ignore",
+        )
+
+        assert config.get_unauthorized_dm_behavior(Platform.FEISHU, account_id="corp_a") == "ignore"
+        assert config.get_unauthorized_dm_behavior(Platform.FEISHU, account_id="corp_b") == "pair"
 
 
 class TestHomeChannelEnvOverrides:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -699,6 +699,14 @@ class TestAdapterBehavior(unittest.TestCase):
                 calls.append("card_action")
                 return self
 
+            def register_p2_im_chat_member_bot_added_v1(self, _handler):
+                calls.append("bot_added")
+                return self
+
+            def register_p2_im_chat_member_bot_deleted_v1(self, _handler):
+                calls.append("bot_deleted")
+                return self
+
             def build(self):
                 calls.append("build")
                 return "handler"
@@ -722,6 +730,8 @@ class TestAdapterBehavior(unittest.TestCase):
                 "reaction_created",
                 "reaction_deleted",
                 "card_action",
+                "bot_added",
+                "bot_deleted",
                 "build",
             ],
         )
@@ -827,6 +837,51 @@ class TestAdapterBehavior(unittest.TestCase):
         message_with_mention = SimpleNamespace(mentions=[SimpleNamespace(key="@_user_1")])
         self.assertFalse(adapter._should_accept_group_message(message_with_mention, sender_id, ""))
 
+    def test_group_message_can_disable_require_mention_at_account_level(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(extra={"group_policy": "open", "require_mention": False})
+        )
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertTrue(adapter._should_accept_group_message(SimpleNamespace(mentions=[]), sender_id, ""))
+
+    def test_group_rule_can_override_require_mention(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "group_policy": "open",
+                    "require_mention": False,
+                    "group_rules": {
+                        "oc_strict": {
+                            "policy": "open",
+                            "require_mention": True,
+                        }
+                    },
+                }
+            )
+        )
+        adapter._bot_open_id = "ou_bot"
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        bot_mention = SimpleNamespace(
+            name="Bot",
+            id=SimpleNamespace(open_id="ou_bot", user_id=None),
+        )
+
+        self.assertFalse(adapter._should_accept_group_message(SimpleNamespace(mentions=[]), sender_id, "oc_strict"))
+        self.assertTrue(
+            adapter._should_accept_group_message(
+                SimpleNamespace(mentions=[bot_mention]),
+                sender_id,
+                "oc_strict",
+            )
+        )
+
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_with_other_user_mention_is_rejected_when_bot_identity_unknown(self):
         from gateway.config import PlatformConfig
@@ -859,7 +914,7 @@ class TestAdapterBehavior(unittest.TestCase):
             mentions=[
                 SimpleNamespace(
                     name="Hermes Bot",
-                    id=SimpleNamespace(open_id="ou_other", user_id="u_other"),
+                    id=SimpleNamespace(open_id=None, user_id=None),
                 )
             ]
         )
@@ -1077,6 +1132,65 @@ class TestAdapterBehavior(unittest.TestCase):
             )
         )
 
+    @patch.dict(os.environ, {"FEISHU_BOT_NAME": "Legacy Bot"}, clear=True)
+    def test_account_scoped_adapter_ignores_legacy_bot_name_env(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "account_id": "corp_a",
+                    "app_id": "cli_corp_a",
+                    "app_secret": "sec_corp_a",
+                    "group_policy": "open",
+                }
+            )
+        )
+
+        self.assertEqual(adapter._bot_name, "")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_adapter_ignores_bot_name_in_config(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "app_id": "cli_demo",
+                    "app_secret": "sec_demo",
+                    "bot_name": "Config Bot",
+                }
+            )
+        )
+
+        self.assertEqual(adapter._bot_name, "")
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_APP_ID_FROM_ENV": "cli_env",
+            "FEISHU_APP_SECRET_FROM_ENV": "sec_env",
+        },
+        clear=True,
+    )
+    def test_adapter_resolves_env_references_for_credentials(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                extra={
+                    "app_id": "env:FEISHU_APP_ID_FROM_ENV",
+                    "app_secret": "env:FEISHU_APP_SECRET_FROM_ENV",
+                }
+            )
+        )
+
+        self.assertEqual(adapter._app_id, "cli_env")
+        self.assertEqual(adapter._app_secret, "sec_env")
+
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_matches_bot_open_id_when_configured(self):
         from gateway.config import PlatformConfig
@@ -1109,15 +1223,136 @@ class TestAdapterBehavior(unittest.TestCase):
 
         named_mention = SimpleNamespace(
             name="Hermes Bot",
-            id=SimpleNamespace(open_id="ou_other", user_id="u_other"),
+            id=SimpleNamespace(open_id=None, user_id=None),
         )
         different_mention = SimpleNamespace(
             name="Another Bot",
-            id=SimpleNamespace(open_id="ou_other", user_id="u_other"),
+            id=SimpleNamespace(open_id=None, user_id=None),
         )
 
         self.assertTrue(adapter._should_accept_group_message(SimpleNamespace(mentions=[named_mention]), sender_id, ""))
         self.assertFalse(adapter._should_accept_group_message(SimpleNamespace(mentions=[different_mention]), sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_does_not_fallback_to_name_when_payload_has_different_id(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_name = "Hermes Bot"
+        adapter._bot_open_id = "ou_bot"
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        conflicting_mention = SimpleNamespace(
+            name="Hermes Bot",
+            id=SimpleNamespace(open_id="ou_other", user_id="u_other"),
+        )
+
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                SimpleNamespace(mentions=[conflicting_mention]),
+                sender_id,
+                "",
+            )
+        )
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_hydrate_bot_identity_prefers_bot_info_endpoint(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            request=Mock(
+                return_value=SimpleNamespace(
+                    success=lambda: True,
+                    raw=SimpleNamespace(
+                        content=b'{"code":0,"msg":"success","bot":{"open_id":"ou_bot","bot_name":"Hermes Bot"}}'
+                    ),
+                )
+            ),
+            application=SimpleNamespace(
+                v6=SimpleNamespace(
+                    application=SimpleNamespace(get=Mock())
+                )
+            ),
+        )
+
+        asyncio.run(adapter._hydrate_bot_identity())
+
+        self.assertEqual(adapter._bot_open_id, "ou_bot")
+        self.assertEqual(adapter._bot_name, "Hermes Bot")
+        adapter._client.application.v6.application.get.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "Legacy Bot",
+        },
+        clear=True,
+    )
+    def test_hydrate_bot_identity_does_not_short_circuit_on_legacy_bot_name_env(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            request=Mock(
+                return_value=SimpleNamespace(
+                    success=lambda: True,
+                    raw=SimpleNamespace(
+                        content=b'{"code":0,"msg":"success","bot":{"open_id":"ou_bot","bot_name":"Official Bot"}}'
+                    ),
+                )
+            ),
+            application=SimpleNamespace(
+                v6=SimpleNamespace(
+                    application=SimpleNamespace(get=Mock())
+                )
+            ),
+        )
+
+        asyncio.run(adapter._hydrate_bot_identity())
+
+        self.assertEqual(adapter._bot_open_id, "ou_bot")
+        self.assertEqual(adapter._bot_name, "Official Bot")
+        adapter._client.request.assert_called_once()
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_hydrate_bot_identity_falls_back_to_application_info(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            request=Mock(
+                return_value=SimpleNamespace(
+                    success=lambda: False,
+                    code=9999,
+                    msg="not available",
+                )
+            ),
+            application=SimpleNamespace(
+                v6=SimpleNamespace(
+                    application=SimpleNamespace(
+                        get=Mock(
+                            return_value=SimpleNamespace(
+                                success=lambda: True,
+                                data=SimpleNamespace(
+                                    app=SimpleNamespace(app_name="Fallback App")
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+        )
+
+        asyncio.run(adapter._hydrate_bot_identity())
+
+        self.assertFalse(adapter._bot_open_id)
+        self.assertEqual(adapter._bot_name, "Fallback App")
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_post_message_uses_parsed_mentions_when_sdk_mentions_missing(self):

--- a/tests/gateway/test_feishu_ws_runtime.py
+++ b/tests/gateway/test_feishu_ws_runtime.py
@@ -1,0 +1,86 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from gateway.platforms.feishu import (
+    _FEISHU_WS_THREAD_STATE,
+    _FeishuWSLoopProxy,
+    _feishu_ws_connect_proxy,
+    _install_feishu_ws_runtime_proxies,
+)
+
+
+def test_feishu_ws_loop_proxy_uses_thread_local_loops():
+    proxy = _FeishuWSLoopProxy()
+    results = {}
+
+    def worker(name: str) -> None:
+        loop = asyncio.new_event_loop()
+        _FEISHU_WS_THREAD_STATE.loop = loop
+        try:
+            async def current_loop_id() -> int:
+                return id(asyncio.get_running_loop())
+
+            results[name] = proxy.run_until_complete(current_loop_id())
+        finally:
+            delattr(_FEISHU_WS_THREAD_STATE, "loop")
+            loop.close()
+
+    threads = [
+        threading.Thread(target=worker, args=("a",)),
+        threading.Thread(target=worker, args=("b",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results["a"] != results["b"]
+
+
+def test_install_feishu_ws_runtime_proxies_patches_once():
+    original_connect = object()
+    original_loop = asyncio.new_event_loop()
+    module = SimpleNamespace(
+        websockets=SimpleNamespace(connect=original_connect),
+        loop=original_loop,
+    )
+
+    try:
+        _install_feishu_ws_runtime_proxies(module)
+        first_loop = module.loop
+        first_connect = module.websockets.connect
+
+        _install_feishu_ws_runtime_proxies(module)
+
+        assert module.loop is first_loop
+        assert module.websockets.connect is first_connect
+        assert module._hermes_ws_original_connect is original_connect
+    finally:
+        original_loop.close()
+
+
+def test_feishu_ws_connect_proxy_applies_thread_local_ping_overrides():
+    seen = {}
+
+    async def fake_connect(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return "ok"
+
+    loop = asyncio.new_event_loop()
+    _FEISHU_WS_THREAD_STATE.loop = loop
+    _FEISHU_WS_THREAD_STATE.original_connect = fake_connect
+    _FEISHU_WS_THREAD_STATE.ping_interval = 7
+    _FEISHU_WS_THREAD_STATE.ping_timeout = 3
+    try:
+        result = loop.run_until_complete(_feishu_ws_connect_proxy("wss://example.invalid/ws"))
+    finally:
+        for attr in ("loop", "original_connect", "ping_interval", "ping_timeout"):
+            delattr(_FEISHU_WS_THREAD_STATE, attr)
+        loop.close()
+
+    assert result == "ok"
+    assert seen["args"] == ("wss://example.invalid/ws",)
+    assert seen["kwargs"]["ping_interval"] == 7
+    assert seen["kwargs"]["ping_timeout"] == 3

--- a/tests/gateway/test_runner_fatal_adapter.py
+++ b/tests/gateway/test_runner_fatal_adapter.py
@@ -83,8 +83,7 @@ async def test_runner_queues_retryable_runtime_fatal_for_reconnection(monkeypatc
         retryable=True,
     )
 
-    runner.adapters = {Platform.WHATSAPP: adapter}
-    runner.delivery_router.adapters = runner.adapters
+    runner._register_adapter(Platform.WHATSAPP, adapter)
     runner.stop = AsyncMock()
 
     await runner._handle_adapter_fatal_error(adapter)
@@ -94,3 +93,32 @@ async def test_runner_queues_retryable_runtime_fatal_for_reconnection(monkeypatc
     assert runner._exit_with_failure is True
     assert Platform.WHATSAPP in runner._failed_platforms
     assert runner._failed_platforms[Platform.WHATSAPP]["attempts"] == 0
+
+
+def test_runner_prefers_account_specific_adapter_for_source(tmp_path):
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"default_account": "a1"},
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    default_adapter = _RuntimeRetryableAdapter()
+    default_adapter.platform = Platform.FEISHU
+    default_adapter.account_id = "a1"
+    second_adapter = _RuntimeRetryableAdapter()
+    second_adapter.platform = Platform.FEISHU
+    second_adapter.account_id = "a2"
+
+    runner._register_adapter(Platform.FEISHU, default_adapter)
+    runner._register_adapter(Platform.FEISHU, second_adapter)
+
+    from gateway.session import SessionSource
+
+    assert runner._get_adapter_for_source(
+        SessionSource(platform=Platform.FEISHU, chat_id="oc_1", account_id="a2")
+    ) is second_adapter

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -19,6 +19,7 @@ class TestSessionSourceRoundtrip:
         source = SessionSource(
             platform=Platform.TELEGRAM,
             chat_id="12345",
+            account_id="main",
             chat_name="My Group",
             chat_type="group",
             user_id="99",
@@ -30,6 +31,7 @@ class TestSessionSourceRoundtrip:
 
         assert restored.platform == Platform.TELEGRAM
         assert restored.chat_id == "12345"
+        assert restored.account_id == "main"
         assert restored.chat_name == "My Group"
         assert restored.chat_type == "group"
         assert restored.user_id == "99"
@@ -86,6 +88,16 @@ class TestSessionSourceRoundtrip:
     def test_invalid_platform_raises(self):
         with pytest.raises((ValueError, KeyError)):
             SessionSource.from_dict({"platform": "nonexistent", "chat_id": "1"})
+
+    def test_build_session_key_includes_account_scope(self):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            account_id="corp_a",
+            chat_id="oc_123",
+            chat_type="dm",
+        )
+
+        assert build_session_key(source) == "agent:main:feishu[corp_a]:dm:oc_123"
 
 
 class TestSessionSourceDescription:

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -31,6 +31,9 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID_ALT", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
 
     tokens = runner._set_session_env(context)
 
@@ -41,6 +44,9 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
+    assert get_session_env("HERMES_SESSION_USER_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == ""
+    assert get_session_env("HERMES_SESSION_USER_NAME") == ""
 
     # os.environ should NOT be touched
     assert os.getenv("HERMES_SESSION_PLATFORM") is None
@@ -60,6 +66,9 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID_ALT", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
 
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -85,6 +94,9 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     assert get_session_env("HERMES_SESSION_USER_ID") == ""
     assert get_session_env("HERMES_SESSION_USER_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == ""
+    assert get_session_env("HERMES_SESSION_USER_NAME") == ""
 
 
 def test_get_session_env_falls_back_to_os_environ(monkeypatch):
@@ -95,8 +107,10 @@ def test_get_session_env_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == "discord"
 
     # Now set a contextvar — should prefer it
-    tokens = set_session_vars(platform="telegram")
+    tokens = set_session_vars(platform="telegram", user_id="u_1", user_name="Alice")
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
+    assert get_session_env("HERMES_SESSION_USER_ID") == "u_1"
+    assert get_session_env("HERMES_SESSION_USER_NAME") == "Alice"
 
     # Restore — should fall back to os.environ again
     clear_session_vars(tokens)
@@ -129,6 +143,33 @@ def test_set_session_env_handles_missing_optional_fields():
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == ""
+    assert get_session_env("HERMES_SESSION_USER_NAME") == ""
+
+    runner._clear_session_env(tokens)
+
+
+def test_set_session_env_includes_sender_identity():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_123",
+        account_id="laok-personal",
+        chat_name="Team CLAIRE",
+        chat_type="group",
+        user_id="ou_abc",
+        user_id_alt="on_union",
+        user_name="Ethan",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+
+    assert get_session_env("HERMES_SESSION_ACCOUNT_ID") == "laok-personal"
+    assert get_session_env("HERMES_SESSION_USER_ID") == "ou_abc"
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == "on_union"
+    assert get_session_env("HERMES_SESSION_USER_NAME") == "Ethan"
 
     runner._clear_session_env(tokens)
 

--- a/tests/gateway/test_sethome_multi_account.py
+++ b/tests/gateway/test_sethome_multi_account.py
@@ -1,0 +1,268 @@
+import yaml
+import pytest
+from datetime import datetime
+from time import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+@pytest.mark.asyncio
+async def test_sethome_persists_feishu_platform_home_channel(monkeypatch, tmp_path):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                        },
+                    },
+                },
+            ),
+        },
+    )
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            account_id="corp",
+            chat_id="oc_c7a439d23a9a824e7c5b4352f802d660",
+            chat_name="Team CLAIRE",
+            chat_type="group",
+            user_id="ou_owner",
+            user_name="Ethan",
+        ),
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    home = saved["platforms"]["feishu"]["home_channel"]
+
+    assert home["account_id"] == "corp"
+    assert home["chat_id"] == "oc_c7a439d23a9a824e7c5b4352f802d660"
+    assert home["name"] == "Team CLAIRE"
+    assert (
+        runner.config.get_home_channel(Platform.FEISHU).chat_id
+        == "oc_c7a439d23a9a824e7c5b4352f802d660"
+    )
+    assert runner.config.get_home_channel(Platform.FEISHU).account_id == "corp"
+    assert "Home channel set to **Team CLAIRE**" in result
+
+
+def test_has_home_channel_for_feishu_account_uses_platform_scoped_config():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                home_channel=HomeChannel(
+                    platform=Platform.FEISHU,
+                    chat_id="oc_dm_home",
+                    name="Owner DM",
+                    account_id="corp",
+                ),
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                        },
+                    },
+                },
+            ),
+        },
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        account_id="corp",
+        chat_id="oc_group",
+        chat_name="Team CLAIRE",
+        chat_type="group",
+        user_id="ou_owner",
+        user_name="Ethan",
+    )
+
+    assert runner._has_home_channel_for_source(source) is True
+
+
+def test_has_home_channel_for_feishu_account_accepts_legacy_account_scoped_fallback():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                            "home_channel": {
+                                "chat_id": "oc_dm_home",
+                                "name": "Owner DM",
+                            },
+                        },
+                    },
+                },
+            ),
+        },
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        account_id="corp",
+        chat_id="oc_group",
+        chat_name="Team CLAIRE",
+        chat_type="group",
+        user_id="ou_owner",
+        user_name="Ethan",
+    )
+
+    assert runner._has_home_channel_for_source(source) is True
+
+
+def test_has_home_channel_for_feishu_account_does_not_fallback_to_global_env(monkeypatch):
+    monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_global_home")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                        },
+                    },
+                },
+            ),
+        },
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        account_id="corp",
+        chat_id="oc_group",
+        chat_name="Team CLAIRE",
+        chat_type="group",
+        user_id="ou_owner",
+        user_name="Ethan",
+    )
+
+    assert runner._has_home_channel_for_source(source) is False
+
+
+def test_get_adapter_does_not_fallback_to_platform_default_for_account_bound_source():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    default_adapter = MagicMock()
+    runner.adapters = {Platform.FEISHU: default_adapter}
+    runner._adapters_by_binding = {Platform.FEISHU: default_adapter}
+
+    adapter = runner._get_adapter(Platform.FEISHU, account_id="corp")
+
+    assert adapter is None
+
+
+@pytest.mark.asyncio
+async def test_sethome_bypasses_running_agent_guard():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                        },
+                    },
+                },
+            ),
+        },
+    )
+
+    adapter = MagicMock()
+    adapter.account_id = "corp"
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.FEISHU: adapter}
+    runner._adapters_by_binding = {}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        account_id="corp",
+        chat_id="oc_dm_home",
+        chat_name="Owner DM",
+        chat_type="dm",
+        user_id="ou_owner",
+        user_name="Ethan",
+    )
+    session_key = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.FEISHU,
+        chat_type="dm",
+    )
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    running_agent = SimpleNamespace(
+        interrupt=MagicMock(),
+        get_activity_summary=lambda: {
+            "seconds_since_activity": 0,
+            "last_activity_desc": "test",
+            "api_call_count": 1,
+            "max_iterations": 8,
+        },
+    )
+    runner._running_agents = {session_key: running_agent}
+    runner._running_agents_ts = {session_key: time()}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._draining = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._handle_set_home_command = AsyncMock(return_value="sethome ok")
+
+    event = MessageEvent(text="/sethome", source=source, message_id="om_cmd")
+
+    result = await runner._handle_message(event)
+
+    assert result == "sethome ok"
+    runner._handle_set_home_command.assert_awaited_once_with(event)
+    running_agent.interrupt.assert_not_called()

--- a/tests/gateway/test_shared_thread_sender_prefix.py
+++ b/tests/gateway/test_shared_thread_sender_prefix.py
@@ -1,0 +1,92 @@
+import importlib
+import sys
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_shared_thread_prefixes_sender_once(monkeypatch):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = False
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.config = MagicMock()
+    runner.session_store.config.get_reset_policy.return_value = SimpleNamespace(
+        notify=False,
+        at_hour=0,
+        notify_exclude_platforms=[],
+    )
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: []
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._show_reasoning = False
+    runner._has_setup_skill = lambda: False
+    runner._has_home_channel_for_source = lambda source: True
+    runner._resolve_session_agent_runtime = lambda **kwargs: ("test-model", {"api_key": "fake"})
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", gateway_run.Path("/tmp"))
+    monkeypatch.setattr(gateway_run, "_config_path", "/tmp/nonexistent-config.yaml")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+        user_name="alice",
+    )
+    event = MessageEvent(text="hello", source=source, message_id="1")
+
+    result = await runner._handle_message_with_agent(event, source, "q")
+
+    assert result == "ok"
+    sent_message = runner._run_agent.await_args.kwargs["message"]
+    assert sent_message == "[alice] hello"

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -37,16 +37,26 @@ def _clear_auth_env(monkeypatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
-def _make_event(platform: Platform, user_id: str, chat_id: str) -> MessageEvent:
+def _make_event(
+    platform: Platform,
+    user_id: str,
+    chat_id: str,
+    *,
+    account_id: str | None = None,
+    chat_type: str = "dm",
+    user_id_alt: str | None = None,
+) -> MessageEvent:
     return MessageEvent(
         text="hello",
         message_id="m1",
         source=SessionSource(
             platform=platform,
+            account_id=account_id,
             user_id=user_id,
+            user_id_alt=user_id_alt,
             chat_id=chat_id,
             user_name="tester",
-            chat_type="dm",
+            chat_type=chat_type,
         ),
     )
 
@@ -253,3 +263,126 @@ async def test_global_ignore_suppresses_pairing_reply(monkeypatch):
     assert result is None
     runner.pairing_store.generate_code.assert_not_called()
     adapter.send.assert_not_awaited()
+
+
+def test_feishu_account_allowlist_authorizes_listed_dm_user(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                            "dm_policy": "allowlist",
+                            "allowed_users": ["ou_allowed"],
+                        },
+                    },
+                },
+            ),
+        },
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config)
+
+    assert runner._is_user_authorized(
+        _make_event(Platform.FEISHU, "ou_allowed", "oc_dm", account_id="corp").source
+    ) is True
+
+
+def test_feishu_account_allowlist_checks_alternate_ids(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                            "dm_policy": "allowlist",
+                            "allowed_users": ["on_union_user"],
+                        },
+                    },
+                },
+            ),
+        },
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config)
+
+    assert runner._is_user_authorized(
+        _make_event(
+            Platform.FEISHU,
+            "ou_sender",
+            "oc_dm",
+            account_id="corp",
+            user_id_alt="on_union_user",
+        ).source
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_feishu_account_allowlist_ignores_unauthorized_dm(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                            "dm_policy": "allowlist",
+                            "allowed_users": ["ou_allowed"],
+                        },
+                    },
+                },
+            ),
+        },
+    )
+    runner, adapter = _make_runner(Platform.FEISHU, config)
+
+    result = await runner._handle_message(
+        _make_event(Platform.FEISHU, "ou_stranger", "oc_dm", account_id="corp")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+def test_feishu_account_group_messages_bypass_dm_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "accounts": {
+                        "corp": {
+                            "app_id": "cli_corp",
+                            "app_secret": "sec_corp",
+                            "dm_policy": "allowlist",
+                            "allowed_users": ["ou_allowed"],
+                            "group_policy": "open",
+                            "require_mention": True,
+                        },
+                    },
+                },
+            ),
+        },
+    )
+    runner, _adapter = _make_runner(Platform.FEISHU, config)
+
+    assert runner._is_user_authorized(
+        _make_event(
+            Platform.FEISHU,
+            "ou_group_user",
+            "oc_group",
+            account_id="corp",
+            chat_type="group",
+        ).source
+    ) is True

--- a/tests/tools/test_feishu_id_tool.py
+++ b/tests/tools/test_feishu_id_tool.py
@@ -1,0 +1,606 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.config import Platform
+from gateway.session import SessionEntry, SessionSource
+from tools.feishu_id_tool import feishu_id_tool
+
+
+class _FakeResponse:
+    def __init__(self, *, success: bool, data=None, code=0, msg="ok"):
+        self._success = success
+        self.data = data
+        self.code = code
+        self.msg = msg
+
+    def success(self):
+        return self._success
+
+
+def _make_fake_client(
+    *,
+    user=None,
+    chat=None,
+    members=None,
+    batch_users=None,
+    search_chats=None,
+):
+    def _user_get(_request):
+        if user is None:
+            return _FakeResponse(success=False, code=404, msg="user not found")
+        return _FakeResponse(success=True, data=SimpleNamespace(user=user))
+
+    def _user_batch(_request):
+        if batch_users is None:
+            return _FakeResponse(success=False, code=404, msg="batch not found")
+        return _FakeResponse(success=True, data=SimpleNamespace(items=batch_users))
+
+    def _chat_get(_request):
+        if chat is None:
+            return _FakeResponse(success=False, code=404, msg="chat not found")
+        return _FakeResponse(success=True, data=chat)
+
+    def _chat_search(_request):
+        if search_chats is None:
+            return _FakeResponse(success=False, code=404, msg="search not found")
+        return _FakeResponse(success=True, data=SimpleNamespace(items=search_chats))
+
+    def _chat_members_get(_request):
+        if members is None:
+            return _FakeResponse(success=False, code=404, msg="members not found")
+        return _FakeResponse(
+            success=True,
+            data=SimpleNamespace(
+                items=members,
+                page_token=None,
+                has_more=False,
+                member_total=str(len(members)),
+            ),
+        )
+
+    return SimpleNamespace(
+        contact=SimpleNamespace(
+            v3=SimpleNamespace(
+                user=SimpleNamespace(
+                    get=_user_get,
+                    batch=_user_batch,
+                )
+            )
+        ),
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                chat=SimpleNamespace(
+                    get=_chat_get,
+                    search=_chat_search,
+                ),
+                chat_members=SimpleNamespace(get=_chat_members_get),
+            )
+        ),
+    )
+
+
+def _write_sessions(home: Path, payloads: list[dict]) -> None:
+    sessions_dir = home / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now().isoformat()
+    data = {}
+    for item in payloads:
+        source = SessionSource(**item["source"])
+        entry = SessionEntry(
+            session_key=item["session_key"],
+            session_id=item["session_id"],
+            created_at=datetime.fromisoformat(item.get("created_at", now)),
+            updated_at=datetime.fromisoformat(item.get("updated_at", now)),
+            origin=source,
+            display_name=source.chat_name,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
+        data[item["session_key"]] = entry.to_dict()
+    (sessions_dir / "sessions.json").write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def _make_config(accounts: dict[str, dict], default_account: str | None = None):
+    configs = {}
+    for account_id, item in accounts.items():
+        configs[account_id] = SimpleNamespace(
+            enabled=True,
+            extra={"account_id": account_id, "admins": item.get("admins", [])},
+            home_channel=SimpleNamespace(
+                chat_id=item["home_chat_id"],
+                name=item.get("home_name", item["home_chat_id"]),
+            ) if item.get("home_chat_id") else None,
+        )
+
+    return SimpleNamespace(
+        get_default_account_id=lambda platform: default_account if platform == Platform.FEISHU else None,
+        get_platform_config=lambda platform, account_id=None: (
+            configs.get(account_id or default_account) if platform == Platform.FEISHU else None
+        ),
+        iter_platform_account_configs=lambda platform: (
+            list(configs.items()) if platform == Platform.FEISHU else []
+        ),
+        get_connected_platforms=lambda: {Platform.FEISHU},
+        platforms={Platform.FEISHU: next(iter(configs.values())) if configs else None},
+    )
+
+
+class TestFeishuIdTool:
+    def test_whois_user_prefers_official_api_and_merges_observed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:dm:oc_dm",
+                    "session_id": "sess-official-user",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_dm",
+                        "chat_name": "Ethan",
+                        "chat_type": "dm",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan Observed",
+                    },
+                }
+            ],
+        )
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_home"}},
+            default_account="laok-personal",
+        )
+        fake_client = _make_fake_client(
+            user=SimpleNamespace(
+                open_id="ou_ethan",
+                user_id="u_ethan",
+                union_id="on_ethan",
+                name="Ethan",
+                nickname="E",
+                en_name="Ethan Z",
+                job_title="Operator",
+                department_ids=["od_dept"],
+                email="ethan@example.com",
+                enterprise_email="ethan@corp.example.com",
+                mobile="+8613800000000",
+            )
+        )
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("tools.feishu_id_tool._build_official_client", return_value=(fake_client, None)),
+        ):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "whois_user",
+                        "open_id": "ou_ethan",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "official_api"
+        assert result["authoritative"] is True
+        assert result["user"]["open_ids"] == ["ou_ethan"]
+        assert result["user"]["user_ids"] == ["u_ethan"]
+        assert result["user"]["union_ids"] == ["on_ethan"]
+        assert "Ethan Observed" in result["user"]["names"]
+        assert result["user"]["job_title"] == "Operator"
+        assert result["user"]["email"] == "ethan@example.com"
+
+    def test_whois_chat_returns_members_and_home_channel(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:group:oc_team:ou_ethan",
+                    "session_id": "sess-1",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_team",
+                        "chat_name": "Team CLAIRE",
+                        "chat_type": "group",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan",
+                    },
+                }
+            ],
+        )
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_team", "home_name": "Team CLAIRE"}},
+            default_account="laok-personal",
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            result = json.loads(feishu_id_tool({"action": "whois_chat", "chat_id": "oc_team"}))
+
+        assert result["success"] is True
+        assert result["chat"]["account_id"] == "laok-personal"
+        assert result["chat"]["is_home_channel"] is True
+        assert "Team CLAIRE" in result["chat"]["names"]
+        member = result["chat"]["observed_members"][0]
+        assert member["open_ids"] == ["ou_ethan"]
+        assert member["union_ids"] == ["on_ethan"]
+        assert member["names"] == ["Ethan"]
+
+    def test_members_prefers_official_api_and_enriches_member_ids(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:group:oc_team:ou_ethan",
+                    "session_id": "sess-official-members",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_team",
+                        "chat_name": "Team CLAIRE",
+                        "chat_type": "group",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan Observed",
+                    },
+                }
+            ],
+        )
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_team", "home_name": "Team CLAIRE"}},
+            default_account="laok-personal",
+        )
+        fake_client = _make_fake_client(
+            chat=SimpleNamespace(
+                name="Team CLAIRE",
+                description="Core room",
+                chat_type="group",
+                owner_id="ou_owner",
+                owner_id_type="open_id",
+                external=False,
+                tenant_key="tenant_a",
+                labels=["core"],
+                user_count="2",
+                bot_count="1",
+                chat_status="normal",
+            ),
+            members=[
+                SimpleNamespace(member_id="ou_ethan", name="Ethan", tenant_key="tenant_a"),
+                SimpleNamespace(member_id="ou_zoe", name="Zoe", tenant_key="tenant_a"),
+            ],
+            batch_users=[
+                SimpleNamespace(
+                    open_id="ou_ethan",
+                    user_id="u_ethan",
+                    union_id="on_ethan",
+                    name="Ethan",
+                    job_title="Operator",
+                    department_ids=["od_ops"],
+                ),
+                SimpleNamespace(
+                    open_id="ou_zoe",
+                    user_id="u_zoe",
+                    union_id="on_zoe",
+                    name="Zoe",
+                    department_ids=["od_research"],
+                ),
+            ],
+        )
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("tools.feishu_id_tool._build_official_client", return_value=(fake_client, None)),
+        ):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "members",
+                        "chat_id": "oc_team",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "official_api"
+        assert result["authoritative"] is True
+        assert result["chat"]["chat_id"] == "oc_team"
+        assert result["chat"]["is_home_channel"] is True
+        assert result["chat"]["member_count"] == 2
+        assert result["member_total"] == 2
+        assert result["members"][0]["open_ids"] == ["ou_ethan"]
+        assert result["members"][0]["user_ids"] == ["u_ethan"]
+        assert result["members"][0]["union_ids"] == ["on_ethan"]
+        assert "Ethan Observed" in result["members"][0]["names"]
+
+    def test_search_chats_prefers_official_api(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(tmp_path, [])
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_team", "home_name": "Team CLAIRE"}},
+            default_account="laok-personal",
+        )
+        fake_client = _make_fake_client(
+            search_chats=[
+                SimpleNamespace(
+                    chat_id="oc_team",
+                    name="Team CLAIRE",
+                    description="Core room",
+                    owner_id="ou_owner",
+                    owner_id_type="open_id",
+                    external=False,
+                    tenant_key="tenant_a",
+                    labels=["core"],
+                    chat_status="normal",
+                ),
+                SimpleNamespace(
+                    chat_id="oc_team_archive",
+                    name="Team CLAIRE Archive",
+                    description="Archive room",
+                    owner_id="ou_owner",
+                    owner_id_type="open_id",
+                    external=False,
+                    tenant_key="tenant_a",
+                    labels=["archive"],
+                    chat_status="normal",
+                ),
+            ]
+        )
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("tools.feishu_id_tool._build_official_client", return_value=(fake_client, None)),
+        ):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "search_chats",
+                        "query": "Team CLAIRE",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "official_api"
+        assert result["authoritative"] is True
+        assert [item["chat_id"] for item in result["matches"]] == ["oc_team", "oc_team_archive"]
+        assert result["matches"][0]["is_home_channel"] is True
+
+    def test_resolve_user_by_name_returns_observed_ids(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:dm:oc_dm",
+                    "session_id": "sess-2",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_dm",
+                        "chat_name": "oc_dm",
+                        "chat_type": "dm",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan",
+                    },
+                }
+            ],
+        )
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_home"}},
+            default_account="laok-personal",
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "resolve_user",
+                        "query": "eth",
+                        "account_id": "laok-personal",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert len(result["matches"]) == 1
+        assert result["matches"][0]["names"] == ["Ethan"]
+        assert result["matches"][0]["open_ids"] == ["ou_ethan"]
+        assert result["matches"][0]["union_ids"] == ["on_ethan"]
+
+    def test_session_lookup_infers_account_from_scoped_session_key(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-gradients]:dm:oc_dm",
+                    "session_id": "sess-3",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "chat_id": "oc_dm",
+                        "chat_name": "oc_dm",
+                        "chat_type": "dm",
+                        "user_id": "ou_jiawen",
+                        "user_name": "嘉文",
+                    },
+                }
+            ],
+        )
+        config = _make_config(
+            {
+                "laok-personal": {"home_chat_id": "oc_home"},
+                "laok-gradients": {"home_chat_id": "oc_grad"},
+            },
+            default_account="laok-personal",
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "session_lookup",
+                        "session_key": "agent:main:feishu[laok-gradients]:dm:oc_dm",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["session"]["account_id"] == "laok-gradients"
+        assert result["session"]["account_id_inferred"] is False
+
+    def test_my_chats_uses_current_sender_context(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "feishu")
+        monkeypatch.setenv("HERMES_SESSION_ACCOUNT_ID", "laok-personal")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "ou_ethan")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID_ALT", "on_ethan")
+        monkeypatch.setenv("HERMES_SESSION_USER_NAME", "Ethan")
+        _write_sessions(
+            tmp_path,
+            [
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:group:oc_team:ou_ethan",
+                    "session_id": "sess-4",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_team",
+                        "chat_name": "Team CLAIRE",
+                        "chat_type": "group",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan",
+                    },
+                },
+                {
+                    "session_key": "agent:main:feishu[laok-personal]:dm:oc_dm",
+                    "session_id": "sess-5",
+                    "source": {
+                        "platform": Platform.FEISHU,
+                        "account_id": "laok-personal",
+                        "chat_id": "oc_dm",
+                        "chat_name": "oc_dm",
+                        "chat_type": "dm",
+                        "user_id": "ou_ethan",
+                        "user_id_alt": "on_ethan",
+                        "user_name": "Ethan",
+                    },
+                },
+            ],
+        )
+        config = _make_config(
+            {"laok-personal": {"home_chat_id": "oc_home"}},
+            default_account="laok-personal",
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            result = json.loads(feishu_id_tool({"action": "my_chats"}))
+
+        assert result["success"] is True
+        chat_ids = [item["chat_id"] for item in result["chats"]]
+        assert chat_ids == ["oc_dm", "oc_team"]
+
+    def test_cross_account_query_denied_for_non_admin_feishu_session(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "feishu")
+        monkeypatch.setenv("HERMES_SESSION_ACCOUNT_ID", "laok-personal")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "ou_viewer")
+        _write_sessions(tmp_path, [])
+        config = _make_config(
+            {
+                "laok-personal": {"home_chat_id": "oc_home", "admins": ["ou_admin"]},
+                "laok-gradients": {"home_chat_id": "oc_grad"},
+            },
+            default_account="laok-personal",
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "search_chats",
+                        "query": "team",
+                        "as_account_id": "laok-gradients",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "Cross-account feishu_id query denied" in result["error"]
+
+    def test_cross_account_query_allowed_for_admin_and_scoped_to_requested_account(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "feishu")
+        monkeypatch.setenv("HERMES_SESSION_ACCOUNT_ID", "laok-personal")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "u_owner")
+        _write_sessions(tmp_path, [])
+        config = _make_config(
+            {
+                "laok-personal": {"home_chat_id": "oc_home", "admins": ["u_owner"]},
+                "laok-gradients": {"home_chat_id": "oc_grad"},
+            },
+            default_account="laok-personal",
+        )
+
+        clients = {
+            "laok-personal": _make_fake_client(
+                chat=SimpleNamespace(
+                    name="Personal Chat",
+                    description="personal",
+                    chat_type="group",
+                    owner_id="ou_owner",
+                    owner_id_type="open_id",
+                    external=False,
+                    tenant_key="tenant_personal",
+                    labels=["personal"],
+                    chat_status="normal",
+                    user_count="3",
+                    bot_count="1",
+                )
+            ),
+            "laok-gradients": _make_fake_client(
+                chat=SimpleNamespace(
+                    name="Team CLAIRE",
+                    description="gradients",
+                    chat_type="group",
+                    owner_id="ou_owner",
+                    owner_id_type="open_id",
+                    external=False,
+                    tenant_key="tenant_gradients",
+                    labels=["team"],
+                    chat_status="normal",
+                    user_count="8",
+                    bot_count="2",
+                )
+            ),
+        }
+
+        def _build_client(_config, account_id):
+            return clients[account_id], None
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("tools.feishu_id_tool._build_official_client", side_effect=_build_client),
+        ):
+            result = json.loads(
+                feishu_id_tool(
+                    {
+                        "action": "whois_chat",
+                        "chat_id": "oc_team_claire",
+                        "as_account_id": "laok-gradients",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "official_api"
+        assert result["chat"]["account_id"] == "laok-gradients"
+        assert result["chat"]["names"] == ["Team CLAIRE"]
+        assert result["chat"]["tenant_key"] == "tenant_gradients"

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -594,6 +594,119 @@ class TestSendToPlatformChunking:
         assert all(call == [] for call in sent_calls[:-1])
         assert sent_calls[-1] == media
 
+    def test_feishu_send_uses_session_account_home_channel(self):
+        feishu_personal_cfg = SimpleNamespace(enabled=True, extra={"account_id": "laok-personal"})
+        feishu_gradients_cfg = SimpleNamespace(enabled=True, extra={"account_id": "laok-gradients"})
+        gradients_home = SimpleNamespace(
+            chat_id="oc_team_claire",
+            name="Team CLAIRE",
+            account_id="laok-gradients",
+        )
+
+        config = SimpleNamespace(
+            platforms={Platform.FEISHU: feishu_personal_cfg},
+            get_platform_config=lambda platform, account_id=None: (
+                feishu_gradients_cfg
+                if platform == Platform.FEISHU and account_id == "laok-gradients"
+                else feishu_personal_cfg
+            ),
+            get_home_channel=lambda platform, account_id=None: (
+                gradients_home if platform == Platform.FEISHU else None
+            ),
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "feishu",
+                "HERMES_SESSION_ACCOUNT_ID": "laok-gradients",
+            },
+            clear=False,
+        ), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "feishu",
+                        "message": "hello from gradients",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["note"] == "Sent to feishu home channel (chat_id: oc_team_claire)"
+        send_mock.assert_awaited_once_with(
+            Platform.FEISHU,
+            feishu_gradients_cfg,
+            "oc_team_claire",
+            "hello from gradients",
+            thread_id=None,
+            media_files=[],
+        )
+
+    def test_feishu_cron_duplicate_check_is_account_aware(self):
+        feishu_personal_cfg = SimpleNamespace(enabled=True, extra={"account_id": "laok-personal"})
+        feishu_gradients_cfg = SimpleNamespace(enabled=True, extra={"account_id": "laok-gradients"})
+        gradients_home = SimpleNamespace(
+            chat_id="oc_team_claire",
+            name="Team CLAIRE",
+            account_id="laok-gradients",
+        )
+
+        config = SimpleNamespace(
+            platforms={Platform.FEISHU: feishu_personal_cfg},
+            get_platform_config=lambda platform, account_id=None: (
+                feishu_gradients_cfg
+                if platform == Platform.FEISHU and account_id == "laok-gradients"
+                else feishu_personal_cfg
+            ),
+            get_home_channel=lambda platform, account_id=None: (
+                gradients_home if platform == Platform.FEISHU else None
+            ),
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "feishu",
+                "HERMES_SESSION_ACCOUNT_ID": "laok-gradients",
+                "HERMES_CRON_AUTO_DELIVER_PLATFORM": "feishu",
+                "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "oc_team_claire",
+                "HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID": "laok-personal",
+            },
+            clear=False,
+        ), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "feishu",
+                        "message": "extra notice",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result.get("skipped") is not True
+        send_mock.assert_awaited_once_with(
+            Platform.FEISHU,
+            feishu_gradients_cfg,
+            "oc_team_claire",
+            "extra notice",
+            thread_id=None,
+            media_files=[],
+        )
+
 
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -79,9 +79,13 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             )
         return {
             "platform": origin_platform,
+            "account_id": get_session_env("HERMES_SESSION_ACCOUNT_ID") or None,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
             "thread_id": thread_id,
+            "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
+            "user_id_alt": get_session_env("HERMES_SESSION_USER_ID_ALT") or None,
+            "user_name": get_session_env("HERMES_SESSION_USER_NAME") or None,
         }
     return None
 

--- a/tools/feishu_id_tool.py
+++ b/tools/feishu_id_tool.py
@@ -1,0 +1,1340 @@
+"""Feishu identity/chat lookup tool with official API first, local fallback.
+
+Primary resolution uses the official Feishu APIs for:
+- user identity lookup by open_id/user_id/union_id
+- chat lookup by chat_id
+- chat search by name/query
+- chat member enumeration
+
+When official API credentials are unavailable, or an authoritative lookup does
+not succeed, the tool falls back to Hermes' locally observed session metadata
+from ``~/.hermes/sessions/sessions.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_SESSION_KEY_ACCOUNT_RE = re.compile(r":feishu\[([^\]]+)\]:")
+
+_ID_PREFIX_MAP = {
+    "ou_": "open_id",
+    "on_": "union_id",
+    "u_": "user_id",
+}
+
+FEISHU_ID_SCHEMA = {
+    "name": "feishu_id",
+    "description": (
+        "Inspect Feishu identities, chats, and session routes for Hermes. "
+        "Uses official Feishu APIs when credentials are configured, and falls back "
+        "to Hermes' local observed session metadata when needed. Supports chat_id/name "
+        "lookup, open_id/user_id/union_id lookup, group member lookup, and session-key resolution."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "resolve_user",
+                    "whois_user",
+                    "search_chats",
+                    "whois_chat",
+                    "members",
+                    "session_lookup",
+                    "my_chats",
+                ],
+                "description": "Lookup action to perform.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Free-text query for name-based lookup (user or chat).",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": "Feishu chat ID such as oc_xxx.",
+            },
+            "session_key": {
+                "type": "string",
+                "description": "Hermes gateway session key to resolve.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Hermes runtime session_id to resolve.",
+            },
+            "open_id": {
+                "type": "string",
+                "description": "Feishu open_id (ou_xxx).",
+            },
+            "user_id": {
+                "type": "string",
+                "description": "Feishu tenant-scoped user_id (u_xxx).",
+            },
+            "union_id": {
+                "type": "string",
+                "description": "Feishu union_id (on_xxx).",
+            },
+            "account_id": {
+                "type": "string",
+                "description": "Preferred account scope for the query. Defaults to the current Feishu account when applicable.",
+            },
+            "as_account_id": {
+                "type": "string",
+                "description": "Explicit target account for cross-account lookup. From Feishu sessions this is allowed only for configured admins.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results to return. Default 10, max 50.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _sessions_path() -> Path:
+    return get_hermes_home() / "sessions" / "sessions.json"
+
+
+def _check_feishu_id() -> bool:
+    from gateway.session_context import get_session_env
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    if platform in {"", "local", "feishu"} and _sessions_path().exists():
+        return True
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        return Platform.FEISHU in config.get_connected_platforms()
+    except Exception:
+        return _sessions_path().exists()
+
+
+def _get_config_callable(config, name):
+    try:
+        instance_attr = vars(config).get(name)
+    except Exception:
+        instance_attr = None
+    if callable(instance_attr):
+        return instance_attr
+
+    class_attr = getattr(type(config), name, None)
+    if callable(class_attr):
+        return getattr(config, name)
+    return None
+
+
+def _load_gateway_config_safe():
+    try:
+        from gateway.config import load_gateway_config
+
+        return load_gateway_config()
+    except Exception as exc:
+        logger.debug("feishu_id: failed to load gateway config: %s", exc)
+        return None
+
+
+def _resolve_default_account_id(config) -> Optional[str]:
+    if config is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        getter = _get_config_callable(config, "get_default_account_id")
+        if getter:
+            return getter(Platform.FEISHU)
+    except Exception:
+        pass
+    return None
+
+
+def _resolve_platform_config(config, account_id: Optional[str] = None):
+    if config is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        getter = _get_config_callable(config, "get_platform_config")
+        if getter:
+            try:
+                return getter(Platform.FEISHU, account_id=account_id)
+            except TypeError:
+                return getter(Platform.FEISHU)
+
+        platforms = getattr(config, "platforms", {}) or {}
+        return platforms.get(Platform.FEISHU)
+    except Exception:
+        return None
+
+
+def _iter_feishu_accounts(config) -> List[str]:
+    if config is None:
+        return []
+    try:
+        from gateway.config import Platform
+
+        iterator = _get_config_callable(config, "iter_platform_account_configs")
+        if iterator:
+            return [
+                account_id
+                for account_id, _platform_config in iterator(Platform.FEISHU)
+                if str(account_id or "").strip()
+            ]
+    except Exception:
+        pass
+    return []
+
+
+def _extract_admin_ids(account_config) -> set[str]:
+    ids: set[str] = set()
+    if not account_config:
+        return ids
+    extra = getattr(account_config, "extra", {}) or {}
+    raw_admins = extra.get("admins", []) or []
+    for item in raw_admins:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                ids.add(text)
+            continue
+        if isinstance(item, dict):
+            for field in ("user_id", "open_id", "union_id"):
+                value = str(item.get(field) or "").strip()
+                if value:
+                    ids.add(value)
+    return ids
+
+
+def _classify_id(value: Optional[str]) -> Optional[Tuple[str, str]]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    for prefix, id_type in _ID_PREFIX_MAP.items():
+        if text.startswith(prefix):
+            return id_type, text
+    return None, text
+
+
+def _normalize_text(value: Optional[str]) -> str:
+    return str(value or "").strip().lower()
+
+
+def _extract_account_from_session_key(session_key: str) -> Optional[str]:
+    match = _SESSION_KEY_ACCOUNT_RE.search(session_key or "")
+    if match:
+        return match.group(1)
+    return None
+
+
+def _safe_sort_strings(values) -> List[str]:
+    return sorted({str(v).strip() for v in values if str(v).strip()})
+
+
+def _read_session_entries() -> List[Dict[str, Any]]:
+    from gateway.session import SessionEntry
+
+    path = _sessions_path()
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("feishu_id: failed to read %s: %s", path, exc)
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for session_key, entry_data in raw.items():
+        try:
+            entry = SessionEntry.from_dict(entry_data)
+        except Exception:
+            logger.debug("feishu_id: failed to parse session entry %s", session_key, exc_info=True)
+            continue
+        origin = entry.origin
+        if not origin or getattr(origin.platform, "value", None) != "feishu":
+            continue
+        entries.append(
+            {
+                "session_key": session_key,
+                "session_id": entry.session_id,
+                "created_at": entry.created_at.isoformat(),
+                "updated_at": entry.updated_at.isoformat(),
+                "origin": origin.to_dict(),
+            }
+        )
+    return entries
+
+
+def _ensure_user_record(
+    users_by_key: Dict[str, Dict[str, Any]],
+    id_lookup: Dict[Tuple[Optional[str], str, str], str],
+    *,
+    account_id: Optional[str],
+    identifiers: Dict[str, str],
+    name: Optional[str],
+) -> Optional[str]:
+    if not identifiers and not str(name or "").strip():
+        return None
+
+    existing_keys = {
+        id_lookup[(account_id, id_type, id_value)]
+        for id_type, id_value in identifiers.items()
+        if (account_id, id_type, id_value) in id_lookup
+    }
+
+    if existing_keys:
+        record_key = sorted(existing_keys)[0]
+    else:
+        seed = identifiers.get("union_id") or identifiers.get("user_id") or identifiers.get("open_id") or name or "unknown"
+        record_key = f"{account_id or '_'}:{seed}"
+        users_by_key.setdefault(
+            record_key,
+            {
+                "account_id": account_id,
+                "ids": {"open_id": set(), "user_id": set(), "union_id": set(), "unknown": set()},
+                "names": set(),
+                "chat_ids": set(),
+                "session_keys": set(),
+                "session_ids": set(),
+            },
+        )
+
+    record = users_by_key[record_key]
+    if name:
+        record["names"].add(name)
+    for id_type, id_value in identifiers.items():
+        bucket = id_type if id_type in record["ids"] else "unknown"
+        record["ids"][bucket].add(id_value)
+        id_lookup[(account_id, id_type, id_value)] = record_key
+
+    # Merge split observations if the same person was first seen under different IDs.
+    for other_key in sorted(existing_keys - {record_key}):
+        other = users_by_key.pop(other_key, None)
+        if not other:
+            continue
+        for bucket, values in other["ids"].items():
+            record["ids"][bucket].update(values)
+            for id_value in values:
+                id_lookup[(account_id, bucket, id_value)] = record_key
+        record["names"].update(other["names"])
+        record["chat_ids"].update(other["chat_ids"])
+        record["session_keys"].update(other["session_keys"])
+        record["session_ids"].update(other["session_ids"])
+
+    return record_key
+
+
+def _build_observed_index(config) -> Dict[str, Any]:
+    default_account_id = _resolve_default_account_id(config)
+    home_channels = {}
+    for account_id in _iter_feishu_accounts(config):
+        account_config = _resolve_platform_config(config, account_id=account_id)
+        home = getattr(account_config, "home_channel", None)
+        if home and getattr(home, "chat_id", None):
+            home_channels[(account_id, str(home.chat_id))] = getattr(home, "name", None)
+
+    users_by_key: Dict[str, Dict[str, Any]] = {}
+    user_id_lookup: Dict[Tuple[Optional[str], str, str], str] = {}
+    chats: Dict[Tuple[Optional[str], str], Dict[str, Any]] = {}
+    sessions_by_key: Dict[str, Dict[str, Any]] = {}
+
+    for item in _read_session_entries():
+        origin = item["origin"]
+        session_key = item["session_key"]
+        raw_account_id = str(origin.get("account_id") or "").strip() or None
+        inferred_account_id = False
+        account_id = raw_account_id or _extract_account_from_session_key(session_key)
+        if not account_id and default_account_id:
+            account_id = default_account_id
+            inferred_account_id = True
+
+        identifiers: Dict[str, str] = {}
+        for raw_value in (origin.get("user_id"), origin.get("user_id_alt")):
+            classified = _classify_id(raw_value)
+            if not classified:
+                continue
+            id_type, id_value = classified
+            bucket = id_type or "unknown"
+            identifiers[bucket] = id_value
+
+        user_key = _ensure_user_record(
+            users_by_key,
+            user_id_lookup,
+            account_id=account_id,
+            identifiers=identifiers,
+            name=origin.get("user_name"),
+        )
+        if user_key:
+            user_record = users_by_key[user_key]
+            user_record["chat_ids"].add(str(origin.get("chat_id") or ""))
+            user_record["session_keys"].add(session_key)
+            user_record["session_ids"].add(item["session_id"])
+
+        chat_id = str(origin.get("chat_id") or "").strip()
+        if not chat_id:
+            continue
+
+        chat_key = (account_id, chat_id)
+        chat_record = chats.setdefault(
+            chat_key,
+            {
+                "account_id": account_id,
+                "chat_id": chat_id,
+                "chat_types": set(),
+                "names": set(),
+                "session_keys": set(),
+                "session_ids": set(),
+                "observed_member_keys": set(),
+                "updated_at": item["updated_at"],
+                "home_channel_name": home_channels.get((account_id, chat_id)),
+                "account_id_inferred": inferred_account_id,
+            },
+        )
+        chat_record["chat_types"].add(str(origin.get("chat_type") or "dm"))
+        if origin.get("chat_name"):
+            chat_record["names"].add(str(origin["chat_name"]))
+        if origin.get("user_name") and str(origin.get("chat_type") or "") == "dm":
+            chat_record["names"].add(str(origin["user_name"]))
+        chat_record["session_keys"].add(session_key)
+        chat_record["session_ids"].add(item["session_id"])
+        if item["updated_at"] > chat_record["updated_at"]:
+            chat_record["updated_at"] = item["updated_at"]
+        if user_key:
+            chat_record["observed_member_keys"].add(user_key)
+
+        sessions_by_key[session_key] = {
+            "session_key": session_key,
+            "session_id": item["session_id"],
+            "account_id": account_id,
+            "account_id_inferred": inferred_account_id,
+            "chat_id": chat_id,
+            "chat_name": origin.get("chat_name"),
+            "chat_type": origin.get("chat_type"),
+            "user_name": origin.get("user_name"),
+            "identifiers": identifiers,
+            "created_at": item["created_at"],
+            "updated_at": item["updated_at"],
+        }
+
+    users = []
+    for record in users_by_key.values():
+        users.append(
+            {
+                "account_id": record["account_id"],
+                "names": _safe_sort_strings(record["names"]),
+                "open_ids": _safe_sort_strings(record["ids"]["open_id"]),
+                "user_ids": _safe_sort_strings(record["ids"]["user_id"]),
+                "union_ids": _safe_sort_strings(record["ids"]["union_id"]),
+                "unknown_ids": _safe_sort_strings(record["ids"]["unknown"]),
+                "chat_ids": _safe_sort_strings(record["chat_ids"]),
+                "session_keys": _safe_sort_strings(record["session_keys"]),
+                "session_ids": _safe_sort_strings(record["session_ids"]),
+            }
+        )
+
+    normalized_chats = []
+    for chat_record in chats.values():
+        members = []
+        for user_key in sorted(chat_record["observed_member_keys"]):
+            user_record = users_by_key.get(user_key)
+            if not user_record:
+                continue
+            members.append(
+                {
+                    "names": _safe_sort_strings(user_record["names"]),
+                    "open_ids": _safe_sort_strings(user_record["ids"]["open_id"]),
+                    "user_ids": _safe_sort_strings(user_record["ids"]["user_id"]),
+                    "union_ids": _safe_sort_strings(user_record["ids"]["union_id"]),
+                }
+            )
+        normalized_chats.append(
+            {
+                "account_id": chat_record["account_id"],
+                "account_id_inferred": chat_record["account_id_inferred"],
+                "chat_id": chat_record["chat_id"],
+                "chat_types": _safe_sort_strings(chat_record["chat_types"]),
+                "names": _safe_sort_strings(chat_record["names"]),
+                "session_keys": _safe_sort_strings(chat_record["session_keys"]),
+                "session_ids": _safe_sort_strings(chat_record["session_ids"]),
+                "updated_at": chat_record["updated_at"],
+                "is_home_channel": bool(chat_record["home_channel_name"]),
+                "home_channel_name": chat_record["home_channel_name"],
+                "observed_members": members,
+            }
+        )
+
+    sessions = list(sessions_by_key.values())
+    sessions.sort(key=lambda item: item["updated_at"], reverse=True)
+    users.sort(key=lambda item: ((item["account_id"] or ""), item["names"][0] if item["names"] else item["open_ids"][0] if item["open_ids"] else ""))
+    normalized_chats.sort(key=lambda item: ((item["account_id"] or ""), item["chat_id"]))
+
+    return {
+        "users": users,
+        "chats": normalized_chats,
+        "sessions": sessions,
+    }
+
+
+def _resolve_secret(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if not text.startswith("env:"):
+        return text
+    return os.getenv(text[4:].strip(), "").strip()
+
+
+def _candidate_account_ids(config, account_id: Optional[str]) -> List[Optional[str]]:
+    if account_id is not None:
+        return [account_id]
+
+    account_ids = _iter_feishu_accounts(config)
+    if account_ids:
+        return list(account_ids)
+
+    if _resolve_platform_config(config) is not None:
+        return [None]
+    return []
+
+
+def _home_channel_name(config, account_id: Optional[str], chat_id: str) -> Optional[str]:
+    account_config = _resolve_platform_config(config, account_id=account_id)
+    home = getattr(account_config, "home_channel", None) if account_config else None
+    if not home:
+        return None
+    if str(getattr(home, "chat_id", "") or "").strip() != str(chat_id or "").strip():
+        return None
+    return str(getattr(home, "name", "") or "").strip() or None
+
+
+def _response_succeeded(response: Any) -> bool:
+    return bool(response and getattr(response, "success", lambda: False)())
+
+
+def _response_error(response: Any, default_message: str) -> str:
+    if response is None:
+        return default_message
+    code = getattr(response, "code", "unknown")
+    msg = getattr(response, "msg", default_message)
+    return f"[{code}] {msg}"
+
+
+def _merge_lists(*values: List[str]) -> List[str]:
+    merged: List[str] = []
+    for items in values:
+        merged.extend(items or [])
+    return _safe_sort_strings(merged)
+
+
+def _map_chat_type(raw_chat_type: Optional[str]) -> str:
+    raw = str(raw_chat_type or "").strip().lower()
+    if raw in {"p2p", "single"}:
+        return "dm"
+    if raw in {"group", "topic"}:
+        return "group"
+    return raw or "dm"
+
+
+def _observed_chat_for_merge(index: Dict[str, Any], account_id: Optional[str], chat_id: str) -> Optional[Dict[str, Any]]:
+    return _find_chat(index, account_id, chat_id)
+
+
+def _observed_user_for_merge(
+    index: Dict[str, Any],
+    account_id: Optional[str],
+    *,
+    open_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    union_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    identifiers = {}
+    if open_id:
+        identifiers["open_id"] = open_id
+    if user_id:
+        identifiers["user_id"] = user_id
+    if union_id:
+        identifiers["union_id"] = union_id
+    return _find_user_by_ids(index, account_id, identifiers)
+
+
+def _serialize_official_user(user: Any, account_id: Optional[str]) -> Dict[str, Any]:
+    return {
+        "account_id": account_id,
+        "names": _safe_sort_strings(
+            [
+                getattr(user, "name", None),
+                getattr(user, "nickname", None),
+                getattr(user, "en_name", None),
+            ]
+        ),
+        "open_ids": _safe_sort_strings([getattr(user, "open_id", None)]),
+        "user_ids": _safe_sort_strings([getattr(user, "user_id", None)]),
+        "union_ids": _safe_sort_strings([getattr(user, "union_id", None)]),
+        "unknown_ids": [],
+        "chat_ids": [],
+        "session_keys": [],
+        "session_ids": [],
+        "email": str(getattr(user, "email", "") or "").strip() or None,
+        "enterprise_email": str(getattr(user, "enterprise_email", "") or "").strip() or None,
+        "mobile": str(getattr(user, "mobile", "") or "").strip() or None,
+        "job_title": str(getattr(user, "job_title", "") or "").strip() or None,
+        "department_ids": _safe_sort_strings(getattr(user, "department_ids", None) or []),
+    }
+
+
+def _merge_user_payload(official_user: Dict[str, Any], observed_user: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not observed_user:
+        return official_user
+
+    merged = dict(official_user)
+    for key in (
+        "names",
+        "open_ids",
+        "user_ids",
+        "union_ids",
+        "unknown_ids",
+        "chat_ids",
+        "session_keys",
+        "session_ids",
+    ):
+        merged[key] = _merge_lists(official_user.get(key, []), observed_user.get(key, []))
+    return merged
+
+
+def _serialize_official_chat(
+    chat_id: str,
+    data: Any,
+    account_id: Optional[str],
+    *,
+    home_channel_name: Optional[str],
+) -> Dict[str, Any]:
+    raw_chat_type = (
+        str(getattr(data, "chat_type", "") or "").strip().lower()
+        or str(getattr(data, "type", "") or "").strip().lower()
+    )
+
+    user_count_raw = str(getattr(data, "user_count", "") or "").strip()
+    bot_count_raw = str(getattr(data, "bot_count", "") or "").strip()
+
+    return {
+        "account_id": account_id,
+        "account_id_inferred": False,
+        "chat_id": chat_id,
+        "chat_types": _safe_sort_strings([_map_chat_type(raw_chat_type)]),
+        "raw_type": raw_chat_type or None,
+        "names": _safe_sort_strings([getattr(data, "name", None)]),
+        "description": str(getattr(data, "description", "") or "").strip() or None,
+        "owner_id": str(
+            getattr(data, "owner_id", None)
+            or getattr(data, "owner_user_id", None)
+            or ""
+        ).strip() or None,
+        "owner_id_type": str(getattr(data, "owner_id_type", "") or "").strip() or None,
+        "chat_status": str(getattr(data, "chat_status", "") or "").strip() or None,
+        "external": getattr(data, "external", None),
+        "tenant_key": str(getattr(data, "tenant_key", "") or "").strip() or None,
+        "labels": _safe_sort_strings(getattr(data, "labels", None) or []),
+        "member_count": int(user_count_raw) if user_count_raw.isdigit() else None,
+        "bot_count": int(bot_count_raw) if bot_count_raw.isdigit() else None,
+        "session_keys": [],
+        "session_ids": [],
+        "updated_at": None,
+        "is_home_channel": bool(home_channel_name),
+        "home_channel_name": home_channel_name,
+        "observed_members": [],
+    }
+
+
+def _merge_chat_payload(official_chat: Dict[str, Any], observed_chat: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not observed_chat:
+        return official_chat
+
+    merged = dict(official_chat)
+    merged["chat_types"] = _merge_lists(official_chat.get("chat_types", []), observed_chat.get("chat_types", []))
+    merged["names"] = _merge_lists(official_chat.get("names", []), observed_chat.get("names", []))
+    merged["session_keys"] = _merge_lists(official_chat.get("session_keys", []), observed_chat.get("session_keys", []))
+    merged["session_ids"] = _merge_lists(official_chat.get("session_ids", []), observed_chat.get("session_ids", []))
+    merged["observed_members"] = observed_chat.get("observed_members", [])
+    merged["updated_at"] = observed_chat.get("updated_at") or official_chat.get("updated_at")
+    merged["account_id_inferred"] = bool(observed_chat.get("account_id_inferred"))
+    merged["is_home_channel"] = bool(official_chat.get("is_home_channel") or observed_chat.get("is_home_channel"))
+    merged["home_channel_name"] = (
+        official_chat.get("home_channel_name")
+        or observed_chat.get("home_channel_name")
+    )
+    if not merged.get("description"):
+        merged["description"] = observed_chat.get("description")
+    if not merged.get("chat_status"):
+        merged["chat_status"] = observed_chat.get("chat_status")
+    if merged.get("member_count") is None:
+        observed_count = len(observed_chat.get("observed_members", []) or [])
+        merged["member_count"] = observed_count or None
+    return merged
+
+
+def _build_official_client(config, account_id: Optional[str]) -> Tuple[Optional[Any], Optional[str]]:
+    try:
+        import lark_oapi as lark
+        from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+    except Exception as exc:
+        return None, f"lark_oapi unavailable: {exc}"
+
+    account_config = _resolve_platform_config(config, account_id=account_id)
+    if account_config is None:
+        return None, f"No Feishu config found for account_id={account_id!r}."
+
+    extra = getattr(account_config, "extra", {}) or {}
+    app_id = _resolve_secret(extra.get("app_id"))
+    app_secret = _resolve_secret(extra.get("app_secret"))
+    domain_name = str(extra.get("domain") or "feishu").strip().lower() or "feishu"
+    if not app_id or not app_secret:
+        return None, f"Feishu official API credentials missing for account_id={account_id!r}."
+
+    domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
+    client = (
+        lark.Client.builder()
+        .app_id(app_id)
+        .app_secret(app_secret)
+        .domain(domain)
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
+    return client, None
+
+
+def _official_get_user(
+    config,
+    index: Dict[str, Any],
+    account_id: Optional[str],
+    identifiers: Dict[str, str],
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    if not identifiers:
+        return None, "Official Feishu user lookup requires an identifier."
+
+    client, error = _build_official_client(config, account_id)
+    if not client:
+        return None, error
+
+    try:
+        from lark_oapi.api.contact.v3 import GetUserRequest
+    except Exception as exc:
+        return None, f"GetUserRequest unavailable: {exc}"
+
+    for id_type in ("user_id", "open_id", "union_id"):
+        id_value = identifiers.get(id_type)
+        if not id_value:
+            continue
+        try:
+            request = (
+                GetUserRequest.builder()
+                .user_id(id_value)
+                .user_id_type(id_type)
+                .department_id_type("open_department_id")
+                .build()
+            )
+            response = client.contact.v3.user.get(request)
+        except Exception as exc:
+            return None, f"Official Feishu user lookup failed for account_id={account_id!r}: {exc}"
+        if not _response_succeeded(response):
+            continue
+        user = getattr(getattr(response, "data", None), "user", None)
+        if not user:
+            continue
+        payload = _serialize_official_user(user, account_id)
+        observed = _observed_user_for_merge(
+            index,
+            account_id,
+            open_id=payload["open_ids"][0] if payload["open_ids"] else None,
+            user_id=payload["user_ids"][0] if payload["user_ids"] else None,
+            union_id=payload["union_ids"][0] if payload["union_ids"] else None,
+        )
+        return _merge_user_payload(payload, observed), None
+
+    return None, "No official Feishu user matched the provided identifiers."
+
+
+def _official_get_chat(
+    config,
+    index: Dict[str, Any],
+    account_id: Optional[str],
+    chat_id: str,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    client, error = _build_official_client(config, account_id)
+    if not client:
+        return None, error
+
+    try:
+        from lark_oapi.api.im.v1 import GetChatRequest
+    except Exception as exc:
+        return None, f"GetChatRequest unavailable: {exc}"
+
+    try:
+        request = GetChatRequest.builder().chat_id(chat_id).user_id_type("open_id").build()
+        response = client.im.v1.chat.get(request)
+    except Exception as exc:
+        return None, f"Official Feishu chat lookup failed for account_id={account_id!r}: {exc}"
+    if not _response_succeeded(response):
+        return None, _response_error(response, "Official Feishu chat lookup failed.")
+
+    data = getattr(response, "data", None)
+    payload = _serialize_official_chat(
+        chat_id,
+        data,
+        account_id,
+        home_channel_name=_home_channel_name(config, account_id, chat_id),
+    )
+    observed = _observed_chat_for_merge(index, account_id, chat_id)
+    return _merge_chat_payload(payload, observed), None
+
+
+def _official_get_members(
+    config,
+    index: Dict[str, Any],
+    account_id: Optional[str],
+    chat_id: str,
+    limit: int,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    client, error = _build_official_client(config, account_id)
+    if not client:
+        return None, error
+
+    try:
+        from lark_oapi.api.contact.v3 import BatchUserRequest
+        from lark_oapi.api.im.v1 import GetChatMembersRequest
+    except Exception as exc:
+        return None, f"Feishu member APIs unavailable: {exc}"
+
+    try:
+        request = (
+            GetChatMembersRequest.builder()
+            .chat_id(chat_id)
+            .member_id_type("open_id")
+            .page_size(limit)
+            .build()
+        )
+        response = client.im.v1.chat_members.get(request)
+    except Exception as exc:
+        return None, f"Official Feishu member lookup failed for account_id={account_id!r}: {exc}"
+    if not _response_succeeded(response):
+        return None, _response_error(response, "Official Feishu member lookup failed.")
+
+    data = getattr(response, "data", None)
+    raw_members = list(getattr(data, "items", None) or [])
+    open_ids = _safe_sort_strings([getattr(item, "member_id", None) for item in raw_members])
+
+    enriched_by_open_id: Dict[str, Dict[str, Any]] = {}
+    batch_error: Optional[str] = None
+    if open_ids:
+        try:
+            batch_request = (
+                BatchUserRequest.builder()
+                .user_ids(open_ids)
+                .user_id_type("open_id")
+                .department_id_type("open_department_id")
+                .build()
+            )
+            batch_response = client.contact.v3.user.batch(batch_request)
+            if _response_succeeded(batch_response):
+                for user in list(getattr(getattr(batch_response, "data", None), "items", None) or []):
+                    serialized = _serialize_official_user(user, account_id)
+                    open_id = serialized["open_ids"][0] if serialized["open_ids"] else None
+                    if open_id:
+                        observed_user = _observed_user_for_merge(
+                            index,
+                            account_id,
+                            open_id=open_id,
+                            user_id=serialized["user_ids"][0] if serialized["user_ids"] else None,
+                            union_id=serialized["union_ids"][0] if serialized["union_ids"] else None,
+                        )
+                        enriched_by_open_id[open_id] = _merge_user_payload(serialized, observed_user)
+            else:
+                batch_error = _response_error(batch_response, "Official Feishu batch user lookup failed.")
+        except Exception as exc:
+            batch_error = f"Official Feishu batch user lookup failed: {exc}"
+
+    members = []
+    for item in raw_members:
+        open_id = str(getattr(item, "member_id", "") or "").strip() or None
+        if open_id and open_id in enriched_by_open_id:
+            member = dict(enriched_by_open_id[open_id])
+        else:
+            member = {
+                "account_id": account_id,
+                "names": _safe_sort_strings([getattr(item, "name", None)]),
+                "open_ids": _safe_sort_strings([open_id]),
+                "user_ids": [],
+                "union_ids": [],
+                "unknown_ids": [],
+                "chat_ids": [],
+                "session_keys": [],
+                "session_ids": [],
+            }
+            observed_user = _observed_user_for_merge(index, account_id, open_id=open_id)
+            member = _merge_user_payload(member, observed_user)
+        member["tenant_key"] = str(getattr(item, "tenant_key", "") or "").strip() or None
+        members.append(member)
+
+    chat_payload, chat_error = _official_get_chat(config, index, account_id, chat_id)
+    if chat_error:
+        observed_chat = _observed_chat_for_merge(index, account_id, chat_id)
+        if not observed_chat:
+            return None, chat_error
+        chat_payload = observed_chat
+
+    return {
+        "success": True,
+        "source": "official_api",
+        "authoritative": True,
+        "members_only": True,
+        "chat": chat_payload,
+        "members": members,
+        "member_total": int(str(getattr(data, "member_total", "") or "0") or "0") or len(members),
+        "has_more": bool(getattr(data, "has_more", False)),
+        "page_token": str(getattr(data, "page_token", "") or "").strip() or None,
+        "official_member_enrichment_error": batch_error,
+    }, None
+
+
+def _official_search_chats(
+    config,
+    index: Dict[str, Any],
+    account_id: Optional[str],
+    query: str,
+    limit: int,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    candidate_accounts = _candidate_account_ids(config, account_id)
+    if not candidate_accounts:
+        return None, "No Feishu accounts are configured for official chat search."
+
+    try:
+        from lark_oapi.api.im.v1 import SearchChatRequest
+    except Exception as exc:
+        return None, f"SearchChatRequest unavailable: {exc}"
+
+    matches_by_key: Dict[Tuple[Optional[str], str], Dict[str, Any]] = {}
+    errors: List[str] = []
+    for candidate_account_id in candidate_accounts:
+        client, error = _build_official_client(config, candidate_account_id)
+        if not client:
+            errors.append(str(error))
+            continue
+        try:
+            request = (
+                SearchChatRequest.builder()
+                .query(query)
+                .user_id_type("open_id")
+                .page_size(limit)
+                .build()
+            )
+            response = client.im.v1.chat.search(request)
+        except Exception as exc:
+            errors.append(f"Official Feishu chat search failed for account_id={candidate_account_id!r}: {exc}")
+            continue
+        if not _response_succeeded(response):
+            errors.append(_response_error(response, "Official Feishu chat search failed."))
+            continue
+
+        items = list(getattr(getattr(response, "data", None), "items", None) or [])
+        for item in items:
+            chat_id = str(getattr(item, "chat_id", "") or "").strip()
+            if not chat_id:
+                continue
+            serialized = _serialize_official_chat(
+                chat_id,
+                item,
+                candidate_account_id,
+                home_channel_name=_home_channel_name(config, candidate_account_id, chat_id),
+            )
+            observed_chat = _observed_chat_for_merge(index, candidate_account_id, chat_id)
+            matches_by_key[(candidate_account_id, chat_id)] = _merge_chat_payload(serialized, observed_chat)
+
+    if matches_by_key:
+        matches = list(matches_by_key.values())
+        matches.sort(
+            key=lambda item: _search_score(query, item["names"] + [item["chat_id"]])
+        )
+        return {
+            "success": True,
+            "source": "official_api",
+            "authoritative": True,
+            "matches": matches[:limit],
+        }, None
+
+    if errors:
+        return None, "; ".join(errors)
+    return None, "No official Feishu chats matched the provided query."
+
+
+def _current_session_principal() -> Dict[str, Optional[str]]:
+    from gateway.session_context import get_session_env
+
+    return {
+        "platform": get_session_env("HERMES_SESSION_PLATFORM") or None,
+        "account_id": get_session_env("HERMES_SESSION_ACCOUNT_ID") or None,
+        "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
+        "user_id_alt": get_session_env("HERMES_SESSION_USER_ID_ALT") or None,
+        "user_name": get_session_env("HERMES_SESSION_USER_NAME") or None,
+        "chat_id": get_session_env("HERMES_SESSION_CHAT_ID") or None,
+    }
+
+
+def _authorize_account_scope(config, requested_account_id: Optional[str]) -> Optional[str]:
+    if not requested_account_id:
+        return None
+
+    current = _current_session_principal()
+    current_platform = str(current.get("platform") or "").lower()
+    current_account_id = current.get("account_id")
+    if current_platform in {"", "local"}:
+        return None
+    if current_platform != "feishu":
+        return None
+    if not current_account_id or current_account_id == requested_account_id:
+        return None
+
+    current_ids = {
+        str(current.get("user_id") or "").strip(),
+        str(current.get("user_id_alt") or "").strip(),
+    }
+    current_ids.discard("")
+    if not current_ids:
+        return "Cross-account feishu_id query requires current sender identity in session context."
+
+    current_config = _resolve_platform_config(config, account_id=current_account_id)
+    admins = _extract_admin_ids(current_config)
+    if current_ids & admins:
+        return None
+    return (
+        f"Cross-account feishu_id query denied for current Feishu session. "
+        f"Requested account_id={requested_account_id!r}, current account_id={current_account_id!r}. "
+        "Configure the current sender as an admin on the current account to allow this."
+    )
+
+
+def _effective_account_scope(args: Dict[str, Any], config) -> Optional[str]:
+    requested = str(args.get("as_account_id") or args.get("account_id") or "").strip() or None
+    if requested:
+        return requested
+    current = _current_session_principal()
+    if str(current.get("platform") or "").lower() == "feishu" and current.get("account_id"):
+        return str(current["account_id"])
+    return None
+
+
+def _normalize_limit(value: Any, default: int = 10) -> int:
+    try:
+        limit = int(value if value is not None else default)
+    except Exception:
+        limit = default
+    return max(1, min(limit, 50))
+
+
+def _search_score(query: str, values: List[str]) -> Tuple[int, str]:
+    query_l = _normalize_text(query)
+    best = 99
+    exemplar = ""
+    for value in values:
+        current = _normalize_text(value)
+        if current == query_l:
+            return 0, value
+        if current.startswith(query_l):
+            best = min(best, 1)
+            exemplar = exemplar or value
+        elif query_l in current:
+            best = min(best, 2)
+            exemplar = exemplar or value
+    return best, exemplar
+
+
+def _match_account(item: Dict[str, Any], account_id: Optional[str]) -> bool:
+    return account_id is None or item.get("account_id") == account_id
+
+
+def _find_user_by_ids(index: Dict[str, Any], account_id: Optional[str], identifiers: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    if not identifiers:
+        return None
+    for user in index["users"]:
+        if not _match_account(user, account_id):
+            continue
+        if any(value in user[f"{id_type}s"] for id_type, value in identifiers.items()):
+            return user
+    return None
+
+
+def _find_chat(index: Dict[str, Any], account_id: Optional[str], chat_id: str) -> Optional[Dict[str, Any]]:
+    for chat in index["chats"]:
+        if not _match_account(chat, account_id):
+            continue
+        if chat["chat_id"] == chat_id:
+            return chat
+    return None
+
+
+def _handle_whois_chat(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    current = _current_session_principal()
+    chat_id = str(args.get("chat_id") or current.get("chat_id") or "").strip()
+    if not chat_id:
+        return None, "chat_id is required for whois_chat outside an active Feishu session."
+    official_accounts = _candidate_account_ids(config, account_id)
+    official_errors: List[str] = []
+    for candidate_account_id in official_accounts:
+        chat, official_error = _official_get_chat(config, index, candidate_account_id, chat_id)
+        if chat:
+            return {
+                "success": True,
+                "source": "official_api",
+                "authoritative": True,
+                "chat": chat,
+            }, None
+        if official_error:
+            official_errors.append(official_error)
+
+    chat = _find_chat(index, account_id, chat_id)
+    if not chat:
+        if official_errors:
+            return None, "; ".join(official_errors)
+        return None, f"No observed Feishu chat found for chat_id={chat_id!r}."
+    payload = {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "note": "Chat names and members are derived from local observed Hermes sessions only.",
+        "chat": chat,
+    }
+    if official_errors:
+        payload["official_error"] = "; ".join(official_errors)
+    return payload, None
+
+
+def _handle_members(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    current = _current_session_principal()
+    chat_id = str(args.get("chat_id") or current.get("chat_id") or "").strip()
+    if not chat_id:
+        return None, "chat_id is required for members outside an active Feishu session."
+
+    limit = _normalize_limit(args.get("limit"))
+    official_accounts = _candidate_account_ids(config, account_id)
+    official_errors: List[str] = []
+    for candidate_account_id in official_accounts:
+        payload, official_error = _official_get_members(config, index, candidate_account_id, chat_id, limit)
+        if payload:
+            return payload, None
+        if official_error:
+            official_errors.append(official_error)
+
+    chat_payload, error = _handle_whois_chat(args, index, account_id, config)
+    if error:
+        return None, error
+    chat_payload["members_only"] = True
+    chat_payload["members"] = chat_payload["chat"].get("observed_members", [])
+    chat_payload["note"] = "Members are only the Feishu users Hermes has locally observed in this chat."
+    if official_errors:
+        chat_payload["official_error"] = "; ".join(official_errors)
+    return chat_payload, None
+
+
+def _handle_search_chats(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    query = str(args.get("query") or "").strip()
+    if not query:
+        return None, "query is required for search_chats."
+    limit = _normalize_limit(args.get("limit"))
+
+    official_payload, official_error = _official_search_chats(config, index, account_id, query, limit)
+    if official_payload:
+        return official_payload, None
+
+    matches = []
+    for chat in index["chats"]:
+        if not _match_account(chat, account_id):
+            continue
+        score, exemplar = _search_score(query, chat["names"] + [chat["chat_id"]])
+        if score >= 99:
+            continue
+        matches.append((score, exemplar or chat["chat_id"], chat))
+    matches.sort(key=lambda item: (item[0], item[1]))
+    payload = {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "matches": [item[2] for item in matches[:limit]],
+    }
+    if official_error:
+        payload["official_error"] = official_error
+    return payload, None
+
+
+def _handle_whois_user(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    current = _current_session_principal()
+    identifiers = {}
+    for field in ("open_id", "user_id", "union_id"):
+        value = str(args.get(field) or "").strip()
+        if value:
+            identifiers[field] = value
+    if not identifiers and current.get("platform") == "feishu":
+        classified = _classify_id(current.get("user_id"))
+        if classified and classified[0]:
+            identifiers[classified[0]] = classified[1]
+        classified_alt = _classify_id(current.get("user_id_alt"))
+        if classified_alt and classified_alt[0]:
+            identifiers[classified_alt[0]] = classified_alt[1]
+    if not identifiers:
+        return None, "whois_user requires open_id, user_id, or union_id."
+
+    official_accounts = _candidate_account_ids(config, account_id)
+    official_errors: List[str] = []
+    for candidate_account_id in official_accounts:
+        user, official_error = _official_get_user(config, index, candidate_account_id, identifiers)
+        if user:
+            return {
+                "success": True,
+                "source": "official_api",
+                "authoritative": True,
+                "user": user,
+            }, None
+        if official_error:
+            official_errors.append(official_error)
+
+    user = _find_user_by_ids(index, account_id, identifiers)
+    if not user:
+        if official_errors:
+            return None, "; ".join(official_errors)
+        return None, "No observed Feishu user matched the provided identifiers."
+    payload = {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "user": user,
+    }
+    if official_errors:
+        payload["official_error"] = "; ".join(official_errors)
+    return payload, None
+
+
+def _handle_resolve_user(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    query = str(args.get("query") or "").strip()
+    if not query:
+        return None, "query is required for resolve_user."
+    limit = _normalize_limit(args.get("limit"))
+    matches = []
+    for user in index["users"]:
+        if not _match_account(user, account_id):
+            continue
+        score, exemplar = _search_score(query, user["names"])
+        if score >= 99:
+            continue
+        matches.append((score, exemplar or (user["names"][0] if user["names"] else ""), user))
+    matches.sort(key=lambda item: (item[0], item[1]))
+    return {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "matches": [item[2] for item in matches[:limit]],
+    }, None
+
+
+def _handle_session_lookup(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    session_key = str(args.get("session_key") or "").strip()
+    session_id = str(args.get("session_id") or "").strip()
+    if session_key:
+        session = next((item for item in index["sessions"] if item["session_key"] == session_key), None)
+    elif session_id:
+        session = next((item for item in index["sessions"] if item["session_id"] == session_id), None)
+    else:
+        return None, "session_lookup requires session_key or session_id."
+
+    if not session or not _match_account(session, account_id):
+        return None, "No observed Feishu session matched the provided key."
+    return {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "session": session,
+    }, None
+
+
+def _handle_my_chats(args: Dict[str, Any], index: Dict[str, Any], account_id: Optional[str], config):
+    current = _current_session_principal()
+    identifiers = {}
+    for field in ("open_id", "user_id", "union_id"):
+        value = str(args.get(field) or "").strip()
+        if value:
+            identifiers[field] = value
+    if not identifiers and current.get("platform") == "feishu":
+        classified = _classify_id(current.get("user_id"))
+        if classified and classified[0]:
+            identifiers[classified[0]] = classified[1]
+        classified_alt = _classify_id(current.get("user_id_alt"))
+        if classified_alt and classified_alt[0]:
+            identifiers[classified_alt[0]] = classified_alt[1]
+    if not identifiers:
+        return None, "my_chats requires a Feishu sender context or explicit open_id/user_id/union_id."
+
+    user = _find_user_by_ids(index, account_id, identifiers)
+    if not user:
+        return None, "No observed Feishu user matched the requested principal."
+
+    chat_ids = set(user["chat_ids"])
+    chats = [chat for chat in index["chats"] if chat["chat_id"] in chat_ids and _match_account(chat, account_id)]
+    chats.sort(key=lambda item: ((item.get("account_id") or ""), item["chat_id"]))
+    return {
+        "success": True,
+        "source": "observed_local_index",
+        "authoritative": False,
+        "user": user,
+        "chats": chats[:_normalize_limit(args.get("limit"))],
+    }, None
+
+
+_ACTION_HANDLERS = {
+    "whois_chat": _handle_whois_chat,
+    "members": _handle_members,
+    "search_chats": _handle_search_chats,
+    "whois_user": _handle_whois_user,
+    "resolve_user": _handle_resolve_user,
+    "session_lookup": _handle_session_lookup,
+    "my_chats": _handle_my_chats,
+}
+
+
+def feishu_id_tool(args: Dict[str, Any], **_kw) -> str:
+    from tools.registry import tool_error, tool_result
+
+    action = str(args.get("action") or "").strip()
+    handler = _ACTION_HANDLERS.get(action)
+    if not handler:
+        return tool_error(f"Unknown action: {action}")
+
+    config = _load_gateway_config_safe()
+    account_id = _effective_account_scope(args, config)
+    auth_error = _authorize_account_scope(config, account_id)
+    if auth_error:
+        return tool_error(auth_error)
+
+    index = _build_observed_index(config)
+    payload, error = handler(args, index, account_id, config)
+    if error:
+        return tool_error(error)
+    return tool_result(payload)
+
+
+from tools.registry import registry
+
+registry.register(
+    name="feishu_id",
+    toolset="messaging",
+    schema=FEISHU_ID_SCHEMA,
+    handler=feishu_id_tool,
+    check_fn=_check_feishu_id,
+    emoji="🪪",
+)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -99,6 +99,45 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
+def _get_config_callable(config, name):
+    """Return a real config helper method, ignoring MagicMock auto-attributes."""
+    try:
+        instance_attr = vars(config).get(name)
+    except Exception:
+        instance_attr = None
+    if callable(instance_attr):
+        return instance_attr
+
+    class_attr = getattr(type(config), name, None)
+    if callable(class_attr):
+        return getattr(config, name)
+    return None
+
+
+def _resolve_platform_config(config, platform, account_id=None):
+    """Support both GatewayConfig and lightweight test doubles."""
+    getter = _get_config_callable(config, "get_platform_config")
+    if getter:
+        try:
+            return getter(platform, account_id=account_id)
+        except TypeError:
+            return getter(platform)
+
+    platforms = getattr(config, "platforms", {}) or {}
+    return platforms.get(platform)
+
+
+def _resolve_home_channel(config, platform, account_id=None):
+    """Support both GatewayConfig and lightweight test doubles."""
+    getter = _get_config_callable(config, "get_home_channel")
+    if getter:
+        try:
+            return getter(platform, account_id=account_id)
+        except TypeError:
+            return getter(platform)
+    return None
+
+
 def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
@@ -168,9 +207,12 @@ def _handle_send(args):
         avail = ", ".join(platform_map.keys())
         return tool_error(f"Unknown platform: {platform_name}. Available: {avail}")
 
-    pconfig = config.platforms.get(platform)
-    if not pconfig or not pconfig.enabled:
-        return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+    from gateway.session_context import get_session_env
+
+    session_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    session_account_id = get_session_env("HERMES_SESSION_ACCOUNT_ID", "")
+    effective_account_id = session_account_id if session_platform == platform_name else ""
+    delivery_account_id = effective_account_id or None
 
     from gateway.platforms.base import BasePlatformAdapter
 
@@ -179,9 +221,10 @@ def _handle_send(args):
 
     used_home_channel = False
     if not chat_id:
-        home = config.get_home_channel(platform)
+        home = _resolve_home_channel(config, platform, account_id=effective_account_id or None)
         if home:
             chat_id = home.chat_id
+            delivery_account_id = getattr(home, "account_id", None) or delivery_account_id
             used_home_channel = True
         else:
             return json.dumps({
@@ -190,7 +233,16 @@ def _handle_send(args):
                 f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
             })
 
-    duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
+    pconfig = _resolve_platform_config(config, platform, account_id=delivery_account_id)
+    if not pconfig or not pconfig.enabled:
+        return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+
+    duplicate_skip = _maybe_skip_cron_duplicate_send(
+        platform_name,
+        chat_id,
+        thread_id,
+        account_id=delivery_account_id,
+    )
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
@@ -213,7 +265,6 @@ def _handle_send(args):
         if isinstance(result, dict) and result.get("success") and mirror_text:
             try:
                 from gateway.mirror import mirror_to_session
-                from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
                 if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
                     result["mirrored"] = True
@@ -276,14 +327,21 @@ def _get_cron_auto_delivery_target():
     if not platform or not chat_id:
         return None
     thread_id = os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
+    account_id = os.getenv("HERMES_CRON_AUTO_DELIVER_ACCOUNT_ID", "").strip() or None
     return {
         "platform": platform,
         "chat_id": chat_id,
         "thread_id": thread_id,
+        "account_id": account_id,
     }
 
 
-def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id: str | None):
+def _maybe_skip_cron_duplicate_send(
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    account_id: str | None = None,
+):
     """Skip redundant cron send_message calls when the scheduler will auto-deliver there."""
     auto_target = _get_cron_auto_delivery_target()
     if not auto_target:
@@ -293,6 +351,7 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
         auto_target["platform"] == platform_name
         and str(auto_target["chat_id"]) == str(chat_id)
         and auto_target.get("thread_id") == thread_id
+        and (auto_target.get("account_id") or None) == (account_id or None)
     )
     if not same_target:
         return None

--- a/toolsets.py
+++ b/toolsets.py
@@ -58,6 +58,8 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
+    # Feishu identity/chat inspection (gated via check_fn)
+    "feishu_id",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 ]

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -107,7 +107,39 @@ Select **Feishu / Lark** and fill in the prompts.
 
 ### Option B: Manual Configuration
 
-Add the following to `~/.hermes/.env`:
+Recommended: configure Feishu in `~/.hermes/config.yaml` with one or more account blocks under the same Hermes agent:
+
+```yaml
+platforms:
+  feishu:
+    home_channel:
+      account_id: laok-gradients
+      chat_id: oc_team_claire
+      name: Team CLAIRE
+    accounts:
+      laok-personal:
+        app_id: cli_personal_xxx
+        app_secret: env:FEISHU_PERSONAL_APP_SECRET
+        domain: feishu
+        connection_mode: websocket
+        require_mention: true
+        default_group_policy: open
+      laok-gradients:
+        app_id: cli_gradients_xxx
+        app_secret: env:FEISHU_GRADIENTS_APP_SECRET
+        domain: feishu
+        connection_mode: websocket
+        require_mention: true
+        default_group_policy: allowlist
+        admins:
+          - u_owner_in_gradients_tenant
+```
+
+`account_id` is Hermes' local key for one Feishu bot account binding. Use names that identify the bot deployment instance, such as `laok-personal` or `laok-gradients`.
+
+`platforms.feishu.home_channel` is the platform's single default outbound target. It stores both the target chat and the bot account Hermes should send through when a job or tool only specifies `feishu` and not an explicit chat ID.
+
+Legacy single-account deployments can still use `~/.hermes/.env`:
 
 ```bash
 FEISHU_APP_ID=cli_xxx
@@ -120,7 +152,9 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 FEISHU_HOME_CHANNEL=oc_xxx
 ```
 
-`FEISHU_DOMAIN` accepts:
+For `config.yaml`, `app_secret`, `encrypt_key`, and similar sensitive values may be written as `env:VAR_NAME` references.
+
+`FEISHU_DOMAIN` / `domain` accepts:
 
 - `feishu` for Feishu China
 - `lark` for Lark international
@@ -137,7 +171,20 @@ Then message the bot from Feishu/Lark to confirm that the connection is live.
 
 Use `/set-home` in a Feishu/Lark chat to mark it as the home channel for cron job results and cross-platform notifications.
 
-You can also preconfigure it:
+You can also preconfigure it in `config.yaml`:
+
+```yaml
+platforms:
+  feishu:
+    home_channel:
+      account_id: laok-gradients
+      chat_id: oc_team_claire
+      name: Team CLAIRE
+```
+
+`home_channel.name` is optional display metadata. Routing is keyed by `chat_id`, and `account_id` selects which configured Feishu bot should send the message.
+
+Legacy single-account mode can still use:
 
 ```bash
 FEISHU_HOME_CHANNEL=oc_xxx
@@ -201,19 +248,21 @@ FEISHU_GROUP_POLICY=allowlist   # default
 | `allowlist` | Hermes only responds to @mentions from users listed in `FEISHU_ALLOWED_USERS`. |
 | `disabled` | Hermes ignores all group messages entirely. |
 
-In all modes, the bot must be explicitly @mentioned (or @all) in the group before the message is processed. Direct messages bypass this gate.
+In all modes, the bot must be explicitly @mentioned (or `@all`) in the group before the message is processed. Direct messages bypass this gate.
 
 ### Bot Identity for @Mention Gating
 
-For precise @mention detection in groups, the adapter needs to know the bot's identity. It can be provided explicitly:
+Hermes accepts group messages only when the Feishu message actually mentions the bot, unless a chat-specific rule disables mention gating.
 
-```bash
-FEISHU_BOT_OPEN_ID=ou_xxx
-FEISHU_BOT_USER_ID=xxx
-FEISHU_BOT_NAME=MyBot
-```
+Mention matching works in this order:
 
-If none of these are set, the adapter will attempt to auto-discover the bot name via the Application Info API on startup. For this to work, grant the `admin:app.info:readonly` or `application:application:self_manage` permission scope.
+1. Mention payload ID match against the bot's runtime identity, when the event carries bot IDs.
+2. Parsed rich-text mention targets in `post` messages.
+3. Best-effort display-name fallback when Hermes can auto-discover the app name from the Application Info API.
+
+`FEISHU_BOT_OPEN_ID`, `FEISHU_BOT_USER_ID`, and `FEISHU_BOT_NAME` remain legacy environment-variable compatibility fallbacks for older single-account deployments. They are not canonical multi-account config fields and should not be added under `platforms.feishu.accounts.*`.
+
+If Hermes cannot auto-discover the app name, grant the `admin:app.info:readonly` or `application:application:self_manage` permission scope.
 
 ## Interactive Card Actions
 
@@ -347,9 +396,10 @@ When using `websocket` mode, you can customize reconnect and ping behavior:
 ```yaml
 platforms:
   feishu:
-    extra:
-      ws_reconnect_interval: 120   # Seconds between reconnect attempts (default: 120)
-      ws_ping_interval: 30         # Seconds between WebSocket pings (optional; SDK default if unset)
+    accounts:
+      laok-gradients:
+        ws_reconnect_interval: 120   # Seconds between reconnect attempts (default: 120)
+        ws_ping_interval: 30         # Seconds between WebSocket pings (optional; SDK default if unset)
 ```
 
 | Setting | Config key | Default | Description |
@@ -364,22 +414,25 @@ Beyond the global `FEISHU_GROUP_POLICY`, you can set fine-grained rules per grou
 ```yaml
 platforms:
   feishu:
-    extra:
-      default_group_policy: "open"     # Default for groups not in group_rules
-      admins:                          # Users who can manage bot settings
-        - "ou_admin_open_id"
-      group_rules:
-        "oc_group_chat_id_1":
-          policy: "allowlist"          # open | allowlist | blacklist | admin_only | disabled
-          allowlist:
-            - "ou_user_open_id_1"
-            - "ou_user_open_id_2"
-        "oc_group_chat_id_2":
-          policy: "admin_only"
-        "oc_group_chat_id_3":
-          policy: "blacklist"
-          blacklist:
-            - "ou_blocked_user"
+    accounts:
+      laok-gradients:
+        require_mention: true          # account-level default
+        default_group_policy: open     # Default for groups not in group_rules
+        admins:
+          - "u_admin_in_this_tenant"
+        group_rules:
+          "oc_group_chat_id_1":
+            policy: allowlist          # open | allowlist | blacklist | admin_only | disabled
+            require_mention: false     # optional per-chat override
+            allowlist:
+              - "u_user_id_1"
+              - "u_user_id_2"
+          "oc_group_chat_id_2":
+            policy: admin_only
+          "oc_group_chat_id_3":
+            policy: blacklist
+            blacklist:
+              - "u_blocked_user"
 ```
 
 | Policy | Description |
@@ -390,7 +443,7 @@ platforms:
 | `admin_only` | Only users in the global `admins` list can use the bot in this group |
 | `disabled` | Bot ignores all messages in this group |
 
-Groups not listed in `group_rules` fall back to `default_group_policy` (defaults to the value of `FEISHU_GROUP_POLICY`).
+Groups not listed in `group_rules` fall back to `default_group_policy`. `require_mention` is resolved at two levels: account default first, then per-chat override when present.
 
 ## Deduplication
 
@@ -400,7 +453,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 |---------|---------|---------|
 | Cache size | `HERMES_FEISHU_DEDUP_CACHE_SIZE` | 2048 entries |
 
-## All Environment Variables
+## Legacy Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -413,9 +466,9 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_ENCRYPT_KEY` | — | _(empty)_ | Encrypt key for webhook signature verification |
 | `FEISHU_VERIFICATION_TOKEN` | — | _(empty)_ | Verification token for webhook payload auth |
 | `FEISHU_GROUP_POLICY` | — | `allowlist` | Group message policy: `open`, `allowlist`, `disabled` |
-| `FEISHU_BOT_OPEN_ID` | — | _(empty)_ | Bot's open_id (for @mention detection) |
-| `FEISHU_BOT_USER_ID` | — | _(empty)_ | Bot's user_id (for @mention detection) |
-| `FEISHU_BOT_NAME` | — | _(empty)_ | Bot's display name (for @mention detection) |
+| `FEISHU_BOT_OPEN_ID` | — | _(empty)_ | Legacy mention-payload open_id fallback for single-account compatibility |
+| `FEISHU_BOT_USER_ID` | — | _(empty)_ | Legacy mention-payload user_id fallback for single-account compatibility |
+| `FEISHU_BOT_NAME` | — | _(empty)_ | Legacy display-name fallback for single-account compatibility |
 | `FEISHU_WEBHOOK_HOST` | — | `127.0.0.1` | Webhook server bind address |
 | `FEISHU_WEBHOOK_PORT` | — | `8765` | Webhook server port |
 | `FEISHU_WEBHOOK_PATH` | — | `/feishu/webhook` | Webhook endpoint path |
@@ -425,7 +478,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `HERMES_FEISHU_TEXT_BATCH_MAX_CHARS` | — | `4000` | Max characters merged per text batch |
 | `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | — | `0.8` | Media burst debounce quiet period |
 
-WebSocket and per-group ACL settings are configured via `config.yaml` under `platforms.feishu.extra` (see [WebSocket Tuning](#websocket-tuning) and [Per-Group Access Control](#per-group-access-control) above).
+These environment variables are for legacy single-account compatibility. New multi-account deployments should use `config.yaml` under `platforms.feishu.accounts.<account_id>`.
 
 ## Troubleshooting
 
@@ -434,17 +487,19 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `lark-oapi not installed` | Install the SDK: `pip install lark-oapi` |
 | `websockets not installed; websocket mode unavailable` | Install websockets: `pip install websockets` |
 | `aiohttp not installed; webhook mode unavailable` | Install aiohttp: `pip install aiohttp` |
-| `FEISHU_APP_ID or FEISHU_APP_SECRET not set` | Set both env vars or configure via `hermes gateway setup` |
+| `FEISHU_APP_ID or FEISHU_APP_SECRET not set` | Set both env vars for legacy single-account mode, or configure `platforms.feishu.accounts.<account_id>` in `config.yaml` |
 | `Another local Hermes gateway is already using this Feishu app_id` | Only one Hermes instance can use the same app_id at a time. Stop the other gateway first. |
-| Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
+| Bot doesn't respond in groups | Ensure the bot is actually @mentioned, check `require_mention`, and verify the sender passes the account or per-group policy |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
-| Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
+| Bot identity not auto-detected | Grant `admin:app.info:readonly` or `application:application:self_manage`; `FEISHU_BOT_NAME` is legacy compatibility only |
 | Error 200340 when clicking approval buttons | Enable **Interactive Card** capability and configure **Card Request URL** in the Feishu Developer Console. See [Required Feishu App Configuration](#required-feishu-app-configuration) above. |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |
 
 ## Toolset
 
 Feishu / Lark uses the `hermes-feishu` platform preset, which includes the same core tools as Telegram and other gateway-based messaging platforms.
+
+It also exposes `feishu_id`, which lets an agent inspect Feishu users, chats, members, and session routes. The tool uses official Feishu APIs when credentials are available and falls back to Hermes' observed local session metadata when they are not.


### PR DESCRIPTION
## What this PR fixes

This PR corrects Hermes' Feishu identity model.

The core bug is that Hermes previously treated Feishu IDs with the wrong mental model, especially around bot identity versus human identity. In practice this caused Hermes to behave as if Feishu were effectively a single-bot platform and led to incorrect routing assumptions in group mentions, home-channel delivery, and cross-account usage.

The most important correction is this:

- `open_id` is **not** the canonical identity of a Feishu bot.
- A Feishu bot/app is identified by its configured `app_id`.
- For human users, `user_id` is the stable tenant-scoped identifier.
- `open_id` is an app-scoped alias for a human user, so the same person can have different `open_id` values under different bot namespaces.

That identity-model mismatch is the root bug. This PR fixes that model first, then builds the routing and tooling changes on top of it.

## What follows from that fix

Once Hermes uses the correct Feishu identity model, a few capabilities naturally become possible or necessary:

- multi-account Feishu support under one Hermes agent
- account-aware session routing
- account-aware outbound delivery
- correct group-mention handling against the receiving bot account
- agent-side Feishu identity/chat inspection via `feishu_id`

So multi-account and ID-aware delivery are not the primary story by themselves; they are the downstream capability expansion that becomes possible after fixing the identity bug.

## Main implementation changes

- Add account-scoped Feishu bindings under `platforms.feishu.accounts.<account_id>`.
- Make Feishu adapter lookup, session routing, and outbound delivery account-aware.
- Treat bot display name only as legacy compatibility metadata, not as canonical identity.
- Prefer configured/runtime bot IDs and official Feishu identity fields for mention routing.
- Add `feishu_id` so agents can inspect Feishu users, chats, members, and session routes.
- Make Feishu's canonical default outbound target a single platform-level home channel:
  - `platforms.feishu.home_channel.account_id`
  - `platforms.feishu.home_channel.chat_id`
  - `platforms.feishu.home_channel.name`
- Keep legacy single-account env-based setup compatible.
- Keep legacy account-scoped Feishu `home_channel` readable as a compatibility fallback, while making the platform-level home channel canonical.

## Why the home-channel change is part of the fix

In a multi-bot Feishu deployment, `platform=feishu` is not enough to identify which bot should send an outbound message. Hermes needs both:

- the destination chat
- the sending bot account

That is why the canonical Feishu home channel is now a platform-level target that stores both `account_id` and `chat_id`. This preserves Hermes' original bare-platform UX while making the sending identity explicit and correct.

## Tests

Ran locally:

```bash
/Users/claire/.hermes/hermes-agent/venv/bin/python -m pytest -q -n0 \
  tests/gateway/test_config.py \
  tests/gateway/test_sethome_multi_account.py \
  tests/gateway/test_feishu.py \
  tests/gateway/test_feishu_ws_runtime.py \
  tests/gateway/test_webhook_adapter.py \
  tests/gateway/test_command_bypass_active_session.py \
  tests/gateway/test_unknown_command.py \
  tests/tools/test_send_message_tool.py \
  tests/tools/test_feishu_id_tool.py \
  tests/cron/test_scheduler.py \
  tests/e2e/test_platform_commands.py
```

Result: `371 passed`

## Notes

- This PR is best understood as a Feishu identity-model bug fix first.
- Multi-account support and ID-aware delivery are the capability extensions that follow from that correction.
- Legacy single-bot users can continue using the env-based setup unchanged.
