### PR TITLE
fix(gateway): serialize reset command handoff

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -744,10 +744,13 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_retryable = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
         
-        # Track active message handlers per session for interrupt support
-        # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
+        # Track active message handlers per session for interrupt support.
+        # _active_sessions stores the per-session interrupt Event, while
+        # _session_tasks keeps the task currently processing that session so
+        # reset-like commands can cancel it immediately.
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
+        self._session_tasks: Dict[str, asyncio.Task] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -1462,6 +1465,8 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
+                    if cmd in ("stop", "new", "reset"):
+                        await self.cancel_session_processing(session_key)
                     _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
                     response = await self._message_handler(event)
                     if response:
@@ -1506,11 +1511,13 @@ class BasePlatformAdapter(ABC):
 
         # Spawn background task to process this message
         task = asyncio.create_task(self._process_message_background(event, session_key))
+        self._session_tasks[session_key] = task
         try:
             self._background_tasks.add(task)
         except TypeError:
             # Some tests stub create_task() with lightweight sentinels that are not
             # hashable and do not support lifecycle callbacks.
+            self._session_tasks.pop(session_key, None)
             return
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
@@ -1808,7 +1815,31 @@ class BasePlatformAdapter(ABC):
             # Clean up session tracking
             if session_key in self._active_sessions:
                 del self._active_sessions[session_key]
-    
+            current_task = asyncio.current_task()
+            if current_task is not None and self._session_tasks.get(session_key) is current_task:
+                del self._session_tasks[session_key]
+
+    async def cancel_session_processing(self, session_key: str) -> None:
+        """Cancel in-flight processing for a single session and release its guard."""
+        task = self._session_tasks.pop(session_key, None)
+        if task is not None and not task.done():
+            logger.debug("[%s] Cancelling active processing for session %s", self.name, session_key)
+            self._expected_cancelled_tasks.add(task)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "[%s] Session cancellation raised while unwinding %s",
+                    self.name,
+                    session_key,
+                    exc_info=True,
+                )
+        self._pending_messages.pop(session_key, None)
+        self._active_sessions.pop(session_key, None)
+
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.
 
@@ -1823,6 +1854,7 @@ class BasePlatformAdapter(ABC):
             await asyncio.gather(*tasks, return_exceptions=True)
         self._background_tasks.clear()
         self._expected_cancelled_tasks.clear()
+        self._session_tasks.clear()
         self._pending_messages.clear()
         self._active_sessions.clear()
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1429,6 +1429,107 @@ class BasePlatformAdapter(ABC):
             return f"{existing_text}\n\n{new_text}".strip()
         return existing_text
 
