### PR TITLE
fix: native multimodal image embedding for messaging platforms

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -54,6 +54,7 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
+from agent.model_metadata import _IMAGE_TOKEN_ESTIMATE
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
 
@@ -211,7 +212,17 @@ class ContextCompressor(ContextEngine):
             min_protect = min(protect_tail_count, len(result) - 1)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                content_len = len(msg.get("content") or "")
+                content = msg.get("content")
+                if isinstance(content, list):
+                    # Multimodal: count text normally, images at ~1600 tokens
+                    content_len = sum(
+                        len(p.get("text", "")) if isinstance(p, dict) and p.get("type") == "text"
+                        else _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN if isinstance(p, dict) and p.get("type") in ("image_url", "image")
+                        else len(str(p))
+                        for p in content
+                    )
+                else:
+                    content_len = len(content or "")
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -228,12 +239,29 @@ class ContextCompressor(ContextEngine):
 
         for i in range(prune_boundary):
             msg = result[i]
-            if msg.get("role") != "tool":
+            role = msg.get("role")
+
+            # Strip base64 image data from old multimodal messages.
+            # Vision enrichment text is preserved so context isn't lost.
+            content = msg.get("content")
+            if isinstance(content, list):
+                stripped = []
+                had_images = False
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "image_url":
+                        had_images = True
+                    else:
+                        stripped.append(part)
+                if had_images:
+                    stripped.append({"type": "text", "text": "[Image removed during compression — see description above]"})
+                    result[i] = {**msg, "content": stripped}
+                    pruned += 1
                 continue
-            content = msg.get("content", "")
+
+            if role != "tool":
+                continue
             if not content or content == _PRUNED_TOOL_PLACEHOLDER:
                 continue
-            # Only prune if the content is substantial (>200 chars)
             if len(content) > 200:
                 result[i] = {**msg, "content": _PRUNED_TOOL_PLACEHOLDER}
                 pruned += 1

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1056,10 +1056,52 @@ def estimate_tokens_rough(text: str) -> int:
     return (len(text) + 3) // 4
 
 
