### PR TITLE
fix(gateway): flush fallback text before segment reset to prevent silent data loss

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -269,6 +269,14 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
+                    # Flush any pending fallback text before resetting.
+                    # Without this, accumulated text from a failed edit is
+                    # silently dropped when a tool boundary arrives.  (#8124)
+                    # Skip for __no_edit__ platforms (Signal, webhook) where
+                    # all text intentionally accumulates until _DONE.
+                    if (self._fallback_final_send and self._accumulated
+                            and self._message_id != "__no_edit__"):
+                        await self._send_fallback_final(self._accumulated)
                     self._reset_segment_state(preserve_no_edit=True)
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -356,12 +356,14 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer.already_sent
 
     @pytest.mark.asyncio
-    async def test_segment_break_clears_failed_edit_fallback_state(self):
-        """A tool boundary after edit failure must not duplicate the next segment."""
+    async def test_segment_break_flushes_fallback_before_reset(self):
+        """A tool boundary after edit failure must flush pending text, then
+        start a fresh segment without duplicating it.  Regression for #8124."""
         adapter = MagicMock()
         send_results = [
-            SimpleNamespace(success=True, message_id="msg_1"),
-            SimpleNamespace(success=True, message_id="msg_2"),
+            SimpleNamespace(success=True, message_id="msg_1"),   # initial "Hello ▉"
+            SimpleNamespace(success=True, message_id="msg_2"),   # fallback "world"
+            SimpleNamespace(success=True, message_id="msg_3"),   # "Next segment"
         ]
         adapter.send = AsyncMock(side_effect=send_results)
         adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=False, error="flood_control:6"))
@@ -381,7 +383,7 @@ class TestSegmentBreakOnToolBoundary:
         await task
 
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
-        assert sent_texts == ["Hello ▉", "Next segment"]
+        assert sent_texts == ["Hello ▉", "world", "Next segment"]
 
     @pytest.mark.asyncio
     async def test_no_message_id_enters_fallback_mode(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #8124 — streaming text silently dropped when a tool boundary arrives during fallback mode.

## Problem

When a progressive edit fails (flood control), the stream consumer enters fallback mode: it sets `_fallback_final_send = True` and continues accumulating text. At `_DONE`, the accumulated text is sent as a new message via `_send_fallback_final()`.

However, when a **tool boundary** (`_NEW_SEGMENT`) arrives before `_DONE`, `_reset_segment_state()` clears `_accumulated`, `_fallback_final_send`, and `_fallback_prefix` — destroying the pending content. The user never receives the text that was buffered between the edit failure and the tool call.

**Before:** `["Hello ▉", "Next segment"]` — " world" silently dropped  
**After:** `["Hello ▉", "world", "Next segment"]` — all text delivered

## Fix

Flush pending fallback text via `_send_fallback_final()` before calling `_reset_segment_state()` on segment breaks. This mirrors the existing flush pattern in the `_DONE` handler (line 241–242).

The flush is skipped for `__no_edit__` platforms (Signal, webhook with `github_comment`) where all text intentionally accumulates across boundaries and is sent once at stream end.

## Changes

- `gateway/stream_consumer.py`: 3-line guard + flush before segment reset
- `tests/gateway/test_stream_consumer.py`: updated existing test to verify content is delivered instead of dropped

## How to Test

```bash
pytest tests/gateway/test_stream_consumer.py -v
```

All 28 tests pass, including the updated regression test and the existing `__no_edit__` path test (`test_no_message_id_segment_breaks_do_not_resend`).