### PR TITLE
fix(honcho): prevent orphan sessions + restore gateway_session_key

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3356,6 +3356,7 @@ class GatewayRunner:
                                     model=_hyg_model,
                                     max_iterations=4,
                                     quiet_mode=True,
+                                    skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
                                 )
@@ -5758,6 +5759,7 @@ class GatewayRunner:
                 model=model,
                 max_iterations=4,
                 quiet_mode=True,
+                skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7651,6 +7651,7 @@ class GatewayRunner:
                     session_id=session_id,
                     platform=platform_key,
                     user_id=source.user_id,
+                    gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -287,8 +287,13 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # ----- B3: resolve_session_name -----
         session_title = kwargs.get("session_title")
+        gateway_session_key = kwargs.get("gateway_session_key")
         self._session_key = (
-            cfg.resolve_session_name(session_title=session_title, session_id=session_id)
+            cfg.resolve_session_name(
+                session_title=session_title,
+                session_id=session_id,
+                gateway_session_key=gateway_session_key,
+            )
             or session_id
             or "hermes-default"
         )

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -299,12 +299,21 @@ class HonchoMemoryProvider(MemoryProvider):
         self._session_initialized = True
 
         # ----- B6: Memory file migration (one-time, for new sessions) -----
+        # Skip under per-session strategy: every Hermes run creates a fresh
+        # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
+        # each one would flood the backend with short-lived duplicates instead
+        # of performing a one-time migration.
         try:
-            if not session.messages:
+            if not session.messages and cfg.session_strategy != "per-session":
                 from hermes_constants import get_hermes_home
                 mem_dir = str(get_hermes_home() / "memories")
                 self._manager.migrate_memory_files(self._session_key, mem_dir)
                 logger.debug("Honcho memory file migration attempted for new session: %s", self._session_key)
+            elif cfg.session_strategy == "per-session":
+                logger.debug(
+                    "Honcho memory file migration skipped: per-session strategy creates a fresh session per run (%s)",
+                    self._session_key,
+                )
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -422,16 +422,18 @@ class HonchoClientConfig:
         cwd: str | None = None,
         session_title: str | None = None,
         session_id: str | None = None,
+        gateway_session_key: str | None = None,
     ) -> str | None:
         """Resolve Honcho session name.
 
         Resolution order:
           1. Manual directory override from sessions map
           2. Hermes session title (from /title command)
-          3. per-session strategy — Hermes session_id ({timestamp}_{hex})
-          4. per-repo strategy — git repo root directory name
-          5. per-directory strategy — directory basename
-          6. global strategy — workspace name
+          3. Gateway session key (stable per-chat identifier from gateway platforms)
+          4. per-session strategy — Hermes session_id ({timestamp}_{hex})
+          5. per-repo strategy — git repo root directory name
+          6. per-directory strategy — directory basename
+          7. global strategy — workspace name
         """
         import re
 
@@ -449,6 +451,16 @@ class HonchoClientConfig:
             if sanitized:
                 if self.session_peer_prefix and self.peer_name:
                     return f"{self.peer_name}-{sanitized}"
+                return sanitized
+
+        # Gateway session key: stable per-chat identifier passed by the gateway
+        # (e.g. "agent:main:telegram:dm:8439114563"). Sanitize colons to hyphens
+        # for Honcho session ID compatibility. This takes priority over strategy-
+        # based resolution because gateway platforms need per-chat isolation that
+        # cwd-based strategies cannot provide.
+        if gateway_session_key:
+            sanitized = re.sub(r'[^a-zA-Z0-9_-]', '-', gateway_session_key).strip('-')
+            if sanitized:
                 return sanitized
 
         # per-session: inherit Hermes session_id (new Honcho session each run)

--- a/run_agent.py
+++ b/run_agent.py
@@ -559,6 +559,7 @@ class AIAgent:
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
+        gateway_session_key: str = None,
         skip_context_files: bool = False,
         skip_memory: bool = False,
         session_db=None,
@@ -624,6 +625,7 @@ class AIAgent:
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
+        self._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -1163,6 +1165,9 @@ class AIAgent:
                         # Thread gateway user identity for per-user memory scoping
                         if self._user_id:
                             _init_kwargs["user_id"] = self._user_id
+                        # Thread gateway session key for stable per-chat Honcho session isolation
+                        if self._gateway_session_key:
+                            _init_kwargs["gateway_session_key"] = self._gateway_session_key
                         # Profile identity for per-profile provider scoping
                         try:
                             from hermes_cli.profiles import get_active_profile_name

