### PR TITLE
Add repo-shipped LCM context engine integration

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -78,6 +78,7 @@ class ContextEngine(ABC):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Compact the message list and return the new message list.
 
@@ -86,6 +87,10 @@ class ContextEngine(ABC):
         context budget. The implementation is free to summarize, build a
         DAG, or do anything else — as long as the returned list is a valid
         OpenAI-format message sequence.
+
+        ``focus_topic`` is an optional guided-compression hint (for example
+        from ``/compress <topic>``). Engines may use it to preserve topic-
+        relevant detail more aggressively, or ignore it.
         """
 
     # -- Optional: pre-flight check ----------------------------------------

--- a/cli.py
+++ b/cli.py
@@ -3982,6 +3982,7 @@ class HermesCLI:
             except Exception:
                 pass
 
+        _old_history = list(self.conversation_history)
         self.session_start = datetime.now()
         timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
         short_uuid = uuid.uuid4().hex[:6]
@@ -3993,7 +3994,11 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=old_session_id,
+                carry_over_context=True,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
@@ -4061,6 +4066,8 @@ class HermesCLI:
             pass
 
         # Switch to the target session
+        _old_history = list(self.conversation_history)
+        _old_agent_session_id = getattr(self.agent, "session_id", None) if self.agent else None
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
@@ -4079,7 +4086,11 @@ class HermesCLI:
         # Sync the agent if already initialised
         if self.agent:
             self.agent.session_id = target_id
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=_old_agent_session_id,
+                carry_over_context=False,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
@@ -4184,6 +4195,8 @@ class HermesCLI:
             pass
 
         # Switch to the new session
+        _old_history = list(self.conversation_history)
+        _old_agent_session_id = getattr(self.agent, "session_id", None) if self.agent else None
         self.session_id = new_session_id
         self.session_start = now
         self._pending_title = None
@@ -4193,7 +4206,11 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = new_session_id
             self.agent.session_start = now
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=_old_agent_session_id,
+                carry_over_context=False,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):

--- a/plugins/context_engine/lcm/__init__.py
+++ b/plugins/context_engine/lcm/__init__.py
@@ -1,0 +1,36 @@
+"""Repo-shipped Hermes LCM context engine.
+
+Replaces the built-in ContextCompressor with a DAG-based context engine
+that persists every message and provides structured retrieval tools.
+
+Based on the LCM paper by Ehrlich & Blackman (Voltropy PBC, Feb 2026).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def register(ctx):
+    """Plugin entry point — register the LCM context engine."""
+    from .config import LCMConfig
+    from .engine import LCMEngine
+
+    config = LCMConfig.from_env()
+
+    # Resolve hermes_home for profile-scoped storage.
+    # Use the import-safe shared helper so profile overrides are honored.
+    hermes_home = ""
+    try:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = str(get_hermes_home())
+    except Exception:
+        hermes_home = ""
+
+    engine = LCMEngine(config=config, hermes_home=hermes_home)
+
+    # Register as the context engine (replaces ContextCompressor)
+    ctx.register_context_engine(engine)
+
+    logger.info("LCM plugin loaded — lossless context management active")

--- a/plugins/context_engine/lcm/config.py
+++ b/plugins/context_engine/lcm/config.py
@@ -1,0 +1,68 @@
+"""LCM configuration with defaults and env var overrides."""
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LCMConfig:
+    """All tunables for the LCM engine."""
+
+    # -- Fresh tail: recent messages never compacted ---
+    fresh_tail_count: int = 64
+
+    # -- Compaction thresholds ---
+    # Max source tokens in a leaf chunk before summarization triggers
+    leaf_chunk_tokens: int = 20_000
+    # Fraction of context window that triggers compaction (0.0–1.0)
+    context_threshold: float = 0.75
+    # Max condensation depth (-1 = unlimited, 0 = leaf only)
+    incremental_max_depth: int = 1
+    # How many same-depth summaries trigger condensation
+    condensation_fanin: int = 4
+
+    # -- Escalation ---
+    # L2 bullet budget as fraction of L1
+    l2_budget_ratio: float = 0.50
+    # L3 deterministic truncate token limit
+    l3_truncate_tokens: int = 512
+
+    # -- Assembly guardrails ---
+    # Hard cap for the assembled active context (0 = disabled)
+    max_assembly_tokens: int = 0
+    # Reserve this many tokens from the model context window before assembly
+    # (0 = disabled). Effective cap becomes context_length - reserve_tokens_floor.
+    reserve_tokens_floor: int = 0
+
+    # -- Models ---
+    summary_model: str = ""       # empty = use Hermes auxiliary model
+
+    # -- Storage ---
+    database_path: str = ""       # empty = auto ({HERMES_HOME}/lcm.db)
+
+    # -- Session carry-over ---
+    # Depth retained after /new (-1 = all, 0 = nothing, 2 = keep d2+)
+    new_session_retain_depth: int = 2
+
+    @classmethod
+    def from_env(cls) -> "LCMConfig":
+        """Build config from environment variables (LCM_ prefix)."""
+        c = cls()
+        _int = lambda key, default: int(os.environ.get(key, default))
+        _float = lambda key, default: float(os.environ.get(key, default))
+        _str = lambda key, default: os.environ.get(key, default)
+
+        c.fresh_tail_count = _int("LCM_FRESH_TAIL_COUNT", c.fresh_tail_count)
+        c.leaf_chunk_tokens = _int("LCM_LEAF_CHUNK_TOKENS", c.leaf_chunk_tokens)
+        c.context_threshold = _float("LCM_CONTEXT_THRESHOLD", c.context_threshold)
+        c.incremental_max_depth = _int("LCM_INCREMENTAL_MAX_DEPTH", c.incremental_max_depth)
+        c.condensation_fanin = _int("LCM_CONDENSATION_FANIN", c.condensation_fanin)
+        c.l2_budget_ratio = _float("LCM_L2_BUDGET_RATIO", c.l2_budget_ratio)
+        c.l3_truncate_tokens = _int("LCM_L3_TRUNCATE_TOKENS", c.l3_truncate_tokens)
+        c.max_assembly_tokens = _int("LCM_MAX_ASSEMBLY_TOKENS", c.max_assembly_tokens)
+        c.reserve_tokens_floor = _int("LCM_RESERVE_TOKENS_FLOOR", c.reserve_tokens_floor)
+        c.summary_model = _str("LCM_SUMMARY_MODEL", c.summary_model)
+        c.database_path = _str("LCM_DATABASE_PATH", c.database_path)
+        c.new_session_retain_depth = _int("LCM_NEW_SESSION_RETAIN_DEPTH", c.new_session_retain_depth)
+
+        return c

