### PR TITLE
fix(trajectory): use UTF-8 for YAML config and metrics JSON

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -97,7 +97,7 @@ class CompressionConfig:
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "CompressionConfig":
         """Load configuration from YAML file."""
-        with open(yaml_path, 'r') as f:
+        with open(yaml_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
         
         config = cls()
@@ -1123,7 +1123,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         # Save metrics
         if self.config.metrics_enabled:
             metrics_path = output_dir / self.config.metrics_output_file
-            with open(metrics_path, 'w') as f:
+            with open(metrics_path, "w", encoding="utf-8") as f:
                 json.dump(self.aggregate_metrics.to_dict(), f, indent=2)
             console.print(f"\n💾 Metrics saved to {metrics_path}")
     


### PR DESCRIPTION
## What
- Open compression YAML config with explicit UTF-8.
- Write metrics JSON with UTF-8.

## Why
Default text encoding on Windows follows the active code page; explicit UTF-8 matches the rest of this script and avoids mojibake.

## How to test
\\\ash
python -c " from trajectory_compressor import CompressionConfig