### PR TITLE
fix(plugins): read plugin.yaml as UTF-8 in manifest scanner

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -346,7 +346,7 @@ class PluginManager:
                 if yaml is None:
                     logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                     continue
-                data = yaml.safe_load(manifest_file.read_text()) or {}
+                data = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
                 manifest = PluginManifest(
                     name=data.get("name", child.name),
                     version=str(data.get("version", "")),


### PR DESCRIPTION
Plugin discovery uses Path.read_text() on plugin.yaml without encoding, which follows the platform default on Windows. UTF-8 manifests with non-ASCII descriptions then fail yaml.safe_load and are skipped with a warning.

Made with [Cursor](https://cursor.com)