### PR TITLE
fix(slack): clear assistant thread status after reply

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -341,6 +341,18 @@ class SlackAdapter(BasePlatformAdapter):
                 ts=message_id,
                 text=formatted,
             )
+            # Clear assistant thread status after edit (streaming final chunk).
+            # Hermes uses edit_message for streamed responses, so the status
+            # must be cleared here as well as in send().  See #8387.
+            try:
+                await self._get_client(chat_id).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=message_id,
+                    status="",
+                )
+            except Exception:
+                pass  # Not in assistant context or lacking scope
+
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -109,6 +109,7 @@ class SlackAdapter(BasePlatformAdapter):
         # events, and they carry the user/thread identity needed for stable
         # session + memory scoping.
         self._assistant_threads: Dict[Tuple[str, str], Dict[str, str]] = {}
+        self._msg_to_thread: Dict[str, str] = {}  # message_id -> thread_ts cache (#8387)
         self._ASSISTANT_THREADS_MAX = 5000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
@@ -301,10 +302,15 @@ class SlackAdapter(BasePlatformAdapter):
                     for old_ts in list(self._bot_message_ts)[:excess]:
                         self._bot_message_ts.discard(old_ts)
 
-            # Explicitly clear assistant thread status after reply.
-            # Slack's assistant.threads.setStatus auto-clears on reply in
-            # simple cases, but when MCP tools execute post-response the
-            # status persists and blocks the compose box.  See #8387.
+            # Cache message_id -> thread_ts for edit_message status clear (#8387)
+            if thread_ts and sent_ts:
+                self._msg_to_thread[sent_ts] = thread_ts
+                if len(self._msg_to_thread) > 200:
+                    excess = list(self._msg_to_thread.keys())[:100]
+                    for k in excess:
+                        del self._msg_to_thread[k]
+
+            # Clear assistant thread status after reply (fix for #8387)
             if thread_ts:
                 try:
                     await self._get_client(chat_id).assistant_threads_setStatus(
@@ -342,16 +348,17 @@ class SlackAdapter(BasePlatformAdapter):
                 text=formatted,
             )
             # Clear assistant thread status after edit (streaming final chunk).
-            # Hermes uses edit_message for streamed responses, so the status
-            # must be cleared here as well as in send().  See #8387.
-            try:
-                await self._get_client(chat_id).assistant_threads_setStatus(
-                    channel_id=chat_id,
-                    thread_ts=message_id,
-                    status="",
-                )
-            except Exception:
-                pass  # Not in assistant context or lacking scope
+            # Look up cached thread_ts from send(). See #8387.
+            _thread_ts = self._msg_to_thread.get(message_id)
+            if _thread_ts:
+                try:
+                    await self._get_client(chat_id).assistant_threads_setStatus(
+                        channel_id=chat_id,
+                        thread_ts=_thread_ts,
+                        status='',
+                    )
+                except Exception:
+                    pass  # Not in assistant context or lacking scope
 
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -301,6 +301,20 @@ class SlackAdapter(BasePlatformAdapter):
                     for old_ts in list(self._bot_message_ts)[:excess]:
                         self._bot_message_ts.discard(old_ts)
 
+            # Explicitly clear assistant thread status after reply.
+            # Slack's assistant.threads.setStatus auto-clears on reply in
+            # simple cases, but when MCP tools execute post-response the
+            # status persists and blocks the compose box.  See #8387.
+            if thread_ts:
+                try:
+                    await self._get_client(chat_id).assistant_threads_setStatus(
+                        channel_id=chat_id,
+                        thread_ts=thread_ts,
+                        status="",
+                    )
+                except Exception:
+                    pass  # Not in assistant context or lacking scope
+
             return SendResult(
                 success=True,
                 message_id=sent_ts,


### PR DESCRIPTION
## Summary

- Explicitly clears `assistant.threads.setStatus` after every successful reply in the Slack adapter
- Fixes the compose box being blocked when MCP tools execute post-response

## Problem

When MCP servers (e.g., MemPalace) execute tool calls after the main text response is sent, Slack's `assistant.threads.setStatus("is thinking...")` persists indefinitely. This blocks the user's compose box until the ~2 minute Slack timeout clears it.

The status is supposed to auto-clear when the bot sends a reply, but additional MCP processing after the text response keeps Slack's assistant status alive.

## Fix

Add an explicit `setStatus(status="")` call in `send()` after the message is successfully posted (`gateway/platforms/slack.py`). The call is wrapped in a try/except so it silently skips when:
- Not in an assistant thread context
- The `assistant:write` scope is missing

## Testing

1. Configure an MCP server (e.g., MemPalace) in `mcp_servers`
2. Enable Slack assistant events (`assistant_thread_started`, `assistant_thread_context_changed`)
3. Send a message that triggers both a text response AND post-response MCP tool calls
4. **Before fix**: "Processing..." persists, compose box blocked for ~2 minutes
5. **After fix**: Status clears immediately after response, compose box unblocked

Fixes #8387

🤖 Generated with [Claude Code](https://claude.com/claude-code)