### PR TITLE
fix(scripts): read config.yaml as UTF-8 in discord-voice-doctor

### DIFF
--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -239,7 +239,7 @@ def check_config(groq_key, eleven_key):
     if config_path.exists():
         try:
             import yaml
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
 
             stt_provider = cfg.get("stt", {}).get("provider", "local")


### PR DESCRIPTION
Open Hermes config.yaml with explicit UTF-8 so yaml.safe_load does not depend on the Windows code page.

Made with [Cursor](https://cursor.com)