### PR TITLE
fix(hindsight): use descriptive context and stable document_id in sync_turn

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -411,12 +411,21 @@ class HindsightMemoryProvider(MemoryProvider):
         """Retain conversation turn in background (non-blocking)."""
         combined = f"User: {user_content}\nAssistant: {assistant_content}"
 
+        # Per Hindsight best practices: set a descriptive context (not just
+        # "conversation") and use a stable document_id keyed to the session
+        # so repeated retains upsert instead of creating duplicates.
+        context = f"Conversation turn in session {session_id}" if session_id else "Conversation turn"
+        doc_id = f"session-{session_id}" if session_id else None
+
         def _sync():
             try:
                 client = self._get_client()
-                _run_sync(client.aretain(
-                    bank_id=self._bank_id, content=combined, context="conversation"
-                ))
+                retain_kwargs = dict(
+                    bank_id=self._bank_id, content=combined, context=context
+                )
+                if doc_id:
+                    retain_kwargs["document_id"] = doc_id
+                _run_sync(client.aretain(**retain_kwargs))
             except Exception as e:
                 logger.warning("Hindsight sync failed: %s", e)
 


### PR DESCRIPTION
## Summary
- `sync_turn()` now passes a descriptive `context` field (includes session_id) instead of the generic `"conversation"` string
- Uses a stable `document_id` keyed to `session-{session_id}` so repeated retains upsert instead of creating duplicate documents

## Why
Per [Hindsight best practices](https://hindsight.vectorize.io/best-practices):
- **Context field**: *"High-impact on extraction quality. Always set it."* — the generic `"conversation"` provides no signal to the extraction LLM
- **document_id**: *"Always use the same ID for growing conversations. Do NOT use random UUIDs per retain call; this creates duplicates."* — without `document_id`, every turn creates a new document, leading to 100+ near-duplicate memories per session

## Test plan
- [x] Verified `aretain` accepts `document_id` kwarg (hindsight-client SDK)
- [ ] Run with active Hindsight instance, confirm single document per session in bank
- [ ] Verify no `invalid JSON` regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)