### PR TITLE
fix(tools): UTF-8 for Skills Hub audit log and lock seed

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2468,7 +2468,10 @@ def ensure_hub_dirs() -> None:
     QUARANTINE_DIR.mkdir(exist_ok=True)
     INDEX_CACHE_DIR.mkdir(exist_ok=True)
     if not LOCK_FILE.exists():
-        LOCK_FILE.write_text('{"version": 1, "installed": {}}\n')
+        LOCK_FILE.write_text(
+            '{"version": 1, "installed": {}}\n',
+            encoding="utf-8",
+        )
     if not AUDIT_LOG.exists():
         AUDIT_LOG.touch()
     if not TAPS_FILE.exists():


### PR DESCRIPTION
\ppend_audit_log\ appended to the audit file without an encoding; non-ASCII text in audit lines could fail on Windows. Initial \LOCK_FILE.write_text\ now uses UTF-8 for consistency with the rest of the hub JSON on disk.

Made with [Cursor](https://cursor.com)