--- a/run_agent.py
+++ b/run_agent.py
@@ -2105,6 +2105,7 @@ class AIAgent:
                         model=self.model,
                         max_iterations=8,
                         quiet_mode=True,
+                        skip_memory=True,
                         platform=self.platform,
                         provider=self.provider,
                     )

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -542,6 +542,52 @@ class TestInitOnSessionStart:
         assert cfg.init_on_session_start is False
 
 
+class TestResolveSessionNameGatewayKey:
+    """Regression tests for gateway_session_key priority in resolve_session_name.
+
+    Ensures gateway platforms get stable per-chat Honcho sessions even when
+    sessionStrategy=per-session would otherwise create ephemeral sessions.
+    Regression: plugin refactor 924bc67e dropped gateway key plumbing.
+    """
+
+    def test_gateway_key_overrides_per_session_strategy(self):
+        """gateway_session_key must win over per-session session_id."""
+        config = HonchoClientConfig(session_strategy="per-session")
+        result = config.resolve_session_name(
+            session_id="20260412_171002_69bb38",
+            gateway_session_key="agent:main:telegram:dm:8439114563",
+        )
+        assert result == "agent-main-telegram-dm-8439114563"
+
+    def test_session_title_still_wins_over_gateway_key(self):
+        """Explicit /title remap takes priority over gateway_session_key."""
+        config = HonchoClientConfig(session_strategy="per-session")
+        result = config.resolve_session_name(
+            session_title="my-custom-title",
+            session_id="20260412_171002_69bb38",
+            gateway_session_key="agent:main:telegram:dm:8439114563",
+        )
+        assert result == "my-custom-title"
+
+    def test_per_session_fallback_without_gateway_key(self):
+        """Without gateway_session_key, per-session returns session_id (CLI path)."""
+        config = HonchoClientConfig(session_strategy="per-session")
+        result = config.resolve_session_name(
+            session_id="20260412_171002_69bb38",
+            gateway_session_key=None,
+        )
+        assert result == "20260412_171002_69bb38"
+
+    def test_gateway_key_sanitizes_special_chars(self):
+        """Colons and other non-alphanumeric chars are replaced with hyphens."""
+        config = HonchoClientConfig()
+        result = config.resolve_session_name(
+            gateway_session_key="agent:main:telegram:dm:8439114563",
+        )
+        assert result == "agent-main-telegram-dm-8439114563"
+        assert ":" not in result
+
+
 class TestResetHonchoClient:
     def test_reset_clears_singleton(self):
         import plugins.memory.honcho.client as mod

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -366,6 +366,54 @@ class TestToolsModeInitBehavior:
         assert cfg.peer_name == "8439114563"
 
 
