### PR TITLE
docs(contributing): add Windows PowerShell dev setup steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,30 @@ git checkout -b fix/description
 scripts/run_tests.sh
 ```
 
+### Windows (native) — PowerShell installer
+
+On native Windows, prefer the supported PowerShell installer (same layout the
+CLI and updater expect). Full details:
+[Windows (Native) Guide](https://hermes-agent.nousresearch.com/docs/user-guide/windows-native).
+
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+
+# Open a *new* terminal so User PATH picks up `hermes`, then:
+cd "$env:LOCALAPPDATA\hermes\hermes-agent"
+
+# Add dev/test extras on top of the standard install.
+uv pip install -e ".[all,dev]"
+
+# Optional: browser tools / docs site dependencies.
+npm install
+```
+
+Native Windows defaults: `HERMES_HOME` is `%LOCALAPPDATA%\hermes`, and the
+git checkout lives at `%LOCALAPPDATA%\hermes\hermes-agent`. Do **not** assume
+`%USERPROFILE%\.hermes` unless you deliberately override `HERMES_HOME` (for
+example to mirror a Linux/WSL layout).
+
 ### Manual clone fallback
 
 Use this only if you intentionally do not want Hermes' managed install layout
@@ -171,6 +195,32 @@ uv pip install -e ".[all,dev]"
 npm install
 ```
 
+#### Manual clone on Windows (PowerShell)
+
+Same rule as above: create the venv **outside** the cloned source tree so a
+workspace-relative agent command cannot wipe the running runtime.
+
+```powershell
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+
+$HermesHome = Join-Path $env:LOCALAPPDATA "hermes"
+$VenvDir = Join-Path $HermesHome "venvs\hermes-dev"
+New-Item -ItemType Directory -Force -Path (Join-Path $HermesHome "venvs") | Out-Null
+
+uv venv $VenvDir --python 3.11
+& (Join-Path $VenvDir "Scripts\Activate.ps1")
+
+uv pip install -e ".[all,dev]"
+
+# Optional: browser tools
+npm install
+```
+
+Set `$env:HERMES_HOME = $HermesHome` in that session (or permanently as a User
+environment variable) so config and secrets resolve under
+`%LOCALAPPDATA%\hermes`, matching the supported native layout.
+
 ### Configure for development
 
 ```bash
@@ -180,6 +230,19 @@ touch ~/.hermes/.env
 
 # Add at minimum an LLM provider key:
 echo "OPENROUTER_API_KEY=***" >> ~/.hermes/.env
+```
+
+On native Windows, create the same layout under `%LOCALAPPDATA%\hermes`
+(not `%USERPROFILE%\.hermes`, unless you overrode `HERMES_HOME`):
+
+```powershell
+$HermesHome = Join-Path $env:LOCALAPPDATA "hermes"
+foreach ($d in "cron", "sessions", "logs", "memories", "skills") {
+    New-Item -ItemType Directory -Force -Path (Join-Path $HermesHome $d) | Out-Null
+}
+Copy-Item -Path "cli-config.yaml.example" -Destination (Join-Path $HermesHome "config.yaml")
+New-Item -ItemType File -Force -Path (Join-Path $HermesHome ".env") | Out-Null
+Add-Content -Path (Join-Path $HermesHome ".env") -Value "OPENROUTER_API_KEY=***"
 ```
 
 ### Run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,26 @@ uv pip install -e ".[all,dev]"
 npm install
 ```
 
+### Clone and install (Windows PowerShell)
+
+For daily CLI use, the project recommends **WSL2** (see the [README](README.md)). If you are developing on native Windows (tests, patches, IDE workflows), use the same flow with PowerShell:
+
+```powershell
+git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+
+uv venv venv --python 3.11
+.\venv\Scripts\Activate.ps1
+
+uv pip install -e ".[all,dev]"
+
+# Optional: RL training submodule
+# git submodule update --init tinker-atropos; uv pip install -e ".\tinker-atropos"
+
+# Optional: browser tools
+npm install
+```
+
 ### Configure for development
 
 ```bash
@@ -91,6 +111,18 @@ touch ~/.hermes/.env
 echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
 ```
 
+### Configure for development (Windows PowerShell)
+
+```powershell
+$HermesHome = Join-Path $env:USERPROFILE ".hermes"
+foreach ($d in "cron", "sessions", "logs", "memories", "skills") {
+    New-Item -ItemType Directory -Force -Path (Join-Path $HermesHome $d) | Out-Null
+}
+Copy-Item -Path "cli-config.yaml.example" -Destination (Join-Path $HermesHome "config.yaml")
+New-Item -ItemType File -Force -Path (Join-Path $HermesHome ".env") | Out-Null
+Add-Content -Path (Join-Path $HermesHome ".env") -Value "OPENROUTER_API_KEY=sk-or-v1-your-key"
+```
+
 ### Run
 
 ```bash
@@ -99,6 +131,16 @@ mkdir -p ~/.local/bin
 ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 
 # Verify
+hermes doctor
+hermes chat -q "Hello"
+```
+
+### Run (Windows PowerShell)
+
+With the venv activated, the `hermes` console script is on your `PATH` for that session:
+
+```powershell
+.\venv\Scripts\Activate.ps1
 hermes doctor
 hermes chat -q "Hello"
 ```


### PR DESCRIPTION
## What

Adds native Windows PowerShell steps to CONTRIBUTING Development Setup:

- Preferred path via the supported `install.ps1` installer and `%LOCALAPPDATA%\hermes` layout
- Manual-clone fallback with the venv **outside** the source tree (`%LOCALAPPDATA%\hermes\venvs\hermes-dev`)
- Configure examples under `%LOCALAPPDATA%\hermes` (not `%USERPROFILE%\.hermes`)

## Why

CONTRIBUTING prioritizes cross-platform compatibility; Windows developers previously only had bash-oriented setup steps. This aligns contributor docs with the [Windows (Native) Guide](https://hermes-agent.nousresearch.com/docs/user-guide/windows-native) and the external-venv safety rule already documented for Unix.

## How to test

Read CONTRIBUTING.md Development Setup; optionally follow the PowerShell blocks on Windows.

## Platforms

Documentation-only change.

Made with [Cursor](https://cursor.com)