### PR TITLE
fix(memory): read plugin.yaml as UTF-8 in memory setup

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -67,7 +67,7 @@ def _install_dependencies(provider_name: str) -> None:
 
     try:
         import yaml
-        with open(yaml_path) as f:
+        with open(yaml_path, encoding="utf-8") as f:
             meta = yaml.safe_load(f) or {}
     except Exception:
         return


### PR DESCRIPTION
Memory setup loads plugins/memory/<provider>/plugin.yaml to read pip_dependencies. The reader used the process default encoding; on Windows, valid UTF-8 YAML (e.g. non-ASCII description text) could fail parsing. The failure was swallowed, so users might not get pip install guidance when dependencies were missing.

Made with [Cursor](https://cursor.com)