+class TestPerSessionMigrateGuard:
+    """Verify migrate_memory_files is skipped under per-session strategy.
+
+    per-session creates a fresh Honcho session every Hermes run. Uploading
+    MEMORY.md/USER.md/SOUL.md to each short-lived session floods the backend
+    with duplicate content. The guard was added to prevent orphan sessions
+    containing only <prior_memory_file> wrappers.
+    """
+
+    def _make_provider_with_strategy(self, strategy, init_on_session_start=True):
+        """Create a HonchoMemoryProvider and track migrate_memory_files calls."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from unittest.mock import patch, MagicMock
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="tools",
+            init_on_session_start=init_on_session_start,
+            session_strategy=strategy,
+        )
+
+        provider = HonchoMemoryProvider()
+
+        mock_manager = MagicMock()
+        mock_session = MagicMock()
+        mock_session.messages = []  # empty = new session → triggers migration path
+        mock_manager.get_or_create.return_value = mock_session
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
+             patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
+             patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
+             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            provider.initialize(session_id="test-session-001")
+
+        return provider, mock_manager
+
+    def test_migrate_skipped_for_per_session(self):
+        """per-session strategy must NOT call migrate_memory_files."""
+        _, mock_manager = self._make_provider_with_strategy("per-session")
+        mock_manager.migrate_memory_files.assert_not_called()
+
+    def test_migrate_runs_for_per_directory(self):
+        """per-directory strategy with empty session SHOULD call migrate_memory_files."""
+        _, mock_manager = self._make_provider_with_strategy("per-directory")
+        mock_manager.migrate_memory_files.assert_called_once()
+
+
 class TestChunkMessage:
     def test_short_message_single_chunk(self):
         result = HonchoMemoryProvider._chunk_message("hello world", 100)


### PR DESCRIPTION
## Summary

Fixes two related Honcho memory provider issues observed after NousResearch/hermes-agent#4623 and later made visible by NousResearch/hermes-agent#6995 eager init behavior:

1. **Orphan sessions from temporary agents** — Three internal code paths constructed `AIAgent` instances without `skip_memory=True`, triggering Honcho eager init and creating sessions that were never written to:
   - `gateway/run.py` — hygiene auto-compress and `/compress` temp agents
   - `plugins/memory/honcho/__init__.py` — `migrate_memory_files` ran unconditionally under `per-session` strategy
   - `run_agent.py` — `_spawn_background_review` created a full agent for local memory extraction but unnecessarily initialised Honcho

2. **Session key regression from plugin refactor** — The pluggable memory provider refactor (NousResearch/hermes-agent#4623, commit `924bc67e`) removed `honcho_session_key` from `AIAgent`, breaking the gateway → Honcho session key plumbing. All Honcho sessions fell back to bare timestamp IDs instead of the stable per-chat key (e.g. `agent-main-telegram-dm-<CHAT_SCOPE_ID>`), fragmenting conversation history across disposable sessions.

## Value / Why this matters

- **Restores stable per-chat Honcho session continuity** in gateway chats. Turns from the same Telegram/Discord chat accumulate into one stable Honcho session instead of being split across ephemeral Hermes session IDs.
- **Prevents long-memory fragmentation** caused by per-session slicing in gateway scenarios — Honcho's observation/conclusion/representation extraction requires sustained turn accumulation to form useful context.
- **Eliminates orphan session pollution** — temporary agents (compress, hygiene, background review) no longer create empty Honcho sessions that waste storage and pollute the session list.

## Non-claim

- This PR does not change non-gateway per-session semantics when no `gateway_session_key` is provided (CLI path unaffected).
- This PR does not address the `/task` background agent path (line 5227) which also lacks `skip_memory` — that is a lower-priority item due to infrequent use.

## Changes

### Commit 1: `fix(honcho): prevent orphan Honcho sessions from temporary agents`

| File | Change |
|------|--------|
| `gateway/run.py` | Add `skip_memory=True` to hygiene and `/compress` temp agents |
| `plugins/memory/honcho/__init__.py` | Short-circuit `migrate_memory_files` when `session_strategy == "per-session"` |
| `run_agent.py` | Add `skip_memory=True` to `_spawn_background_review` agent |
| `tests/honcho_plugin/test_session.py` | +2 tests: per-session migrate guard (skipped) + per-directory migrate (preserved) |

### Commit 2: `fix(honcho): restore gateway_session_key for stable per-chat session isolation`

| File | Change |
|------|--------|
| `gateway/run.py` | Pass `gateway_session_key=session_key` to main agent constructor |
| `run_agent.py` | Accept, store, and forward `gateway_session_key` via `_init_kwargs` |
| `plugins/memory/honcho/__init__.py` | Extract and pass `gateway_session_key` to session name resolver |
| `plugins/memory/honcho/client.py` | Add `gateway_session_key` as priority level in `resolve_session_name` |
| `tests/honcho_plugin/test_client.py` | +4 tests: gateway_key > per-session, title > gateway_key, CLI fallback, sanitization |

## Regression introduction

- Plugin refactor: NousResearch/hermes-agent#4623 (commit `924bc67e`, 2026-04-02) — `honcho_session_key` was no longer passed through `AIAgent`
- Exposed by: NousResearch/hermes-agent#6995 — `initOnSessionStart=true` made the orphan creation visible (eager init exposed paths that lazy init previously masked)

## Validation

- **Unit tests**: `tests/honcho_plugin/` — **140 passed** (134 existing + 6 new regression tests)
- **E2E (Telegram gateway)**:
  - [x] Send messages → turns write to stable `agent-main-telegram-dm-<CHAT_SCOPE_ID>` session
  - [x] `/new` → same stable Honcho session continues accumulating turns
  - [x] `/compress` → no new orphan sessions created
  - [x] Gateway restart → no orphan sessions from re-initialization
  - [x] `💾 Memory updated` notifications continue working (local memory path unaffected by `skip_memory`)

