### PR TITLE
feat: Alt+Enter queues follow-up messages, Alt+Up recalls them

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1806,6 +1806,7 @@ class HermesCLI:
         self._agent_running = False
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
+        self._followup_queue: list = []  # mirror of _pending_input for display (Alt+Enter queued messages)
         self._should_exit = False
         self._last_ctrl_c_time = 0
         self._clarify_state = None
@@ -2117,6 +2118,11 @@ class HermesCLI:
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
                     ]
+
+            # Follow-up queue indicator
+            if self._followup_queue:
+                frags.append(("class:status-bar-dim", " │ "))
+                frags.append(("class:status-bar-warn", f"📬 {len(self._followup_queue)}"))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
@@ -8326,12 +8332,40 @@ class HermesCLI:
         
         @kb.add('escape', 'enter')
         def handle_alt_enter(event):
-            """Alt+Enter inserts a newline for multi-line input."""
-            event.current_buffer.insert_text('\n')
+            """Alt+Enter: queue message as follow-up (sent after current response).
+
+            When agent is idle, behaves like Enter (sends immediately to _pending_input).
+            When agent is running, queues without interrupting — sent as the next turn.
+            _followup_queue mirrors what's pending for status display.
+            Use Ctrl+J / Ctrl+Enter for inserting a newline in multi-line input.
+            """
+            if cli_ref._sudo_state or cli_ref._secret_state or cli_ref._clarify_state or cli_ref._approval_state:
+                return
+
+            text = event.app.current_buffer.text.strip()
+            has_images = bool(cli_ref._attached_images)
+            if not text and not has_images:
+                return
+
+            images = list(cli_ref._attached_images)
+            cli_ref._attached_images.clear()
+            payload = (text, images) if images else text
+
+            cli_ref._pending_input.put(payload)
+            cli_ref._followup_queue.append(payload)
+            event.app.current_buffer.reset(append_to_history=True)
+
+            queue_depth = len(cli_ref._followup_queue)
+            preview = text[:60] + ("..." if len(text) > 60 else "")
+            if cli_ref._agent_running:
+                _cprint(f"  {_DIM}📬 Queued follow-up #{queue_depth}: \"{preview}\"{_RST}")
+            else:
+                _cprint(f"  {_DIM}📬 Queued: \"{preview}\"{_RST}")
+            event.app.invalidate()
 
         @kb.add('c-j')
         def handle_ctrl_enter(event):
-            """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
+            """Ctrl+J (Ctrl+Enter in most terminals): insert a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
         @kb.add('tab', eager=True)
@@ -8843,7 +8877,13 @@ class HermesCLI:
                 status = cli_ref._command_status or "Processing command..."
                 return f"{frame} {status}"
             if cli_ref._agent_running:
-                return "type a message + Enter to interrupt, Ctrl+C to cancel"
+                hints = []
+                if cli_ref._followup_queue:
+                    hints.append(f"📬 {len(cli_ref._followup_queue)} queued")
+                suffix = "  · " + " · ".join(hints) if hints else ""
+                return f"Enter to interrupt · Alt+Enter to queue follow-up{suffix}"
+            if cli_ref._followup_queue:
+                return f"📬 {len(cli_ref._followup_queue)} follow-up{'s' if len(cli_ref._followup_queue) > 1 else ''} queued — Alt+Enter to add more"
             if cli_ref._voice_mode:
                 return "type or Ctrl+B to record"
             return ""
@@ -9391,6 +9431,10 @@ class HermesCLI:
                     # Check for pending input with timeout
                     try:
                         user_input = self._pending_input.get(timeout=0.1)
+                        # Keep _followup_queue in sync — pop the oldest entry if present
+                        if self._followup_queue:
+                            self._followup_queue.pop(0)
+                            app.invalidate()
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:

--- a/cli.py
+++ b/cli.py
@@ -1808,6 +1808,7 @@ class HermesCLI:
         self._interrupt_queue = queue.Queue()
         self._followup_queue: list = []  # mirror of _pending_input for display (Alt+Enter queued messages)
         self._cancelled_followups: set = set()  # texts recalled via Alt+Up, skipped in process_loop
+        self._followup_recall_count: int = 0   # how many recalls done in this recall session
         self._should_exit = False
         self._last_ctrl_c_time = 0
         self._clarify_state = None
@@ -8390,18 +8391,20 @@ class HermesCLI:
             # Mark as cancelled so process_loop skips it when dequeued
             cli_ref._cancelled_followups.add(recalled_text)
 
-            # Append to current buffer with separator
+            # Append to current buffer — separator only from the second recall onwards
             current = buf.text
-            if current.strip():
+            if cli_ref._followup_recall_count > 0 and current.strip():
                 buf.text = current.rstrip() + '\n---\n' + recalled_text
             else:
-                buf.text = recalled_text
+                buf.text = (current + recalled_text) if current else recalled_text
             buf.cursor_position = len(buf.text)
+            cli_ref._followup_recall_count += 1
 
             remaining = len(cli_ref._followup_queue)
             if remaining:
                 _cprint(f"  {_DIM}📬 Recalled follow-up ({remaining} still queued){_RST}")
             else:
