### PR TITLE
fix: normalize OpenRouter GPT point-release context lookup

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -914,6 +914,38 @@ def _resolve_nous_context_length(model: str) -> Optional[int]:
     return None
 
 
+def _lookup_openrouter_metadata_context(model: str, metadata: Dict[str, Dict[str, Any]]) -> Optional[int]:
+    """Resolve a model context from OpenRouter metadata with dot↔dash tolerance.
+
+    This is a provider-unaware fallback, so keep matching narrow: exact model ID
+    first, then only a version-separator-normalized equality check. Do not treat a
+    bare OpenRouter suffix as a generic fallback for all providers, or provider-
+    specific differences (for example MiniMax limits) can override Hermes'
+    explicit per-provider defaults.
+    """
+    entry = metadata.get(model)
+    if isinstance(entry, dict):
+        ctx = entry.get("context_length")
+        if isinstance(ctx, int) and ctx > 0:
+            return ctx
+
+    model_lower = model.lower()
+    normalized = _normalize_model_version(model).lower()
+    for or_id, entry in metadata.items():
+        if not isinstance(entry, dict):
+            continue
+        bare = or_id.split("/", 1)[1] if "/" in or_id else or_id
+        bare_lower = bare.lower()
+        if bare_lower == model_lower:
+            continue
+        if _normalize_model_version(bare).lower() == normalized:
+            ctx = entry.get("context_length")
+            if isinstance(ctx, int) and ctx > 0:
+                return ctx
+
+    return None
+
+
 def get_model_context_length(
     model: str,
     base_url: str = "",
@@ -1019,8 +1051,9 @@ def get_model_context_length(
 
     # 6. OpenRouter live API metadata (provider-unaware fallback)
     metadata = fetch_model_metadata()
-    if model in metadata:
-        return metadata[model].get("context_length", 128000)
+    ctx = _lookup_openrouter_metadata_context(model, metadata)
+    if ctx:
+        return ctx
 
     # 8. Hardcoded defaults (fuzzy match — longest key first for specificity)
     # Only check `default_model in model` (is the key a substring of the input).

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2181,6 +2181,45 @@ def _normalize_model_version(model: str) -> str:
     return model.replace(".", "-")
 
 
+def _match_openrouter_metadata_entry(
+    model: str,
+    metadata: Dict[str, Dict[str, Any]],
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Find an OpenRouter metadata entry for *model*.
+
+    Match order mirrors ``_resolve_nous_context_length``:
+
+    1. Exact catalog key (``openai/gpt-5.4``)
+    2. Bare-id equality after stripping a vendor prefix
+    3. Version-separator equality (dot↔dash), so ``gpt-5-4`` resolves the
+       ``gpt-5.4`` / ``openai/gpt-5.4`` catalog row instead of falling through
+       to the generic ``gpt-5`` hardcoded default
+
+    Returns ``(or_id, entry)`` or ``None``.
+    """
+    if not model or not isinstance(metadata, dict):
+        return None
+
+    entry = metadata.get(model)
+    if isinstance(entry, dict):
+        return model, entry
+
+    # Strip a vendor prefix from the query so openai/gpt-5-4 can still match
+    # openai/gpt-5.4 or bare gpt-5.4.
+    query = model.split("/", 1)[1] if "/" in model else model
+    query_lower = query.lower()
+    normalized = _normalize_model_version(query).lower()
+
+    for or_id, entry in metadata.items():
+        if not isinstance(entry, dict):
+            continue
+        bare = or_id.split("/", 1)[1] if "/" in or_id else or_id
+        if bare.lower() == query_lower or _normalize_model_version(bare).lower() == normalized:
+            return or_id, entry
+
+    return None
+
+
 def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> Optional[int]:
     """Query Anthropic's /v1/models endpoint for context length.
 
@@ -2903,13 +2942,16 @@ def get_model_context_length(
     # the dedicated Nous/Copilot/GMI branches above.
     if effective_provider == "openrouter":
         metadata = fetch_model_metadata()
-        entry = metadata.get(model)
-        if entry:
+        matched = _match_openrouter_metadata_entry(model, metadata)
+        if matched:
+            or_id, entry = matched
             or_ctx = entry.get("context_length")
             # Guard against the known OpenRouter Kimi-family 32k underreport
             # (same class the hardcoded overrides exist to mitigate).
             if isinstance(or_ctx, int) and or_ctx > 0 and not (
-                or_ctx == 32768 and _model_name_suggests_kimi(model)
+                or_ctx == 32768 and (
+                    _model_name_suggests_kimi(model) or _model_name_suggests_kimi(or_id)
+                )
             ):
                 return or_ctx
 
@@ -2936,10 +2978,14 @@ def get_model_context_length(
     # for models that belong to known providers with curated defaults.
     if not effective_provider:
         metadata = fetch_model_metadata()
-        if model in metadata:
-            or_ctx = metadata[model].get("context_length", DEFAULT_FALLBACK_CONTEXT)
+        matched = _match_openrouter_metadata_entry(model, metadata)
+        if matched:
+            or_id, entry = matched
+            or_ctx = entry.get("context_length", DEFAULT_FALLBACK_CONTEXT)
             # Guard against stale OpenRouter metadata for Kimi-family models.
-            if or_ctx == 32768 and _model_name_suggests_kimi(model):
+            if or_ctx == 32768 and (
+                _model_name_suggests_kimi(model) or _model_name_suggests_kimi(or_id)
+            ):
                 logger.info(
                     "Rejecting OpenRouter metadata context=%s for %r "
                     "(Kimi-family underreport); falling through to hardcoded defaults",

--- a/contributors/emails/hello@mysticmages.xyz
+++ b/contributors/emails/hello@mysticmages.xyz
@@ -1,0 +1,2 @@
+DomGrieco
+# PR #8428 OpenRouter GPT point-release context lookup

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -675,6 +675,59 @@ class TestNousPortalContextResolution:
 
 
 # =========================================================================
+# OpenRouter metadata — version-separator (dot↔dash) matching
+# =========================================================================
+
+class TestOpenRouterVersionNormalizedContextLookup:
+    """OpenRouter catalog rows use dotted GPT point releases (gpt-5.4).
+
+    Some routers hand Hermes hyphenated slugs (gpt-5-4). Exact dict lookup
+    misses those and falls through to the generic gpt-5 400k default, which
+    under-reports the real window and can trip false compression warnings.
+    """
+
+    _OR_METADATA = {
+        "openai/gpt-5.4": {"context_length": 1_050_000},
+    }
+
+    def _resolve(self, model: str, *, provider: str = "openrouter", base_url: str = ""):
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value=self._OR_METADATA), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_local_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None), \
+             patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None):
+            return get_model_context_length(
+                model,
+                provider=provider,
+                base_url=base_url or "https://openrouter.ai/api/v1",
+            )
+
+    def test_openrouter_provider_hyphenated_point_release_matches_dotted_metadata(self):
+        assert self._resolve("gpt-5-4", provider="openrouter") == 1_050_000
+
+    def test_openrouter_provider_prefixed_hyphenated_slug(self):
+        assert self._resolve("openai/gpt-5-4", provider="openrouter") == 1_050_000
+
+    def test_openrouter_provider_exact_dotted_slug_still_works(self):
+        assert self._resolve("gpt-5.4", provider="openrouter") == 1_050_000
+        assert self._resolve("openai/gpt-5.4", provider="openrouter") == 1_050_000
+
+    def test_provider_unaware_fallback_hyphenated_slug(self):
+        """No effective provider: step-6 OpenRouter fallback must normalize too."""
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value=self._OR_METADATA), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_local_context_length", return_value=None), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None), \
+             patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None), \
+             patch("agent.model_metadata._infer_provider_from_url", return_value=None):
+            assert get_model_context_length("gpt-5-4", provider="", base_url="") == 1_050_000
+
+
+# =========================================================================
 # get_model_context_length — resolution order
 # =========================================================================
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -130,6 +130,30 @@ def test_feasibility_check_passes_live_main_runtime():
     )
 
 
+@patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+@patch("agent.model_metadata.fetch_model_metadata", return_value={
+    "gpt-5.4": {"context_length": 1_050_000}
+})
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_no_warning_for_opencode_gpt54_version_normalization(
+    mock_get_client, mock_fetch_model_metadata, mock_lookup_models_dev_context
+):
+    """Hyphenated OpenCode GPT slugs should still resolve via GPT-5.4 metadata."""
+    agent = _make_agent(main_context=1_050_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://opencode.ai/zen/v1"
+    mock_client.api_key = "sk-opencode"
+    mock_get_client.return_value = (mock_client, "gpt-5-4")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 0
+    assert agent._compression_warning is None
+
+
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_warns_when_no_auxiliary_provider(mock_get_client):
     """Warning emitted when no auxiliary provider is configured."""


### PR DESCRIPTION
## Summary
- reuse the existing Nous bare-id / dot↔dash matching pattern on the dedicated OpenRouter metadata branch and the provider-unaware fallback
- so hyphenated GPT point-release slugs like `gpt-5-4` resolve the OpenRouter `gpt-5.4` catalog row instead of falling through to the generic `gpt-5` 400k default
- add direct resolver regressions in `tests/agent/test_model_metadata.py`

## Root cause
OpenRouter catalog rows use dotted GPT point releases (`gpt-5.4`). Some routers hand Hermes hyphenated slugs (`gpt-5-4`). The dedicated OpenRouter branch did an exact `metadata.get(model)` only, so the hyphenated form missed and fell through to the generic `gpt-5` hardcoded default. That under-reports the real window and can trip false compression feasibility warnings.

## What changed
- add `_match_openrouter_metadata_entry` next to `_normalize_model_version`, matching the pattern already used by `_resolve_nous_context_length`
- wire it into the OpenRouter provider branch and the provider-unaware OpenRouter fallback
- preserve Kimi 32k underreport guards and provider-specific precedence

## Test plan
- `uv run pytest -o addopts='' tests/agent/test_model_metadata.py::TestOpenRouterVersionNormalizedContextLookup tests/agent/test_model_metadata.py::TestGetModelContextLength tests/agent/test_model_metadata.py::TestNousPortalContextResolution -q`
- `uv run pytest -o addopts='' tests/agent/test_model_metadata.py -q`