### PR TITLE
fix(cli): read profile config.yaml as UTF-8

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -286,7 +286,7 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
     try:
         import yaml
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):


### PR DESCRIPTION
Explicit UTF-8 when loading profile config.yaml so model/provider display matches other CLI config readers.

Made with [Cursor](https://cursor.com)