### PR TITLE
fix(time): read timezone from config.yaml as UTF-8

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -50,7 +50,7 @@ def _resolve_timezone_name() -> str:
         import yaml
         config_path = get_config_path()
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             tz_cfg = cfg.get("timezone", "")
             if isinstance(tz_cfg, str) and tz_cfg.strip():


### PR DESCRIPTION
hermes_time falls back to config.yaml for HERMES_TIMEZONE. The file was opened without encoding, so on Windows valid UTF-8 YAML could fail to parse and the configured timezone would be ignored.

Made with [Cursor](https://cursor.com)