### PR TITLE
fix(plugins): read memory plugin.yaml as UTF-8

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -53,7 +53,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         if yaml_file.exists():
             try:
                 import yaml
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     meta = yaml.safe_load(f) or {}
                 desc = meta.get("description", "")
             except Exception:
@@ -291,7 +291,7 @@ def discover_plugin_cli_commands() -> List[dict]:
         if yaml_file.exists():
             try:
                 import yaml
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     meta = yaml.safe_load(f) or {}
                 desc = meta.get("description", "")
                 if desc:


### PR DESCRIPTION
Memory provider discovery reads each provider's \plugin.yaml\ for descriptions (two call sites). Both used the process default text encoding; on Windows, valid UTF-8 YAML with non-ASCII text could fail inside broad \except\ handlers and hide descriptions.