### PR TITLE
fix(dump): latin-1 fallback for project .env

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -211,8 +211,13 @@ def run_dump(args):
             load_dotenv(env_path, encoding="utf-8")
         except UnicodeDecodeError:
             load_dotenv(env_path, encoding="latin-1")
-    # Also try project .env as dev fallback
-    load_dotenv(get_project_root() / ".env", override=False, encoding="utf-8")
+    # Also try project .env as dev fallback (Windows may save as cp1252)
+    _proj_env = get_project_root() / ".env"
+    if _proj_env.exists():
+        try:
+            load_dotenv(_proj_env, override=False, encoding="utf-8")
+        except UnicodeDecodeError:
+            load_dotenv(_proj_env, override=False, encoding="latin-1")
 
     project_root = get_project_root()
     hermes_home = get_hermes_home()


### PR DESCRIPTION
## Problem\n\hermes dump\ loads \~/.hermes/.env\ with a latin-1 fallback after UTF-8, but the repository root \.env\ was opened with UTF-8 only. On Windows, \.env\ files edited in Notepad are often cp1252; that could raise \UnicodeDecodeError\ and leave project keys out of the pasted support bundle.\n\n## Change\nMirror the same try/UTF-8 / except/latin-1 pattern for the project \.env\, only when the file exists.

Made with [Cursor](https://cursor.com)