### PR TITLE
fix(logging): attach gateway.log handler when CLI initializes first

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -202,7 +202,25 @@ def setup_logging(
     global _logging_initialized
     if _logging_initialized and not force:
         home = hermes_home or get_hermes_home()
-        return home / "logs"
+        log_dir = home / "logs"
+        # Late gateway mode: attach the gateway-specific handler even when
+        # CLI-mode initialisation already ran.  This is the normal path for
+        # ``hermes gateway run``, which enters via hermes_cli/main.py (cli
+        # mode) before gateway/run.py calls us again with mode="gateway".
+        # _add_rotating_handler() is idempotent, so a duplicate call is safe.
+        if mode == "gateway":
+            from agent.redact import RedactingFormatter
+
+            _add_rotating_handler(
+                logging.getLogger(),
+                log_dir / "gateway.log",
+                level=logging.INFO,
+                max_bytes=5 * 1024 * 1024,
+                backup_count=3,
+                formatter=RedactingFormatter(_LOG_FORMAT),
+                log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
+            )
+        return log_dir
 
     home = hermes_home or get_hermes_home()
     log_dir = home / "logs"

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -309,6 +309,44 @@ class TestGatewayMode:
         assert "gateway msg" in content
         assert "file msg" in content
 
+    def test_gateway_log_created_after_cli_init(self, hermes_home):
+        """gateway.log handler is attached when CLI mode initializes first.
+
+        This is the normal ``hermes gateway run`` path: hermes_cli/main.py
+        calls setup_logging(mode="cli"), then gateway/run.py calls
+        setup_logging(mode="gateway").  The second call must still create the
+        gateway.log handler even though _logging_initialized is already True.
+        Regression test for #8404.
+        """
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+        root = logging.getLogger()
+
+        gw_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "gateway.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(gw_handlers) == 1
+
+    def test_gateway_log_receives_records_after_cli_init(self, hermes_home):
+        """gateway.log receives gateway records even when CLI initialized first.
+
+        Regression test for #8404.
+        """
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+
+        gw_logger = logging.getLogger("gateway.platforms.discord")
+        gw_logger.info("discord connected")
+
+        for h in logging.getLogger().handlers:
+            h.flush()
+
+        gw_log = hermes_home / "logs" / "gateway.log"
+        assert gw_log.exists()
+        assert "discord connected" in gw_log.read_text()
+
 
 class TestSessionContext:
     """set_session_context / clear_session_context + _SessionFilter."""


### PR DESCRIPTION
Closes #8404

## Problem

On the normal `hermes gateway run` path, `hermes_cli/main.py` calls `setup_logging(mode="cli")` at import time, which sets `_logging_initialized = True`. When `gateway/run.py` later calls `setup_logging(mode="gateway")`, the idempotency guard at line 203 returns early — the gateway.log handler is never created.

Gateway records still reach `agent.log`, but `gateway.log` stays empty for the entire process lifetime.

## Before

```
hermes_cli/main.py  →  setup_logging(mode="cli")   → _logging_initialized = True
gateway/run.py      →  setup_logging(mode="gateway") → early return, gateway.log skipped
```

## After

```
hermes_cli/main.py  →  setup_logging(mode="cli")   → _logging_initialized = True
gateway/run.py      →  setup_logging(mode="gateway") → early return, but gateway.log handler attached
```

## Fix

When the early-return path is taken with `mode="gateway"`, attach the gateway.log handler via `_add_rotating_handler()`. That helper is already idempotent (checks for an existing handler at the same resolved path), so duplicate calls are safe.

## Validation

```
pytest tests/test_hermes_logging.py -v -o "addopts="
# 50 passed (48 existing + 2 new regression tests)
```

New tests cover the exact `cli → gateway` initialization sequence and verify that gateway.log both exists and receives gateway-component records.