### PR TITLE
fix(scripts): read Hermes config.yaml as UTF-8 in discord-voice-doctor

### DIFF
--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -239,7 +239,7 @@ def check_config(groq_key, eleven_key):
     if config_path.exists():
         try:
             import yaml
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
 
             stt_provider = cfg.get("stt", {}).get("provider", "local")


### PR DESCRIPTION
The doctor script reads ~/.hermes/config.yaml for STT/TTS provider settings. Opening without encoding uses the process default on Windows and can mis-read valid UTF-8 YAML.

Made with [Cursor](https://cursor.com)