### PR TITLE
fix(install): set .env file permissions to 600 to protect secrets

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1009,6 +1009,8 @@ copy_config_templates() {
             touch "$HERMES_HOME/.env"
             log_success "Created ~/.hermes/.env"
         fi
+        # .env contains API keys and tokens — restrict to owner-only access
+        chmod 600 "$HERMES_HOME/.env"
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi


### PR DESCRIPTION
## Summary

- The install script creates `~/.hermes/.env` without setting restrictive file permissions
- On most systems the default umask (022) results in mode 644, making API keys, bot tokens, and other secrets readable by all local users on the system
- Add `chmod 600` after `.env` creation so only the owner can read it

## Changes

- `scripts/install.sh`: Add `chmod 600 "$HERMES_HOME/.env"` after file creation (+2 lines)

## Test plan

- [ ] Fresh install: verify `~/.hermes/.env` is created with mode 600
- [ ] Existing install (`.env` already exists): verify the file is not touched (existing permissions preserved)
- [ ] Verify `.env` contents are still readable by the Hermes process (same user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)