### PR TITLE
feat: add BlockRun / ClawRouter as first-class provider plugin with x402 micropayments

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -258,6 +258,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "blockrun": ProviderConfig(
+        id="blockrun",
+        name="BlockRun / ClawRouter",
+        auth_type="api_key",
+        inference_base_url="https://blockrun.ai/api/v1",
+        api_key_env_vars=("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY", "SOLANA_WALLET_KEY"),
+        base_url_env_var="BLOCKRUN_BASE_URL",
+    ),
 }
 
 
@@ -941,6 +949,8 @@ def resolve_provider(
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        "clawrouter": "blockrun", "claw-router": "blockrun", "claw": "blockrun",
+        "x402": "blockrun", "blockrun-ai": "blockrun",
         # Local server aliases — route through the generic custom provider
         "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
         "ollama": "custom", "vllm": "custom", "llamacpp": "custom",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -610,6 +610,24 @@ def resolve_runtime_provider(
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
 
+    # ── Provider plugins (plugins/providers/<name>/) ──────────────────────
+    # Check before resolve_provider() which raises AuthError for unknown names.
+    try:
+        from plugins.providers import get_provider_plugin
+        _plugin_resolver = get_provider_plugin(requested_provider)
+        if _plugin_resolver is not None:
+            model_cfg = _get_model_config()
+            plugin_runtime = _plugin_resolver(
+                explicit_api_key=explicit_api_key,
+                explicit_base_url=explicit_base_url,
+                model_cfg=model_cfg,
+            )
+            if plugin_runtime:
+                plugin_runtime.setdefault("requested_provider", requested_provider)
+                return plugin_runtime
+    except Exception as exc:
+        logger.debug("Provider plugin check failed for '%s': %s", requested_provider, exc)
+
     provider = resolve_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,

--- a/plugins/providers/__init__.py
+++ b/plugins/providers/__init__.py
@@ -1,0 +1,193 @@
+"""Provider plugin discovery.
+
+Scans ``plugins/providers/<name>/`` directories for provider plugins.
+Each subdirectory must contain ``__init__.py`` with a ``resolve()``
+function that returns a runtime provider dict (same shape as
+``resolve_runtime_provider()`` in ``hermes_cli/runtime_provider.py``).
+
+Provider plugins are separate from the general plugin system — they live
+in the repo and are always available. They are checked BEFORE the static
+PROVIDER_REGISTRY in auth.py, so they can handle provider names that
+would otherwise raise AuthError.
+
+Usage:
+    from plugins.providers import get_provider_plugin
+
+    resolver = get_provider_plugin("blockrun")
+    if resolver:
+        runtime = resolver(explicit_api_key=None, explicit_base_url=None)
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PROVIDERS_DIR = Path(__file__).parent
+
+# Cache: provider_name -> resolve function
+_provider_cache: Dict[str, Callable] = {}
+_discovered: bool = False
+
+
+def discover_provider_plugins() -> List[Tuple[str, str, bool]]:
+    """Scan plugins/providers/ for available provider plugins.
+
+    Returns list of (name, description, is_available) tuples.
+    """
+    results = []
+    if not _PROVIDERS_DIR.is_dir():
+        return results
+
+    for child in sorted(_PROVIDERS_DIR.iterdir()):
+        if not child.is_dir() or child.name.startswith(("_", ".")):
+            continue
+        init_file = child / "__init__.py"
+        if not init_file.exists():
+            continue
+
+        # Read description from plugin.yaml if present
+        desc = ""
+        yaml_file = child / "plugin.yaml"
+        if yaml_file.exists():
+            try:
+                import yaml
+                with open(yaml_file) as f:
+                    meta = yaml.safe_load(f) or {}
+                desc = meta.get("description", "")
+            except Exception:
+                pass
+
+        # Check if the module has a resolve() function
+        available = False
+        try:
+            mod = _load_module(child)
+            if mod and hasattr(mod, "resolve"):
+                available = True
+        except Exception:
+            pass
+
+        results.append((child.name, desc, available))
+
+    return results
+
+
+def get_provider_plugin(name: str) -> Optional[Callable[..., Dict[str, Any]]]:
+    """Return the resolve() function for a provider plugin, or None.
+
+    Also checks aliases defined in the plugin's ALIASES list.
+    """
+    global _discovered
+    if not _discovered:
+        _discover_all()
+        _discovered = True
+
+    return _provider_cache.get(name.lower())
+
+
+def _discover_all() -> None:
+    """Load all provider plugins and cache their resolve functions."""
+    if not _PROVIDERS_DIR.is_dir():
+        return
+
+    for child in sorted(_PROVIDERS_DIR.iterdir()):
+        if not child.is_dir() or child.name.startswith(("_", ".")):
+            continue
+        init_file = child / "__init__.py"
+        if not init_file.exists():
+            continue
+
+        try:
+            mod = _load_module(child)
+            if mod and hasattr(mod, "resolve"):
+                _provider_cache[child.name] = mod.resolve
+                # Register aliases if defined
+                aliases = getattr(mod, "ALIASES", [])
+                for alias in aliases:
+                    _provider_cache[alias.lower()] = mod.resolve
+                logger.debug(
+                    "Provider plugin '%s' loaded (aliases: %s)",
+                    child.name, aliases or "none",
+                )
+        except Exception as exc:
+            logger.debug("Failed to load provider plugin '%s': %s", child.name, exc)
+
+
+def _load_module(provider_dir: Path):
+    """Import a provider plugin module with submodule support for relative imports.
+
+    Follows the same pattern as plugins/memory/__init__.py — registers parent
+    packages, pre-loads submodules, then executes the __init__.py.
+    """
+    name = provider_dir.name
+    module_name = f"plugins.providers.{name}"
+
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    init_file = provider_dir / "__init__.py"
+    if not init_file.exists():
+        return None
+
+    # Ensure parent packages are registered
+    for parent in ("plugins", "plugins.providers"):
+        if parent not in sys.modules:
+            parent_path = _PROVIDERS_DIR.parent if parent == "plugins" else _PROVIDERS_DIR
+            parent_init = parent_path / "__init__.py"
+            if parent_init.exists():
+                spec = importlib.util.spec_from_file_location(
+                    parent, str(parent_init),
+                    submodule_search_locations=[str(parent_path)]
+                )
+                if spec:
+                    parent_mod = importlib.util.module_from_spec(spec)
+                    sys.modules[parent] = parent_mod
+                    try:
+                        spec.loader.exec_module(parent_mod)
+                    except Exception:
+                        pass
+
+    # Now load the provider module
+    spec = importlib.util.spec_from_file_location(
+        module_name, str(init_file),
+        submodule_search_locations=[str(provider_dir)]
+    )
+    if not spec:
+        return None
+
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+
+    # Register submodules so relative imports work
+    # e.g., "from .provider import resolve_blockrun_provider" in blockrun plugin
+    for sub_file in provider_dir.glob("*.py"):
+        if sub_file.name == "__init__.py":
+            continue
+        sub_name = sub_file.stem
+        full_sub_name = f"{module_name}.{sub_name}"
+        if full_sub_name not in sys.modules:
+            sub_spec = importlib.util.spec_from_file_location(
+                full_sub_name, str(sub_file)
+            )
+            if sub_spec:
+                sub_mod = importlib.util.module_from_spec(sub_spec)
+                sys.modules[full_sub_name] = sub_mod
+                try:
+                    sub_spec.loader.exec_module(sub_mod)
+                except Exception as e:
+                    logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
+
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        logger.debug("Failed to exec_module %s: %s", module_name, e)
+        sys.modules.pop(module_name, None)
+        return None
+
+    return mod

--- a/plugins/providers/__init__.py
+++ b/plugins/providers/__init__.py
@@ -106,7 +106,7 @@ def _discover_all() -> None:
         try:
             mod = _load_module(child)
             if mod and hasattr(mod, "resolve"):
-                _provider_cache[child.name] = mod.resolve
+                _provider_cache[child.name.lower()] = mod.resolve
                 # Register aliases if defined
                 aliases = getattr(mod, "ALIASES", [])
                 for alias in aliases:

--- a/plugins/providers/blockrun/SKILL.md
+++ b/plugins/providers/blockrun/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: blockrun
+description: Use BlockRun (blockrun.ai) as your LLM provider — 50+ models, no API key, pay per request with USDC on Base or Solana via x402 micropayments. Includes wallet setup, balance checking, and smart model routing.
+version: 1.0.0
+author: BlockRun
+license: MIT
+metadata:
+  hermes:
+    tags: [LLM, Payments, Crypto, Web3, Base, Solana, x402, OpenRouter, Models, Wallet]
+    related_skills: [mcp]
+---
+
+# BlockRun / ClawRouter
+
+BlockRun is an AI model gateway with **x402 micropayments** — think OpenRouter, but crypto-native. No API key, no subscription. Your wallet is your credential. Each request is paid automatically with USDC on Base or Solana.
+
+**50+ models:** OpenAI GPT-5, Anthropic Claude, Google Gemini, DeepSeek, xAI Grok, and more.
+**Free fallback:** `nvidia/gpt-oss-20b` is always available at no cost when balance is low.
+
+---
+
+## Quick Reference
+
+| Task | Tool |
+|------|------|
+| Set up Base wallet | `blockrun_wallet_setup` |
+| Set up Solana wallet | `blockrun_solana_wallet_setup` |
+| Check balance (Base) | `blockrun_wallet_balance` |
+| Check balance (Solana) | `blockrun_solana_wallet_balance` |
+| Get wallet address | `blockrun_wallet_address` |
+| Generate an image | `blockrun_image_generate` |
+| Edit an image | `blockrun_image_edit` |
+| Query prediction markets | `blockrun_prediction_markets` |
+| Switch to BlockRun LLM provider | Edit `cli-config.yaml` → `provider: blockrun` |
+| List available LLM models | `curl https://blockrun.ai/api/v1/models` |
+
+---
+
+## Step 1 — Install the SDK
+
+```bash
+pip install blockrun-llm eth-account
+# For Solana support (optional):
+pip install blockrun-llm solders base58
+```
+
+---
+
+## Step 2 — Set Up Your Wallet
+
+### Base (default — USDC on Base mainnet)
+
+Call the `blockrun_wallet_setup` tool. It will:
+- Create a new wallet at `~/.blockrun/.session` (or load existing)
+- Show your address and current balance
+- Print funding instructions
+
+Or do it from the terminal:
+
+```bash
+python -c "
+from blockrun_llm import setup_agent_wallet
+client = setup_agent_wallet()
+print('Address:', client.get_wallet_address())
+print('Balance:', client.get_balance(), 'USDC')
+"
+```
+
+Set the key in your environment:
+```bash
+export BLOCKRUN_WALLET_KEY=0x...    # from ~/.blockrun/.session
+```
+
+### Solana (alternative — SPL-USDC on Solana mainnet)
+
+Call the `blockrun_solana_wallet_setup` tool, or:
+
+```bash
+python -c "
+from blockrun_llm.solana_wallet import setup_agent_solana_wallet
+client = setup_agent_solana_wallet()
+print('Address:', client.get_wallet_address())
+"
+```
+
+```bash
+export SOLANA_WALLET_KEY=<base58-private-key>
+export BLOCKRUN_CHAIN=solana
+```
+
+### Fund Your Wallet
+
+Deposit $5–$20 USDC — enough for hundreds of requests.
+
+```
+Base:   https://blockrun.ai/fund
+Solana: https://blockrun.ai/fund?chain=solana
+
+Testnet (free, for development):
+  https://faucet.circle.com  →  select "Base Sepolia"
+  export NETWORK_MODE=testnet
+```
+
+---
+
+## Step 3 — Configure hermes to Use BlockRun
+
+Edit `~/.hermes/cli-config.yaml`:
+
+```yaml
+model:
+  provider: "blockrun"           # or "clawrouter" (alias)
+  default: "openai/gpt-5.2"     # any model below
+  # chain: "solana"              # optional — defaults to "base"
+```
+
+That's it. All LLM calls now route through BlockRun and pay automatically.
+
+---
+
+## Available Models
+
+### Free / Ultra-Cheap (no x402 required or very low cost)
+| Model ID | Notes |
+|----------|-------|
+| `nvidia/gpt-oss-20b` | Smallest NVIDIA model — good for testing |
+| `nvidia/gpt-oss-120b` | Larger NVIDIA model |
+| `nvidia/kimi-k2.5` | Moonshot via NVIDIA |
+
+### OpenAI
+| Model ID | Notes |
+|----------|-------|
+| `openai/gpt-5.4` | Latest, 1M context |
+| `openai/gpt-5.2` | Balanced |
+| `openai/gpt-5-mini` | Fast + cheap |
+| `openai/gpt-5.4-nano` | Smallest GPT-5 |
+| `openai/o3` | Reasoning |
+| `openai/o1` | Reasoning |
+
+### Anthropic
+| Model ID | Notes |
+|----------|-------|
+| `anthropic/claude-opus-4-6` | Most capable |
+| `anthropic/claude-sonnet-4-6` | Balanced |
+| `anthropic/claude-haiku-4-5` | Fast + cheap |
+
+### Google
+| Model ID | Notes |
+|----------|-------|
+| `google/gemini-3.1-pro` | Latest Gemini |
+| `google/gemini-2.5-pro` | 1M context |
+| `google/gemini-2.5-flash` | Fast |
+| `google/gemini-3.1-flash-lite` | Cheapest Gemini |
+
+### Other Providers
+| Model ID | Provider |
+|----------|---------|
+| `x-ai/grok-4` | xAI |
+| `x-ai/grok-3` | xAI |
+| `deepseek/deepseek-v3` | DeepSeek |
+| `minimax/minimax-m2.7` | MiniMax |
+| `nvidia/nemotron-ultra-253b` | NVIDIA |
+
+Full live list: `curl https://blockrun.ai/api/v1/models | python -m json.tool`
+
+---
+
+## Checking Balance & Spending
+
+Use the `blockrun_wallet_balance` tool, or:
+
+```python
+from blockrun_llm import LLMClient
+
+client = LLMClient()
+print(f"Balance : ${client.get_balance():.4f} USDC")
+print(f"Spent   : ${client.get_spending()['total_usd']:.4f} this session")
+```
+
+---
+
+## Pricing
+
+BlockRun charges provider cost + 5% margin. No subscription, no monthly fee.
+
+Example costs per 1M tokens:
+| Model | Input | Output |
+|-------|-------|--------|
+| GPT-5.2 | ~$2.50 | ~$10.00 |
+| Claude Sonnet 4.6 | ~$3.00 | ~$15.00 |
+| Gemini 2.5 Flash | ~$0.15 | ~$0.60 |
+| DeepSeek V3 | ~$0.27 | ~$1.10 |
+| `nvidia/gpt-oss-20b` | FREE | FREE |
+
+Full pricing: `curl https://blockrun.ai/api/pricing`
+
+---
+
+## Switching Chains
+
+```bash
+# Use Base (default)
+export BLOCKRUN_WALLET_KEY=0x...
+
+# Use Solana
+export SOLANA_WALLET_KEY=<base58-key>
+export BLOCKRUN_CHAIN=solana
+
+# Auto-detect: if only SOLANA_WALLET_KEY is set, Solana is used automatically
+```
+
+---
+
+## Troubleshooting
+
+**"BlockRun provider requires a wallet key"**
+→ Run `blockrun_wallet_setup` tool or set `BLOCKRUN_WALLET_KEY` in `.env`
+
+**"x402 payment failed"**
+→ Check balance with `blockrun_wallet_balance`. Fund at https://blockrun.ai/fund
+
+**"Low balance — switching to free model"**
+→ Normal behavior. `nvidia/gpt-oss-20b` activates automatically. Top up to restore full model access.
+
+**Want testnet (free, for development)?**
+```bash
+export NETWORK_MODE=testnet
+# Get free testnet USDC: https://faucet.circle.com (select Base Sepolia)
+```
+
+---
+
+## Image Generation
+
+Generate images with `blockrun_image_generate`. Costs $0.02–$0.10/image, paid automatically via x402.
+
+| Model key | Full ID | Price | Best for |
+|-----------|---------|-------|----------|
+| `nano-banana` | google/nano-banana | $0.05 | Fast, everyday use |
+| `nano-banana-pro` | google/nano-banana-pro | $0.10 | High quality, up to 4K |
+| `gpt-image-1` | openai/gpt-image-1 | $0.02 | Cheapest, good quality |
+| `dall-e-3` | openai/dall-e-3 | $0.04 | Photorealistic |
+| `flux` | black-forest/flux-1.1-pro | $0.04 | Artistic styles |
+
+**Generate:**
+```
+Tool: blockrun_image_generate
+Args: { "prompt": "a futuristic city at night", "model": "nano-banana", "size": "1024x1024" }
+```
+
+**Edit (inpainting):**
+```
+Tool: blockrun_image_edit
+Args: {
+  "prompt": "replace the sky with a sunset",
+  "image": "data:image/png;base64,<base64-string>"
+}
+```
+
+---
+
+## Prediction Markets
+
+Query live market data from Polymarket, Kalshi, dFlow, and more.
+Cost: $0.001/call (GET) · $0.005/call (POST analytics).
+
+**Available platforms:** Polymarket, Kalshi, dFlow, Limitless, Opinion, Predict.Fun, Binance
+
+```
+Tool: blockrun_prediction_markets
+Args: {}   ← (no args = show all available endpoints)
+```
+
+### Common queries
+
+```
+# Polymarket — open markets
+{ "path": "polymarket/markets" }
+
+# Polymarket — top traders leaderboard
+{ "path": "polymarket/leaderboard" }
+
+# Polymarket — wallet positions & analytics
+{ "path": "polymarket/wallet/0x123...abc" }
+
+# Polymarket — smart money flows
+{ "path": "polymarket/smart-money" }
+
+# Kalshi — open markets
+{ "path": "kalshi/markets" }
+
+# dFlow — wallet P&L
+{ "path": "dflow/wallet/pnl/0x123...abc" }
+
+# Binance — BTC candlesticks
+{ "path": "binance/candles/BTC-USD" }
+
+# Cross-platform — same event on multiple markets
+{ "path": "matching-markets" }
+```
+
+---
+
+## How It Works
+
+```
+hermes-agent
+    │
+    ▼  (OpenAI-compatible request)
+BlockRunX402Transport  ──── intercepts 402 ────► sign with wallet key (local)
+    │                                             retry with PAYMENT-SIGNATURE
+    ▼
+blockrun.ai/api/v1  (or sol.blockrun.ai)
+    │
+    ▼  verify + settle USDC on-chain
+    ▼
+model provider (OpenAI / Anthropic / Google / ...)
+    │
+    ▼
+response back to hermes
+```
+
+Payment signing is **non-custodial** — your private key never leaves your machine. Only the cryptographic signature is transmitted.

--- a/plugins/providers/blockrun/__init__.py
+++ b/plugins/providers/blockrun/__init__.py
@@ -8,10 +8,30 @@ Provider names: "blockrun", "clawrouter"
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Optional
 
 # Aliases that map to this provider (checked by plugins/providers/__init__.py)
 ALIASES = ["clawrouter"]
+
+
+def _export_session_wallet() -> None:
+    """If BLOCKRUN_WALLET_KEY is not set but ~/.blockrun/.session exists,
+    export it so auth.py auto-detection can find BlockRun as a provider."""
+    if os.environ.get("BLOCKRUN_WALLET_KEY"):
+        return
+    session_file = os.path.expanduser("~/.blockrun/.session")
+    try:
+        if os.path.exists(session_file):
+            key = open(session_file).read().strip()
+            if key:
+                os.environ["BLOCKRUN_WALLET_KEY"] = key
+    except OSError:
+        pass
+
+
+# Export wallet from session file at import time — enables auto-detection
+_export_session_wallet()
 
 
 def resolve(

--- a/plugins/providers/blockrun/__init__.py
+++ b/plugins/providers/blockrun/__init__.py
@@ -1,0 +1,53 @@
+"""BlockRun / ClawRouter provider plugin for hermes-agent.
+
+50+ LLM models via x402 micropayments (USDC on Base or Solana).
+No API key needed — your crypto wallet IS your credential.
+
+Provider names: "blockrun", "clawrouter"
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Aliases that map to this provider (checked by plugins/providers/__init__.py)
+ALIASES = ["clawrouter"]
+
+
+def resolve(
+    *,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    model_cfg: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Resolve BlockRun runtime provider config.
+
+    Called by runtime_provider.py when provider="blockrun" or "clawrouter".
+    Returns the standard hermes runtime dict.
+    """
+    from .provider import resolve_blockrun_provider
+
+    chain = None
+    if model_cfg:
+        chain = str(model_cfg.get("chain") or "").strip().lower() or None
+
+    return resolve_blockrun_provider(
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+        chain=chain,
+    )
+
+
+def register_tools() -> None:
+    """Register BlockRun tools (wallet, image, prediction markets).
+
+    Importing tools.py triggers registry.register() calls at module level.
+    """
+    from . import tools  # noqa: F401 — side-effect: registers tools
+
+
+# Auto-register tools on plugin load so they appear in the toolset menu
+try:
+    register_tools()
+except Exception:
+    pass  # blockrun-llm not installed — tools just won't appear

--- a/plugins/providers/blockrun/plugin.yaml
+++ b/plugins/providers/blockrun/plugin.yaml
@@ -1,0 +1,14 @@
+name: blockrun
+version: 1.0.0
+description: "BlockRun / ClawRouter — 50+ LLM models via x402 micropayments (USDC on Base or Solana)"
+author: BlockRun
+license: MIT
+pip_dependencies:
+  - blockrun-llm
+tags:
+  - LLM
+  - Payments
+  - Crypto
+  - x402
+  - Base
+  - Solana

--- a/plugins/providers/blockrun/provider.py
+++ b/plugins/providers/blockrun/provider.py
@@ -1,0 +1,386 @@
+"""
+BlockRun / ClawRouter provider for hermes-agent.
+
+Plugs into hermes's runtime_provider system.  When the user selects
+provider="blockrun" (or "clawrouter"), we:
+
+  1. Load the user's wallet key from the environment (Base or Solana).
+  2. Attach a custom httpx transport to the OpenAI client constructed in
+     hermes's inference loop.
+  3. The transport intercepts HTTP 402 Payment Required responses from
+     blockrun.ai / sol.blockrun.ai, signs the payment locally, and retries
+     the request — fully transparent to the rest of hermes.
+
+No API key is required: the wallet private key IS the credential.
+Payments are non-custodial signatures; the key never leaves the user's machine.
+
+Supported chains:
+  Base (default) — USDC on Base mainnet, EIP-712 signing
+    gateway : https://blockrun.ai/api/v1
+    env var : BLOCKRUN_WALLET_KEY=0x...
+
+  Solana        — USDC on Solana, Ed25519 signing
+    gateway : https://sol.blockrun.ai/api/v1
+    env var : SOLANA_WALLET_KEY=<base58-private-key>
+
+Chain auto-detection:
+  • If SOLANA_WALLET_KEY is set (and BLOCKRUN_WALLET_KEY is not) → Solana
+  • If BLOCKRUN_CHAIN=solana                                      → Solana
+  • Otherwise                                                     → Base
+
+Usage in cli-config.yaml:
+  model:
+    provider: "blockrun"          # or "clawrouter" (alias)
+    default: "openai/gpt-5.2"    # any model from blockrun.ai/api/v1/models
+    # chain: "solana"             # optional — defaults to "base"
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+import httpx
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+BLOCKRUN_BASE_URL        = "https://blockrun.ai/api/v1"
+BLOCKRUN_BASE_TESTNET    = "https://testnet.blockrun.ai/api/v1"
+BLOCKRUN_SOLANA_URL      = "https://sol.blockrun.ai/api/v1"
+
+# ── Env var names ─────────────────────────────────────────────────────────────
+_BASE_KEY_VARS   = ("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY")
+_SOLANA_KEY_VARS = ("SOLANA_WALLET_KEY", "BLOCKRUN_SOLANA_KEY")
+
+Chain = Literal["base", "solana"]
+
+
+# ── Wallet helpers ────────────────────────────────────────────────────────────
+
+def _load_base_key() -> str | None:
+    for var in _BASE_KEY_VARS:
+        val = os.environ.get(var)
+        if val:
+            return val
+    session_file = os.path.expanduser("~/.blockrun/.session")
+    if os.path.exists(session_file):
+        try:
+            key = open(session_file).read().strip()
+            if key:
+                return key
+        except OSError:
+            pass
+    return None
+
+
+def _load_solana_key() -> str | None:
+    for var in _SOLANA_KEY_VARS:
+        val = os.environ.get(var)
+        if val:
+            return val
+    return None
+
+
+def _detect_chain() -> Chain:
+    """
+    Auto-detect chain from env vars only (not session files, which are storage
+    not preference signals).  Priority:
+      1. BLOCKRUN_CHAIN=solana → Solana
+      2. SOLANA_WALLET_KEY set and BLOCKRUN_WALLET_KEY not set → Solana
+      3. Otherwise → Base
+    """
+    if os.environ.get("BLOCKRUN_CHAIN", "").lower() == "solana":
+        return "solana"
+    has_solana_env = any(os.environ.get(v) for v in _SOLANA_KEY_VARS)
+    has_base_env   = any(os.environ.get(v) for v in _BASE_KEY_VARS)
+    if has_solana_env and not has_base_env:
+        return "solana"
+    return "base"
+
+
+# ---------------------------------------------------------------------------
+# Shared transport mixin — sign x402 payments (Base or Solana)
+# ---------------------------------------------------------------------------
+
+_USER_AGENT = "hermes-agent/blockrun-integration/1.0.0"
+
+
+class _X402Mixin:
+    """
+    Common signing logic shared by sync and async transports.
+    Detects chain from the 402 response headers and dispatches to the
+    appropriate signing implementation.
+    """
+
+    def _inject_ua(self, request: httpx.Request) -> httpx.Request:
+        """Stamp every outgoing request with the hermes-agent User-Agent."""
+        headers = dict(request.headers)
+        headers["user-agent"] = _USER_AGENT
+        return httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=headers,
+            content=request.content,
+        )
+
+    def _sign_base_payment(
+        self, account: Any, request: httpx.Request, payment_header: str
+    ) -> str:
+        """EIP-712 signing for Base (USDC on eip155:8453)."""
+        from blockrun_llm.x402 import (
+            parse_payment_required,
+            extract_payment_details,
+            create_payment_payload,
+        )
+        payment_required = parse_payment_required(payment_header)
+        details = extract_payment_details(payment_required)
+        return create_payment_payload(
+            account=account,
+            recipient=details["recipient"],
+            amount=details["amount"],
+            network=details.get("network", "eip155:8453"),
+            resource_url=str(request.url),
+            resource_description="BlockRun AI API call via hermes-agent",
+        )
+
+    def _sign_solana_payment(
+        self, x402_client: Any, request: httpx.Request, payment_header: str
+    ) -> str:
+        """
+        Ed25519 signing for Solana (USDC-SPL).
+        Uses x402ClientSync (same approach as SolanaLLMClient internally).
+        """
+        from blockrun_llm.solana_client import (
+            decode_payment_required_header,
+            encode_payment_signature_header,
+        )
+        payment_required = decode_payment_required_header(payment_header)
+        payment_payload  = x402_client.create_payment_payload(payment_required)
+        return encode_payment_signature_header(payment_payload)
+
+    def _sign_payment(self, request: httpx.Request, payment_header: str) -> str:
+        if self._chain == "solana":
+            return self._sign_solana_payment(self._signer, request, payment_header)
+        return self._sign_base_payment(self._signer, request, payment_header)
+
+    def _payment_header(self, response: httpx.Response) -> str | None:
+        return (
+            response.headers.get("X-Payment-Required")
+            or response.headers.get("x-payment-required")
+        )
+
+    def _make_retry(
+        self, request: httpx.Request, signed: str
+    ) -> httpx.Request:
+        headers = dict(request.headers)
+        headers["PAYMENT-SIGNATURE"] = signed
+        return httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=headers,
+            content=request.content,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sync transport
+# ---------------------------------------------------------------------------
+
+class BlockRunX402Transport(_X402Mixin, httpx.HTTPTransport):
+    """
+    Synchronous httpx transport that handles HTTP 402 Payment Required
+    responses from blockrun.ai (Base) and sol.blockrun.ai (Solana).
+    """
+
+    def __init__(self, private_key: str, chain: Chain = "base", **kwargs: Any) -> None:
+        httpx.HTTPTransport.__init__(self, **kwargs)
+        self._chain = chain
+        self._signer = _load_signer(private_key, chain)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        request = self._inject_ua(request)
+        response = super().handle_request(request)
+        payment_header = self._payment_header(response)
+        if response.status_code != 402 or not payment_header:
+            return response
+        try:
+            signed = self._sign_payment(request, payment_header)
+        except Exception as exc:
+            raise RuntimeError(f"BlockRun x402 payment failed: {exc}") from exc
+        return super().handle_request(self._make_retry(request, signed))
+
+
+# ---------------------------------------------------------------------------
+# Async transport
+# ---------------------------------------------------------------------------
+
+class AsyncBlockRunX402Transport(_X402Mixin, httpx.AsyncHTTPTransport):
+    """Async variant — used when hermes constructs an async OpenAI client."""
+
+    def __init__(self, private_key: str, chain: Chain = "base", **kwargs: Any) -> None:
+        httpx.AsyncHTTPTransport.__init__(self, **kwargs)
+        self._chain = chain
+        self._signer = _load_signer(private_key, chain)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        request = self._inject_ua(request)
+        response = await super().handle_async_request(request)
+        payment_header = self._payment_header(response)
+        if response.status_code != 402 or not payment_header:
+            return response
+        try:
+            signed = self._sign_payment(request, payment_header)
+        except Exception as exc:
+            raise RuntimeError(f"BlockRun x402 payment failed: {exc}") from exc
+        return await super().handle_async_request(self._make_retry(request, signed))
+
+
+# ---------------------------------------------------------------------------
+# Signer loader
+# ---------------------------------------------------------------------------
+
+def _load_signer(private_key: str, chain: Chain) -> Any:
+    """
+    Return the appropriate signer for the chain.
+
+    Base   → eth_account.LocalAccount  (used directly in create_payment_payload)
+    Solana → x402ClientSync pre-configured with SVM keypair signer
+             (mirrors SolanaLLMClient's internal setup exactly)
+    """
+    if chain == "solana":
+        try:
+            from blockrun_llm.solana_client import (
+                x402ClientSync,
+                register_exact_svm_client,
+                _create_signer as _solana_create_signer,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "blockrun_llm Solana support required. "
+                "Run: pip install blockrun-llm solders base58"
+            ) from exc
+        x402_client = x402ClientSync()
+        signer = _solana_create_signer(private_key)
+        register_exact_svm_client(x402_client, signer)
+        return x402_client  # stored as self._signer; passed to _sign_solana_payment
+    else:
+        try:
+            from eth_account import Account
+            return Account.from_key(private_key)
+        except ImportError as exc:
+            raise ImportError(
+                "eth-account is required for Base payments. "
+                "Run: pip install eth-account"
+            ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Client factories (called from the hermes inference loop)
+# ---------------------------------------------------------------------------
+
+def create_sync_client(
+    private_key: str,
+    chain: Chain = "base",
+    base_url: str | None = None,
+) -> Any:
+    """
+    Return an openai.OpenAI client wired to BlockRun with x402 payment support.
+    Automatically selects Base or Solana gateway based on `chain`.
+    """
+    import openai
+
+    url = base_url or (BLOCKRUN_SOLANA_URL if chain == "solana" else BLOCKRUN_BASE_URL)
+    transport = BlockRunX402Transport(private_key=private_key, chain=chain)
+    http_client = httpx.Client(
+        transport=transport,
+        timeout=120.0,
+        headers={"User-Agent": "hermes-agent/blockrun-integration/1.0.0"},
+    )
+
+    return openai.OpenAI(
+        base_url=url,
+        api_key="x402-wallet",  # placeholder — auth is the x402 payment signature
+        http_client=http_client,
+    )
+
+
+def create_async_client(
+    private_key: str,
+    chain: Chain = "base",
+    base_url: str | None = None,
+) -> Any:
+    """Async variant of create_sync_client."""
+    import openai
+
+    url = base_url or (BLOCKRUN_SOLANA_URL if chain == "solana" else BLOCKRUN_BASE_URL)
+    transport = AsyncBlockRunX402Transport(private_key=private_key, chain=chain)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        timeout=120.0,
+        headers={"User-Agent": "hermes-agent/blockrun-integration/1.0.0"},
+    )
+
+    return openai.AsyncOpenAI(
+        base_url=url,
+        api_key="x402-wallet",
+        http_client=http_client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider resolver — called from hermes_cli/runtime_provider.py
+# ---------------------------------------------------------------------------
+
+def resolve_blockrun_provider(
+    *,
+    explicit_api_key: str | None,
+    explicit_base_url: str | None,
+    chain: Chain | None = None,
+) -> dict[str, Any]:
+    """
+    Resolve BlockRun / ClawRouter runtime provider config.
+
+    Chain selection (in priority order):
+      1. `chain` argument (from cli-config.yaml model.chain)
+      2. BLOCKRUN_CHAIN env var
+      3. Auto-detect: Solana if only SOLANA_WALLET_KEY is set, else Base
+
+    Returns the standard hermes provider dict plus blockrun_client_factory
+    so the inference layer can build an x402-enabled OpenAI client.
+    """
+    resolved_chain: Chain = chain or _detect_chain()
+
+    # Load wallet key for the chosen chain
+    if resolved_chain == "solana":
+        private_key = explicit_api_key or _load_solana_key()
+        default_url = BLOCKRUN_SOLANA_URL
+        key_hint = "SOLANA_WALLET_KEY=<base58-key>"
+    else:
+        private_key = explicit_api_key or _load_base_key()
+        default_url = (
+            BLOCKRUN_BASE_TESTNET
+            if os.environ.get("NETWORK_MODE") == "testnet"
+            else BLOCKRUN_BASE_URL
+        )
+        key_hint = "BLOCKRUN_WALLET_KEY=0x..."
+
+    if not private_key:
+        raise ValueError(
+            f"BlockRun provider ({resolved_chain}) requires a wallet key.\n"
+            f"  • Set {key_hint} in your environment, or\n"
+            f"  • Run the `blockrun_wallet_setup` tool to create one automatically."
+        )
+
+    base_url = explicit_base_url or os.environ.get("BLOCKRUN_BASE_URL") or default_url
+
+    return {
+        "provider": "blockrun",
+        "api_mode": "chat_completions",
+        "base_url": base_url,
+        "api_key": "x402-wallet",
+        "source": f"blockrun_{resolved_chain}_wallet_key",
+        # Extra metadata for the inference layer
+        "blockrun_chain": resolved_chain,
+        "blockrun_private_key": private_key,
+        "blockrun_client_factory": lambda: create_sync_client(private_key, resolved_chain, base_url),
+        "blockrun_async_client_factory": lambda: create_async_client(private_key, resolved_chain, base_url),
+    }

--- a/plugins/providers/blockrun/provider.py
+++ b/plugins/providers/blockrun/provider.py
@@ -47,6 +47,10 @@ BLOCKRUN_BASE_URL        = "https://blockrun.ai/api/v1"
 BLOCKRUN_BASE_TESTNET    = "https://testnet.blockrun.ai/api/v1"
 BLOCKRUN_SOLANA_URL      = "https://sol.blockrun.ai/api/v1"
 
+# ── ClawRouter (local routing proxy) ─────────────────────────────────────────
+CLAWROUTER_DEFAULT_PORT  = 8402
+CLAWROUTER_DEFAULT_URL   = f"http://localhost:{CLAWROUTER_DEFAULT_PORT}/v1"
+
 # ── Env var names ─────────────────────────────────────────────────────────────
 _BASE_KEY_VARS   = ("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY")
 _SOLANA_KEY_VARS = ("SOLANA_WALLET_KEY", "BLOCKRUN_SOLANA_KEY")
@@ -330,6 +334,28 @@ def create_async_client(
 # Provider resolver — called from hermes_cli/runtime_provider.py
 # ---------------------------------------------------------------------------
 
+def _detect_clawrouter_url() -> str | None:
+    """Check if ClawRouter local proxy is configured or running."""
+    # Explicit env var takes priority
+    port = os.environ.get("CLAWROUTER_PORT")
+    if port:
+        return f"http://localhost:{port}/v1"
+
+    # Check if ClawRouter is running on default port
+    try:
+        import httpx
+        resp = httpx.get(
+            f"{CLAWROUTER_DEFAULT_URL}/models",
+            timeout=1.0,
+        )
+        if resp.status_code == 200:
+            return CLAWROUTER_DEFAULT_URL
+    except Exception:
+        pass
+
+    return None
+
+
 def resolve_blockrun_provider(
     *,
     explicit_api_key: str | None,
@@ -338,6 +364,12 @@ def resolve_blockrun_provider(
 ) -> dict[str, Any]:
     """
     Resolve BlockRun / ClawRouter runtime provider config.
+
+    Resolution order for base_url:
+      1. explicit_base_url (from CLI)
+      2. BLOCKRUN_BASE_URL env var
+      3. ClawRouter local proxy (if running on localhost:8402 or CLAWROUTER_PORT)
+      4. Direct BlockRun API (blockrun.ai or sol.blockrun.ai)
 
     Chain selection (in priority order):
       1. `chain` argument (from cli-config.yaml model.chain)
@@ -370,14 +402,23 @@ def resolve_blockrun_provider(
             f"  • Run the `blockrun_wallet_setup` tool to create one automatically."
         )
 
-    base_url = explicit_base_url or os.environ.get("BLOCKRUN_BASE_URL") or default_url
+    # URL priority: explicit > env > ClawRouter local proxy > direct API
+    base_url = (
+        explicit_base_url
+        or os.environ.get("BLOCKRUN_BASE_URL")
+        or _detect_clawrouter_url()
+        or default_url
+    )
+
+    # Track whether we're routing through ClawRouter
+    is_clawrouter = "localhost" in base_url or "127.0.0.1" in base_url
 
     return {
         "provider": "blockrun",
         "api_mode": "chat_completions",
         "base_url": base_url,
         "api_key": "x402-wallet",
-        "source": f"blockrun_{resolved_chain}_wallet_key",
+        "source": f"{'clawrouter' if is_clawrouter else 'blockrun'}_{resolved_chain}_wallet_key",
         # Extra metadata for the inference layer
         "blockrun_chain": resolved_chain,
         "blockrun_private_key": private_key,

--- a/plugins/providers/blockrun/tools.py
+++ b/plugins/providers/blockrun/tools.py
@@ -10,7 +10,7 @@ Supports both chains:
   Base   — BLOCKRUN_WALLET_KEY=0x...        (default)
   Solana — SOLANA_WALLET_KEY=<base58-key>
 
-LLM calls go through the blockrun provider (hermes_cli/blockrun_provider.py),
+LLM calls go through the blockrun provider (plugins/providers/blockrun/provider.py),
 which attaches an x402-aware httpx transport to the OpenAI client so that
 402 Payment Required responses are handled transparently — no agent involvement.
 """
@@ -531,7 +531,7 @@ def _handle_prediction_markets(args: dict[str, Any], **_) -> str:
 
     try:
         import httpx
-        from hermes_cli.blockrun_provider import BlockRunX402Transport, _load_signer
+        from plugins.providers.blockrun.provider import BlockRunX402Transport, _load_signer
 
         signer    = _load_signer(key, "base")
         transport = BlockRunX402Transport(private_key=key, chain="base")

--- a/plugins/providers/blockrun/tools.py
+++ b/plugins/providers/blockrun/tools.py
@@ -1,0 +1,676 @@
+"""
+BlockRun / ClawRouter tool for hermes-agent.
+
+Tools provided:
+  Wallet     — setup, balance, address (Base + Solana)
+  Images     — generate (DALL-E 3, GPT Image 1, Flux, Nano Banana) + edit
+  Prediction — Polymarket, Kalshi, dFlow, Binance candles, cross-platform markets
+
+Supports both chains:
+  Base   — BLOCKRUN_WALLET_KEY=0x...        (default)
+  Solana — SOLANA_WALLET_KEY=<base58-key>
+
+LLM calls go through the blockrun provider (hermes_cli/blockrun_provider.py),
+which attaches an x402-aware httpx transport to the OpenAI client so that
+402 Payment Required responses are handled transparently — no agent involvement.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+def _get_registry():
+    from tools.registry import registry
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_client():
+    """Return a blockrun_llm.LLMClient, raising a clear error if unavailable."""
+    try:
+        from blockrun_llm import LLMClient
+    except ImportError:
+        raise RuntimeError(
+            "blockrun_llm is not installed. Run: pip install blockrun-llm"
+        )
+
+    key = os.environ.get("BLOCKRUN_WALLET_KEY")
+    if not key:
+        raise RuntimeError(
+            "BLOCKRUN_WALLET_KEY is not set. "
+            "Run the `blockrun_wallet_setup` tool first."
+        )
+    return LLMClient(private_key=key)
+
+
+def _check_requirements() -> tuple[bool, str]:
+    try:
+        import blockrun_llm  # noqa: F401
+        return True, ""
+    except ImportError:
+        return False, "blockrun_llm not installed (pip install blockrun-llm)"
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_wallet_setup
+# ---------------------------------------------------------------------------
+
+def _handle_wallet_setup(args: dict[str, Any], **_) -> str:
+    """
+    Create or load a BlockRun wallet.
+    Stores the private key at ~/.blockrun/.session (mode 600).
+    Prints the wallet address and a funding QR/link.
+    """
+    try:
+        from blockrun_llm.wallet import (
+            get_or_create_wallet,
+            generate_wallet_qr_ascii,
+            get_payment_links,
+            save_wallet,
+        )
+    except ImportError:
+        return "❌ blockrun_llm not installed. Run: pip install blockrun-llm"
+
+    # Honour an explicit key override from the environment
+    explicit_key = os.environ.get("BLOCKRUN_WALLET_KEY")
+
+    address, private_key, is_new = get_or_create_wallet()
+
+    # Persist and export so the rest of the session can use it
+    if is_new:
+        wallet_path = save_wallet(private_key)
+        os.environ["BLOCKRUN_WALLET_KEY"] = private_key
+        status_line = f"✅ New wallet created and saved to {wallet_path}"
+    elif explicit_key:
+        status_line = "✅ Wallet loaded from BLOCKRUN_WALLET_KEY"
+    else:
+        status_line = "✅ Existing wallet loaded from ~/.blockrun/.session"
+
+    # Balance
+    try:
+        from blockrun_llm import LLMClient
+        balance = LLMClient(private_key=private_key).get_balance()
+        balance_line = f"💰 Balance: ${balance:.4f} USDC on Base"
+    except Exception:
+        balance_line = "💰 Balance: (unable to fetch — check network)"
+
+    # Funding links
+    links = get_payment_links(address)
+    qr = generate_wallet_qr_ascii(address)
+
+    lines = [
+        status_line,
+        f"📬 Address: {address}",
+        balance_line,
+        "",
+        "To fund this wallet with USDC on Base:",
+        f"  • BlockRun: {links['blockrun']}",
+        f"  • BaseScan: {links['basescan']}",
+        "",
+        "QR Code (scan with any Ethereum wallet):",
+        qr,
+        "",
+        "Tip: $5–$20 USDC is enough for hundreds of requests.",
+        "Testnet faucet: https://faucet.circle.com (select Base Sepolia)",
+    ]
+    return "\n".join(lines)
+
+
+WALLET_SETUP_SCHEMA = {
+    "name": "blockrun_wallet_setup",
+    "description": (
+        "Set up a BlockRun / ClawRouter wallet for autonomous x402 payments. "
+        "Creates a new wallet if none exists, or loads an existing one. "
+        "Shows the wallet address, current USDC balance, and funding instructions. "
+        "Must be called before using BlockRun as the LLM provider."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_wallet_balance
+# ---------------------------------------------------------------------------
+
+def _handle_wallet_balance(args: dict[str, Any], **_) -> str:
+    """Check current USDC balance and session spending."""
+    try:
+        client = _get_client()
+    except RuntimeError as e:
+        return f"❌ {e}"
+
+    try:
+        address = client.get_wallet_address()
+        balance = client.get_balance()
+        spending = client.get_spending()
+        lines = [
+            f"📬 Address : {address}",
+            f"💰 Balance : ${balance:.4f} USDC (Base mainnet)",
+            f"📊 Session : ${spending['total_usd']:.4f} spent across {spending['calls']} call(s)",
+        ]
+        if balance < 0.01:
+            lines.append(
+                "\n⚠️  Low balance. Fund at: "
+                f"https://blockrun.ai/fund?address={address}"
+            )
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"❌ Failed to fetch balance: {exc}"
+
+
+WALLET_BALANCE_SCHEMA = {
+    "name": "blockrun_wallet_balance",
+    "description": (
+        "Check the current USDC balance of the BlockRun wallet on Base mainnet, "
+        "plus total spending for the current session."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_wallet_address
+# ---------------------------------------------------------------------------
+
+def _handle_wallet_address(args: dict[str, Any], **_) -> str:
+    """Return wallet address and funding links without exposing the private key."""
+    try:
+        from blockrun_llm.wallet import get_wallet_address, get_payment_links
+    except ImportError:
+        return "❌ blockrun_llm not installed. Run: pip install blockrun-llm"
+
+    address = get_wallet_address()
+    if not address:
+        return "❌ No wallet configured. Run `blockrun_wallet_setup` first."
+
+    links = get_payment_links(address)
+    return "\n".join([
+        f"📬 Address : {address}",
+        f"🔗 BlockRun: {links['blockrun']}",
+        f"🔗 BaseScan: {links['basescan']}",
+        f"🔗 EIP-681 : {links['ethereum']}",
+    ])
+
+
+WALLET_ADDRESS_SCHEMA = {
+    "name": "blockrun_wallet_address",
+    "description": (
+        "Return the BlockRun wallet address and funding links. "
+        "Safe to call at any time — never exposes the private key."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_solana_wallet_setup
+# ---------------------------------------------------------------------------
+
+def _handle_solana_wallet_setup(args: dict[str, Any], **_) -> str:
+    """Create or load a Solana wallet for BlockRun x402 payments."""
+    try:
+        from blockrun_llm.solana_wallet import (
+            setup_agent_solana_wallet,
+            get_solana_usdc_balance,
+        )
+    except ImportError:
+        return (
+            "❌ blockrun_llm Solana support not available. "
+            "Run: pip install blockrun-llm solders base58"
+        )
+
+    try:
+        client = setup_agent_solana_wallet()
+        address = client.get_wallet_address()
+        os.environ["SOLANA_WALLET_KEY"] = os.environ.get("SOLANA_WALLET_KEY", "")
+
+        try:
+            balance = get_solana_usdc_balance(address)
+            balance_line = f"💰 Balance : ${balance:.4f} USDC on Solana"
+        except Exception:
+            balance_line = "💰 Balance : (unable to fetch — check network)"
+
+        return "\n".join([
+            "✅ Solana wallet ready",
+            f"📬 Address : {address}",
+            balance_line,
+            "",
+            "To fund with USDC on Solana:",
+            f"  • https://blockrun.ai/fund?address={address}&chain=solana",
+            "  • Send SPL-USDC to the address above from any Solana wallet",
+            "",
+            "Tip: $5–$20 USDC covers hundreds of requests.",
+            "Set BLOCKRUN_CHAIN=solana in your .env to use this wallet by default.",
+        ])
+    except Exception as exc:
+        return f"❌ Solana wallet setup failed: {exc}"
+
+
+SOLANA_WALLET_SETUP_SCHEMA = {
+    "name": "blockrun_solana_wallet_setup",
+    "description": (
+        "Set up a Solana wallet for BlockRun x402 payments (SPL-USDC). "
+        "Creates a new wallet if none exists, or loads an existing one from "
+        "SOLANA_WALLET_KEY. Use this if you prefer to pay on Solana instead of Base."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_solana_wallet_balance
+# ---------------------------------------------------------------------------
+
+def _handle_solana_wallet_balance(args: dict[str, Any], **_) -> str:
+    """Check Solana USDC balance."""
+    try:
+        from blockrun_llm.solana_wallet import (
+            load_solana_wallet,
+            get_solana_usdc_balance,
+        )
+    except ImportError:
+        return "❌ blockrun_llm Solana support not available. Run: pip install blockrun-llm solders base58"
+
+    key = os.environ.get("SOLANA_WALLET_KEY") or os.environ.get("BLOCKRUN_SOLANA_KEY")
+    if not key:
+        return "❌ SOLANA_WALLET_KEY not set. Run `blockrun_solana_wallet_setup` first."
+
+    try:
+        from blockrun_llm import SolanaLLMClient
+        client = SolanaLLMClient(private_key=key)
+        address = client.get_wallet_address()
+        balance = get_solana_usdc_balance(address)
+        spending = client.get_spending()
+        return "\n".join([
+            f"📬 Address : {address}",
+            f"💰 Balance : ${balance:.4f} USDC (Solana)",
+            f"📊 Session : ${spending['total_usd']:.4f} spent across {spending['calls']} call(s)",
+        ])
+    except Exception as exc:
+        return f"❌ Failed to fetch Solana balance: {exc}"
+
+
+SOLANA_WALLET_BALANCE_SCHEMA = {
+    "name": "blockrun_solana_wallet_balance",
+    "description": "Check the current SPL-USDC balance of the BlockRun Solana wallet.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_image_generate
+# ---------------------------------------------------------------------------
+
+_IMAGE_MODELS = {
+    "dall-e-3":          "openai/dall-e-3",
+    "gpt-image-1":       "openai/gpt-image-1",
+    "flux":              "black-forest/flux-1.1-pro",
+    "nano-banana":       "google/nano-banana",
+    "nano-banana-pro":   "google/nano-banana-pro",
+}
+
+_IMAGE_PRICES = {
+    "openai/dall-e-3":              "$0.04",
+    "openai/gpt-image-1":           "$0.02",
+    "black-forest/flux-1.1-pro":    "$0.04",
+    "google/nano-banana":           "$0.05",
+    "google/nano-banana-pro":       "$0.10",
+}
+
+
+def _handle_image_generate(args: dict[str, Any], **_) -> str:
+    prompt    = args.get("prompt", "").strip()
+    model_key = args.get("model", "nano-banana").lower()
+    size      = args.get("size", "1024x1024")
+    n         = int(args.get("n", 1))
+
+    if not prompt:
+        return "❌ 'prompt' is required."
+
+    model_id = _IMAGE_MODELS.get(model_key, model_key)
+
+    try:
+        from blockrun_llm.image import ImageClient
+    except ImportError:
+        return "❌ blockrun_llm not installed. Run: pip install blockrun-llm"
+
+    key = os.environ.get("BLOCKRUN_WALLET_KEY") or os.environ.get("BASE_CHAIN_WALLET_KEY")
+    if not key:
+        return "❌ BLOCKRUN_WALLET_KEY not set. Run `blockrun_wallet_setup` first."
+
+    try:
+        client = ImageClient(private_key=key)
+        result = client.generate(prompt=prompt, model=model_id, size=size, n=n)
+        lines = [
+            f"✅ Generated {len(result.data)} image(s) with {model_id} ({size})",
+            f"💰 Cost: {_IMAGE_PRICES.get(model_id, 'see blockrun.ai/api/pricing')} per image",
+            "",
+        ]
+        for i, img in enumerate(result.data, 1):
+            lines.append(f"Image {i}: {img.url}")
+            if getattr(img, "revised_prompt", None):
+                lines.append(f"  Revised prompt: {img.revised_prompt}")
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"❌ Image generation failed: {exc}"
+
+
+IMAGE_GENERATE_SCHEMA = {
+    "name": "blockrun_image_generate",
+    "description": (
+        "Generate images using BlockRun's image API (x402 micropayment, ~$0.02–$0.10/image). "
+        "Models: dall-e-3, gpt-image-1, flux, nano-banana (default), nano-banana-pro. "
+        "Returns image URLs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Image description / prompt",
+            },
+            "model": {
+                "type": "string",
+                "enum": list(_IMAGE_MODELS.keys()),
+                "description": "Model to use. Default: nano-banana (Google Gemini Flash, fast + cheap)",
+            },
+            "size": {
+                "type": "string",
+                "description": "Image size. Default: 1024x1024. nano-banana-pro supports up to 4096x4096.",
+            },
+            "n": {
+                "type": "integer",
+                "description": "Number of images (default: 1)",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_image_edit
+# ---------------------------------------------------------------------------
+
+def _handle_image_edit(args: dict[str, Any], **_) -> str:
+    prompt     = args.get("prompt", "").strip()
+    image_b64  = args.get("image", "").strip()
+    mask_b64   = args.get("mask", "").strip() or None
+    size       = args.get("size", "1024x1024")
+
+    if not prompt:
+        return "❌ 'prompt' is required."
+    if not image_b64:
+        return "❌ 'image' is required (base64 data URI, e.g. data:image/png;base64,...)."
+
+    try:
+        from blockrun_llm.image import ImageClient
+    except ImportError:
+        return "❌ blockrun_llm not installed. Run: pip install blockrun-llm"
+
+    key = os.environ.get("BLOCKRUN_WALLET_KEY") or os.environ.get("BASE_CHAIN_WALLET_KEY")
+    if not key:
+        return "❌ BLOCKRUN_WALLET_KEY not set. Run `blockrun_wallet_setup` first."
+
+    try:
+        client = ImageClient(private_key=key)
+        result = client.edit(
+            prompt=prompt,
+            image=image_b64,
+            mask=mask_b64,
+            size=size,
+        )
+        lines = [f"✅ Edited image with gpt-image-1 ({size})", ""]
+        for i, img in enumerate(result.data, 1):
+            lines.append(f"Image {i}: {img.url}")
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"❌ Image edit failed: {exc}"
+
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "blockrun_image_edit",
+    "description": (
+        "Edit or inpaint an existing image using GPT Image 1 (x402, ~$0.02/image). "
+        "Provide the original image as a base64 data URI. "
+        "Optionally provide a mask to restrict edits to specific areas."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Edit instruction, e.g. 'Add a sunset background'",
+            },
+            "image": {
+                "type": "string",
+                "description": "Original image as base64 data URI (data:image/png;base64,...)",
+            },
+            "mask": {
+                "type": "string",
+                "description": "Optional mask as base64 data URI — white areas will be edited",
+            },
+            "size": {
+                "type": "string",
+                "description": "Output size. Default: 1024x1024",
+            },
+        },
+        "required": ["prompt", "image"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool: blockrun_prediction_markets
+# ---------------------------------------------------------------------------
+
+_PM_PLATFORMS = ["polymarket", "kalshi", "dflow", "limitless", "opinion", "predict.fun", "binance"]
+
+_PM_ROUTE_HINTS = {
+    "markets":        "/{platform}/markets           — list open markets",
+    "trades":         "/{platform}/trades            — recent trades",
+    "orderbook":      "/{platform}/orderbooks        — live order book",
+    "leaderboard":    "/polymarket/leaderboard       — top traders",
+    "wallet":         "/polymarket/wallet/{address}  — wallet positions + analytics",
+    "smart-money":    "/polymarket/smart-money       — smart money flows",
+    "candles":        "/binance/candles/{symbol}     — OHLCV candlesticks",
+    "matching":       "/matching-markets             — same event across platforms",
+}
+
+
+def _handle_prediction_markets(args: dict[str, Any], **_) -> str:
+    path   = args.get("path", "").strip().lstrip("/")
+    method = args.get("method", "GET").upper()
+    params = args.get("params") or {}
+
+    if not path:
+        # Show available routes
+        lines = [
+            "Available prediction market endpoints (base: blockrun.ai/api/v1/pm/):",
+            "",
+            "Platforms: " + ", ".join(_PM_PLATFORMS),
+            "",
+        ]
+        for hint in _PM_ROUTE_HINTS.values():
+            lines.append(f"  {hint}")
+        lines += [
+            "",
+            "Pricing: GET = $0.001/call  |  POST (analytics) = $0.005/call",
+            "",
+            'Example: {"path": "polymarket/markets", "method": "GET"}',
+        ]
+        return "\n".join(lines)
+
+    key = os.environ.get("BLOCKRUN_WALLET_KEY") or os.environ.get("BASE_CHAIN_WALLET_KEY")
+    if not key:
+        return "❌ BLOCKRUN_WALLET_KEY not set. Run `blockrun_wallet_setup` first."
+
+    try:
+        import httpx
+        from hermes_cli.blockrun_provider import BlockRunX402Transport, _load_signer
+
+        signer    = _load_signer(key, "base")
+        transport = BlockRunX402Transport(private_key=key, chain="base")
+
+        url = f"https://blockrun.ai/api/v1/pm/{path}"
+
+        with httpx.Client(transport=transport, timeout=30.0) as client:
+            if method == "GET":
+                response = client.get(url, params=params)
+            else:
+                response = client.post(url, json=params)
+
+        if response.status_code == 200:
+            import json
+            data = response.json()
+            receipt = response.headers.get("X-Payment-Receipt", "")
+            result_str = json.dumps(data, indent=2)
+            # Truncate very large responses
+            if len(result_str) > 4000:
+                result_str = result_str[:4000] + "\n... (truncated)"
+            lines = [f"✅ {method} /pm/{path}"]
+            if receipt:
+                lines.append(f"💳 Tx: {receipt}")
+            lines += ["", result_str]
+            return "\n".join(lines)
+        else:
+            return f"❌ {response.status_code}: {response.text[:500]}"
+
+    except Exception as exc:
+        return f"❌ Prediction market request failed: {exc}"
+
+
+PREDICTION_MARKETS_SCHEMA = {
+    "name": "blockrun_prediction_markets",
+    "description": (
+        "Query prediction market data via BlockRun (x402, $0.001–$0.005/call). "
+        "Supports Polymarket, Kalshi, dFlow, Limitless, Binance, and more. "
+        "Call with no arguments to see all available endpoints. "
+        "Examples: polymarket/markets, polymarket/leaderboard, kalshi/trades, "
+        "polymarket/wallet/{address}, binance/candles/BTC-USD, matching-markets."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "API path after /api/v1/pm/. "
+                    "E.g. 'polymarket/markets', 'kalshi/trades', 'binance/candles/BTC-USD'. "
+                    "Leave empty to list all available endpoints."
+                ),
+            },
+            "method": {
+                "type": "string",
+                "enum": ["GET", "POST"],
+                "description": "HTTP method. Default: GET. Use POST for advanced analytics.",
+            },
+            "params": {
+                "type": "object",
+                "description": "Query params (GET) or request body (POST).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+_get_registry().register(
+    name="blockrun_wallet_setup",
+    toolset="blockrun",
+    schema=WALLET_SETUP_SCHEMA,
+    handler=_handle_wallet_setup,
+    check_fn=_check_requirements,
+    emoji="🔑",
+)
+
+_get_registry().register(
+    name="blockrun_wallet_balance",
+    toolset="blockrun",
+    schema=WALLET_BALANCE_SCHEMA,
+    handler=_handle_wallet_balance,
+    check_fn=_check_requirements,
+    emoji="💰",
+)
+
+_get_registry().register(
+    name="blockrun_wallet_address",
+    toolset="blockrun",
+    schema=WALLET_ADDRESS_SCHEMA,
+    handler=_handle_wallet_address,
+    check_fn=_check_requirements,
+    emoji="📬",
+)
+
+_get_registry().register(
+    name="blockrun_solana_wallet_setup",
+    toolset="blockrun",
+    schema=SOLANA_WALLET_SETUP_SCHEMA,
+    handler=_handle_solana_wallet_setup,
+    check_fn=_check_requirements,
+    emoji="◎",
+)
+
+_get_registry().register(
+    name="blockrun_solana_wallet_balance",
+    toolset="blockrun",
+    schema=SOLANA_WALLET_BALANCE_SCHEMA,
+    handler=_handle_solana_wallet_balance,
+    check_fn=_check_requirements,
+    emoji="◎",
+)
+
+_get_registry().register(
+    name="blockrun_image_generate",
+    toolset="blockrun",
+    schema=IMAGE_GENERATE_SCHEMA,
+    handler=_handle_image_generate,
+    check_fn=_check_requirements,
+    emoji="🎨",
+)
+
+_get_registry().register(
+    name="blockrun_image_edit",
+    toolset="blockrun",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=_check_requirements,
+    emoji="✏️",
+)
+
+_get_registry().register(
+    name="blockrun_prediction_markets",
+    toolset="blockrun",
+    schema=PREDICTION_MARKETS_SCHEMA,
+    handler=_handle_prediction_markets,
+    check_fn=_check_requirements,
+    emoji="📊",
+)

--- a/tests/test_blockrun_plugin.py
+++ b/tests/test_blockrun_plugin.py
@@ -258,9 +258,10 @@ class TestClientFactory(unittest.TestCase):
 # Group 7: Provider resolver
 # ─────────────────────────────────────────────────────────────────────────────
 
+@patch("plugins.providers.blockrun.provider._detect_clawrouter_url", return_value=None)
 class TestProviderResolver(unittest.TestCase):
 
-    def test_resolve_base(self):
+    def test_resolve_base(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_BASE_URL
         result = resolve_blockrun_provider(
             explicit_api_key=_TEST_ETH_KEY,
@@ -274,7 +275,7 @@ class TestProviderResolver(unittest.TestCase):
         self.assertIn("blockrun_client_factory", result)
         self.assertIn("blockrun_async_client_factory", result)
 
-    def test_resolve_solana(self):
+    def test_resolve_solana(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_SOLANA_URL
         result = resolve_blockrun_provider(
             explicit_api_key=_fresh_solana_key(),
@@ -284,7 +285,7 @@ class TestProviderResolver(unittest.TestCase):
         self.assertEqual(result["blockrun_chain"], "solana")
         self.assertEqual(result["base_url"], BLOCKRUN_SOLANA_URL)
 
-    def test_resolve_testnet(self):
+    def test_resolve_testnet(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_BASE_TESTNET
         with patch.dict(os.environ, {"NETWORK_MODE": "testnet"}):
             result = resolve_blockrun_provider(
@@ -294,7 +295,7 @@ class TestProviderResolver(unittest.TestCase):
             )
         self.assertEqual(result["base_url"], BLOCKRUN_BASE_TESTNET)
 
-    def test_resolve_explicit_base_url_wins(self):
+    def test_resolve_explicit_base_url_wins(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider
         result = resolve_blockrun_provider(
             explicit_api_key=_TEST_ETH_KEY,
@@ -303,7 +304,7 @@ class TestProviderResolver(unittest.TestCase):
         )
         self.assertEqual(result["base_url"], "https://custom.blockrun.ai/api/v1")
 
-    def test_resolve_no_key_raises_value_error(self):
+    def test_resolve_no_key_raises_value_error(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider
         env = {k: "" for k in ("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY")}
         with patch.dict(os.environ, env):
@@ -319,7 +320,7 @@ class TestProviderResolver(unittest.TestCase):
                     )
         self.assertIn("BLOCKRUN_WALLET_KEY", str(ctx.exception))
 
-    def test_client_factory_callable(self):
+    def test_client_factory_callable(self, _mock_claw):
         from plugins.providers.blockrun.provider import resolve_blockrun_provider
         import openai
         result = resolve_blockrun_provider(

--- a/tests/test_blockrun_plugin.py
+++ b/tests/test_blockrun_plugin.py
@@ -1,0 +1,698 @@
+"""
+End-to-end test suite for the BlockRun / ClawRouter hermes-agent integration.
+
+Test groups:
+  Unit   — no network, no real wallet needed (mocked or hardhat keys)
+  Live   — requires BLOCKRUN_WALLET_KEY + funded wallet (marked with @pytest.mark.live)
+
+Run unit tests only (default):
+  python -m pytest tests/test_blockrun_plugin.py -v -k "not live and not Live"
+
+Run all including live API tests:
+  python -m pytest tests/test_blockrun_plugin.py -v -m live
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+import pytest
+
+# Hardhat/Anvil well-known test key (never has real funds)
+_TEST_ETH_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+_TEST_ETH_ADDR = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# Check whether blockrun_llm is available
+try:
+    import blockrun_llm as _blockrun_llm  # noqa: F401
+    _HAS_BLOCKRUN_LLM = True
+except ImportError:
+    _HAS_BLOCKRUN_LLM = False
+
+_skip_no_blockrun_llm = pytest.mark.skipif(
+    not _HAS_BLOCKRUN_LLM,
+    reason="blockrun_llm not installed",
+)
+
+
+def _fresh_solana_key() -> str:
+    """Generate a real Solana keypair for testing (no funds, safe)."""
+    from blockrun_llm.solana_wallet import create_solana_wallet
+    return create_solana_wallet()["private_key"]
+
+
+# Ensure plugin tools are registered
+try:
+    from plugins.providers.blockrun import register_tools
+    register_tools()
+except Exception:
+    pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 1: Imports
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestImports(unittest.TestCase):
+
+    @_skip_no_blockrun_llm
+    def test_provider_module_imports(self):
+        from plugins.providers.blockrun import provider as blockrun_provider
+        self.assertTrue(hasattr(blockrun_provider, "resolve_blockrun_provider"))
+        self.assertTrue(hasattr(blockrun_provider, "BlockRunX402Transport"))
+        self.assertTrue(hasattr(blockrun_provider, "AsyncBlockRunX402Transport"))
+        self.assertTrue(hasattr(blockrun_provider, "create_sync_client"))
+        self.assertTrue(hasattr(blockrun_provider, "create_async_client"))
+
+    @_skip_no_blockrun_llm
+    def test_tool_module_imports(self):
+        from plugins.providers.blockrun import tools as blockrun_tool  # noqa: F401 — side-effects register tools
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 2: Chain detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestChainDetection(unittest.TestCase):
+
+    def _detect(self, env: dict) -> str:
+        from plugins.providers.blockrun.provider import _detect_chain, _BASE_KEY_VARS, _SOLANA_KEY_VARS
+        # Temporarily patch only the relevant env vars
+        all_vars = list(_BASE_KEY_VARS) + list(_SOLANA_KEY_VARS) + ["BLOCKRUN_CHAIN"]
+        clean = {v: "" for v in all_vars}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=False):
+            # Remove the vars we want absent
+            for k, v in clean.items():
+                if v == "":
+                    os.environ.pop(k, None)
+            return _detect_chain()
+
+    def test_default_is_base(self):
+        result = self._detect({})
+        self.assertEqual(result, "base")
+
+    def test_blockrun_chain_env_forces_solana(self):
+        result = self._detect({"BLOCKRUN_CHAIN": "solana"})
+        self.assertEqual(result, "solana")
+
+    def test_only_solana_key_picks_solana(self):
+        result = self._detect({"SOLANA_WALLET_KEY": "somekey"})
+        self.assertEqual(result, "solana")
+
+    def test_both_keys_defaults_to_base(self):
+        result = self._detect({
+            "BLOCKRUN_WALLET_KEY": "0xabc",
+            "SOLANA_WALLET_KEY": "somekey",
+        })
+        self.assertEqual(result, "base")
+
+    def test_session_file_does_not_affect_chain_detection(self):
+        """~/.blockrun/.session must NOT influence chain detection."""
+        # Even if the session file exists (it does on this machine),
+        # chain detection should only look at env vars.
+        result = self._detect({"SOLANA_WALLET_KEY": "somekey"})
+        self.assertEqual(result, "solana")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 3: Wallet key loading
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestWalletKeyLoading(unittest.TestCase):
+
+    def test_base_key_from_env(self):
+        from plugins.providers.blockrun.provider import _load_base_key
+        with patch.dict(os.environ, {"BLOCKRUN_WALLET_KEY": "0xdeadbeef"}):
+            self.assertEqual(_load_base_key(), "0xdeadbeef")
+
+    def test_base_legacy_key_var(self):
+        from plugins.providers.blockrun.provider import _load_base_key
+        env = {"BLOCKRUN_WALLET_KEY": "", "BASE_CHAIN_WALLET_KEY": "0xlegacy"}
+        with patch.dict(os.environ, env):
+            os.environ.pop("BLOCKRUN_WALLET_KEY", None)
+            self.assertEqual(_load_base_key(), "0xlegacy")
+
+    def test_solana_key_from_env(self):
+        from plugins.providers.blockrun.provider import _load_solana_key
+        with patch.dict(os.environ, {"SOLANA_WALLET_KEY": "solanakey123"}):
+            self.assertEqual(_load_solana_key(), "solanakey123")
+
+    def test_base_key_falls_back_to_session_file(self):
+        from plugins.providers.blockrun.provider import _load_base_key
+        session = os.path.expanduser("~/.blockrun/.session")
+        # This machine has a session file — verify it's read
+        if os.path.exists(session):
+            key = _load_base_key()
+            self.assertIsNotNone(key)
+            self.assertTrue(len(key) > 0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 4: Signer loading
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSignerLoading(unittest.TestCase):
+
+    def test_base_signer_returns_local_account(self):
+        from plugins.providers.blockrun.provider import _load_signer
+        from eth_account import Account
+        signer = _load_signer(_TEST_ETH_KEY, "base")
+        self.assertIsInstance(signer, Account.from_key(_TEST_ETH_KEY).__class__)
+        self.assertEqual(signer.address.lower(), _TEST_ETH_ADDR.lower())
+
+    def test_solana_signer_returns_x402_client(self):
+        from plugins.providers.blockrun.provider import _load_signer
+        from blockrun_llm.solana_client import x402ClientSync
+        signer = _load_signer(_fresh_solana_key(), "solana")
+        self.assertIsInstance(signer, x402ClientSync)
+
+    def test_invalid_base_key_raises(self):
+        from plugins.providers.blockrun.provider import _load_signer
+        with self.assertRaises(Exception):
+            _load_signer("not-a-valid-key", "base")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 5: Transport instantiation
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTransportInstantiation(unittest.TestCase):
+
+    def test_sync_base_transport(self):
+        from plugins.providers.blockrun.provider import BlockRunX402Transport
+        t = BlockRunX402Transport(private_key=_TEST_ETH_KEY, chain="base")
+        self.assertEqual(t._chain, "base")
+
+    def test_async_base_transport(self):
+        from plugins.providers.blockrun.provider import AsyncBlockRunX402Transport
+        t = AsyncBlockRunX402Transport(private_key=_TEST_ETH_KEY, chain="base")
+        self.assertEqual(t._chain, "base")
+
+    def test_sync_solana_transport(self):
+        from plugins.providers.blockrun.provider import BlockRunX402Transport
+        from blockrun_llm.solana_client import x402ClientSync
+        t = BlockRunX402Transport(private_key=_fresh_solana_key(), chain="solana")
+        self.assertEqual(t._chain, "solana")
+        self.assertIsInstance(t._signer, x402ClientSync)
+
+    def test_transport_passes_through_200(self):
+        """Transport must not touch non-402 responses."""
+        from plugins.providers.blockrun.provider import BlockRunX402Transport
+        import httpx
+
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_200.headers = {}
+
+        fake_req = httpx.Request("GET", "https://blockrun.ai/api/v1/chat/completions")
+        t = BlockRunX402Transport(private_key=_TEST_ETH_KEY, chain="base")
+        with patch.object(httpx.HTTPTransport, "handle_request", return_value=mock_200):
+            result = t.handle_request(fake_req)
+        self.assertEqual(result.status_code, 200)
+
+    def test_transport_passes_through_402_without_payment_header(self):
+        """402 with no X-Payment-Required header must pass through unchanged."""
+        from plugins.providers.blockrun.provider import BlockRunX402Transport
+        import httpx
+
+        mock_402 = MagicMock()
+        mock_402.status_code = 402
+        mock_402.headers = {}
+
+        fake_req = httpx.Request("GET", "https://blockrun.ai/api/v1/chat/completions")
+        t = BlockRunX402Transport(private_key=_TEST_ETH_KEY, chain="base")
+        with patch.object(httpx.HTTPTransport, "handle_request", return_value=mock_402):
+            result = t.handle_request(fake_req)
+        self.assertEqual(result.status_code, 402)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 6: Client factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClientFactory(unittest.TestCase):
+
+    def test_create_sync_client_base(self):
+        import openai
+        from plugins.providers.blockrun.provider import create_sync_client, BLOCKRUN_BASE_URL
+        client = create_sync_client(_TEST_ETH_KEY, chain="base")
+        self.assertIsInstance(client, openai.OpenAI)
+        self.assertIn("blockrun.ai", str(client.base_url))
+
+    def test_create_sync_client_solana(self):
+        import openai
+        from plugins.providers.blockrun.provider import create_sync_client
+        client = create_sync_client(_fresh_solana_key(), chain="solana")
+        self.assertIsInstance(client, openai.OpenAI)
+        self.assertIn("sol.blockrun.ai", str(client.base_url))
+
+    def test_create_async_client_base(self):
+        import openai
+        from plugins.providers.blockrun.provider import create_async_client
+        client = create_async_client(_TEST_ETH_KEY, chain="base")
+        self.assertIsInstance(client, openai.AsyncOpenAI)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 7: Provider resolver
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestProviderResolver(unittest.TestCase):
+
+    def test_resolve_base(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_BASE_URL
+        result = resolve_blockrun_provider(
+            explicit_api_key=_TEST_ETH_KEY,
+            explicit_base_url=None,
+            chain="base",
+        )
+        self.assertEqual(result["provider"], "blockrun")
+        self.assertEqual(result["api_mode"], "chat_completions")
+        self.assertEqual(result["base_url"], BLOCKRUN_BASE_URL)
+        self.assertEqual(result["blockrun_chain"], "base")
+        self.assertIn("blockrun_client_factory", result)
+        self.assertIn("blockrun_async_client_factory", result)
+
+    def test_resolve_solana(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_SOLANA_URL
+        result = resolve_blockrun_provider(
+            explicit_api_key=_fresh_solana_key(),
+            explicit_base_url=None,
+            chain="solana",
+        )
+        self.assertEqual(result["blockrun_chain"], "solana")
+        self.assertEqual(result["base_url"], BLOCKRUN_SOLANA_URL)
+
+    def test_resolve_testnet(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider, BLOCKRUN_BASE_TESTNET
+        with patch.dict(os.environ, {"NETWORK_MODE": "testnet"}):
+            result = resolve_blockrun_provider(
+                explicit_api_key=_TEST_ETH_KEY,
+                explicit_base_url=None,
+                chain="base",
+            )
+        self.assertEqual(result["base_url"], BLOCKRUN_BASE_TESTNET)
+
+    def test_resolve_explicit_base_url_wins(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider
+        result = resolve_blockrun_provider(
+            explicit_api_key=_TEST_ETH_KEY,
+            explicit_base_url="https://custom.blockrun.ai/api/v1",
+            chain="base",
+        )
+        self.assertEqual(result["base_url"], "https://custom.blockrun.ai/api/v1")
+
+    def test_resolve_no_key_raises_value_error(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider
+        env = {k: "" for k in ("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY")}
+        with patch.dict(os.environ, env):
+            for k in env:
+                os.environ.pop(k, None)
+            # Also ensure no session file interferes — mock _load_base_key
+            with patch("plugins.providers.blockrun.provider._load_base_key", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    resolve_blockrun_provider(
+                        explicit_api_key=None,
+                        explicit_base_url=None,
+                        chain="base",
+                    )
+        self.assertIn("BLOCKRUN_WALLET_KEY", str(ctx.exception))
+
+    def test_client_factory_callable(self):
+        from plugins.providers.blockrun.provider import resolve_blockrun_provider
+        import openai
+        result = resolve_blockrun_provider(
+            explicit_api_key=_TEST_ETH_KEY,
+            explicit_base_url=None,
+            chain="base",
+        )
+        client = result["blockrun_client_factory"]()
+        self.assertIsInstance(client, openai.OpenAI)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 8: Tool schemas
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestToolSchemas(unittest.TestCase):
+
+    def setUp(self):
+        from plugins.providers.blockrun import tools as blockrun_tool  # ensures all tools are registered
+        self.tool = blockrun_tool
+
+    def _schema(self, name):
+        schemas = {
+            "blockrun_wallet_setup":          self.tool.WALLET_SETUP_SCHEMA,
+            "blockrun_wallet_balance":        self.tool.WALLET_BALANCE_SCHEMA,
+            "blockrun_wallet_address":        self.tool.WALLET_ADDRESS_SCHEMA,
+            "blockrun_solana_wallet_setup":   self.tool.SOLANA_WALLET_SETUP_SCHEMA,
+            "blockrun_solana_wallet_balance": self.tool.SOLANA_WALLET_BALANCE_SCHEMA,
+            "blockrun_image_generate":        self.tool.IMAGE_GENERATE_SCHEMA,
+            "blockrun_image_edit":            self.tool.IMAGE_EDIT_SCHEMA,
+            "blockrun_prediction_markets":    self.tool.PREDICTION_MARKETS_SCHEMA,
+        }
+        return schemas[name]
+
+    def test_all_schemas_have_required_fields(self):
+        names = [
+            "blockrun_wallet_setup", "blockrun_wallet_balance",
+            "blockrun_wallet_address", "blockrun_solana_wallet_setup",
+            "blockrun_solana_wallet_balance", "blockrun_image_generate",
+            "blockrun_image_edit", "blockrun_prediction_markets",
+        ]
+        for name in names:
+            schema = self._schema(name)
+            self.assertIn("name", schema, f"{name}: missing 'name'")
+            self.assertIn("description", schema, f"{name}: missing 'description'")
+            self.assertIn("parameters", schema, f"{name}: missing 'parameters'")
+            self.assertEqual(schema["name"], name, f"{name}: name mismatch")
+
+    def test_image_generate_model_enum(self):
+        schema = self._schema("blockrun_image_generate")
+        model_prop = schema["parameters"]["properties"]["model"]
+        self.assertIn("enum", model_prop)
+        self.assertIn("nano-banana", model_prop["enum"])
+        self.assertIn("dall-e-3", model_prop["enum"])
+
+    def test_image_edit_requires_prompt_and_image(self):
+        schema = self._schema("blockrun_image_edit")
+        self.assertIn("prompt", schema["parameters"]["required"])
+        self.assertIn("image", schema["parameters"]["required"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 9: Tool handlers — error cases (no real API)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestToolHandlerErrors(unittest.TestCase):
+
+    def _clear_wallet_env(self):
+        for k in ("BLOCKRUN_WALLET_KEY", "BASE_CHAIN_WALLET_KEY", "SOLANA_WALLET_KEY"):
+            os.environ.pop(k, None)
+
+    def test_wallet_balance_no_key(self):
+        from plugins.providers.blockrun.tools import _handle_wallet_balance
+        self._clear_wallet_env()
+        with patch("plugins.providers.blockrun.provider._load_base_key", return_value=None):
+            result = _handle_wallet_balance({})
+        self.assertIn("❌", result)
+
+    def test_image_generate_no_prompt(self):
+        from plugins.providers.blockrun.tools import _handle_image_generate
+        result = _handle_image_generate({})
+        self.assertIn("❌", result)
+        self.assertIn("prompt", result)
+
+    def test_image_edit_no_prompt(self):
+        from plugins.providers.blockrun.tools import _handle_image_edit
+        result = _handle_image_edit({"image": "data:image/png;base64,abc"})
+        self.assertIn("❌", result)
+        self.assertIn("prompt", result)
+
+    def test_image_edit_no_image(self):
+        from plugins.providers.blockrun.tools import _handle_image_edit
+        result = _handle_image_edit({"prompt": "make it blue"})
+        self.assertIn("❌", result)
+        self.assertIn("image", result)
+
+    def test_prediction_markets_no_path_returns_help(self):
+        from plugins.providers.blockrun.tools import _handle_prediction_markets
+        result = _handle_prediction_markets({})
+        self.assertIn("polymarket", result.lower())
+        self.assertIn("kalshi", result.lower())
+
+    def test_prediction_markets_no_key(self):
+        from plugins.providers.blockrun.tools import _handle_prediction_markets
+        self._clear_wallet_env()
+        with patch("plugins.providers.blockrun.provider._load_base_key", return_value=None):
+            result = _handle_prediction_markets({"path": "polymarket/markets"})
+        self.assertIn("❌", result)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 10: Live API tests (require funded wallet)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.live
+class TestLiveAPI(unittest.TestCase):
+    """
+    These tests hit the real BlockRun API and consume small amounts of USDC.
+    Run with: pytest tests/ -v -m live
+    Requires: BLOCKRUN_WALLET_KEY set and wallet funded with USDC on Base.
+    """
+
+    def setUp(self):
+        self.key = os.environ.get("BLOCKRUN_WALLET_KEY")
+        if not self.key:
+            # Try session file
+            session = os.path.expanduser("~/.blockrun/.session")
+            if os.path.exists(session):
+                self.key = open(session).read().strip()
+        if not self.key:
+            self.skipTest("BLOCKRUN_WALLET_KEY not set and no ~/.blockrun/.session")
+
+    def test_wallet_balance_live(self):
+        from blockrun_llm import LLMClient
+        client = LLMClient(private_key=self.key)
+        balance = client.get_balance()
+        self.assertIsInstance(balance, float)
+        self.assertGreaterEqual(balance, 0)
+        print(f"\n  Balance: ${balance:.4f} USDC")
+
+    def test_llm_completion_live(self):
+        """Basic LLM call through BlockRun x402 (uses cheap NVIDIA model)."""
+        from plugins.providers.blockrun.provider import create_sync_client
+        client = create_sync_client(self.key, chain="base")
+        resp = client.chat.completions.create(
+            model="nvidia/gpt-oss-20b",  # smallest / cheapest
+            messages=[{"role": "user", "content": "Reply with just the word: PASS"}],
+            max_tokens=10,
+        )
+        text = resp.choices[0].message.content.strip()
+        print(f"\n  LLM response: {text!r}")
+        self.assertIsNotNone(text)
+        self.assertTrue(len(text) > 0)
+
+    def test_image_generate_live(self):
+        """Image generation via x402 (uses cheapest model)."""
+        from plugins.providers.blockrun.tools import _handle_image_generate
+        with patch.dict(os.environ, {"BLOCKRUN_WALLET_KEY": self.key}):
+            result = _handle_image_generate({
+                "prompt": "a simple blue circle on white background",
+                "model": "gpt-image-1",
+                "size": "1024x1024",
+                "n": 1,
+            })
+        print(f"\n  Image result: {result[:200]}")
+        self.assertIn("✅", result)
+        # GPT Image 1 returns base64 data URIs; other models return https URLs
+        self.assertTrue(
+            "https://" in result or "data:image/" in result,
+            f"Expected image URL or data URI in result: {result[:300]}"
+        )
+
+    def test_prediction_markets_live(self):
+        """Prediction market data query (Polymarket markets list)."""
+        from plugins.providers.blockrun.tools import _handle_prediction_markets
+        with patch.dict(os.environ, {"BLOCKRUN_WALLET_KEY": self.key}):
+            result = _handle_prediction_markets({"path": "polymarket/markets"})
+        print(f"\n  PM result: {result[:300]}")
+        self.assertNotIn("❌", result)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group 11: Multi-model live tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.live
+class TestLiveMultiModel(unittest.TestCase):
+    """
+    Tests that exercise each supported model family through the x402 transport.
+    Uses the cheapest model per provider to minimise cost (~$0.001 per test).
+
+    Run with: pytest tests/ -v -m live
+    """
+
+    # cheapest confirmed-working model per family
+    MODELS = [
+        ("nvidia",    "nvidia/gpt-oss-20b",           "free NVIDIA baseline"),
+        ("openai",    "openai/gpt-5-mini",             "OpenAI GPT-5 mini"),
+        ("anthropic", "anthropic/claude-haiku-4.5",   "Anthropic Claude Haiku"),
+        ("google",    "google/gemini-2.5-flash",      "Google Gemini Flash"),
+    ]
+
+    PROMPT = "Reply with exactly one word: PASS"
+
+    def setUp(self):
+        key = os.environ.get("BLOCKRUN_WALLET_KEY")
+        if not key:
+            session = os.path.expanduser("~/.blockrun/.session")
+            if os.path.exists(session):
+                key = open(session).read().strip()
+        if not key:
+            self.skipTest("BLOCKRUN_WALLET_KEY not set")
+        from plugins.providers.blockrun.provider import create_sync_client
+        self.client = create_sync_client(key, chain="base")
+
+    def _chat(self, model: str, messages: list, **kwargs) -> str:
+        kwargs.setdefault("max_tokens", 20)
+        resp = self.client.chat.completions.create(
+            model=model, messages=messages, **kwargs
+        )
+        return resp.choices[0].message.content.strip()
+
+    # ── one test per model family ──────────────────────────────────────────
+
+    def test_nvidia_basic(self):
+        text = self._chat("nvidia/gpt-oss-20b",
+                          [{"role": "user", "content": self.PROMPT}])
+        print(f"\n  nvidia: {text!r}")
+        self.assertTrue(len(text) > 0)
+
+    def test_openai_basic(self):
+        text = self._chat("openai/gpt-5-mini",
+                          [{"role": "user", "content": self.PROMPT}])
+        print(f"\n  openai: {text!r}")
+        self.assertTrue(len(text) > 0)
+
+    def test_anthropic_basic(self):
+        text = self._chat("anthropic/claude-haiku-4.5",
+                          [{"role": "user", "content": self.PROMPT}])
+        print(f"\n  anthropic: {text!r}")
+        self.assertTrue(len(text) > 0)
+
+    def test_google_basic(self):
+        text = self._chat("google/gemini-2.5-flash",
+                          [{"role": "user", "content": self.PROMPT}])
+        print(f"\n  google: {text!r}")
+        self.assertTrue(len(text) > 0)
+
+    # ── system prompt ──────────────────────────────────────────────────────
+
+    def test_system_prompt(self):
+        """System prompt must be respected across providers."""
+        messages = [
+            {"role": "system", "content": "You are a robot. Always end every reply with 'BEEP'."},
+            {"role": "user",   "content": "Say hello."},
+        ]
+        text = self._chat("openai/gpt-5-mini", messages, max_tokens=30)
+        print(f"\n  system prompt: {text!r}")
+        self.assertIn("BEEP", text.upper())
+
+    # ── multi-turn ─────────────────────────────────────────────────────────
+
+    def test_multi_turn(self):
+        """Conversation history must be maintained."""
+        messages = [
+            {"role": "user",      "content": "My secret number is 42. Remember it."},
+            {"role": "assistant", "content": "Got it, your secret number is 42."},
+            {"role": "user",      "content": "What is my secret number? Reply with just the number."},
+        ]
+        text = self._chat("openai/gpt-5-mini", messages, max_tokens=30)
+        print(f"\n  multi-turn: {text!r}")
+        self.assertIn("42", text)
+
+    # ── streaming ──────────────────────────────────────────────────────────
+
+    def test_streaming(self):
+        """Streaming must return at least one chunk with content."""
+        chunks = []
+        stream = self.client.chat.completions.create(
+            model="openai/gpt-5-mini",
+            messages=[{"role": "user", "content": "Count to 3."}],
+            max_tokens=20,
+            stream=True,
+        )
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta.content
+            if delta:
+                chunks.append(delta)
+        text = "".join(chunks)
+        print(f"\n  streaming: {text!r} ({len(chunks)} chunks)")
+        self.assertTrue(len(chunks) > 0, "Expected at least one streaming chunk")
+        self.assertTrue(len(text) > 0)
+
+    # ── tool calling ───────────────────────────────────────────────────────
+
+    def test_tool_calling(self):
+        """Model must be able to invoke a tool (function calling)."""
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                    },
+                    "required": ["city"],
+                },
+            },
+        }]
+        resp = self.client.chat.completions.create(
+            model="openai/gpt-5-mini",
+            messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+            tools=tools,
+            tool_choice="auto",
+            max_tokens=256,
+        )
+        msg = resp.choices[0].message
+        print(f"\n  tool calling finish_reason: {resp.choices[0].finish_reason}")
+        # Must either call the tool or give a text answer
+        has_tool_call = bool(msg.tool_calls)
+        has_content   = bool(msg.content and len(msg.content) > 0)
+        self.assertTrue(
+            has_tool_call or has_content,
+            "Expected either a tool call or text content"
+        )
+        if has_tool_call:
+            fn = msg.tool_calls[0].function
+            print(f"  tool called: {fn.name}({fn.arguments})")
+            self.assertEqual(fn.name, "get_weather")
+            self.assertIn("Tokyo", fn.arguments)
+
+    # ── model list ─────────────────────────────────────────────────────────
+
+    def test_models_endpoint(self):
+        """GET /models must return our known families."""
+        models = self.client.models.list()
+        ids = {m.id for m in models.data}
+        print(f"\n  total models: {len(ids)}")
+        for family, model_id, label in self.MODELS:
+            self.assertIn(model_id, ids,
+                          f"Expected {model_id} ({label}) in model list")
+
+    # ── user-agent header ──────────────────────────────────────────────────
+
+    def test_user_agent_header_sent(self):
+        """Requests must carry the hermes-agent User-Agent header.
+
+        The spy is placed on httpx.HTTPTransport.handle_request (the super)
+        so it sees the request AFTER BlockRunX402Transport._inject_ua has
+        stamped the hermes-agent User-Agent onto it.
+        """
+        import httpx as _httpx
+        captured = {}
+
+        original_super = _httpx.HTTPTransport.handle_request
+
+        def spy(self_t, request):
+            if "blockrun.ai" in str(request.url):
+                captured["user_agent"] = request.headers.get("user-agent", "")
+            return original_super(self_t, request)
+
+        with patch.object(_httpx.HTTPTransport, "handle_request", spy):
+            self._chat("nvidia/gpt-oss-20b",
+                       [{"role": "user", "content": "hi"}])
+
+        ua = captured.get("user_agent", "")
+        print(f"\n  User-Agent: {ua!r}")
+        self.assertIn("hermes-agent", ua.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -1,0 +1,209 @@
+"""Test provider plugin discovery and loading infrastructure."""
+
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestProviderPluginDiscovery:
+    """Test plugins/providers/__init__.py discovery and loading."""
+
+    def test_discover_returns_list(self):
+        from plugins.providers import discover_provider_plugins
+        result = discover_provider_plugins()
+        assert isinstance(result, list)
+
+    def test_get_unknown_provider_returns_none(self):
+        from plugins.providers import get_provider_plugin
+        assert get_provider_plugin("nonexistent") is None
+
+    def test_discovery_cache_prevents_rescan(self):
+        """After first discovery, _discovered flag prevents re-scanning."""
+        import plugins.providers as pp
+
+        # Force a fresh discovery
+        pp._discovered = False
+        pp._provider_cache.clear()
+
+        pp.get_provider_plugin("anything")
+        assert pp._discovered is True
+
+        # Mark cache with a sentinel
+        pp._provider_cache["_sentinel"] = lambda: None
+
+        # Second call should NOT reset the cache (sentinel survives)
+        pp.get_provider_plugin("anything_else")
+        assert "_sentinel" in pp._provider_cache
+
+    def test_discover_skips_hidden_and_underscore_dirs(self, tmp_path):
+        """Directories starting with _ or . are skipped."""
+        import plugins.providers as pp
+
+        # Create dirs that should be skipped
+        (tmp_path / ".hidden" / "__init__.py").parent.mkdir(parents=True)
+        (tmp_path / ".hidden" / "__init__.py").write_text("resolve = lambda: {}")
+        (tmp_path / "_private" / "__init__.py").parent.mkdir(parents=True)
+        (tmp_path / "_private" / "__init__.py").write_text("resolve = lambda: {}")
+
+        with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
+            results = pp.discover_provider_plugins()
+            names = [name for name, _, _ in results]
+            assert ".hidden" not in names
+            assert "_private" not in names
+
+    def test_discover_skips_dirs_without_init(self, tmp_path):
+        """Directories without __init__.py are skipped."""
+        import plugins.providers as pp
+
+        (tmp_path / "no_init_dir").mkdir()
+
+        with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
+            results = pp.discover_provider_plugins()
+            names = [name for name, _, _ in results]
+            assert "no_init_dir" not in names
+
+
+class TestAliasResolution:
+    """Test that ALIASES in a provider plugin are resolved correctly."""
+
+    def test_alias_resolves_to_same_function(self, tmp_path):
+        """A plugin with ALIASES should be reachable by any alias."""
+        import plugins.providers as pp
+
+        # Create a fake provider plugin with aliases
+        plugin_dir = tmp_path / "fakeprov"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text(textwrap.dedent("""\
+            ALIASES = ["fakealias", "anothername"]
+            def resolve(**kwargs):
+                return {"provider": "fake"}
+        """))
+
+        # Reset cache and discover from our tmp dir
+        pp._discovered = False
+        pp._provider_cache.clear()
+        original_dir = pp._PROVIDERS_DIR
+
+        with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
+            pp._discover_all()
+
+            assert "fakeprov" in pp._provider_cache
+            assert "fakealias" in pp._provider_cache
+            assert "anothername" in pp._provider_cache
+
+            # All should point to the same resolve function
+            assert pp._provider_cache["fakeprov"] is pp._provider_cache["fakealias"]
+            assert pp._provider_cache["fakeprov"] is pp._provider_cache["anothername"]
+
+        # Cleanup: restore state
+        pp._provider_cache.clear()
+        pp._discovered = False
+
+    def test_alias_lookup_case_insensitive(self, tmp_path):
+        """Alias lookup is case-insensitive."""
+        import plugins.providers as pp
+
+        plugin_dir = tmp_path / "caseprov"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text(textwrap.dedent("""\
+            ALIASES = ["CaseAlias"]
+            def resolve(**kwargs):
+                return {"provider": "case"}
+        """))
+
+        pp._discovered = False
+        pp._provider_cache.clear()
+
+        with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
+            pp._discover_all()
+            pp._discovered = True
+
+            # Should be stored lowercase
+            assert "casealias" in pp._provider_cache
+
+            # get_provider_plugin lowercases the input
+            result = pp.get_provider_plugin("CaseAlias")
+            assert result is not None
+
+        pp._provider_cache.clear()
+        pp._discovered = False
+
+    def test_plugin_without_aliases(self, tmp_path):
+        """A plugin without ALIASES attribute works fine (just primary name)."""
+        import plugins.providers as pp
+
+        plugin_dir = tmp_path / "noalias"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text(textwrap.dedent("""\
+            def resolve(**kwargs):
+                return {"provider": "noalias"}
+        """))
+
+        pp._discovered = False
+        pp._provider_cache.clear()
+
+        with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
+            pp._discover_all()
+            assert "noalias" in pp._provider_cache
+
+        pp._provider_cache.clear()
+        pp._discovered = False
+
+
+class TestLoadModuleEdgeCases:
+    """Test _load_module handles edge cases gracefully."""
+
+    def test_load_module_missing_init(self, tmp_path):
+        """_load_module returns None for dir without __init__.py."""
+        import plugins.providers as pp
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        result = pp._load_module(empty_dir)
+        assert result is None
+
+    def test_load_module_with_syntax_error(self, tmp_path):
+        """_load_module returns None if __init__.py has a syntax error."""
+        import plugins.providers as pp
+
+        bad_dir = tmp_path / "badplugin"
+        bad_dir.mkdir()
+        (bad_dir / "__init__.py").write_text("def resolve(:\n  pass  # syntax error")
+
+        result = pp._load_module(bad_dir)
+        assert result is None
+
+    def test_load_module_with_import_error(self, tmp_path):
+        """_load_module returns None if __init__.py raises ImportError."""
+        import plugins.providers as pp
+
+        bad_dir = tmp_path / "importfail"
+        bad_dir.mkdir()
+        (bad_dir / "__init__.py").write_text(
+            "import nonexistent_module_xyz_12345\ndef resolve(): pass"
+        )
+
+        result = pp._load_module(bad_dir)
+        assert result is None
+
+    def test_load_module_cached(self, tmp_path):
+        """_load_module returns cached module on second call."""
+        import plugins.providers as pp
+
+        plugin_dir = tmp_path / "cached"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("def resolve(**kw): return {}")
+
+        mod1 = pp._load_module(plugin_dir)
+        assert mod1 is not None
+
+        mod2 = pp._load_module(plugin_dir)
+        assert mod2 is mod1
+
+        # Cleanup
+        module_name = f"plugins.providers.cached"
+        sys.modules.pop(module_name, None)

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -85,8 +85,6 @@ class TestAliasResolution:
         # Reset cache and discover from our tmp dir
         pp._discovered = False
         pp._provider_cache.clear()
-        original_dir = pp._PROVIDERS_DIR
-
         with patch.object(pp, "_PROVIDERS_DIR", tmp_path):
             pp._discover_all()
 


### PR DESCRIPTION
## Summary

Adds **BlockRun / ClawRouter** as a first-class provider in hermes-agent via the new `plugins/providers/` plugin system — self-contained, zero merge conflicts, reusable for future providers.

- **First-class in `hermes model`** — appears in provider menu, auto-detected when wallet key is set
- **ClawRouter auto-detection** — when local proxy runs on `:8402`, routes through it for cost-optimized model selection
- **x402 micropayments** — no API key, pay per request with USDC on Base or Solana
- **50+ models** — OpenAI, Anthropic, Google, DeepSeek, xAI, NVIDIA free tier, and more
- **10 tools** — wallet management, image generation, prediction markets

Supersedes #3477 (which modified 5 core files and had merge conflicts).

### How it works

```
hermes-agent  →  provider plugin (plugins/providers/blockrun/)
                      │
                      ▼  resolves wallet key + chain + ClawRouter
                 OpenAI client with x402 httpx transport
                      │
                      ▼  on HTTP 402 response
                 sign payment locally (EIP-712 or Ed25519)
                 retry with PAYMENT-SIGNATURE header
                      │
                      ▼
                 ClawRouter (localhost:8402) or blockrun.ai/api/v1
```

### User setup

```bash
# Option 1: Direct API
pip install blockrun-llm eth-account
export BLOCKRUN_WALLET_KEY=0x...
hermes chat  # auto-detects blockrun

# Option 2: With ClawRouter (cost-optimized routing)
npx @blockrun/clawrouter           # starts on port 8402
hermes chat --model blockrun/auto  # auto-routes through ClawRouter
```

### ClawRouter routing profiles

| Profile | Model name | Strategy | Savings |
|---------|------------|----------|---------|
| Auto | `blockrun/auto` | Balanced quality/cost | 74-100% |
| Eco | `blockrun/eco` | Cheapest possible | 95-100% |
| Premium | `blockrun/premium` | Best quality | 0% |
| Free | `blockrun/free` | Free models only | 100% |

### Core files changed (2 files, minimal)

| File | Change | Lines |
|------|--------|-------|
| `hermes_cli/auth.py` | ProviderConfig + aliases (clawrouter, claw, x402) | +10 |
| `hermes_cli/runtime_provider.py` | Plugin provider check before `resolve_provider()` | +18 |

### Plugin files (self-contained)

```
plugins/providers/__init__.py              — reusable provider plugin infrastructure
plugins/providers/blockrun/__init__.py     — entry: resolve(), ALIASES, wallet auto-export
plugins/providers/blockrun/plugin.yaml     — metadata
plugins/providers/blockrun/provider.py     — x402 transport (sync+async), ClawRouter detection
plugins/providers/blockrun/tools.py        — 10 tools: wallet, images, prediction markets
plugins/providers/blockrun/SKILL.md        — full user-facing docs (323 lines)
tests/test_provider_plugins.py             — 12 infrastructure tests
tests/test_blockrun_plugin.py              — 37 unit + 14 live tests
```

### vs PR #3477

| | #3477 | This PR |
|---|---|---|
| Core files modified | 5 (.env, config, pyproject, runtime_provider, toolsets) | **2** (auth, runtime_provider) |
| Merge conflicts | 3 files | **None** |
| `hermes model` integration | No | **Yes** |
| Auto-detection | No | **Yes** (env var + session file) |
| ClawRouter support | No | **Yes** (auto-detect localhost:8402) |
| Architecture | Hardcoded in core | Self-contained plugin |
| Future providers | Must modify core | Just add `plugins/providers/<name>/` |

### Supported chains

| Chain | Gateway | Signing | Env var |
|-------|---------|---------|---------|
| Base (default) | blockrun.ai/api/v1 | EIP-712 | `BLOCKRUN_WALLET_KEY=0x...` |
| Solana | sol.blockrun.ai/api/v1 | Ed25519 | `SOLANA_WALLET_KEY=<base58>` |

### Dependencies

New optional deps (zero impact on existing installs — user runs `pip install blockrun-llm eth-account`):

```
blockrun-llm>=0.10.0   — SDK for x402 payments + wallet management
eth-account>=0.13.0    — EIP-712 signing for Base chain
solders>=0.21.0        — Ed25519 signing for Solana (optional)
```

## Test plan

- [x] 49 unit tests pass (12 infra + 37 plugin)
- [x] 14 live tests pass with real x402 USDC payments on Base mainnet
- [x] 4 model families tested live (NVIDIA, OpenAI, Anthropic, Google)
- [x] Streaming, tool calling, system prompts, multi-turn verified
- [x] ClawRouter routing profiles tested (`auto` → GLM-5.1, `free` → Nemotron-Ultra-253b)
- [x] Provider auto-detection from env var and `~/.blockrun/.session`
- [x] Alias resolution (`clawrouter`, `claw`, `x402` all → `blockrun`)
- [x] Image generation (GPT Image 1) and prediction markets (Polymarket) verified
- [x] On-chain tx evidence: [basescan.org/address/0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8](https://basescan.org/address/0xCC8c44AD3dc2A58D841c3EB26131E49b22665EF8)