### PR TITLE
fix: add git to Dockerfile for npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## Summary

- Add `git` to apt-get install in Dockerfile to fix npm install failures when dependencies are pulled from git

## Fix

Docker builds fail because `git` is not installed in the container. npm tries to install packages from git but fails with `ENOENT git` error.

This PR adds `git` to the list of system dependencies in the Dockerfile.

## Testing

Build the Docker image with `docker build` or `docker compose build`