### PR TITLE
feat: add qwen/qwen3.6-plus (paid tier) to model catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -256,6 +256,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
+        "qwen/qwen3.6-plus",
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",


### PR DESCRIPTION
Adds the paid `qwen/qwen3.6-plus` model (1M context, thinking support) to the KiloCode provider catalog.\n\nCloses #6601