### PR TITLE
fix(weixin): prevent streaming cursor ▉ sticking and blank message displayed

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -398,15 +398,16 @@ async def _send_message(
     context_token: Optional[str],
     client_id: str,
 ) -> None:
+    if not text or not text.strip():
+        raise ValueError("_send_message: text must not be empty")
     message: Dict[str, Any] = {
         "from_user_id": "",
         "to_user_id": to,
         "client_id": client_id,
         "message_type": MSG_TYPE_BOT,
         "message_state": MSG_STATE_FINISH,
+        "item_list": [{"type": ITEM_TEXT, "text_item": {"text": text}}],
     }
-    if text:
-        message["item_list"] = [{"type": ITEM_TEXT, "text_item": {"text": text}}]
     if context_token:
         message["context_token"] = context_token
     await _api_post(
@@ -813,6 +814,8 @@ def _split_text_for_weixin_delivery(
     """
     if split_per_line:
         # Legacy: one message per top-level delivery unit.
+        if not content:
+            return []
         if len(content) <= max_length and "\n" not in content:
             return [content]
         chunks: List[str] = []
@@ -821,14 +824,16 @@ def _split_text_for_weixin_delivery(
                 chunks.append(unit)
                 continue
             chunks.extend(_pack_markdown_blocks_for_weixin(unit, max_length))
-        return chunks or [content]
+        return [c for c in chunks if c] or [content]
 
     # Compact (default): single message when under the limit — unless the
     # content looks like a short chatty exchange, in which case split into
     # separate bubbles for a more natural chat feel.
     if len(content) <= max_length:
+        if not content:
+            return []
         return (
-            _split_delivery_units_for_weixin(content)
+            [u for u in _split_delivery_units_for_weixin(content) if u]
             if _should_split_short_chat_block_for_weixin(content)
             else [content]
         )
@@ -1041,6 +1046,10 @@ class WeixinAdapter(BasePlatformAdapter):
     """Native Hermes adapter for Weixin personal accounts."""
 
     MAX_MESSAGE_LENGTH = 4000
+
+    # WeChat does not support editing sent messages — streaming must use the
+    # fallback "send-final-only" path so the cursor (▉) is never left visible.
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WEIXIN)
@@ -1451,7 +1460,7 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
         try:
-            chunks = self._split_text(self.format_message(content))
+            chunks = [c for c in self._split_text(self.format_message(content)) if c and c.strip()]
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7663,10 +7663,18 @@ class GatewayRunner:
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                     _adapter = self.adapters.get(source.platform)
                     if _adapter:
+                        # Platforms that don't support editing sent messages
+                        # (e.g. WeChat) must not show a cursor in intermediate
+                        # sends — the cursor would be permanently visible because
+                        # it can never be edited away.  Use an empty cursor for
+                        # such platforms so streaming still delivers the final
+                        # response, just without the typing indicator.
+                        _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                        _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                         _consumer_cfg = StreamConsumerConfig(
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
-                            cursor=_scfg.cursor,
+                            cursor=_effective_cursor,
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -374,3 +374,126 @@ class TestWeixinRemoteMediaSafety:
                 assert "Blocked unsafe URL" in str(exc)
             else:
                 raise AssertionError("expected ValueError for unsafe URL")
+
+
+class TestWeixinBlankMessagePrevention:
+    """Regression tests for the blank-bubble bugs.
+
+    Three separate guards now prevent a blank WeChat message from ever being
+    dispatched:
+
+    1. ``_split_text_for_weixin_delivery("")`` returns ``[]`` — not ``[""]``.
+    2. ``send()`` filters out empty/whitespace-only chunks before calling
+       ``_send_text_chunk``.
+    3. ``_send_message()`` raises ``ValueError`` for empty text as a last-resort
+       safety net.
+    """
+
+    # ------------------------------------------------------------------
+    # Guard 1: _split_text returns [] for empty content
+    # ------------------------------------------------------------------
+
+    def test_split_text_returns_empty_list_for_empty_string(self):
+        adapter = _make_adapter()
+        assert adapter._split_text("") == []
+
+    def test_split_text_returns_empty_list_for_empty_string_split_per_line(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "account_id": "acct",
+                    "token": "***",
+                    "split_multiline_messages": True,
+                },
+            )
+        )
+        assert adapter._split_text("") == []
+
+    # ------------------------------------------------------------------
+    # Guard 2: send() skips empty chunks — _send_message is never called
+    # ------------------------------------------------------------------
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_empty_content_does_not_call_send_message(self, send_message_mock):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+
+        result = asyncio.run(adapter.send("wxid_test123", ""))
+
+        assert result.success is True
+        send_message_mock.assert_not_awaited()
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_whitespace_only_content_does_not_call_send_message(self, send_message_mock):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+
+        result = asyncio.run(adapter.send("wxid_test123", "   \n  "))
+
+        assert result.success is True
+        send_message_mock.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # Guard 3: _send_message raises ValueError for empty text
+    # ------------------------------------------------------------------
+
+    def test_send_message_raises_for_empty_text(self):
+        import pytest
+        from gateway.platforms.weixin import _send_message
+
+        session_mock = AsyncMock()
+
+        with pytest.raises(ValueError, match="text must not be empty"):
+            asyncio.run(
+                _send_message(
+                    session_mock,
+                    base_url="https://weixin.example.com",
+                    token="tok",
+                    to="wxid_test",
+                    text="",
+                    context_token=None,
+                    client_id="test-client-id",
+                )
+            )
+
+    def test_send_message_raises_for_whitespace_only_text(self):
+        import pytest
+        from gateway.platforms.weixin import _send_message
+
+        session_mock = AsyncMock()
+
+        with pytest.raises(ValueError, match="text must not be empty"):
+            asyncio.run(
+                _send_message(
+                    session_mock,
+                    base_url="https://weixin.example.com",
+                    token="tok",
+                    to="wxid_test",
+                    text="   \n  ",
+                    context_token=None,
+                    client_id="test-client-id",
+                )
+            )
+
+
+class TestWeixinSupportsMessageEditing:
+    """WeixinAdapter must declare SUPPORTS_MESSAGE_EDITING = False so the
+    stream consumer never appends the ▉ cursor to outgoing messages.
+
+    WeChat has no edit-message API — any message sent with the cursor appended
+    would leave it permanently visible in the chat.
+    """
+
+    def test_adapter_declares_no_edit_support(self):
+        assert WeixinAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_instance_also_has_no_edit_support(self):
+        adapter = _make_adapter()
+        assert getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True) is False


### PR DESCRIPTION
## What does this PR do?

This PR fixes two distinct bugs in the Weixin (WeChat) platform adapter that caused garbled or malformed messages to be sent to users.

**Bug 1 — Streaming cursor `▉` permanently visible in messages**

When streaming is enabled, the gateway appends a `▉` cursor to partial messages to indicate the response is still being generated. On platforms that support `edit_message` (e.g. Telegram, Discord), the cursor is removed from the final message by editing it in-place. WeChat has no edit-message API — the base adapter stub returns `success=False`. This caused the stream consumer to enter fallback mode after the first cursor-bearing send, leaving the `▉` permanently visible in the first message bubble (e.g. `你好！👋 有什么我可以 ▉`).

Fix: `WeixinAdapter` now declares `SUPPORTS_MESSAGE_EDITING = False`. The stream consumer in `gateway/run.py` checks this flag and sets `cursor=""` for non-editable platforms, so streaming still delivers the final response but never appends a typing indicator that can't be cleaned up.

**Bug 2 — Empty-string chunks dispatched as blank WeChat messages**

`_split_text_for_weixin_delivery("")` could return `[""]` (a list containing one empty string) instead of `[]`, due to `return chunks or [content]` with `content=""`. This empty-string chunk would then pass through `send()` and reach `_send_message()`, which previously sent a WeChat API payload with no `item_list` — resulting in a blank message bubble.

Fix: guards added at the splitter level (`return []` for empty input, empty-string filtering on chunk lists), at the `send()` level (filter `chunks` before the delivery loop), and at the `_send_message()` level (raise `ValueError` for empty/whitespace-only text as a last-resort safety net).

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py`
  - Added `SUPPORTS_MESSAGE_EDITING = False` class attribute to `WeixinAdapter`
  - `_split_text_for_weixin_delivery`: return `[]` for empty input in both `split_per_line` and compact paths; filter empty strings from chunk lists
  - `send()`: filter empty/whitespace-only chunks before dispatch
  - `_send_message()`: raise `ValueError` immediately for empty or whitespace-only `text`; unconditionally include `item_list` (removes dead conditional branch)
- `gateway/run.py`
  - Stream consumer setup: check `SUPPORTS_MESSAGE_EDITING` on the adapter; use `cursor=""` for platforms that return `False`, preventing cursor-bearing intermediate sends

## How to Test

1. Enable streaming in `config.yaml`:
   ```yaml
   streaming:
     enabled: true
   ```
2. Send a message via WeChat and verify the response does **not** contain a trailing `▉` character.
3. Run the unit tests:
   ```bash
   python -m pytest tests/gateway/test_weixin.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs

Before fix:
```
你好！👋 有什么我可以 ▉
你好！👋 有什么我可以帮助你的吗？
```

After fix:
```
你好！👋 有什么我可以帮助你的吗？
```
