### PR TITLE
fix: smart_model_routing silently overrides session-scoped /model switch

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -107,12 +107,23 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     return route
 
 
-def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_turn_route(
+    user_message: str,
+    routing_config: Optional[Dict[str, Any]],
+    primary: Dict[str, Any],
+    *,
+    session_override_active: bool = False,
+) -> Dict[str, Any]:
     """Resolve the effective model/runtime for one turn.
 
     Returns a dict with model/runtime/signature/label fields.
+
+    When *session_override_active* is ``True`` the user has explicitly
+    switched model/provider via ``/model``.  In that case cheap-model
+    routing is skipped so the session override is honoured for every
+    turn, regardless of message complexity heuristics.
     """
-    route = choose_cheap_model_route(user_message, routing_config)
+    route = None if session_override_active else choose_cheap_model_route(user_message, routing_config)
     if not route:
         return {
             "model": primary.get("model"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -876,9 +876,15 @@ class GatewayRunner:
             )
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self, user_message: str, model: str, runtime_kwargs: dict, *, session_key: str | None = None,
+    ) -> dict:
         from agent.smart_model_routing import resolve_turn_route
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        session_override_active = bool(
+            session_key and self._session_model_overrides.get(session_key)
+        )
 
         primary = {
             "model": model,
@@ -890,7 +896,12 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
-        route = resolve_turn_route(user_message, getattr(self, "_smart_model_routing", {}), primary)
+        route = resolve_turn_route(
+            user_message,
+            getattr(self, "_smart_model_routing", {}),
+            primary,
+            session_override_active=session_override_active,
+        )
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
@@ -5220,7 +5231,8 @@ class GatewayRunner:
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            _bg_session_key = self._session_key_for_source(source) if source else None
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs, session_key=_bg_session_key)
 
             def run_sync():
                 agent = AIAgent(
@@ -5386,7 +5398,7 @@ class GatewayRunner:
             platform_key = _platform_config_key(source.platform)
             reasoning_config = self._load_reasoning_config()
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs, session_key=session_key)
             pr = self._provider_routing
 
             # Snapshot history from running agent or stored transcript