--- a/plugins/context_engine/lcm/dag.py
+++ b/plugins/context_engine/lcm/dag.py
@@ -1,0 +1,290 @@
+"""Summary DAG — hierarchical compaction graph.
+
+Each node is a summary of source material (raw messages or lower-depth
+summaries). Nodes form a directed acyclic graph where edges point from
+a summary to its sources.
+
+Depth semantics:
+  D0 — leaf summaries of raw messages (minutes timescale)
+  D1 — condensation of D0 nodes (hours)
+  D2 — condensation of D1 nodes (days)
+  D3+ — further condensation (weeks/months)
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SummaryNode:
+    """A single node in the summary DAG."""
+    node_id: int = 0
+    session_id: str = ""
+    depth: int = 0
+    summary: str = ""
+    token_count: int = 0
+    source_token_count: int = 0  # total tokens of source material
+    source_ids: List[int] = field(default_factory=list)  # store_ids or node_ids
+    source_type: str = "messages"  # "messages" or "nodes"
+    created_at: float = 0.0
+    expand_hint: str = ""  # "Expand for details about: ..."
+
+
+class SummaryDAG:
+    """SQLite-backed DAG of summary nodes."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self):
+        self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS summary_nodes (
+                node_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                depth INTEGER NOT NULL DEFAULT 0,
+                summary TEXT NOT NULL,
+                token_count INTEGER DEFAULT 0,
+                source_token_count INTEGER DEFAULT 0,
+                source_ids TEXT NOT NULL DEFAULT '[]',
+                source_type TEXT NOT NULL DEFAULT 'messages',
+                created_at REAL NOT NULL,
+                expand_hint TEXT DEFAULT ''
+            );
+            CREATE INDEX IF NOT EXISTS idx_nodes_session_depth
+                ON summary_nodes(session_id, depth, created_at);
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
+                summary,
+                content=summary_nodes,
+                content_rowid=node_id
+            );
+
+            CREATE TRIGGER IF NOT EXISTS nodes_fts_insert
+                AFTER INSERT ON summary_nodes BEGIN
+                INSERT INTO nodes_fts(rowid, summary)
+                    VALUES (new.node_id, new.summary);
+            END;
+        """)
+        self._conn.commit()
+
+    # -- Write --------------------------------------------------------------
+
+    def add_node(self, node: SummaryNode) -> int:
+        """Insert a summary node and return its node_id."""
+        cur = self._conn.execute(
+            """INSERT INTO summary_nodes
+               (session_id, depth, summary, token_count, source_token_count,
+                source_ids, source_type, created_at, expand_hint)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                node.session_id,
+                node.depth,
+                node.summary,
+                node.token_count,
+                node.source_token_count,
+                json.dumps(node.source_ids),
+                node.source_type,
+                node.created_at or time.time(),
+                node.expand_hint,
+            ),
+        )
+        self._conn.commit()
+        node.node_id = cur.lastrowid
+        return node.node_id
+
+    def delete_below_depth(self, session_id: str, min_depth: int) -> int:
+        """Delete all nodes for a session with depth < min_depth.
+
+        Returns the number of deleted nodes.  Used during session reset
+        to retain only high-level summaries across sessions.
+        """
+        cur = self._conn.execute(
+            """DELETE FROM summary_nodes
+               WHERE session_id = ? AND depth < ?""",
+            (session_id, min_depth),
+        )
+        deleted = cur.rowcount
+        if deleted:
+            self._conn.commit()
+        return deleted
+
+    def delete_session_nodes(self, session_id: str) -> int:
+        """Delete all nodes for a session. Returns count deleted."""
+        cur = self._conn.execute(
+            "DELETE FROM summary_nodes WHERE session_id = ?",
+            (session_id,),
+        )
+        deleted = cur.rowcount
+        if deleted:
+            self._conn.commit()
+        return deleted
+
+    def reassign_session_nodes(self, old_session_id: str, new_session_id: str) -> int:
+        """Move all nodes from one session_id to another.
+
+        Used for /new carry-over where retained summaries should become part of
+        the fresh session while preserving node IDs and node-to-node links.
+        """
+        cur = self._conn.execute(
+            "UPDATE summary_nodes SET session_id = ? WHERE session_id = ?",
+            (new_session_id, old_session_id),
+        )
+        moved = cur.rowcount
+        if moved:
+            self._conn.commit()
+        return moved
+
+    # -- Read ---------------------------------------------------------------
+
+    def get_node(self, node_id: int) -> Optional[SummaryNode]:
+        row = self._conn.execute(
+            "SELECT * FROM summary_nodes WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        return self._row_to_node(row) if row else None
+
+    def get_session_nodes(self, session_id: str,
+                          depth: int | None = None,
+                          limit: int = 1000) -> List[SummaryNode]:
+        """Get nodes for a session, optionally filtered by depth."""
+        if depth is not None:
+            rows = self._conn.execute(
+                """SELECT * FROM summary_nodes
+                   WHERE session_id = ? AND depth = ?
+                   ORDER BY created_at LIMIT ?""",
+                (session_id, depth, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT * FROM summary_nodes
+                   WHERE session_id = ?
+                   ORDER BY depth, created_at LIMIT ?""",
+                (session_id, limit),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    def count_at_depth(self, session_id: str, depth: int) -> int:
+        """Count nodes at a specific depth for a session."""
+        row = self._conn.execute(
+            """SELECT COUNT(*) FROM summary_nodes
+               WHERE session_id = ? AND depth = ?""",
+            (session_id, depth),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_uncondensed_at_depth(self, session_id: str, depth: int,
+                                  limit: int = 100) -> List[SummaryNode]:
+        """Get nodes at a depth that haven't been condensed yet.
+
+        A node is 'uncondensed' if it's not referenced as a source by
+        any higher-depth node.
+        """
+        rows = self._conn.execute(
+            """SELECT n.* FROM summary_nodes n
+               WHERE n.session_id = ? AND n.depth = ?
+               AND n.node_id NOT IN (
+                   SELECT json_each.value FROM summary_nodes p,
+                   json_each(p.source_ids)
+                   WHERE p.session_id = ? AND p.depth > ? AND p.source_type = 'nodes'
+               )
+               ORDER BY n.created_at LIMIT ?""",
+            (session_id, depth, session_id, depth, limit),
+        ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    # -- Search -------------------------------------------------------------
+
+    def search(self, query: str, session_id: str | None = None,
+               limit: int = 20) -> List[SummaryNode]:
+        """FTS5 search across all summary nodes."""
+        if session_id:
+            rows = self._conn.execute(
+                """SELECT n.* FROM nodes_fts fts
+                   JOIN summary_nodes n ON n.node_id = fts.rowid
+                   WHERE nodes_fts MATCH ? AND n.session_id = ?
+                   ORDER BY rank LIMIT ?""",
+                (query, session_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT n.* FROM nodes_fts fts
+                   JOIN summary_nodes n ON n.node_id = fts.rowid
+                   WHERE nodes_fts MATCH ?
+                   ORDER BY rank LIMIT ?""",
+                (query, limit),
+            ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    # -- DAG traversal ------------------------------------------------------
+
+    def get_source_nodes(self, node: SummaryNode) -> List[SummaryNode]:
+        """Get the immediate child nodes of a summary node."""
+        if node.source_type != "nodes" or not node.source_ids:
+            return []
+        placeholders = ",".join("?" * len(node.source_ids))
+        rows = self._conn.execute(
+            f"""SELECT * FROM summary_nodes
+                WHERE node_id IN ({placeholders})
+                ORDER BY created_at""",
+            node.source_ids,
+        ).fetchall()
+        return [self._row_to_node(r) for r in rows]
+
+    def describe_subtree(self, node_id: int) -> Dict[str, Any]:
+        """Return metadata about a node's subtree without loading content."""
+        node = self.get_node(node_id)
+        if not node:
+            return {"error": f"Node {node_id} not found"}
+
+        children = []
+        if node.source_type == "nodes":
+            for child_node in self.get_source_nodes(node):
+                children.append({
+                    "node_id": child_node.node_id,
+                    "depth": child_node.depth,
+                    "token_count": child_node.token_count,
+                    "source_token_count": child_node.source_token_count,
+                    "expand_hint": child_node.expand_hint,
+                })
+
+        return {
+            "node_id": node.node_id,
+            "depth": node.depth,
+            "token_count": node.token_count,
+            "source_token_count": node.source_token_count,
+            "source_type": node.source_type,
+            "num_sources": len(node.source_ids),
+            "expand_hint": node.expand_hint,
+            "children": children,
+        }
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _row_to_node(self, row) -> SummaryNode:
+        return SummaryNode(
+            node_id=row[0],
+            session_id=row[1],
+            depth=row[2],
+            summary=row[3],
+            token_count=row[4],
+            source_token_count=row[5],
+            source_ids=json.loads(row[6]) if row[6] else [],
+            source_type=row[7],
+            created_at=row[8],
+            expand_hint=row[9] or "",
+        )
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/plugins/context_engine/lcm/engine.py
+++ b/plugins/context_engine/lcm/engine.py
@@ -1,0 +1,576 @@
+"""LCM Engine — Lossless Context Management.
+
+Implements the ContextEngine ABC. Replaces the built-in ContextCompressor
+with a DAG-based summarization system that preserves every message.
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.context_engine import ContextEngine
+from hermes_constants import get_hermes_home
+
+from .config import LCMConfig
+from .dag import SummaryDAG, SummaryNode
+from .escalation import summarize_with_escalation
+from .schemas import LCM_DESCRIBE, LCM_EXPAND, LCM_GREP
+from .store import MessageStore
+from .tokens import count_message_tokens, count_messages_tokens, count_tokens
+from . import tools as lcm_tools
+
+logger = logging.getLogger(__name__)
+
+
+class LCMEngine(ContextEngine):
+    """Lossless Context Management engine.
+
+    Architecture:
+      1. Every message is persisted verbatim in an immutable MessageStore
+      2. When context pressure builds, older messages outside the fresh tail
+         are summarized into leaf nodes (D0) in a SummaryDAG
+      3. When enough nodes accumulate at a depth, they're condensed into
+         higher-depth nodes (D1, D2, ...)
+      4. The agent gets tools (lcm_grep, lcm_describe, lcm_expand) to
+         search and drill into compacted history
+      5. Active context = system prompt + DAG summaries + fresh tail
+    """
+
+    def __init__(self, config: LCMConfig | None = None,
+                 hermes_home: str = ""):
+        self._config = config or LCMConfig.from_env()
+        self._hermes_home = hermes_home
+
+        # Resolve DB path
+        if self._config.database_path:
+            db_path = Path(self._config.database_path)
+        elif hermes_home:
+            db_path = Path(hermes_home) / "lcm.db"
+        else:
+            db_path = get_hermes_home() / "lcm.db"
+
+        self._store = MessageStore(db_path)
+        self._dag = SummaryDAG(db_path)
+
+        self._session_id: str = ""
+
+        # Track which store_ids have been ingested into the DAG
+        self._last_compacted_store_id: int = 0
+
+        # Cursor: index in the current messages list up to which all
+        # messages have been persisted.  After compress() shortens the
+        # list, the cursor resets to len(compressed) so that only
+        # genuinely new messages (appended after compaction) get ingested.
+        self._ingest_cursor: int = 0
+
+        # State required by ContextEngine ABC and run_agent.py compatibility
+        self.model = ""
+        self.base_url = ""
+        self.api_key = ""
+        self.provider = ""
+        self.context_length = 0
+        self.threshold_tokens = 0
+        self.threshold_percent = self._config.context_threshold
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.compression_count = 0
+        # run_agent.py reads these for preflight checks
+        self.protect_first_n = 3
+        self.protect_last_n = self._config.fresh_tail_count
+        # run_agent.py reads these for context probing
+        self._context_probed = False
+        self._context_probe_persistable = False
+        self.quiet_mode = False
+        self.summary_model = self._config.summary_model
+
+    @property
+    def name(self) -> str:
+        return "lcm"
+
+    # -- ContextEngine required methods ------------------------------------
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if self.threshold_tokens <= 0:
+            return False
+        return tokens >= self.threshold_tokens
+
+    def should_compress_preflight(self, messages):
+        """Pre-flight check — also ingests messages into the store."""
+        if self._session_id and messages:
+            try:
+                self._ingest_messages(messages)
+            except Exception as e:
+                logger.debug("Ingest during preflight: %s", e)
+        from .tokens import count_messages_tokens
+        rough = count_messages_tokens(messages)
+        return rough >= self.threshold_tokens
+
+    def compress(self, messages: List[Dict[str, Any]],
+                 current_tokens: int = None,
+                 focus_topic: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Main compaction entry point.
+
+        1. Ingest any new messages into the store
+        2. Identify messages outside the fresh tail
+        3. Summarize them into DAG leaf nodes
+        4. Check if condensation is needed
+        5. Assemble new active context: summaries + fresh tail
+        """
+        if not messages:
+            return messages
+
+        prompt_tokens = current_tokens or self.last_prompt_tokens
+
+        # Step 1: Ingest new messages into the immutable store
+        self._ingest_messages(messages)
+
+        # Step 2: Identify fresh tail boundary
+        n = len(messages)
+        fresh_tail_start = max(0, n - self._config.fresh_tail_count)
+
+        # Protect system prompt (always index 0)
+        if fresh_tail_start <= 1:
+            # Not enough messages to compact
+            return messages
+
+        # Step 3: Identify messages to compact (between system prompt and fresh tail)
+        # Skip system prompt (index 0), compact indices 1..fresh_tail_start
+        to_compact = messages[1:fresh_tail_start]
+
+        if not to_compact:
+            return messages
+
+        # Calculate source tokens
+        source_tokens = count_messages_tokens(to_compact)
+        if source_tokens < self._config.leaf_chunk_tokens:
+            # Not enough to justify compaction
+            return messages
+
+        # Step 4: Serialize and summarize
+        serialized = self._serialize_messages(to_compact)
+        token_budget = max(2000, int(source_tokens * 0.20))
+        token_budget = min(token_budget, 12000)
+
+        summary_text, level = summarize_with_escalation(
+            text=serialized,
+            source_tokens=source_tokens,
+            token_budget=token_budget,
+            depth=0,
+            model=self._config.summary_model,
+            l2_budget_ratio=self._config.l2_budget_ratio,
+            l3_truncate_tokens=self._config.l3_truncate_tokens,
+            focus_topic=focus_topic or "",
+        )
+
+        # Step 5: Create DAG node
+        # Collect store_ids for source tracking
+        source_store_ids = self._get_store_ids_for_messages(to_compact)
+
+        node = SummaryNode(
+            session_id=self._session_id,
+            depth=0,
+            summary=summary_text,
+            token_count=count_tokens(summary_text),
+            source_token_count=source_tokens,
+            source_ids=source_store_ids,
+            source_type="messages",
+            created_at=time.time(),
+            expand_hint=self._extract_expand_hint(summary_text),
+        )
+        self._dag.add_node(node)
+        self._last_compacted_store_id = max(source_store_ids) if source_store_ids else 0
+
+        # Step 6: Check if condensation is needed
+        self._maybe_condense(focus_topic=focus_topic)
+
+        # Step 7: Assemble new active context
+        compressed = self._assemble_context(messages[0], messages[fresh_tail_start:])
+        self.compression_count += 1
+        # Reset cursor to the length of the compressed context so that
+        # only messages appended *after* this point get ingested next time.
+        self._ingest_cursor = len(compressed)
+
+        logger.info(
+            "LCM compaction #%d: %d messages → %d (L%d, %d→%d tokens, %d DAG nodes)",
+            self.compression_count, n, len(compressed), level,
+            source_tokens, count_tokens(summary_text),
+            len(self._dag.get_session_nodes(self._session_id)),
+        )
+
+        return compressed
+
+    # -- ContextEngine optional methods ------------------------------------
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id
+        self._ingest_cursor = 0
+        self._last_compacted_store_id = 0
+        if "hermes_home" in kwargs:
+            self._hermes_home = kwargs["hermes_home"]
+        # Pick up context_length from kwargs if provided
+        if "context_length" in kwargs:
+            self.context_length = kwargs["context_length"]
+            self.threshold_tokens = int(
+                self.context_length * self._config.context_threshold
+            )
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        # Ensure all messages are persisted
+        self._ingest_messages(messages)
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        old_session_id = self._session_id
+        self._last_compacted_store_id = 0
+        self._ingest_cursor = 0
+        self._context_probed = False
+        self._context_probe_persistable = False
+
+        # Retain DAG nodes across sessions based on config.
+        #   -1  → keep all nodes
+        #    0  → delete everything
+        #    N  → keep nodes at depth >= N (e.g. 2 keeps d2+)
+        retain = self._config.new_session_retain_depth
+        if self._session_id and retain != -1:
+            if retain == 0:
+                self._dag.delete_session_nodes(self._session_id)
+            else:
+                self._dag.delete_below_depth(self._session_id, retain)
+    def carry_over_new_session_context(self, old_session_id: str, new_session_id: str) -> int:
+        """Move retained summaries from the old session into the new one."""
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return 0
+        return self._dag.reassign_session_nodes(old_session_id, new_session_id)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [LCM_GREP, LCM_DESCRIBE, LCM_EXPAND]
+
+    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        # Ingest live messages if passed (enables current-turn search)
+        messages = kwargs.get("messages")
+        
+        if messages and self._session_id:
+            try:
+                self._ingest_messages(messages)
+            except Exception as e:
+                logger.debug("Ingest during tool call failed: %s", e)
+
+        handlers = {
+            "lcm_grep": lcm_tools.lcm_grep,
+            "lcm_describe": lcm_tools.lcm_describe,
+            "lcm_expand": lcm_tools.lcm_expand,
+        }
+        handler = handlers.get(name)
+        if handler:
+            return handler(args, engine=self)
+        return json.dumps({"error": f"Unknown LCM tool: {name}"})
+
+    def get_status(self) -> Dict[str, Any]:
+        status = super().get_status()
+        if self._session_id:
+            status["engine"] = "lcm"
+            status["store_messages"] = self._store.get_session_count(self._session_id)
+            status["dag_nodes"] = len(self._dag.get_session_nodes(self._session_id))
+        return status
+
+    def update_model(self, model: str, context_length: int,
+                     base_url: str = "", api_key: str = "",
+                     provider: str = "") -> None:
+        self.context_length = context_length
+        self.threshold_tokens = int(context_length * self._config.context_threshold)
+
+    # -- Internal: message ingestion ---------------------------------------
+
+    def _ingest_messages(self, messages: List[Dict[str, Any]]) -> None:
+        """Persist new messages to the store.
+
+        Uses a cursor to track which portion of the current messages list
+        has already been persisted.  After compress() shortens the list,
+        the cursor is reset to len(compressed), so only messages appended
+        after compaction are ingested — regardless of how the store count
+        compares to the current list length.
+        """
+        if not self._session_id:
+            logger.debug("Ingest skipped: no session_id")
+            return
+
+        n = len(messages)
+        cursor = self._ingest_cursor
+        logger.debug(
+            "Ingest: session=%s cursor=%d incoming=%d",
+            self._session_id, cursor, n,
+        )
+
+        new_messages = messages[cursor:] if cursor < n else []
+
+        if not new_messages:
+            return
+
+        estimates = [count_message_tokens(m) for m in new_messages]
+        self._store.append_batch(self._session_id, new_messages, estimates)
+        self._ingest_cursor = n
+        logger.debug("Ingested %d messages into LCM store", len(new_messages))
+
+    def _get_store_ids_for_messages(self, messages: List[Dict[str, Any]]) -> List[int]:
+        """Map current raw messages back to store_ids in stable store order.
+
+        Matching starts strictly after ``_last_compacted_store_id`` so repeated
+        content from older already-compacted history cannot hijack the mapping.
+        Synthetic summary messages simply fail to match and are skipped.
+        """
+        candidates = [
+            stored for stored in self._store.get_session_messages(self._session_id)
+            if stored["store_id"] > self._last_compacted_store_id
+        ]
+
+        ids: list[int] = []
+        store_idx = 0
+        for msg in messages:
+            role = msg.get("role", "")
+            content = msg.get("content") or ""
+            probe_idx = store_idx
+            while probe_idx < len(candidates):
+                stored = candidates[probe_idx]
+                if stored.get("role", "") == role and (stored.get("content") or "") == content:
+                    ids.append(stored["store_id"])
+                    store_idx = probe_idx + 1
+                    break
+                probe_idx += 1
+
+        return ids
+
+    # -- Internal: summarization -------------------------------------------
+
+    def _serialize_messages(self, messages: List[Dict[str, Any]]) -> str:
+        """Serialize messages into labeled text for the summarizer."""
+        parts = []
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            content = msg.get("content") or ""
+
+            if role == "tool":
+                tool_id = msg.get("tool_call_id", "")
+                if len(content) > 3000:
+                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                parts.append(f"[TOOL RESULT {tool_id}]: {content}")
+                continue
+
+            if role == "assistant":
+                if len(content) > 3000:
+                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                tool_calls = msg.get("tool_calls", [])
+                if tool_calls:
+                    tc_parts = []
+                    for tc in tool_calls:
+                        if isinstance(tc, dict):
+                            fn = tc.get("function", {})
+                            name = fn.get("name", "?")
+                            args = fn.get("arguments", "")
+                            if len(args) > 500:
+                                args = args[:400] + "..."
+                            tc_parts.append(f"  {name}({args})")
+                    content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
+                parts.append(f"[ASSISTANT]: {content}")
+                continue
+
+            if len(content) > 3000:
+                content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+            parts.append(f"[{role.upper()}]: {content}")
+
+        return "\n\n".join(parts)
+
+    # -- Internal: condensation --------------------------------------------
+
+    def _maybe_condense(self, focus_topic: Optional[str] = None) -> None:
+        """Check if any depth level has enough nodes for condensation."""
+        max_depth = self._config.incremental_max_depth
+        if max_depth == 0:
+            return  # condensation disabled
+
+        # When max_depth is -1 (unlimited), derive the upper bound from
+        # the deepest existing node + 1, so condensation can always
+        # create the next depth level.
+        if max_depth < 0:
+            all_nodes = self._dag.get_session_nodes(self._session_id)
+            upper = (max(n.depth for n in all_nodes) + 1) if all_nodes else 1
+        else:
+            upper = max_depth
+
+        for depth in range(upper):
+            uncondensed = self._dag.get_uncondensed_at_depth(
+                self._session_id, depth
+            )
+            if len(uncondensed) < self._config.condensation_fanin:
+                continue
+
+            # Take the first fanin nodes and condense
+            to_condense = uncondensed[:self._config.condensation_fanin]
+            combined_text = "\n\n---\n\n".join(n.summary for n in to_condense)
+            source_tokens = sum(n.token_count for n in to_condense)
+            token_budget = max(1000, int(source_tokens * 0.40))
+
+            summary_text, level = summarize_with_escalation(
+                text=combined_text,
+                source_tokens=source_tokens,
+                token_budget=token_budget,
+                depth=depth + 1,
+                model=self._config.summary_model,
+                l2_budget_ratio=self._config.l2_budget_ratio,
+                l3_truncate_tokens=self._config.l3_truncate_tokens,
+                focus_topic=focus_topic or "",
+            )
+
+            node = SummaryNode(
+                session_id=self._session_id,
+                depth=depth + 1,
+                summary=summary_text,
+                token_count=count_tokens(summary_text),
+                source_token_count=source_tokens,
+                source_ids=[n.node_id for n in to_condense],
+                source_type="nodes",
+                created_at=time.time(),
+                expand_hint=self._extract_expand_hint(summary_text),
+            )
+            self._dag.add_node(node)
+
+            logger.info(
+                "LCM condensation: d%d × %d → d%d (L%d, %d→%d tokens)",
+                depth, len(to_condense), depth + 1, level,
+                source_tokens, count_tokens(summary_text),
+            )
+
+    # -- Internal: context assembly ----------------------------------------
+
+    def _assemble_context(self, system_msg: Dict[str, Any],
+                          tail_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Build the active context from DAG summaries + fresh tail.
+
+        Structure:
+          [system prompt (with LCM note)]
+          [highest-depth summary nodes first, then lower]
+          [fresh tail messages]
+        """
+        result = []
+
+        # System prompt with LCM annotation
+        sys_msg = system_msg.copy()
+        if self.compression_count == 0:
+            sys_content = sys_msg.get("content", "")
+            sys_msg["content"] = (
+                sys_content
+                + "\n\n[Note: This conversation uses Lossless Context Management (LCM). "
+                "Earlier turns have been compacted into hierarchical summaries below. "
+                "Use lcm_grep to search history, lcm_describe to inspect the DAG, "
+                "and lcm_expand to recover original details from any summary.]"
+            )
+        result.append(sys_msg)
+
+        assembly_cap = self._effective_assembly_token_cap()
+
+        tail_selected = tail_messages
+        tail_budget = None
+        if assembly_cap is not None:
+            used = count_message_tokens(sys_msg)
+            kept_tail_reversed: list[Dict[str, Any]] = []
+            tail_token_total = 0
+            for msg in reversed(tail_messages):
+                msg_tokens = count_message_tokens(msg)
+                if used + tail_token_total + msg_tokens > assembly_cap:
+                    continue
+                kept_tail_reversed.append(msg)
+                tail_token_total += msg_tokens
+            tail_selected = list(reversed(kept_tail_reversed))
+            tail_budget = max(0, assembly_cap - used - tail_token_total)
+
+        # Collect DAG summaries — highest depth first for context hierarchy
+        all_nodes = self._dag.get_session_nodes(self._session_id)
+        if all_nodes:
+            # Group by depth, take the most recent uncondensed at each level
+            # For active context, we want the highest-level summaries
+            # that haven't been condensed into even higher levels
+            depths = sorted(set(n.depth for n in all_nodes), reverse=True)
+            summary_parts = []
+            for d in depths:
+                uncondensed = self._dag.get_uncondensed_at_depth(self._session_id, d)
+                for node in uncondensed:
+                    depth_label = {
+                        0: "Recent",
+                        1: "Session Arc",
+                        2: "Durable",
+                    }.get(d, f"Depth-{d}")
+                    summary_parts.append(
+                        f"[{depth_label} Summary (d{d}, node {node.node_id})]\n"
+                        f"{node.summary}\n"
+                        f"[Expand for details: {node.expand_hint}]"
+                    )
+
+            if summary_parts:
+                # Choose role to avoid consecutive same-role
+                last_role = result[-1].get("role", "system")
+                summary_role = "assistant" if last_role != "assistant" else "user"
+                selected_parts = summary_parts
+                if tail_budget is not None:
+                    selected_parts = []
+                    for part in summary_parts:
+                        candidate = "\n\n---\n\n".join(selected_parts + [part])
+                        candidate_msg = {"role": summary_role, "content": candidate}
+                        if count_message_tokens(candidate_msg) <= tail_budget:
+                            selected_parts.append(part)
+                if selected_parts:
+                    combined = "\n\n---\n\n".join(selected_parts)
+                    result.append({"role": summary_role, "content": combined})
+
+        # Fresh tail
+        result.extend(tail_selected)
+
+        return result
+
+    def _effective_assembly_token_cap(self) -> Optional[int]:
+        """Return the active assembly cap, if any.
+
+        Two knobs can constrain the assembled active context:
+        - max_assembly_tokens: explicit hard cap
+        - reserve_tokens_floor: keep headroom inside context_length
+        """
+        caps: list[int] = []
+
+        if self._config.max_assembly_tokens > 0:
+            caps.append(self._config.max_assembly_tokens)
+
+        if self.context_length > 0 and self._config.reserve_tokens_floor > 0:
+            reserve_cap = self.context_length - self._config.reserve_tokens_floor
+            if reserve_cap > 0:
+                caps.append(reserve_cap)
+
+        if not caps:
+            return None
+
+        return max(1, min(caps))
+
+    # -- Internal: helpers -------------------------------------------------
+
+    @staticmethod
+    def _extract_expand_hint(summary: str) -> str:
+        """Extract the 'Expand for details about:' line from a summary."""
+        marker = "Expand for details about:"
+        idx = summary.rfind(marker)
+        if idx >= 0:
+            hint = summary[idx + len(marker):].strip()
+            # Take first line only
+            return hint.split("\n")[0].strip()
+        return ""
+
+    # -- Lifecycle ---------------------------------------------------------
+
+    def shutdown(self):
+        self._store.close()
+        self._dag.close()

--- a/plugins/context_engine/lcm/escalation.py
+++ b/plugins/context_engine/lcm/escalation.py
@@ -1,0 +1,142 @@
+"""Three-level summarization escalation.
+
+Level 1 (Normal):    LLM summary preserving details
+Level 2 (Aggressive): LLM bullet-point summary at half the token budget
+Level 3 (Fallback):   Deterministic truncation — no LLM, guaranteed convergence
+
+Each level checks if Tokens(summary) < Tokens(source). If not, escalates.
+"""
+
+import logging
+from typing import List, Optional
+
+from .tokens import count_tokens
+
+logger = logging.getLogger(__name__)
+
+
+def _call_llm_for_summary(prompt: str, max_tokens: int,
+                           model: str = "") -> Optional[str]:
+    """Call the Hermes auxiliary LLM for summarization."""
+    try:
+        from agent.auxiliary_client import call_llm
+        call_kwargs = {
+            "task": "compression",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.3,
+            "max_tokens": max_tokens,
+        }
+        if model:
+            call_kwargs["model"] = model
+        response = call_llm(**call_kwargs)
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return content.strip()
+    except Exception as e:
+        logger.warning("LLM summarization failed: %s", e)
+        return None
+
+
+def _build_l1_prompt(text: str, token_budget: int, depth: int, focus_topic: str = "") -> str:
+    """Level 1: preserve details."""
+    depth_guidance = {
+        0: "Preserve decisions, rationale, constraints, active tasks, file paths, commands, and specific values.",
+        1: "Distill into arc-level outcomes: what evolved, what was decided, current state. Drop per-turn detail.",
+        2: "Capture durable narrative: decisions in effect, completed milestones, timeline. Drop process detail.",
+    }
+    guidance = depth_guidance.get(depth, depth_guidance[2])
+
+    focus_guidance = ""
+    if focus_topic:
+        focus_guidance = (
+            f'Prioritize preserving information related to: "{focus_topic}".\n'
+            "Spend roughly 60-70% of the summary budget on that topic when relevant.\n"
+        )
+
+    return f"""Summarize this conversation segment for future turns.
+{guidance}
+Remove repetition and conversational filler.
+End with: "Expand for details about: <what was compressed>"
+{focus_guidance}
+
+Target ~{token_budget} tokens.
+
+CONTENT:
+{text}"""
+
+
+def _build_l2_prompt(text: str, token_budget: int, focus_topic: str = "") -> str:
+    """Level 2: aggressive bullet points."""
+    focus_guidance = ""
+    if focus_topic:
+        focus_guidance = (
+            f'Prioritize bullets related to: "{focus_topic}" when present.\n'
+        )
+
+    return f"""Compress this into bullet points. Maximum {token_budget} tokens.
+Keep only: decisions made, files changed, errors hit, current state.
+Drop all reasoning, alternatives considered, and process detail.
+{focus_guidance}
+
+CONTENT:
+{text}"""
+
+
+def _deterministic_truncate(text: str, max_tokens: int) -> str:
+    """Level 3: no LLM, just truncate deterministically.
+
+    Takes the first and last portions to preserve start context and
+    most recent state. Guaranteed to converge.
+    """
+    if count_tokens(text) <= max_tokens:
+        return text
+
+    # Rough char budget (4 chars/token)
+    char_budget = max_tokens * 4
+    if len(text) <= char_budget:
+        return text
+
+    head_budget = int(char_budget * 0.4)
+    tail_budget = int(char_budget * 0.4)
+    middle = "\n\n[...deterministic truncation — details available via lcm_expand...]\n\n"
+
+    return text[:head_budget] + middle + text[-tail_budget:]
+
+
+def summarize_with_escalation(
+    text: str,
+    source_tokens: int,
+    token_budget: int,
+    depth: int = 0,
+    model: str = "",
+    l2_budget_ratio: float = 0.50,
+    l3_truncate_tokens: int = 512,
+    focus_topic: str = "",
+) -> tuple[str, int]:
+    """Run 3-level escalation. Returns (summary, level_used).
+
+    Guarantees convergence: level 3 is deterministic and always produces
+    output shorter than the source.
+    """
+    # Level 1: detailed summary
+    l1_prompt = _build_l1_prompt(text, token_budget, depth, focus_topic=focus_topic)
+    l1_result = _call_llm_for_summary(l1_prompt, token_budget * 2, model=model)
+
+    if l1_result and count_tokens(l1_result) < source_tokens:
+        logger.debug("L1 summarization succeeded (%d tokens)", count_tokens(l1_result))
+        return l1_result, 1
+
+    # Level 2: aggressive bullets at reduced budget
+    l2_budget = int(token_budget * l2_budget_ratio)
+    l2_prompt = _build_l2_prompt(text, l2_budget, focus_topic=focus_topic)
+    l2_result = _call_llm_for_summary(l2_prompt, l2_budget * 2, model=model)
+
+    if l2_result and count_tokens(l2_result) < source_tokens:
+        logger.debug("L2 summarization succeeded (%d tokens)", count_tokens(l2_result))
+        return l2_result, 2
+
+    # Level 3: deterministic truncation — guaranteed convergence
+    l3_result = _deterministic_truncate(text, l3_truncate_tokens)
+    logger.debug("L3 deterministic truncation (%d tokens)", count_tokens(l3_result))
+    return l3_result, 3

--- a/plugins/context_engine/lcm/plugin.yaml
+++ b/plugins/context_engine/lcm/plugin.yaml
@@ -1,0 +1,11 @@
+name: lcm
+version: 0.1.0
+description: "Repo-shipped Lossless Context Management context engine for Hermes Agent"
+author: "Voltropy / Hermes Community"
+provides_tools:
+  - lcm_grep
+  - lcm_describe
+  - lcm_expand
+provides_hooks:
+  - on_session_start
+  - on_session_end

--- a/plugins/context_engine/lcm/schemas.py
+++ b/plugins/context_engine/lcm/schemas.py
@@ -1,0 +1,73 @@
+"""Tool schemas for LCM — what the LLM sees."""
+
+LCM_GREP = {
+    "name": "lcm_grep",
+    "description": (
+        "Search the full conversation history — raw messages AND summaries "
+        "across all depths. Use this to find specific topics, decisions, "
+        "file paths, or error messages from earlier in the conversation, "
+        "even if those turns have been compacted. Returns matches with "
+        "depth labels showing where in the hierarchy each result lives."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query (FTS5 syntax: keywords, phrases, OR/NOT)",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (default 10)",
+                "default": 10,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+LCM_DESCRIBE = {
+    "name": "lcm_describe",
+    "description": (
+        "Inspect a summary node's subtree metadata WITHOUT loading full "
+        "content. Returns token counts, child manifest, and expand hints. "
+        "Use this to plan retrieval strategy before spending tokens on "
+        "lcm_expand. If called with no node_id, returns the top-level "
+        "DAG overview for the current session."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "node_id": {
+                "type": "integer",
+                "description": "Summary node ID to inspect. Omit for session overview.",
+            },
+        },
+        "required": [],
+    },
+}
+
+LCM_EXPAND = {
+    "name": "lcm_expand",
+    "description": (
+        "Recover the original detail behind a summary node. Given a node_id, "
+        "returns the source messages or lower-depth summaries that were "
+        "compacted into that node. Use after lcm_describe to drill into "
+        "specific parts of the conversation history."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "node_id": {
+                "type": "integer",
+                "description": "Summary node ID to expand",
+            },
+            "max_tokens": {
+                "type": "integer",
+                "description": "Token budget for returned content (default 4000)",
+                "default": 4000,
+            },
+        },
+        "required": ["node_id"],
+    },
+}

--- a/plugins/context_engine/lcm/store.py
+++ b/plugins/context_engine/lcm/store.py
@@ -1,0 +1,267 @@
+"""Immutable message store — the source of truth.
+
+Every message is persisted verbatim and never modified. The store is
+append-only with optional pruning of very old messages (configurable).
+
+Each message gets a monotonic store_id used as a stable reference.
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MessageStore:
+    """SQLite-backed immutable message store."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self):
+        self._conn = sqlite3.connect(str(self.db_path), timeout=5.0, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS messages (
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_estimate INTEGER DEFAULT 0,
+                pinned INTEGER DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_msg_session
+                ON messages(session_id, store_id);
+            CREATE INDEX IF NOT EXISTS idx_msg_session_ts
+                ON messages(session_id, timestamp);
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                content,
+                content=messages,
+                content_rowid=store_id
+            );
+
+            CREATE TRIGGER IF NOT EXISTS msg_fts_insert
+                AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content)
+                    VALUES (new.store_id, new.content);
+            END;
+
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+        """)
+        self._conn.commit()
+
+    # -- Write operations ---------------------------------------------------
+
+    def append(self, session_id: str, msg: Dict[str, Any],
+               token_estimate: int = 0) -> int:
+        """Persist a message and return its store_id."""
+        tool_calls = msg.get("tool_calls")
+        tc_json = json.dumps(tool_calls) if tool_calls else None
+
+        cur = self._conn.execute(
+            """INSERT INTO messages
+               (session_id, role, content, tool_call_id, tool_calls,
+                tool_name, timestamp, token_estimate, pinned)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                msg.get("role", "unknown"),
+                msg.get("content"),
+                msg.get("tool_call_id"),
+                tc_json,
+                msg.get("tool_name"),
+                time.time(),
+                token_estimate,
+                0,
+            ),
+        )
+        self._conn.commit()
+        return cur.lastrowid
+
+    def append_batch(self, session_id: str,
+                     messages: List[Dict[str, Any]],
+                     token_estimates: List[int] | None = None) -> List[int]:
+        """Persist multiple messages in one transaction. Returns store_ids."""
+        if token_estimates is None:
+            token_estimates = [0] * len(messages)
+
+        ids = []
+        ts = time.time()
+        with self._conn:
+            for msg, est in zip(messages, token_estimates):
+                tc = msg.get("tool_calls")
+                tc_json = json.dumps(tc) if tc else None
+                cur = self._conn.execute(
+                    """INSERT INTO messages
+                       (session_id, role, content, tool_call_id, tool_calls,
+                        tool_name, timestamp, token_estimate, pinned)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        msg.get("role", "unknown"),
+                        msg.get("content"),
+                        msg.get("tool_call_id"),
+                        tc_json,
+                        msg.get("tool_name"),
+                        ts,
+                        est,
+                        0,
+                    ),
+                )
+                ids.append(cur.lastrowid)
+        return ids
+
+    def pin(self, store_id: int) -> None:
+        """Mark a message as pinned (protected from pruning)."""
+        self._conn.execute(
+            "UPDATE messages SET pinned = 1 WHERE store_id = ?", (store_id,)
+        )
+        self._conn.commit()
+
+    def unpin(self, store_id: int) -> None:
+        self._conn.execute(
+            "UPDATE messages SET pinned = 0 WHERE store_id = ?", (store_id,)
+        )
+        self._conn.commit()
+
+    # -- Read operations ----------------------------------------------------
+
+    def get(self, store_id: int) -> Optional[Dict[str, Any]]:
+        """Retrieve a single message by store_id."""
+        row = self._conn.execute(
+            "SELECT * FROM messages WHERE store_id = ?", (store_id,)
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def get_range(self, session_id: str, start_id: int = 0,
+                  end_id: int | None = None,
+                  limit: int = 1000) -> List[Dict[str, Any]]:
+        """Get messages in a store_id range for a session."""
+        if end_id is not None:
+            rows = self._conn.execute(
+                """SELECT * FROM messages
+                   WHERE session_id = ? AND store_id >= ? AND store_id <= ?
+                   ORDER BY store_id LIMIT ?""",
+                (session_id, start_id, end_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT * FROM messages
+                   WHERE session_id = ? AND store_id >= ?
+                   ORDER BY store_id LIMIT ?""",
+                (session_id, start_id, limit),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def get_session_messages(self, session_id: str,
+                             limit: int = 10000) -> List[Dict[str, Any]]:
+        """Get all messages for a session, ordered by store_id."""
+        rows = self._conn.execute(
+            """SELECT * FROM messages
+               WHERE session_id = ?
+               ORDER BY store_id LIMIT ?""",
+            (session_id, limit),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def get_session_count(self, session_id: str) -> int:
+        """Count messages in a session."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_session_token_total(self, session_id: str) -> int:
+        """Sum of token estimates for a session."""
+        row = self._conn.execute(
+            "SELECT COALESCE(SUM(token_estimate), 0) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        return row[0] if row else 0
+
+    # -- Search -------------------------------------------------------------
+
+    def search(self, query: str, session_id: str | None = None,
+               limit: int = 20) -> List[Dict[str, Any]]:
+        """FTS5 search across messages. Returns matches with snippets."""
+        if session_id:
+            rows = self._conn.execute(
+                """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                   FROM messages_fts fts
+                   JOIN messages m ON m.store_id = fts.rowid
+                   WHERE messages_fts MATCH ? AND m.session_id = ?
+                   ORDER BY rank LIMIT ?""",
+                (query, session_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT m.*, snippet(messages_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                   FROM messages_fts fts
+                   JOIN messages m ON m.store_id = fts.rowid
+                   WHERE messages_fts MATCH ?
+                   ORDER BY rank LIMIT ?""",
+                (query, limit),
+            ).fetchall()
+        results = []
+        for r in rows:
+            d = self._row_to_dict(r)
+            # snippet is the extra column
+            d["snippet"] = r[-1] if len(r) > 10 else ""
+            results.append(d)
+        return results
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _row_to_dict(self, row) -> Dict[str, Any]:
+        """Convert a sqlite3 row to a dict."""
+        if row is None:
+            return {}
+        cols = [
+            "store_id", "session_id", "role", "content", "tool_call_id",
+            "tool_calls", "tool_name", "timestamp", "token_estimate", "pinned",
+        ]
+        d = dict(zip(cols, row[:len(cols)]))
+        # Deserialize tool_calls JSON
+        if d.get("tool_calls"):
+            try:
+                d["tool_calls"] = json.loads(d["tool_calls"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return d
+
+    def to_openai_msg(self, stored: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a stored message back to OpenAI format."""
+        msg: Dict[str, Any] = {"role": stored["role"]}
+        if stored.get("content") is not None:
+            msg["content"] = stored["content"]
+        if stored.get("tool_calls"):
+            msg["tool_calls"] = stored["tool_calls"]
+        if stored.get("tool_call_id"):
+            msg["tool_call_id"] = stored["tool_call_id"]
+        if stored.get("tool_name"):
+            msg["name"] = stored["tool_name"]
+        return msg
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/plugins/context_engine/lcm/tokens.py
+++ b/plugins/context_engine/lcm/tokens.py
@@ -1,0 +1,59 @@
+"""Token counting utilities for LCM.
+
+Uses tiktoken when available, falls back to char-based estimate.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+_CHARS_PER_TOKEN = 4
+_encoder = None
+_encoder_checked = False
+
+
+def _get_encoder():
+    """Lazily load tiktoken cl100k_base encoder."""
+    global _encoder, _encoder_checked
+    if _encoder_checked:
+        return _encoder
+    _encoder_checked = True
+    try:
+        import tiktoken
+        _encoder = tiktoken.get_encoding("cl100k_base")
+    except Exception:
+        logger.debug("tiktoken not available, using char-based estimates")
+    return _encoder
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens in a string."""
+    if not text:
+        return 0
+    enc = _get_encoder()
+    if enc is not None:
+        try:
+            return len(enc.encode(text))
+        except Exception:
+            pass
+    return len(text) // _CHARS_PER_TOKEN + 1
+
+
+def count_message_tokens(msg: Dict[str, Any]) -> int:
+    """Estimate tokens for a single OpenAI-format message."""
+    total = 4  # role + overhead
+    content = msg.get("content") or ""
+    total += count_tokens(content)
+    for tc in msg.get("tool_calls") or []:
+        if isinstance(tc, dict):
+            fn = tc.get("function", {})
+            total += count_tokens(fn.get("name", ""))
+            total += count_tokens(fn.get("arguments", ""))
+        total += 3  # per-call overhead
+    return total
+
+
+def count_messages_tokens(messages: List[Dict[str, Any]]) -> int:
+    """Estimate total tokens for a message list."""
+    return sum(count_message_tokens(m) for m in messages)

--- a/plugins/context_engine/lcm/tools.py
+++ b/plugins/context_engine/lcm/tools.py
@@ -1,0 +1,190 @@
+"""Tool handlers for LCM — the code that runs when the LLM calls each tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .engine import LCMEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _require_engine(kwargs: Dict[str, Any]) -> "LCMEngine | None":
+    engine = kwargs.get("engine")
+    return engine if engine is not None else None
+
+
+def _get_session_node(engine: "LCMEngine", node_id: int):
+    node = engine._dag.get_node(node_id)
+    if node is None or node.session_id != engine._session_id:
+        return None
+    return node
+
+
+def lcm_grep(args: Dict[str, Any], **kwargs) -> str:
+    """Search across the full DAG and raw messages for the current session."""
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+
+    query = args.get("query", "").strip()
+    if not query:
+        return json.dumps({"error": "No query provided"})
+
+    limit = args.get("limit", 10)
+    session_id = engine._session_id
+    results = []
+
+    try:
+        msg_hits = engine._store.search(query, session_id=session_id, limit=limit)
+        for hit in msg_hits:
+            results.append(
+                {
+                    "type": "message",
+                    "depth": "raw",
+                    "store_id": hit["store_id"],
+                    "role": hit["role"],
+                    "snippet": hit.get("snippet", hit.get("content", "")[:200]),
+                }
+            )
+    except Exception as exc:
+        logger.debug("Message search failed: %s", exc)
+
+    try:
+        node_hits = engine._dag.search(query, session_id=session_id, limit=limit)
+        for node in node_hits:
+            results.append(
+                {
+                    "type": "summary",
+                    "depth": f"d{node.depth}",
+                    "node_id": node.node_id,
+                    "snippet": node.summary[:300],
+                    "token_count": node.token_count,
+                    "expand_hint": node.expand_hint,
+                }
+            )
+    except Exception as exc:
+        logger.debug("Node search failed: %s", exc)
+
+    results.sort(key=lambda result: (0 if result["type"] == "message" else 1, result.get("depth", "")))
+    return json.dumps({"query": query, "total_results": len(results), "results": results[:limit]})
+
+
+def lcm_describe(args: Dict[str, Any], **kwargs) -> str:
+    """Inspect a node's subtree or get session DAG overview."""
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+
+    node_id = args.get("node_id")
+    session_id = engine._session_id
+
+    if node_id is not None:
+        node = _get_session_node(engine, node_id)
+        if node is None:
+            return json.dumps({"error": f"Node {node_id} not found in current session"})
+        info = engine._dag.describe_subtree(node_id)
+        return json.dumps(info)
+
+    all_nodes = engine._dag.get_session_nodes(session_id)
+    overview = {
+        "session_id": session_id,
+        "store_message_count": engine._store.get_session_count(session_id),
+        "depths": {},
+    }
+
+    for depth in sorted({node.depth for node in all_nodes}):
+        nodes = [node for node in all_nodes if node.depth == depth]
+        overview["depths"][f"d{depth}"] = {
+            "count": len(nodes),
+            "total_tokens": sum(node.token_count for node in nodes),
+            "total_source_tokens": sum(node.source_token_count for node in nodes),
+            "nodes": [
+                {
+                    "node_id": node.node_id,
+                    "token_count": node.token_count,
+                    "expand_hint": node.expand_hint,
+                }
+                for node in nodes[:20]
+            ],
+        }
+
+    return json.dumps(overview)
+
+
+def lcm_expand(args: Dict[str, Any], **kwargs) -> str:
+    """Expand a summary node to its source content."""
+    engine = _require_engine(kwargs)
+    if engine is None:
+        return json.dumps({"error": "LCM engine not initialized"})
+
+    node_id = args.get("node_id")
+    if node_id is None:
+        return json.dumps({"error": "node_id is required"})
+
+    node = _get_session_node(engine, node_id)
+    if node is None:
+        return json.dumps({"error": f"Node {node_id} not found in current session"})
+
+    max_tokens = args.get("max_tokens", 4000)
+
+    if node.source_type == "messages":
+        from .tokens import count_tokens
+
+        messages = []
+        budget_used = 0
+        for store_id in node.source_ids:
+            stored = engine._store.get(store_id)
+            if not stored or stored.get("session_id") != engine._session_id:
+                continue
+            content = stored.get("content", "")
+            msg_tokens = count_tokens(content)
+            if budget_used + msg_tokens > max_tokens and messages:
+                messages.append(
+                    {
+                        "note": f"Truncated — {len(node.source_ids) - len(messages)} more messages available",
+                    }
+                )
+                break
+            messages.append(
+                {
+                    "store_id": stored["store_id"],
+                    "role": stored["role"],
+                    "content": content[:2000] if len(content) > 2000 else content,
+                }
+            )
+            budget_used += msg_tokens
+
+        return json.dumps(
+            {
+                "node_id": node_id,
+                "depth": node.depth,
+                "source_type": "messages",
+                "expanded": messages,
+            }
+        )
+
+    if node.source_type == "nodes":
+        children = [child for child in engine._dag.get_source_nodes(node) if child.session_id == engine._session_id]
+        return json.dumps(
+            {
+                "node_id": node_id,
+                "depth": node.depth,
+                "source_type": "nodes",
+                "expanded": [
+                    {
+                        "node_id": child.node_id,
+                        "depth": child.depth,
+                        "summary": child.summary[:1000],
+                        "token_count": child.token_count,
+                        "expand_hint": child.expand_hint,
+                    }
+                    for child in children
+                ],
+            }
+        )
+
+    return json.dumps({"error": f"Unknown source_type: {node.source_type}"})

--- a/run_agent.py
+++ b/run_agent.py
@@ -25,6 +25,7 @@ import base64
 import concurrent.futures
 import copy
 import hashlib
+import inspect
 import json
 import logging
 logger = logging.getLogger(__name__)
@@ -1309,6 +1310,28 @@ class AIAgent:
                 provider=self.provider,
                 api_mode=self.api_mode,
             )
+
+        # Ensure the active context engine knows the live model/runtime details.
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                from agent.model_metadata import get_model_context_length
+
+                _engine_context_length = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                    config_context_length=_config_context_length,
+                )
+                self.context_compressor.update_model(
+                    model=self.model,
+                    context_length=_engine_context_length,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                )
+            except Exception as _ce_model_err:
+                logger.debug("Context engine update_model during init: %s", _ce_model_err)
         self.compression_enabled = compression_enabled
 
         # Reject models whose context window is below the minimum required
@@ -1436,7 +1459,12 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
-    def reset_session_state(self):
+    def reset_session_state(
+        self,
+        previous_messages: list | None = None,
+        old_session_id: str | None = None,
+        carry_over_context: bool = False,
+    ):
         """Reset all session-scoped token counters to 0 for a fresh session.
         
         This method encapsulates the reset logic for all session-level metrics
@@ -1454,6 +1482,12 @@ class AIAgent:
         This keeps the counter reset logic DRY and maintainable in one place
         rather than scattering it across multiple methods.
         """
+        if hasattr(self, "context_compressor") and self.context_compressor and previous_messages is not None:
+            try:
+                self.context_compressor.on_session_end(old_session_id or self.session_id or "", previous_messages)
+            except Exception:
+                pass
+
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -1474,6 +1508,21 @@ class AIAgent:
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
+            try:
+                self.context_compressor.on_session_start(
+                    self.session_id,
+                    hermes_home=str(get_hermes_home()),
+                    platform=self.platform or "cli",
+                    model=self.model,
+                    context_length=getattr(self.context_compressor, "context_length", 0),
+                )
+            except Exception:
+                pass
+            if carry_over_context and old_session_id and hasattr(self.context_compressor, "carry_over_new_session_context"):
+                try:
+                    self.context_compressor.carry_over_new_session_context(old_session_id, self.session_id)
+                except Exception:
+                    pass
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -6597,7 +6646,30 @@ class AIAgent:
             except Exception:
                 pass
 
-        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
+        _compress_kwargs = {"current_tokens": approx_tokens}
+        if focus_topic is not None:
+            _supports_focus_topic = False
+            try:
+                _sig = inspect.signature(self.context_compressor.compress)
+                _supports_focus_topic = (
+                    "focus_topic" in _sig.parameters
+                    or any(
+                        param.kind == inspect.Parameter.VAR_KEYWORD
+                        for param in _sig.parameters.values()
+                    )
+                )
+            except (TypeError, ValueError):
+                _supports_focus_topic = False
+
+            if _supports_focus_topic:
+                _compress_kwargs["focus_topic"] = focus_topic
+            else:
+                logger.debug(
+                    "Context engine '%s' does not accept focus_topic; compressing without it",
+                    getattr(self.context_compressor, "name", type(self.context_compressor).__name__),
+                )
+
+        compressed = self.context_compressor.compress(messages, **_compress_kwargs)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -51,7 +51,7 @@ class _FakeAgent:
         self.session_cost_source = "openrouter"
         self.context_compressor = _FakeCompressor()
 
-    def reset_session_state(self):
+    def reset_session_state(self, previous_messages=None, old_session_id=None, carry_over_context=False):
         """Mirror the real AIAgent.reset_session_state()."""
         self.session_total_tokens = 0
         self.session_input_tokens = 0

--- a/tests/plugins/context_engine/test_lcm_core.py
+++ b/tests/plugins/context_engine/test_lcm_core.py
@@ -1,0 +1,290 @@
+"""Core tests for the repo-shipped LCM context engine."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.context_engine import discover_context_engines, load_context_engine
+from plugins.context_engine.lcm.config import LCMConfig
+from plugins.context_engine.lcm.dag import SummaryDAG, SummaryNode
+from plugins.context_engine.lcm.escalation import _deterministic_truncate
+from plugins.context_engine.lcm.store import MessageStore
+from plugins.context_engine.lcm import tokens as lcm_tokens
+
+
+class TestDiscovery:
+    def test_lcm_is_discoverable(self):
+        engines = discover_context_engines()
+        names = {name for name, _desc, _available in engines}
+        assert "lcm" in names
+
+    def test_load_context_engine_returns_lcm(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        engine = load_context_engine("lcm")
+        assert engine is not None
+        assert engine.name == "lcm"
+        assert engine._store.db_path == tmp_path / ".hermes" / "lcm.db"
+
+
+class TestConfig:
+    def test_defaults(self):
+        config = LCMConfig()
+        assert config.fresh_tail_count == 64
+        assert config.leaf_chunk_tokens == 20_000
+        assert config.context_threshold == 0.75
+        assert config.condensation_fanin == 4
+        assert config.new_session_retain_depth == 2
+
+    def test_from_env(self, monkeypatch):
+        monkeypatch.setenv("LCM_FRESH_TAIL_COUNT", "32")
+        monkeypatch.setenv("LCM_CONTEXT_THRESHOLD", "0.80")
+        monkeypatch.setenv("LCM_INCREMENTAL_MAX_DEPTH", "-1")
+        config = LCMConfig.from_env()
+        assert config.fresh_tail_count == 32
+        assert config.context_threshold == 0.80
+        assert config.incremental_max_depth == -1
+
+    def test_removed_placeholder_fields_stay_removed(self):
+        config = LCMConfig()
+        assert not hasattr(config, "expansion_model")
+        assert not hasattr(config, "summary_timeout_ms")
+        assert not hasattr(config, "delegation_timeout_ms")
+
+
+class TestTokens:
+    def test_count_tokens_empty(self):
+        assert lcm_tokens.count_tokens("") == 0
+
+    def test_char_fallback_is_deterministic(self, monkeypatch):
+        monkeypatch.setattr(lcm_tokens, "_encoder", None)
+        monkeypatch.setattr(lcm_tokens, "_encoder_checked", True)
+        assert lcm_tokens.count_tokens("abcdefgh") == 3
+
+    def test_count_message_tokens(self):
+        msg = {"role": "user", "content": "hello world this is a test"}
+        assert lcm_tokens.count_message_tokens(msg) > 0
+
+    def test_count_messages_tokens(self):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        assert lcm_tokens.count_messages_tokens(messages) > 0
+
+
+class TestMessageStore:
+    @pytest.fixture
+    def store(self, tmp_path):
+        return MessageStore(tmp_path / "test.db")
+
+    def test_append_and_get(self, store):
+        store_id = store.append("sess1", {"role": "user", "content": "hello"}, token_estimate=5)
+        retrieved = store.get(store_id)
+        assert retrieved["role"] == "user"
+        assert retrieved["content"] == "hello"
+        assert retrieved["token_estimate"] == 5
+
+    def test_append_batch(self, store):
+        messages = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+        ]
+        ids = store.append_batch("sess1", messages, [1, 2, 3])
+        assert len(ids) == 3
+        assert ids[0] < ids[1] < ids[2]
+
+    def test_get_range(self, store):
+        ids = store.append_batch("sess1", [{"role": "user", "content": f"msg {i}"} for i in range(10)])
+        result = store.get_range("sess1", start_id=ids[3], end_id=ids[7])
+        assert len(result) == 5
+
+    def test_search(self, store):
+        store.append("sess1", {"role": "user", "content": "deploy the docker container"})
+        store.append("sess1", {"role": "assistant", "content": "running kubectl"})
+        results = store.search("docker", session_id="sess1")
+        assert len(results) >= 1
+        assert results[0]["role"] == "user"
+
+    def test_pin_unpin(self, store):
+        store_id = store.append("sess1", {"role": "user", "content": "important"})
+        store.pin(store_id)
+        assert store.get(store_id)["pinned"] == 1
+        store.unpin(store_id)
+        assert store.get(store_id)["pinned"] == 0
+
+    def test_to_openai_msg(self, store):
+        store_id = store.append(
+            "sess1",
+            {
+                "role": "assistant",
+                "content": "hello",
+                "tool_calls": [{"id": "tc1", "function": {"name": "t", "arguments": "{}"}}],
+            },
+        )
+        msg = store.to_openai_msg(store.get(store_id))
+        assert msg["role"] == "assistant"
+        assert len(msg["tool_calls"]) == 1
+
+
+class TestSummaryDAG:
+    @pytest.fixture
+    def dag(self, tmp_path):
+        return SummaryDAG(tmp_path / "test.db")
+
+    def test_add_and_get(self, dag):
+        node = SummaryNode(
+            session_id="s1",
+            depth=0,
+            summary="FastAPI project setup",
+            token_count=10,
+            source_token_count=500,
+            source_ids=[1, 2, 3],
+            source_type="messages",
+            expand_hint="FastAPI setup",
+        )
+        node_id = dag.add_node(node)
+        loaded = dag.get_node(node_id)
+        assert loaded.summary == "FastAPI project setup"
+        assert loaded.source_ids == [1, 2, 3]
+
+    def test_session_nodes(self, dag):
+        for i in range(3):
+            dag.add_node(
+                SummaryNode(
+                    session_id="s1",
+                    depth=0,
+                    summary=f"S{i}",
+                    token_count=10,
+                    source_ids=[i],
+                    source_type="messages",
+                )
+            )
+        dag.add_node(
+            SummaryNode(
+                session_id="s2",
+                depth=0,
+                summary="Other",
+                token_count=10,
+                source_ids=[99],
+                source_type="messages",
+            )
+        )
+        assert len(dag.get_session_nodes("s1")) == 3
+
+    def test_count_at_depth(self, dag):
+        for i in range(4):
+            dag.add_node(
+                SummaryNode(
+                    session_id="s1",
+                    depth=0,
+                    summary=f"D0-{i}",
+                    token_count=10,
+                    source_ids=[i],
+                    source_type="messages",
+                )
+            )
+        dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=1,
+                summary="D1",
+                token_count=20,
+                source_ids=[1, 2, 3, 4],
+                source_type="nodes",
+            )
+        )
+        assert dag.count_at_depth("s1", 0) == 4
+        assert dag.count_at_depth("s1", 1) == 1
+
+    def test_search(self, dag):
+        dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=0,
+                summary="Docker containers for the API",
+                token_count=10,
+                source_ids=[1],
+                source_type="messages",
+            )
+        )
+        results = dag.search("Docker", session_id="s1")
+        assert len(results) >= 1
+
+    def test_describe_subtree(self, dag):
+        child1 = dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=0,
+                summary="Child 1",
+                token_count=10,
+                source_ids=[1],
+                source_type="messages",
+            )
+        )
+        child2 = dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=0,
+                summary="Child 2",
+                token_count=15,
+                source_ids=[2],
+                source_type="messages",
+            )
+        )
+        parent = dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=1,
+                summary="Parent",
+                token_count=20,
+                source_ids=[child1, child2],
+                source_type="nodes",
+            )
+        )
+        info = dag.describe_subtree(parent)
+        assert info["depth"] == 1
+        assert len(info["children"]) == 2
+
+    def test_delete_below_depth(self, dag):
+        for depth in range(4):
+            dag.add_node(
+                SummaryNode(
+                    session_id="s1",
+                    depth=depth,
+                    summary=f"depth {depth}",
+                    token_count=10,
+                    source_ids=[depth],
+                    source_type="messages",
+                )
+            )
+        deleted = dag.delete_below_depth("s1", 2)
+        remaining = dag.get_session_nodes("s1")
+        assert deleted == 2
+        assert all(node.depth >= 2 for node in remaining)
+
+    def test_delete_session_nodes(self, dag):
+        dag.add_node(
+            SummaryNode(
+                session_id="s1",
+                depth=0,
+                summary="one",
+                token_count=10,
+                source_ids=[1],
+                source_type="messages",
+            )
+        )
+        assert dag.delete_session_nodes("s1") == 1
+        assert dag.get_session_nodes("s1") == []
+
+
+class TestEscalation:
+    def test_truncate_long(self):
+        result = _deterministic_truncate("A" * 10000, 100)
+        assert len(result) < 10000
+        assert "deterministic truncation" in result
+
+    def test_truncate_short(self):
+        assert _deterministic_truncate("hello", 1000) == "hello"

--- a/tests/plugins/context_engine/test_lcm_engine.py
+++ b/tests/plugins/context_engine/test_lcm_engine.py
@@ -1,0 +1,460 @@
+"""Engine tests for the repo-shipped LCM context engine."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from agent.context_engine import ContextEngine
+from plugins.context_engine.lcm.config import LCMConfig
+from plugins.context_engine.lcm.dag import SummaryNode
+from plugins.context_engine.lcm.engine import LCMEngine
+from plugins.context_engine.lcm import escalation as lcm_escalation
+
+
+@pytest.fixture
+def engine(tmp_path):
+    config = LCMConfig()
+    config.fresh_tail_count = 4
+    config.leaf_chunk_tokens = 100
+    config.database_path = str(tmp_path / "lcm_test.db")
+    instance = LCMEngine(config=config)
+    instance._session_id = "test-session"
+    instance.context_length = 200000
+    instance.threshold_tokens = int(200000 * config.context_threshold)
+    return instance
+
+
+@pytest.fixture
+def mock_summary(monkeypatch):
+    def _mock(_prompt, _max_tokens, model=""):
+        return "Mock summary of conversation.\nExpand for details about: earlier turns"
+
+    monkeypatch.setattr(lcm_escalation, "_call_llm_for_summary", _mock)
+
+
+class TestEngineABC:
+    def test_is_context_engine(self, engine):
+        assert isinstance(engine, ContextEngine)
+
+    def test_name(self, engine):
+        assert engine.name == "lcm"
+
+    def test_tool_schemas(self, engine):
+        names = [schema["name"] for schema in engine.get_tool_schemas()]
+        assert names == ["lcm_grep", "lcm_describe", "lcm_expand"]
+
+    def test_should_compress(self, engine):
+        assert not engine.should_compress(1000)
+        assert engine.should_compress(engine.threshold_tokens)
+
+    def test_update_from_response(self, engine):
+        engine.update_from_response({"prompt_tokens": 5000, "completion_tokens": 200, "total_tokens": 5200})
+        assert engine.last_prompt_tokens == 5000
+        assert engine.last_completion_tokens == 200
+        assert engine.last_total_tokens == 5200
+
+    def test_session_reset(self, engine):
+        engine.compression_count = 5
+        engine.last_prompt_tokens = 9999
+        engine.on_session_reset()
+        assert engine.compression_count == 0
+        assert engine.last_prompt_tokens == 0
+
+    def test_get_status(self, engine):
+        status = engine.get_status()
+        assert status["engine"] == "lcm"
+        assert "store_messages" in status
+        assert "dag_nodes" in status
+
+    def test_compress_accepts_focus_topic(self, engine, monkeypatch):
+        captured = {}
+
+        def _mock_summary(*, text, source_tokens, token_budget, depth=0, model="", l2_budget_ratio=0.50,
+                          l3_truncate_tokens=512, focus_topic=""):
+            captured["focus_topic"] = focus_topic
+            return "Focused summary\nExpand for details about: database", 1
+
+        monkeypatch.setattr(
+            "plugins.context_engine.lcm.engine.summarize_with_escalation",
+            _mock_summary,
+        )
+
+        messages = _ConversationMixin.make_long_conversation(20)
+        engine.compress(messages, focus_topic="database schema")
+
+        assert captured["focus_topic"] == "database schema"
+
+
+class TestEngineIngest:
+    def test_ingest_stores_messages(self, engine):
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("test-session") == 3
+
+    def test_ingest_idempotent(self, engine):
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+        ]
+        engine._ingest_messages(messages)
+        engine._ingest_messages(messages)
+        assert engine._store.get_session_count("test-session") == 2
+
+
+class _ConversationMixin:
+    @staticmethod
+    def make_long_conversation(n_turns=20):
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for i in range(n_turns):
+            messages.append({"role": "user", "content": f"Question {i}: " + "x" * 200})
+            messages.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 200})
+        return messages
+
+
+class TestEngineCompress(_ConversationMixin):
+    def test_compress_short_conversation_noop(self, engine):
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        result = engine.compress(messages)
+        assert result == messages
+
+    def test_compress_preserves_system_and_tail(self, engine, mock_summary):
+        messages = self.make_long_conversation(20)
+        result = engine.compress(messages)
+        assert result[0]["role"] == "system"
+        assert result[-1] == messages[-1]
+        assert len(result) < len(messages)
+        assert engine.compression_count == 1
+
+    def test_compress_creates_dag_node(self, engine, mock_summary):
+        engine.compress(self.make_long_conversation(20))
+        nodes = engine._dag.get_session_nodes("test-session")
+        assert len(nodes) >= 1
+        assert nodes[0].depth == 0
+        assert nodes[0].source_type == "messages"
+
+
+class TestPostCompactionIngestion(_ConversationMixin):
+    def test_ingest_after_compaction(self, engine, mock_summary):
+        messages = self.make_long_conversation(20)
+        compressed = engine.compress(messages)
+        count_after_compress = engine._store.get_session_count("test-session")
+        assert count_after_compress == len(messages)
+
+        compressed.append({"role": "user", "content": "Brand new question"})
+        compressed.append({"role": "assistant", "content": "Brand new answer"})
+
+        engine._ingest_messages(compressed)
+        count_after_new = engine._store.get_session_count("test-session")
+        assert count_after_new == count_after_compress + 2
+
+    def test_ingest_cursor_reset_on_session_reset(self, engine):
+        engine._ingest_cursor = 42
+        engine.on_session_reset()
+        assert engine._ingest_cursor == 0
+
+    def test_multiple_compactions(self, engine, mock_summary):
+        messages = self.make_long_conversation(20)
+        compressed = engine.compress(messages)
+        count1 = engine._store.get_session_count("test-session")
+
+        for i in range(15):
+            compressed.append({"role": "user", "content": f"Round2 Q{i}: " + "z" * 200})
+            compressed.append({"role": "assistant", "content": f"Round2 A{i}: " + "w" * 200})
+
+        compressed2 = engine.compress(compressed)
+        count2 = engine._store.get_session_count("test-session")
+        assert count2 == count1 + 30
+
+        compressed2.append({"role": "user", "content": "Final question"})
+        engine._ingest_messages(compressed2)
+        count3 = engine._store.get_session_count("test-session")
+        assert count3 == count2 + 1
+
+
+class TestStoreIdMapping(_ConversationMixin):
+    def test_source_ids_correct_after_second_compaction(self, engine, mock_summary):
+        messages = self.make_long_conversation(20)
+        compressed = engine.compress(messages)
+
+        for i in range(15):
+            compressed.append({"role": "user", "content": f"Round2 Q{i}: " + "z" * 200})
+            compressed.append({"role": "assistant", "content": f"Round2 A{i}: " + "w" * 200})
+
+        engine.compress(compressed)
+        nodes = engine._dag.get_session_nodes("test-session")
+        assert len(nodes) >= 2
+
+        second_node = nodes[1]
+        for store_id in second_node.source_ids:
+            stored = engine._store.get(store_id)
+            assert stored is not None
+            assert "Mock summary" not in (stored.get("content") or "")
+
+    def test_repeated_content_maps_to_later_store_rows(self, engine, mock_summary):
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+        for _ in range(20):
+            messages.append({"role": "user", "content": "repeat"})
+            messages.append({"role": "assistant", "content": "same"})
+
+        compressed = engine.compress(messages)
+        first_node = engine._dag.get_session_nodes("test-session")[0]
+        first_max = max(first_node.source_ids)
+
+        for _ in range(15):
+            compressed.append({"role": "user", "content": "repeat"})
+            compressed.append({"role": "assistant", "content": "same"})
+
+        engine.compress(compressed)
+        nodes = engine._dag.get_session_nodes("test-session")
+        second_node = nodes[1]
+        assert second_node.source_ids
+        assert all(store_id > first_max for store_id in second_node.source_ids)
+
+
+class TestSessionRetainDepth:
+    def test_retain_depth_zero_deletes_all(self, engine):
+        engine._config.new_session_retain_depth = 0
+        for depth in range(3):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=depth,
+                    summary=f"d{depth} summary",
+                    token_count=100,
+                    source_token_count=500,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=time.time(),
+                )
+            )
+        engine.on_session_reset()
+        assert engine._dag.get_session_nodes("test-session") == []
+
+    def test_retain_depth_keeps_high_nodes(self, engine):
+        engine._config.new_session_retain_depth = 2
+        for depth in range(4):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=depth,
+                    summary=f"d{depth} summary",
+                    token_count=100,
+                    source_token_count=500,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=time.time(),
+                )
+            )
+        engine.on_session_reset()
+        remaining = engine._dag.get_session_nodes("test-session")
+        assert len(remaining) == 2
+        assert all(node.depth >= 2 for node in remaining)
+
+    def test_retain_depth_minus_one_keeps_all(self, engine):
+        engine._config.new_session_retain_depth = -1
+        for depth in range(3):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=depth,
+                    summary=f"d{depth} summary",
+                    token_count=100,
+                    source_token_count=500,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=time.time(),
+                )
+            )
+        engine.on_session_reset()
+        assert len(engine._dag.get_session_nodes("test-session")) == 3
+
+    def test_carry_over_moves_retained_nodes_into_new_session(self, engine):
+        engine._config.new_session_retain_depth = 2
+        for depth in range(4):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="old-session",
+                    depth=depth,
+                    summary=f"d{depth} summary",
+                    token_count=100,
+                    source_token_count=500,
+                    source_ids=[],
+                    source_type="messages",
+                    created_at=time.time(),
+                )
+            )
+
+        engine._session_id = "old-session"
+        engine.on_session_reset()
+        moved = engine.carry_over_new_session_context("old-session", "new-session")
+
+        assert moved == 2
+        assert engine._dag.get_session_nodes("old-session") == []
+        new_nodes = engine._dag.get_session_nodes("new-session")
+        assert len(new_nodes) == 2
+        assert all(node.depth >= 2 for node in new_nodes)
+
+
+class TestUnlimitedCondensationDepth:
+    def test_unlimited_depth_condenses_beyond_ten(self, engine, mock_summary):
+        engine._config.incremental_max_depth = -1
+        engine._config.condensation_fanin = 2
+
+        for i in range(3):
+            engine._dag.add_node(
+                SummaryNode(
+                    session_id="test-session",
+                    depth=11,
+                    summary=f"Deep node {i}",
+                    token_count=100,
+                    source_token_count=200,
+                    source_ids=[],
+                    source_type="nodes",
+                    created_at=time.time(),
+                )
+            )
+
+        engine._maybe_condense()
+        d12_nodes = engine._dag.get_session_nodes("test-session", depth=12)
+        assert len(d12_nodes) >= 1
+
+
+class TestAssemblyGuardrails:
+    def test_max_assembly_tokens_caps_recent_tail(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_guardrail.db"),
+            max_assembly_tokens=60,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+
+        monkeypatch.setattr(
+            "plugins.context_engine.lcm.engine.count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+
+        result = instance._assemble_context(
+            {"role": "system", "content": "s" * 10},
+            [
+                {"role": "user", "content": "a" * 20},
+                {"role": "assistant", "content": "b" * 20},
+                {"role": "user", "content": "c" * 20},
+            ],
+        )
+
+        assert [msg["content"] for msg in result[1:]] == ["b" * 20, "c" * 20]
+
+    def test_reserve_tokens_floor_caps_recent_tail(self, tmp_path, monkeypatch):
+        config = LCMConfig(
+            fresh_tail_count=10,
+            database_path=str(tmp_path / "lcm_headroom.db"),
+            reserve_tokens_floor=40,
+        )
+        instance = LCMEngine(config=config)
+        instance._session_id = "guardrail-session"
+        instance.compression_count = 1
+        instance.context_length = 100
+
+        monkeypatch.setattr(
+            "plugins.context_engine.lcm.engine.count_message_tokens",
+            lambda msg: len(msg.get("content", "")),
+        )
+
+        result = instance._assemble_context(
+            {"role": "system", "content": "s" * 10},
+            [
+                {"role": "user", "content": "a" * 20},
+                {"role": "assistant", "content": "b" * 20},
+                {"role": "user", "content": "c" * 20},
+            ],
+        )
+
+        assert [msg["content"] for msg in result[1:]] == ["b" * 20, "c" * 20]
+
+
+class TestEngineTools:
+    def test_handle_grep(self, engine):
+        engine._store.append("test-session", {"role": "user", "content": "deploy docker containers"})
+        result = json.loads(engine.handle_tool_call("lcm_grep", {"query": "docker"}))
+        assert "results" in result
+
+    def test_handle_describe_overview(self, engine):
+        result = json.loads(engine.handle_tool_call("lcm_describe", {}))
+        assert "session_id" in result
+        assert "store_message_count" in result
+
+    def test_handle_unknown_tool(self, engine):
+        result = json.loads(engine.handle_tool_call("unknown_tool", {}))
+        assert "error" in result
+
+    def test_tool_dispatch_is_bound_to_engine_instance(self, tmp_path):
+        config_a = LCMConfig(database_path=str(tmp_path / "a.db"))
+        config_b = LCMConfig(database_path=str(tmp_path / "b.db"))
+
+        engine_a = LCMEngine(config=config_a)
+        engine_a._session_id = "session-a"
+        engine_b = LCMEngine(config=config_b)
+        engine_b._session_id = "session-b"
+
+        engine_a._store.append("session-a", {"role": "user", "content": "alpha project"})
+        engine_b._store.append("session-b", {"role": "user", "content": "beta project"})
+
+        result_a = json.loads(engine_a.handle_tool_call("lcm_grep", {"query": "alpha"}))
+        result_b = json.loads(engine_b.handle_tool_call("lcm_grep", {"query": "beta"}))
+
+        assert result_a["total_results"] == 1
+        assert result_b["total_results"] == 1
+        assert "alpha" in result_a["results"][0]["snippet"]
+        assert "beta" in result_b["results"][0]["snippet"]
+
+    def test_describe_and_expand_are_session_scoped(self, engine):
+        node_id = engine._dag.add_node(
+            SummaryNode(
+                session_id="session-a",
+                depth=0,
+                summary="secret summary",
+                token_count=10,
+                source_token_count=20,
+                source_ids=[],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        engine._session_id = "session-b"
+
+        describe = json.loads(engine.handle_tool_call("lcm_describe", {"node_id": node_id}))
+        expand = json.loads(engine.handle_tool_call("lcm_expand", {"node_id": node_id}))
+
+        assert "error" in describe
+        assert "error" in expand
+
+    def test_describe_overview_includes_sparse_high_depth_nodes(self, engine):
+        engine._dag.add_node(
+            SummaryNode(
+                session_id="test-session",
+                depth=2,
+                summary="durable summary",
+                token_count=100,
+                source_token_count=500,
+                source_ids=[],
+                source_type="messages",
+                created_at=time.time(),
+            )
+        )
+
+        overview = json.loads(engine.handle_tool_call("lcm_describe", {}))
+        assert "d2" in overview["depths"]

--- a/tests/run_agent/test_lcm_context_engine_init.py
+++ b/tests/run_agent/test_lcm_context_engine_init.py
@@ -1,0 +1,87 @@
+"""Tests for selecting the repo-shipped LCM engine during AIAgent init."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+class TestLCMContextEngineInit:
+    def test_aiagent_initializes_lcm_engine_with_context_length_and_tools(self):
+        config = {
+            "context": {"engine": "lcm"},
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.context_compressor.name == "lcm"
+        assert agent.context_compressor.context_length == 131072
+        assert agent.context_compressor.threshold_tokens == int(131072 * 0.75)
+        assert {"lcm_grep", "lcm_describe", "lcm_expand"}.issubset(agent.valid_tool_names)
+        assert {"lcm_grep", "lcm_describe", "lcm_expand"}.issubset(agent._context_engine_tool_names)
+
+    def test_compress_context_supports_legacy_engine_without_focus_topic(self):
+        config = {
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        class LegacyEngine:
+            name = "legacy"
+            threshold_tokens = 999999
+            compression_count = 0
+            last_prompt_tokens = 0
+            last_completion_tokens = 0
+
+            def __init__(self):
+                self.seen_current_tokens = None
+
+            def compress(self, messages, current_tokens=None):
+                self.seen_current_tokens = current_tokens
+                return list(messages)
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.flush_memories = MagicMock()
+        engine = LegacyEngine()
+        agent.context_compressor = engine
+
+        messages = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+
+        compressed, _ = agent._compress_context(
+            messages,
+            "",
+            approx_tokens=1234,
+            focus_topic="database schema",
+        )
+
+        assert compressed == messages
+        assert engine.seen_current_tokens == 1234

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -119,3 +119,46 @@ class TestResetSessionState:
         agent.reset_session_state()
 
         assert agent._user_turn_count == 0
+
+    def test_plugin_context_engine_restarts_with_new_session_id(self):
+        """Plugin engines should be re-bound to the agent's current session after /new."""
+        agent = _make_minimal_agent()
+        agent.session_id = "new-session-id"
+        agent.platform = "cli"
+        agent.model = "test-model"
+
+        class FakePluginEngine:
+            def __init__(self):
+                self.context_length = 1234
+                self.reset_called = False
+                self.started_with = None
+                self.ended_with = None
+                self.carried_over = None
+
+            def on_session_end(self, session_id, messages):
+                self.ended_with = (session_id, list(messages))
+
+            def on_session_reset(self):
+                self.reset_called = True
+
+            def on_session_start(self, session_id, **kwargs):
+                self.started_with = (session_id, kwargs)
+
+            def carry_over_new_session_context(self, old_session_id, new_session_id):
+                self.carried_over = (old_session_id, new_session_id)
+
+        engine = FakePluginEngine()
+        agent.context_compressor = engine
+
+        agent.reset_session_state(
+            previous_messages=[{"role": "user", "content": "old stuff"}],
+            old_session_id="old-session-id",
+            carry_over_context=True,
+        )
+
+        assert engine.ended_with == ("old-session-id", [{"role": "user", "content": "old stuff"}])
+        assert engine.reset_called is True
+        assert engine.started_with is not None
+        assert engine.started_with[0] == "new-session-id"
+        assert engine.started_with[1]["context_length"] == 1234
+        assert engine.carried_over == ("old-session-id", "new-session-id")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -14,8 +14,10 @@ Context management is built on the `ContextEngine` ABC (`agent/context_engine.py
 ```yaml
 context:
   engine: "compressor"    # default — built-in lossy summarization
-  engine: "lcm"           # example — plugin providing lossless context
+  engine: "lcm"           # repo-scanned lossless context engine
 ```
+
+Hermes now ships a repo-scanned `plugins/context_engine/lcm/` engine as the reference lossless implementation. When enabled, it persists every message in SQLite, builds a hierarchical summary DAG, and injects three engine tools into the agent: `lcm_grep`, `lcm_describe`, and `lcm_expand`.
 
 The engine is responsible for:
 - Deciding when compaction should fire (`should_compress()`)

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -34,6 +34,8 @@ plugins/context_engine/lcm/
 └── ...              # any other modules your engine needs
 ```
 
+Hermes ships `plugins/context_engine/lcm/` as a real example of a repo-scanned context engine, so this directory layout is not just theoretical.
+
 ## The ContextEngine ABC
 
 Your engine must implement these **required** methods:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -493,7 +493,9 @@ context:
   engine: "compressor"    # default — built-in lossy summarization
 ```
 
-To use a plugin engine (e.g., LCM for lossless context management):
+Hermes also ships a repo-scanned `lcm` engine for Lossless Context Management. It persists every message, builds a summary DAG, and exposes retrieval tools (`lcm_grep`, `lcm_describe`, `lcm_expand`) for drilling back into compacted history.
+
+To enable LCM:
 
 ```yaml
 context:


### PR DESCRIPTION
This brings the LCM context engine into Hermes as a repo-shipped context engine and wires it into the existing context-engine slot.

What’s in here:
- adds the repo-shipped `plugins/context_engine/lcm/` engine
- loads it through `context.engine: lcm`
- exposes the LCM tools through the active Hermes runtime
- covers init/runtime selection with tests
- wires reset/new-session flows so engine session state gets restarted cleanly
- updates the relevant docs/config references

Why I split it this way:
- this PR is the Hermes-side integration layer
- the standalone `hermes-lcm` repo still has a few upstream follow-up PRs open, and I wanted those links visible here instead of hiding the dependency chain

Upstream `hermes-lcm` follow-ups referenced by this integration:
- focus-topic support: https://github.com/stephenschoettler/hermes-lcm/pull/3
- assembly cap guardrails: https://github.com/stephenschoettler/hermes-lcm/pull/4
- session-scoped tool binding: https://github.com/stephenschoettler/hermes-lcm/pull/6
- source mapping + carry-over helper: https://github.com/stephenschoettler/hermes-lcm/pull/7

Validation:
- `python -m pytest tests/run_agent/test_lcm_context_engine_init.py tests/plugins/context_engine/test_lcm_engine.py tests/plugins/context_engine/test_lcm_core.py tests/run_agent/test_session_reset_fix.py tests/cli/test_cli_new_session.py tests/agent/test_context_engine.py tests/hermes_cli/test_plugins_cmd.py -q`
- result: `145 passed`

I intentionally left unrelated `package-lock.json` churn out of this PR.