+                cli_ref._followup_recall_count = 0
                 _cprint(f"  {_DIM}📬 Follow-up recalled — queue empty{_RST}")
             event.app.invalidate()
 

--- a/cli.py
+++ b/cli.py
@@ -1806,8 +1806,8 @@ class HermesCLI:
         self._agent_running = False
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
-        self._followup_queue: list = []  # mirror of _pending_input for display (Alt+Enter queued messages)
-        self._cancelled_followups: set = set()  # texts recalled via Alt+Up, skipped in process_loop
+        self._followup_queue: list = []  # mirror of _pending_input for display; entries are {"id": str, "payload": ...}
+        self._cancelled_followups: set = set()  # UUIDs recalled via Alt+Up, skipped in process_loop
         self._followup_recall_count: int = 0   # how many recalls done in this recall session
         self._should_exit = False
         self._last_ctrl_c_time = 0
@@ -8353,8 +8353,11 @@ class HermesCLI:
             cli_ref._attached_images.clear()
             payload = (text, images) if images else text
 
-            cli_ref._pending_input.put(payload)
-            cli_ref._followup_queue.append(payload)
+            import uuid as _uuid_mod
+            tag = _uuid_mod.uuid4().hex
+            # Wrap with tag so process_loop can identify and cancel by ID, not text
+            cli_ref._pending_input.put({"_followup_tag": tag, "payload": payload})
+            cli_ref._followup_queue.append({"id": tag, "payload": payload, "text": text})
             event.app.current_buffer.reset(append_to_history=True)
 
             queue_depth = len(cli_ref._followup_queue)
@@ -8385,11 +8388,11 @@ class HermesCLI:
             buf = event.app.current_buffer
 
             # Pop the most recently queued item (last = most recent)
-            payload = cli_ref._followup_queue.pop()
-            recalled_text = payload[0] if isinstance(payload, tuple) else payload
+            item = cli_ref._followup_queue.pop()
+            recalled_text = item["text"]
 
-            # Mark as cancelled so process_loop skips it when dequeued
-            cli_ref._cancelled_followups.add(recalled_text)
+            # Cancel by UUID — immune to duplicate-text false positives
+            cli_ref._cancelled_followups.add(item["id"])
 
             # Append to current buffer — separator only from the second recall onwards
             current = buf.text
@@ -9471,15 +9474,18 @@ class HermesCLI:
                     # Check for pending input with timeout
                     try:
                         user_input = self._pending_input.get(timeout=0.1)
-                        # Keep _followup_queue in sync — pop the oldest entry if present
-                        if self._followup_queue:
-                            self._followup_queue.pop(0)
-                            app.invalidate()
-                        # Skip items recalled via Alt+Up
-                        _input_text = user_input[0] if isinstance(user_input, tuple) else user_input
-                        if _input_text in self._cancelled_followups:
-                            self._cancelled_followups.discard(_input_text)
-                            continue
+                        # Unwrap tagged followup items (queued via Alt+Enter)
+                        if isinstance(user_input, dict) and "_followup_tag" in user_input:
+                            tag = user_input["_followup_tag"]
+                            user_input = user_input["payload"]
+                            # Sync display mirror — only pop for tagged items, not regular Enter
+                            if self._followup_queue:
+                                self._followup_queue.pop(0)
+                                app.invalidate()
+                            # Skip items recalled via Alt+Up (cancelled by UUID, not text)
+                            if tag in self._cancelled_followups:
+                                self._cancelled_followups.discard(tag)
+                                continue
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:

--- a/cli.py
+++ b/cli.py
@@ -1807,6 +1807,7 @@ class HermesCLI:
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
         self._followup_queue: list = []  # mirror of _pending_input for display (Alt+Enter queued messages)
+        self._cancelled_followups: set = set()  # texts recalled via Alt+Up, skipped in process_loop
         self._should_exit = False
         self._last_ctrl_c_time = 0
         self._clarify_state = None
@@ -8368,6 +8369,42 @@ class HermesCLI:
             """Ctrl+J (Ctrl+Enter in most terminals): insert a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        @kb.add('escape', 'up')
+        def handle_recall_followup(event):
+            """Alt+Up: recall the most recently queued follow-up back into the input.
+
+            Pops the last item from _followup_queue (LIFO — most recent first) and
+            appends its text to the current input, separated by '\\n---\\n'.
+            If multiple follow-ups are queued, repeated Alt+Up recalls them one by one.
+            The recalled item is added to _cancelled_followups so process_loop skips it.
+            """
+            if not cli_ref._followup_queue:
+                return
+
+            buf = event.app.current_buffer
+
+            # Pop the most recently queued item (last = most recent)
+            payload = cli_ref._followup_queue.pop()
+            recalled_text = payload[0] if isinstance(payload, tuple) else payload
+
+            # Mark as cancelled so process_loop skips it when dequeued
+            cli_ref._cancelled_followups.add(recalled_text)
+
+            # Append to current buffer with separator
+            current = buf.text
+            if current.strip():
+                buf.text = current.rstrip() + '\n---\n' + recalled_text
+            else:
+                buf.text = recalled_text
+            buf.cursor_position = len(buf.text)
+
+            remaining = len(cli_ref._followup_queue)
+            if remaining:
+                _cprint(f"  {_DIM}📬 Recalled follow-up ({remaining} still queued){_RST}")
+            else:
+                _cprint(f"  {_DIM}📬 Follow-up recalled — queue empty{_RST}")
+            event.app.invalidate()
+
         @kb.add('tab', eager=True)
         def handle_tab(event):
             """Tab: accept completion, auto-suggestion, or start completions.