@@ -7605,7 +7617,7 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs, session_key=session_key)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -59,3 +59,26 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+def test_resolve_turn_route_skips_cheap_model_when_session_override_active():
+    """When a session override is active, smart routing must not replace the primary model."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    primary = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "api_key": "sk-session",
+    }
+    # "hi" is a trivially simple message that would normally trigger cheap routing
+    result = resolve_turn_route(
+        "hi",
+        _BASE_CONFIG,
+        primary,
+        session_override_active=True,
+    )
+    assert result["model"] == "gpt-5.4"
+    assert result["runtime"]["provider"] == "openai-codex"
+    assert result["label"] is None

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -123,6 +123,59 @@ def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     assert _CapturingAgent.last_init["api_key"] == "***"
 
 
+def test_smart_routing_skipped_when_session_override_active(monkeypatch):
+    """smart_model_routing must not replace a /model session override with the cheap model."""
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _explode_runtime_resolution)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    _CapturingAgent.last_init = None
+    runner = _make_runner()
+
+    # Enable smart routing with a cheap model that would match a simple message
+    runner._smart_model_routing = {
+        "enabled": True,
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+        "cheap_model": {
+            "provider": "openrouter",
+            "model": "openai/gpt-4o-mini",
+        },
+    }
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_name="CLI",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    session_key = "agent:main:local:dm"
+    runner._session_model_overrides[session_key] = _codex_override()
+
+    # "hi" is a short, simple message that smart routing would normally reroute
+    result = asyncio.run(
+        runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+        )
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    # Session override must win over smart routing
+    assert _CapturingAgent.last_init["model"] == "gpt-5.4"
+    assert _CapturingAgent.last_init["provider"] == "openai-codex"
+
+
 @pytest.mark.asyncio
 async def test_background_task_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})


### PR DESCRIPTION
## Summary

`smart_model_routing` unconditionally evaluates the cheap-model heuristic on every turn, even when the user has explicitly switched model/provider via `/model`. This silently replaces the user's chosen model with the configured cheap model for short or simple messages.

- Pass `session_override_active` flag to `resolve_turn_route()` to skip cheap-model routing when a `/model` session override is active
- Wire `session_key` through `_resolve_turn_agent_config()` at all three call sites (`_run_agent`, `_run_background_task`, `_run_btw_task`)
- Regression tests at both unit and integration layers

Fixes #8462

## Bug Description

After PR #7662 correctly wired session overrides into agent construction, there is a remaining gap: the `smart_model_routing` layer runs *after* the session override is applied and can silently undo it.

### Evidence Chain

1. **`/model` stores override** — `gateway/run.py:4396` stores `{model, provider, api_key, base_url, api_mode}` in `_session_model_overrides[session_key]`
2. **`_resolve_session_agent_runtime()` applies it** — `gateway/run.py:860-876` correctly resolves the session override into `model` and `runtime_kwargs`
3. **`_resolve_turn_agent_config()` passes it to smart routing** — `gateway/run.py:893` calls `resolve_turn_route(user_message, routing_config, primary)` with no indication that a session override is active
4. **`resolve_turn_route()` unconditionally checks `choose_cheap_model_route()`** — `smart_model_routing.py:115` evaluates the cheap-model heuristic regardless of whether the model was explicitly chosen by the user
5. **For short/simple messages, the session override is silently replaced** — `smart_model_routing.py:176` returns `route.get("model")` (the cheap model) instead of the user's chosen model

### `smart_model_routing.py` has zero awareness of session overrides

```python
# smart_model_routing.py:110 — no session_override parameter exists (before this PR)
def resolve_turn_route(user_message, routing_config, primary):
    route = choose_cheap_model_route(user_message, routing_config)  # line 115
    # If message is "simple", route replaces primary.model
```

## Steps to Reproduce

```yaml
# ~/.hermes/config.yaml
model:
  default: anthropic/claude-sonnet-4.6
  provider: openrouter

smart_model_routing:
  enabled: true
  cheap_model:
    provider: openrouter
    model: openai/gpt-4o-mini
```

1. `hermes chat`
2. `/model gpt-5.4 --provider openai-codex`
3. Send a short message: `hi`
4. **Expected**: Request goes to `gpt-5.4` on `openai-codex` (the explicitly chosen model)
5. **Actual**: Request goes to `gpt-4o-mini` on `openrouter` (the cheap model from smart routing)

The same issue affects `/background` and `/btw` tasks.

## Fix

- Added `session_override_active: bool = False` keyword argument to `resolve_turn_route()`
- When `True`, `choose_cheap_model_route()` is skipped entirely — the primary (session-overridden) model is returned as-is
- `_resolve_turn_agent_config()` now accepts an optional `session_key` and checks `_session_model_overrides` to set the flag
- All three call sites (`_run_agent`, `_run_background_task`, `_run_btw_task`) pass their session key

## Test Plan

- [x] New unit test: `test_resolve_turn_route_skips_cheap_model_when_session_override_active` — verifies `resolve_turn_route()` preserves primary model when flag is set
- [x] New integration test: `test_smart_routing_skipped_when_session_override_active` — verifies full `_run_agent` path with smart routing enabled + session override active, asserts cheap model is NOT used
- [x] Existing tests still pass: `test_run_agent_prefers_session_override_over_global_runtime`, `test_background_task_prefers_session_override_over_global_runtime`
- [x] All `test_smart_model_routing.py` tests pass (7/7)

## Related Issues

- #7662 — `fix: honor session-scoped gateway model overrides` (merged) — fixed agent construction paths but missed the smart routing layer
- #7798 — `smart_model_routing triggers preflight compression against the cheap model's threshold` — related symptom where smart routing causes compression issues; this PR prevents the routing from happening at all when a session override is active, which also prevents that compression scenario for those users
- #4568 — CLI status bar shows stale model during smart routing (same category of smart-routing-mutates-state bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)