### PR TITLE
fix(profile): read profile config.yaml as UTF-8

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -286,7 +286,7 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
     try:
         import yaml
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):


### PR DESCRIPTION
When listing or resolving profiles, model/provider are read from each profile config.yaml. Without explicit UTF-8, Windows used the ANSI code page and valid UTF-8 files could fail parsing; the code then returned (None, None) and the UI showed no model despite a correct config.

Made with [Cursor](https://cursor.com)