### PR TITLE
fix(slack): clear assistant typing indicator after response delivery

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -113,6 +113,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
+        # Track thread_ts for active typing indicators so stop_typing() can
+        # explicitly clear the assistant status after the response is sent.
+        self._typing_thread_ts: Dict[str, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
@@ -355,6 +358,8 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
+        self._typing_thread_ts[chat_id] = thread_ts
+
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -365,6 +370,26 @@ class SlackAdapter(BasePlatformAdapter):
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Clear the assistant typing indicator for a Slack thread.
+
+        Slack's assistant.threads.setStatus normally auto-clears when the bot
+        sends a reply.  However, when MCP tools or other post-reply processing
+        triggers additional API activity, Slack can keep the indicator alive.
+        Explicitly setting an empty status ensures it is cleared.
+        """
+        thread_ts = self._typing_thread_ts.pop(chat_id, None)
+        if not thread_ts or not self._app:
+            return
+        try:
+            await self._get_client(chat_id).assistant_threads_setStatus(
+                channel_id=chat_id,
+                thread_ts=thread_ts,
+                status="",
+            )
+        except Exception as e:
+            logger.debug("[Slack] Failed to clear assistant status: %s", e)
 
     def _resolve_thread_ts(
         self,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -592,6 +592,52 @@ class TestSendTyping:
 
 
 # ---------------------------------------------------------------------------
+# TestStopTyping — clear assistant.threads.setStatus
+# ---------------------------------------------------------------------------
+
+
+class TestStopTyping:
+    """Test clearing the assistant typing indicator."""
+
+    @pytest.mark.asyncio
+    async def test_clears_status_after_send_typing(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        await adapter.stop_typing("C123")
+        # Second call should clear the status
+        assert adapter._app.client.assistant_threads_setStatus.call_count == 2
+        adapter._app.client.assistant_threads_setStatus.assert_called_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_noop_without_prior_send_typing(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.stop_typing("C123")
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clears_only_once(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "ts1"})
+        await adapter.stop_typing("C123")
+        await adapter.stop_typing("C123")  # second call should be a no-op
+        # 1 call for send_typing + 1 call for first stop_typing = 2
+        assert adapter._app.client.assistant_threads_setStatus.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_handles_api_error_gracefully(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=[None, Exception("api_error")]
+        )
+        await adapter.send_typing("C123", metadata={"thread_id": "ts1"})
+        # Should not raise
+        await adapter.stop_typing("C123")
+
+
+# ---------------------------------------------------------------------------
 # TestFormatMessage — Markdown → mrkdwn conversion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

When MCP tools execute after the main text response is sent, Slack's `assistant.threads.setStatus` indicator ("is thinking...") can persist for up to 2 minutes instead of auto-clearing. This adds an explicit `stop_typing()` override to clear the status after all processing completes.

## Related Issue

Fixes #8387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/slack.py`: Added `_typing_thread_ts` dict to track active thread timestamps, stored `thread_ts` during `send_typing()`, and added `stop_typing()` override that calls `setStatus(status="")` to explicitly clear the indicator.
- `tests/gateway/test_slack.py`: Added 4 regression tests covering: normal clear, no-op without prior `send_typing`, idempotent double-call, and graceful API error handling.

## How to Test

1. Configure Hermes with a Slack bot using Assistant API events + an MCP server
2. Send a message that triggers both a text response and post-reply MCP tool calls
3. Verify the "is thinking..." indicator clears immediately after the response, not after Slack's ~2 min timeout

Unit tests:
```bash
pytest tests/gateway/test_slack.py::TestStopTyping -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests only — no live Slack workspace)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A