+# Anthropic charges ~(w*h)/750 tokens per image; after resizing to
+# ≤1200px long edge this is typically ~1500 tokens.
+_IMAGE_TOKEN_ESTIMATE = 1600
+
+
+def _estimate_content_tokens(content: Any) -> int:
+    """Estimate tokens for a message content field, handling multimodal."""
+    if content is None:
+        return 0
+    if isinstance(content, str):
+        return (len(content) + 3) // 4
+    if isinstance(content, list):
+        total = 0
+        for part in content:
+            if not isinstance(part, dict):
+                total += (len(str(part)) + 3) // 4
+                continue
+            ptype = part.get("type", "")
+            if ptype == "text":
+                total += (len(part.get("text", "")) + 3) // 4
+            elif ptype in ("image_url", "image"):
+                total += _IMAGE_TOKEN_ESTIMATE
+            else:
+                total += (len(str(part)) + 3) // 4
+        return total
+    return (len(str(content)) + 3) // 4
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
-    """Rough token estimate for a message list (pre-flight only)."""
-    total_chars = sum(len(str(msg)) for msg in messages)
-    return (total_chars + 3) // 4
+    """Rough token estimate for a message list (pre-flight only).
+
+    Handles multimodal messages — image content blocks are estimated at
+    ~1600 tokens (Anthropic's actual cost) instead of counting the raw
+    base64 string length as text.
+    """
+    total = 0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            total += (len(str(msg)) + 3) // 4
+            continue
+        for k, v in msg.items():
+            if k == "content":
+                total += _estimate_content_tokens(v)
+            else:
+                total += (len(str(v)) + 3) // 4
+    return total
 
 
 def estimate_request_tokens_rough(
@@ -1075,11 +1117,11 @@ def estimate_request_tokens_rough(
     tools enabled, schemas alone can add 20-30K tokens — a significant
     blind spot when only counting messages.
     """
-    total_chars = 0
+    total = 0
     if system_prompt:
-        total_chars += len(system_prompt)
+        total += (len(system_prompt) + 3) // 4
     if messages:
-        total_chars += sum(len(str(msg)) for msg in messages)
+        total += estimate_messages_tokens_rough(messages)
     if tools:
-        total_chars += len(str(tools))
-    return (total_chars + 3) // 4
+        total += (len(str(tools)) + 3) // 4
+    return total

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -3081,6 +3082,21 @@ class GatewayRunner:
                     message_text = _ctx_result.message
             except Exception as exc:
                 logger.debug("@ context reference expansion failed: %s", exc)
+
+        # Embed resized image bytes as multimodal content blocks AFTER all
+        # string-based processing is complete.  _embed_images_in_message
+        # converts message_text from str → list[dict], so it must be last.
+        if event.media_urls:
+            _img_paths = [
+                p for i, p in enumerate(event.media_urls)
+                if (event.media_types[i] if i < len(event.media_types) else "").startswith("image/")
+                or event.message_type == MessageType.PHOTO
+            ]
+            if _img_paths:
+                try:
+                    message_text = self._embed_images_in_message(message_text, _img_paths)
+                except Exception:
+                    logger.debug("Image embedding failed, using text-only", exc_info=True)
 
         return message_text
 
@@ -6845,6 +6861,78 @@ class GatewayRunner:
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
     
+    # Anthropic auto-scales images beyond 1568px; 1200px keeps detail
+    # while saving ~40% tokens vs 1568px (~1500 vs ~2500 tokens/image).
+    _EMBED_MAX_LONG_EDGE = 1200
+
+    _FMT_TO_MIME = {
+        "PNG": "image/png", "GIF": "image/gif",
+        "WEBP": "image/webp", "JPEG": "image/jpeg",
+    }
+
+    @staticmethod
+    def _embed_images_in_message(
+        message_text: str,
+        image_paths: List[str],
+    ):
+        """Convert a text message + image paths into a multimodal content list.
+
+        Images are resized to fit within _EMBED_MAX_LONG_EDGE before encoding
+        to avoid inflating session history.  Token cost is ~(w*h)/750.
+        """
+        try:
+            from PIL import Image as _PILImage
+        except ImportError:
+            logger.debug("Pillow not installed — skipping image embedding")
+            return message_text
+        import io as _io
+
+        max_edge = GatewayRunner._EMBED_MAX_LONG_EDGE
+        fmt_to_mime = GatewayRunner._FMT_TO_MIME
+
+        parts = []
+        if message_text:
+            parts.append({"type": "text", "text": message_text})
+
+        for path in image_paths:
+            try:
+                img = _PILImage.open(path)
+                w, h = img.size
+                fmt = img.format or "JPEG"
+                mime = fmt_to_mime.get(fmt, "image/jpeg")
+                needs_resize = max(w, h) > max_edge
+                needs_convert = fmt == "JPEG" and img.mode in ("RGBA", "P")
+
+                if needs_resize or needs_convert:
+                    if needs_resize:
+                        scale = max_edge / max(w, h)
+                        new_w, new_h = int(w * scale), int(h * scale)
+                        img = img.resize((new_w, new_h), _PILImage.LANCZOS)
+                        logger.info(
+                            "Image resized for embedding: %s %dx%d → %dx%d",
+                            path, w, h, new_w, new_h,
+                        )
+                    if needs_convert:
+                        img = img.convert("RGB")
+                    buf = _io.BytesIO()
+                    img.save(buf, format=fmt, quality=85)
+                    data = buf.getvalue()
+                else:
+                    data = Path(path).read_bytes()
+
+                b64 = base64.b64encode(data).decode("ascii")
+                parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{b64}"},
+                })
+            except Exception:
+                logger.debug("Failed to embed image %s, skipping", path)
+
+        has_images = any(p.get("type") == "image_url" for p in parts)
+        if not has_images:
+            return message_text
+        return parts
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,


### PR DESCRIPTION
## Summary

When users send images via Feishu (and other messaging platforms), the gateway now embeds resized images as **native multimodal content blocks** alongside the existing vision-enrichment text descriptions. This allows multimodal models (Claude, GPT-5.4) to see actual image pixels instead of relying solely on auxiliary-model text descriptions.

**Three interconnected fixes:**

1. **Image embedding with resize** (`gateway/run.py`) — New `_embed_images_in_message()` resizes to ≤1200px with PIL, uses `img.format` for MIME detection (fixes Feishu incorrect Content-Type), fast path for small images, Pillow soft dependency.

2. **Token estimation for multimodal** (`agent/model_metadata.py`) — `_estimate_content_tokens()` counts image blocks at ~1600 tokens (Anthropic actual cost) instead of counting base64 string length as text (~675K false tokens for a 2.7MB image).

3. **Image stripping during compression** (`agent/context_compressor.py`) — Strips `image_url` blocks from old messages during pruning while preserving vision text descriptions. Prevents multi-MB base64 accumulation in session history.

## Problem

When a user sends a 4284×5712 JPEG via Feishu:
- The 2.7MB base64 was stored in session history
- `estimate_messages_tokens_rough()` counted it as ~675K text tokens
- Session appeared at 2.5M tokens, triggering false compression
- Claude received the request but returned empty content → fallback to GLM-5.1 → also failed (400: Invalid API parameter — GLM can't handle multimodal)
- User got an error instead of a response

## Solution

- Pre-resize to 1200px (Anthropic formula: `tokens = w×h/750`, ~1500 tokens at 1200px)
- Correct token estimation for image blocks
- Strip old images during compression (text descriptions survive)

## Test plan

- [x] Unit tests: resize, fast path, PNG format detection, token estimation, compression stripping, PIL fallback
- [x] Live test: Feishu → Claude Sonnet 4.6 — 4284×5712 JPEG resized to 900×1200, responded in 1 API call (35s) with no fallback
- [x] Codex CLI cross-review (2 rounds): critical type-safety bug found and fixed (embed must be last in pipeline)
- [ ] Test with other providers (OpenAI, Gemini) — should work since output is OpenAI-compatible `image_url` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)