### PR TITLE
feat: double ESC clears the input buffer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8329,6 +8329,20 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        @kb.add('escape', 'escape')
+        def handle_double_escape(event):
+            """Double ESC: clear the input buffer and any attached images.
+
+            Press ESC twice quickly to discard the current draft.
+            Single ESC is the prefix for Alt key sequences (escape+enter,
+            escape+up, escape+v etc.) so the double-press avoids conflicts.
+            """
+            buf = event.app.current_buffer
+            if buf.text or cli_ref._attached_images:
+                buf.reset()
+                cli_ref._attached_images.clear()
+                event.app.invalidate()
+
         @kb.add('c-j')
         def handle_ctrl_enter(event):
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""


### PR DESCRIPTION
Pressing **Escape** twice quickly clears the input buffer and detaches any attached images.

A single Escape still dismisses completions/suggestions without clearing.

Closes #5510