+    def _release_session_guard(
+        self,
+        session_key: str,
+        *,
+        guard: Optional[asyncio.Event] = None,
+    ) -> None:
+        """Release the adapter-level guard for a session.
+
+        When ``guard`` is provided, only release the entry if it still points
+        at that exact Event. This lets reset-like commands swap in a temporary
+        guard while the old processing task unwinds, without having the old
+        task's cleanup accidentally clear the replacement guard.
+        """
+        current_guard = self._active_sessions.get(session_key)
+        if current_guard is None:
+            return
+        if guard is not None and current_guard is not guard:
+            return
+        del self._active_sessions[session_key]
+
+    def _start_session_processing(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        interrupt_event: Optional[asyncio.Event] = None,
+    ) -> bool:
+        """Spawn a background processing task under the given session guard."""
+        guard = interrupt_event or asyncio.Event()
+        self._active_sessions[session_key] = guard
+
+        task = asyncio.create_task(self._process_message_background(event, session_key))
+        self._session_tasks[session_key] = task
+        try:
+            self._background_tasks.add(task)
+        except TypeError:
+            # Some tests stub create_task() with lightweight sentinels that are
+            # not hashable and do not support lifecycle callbacks.
+            self._session_tasks.pop(session_key, None)
+            self._release_session_guard(session_key, guard=guard)
+            return False
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(self._expected_cancelled_tasks.discard)
+        return True
+
+    async def _drain_pending_after_session_command(
+        self,
+        session_key: str,
+        command_guard: asyncio.Event,
+    ) -> None:
+        """Resume the latest queued follow-up once a session command completes."""
+        pending_event = self._pending_messages.pop(session_key, None)
+        self._release_session_guard(session_key, guard=command_guard)
+        if pending_event is None:
+            return
+        self._start_session_processing(pending_event, session_key)
+
+    async def _dispatch_active_session_command(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        cmd: str,
+    ) -> None:
+        """Dispatch a reset-like bypass command while preserving guard ordering."""
+        logger.debug(
+            "[%s] Command '/%s' bypassing active-session guard for %s",
+            self.name,
+            cmd,
+            session_key,
+        )
+
+        current_guard = self._active_sessions.get(session_key)
+        command_guard = asyncio.Event()
+        self._active_sessions[session_key] = command_guard
+        thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+
+        try:
+            response = await self._message_handler(event)
+            await self.cancel_session_processing(
+                session_key,
+                release_guard=False,
+                discard_pending=False,
+            )
+            if response:
+                await self._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=response,
+                    reply_to=event.message_id,
+                    metadata=thread_meta,
+                )
+        except Exception:
+            if self._active_sessions.get(session_key) is command_guard:
+                if session_key in self._session_tasks and current_guard is not None:
+                    self._active_sessions[session_key] = current_guard
+                else:
+                    self._release_session_guard(session_key, guard=command_guard)
+            raise
+
+        await self._drain_pending_after_session_command(session_key, command_guard)
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
@@ -1460,22 +1561,25 @@ class BasePlatformAdapter(ABC):
             # (see PR #4926).
             cmd = event.get_command()
             if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
-                logger.debug(
-                    "[%s] Command '/%s' bypassing active-session guard for %s",
-                    self.name, cmd, session_key,
-                )
                 try:
                     if cmd in ("stop", "new", "reset"):
-                        await self.cancel_session_processing(session_key)
-                    _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-                    response = await self._message_handler(event)
-                    if response:
-                        await self._send_with_retry(
-                            chat_id=event.source.chat_id,
-                            content=response,
-                            reply_to=event.message_id,
-                            metadata=_thread_meta,
+                        await self._dispatch_active_session_command(event, session_key, cmd)
+                    else:
+                        logger.debug(
+                            "[%s] Command '/%s' bypassing active-session guard for %s",
+                            self.name,
+                            cmd,
+                            session_key,
                         )
+                        _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                        response = await self._message_handler(event)
+                        if response:
+                            await self._send_with_retry(
+                                chat_id=event.source.chat_id,
+                                content=response,
+                                reply_to=event.message_id,
+                                metadata=_thread_meta,
+                            )
                 except Exception as e:
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
                 return
@@ -1507,21 +1611,7 @@ class BasePlatformAdapter(ABC):
         # starts would also pass the _active_sessions check and spawn a
         # duplicate task.  (grammY sequentialize / aiogram EventIsolation
         # pattern — set the guard synchronously, not inside the task.)
-        self._active_sessions[session_key] = asyncio.Event()
-
-        # Spawn background task to process this message
-        task = asyncio.create_task(self._process_message_background(event, session_key))
-        self._session_tasks[session_key] = task
-        try:
-            self._background_tasks.add(task)
-        except TypeError:
-            # Some tests stub create_task() with lightweight sentinels that are not
-            # hashable and do not support lifecycle callbacks.
-            self._session_tasks.pop(session_key, None)
-            return
-        if hasattr(task, "add_done_callback"):
-            task.add_done_callback(self._background_tasks.discard)
-            task.add_done_callback(self._expected_cancelled_tasks.discard)
+        self._start_session_processing(event, session_key)
     
     @staticmethod
     def _get_human_delay() -> float:
@@ -1757,12 +1847,14 @@ class BasePlatformAdapter(ABC):
             )
 
             # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
