### PR TITLE
fix(gateway): honor dedup TTL in shared message cache

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -48,8 +48,14 @@ class MessageDeduplicator:
         if not msg_id:
             return False
         now = time.time()
-        if msg_id in self._seen:
-            return True
+        seen_at = self._seen.get(msg_id)
+        if seen_at is not None:
+            if now - seen_at <= self._ttl:
+                return True
+            # Expired entries must be treated as new messages, otherwise a
+            # long-lived process can suppress legitimate retries forever until
+            # the cache happens to overflow.
+            self._seen.pop(msg_id, None)
         self._seen[msg_id] = now
         if len(self._seen) > self._max_size:
             cutoff = now - self._ttl

--- a/tests/gateway/test_platform_helpers.py
+++ b/tests/gateway/test_platform_helpers.py
@@ -1,0 +1,30 @@
+import time
+
+from gateway.platforms.helpers import MessageDeduplicator
+
+
+def test_message_deduplicator_rejects_duplicate_within_ttl():
+    dedup = MessageDeduplicator(ttl_seconds=60)
+
+    assert dedup.is_duplicate("msg-1") is False
+    assert dedup.is_duplicate("msg-1") is True
+
+
+def test_message_deduplicator_accepts_message_after_ttl_expires():
+    dedup = MessageDeduplicator(ttl_seconds=0.1)
+
+    assert dedup.is_duplicate("msg-1") is False
+    time.sleep(0.2)
+
+    assert dedup.is_duplicate("msg-1") is False
+
+
+def test_message_deduplicator_replaces_expired_timestamp_on_reuse():
+    dedup = MessageDeduplicator(ttl_seconds=0.1)
+
+    assert dedup.is_duplicate("msg-1") is False
+    first_seen = dedup._seen["msg-1"]
+    time.sleep(0.2)
+
+    assert dedup.is_duplicate("msg-1") is False
+    assert dedup._seen["msg-1"] > first_seen


### PR DESCRIPTION
## What
Fixes a bug in the shared gateway MessageDeduplicator where cached message IDs were treated as duplicates forever unless the cache overflowed.

Previously, ttl_seconds was only used during overflow pruning. In normal long-lived gateway processes, a message ID that had expired from the intended TTL window could still be rejected indefinitely. This affected every adapter using the shared helper, including Slack, Discord, Mattermost, WeCom, Weixin, and DingTalk.

## Why
This caused legitimate delayed retries / redeliveries to be silently dropped even after the dedup TTL had expired.

The intended behavior is:

duplicate within TTL: reject
same ID after TTL expiry: accept as a new message
Changes
Update gateway/platforms/helpers.py so MessageDeduplicator.is_duplicate() checks the stored timestamp against the configured TTL
Expired entries are now removed and reinserted with a fresh timestamp instead of being treated as permanent duplicates
Add regression tests covering:
duplicate rejection within TTL
acceptance after TTL expiry
timestamp refresh after reuse
Files
gateway/platforms/helpers.py
tests/gateway/test_platform_helpers.py

## How To Test
Run:

python -m pytest tests/gateway/test_platform_helpers.py -q
python -m pytest tests/gateway/test_dingtalk.py -q
python -m pytest tests/gateway/test_mattermost.py -q