### PR TITLE
fix(gateway): queue voice/audio messages instead of interrupting with empty text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2611,6 +2611,18 @@ class GatewayRunner:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
+            # Voice/audio messages need STT transcription before the agent
+            # can act on them.  Transcription only runs inside
+            # _handle_message_with_agent, so interrupting the running agent
+            # with event.text (which is empty pre-transcription) causes a
+            # hang.  Queue them like photos instead.
+            if event.message_type in (MessageType.VOICE, MessageType.AUDIO):
+                logger.debug("PRIORITY voice follow-up for session %s — queueing without interrupt", _quick_key[:20])
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                return None
+
             running_agent = self._running_agents.get(_quick_key)
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.


### PR DESCRIPTION
## Summary

- When a voice/audio message arrives while an agent is already running, the gateway interrupts the agent with `event.text` — but voice messages haven't been through STT transcription yet, so `event.text` is empty. This causes the agent to hang.
- Photos already have dedicated queueing logic that avoids interrupting the running agent. This PR applies the same `merge_pending_message_event` pattern to `MessageType.VOICE` and `MessageType.AUDIO`.

## Reproducer

1. Send a voice message to the Telegram bot
2. Before the agent finishes responding, send a second voice message
3. **Expected**: second voice is queued and processed after the first completes
4. **Actual**: agent hangs indefinitely (interrupted with empty text)

## Changes

- `gateway/run.py`: Add voice/audio check between the existing photo queueing block and the `_AGENT_PENDING_SENTINEL` check (+12 lines)

## Test plan

- [ ] Send two consecutive voice messages in quick succession — second should be queued and processed after the first
- [ ] Send a voice message while agent is processing a text message — should queue without interrupt
- [ ] Send a text message while agent is processing — should still interrupt normally (existing behavior preserved)
- [ ] Verify photo queueing still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)