+            if (
+                session_key in self._pending_messages
+                and self._active_sessions.get(session_key) is interrupt_event
+            ):
                 pending_event = self._pending_messages.pop(session_key)
                 logger.debug("[%s] Processing queued message from interrupt", self.name)
                 # Clean up current session before processing pending
-                if session_key in self._active_sessions:
-                    del self._active_sessions[session_key]
+                self._release_session_guard(session_key, guard=interrupt_event)
                 typing_task.cancel()
                 try:
                     await typing_task
@@ -1813,14 +1905,24 @@ class BasePlatformAdapter(ABC):
             except Exception:
                 pass
             # Clean up session tracking
-            if session_key in self._active_sessions:
-                del self._active_sessions[session_key]
+            self._release_session_guard(session_key, guard=interrupt_event)
             current_task = asyncio.current_task()
             if current_task is not None and self._session_tasks.get(session_key) is current_task:
                 del self._session_tasks[session_key]
 
-    async def cancel_session_processing(self, session_key: str) -> None:
-        """Cancel in-flight processing for a single session and release its guard."""
+    async def cancel_session_processing(
+        self,
+        session_key: str,
+        *,
+        release_guard: bool = True,
+        discard_pending: bool = True,
+    ) -> None:
+        """Cancel in-flight processing for a single session.
+
+        ``release_guard=False`` keeps the adapter-level session guard in place
+        so reset-like commands can finish atomically before follow-up messages
+        are allowed to start a fresh background task.
+        """
         task = self._session_tasks.pop(session_key, None)
         if task is not None and not task.done():
             logger.debug("[%s] Cancelling active processing for session %s", self.name, session_key)
@@ -1837,8 +1939,10 @@ class BasePlatformAdapter(ABC):
                     session_key,
                     exc_info=True,
                 )
-        self._pending_messages.pop(session_key, None)
-        self._active_sessions.pop(session_key, None)
+        if discard_pending:
+            self._pending_messages.pop(session_key, None)
+        if release_guard:
+            self._release_session_guard(session_key)
 
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -190,10 +190,10 @@ class TestCommandBypassActiveSession:
         command_text,
         expected_command,
     ):
-        """Session-terminating commands must cancel the active task before bypassing.
+        """Session-terminating commands must cancel the active task after dispatch.
 
         Without this, the adapter-level session guard can survive a /new or /stop,
-        causing the next /model or plain-text message to queue behind a stale task.
+        causing the next /model or plain-text message to queue behind stale work.
         """
         adapter = _make_adapter()
         sk = _session_key()
@@ -245,6 +245,68 @@ class TestCommandBypassActiveSession:
         assert any("handled:model" in r for r in adapter.sent_responses), (
             f"follow-up /model stayed blocked after {command_text}"
         )
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_new_keeps_guard_until_command_finishes_and_then_runs_follow_up(self):
+        """/new must finish runner logic before cancelling old work or releasing the guard."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        processing_started = asyncio.Event()
+        command_started = asyncio.Event()
+        allow_command_finish = asyncio.Event()
+        follow_up_processed = asyncio.Event()
+        call_order = []
+
+        async def _handler(event):
+            cmd = event.get_command()
+            if cmd == "new":
+                call_order.append("command:start")
+                command_started.set()
+                await allow_command_finish.wait()
+                call_order.append("command:end")
+                return "handled:new"
+
+            if event.text == "hello world":
+                processing_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    call_order.append("original:cancelled")
+                    raise
+
+            if event.text == "after reset":
+                call_order.append("followup:processed")
+                follow_up_processed.set()
+            return f"handled:text:{event.text}"
+
+        adapter._message_handler = _handler
+
+        await adapter.handle_message(_make_event("hello world"))
+        await processing_started.wait()
+
+        command_task = asyncio.create_task(adapter.handle_message(_make_event("/new")))
+        await command_started.wait()
+        await asyncio.sleep(0)
+
+        assert sk in adapter._active_sessions
+
+        await adapter.handle_message(_make_event("after reset"))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert sk in adapter._active_sessions, "guard must stay active while /new is still running"
+        assert sk in adapter._pending_messages, "follow-up should stay queued until /new finishes"
+        assert not follow_up_processed.is_set(), "follow-up ran before /new completed"
+        assert "original:cancelled" not in call_order, "old task was cancelled before runner completed /new"
+
+        allow_command_finish.set()
+        await command_task
+        await asyncio.wait_for(follow_up_processed.wait(), timeout=1.0)
+
+        assert any("handled:new" in r for r in adapter.sent_responses)
+        assert call_order.index("command:end") < call_order.index("original:cancelled")
+        assert call_order.index("original:cancelled") < call_order.index("followup:processed")
         assert sk not in adapter._pending_messages
 
 

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -176,6 +176,77 @@ class TestCommandBypassActiveSession:
             "/background response was not sent back to the user"
         )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command_text", "expected_command"),
