### PR TITLE
fix: Correct label width and enable skin spinner config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2569,7 +2569,12 @@ class HermesCLI:
             except (ValueError, IndexError):
                 self._stream_text_ansi = ""
             w = shutil.get_terminal_size().columns
-            fill = w - 2 - len(label)
+            try:
+                from rich.cells import cell_len
+                label_width = cell_len(label)
+            except ImportError:
+                label_width = len(label)
+            fill = w - 2 - label_width
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
         self._stream_buf += text

--- a/run_agent.py
+++ b/run_agent.py
@@ -101,6 +101,7 @@ from agent.display import (
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
+    get_skin_faces, get_skin_verbs,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
@@ -6893,7 +6894,7 @@ class AIAgent:
         # Start spinner for CLI mode (skip when TUI handles tool progress)
         spinner = None
         if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-            face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+            face = random.choice(get_skin_faces("waiting_faces", KawaiiSpinner.KAWAII_WAITING))
             spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=self._print_fn)
             spinner.start()
 
@@ -7140,7 +7141,7 @@ class AIAgent:
                     spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_faces("waiting_faces", KawaiiSpinner.KAWAII_WAITING))
                     spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots', print_fn=self._print_fn)
                     spinner.start()
                 self._delegate_spinner = spinner
@@ -7167,7 +7168,7 @@ class AIAgent:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None
                 if self.quiet_mode and not self.tool_progress_callback:
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_faces("waiting_faces", KawaiiSpinner.KAWAII_WAITING))
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7191,7 +7192,7 @@ class AIAgent:
                 # These are not in the tool registry — route through MemoryManager.
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_faces("waiting_faces", KawaiiSpinner.KAWAII_WAITING))
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7213,7 +7214,7 @@ class AIAgent:
             elif self.quiet_mode:
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_faces("waiting_faces", KawaiiSpinner.KAWAII_WAITING))
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -8037,8 +8038,8 @@ class AIAgent:
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
                 # Animated thinking spinner in quiet mode
-                face = random.choice(KawaiiSpinner.KAWAII_THINKING)
-                verb = random.choice(KawaiiSpinner.THINKING_VERBS)
+                face = random.choice(get_skin_faces("thinking_faces", KawaiiSpinner.KAWAII_THINKING))
+                verb = random.choice(get_skin_verbs())
                 if self.thinking_callback:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     # (works in both streaming and non-streaming modes)


### PR DESCRIPTION
    ## Description
    This PR fixes two minor UI/Customization issues:

    1. **Fix response_label overflow in `cli.py`**:
       - **Issue**: Python's `len()` does not account for the display width of CJK characters and Emojis (e.g., "✨ Agent"). This causes the border line `──╮` to wrap to the next line.
       - **Fix**: Use `rich.cells.cell_len` to calculate the correct visual width.

    2. **Enable skin spinner customization in `run_agent.py`**:
       - **Issue**: The `skin_engine` supports custom `thinking_verbs` and `waiting_faces`, but `run_agent.py` hardcodes `KawaiiSpinner.KAWAII_*` and `THINKING_VERBS`. Skin configs are ignored.
       - **Fix**: Replace hardcoded constants with calls to `get_skin_faces()` and `get_skin_verbs()`.

    ## How to test
    1. Set `display.skin` in config.yaml to a custom skin with CJK/Emoji branding.
    2. Verify the response box header renders correctly without line wrapping.
    3. Verify spinner faces and verbs change according to the skin config.