### PR TITLE
fix(gateway): append WhatsApp bridge.log as UTF-8

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -351,7 +351,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # messages are preserved for troubleshooting.
             whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
             self._bridge_log = self._session_path.parent / "bridge.log"
-            bridge_log_fh = open(self._bridge_log, "a")
+            bridge_log_fh = open(
+                self._bridge_log, "a", encoding="utf-8", errors="replace"
+            )
             self._bridge_log_fh = bridge_log_fh
 
             # Build bridge subprocess environment.


### PR DESCRIPTION
Open bridge.log in UTF-8 with errors=replace so mixed Node output and non-ASCII QR or errors do not depend on the process locale.

Made with [Cursor](https://cursor.com)