+        [
+            ("/stop", "stop"),
+            ("/new", "new"),
+            ("/reset", "reset"),
+        ],
+    )
+    async def test_reset_like_command_cancels_active_session_and_unblocks_follow_up(
+        self,
+        command_text,
+        expected_command,
+    ):
+        """Session-terminating commands must cancel the active task before bypassing.
+
+        Without this, the adapter-level session guard can survive a /new or /stop,
+        causing the next /model or plain-text message to queue behind a stale task.
+        """
+        adapter = _make_adapter()
+        sk = _session_key()
+        processing_started = asyncio.Event()
+        processing_cancelled = asyncio.Event()
+        blocked_first_message = True
+
+        async def _handler(event):
+            nonlocal blocked_first_message
+            cmd = event.get_command()
+            if cmd in {"stop", "new", "reset", "model"}:
+                return f"handled:{cmd}"
+
+            if blocked_first_message:
+                blocked_first_message = False
+                processing_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    processing_cancelled.set()
+                    raise
+            return f"handled:text:{event.text}"
+
+        adapter._message_handler = _handler
+
+        await adapter.handle_message(_make_event("hello world"))
+        await processing_started.wait()
+        await asyncio.sleep(0)
+
+        assert sk in adapter._active_sessions
+        assert sk in adapter._session_tasks
+
+        await adapter.handle_message(_make_event(command_text))
+
+        assert processing_cancelled.is_set(), (
+            f"{command_text} did not cancel the active processing task"
+        )
+        assert sk not in adapter._active_sessions
+        assert sk not in adapter._pending_messages
+        assert sk not in adapter._session_tasks
+        assert any(f"handled:{expected_command}" in r for r in adapter.sent_responses)
+
+        await adapter.handle_message(
+            _make_event("/model xiaomi/mimo-v2-pro --provider nous")
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert any("handled:model" in r for r in adapter.sent_responses), (
+            f"follow-up /model stayed blocked after {command_text}"
+        )
+        assert sk not in adapter._pending_messages
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued


### PR DESCRIPTION
Why
- /new and /reset can clear runner state while the adapter still holds an active-session guard for stale work. That leaves follow-up /model messages blocked behind the old task until the gateway is restarted.
- Releasing the adapter guard too early also lets follow-up messages race with the reset command itself, so session reset and queued follow-ups can interleave in the wrong order.

How
- Track the active adapter task per session and add targeted cancellation/release helpers for reset-like commands.
- Keep a temporary command guard in place while /stop, /new, or /reset finishes, then drain the latest queued follow-up only after the old task is cancelled and the command response has been sent.
- Add regression coverage for busy-session reset handoff and queued follow-ups after /new.

Tests
- `source venv/bin/activate && pytest tests/gateway/test_command_bypass_active_session.py tests/gateway/test_session_model_reset.py tests/gateway/test_gateway_shutdown.py` (31 passed)
- Confirmed separately that `tests/gateway/test_session_race_guard.py` already fails on the current upstream baseline, so it is not treated as a regression from this branch.