### PR TITLE
fix(install): gate voice extra out of [all] on 32-bit ARM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,15 @@ all = [
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",
-  "hermes-agent[voice]",
+  # voice: faster-whisper pulls in ctranslate2 / onnxruntime, which ship no
+  # prebuilt wheels for 32-bit ARM (armv6l / armv7l). Building from source
+  # either OOMs or fills tmpfs on 1GB-RAM devices like Raspberry Pi 3B / Zero,
+  # so `pip install -e .[all]` hangs for those users. Gate voice out of the
+  # [all] profile on 32-bit ARM — mirrors the `termux` extras' rationale and
+  # follows the same marker pattern already used for [matrix]. Users on
+  # armv6l/armv7l who still want voice can install it explicitly:
+  #   pip install -e '.[voice]'
+  "hermes-agent[voice] ; platform_machine != 'armv6l' and platform_machine != 'armv7l'",
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
   "hermes-agent[mistral]",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,58 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_all_extra_gates_voice_off_arm32():
+    """The [all] profile must exclude voice on 32-bit ARM hosts.
+
+    faster-whisper's transitive deps (ctranslate2, onnxruntime) ship no
+    prebuilt wheels for armv6l / armv7l. Building from source OOMs or
+    fills tmpfs on 1GB-RAM devices like Raspberry Pi 3B / 2 / Zero, so
+    `pip install -e .[all]` hangs indefinitely for those users. Voice
+    must carry a platform_machine marker in [all]; users who still need
+    it on ARM32 can install the voice extra explicitly.
+
+    This mirrors the existing `termux` extras' rationale and the
+    `sys_platform == 'linux'` marker already used for [matrix].
+    """
+    from packaging.requirements import Requirement
+
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    all_extras = data["project"]["optional-dependencies"]["all"]
+
+    # Unconditional voice entry would hang ARM32 installs — must not appear.
+    assert "hermes-agent[voice]" not in all_extras, (
+        "hermes-agent[voice] must not appear in [all] without a platform marker; "
+        "the raw entry hangs pip install on 32-bit ARM hosts where "
+        "ctranslate2 / onnxruntime have no prebuilt wheels."
+    )
+
+    voice_entries = [e for e in all_extras if e.startswith("hermes-agent[voice]")]
+    assert len(voice_entries) == 1, (
+        f"expected exactly one voice entry in [all], got {voice_entries}"
+    )
+
+    req = Requirement(voice_entries[0])
+    assert req.marker is not None, (
+        f"voice entry in [all] must carry a platform marker: {voice_entries[0]}"
+    )
+
+    # ARM32 hosts: voice must be excluded from [all]
+    for machine in ("armv6l", "armv7l"):
+        assert req.marker.evaluate({"platform_machine": machine}) is False, (
+            f"voice must be excluded from [all] on {machine}"
+        )
+
+    # All other architectures: voice stays in [all]
+    for machine in ("arm64", "aarch64", "x86_64", "i686", "ppc64le", "s390x"):
+        assert req.marker.evaluate({"platform_machine": machine}) is True, (
+            f"voice must remain in [all] on {machine}"
+        )
+
+    # The voice extra itself must still exist so users can install it manually.
+    voice_extra = data["project"]["optional-dependencies"]["voice"]
+    assert any(dep.startswith("faster-whisper") for dep in voice_extra), (
+        "the voice extra definition must still contain faster-whisper so that "
+        "`pip install -e '.[voice]'` remains a valid manual install path on ARM32"
+    )


### PR DESCRIPTION
## Problem

`pip install -e .[all]` hangs indefinitely on Raspberry Pi 3B / 32-bit ARM. The `voice` extras pull in `faster-whisper → ctranslate2 / onnxruntime`, neither of which ships `armv6l` / `armv7l` wheels. Source build either OOMs or fills `/tmp` tmpfs on 1GB-RAM devices, and `hermes update --gateway` (triggered by Telegram `/update`) therefore never returns.

Closes #8397

## Changes

**`pyproject.toml`** — Gate the `voice` entry in `[all]` with a platform marker, mirroring `[matrix]; sys_platform == 'linux'` merged in #7461 and the existing `termux` extras' rationale:

```toml
"hermes-agent[voice] ; platform_machine != 'armv6l' and platform_machine != 'armv7l'",
```

Users on ARM32 who still want local STT can install it explicitly with `pip install -e '.[voice]'`.

**`tests/test_packaging_metadata.py`** — Add `test_all_extra_gates_voice_off_arm32`: asserts the unconditional entry is gone, the gated entry is present, the marker excludes `armv6l` / `armv7l`, and voice stays in `[all]` on `arm64` / `aarch64` / `x86_64` / `i686` / `ppc64le` / `s390x`. Also asserts the standalone `voice` extra still contains `faster-whisper` so the manual install path remains valid.

## Test plan

- [x] `pytest tests/test_packaging_metadata.py -q` — 3 passed, 0 failed
- [x] Verified on Raspberry Pi 3B (`armv7l`, Raspbian 12, Python 3.11.2) via `packaging.requirements.Requirement` — marker evaluates to `False` on the actual host (voice excluded from `[all]`)
- [x] Full `pytest tests/ -q` run locally; failures mirror pre-existing failures on `main` (`4eecaf06` baseline: 69 failed, this branch: 59 failed — all unrelated to this change: voice/audio hardware deps, gateway session race guards, `test_run_agent.TestBuildSystemPrompt` fixtures, `agent.builtin_memory_provider` module, auth/provider fixtures)