@@ -9435,6 +9472,11 @@ class HermesCLI:
                         if self._followup_queue:
                             self._followup_queue.pop(0)
                             app.invalidate()
+                        # Skip items recalled via Alt+Up
+                        _input_text = user_input[0] if isinstance(user_input, tuple) else user_input
+                        if _input_text in self._cancelled_followups:
+                            self._cancelled_followups.discard(_input_text)
+                            continue
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:

--- a/tests/test_cli_followup_queue.py
+++ b/tests/test_cli_followup_queue.py
@@ -1,0 +1,140 @@
+"""Tests for PR #4788 feat/queue-followup.
+
+Covers: Alt+Enter queues followup messages.
+Attributes on HermesCLI: _followup_queue, _cancelled_followups, _followup_recall_count.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
+    """Create a HermesCLI instance with minimal mocking (mirrors test_cli_init.py)."""
+    import importlib
+
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    if config_overrides:
+        for key, value in config_overrides.items():
+            if key in _clean_config and isinstance(_clean_config[key], dict) and isinstance(value, dict):
+                _clean_config[key] = {**_clean_config[key], **value}
+            else:
+                _clean_config[key] = value
+
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    if env_overrides:
+        clean_env.update(env_overrides)
+
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), \
+         patch.dict("os.environ", clean_env, clear=False):
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+            return _cli_mod.HermesCLI(**kwargs)
+
+
+class TestFollowupQueueInit:
+    """_followup_queue must be initialized as an empty list."""
+
+    def test_followup_queue_attribute_exists(self):
+        cli = _make_cli()
+        assert hasattr(cli, "_followup_queue"), (
+            "_followup_queue must be initialized in HermesCLI.__init__"
+        )
+
+    def test_followup_queue_is_empty_list(self):
+        cli = _make_cli()
+        assert cli._followup_queue == []
+
+    def test_followup_queue_is_list_type(self):
+        cli = _make_cli()
+        assert isinstance(cli._followup_queue, list), (
+            "_followup_queue must be a list (not a queue or deque)"
+        )
+
+
+class TestCancelledFollowupsInit:
+    """_cancelled_followups must be initialized as an empty set."""
+
+    def test_cancelled_followups_attribute_exists(self):
+        cli = _make_cli()
+        assert hasattr(cli, "_cancelled_followups"), (
+            "_cancelled_followups must be initialized in HermesCLI.__init__"
+        )
+
+    def test_cancelled_followups_is_empty_set(self):
+        cli = _make_cli()
+        assert cli._cancelled_followups == set()
+
+    def test_cancelled_followups_is_set_type(self):
+        cli = _make_cli()
+        assert isinstance(cli._cancelled_followups, set), (
+            "_cancelled_followups must be a set (not a list)"
+        )
+
+
+class TestFollowupRecallCountInit:
+    """_followup_recall_count must be initialized to 0."""
+
+    def test_followup_recall_count_attribute_exists(self):
+        cli = _make_cli()
+        assert hasattr(cli, "_followup_recall_count"), (
+            "_followup_recall_count must be initialized in HermesCLI.__init__"
+        )
+
+    def test_followup_recall_count_is_zero(self):
+        cli = _make_cli()
+        assert cli._followup_recall_count == 0
+
+    def test_followup_recall_count_is_int(self):
+        cli = _make_cli()
+        assert isinstance(cli._followup_recall_count, int)
+
+
+class TestFollowupQueueIndependence:
+    """Each HermesCLI instance has its own queue/set (no shared mutable defaults)."""
+
+    def test_two_instances_have_independent_queues(self):
+        cli_a = _make_cli()
+        cli_b = _make_cli()
+        cli_a._followup_queue.append("item")
+        assert cli_b._followup_queue == [], (
+            "_followup_queue must not be shared between instances"
+        )
+
+    def test_two_instances_have_independent_cancelled_sets(self):
+        cli_a = _make_cli()
+        cli_b = _make_cli()
+        cli_a._cancelled_followups.add("uid-abc")
+        assert cli_b._cancelled_followups == set(), (
+            "_cancelled_followups must not be shared between instances"
+        )


### PR DESCRIPTION
Two complementary keybindings for managing a follow-up message queue while the agent is running.

### Alt+Enter -- Queue follow-up
Queues the current input as a follow-up message instead of interrupting the running agent. Status bar shows queued count.

### Alt+Up -- Recall queued follow-up
Pulls the most recently queued follow-up back into the input (LIFO).

Closes #5504