### PR TITLE
fix(scripts): read gateway_voice_mode.json as UTF-8

### DIFF
--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -265,7 +265,7 @@ def check_config(groq_key, eleven_key):
     if voice_mode_path.exists():
         try:
             import json
-            modes = json.loads(voice_mode_path.read_text())
+            modes = json.loads(voice_mode_path.read_text(encoding="utf-8"))
             off_count = sum(1 for v in modes.values() if v == "off")
             all_count = sum(1 for v in modes.values() if v == "all")
             check("Voice mode state", True, f"{all_count} on, {off_count} off, {len(modes)} total")


### PR DESCRIPTION
discord-voice-doctor loads gateway_voice_mode.json. Use read_text(encoding=utf-8) so Windows default code page does not mis-read UTF-8 JSON.

Made with [Cursor](https://cursor.com)