### PR TITLE
fix(doctor): use load_dotenv_path and UTF-8 for config reads

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -17,15 +17,10 @@ HERMES_HOME = get_hermes_home()
 _DHH = display_hermes_home()  # user-facing display path (e.g. ~/.hermes or ~/.hermes/profiles/coder)
 
 # Load environment variables from ~/.hermes/.env so API key checks work
-from dotenv import load_dotenv
-_env_path = get_env_path()
-if _env_path.exists():
-    try:
-        load_dotenv(_env_path, encoding="utf-8")
-    except UnicodeDecodeError:
-        load_dotenv(_env_path, encoding="latin-1")
-# Also try project .env as dev fallback
-load_dotenv(PROJECT_ROOT / ".env", override=False, encoding="utf-8")
+from hermes_cli.env_loader import load_dotenv_path
+
+load_dotenv_path(get_env_path(), override=False)
+load_dotenv_path(PROJECT_ROOT / ".env", override=False)
 
 from hermes_cli.colors import Colors, color
 from hermes_constants import OPENROUTER_MODELS_URL
@@ -321,7 +316,7 @@ def run_doctor(args):
         # Detect stale root-level model keys (known bug source — PR #4329)
         try:
             import yaml
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 raw_config = yaml.safe_load(f) or {}
             stale_root_keys = [k for k in ("provider", "base_url") if k in raw_config and isinstance(raw_config[k], str)]
             if stale_root_keys:
@@ -873,7 +868,7 @@ def run_doctor(args):
         import yaml as _yaml
         _mem_cfg_path = HERMES_HOME / "config.yaml"
         if _mem_cfg_path.exists():
-            with open(_mem_cfg_path) as _f:
+            with open(_mem_cfg_path, encoding="utf-8") as _f:
                 _raw_cfg = _yaml.safe_load(_f) or {}
             _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
     except Exception:


### PR DESCRIPTION
## What
- Load user and project `.env` via `load_dotenv_path` (UTF-8 + latin-1 fallback).
- Read `config.yaml` as UTF-8 in stale-key detection and memory-provider probe.

## Why
Project `.env` previously used UTF-8 only; Windows cp1252 files could fail. YAML reads without encoding use locale defaults on Windows.

## How to test
\\\ash
hermes doctor
\\\

Made with [Cursor](https://cursor.com)