### PR TITLE
fix: recover launchd_start when launchctl kickstart times out

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1363,6 +1363,7 @@ def launchd_start():
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
         subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service started")
         return
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1354,26 +1354,31 @@ def launchd_uninstall():
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    domain = _launchd_domain()
+    target = f"{domain}/{label}"
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
     if not plist_path.exists():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], check=True, timeout=30)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in (3, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        print("↻ launchctl kickstart timed out; booting the service out and reloading it")
+        subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+        subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -268,6 +268,32 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_recovers_from_kickstart_timeout(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        calls = []
+        domain = gateway_cli._launchd_domain()
+        target = f"{domain}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", target] and calls.count(cmd) == 1:
+                raise gateway_cli.subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 30))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        assert calls == [
+            ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", target],
+            ["launchctl", "bootstrap", domain, str(plist_path)],
+        ]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"


### PR DESCRIPTION
## Problem

On some macOS systems, after a prior gateway session exited with a bad config (for example an invalid Telegram token that leaves launchd with `last exit code = 78`), the launchd job can enter a limbo state where `launchctl kickstart` hangs and raises `TimeoutExpired` instead of returning the expected unloaded-service codes 3 or 113.

This leaves the gateway appearing configured but unresponsive, so the bot never comes online.

## Root Cause

`launchd_start()` already handled the unloaded-job case (`CalledProcessError` with return code 3 or 113), but it did not handle `subprocess.TimeoutExpired` from `launchctl kickstart`.

In that hung state, the command failed without any recovery path.

## Fix

- Keep the existing bootstrap + explicit kickstart flow for the missing-plist self-heal path.
- Add a `subprocess.TimeoutExpired` recovery path in `launchd_start()` that:
  1. boots out the stale/hung launchd job
  2. bootstraps the plist again cleanly
- Reuse the computed `domain` / `target` values instead of rebuilding them repeatedly.

## Test

Added `test_launchd_start_recovers_from_kickstart_timeout` in `tests/hermes_cli/test_gateway_service.py` to verify the timeout recovery sequence.

Local verification:
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q -o addopts=''`
- `python -m pytest tests/hermes_cli/test_update_gateway_restart.py -q -o addopts=''`
- combined result: `97 passed`
