### PR TITLE
fix(cron): read config.yaml as UTF-8 in job subprocess

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -630,7 +630,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):


### PR DESCRIPTION
Scheduled jobs spawn with a loader that reads config.yaml for model, reasoning, prefill paths, etc. The file was opened without an encoding, so on Windows the active ANSI code page could break valid UTF-8 YAML and trigger the existing warning path with empty _cfg.

Made with [Cursor](https://cursor.com)