### PR TITLE
fix: Ctrl+D deletes char under cursor, only exits on empty input (bash/zsh behaviour)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8531,9 +8531,15 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Ctrl+D: delete char under cursor (standard readline behaviour).
+            Only exit when the input is empty — same as bash/zsh.
+            """
+            buf = event.app.current_buffer
+            if buf.text:
+                buf.delete()
+            else:
+                self._should_exit = True
+                event.app.exit()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):


### PR DESCRIPTION
In bash/zsh, Ctrl+D deletes the character under the cursor when there is text in the buffer, and only sends EOF when the buffer is empty. Hermes now matches this behavior.

Closes #8478