### PR TITLE
fix(logging): attach gateway.log handler when CLI init runs first

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -202,7 +202,25 @@ def setup_logging(
     global _logging_initialized
     if _logging_initialized and not force:
         home = hermes_home or get_hermes_home()
-        return home / "logs"
+        log_dir = home / "logs"
+        # Even when already initialized, ensure mode-specific handlers
+        # exist.  The normal startup path calls setup_logging(mode="cli")
+        # first (hermes_cli/main.py) and setup_logging(mode="gateway")
+        # later (gateway/run.py).  Without this, gateway.log is never
+        # attached.  _add_rotating_handler() is idempotent so calling it
+        # again for an already-attached path is a no-op.
+        if mode == "gateway":
+            from agent.redact import RedactingFormatter
+            _add_rotating_handler(
+                logging.getLogger(),
+                log_dir / "gateway.log",
+                level=logging.INFO,
+                max_bytes=5 * 1024 * 1024,
+                backup_count=3,
+                formatter=RedactingFormatter(_LOG_FORMAT),
+                log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
+            )
+        return log_dir
 
     home = hermes_home or get_hermes_home()
     log_dir = home / "logs"

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -309,6 +309,35 @@ class TestGatewayMode:
         assert "gateway msg" in content
         assert "file msg" in content
 
+    def test_gateway_log_created_after_cli_init(self, hermes_home):
+        """gateway.log is attached even when CLI-mode init ran first.
+
+        Regression test for #8404 — the normal ``hermes gateway run`` path
+        calls setup_logging(mode="cli") at CLI import time and then
+        setup_logging(mode="gateway") during gateway startup.  The second
+        call must still create the gateway.log handler.
+        """
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+
+        root = logging.getLogger()
+        gw_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "gateway.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(gw_handlers) == 1
+
+        # Verify it actually receives gateway records.
+        gw_logger = logging.getLogger("gateway.platforms.discord")
+        gw_logger.info("discord test message")
+        for h in root.handlers:
+            h.flush()
+
+        gw_log = hermes_home / "logs" / "gateway.log"
+        assert gw_log.exists()
+        assert "discord test message" in gw_log.read_text()
+
 
 class TestSessionContext:
     """set_session_context / clear_session_context + _SessionFilter."""


### PR DESCRIPTION
## What does this PR do?

Fixes the `gateway.log` handler not being created on the normal `hermes gateway run` startup path.

`hermes_cli/main.py` calls `setup_logging(mode="cli")` at import time, setting `_logging_initialized = True`. When `gateway/run.py` later calls `setup_logging(mode="gateway")`, the idempotency guard returns early and the gateway.log handler is never attached.

## Related Issue

Fixes #8404

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_logging.py`: In the early-return path of `setup_logging()`, add the gateway.log handler when `mode="gateway"` is requested. `_add_rotating_handler()` already deduplicates by resolved path, so this is safe to call multiple times.
- `tests/test_hermes_logging.py`: Regression test covering the CLI → gateway init sequence.

## How to Test

1. `python -m pytest tests/test_hermes_logging.py -v` — 49 passed
2. The new test `test_gateway_log_created_after_cli_init` reproduces the exact bug: calls `setup_logging(mode="cli")` then `setup_logging(mode="gateway")` and asserts that the gateway.log handler exists and receives gateway records.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A