### PR TITLE
fix(agent): improve LiteLLM context length detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -371,6 +371,23 @@ def _extract_context_length(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _CONTEXT_LENGTH_KEYS)
 
 
+def _extract_litellm_context_length(payload: Dict[str, Any]) -> Optional[int]:
+    """Extract context length from LiteLLM ``model_info`` metadata.
+
+    LiteLLM proxies often surface context under ``model_info.max_input_tokens``
+    or ``model_info.context_window``. Some deployments only populate
+    ``model_info.max_tokens`` to represent the total context window.
+    """
+    model_info = payload.get("model_info")
+    if not isinstance(model_info, dict):
+        return None
+    for key in ("max_input_tokens", "context_window", "max_tokens"):
+        coerced = _coerce_reasonable_int(model_info.get(key))
+        if coerced is not None:
+            return coerced
+    return None
+
+
 def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
@@ -403,6 +420,40 @@ def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: D
     if "/" in model_id:
         bare_model = model_id.split("/", 1)[1]
         cache.setdefault(bare_model, entry)
+
+
+def _merge_endpoint_model_entry(
+    cache: Dict[str, Dict[str, Any]],
+    payload: Dict[str, Any],
+    *model_ids: Optional[str],
+) -> None:
+    aliases = [model_id for model_id in model_ids if model_id]
+    if not aliases:
+        return
+
+    entry = None
+    for alias in aliases:
+        existing = cache.get(alias)
+        if existing is not None:
+            entry = existing
+            break
+    if entry is None:
+        entry = {"name": payload.get("name") or payload.get("model_name") or aliases[0]}
+
+    context_length = _extract_litellm_context_length(payload) or _extract_context_length(payload)
+    if context_length is not None:
+        entry["context_length"] = context_length
+
+    max_completion_tokens = _extract_max_completion_tokens(payload)
+    if max_completion_tokens is not None:
+        entry["max_completion_tokens"] = max_completion_tokens
+
+    pricing = _extract_pricing(payload)
+    if pricing:
+        entry["pricing"] = pricing
+
+    for alias in aliases:
+        _add_model_aliases(cache, alias, entry)
 
 
 def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
@@ -482,20 +533,35 @@ def fetch_endpoint_model_metadata(
             for model in payload.get("data", []):
                 if not isinstance(model, dict):
                     continue
-                model_id = model.get("id")
-                if not model_id:
-                    continue
-                entry: Dict[str, Any] = {"name": model.get("name", model_id)}
-                context_length = _extract_context_length(model)
-                if context_length is not None:
-                    entry["context_length"] = context_length
-                max_completion_tokens = _extract_max_completion_tokens(model)
-                if max_completion_tokens is not None:
-                    entry["max_completion_tokens"] = max_completion_tokens
-                pricing = _extract_pricing(model)
-                if pricing:
-                    entry["pricing"] = pricing
-                _add_model_aliases(cache, model_id, entry)
+                _merge_endpoint_model_entry(
+                    cache,
+                    model,
+                    model.get("id"),
+                    model.get("model_name"),
+                    model.get("model_info", {}).get("key") if isinstance(model.get("model_info"), dict) else None,
+                    model.get("litellm_params", {}).get("model") if isinstance(model.get("litellm_params"), dict) else None,
+                )
+
+            if not cache or any(not isinstance(entry.get("context_length"), int) for entry in cache.values()):
+                try:
+                    info_response = requests.get(candidate.rstrip("/") + "/model/info", headers=headers, timeout=10)
+                    if info_response.ok:
+                        info_payload = info_response.json()
+                        info_items = info_payload.get("data", [])
+                        if isinstance(info_items, dict):
+                            info_items = [info_items]
+                        for model in info_items:
+                            if not isinstance(model, dict):
+                                continue
+                            _merge_endpoint_model_entry(
+                                cache,
+                                model,
+                                model.get("model_name"),
+                                model.get("model_info", {}).get("key") if isinstance(model.get("model_info"), dict) else None,
+                                model.get("litellm_params", {}).get("model") if isinstance(model.get("litellm_params"), dict) else None,
+                            )
+                except Exception:
+                    pass
 
             # If this is a llama.cpp server, query /props for actual allocated context
             is_llamacpp = any(
@@ -907,7 +973,7 @@ def get_model_context_length(
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
     1. Persistent cache (previously discovered via probing)
-    2. Active endpoint metadata (/models for explicit custom endpoints)
+    2. Active endpoint metadata (/models and LiteLLM /model/info for explicit custom endpoints)
     3. Local server query (for local endpoints)
     4. Anthropic /v1/models API (API-key users only, not OAuth)
     5. OpenRouter live API metadata
@@ -953,20 +1019,17 @@ def get_model_context_length(
             context_length = matched.get("context_length")
             if isinstance(context_length, int):
                 return context_length
-        if not _is_known_provider_base_url(base_url):
-            # 3. Try querying local server directly
-            if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url)
-                if local_ctx and local_ctx > 0:
-                    save_context_length(model, base_url, local_ctx)
-                    return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
-            )
-            return DEFAULT_FALLBACK_CONTEXT
+        # 3. Try querying local server directly
+        if is_local_endpoint(base_url):
+            local_ctx = _query_local_context_length(model, base_url)
+            if local_ctx and local_ctx > 0:
+                save_context_length(model, base_url, local_ctx)
+                return local_ctx
+        logger.info(
+            "Could not detect context length for model %r at %s from endpoint metadata; "
+            "continuing with provider/model-family fallback heuristics before probe-down.",
+            model, base_url,
+        )
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -25,6 +25,7 @@ from agent.model_metadata import (
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
+    fetch_endpoint_model_metadata,
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
@@ -285,12 +286,26 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_endpoint_fetch, mock_fetch):
+    def test_custom_endpoint_without_metadata_uses_family_default(self, mock_endpoint_fetch, mock_fetch):
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 
         result = get_model_context_length(
-            "zai-org/GLM-5-TEE",
+            "gemini/gemini-3-flash-preview",
+            base_url="https://llm.chutes.ai/v1",
+            api_key="test-key",
+        )
+
+        assert result == 1048576
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_without_metadata_unknown_model_uses_probe_default(self, mock_endpoint_fetch, mock_fetch):
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            "totally-unknown-model-family",
             base_url="https://llm.chutes.ai/v1",
             api_key="test-key",
         )
@@ -534,6 +549,70 @@ class TestFetchModelMetadata:
 
         result = fetch_model_metadata(force_refresh=True)
         assert result == {}
+
+
+class TestFetchEndpointModelMetadata:
+    def _reset_cache(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache = {}
+        mm._endpoint_model_metadata_cache_time = {}
+
+    @patch("agent.model_metadata.requests.get")
+    def test_litellm_model_info_fills_missing_context_length(self, mock_get):
+        self._reset_cache()
+
+        models_response = MagicMock()
+        models_response.raise_for_status = MagicMock()
+        models_response.ok = True
+        models_response.json.return_value = {
+            "data": [{"id": "gemini/gemini-3-flash-preview", "name": "Gemini Flash"}]
+        }
+
+        model_info_response = MagicMock()
+        model_info_response.ok = True
+        model_info_response.json.return_value = {
+            "data": [{
+                "model_name": "gemini/gemini-3-flash-preview",
+                "litellm_params": {"model": "gemini/gemini-3-flash-preview"},
+                "model_info": {"key": "gemini/gemini-3-flash-preview", "max_input_tokens": 1048576},
+            }]
+        }
+
+        mock_get.side_effect = [models_response, model_info_response]
+
+        result = fetch_endpoint_model_metadata("http://litellm:4000/v1", force_refresh=True)
+
+        assert result["gemini/gemini-3-flash-preview"]["context_length"] == 1048576
+
+    @patch("agent.model_metadata.requests.get")
+    def test_litellm_model_info_enriches_only_missing_models(self, mock_get):
+        self._reset_cache()
+
+        models_response = MagicMock()
+        models_response.raise_for_status = MagicMock()
+        models_response.ok = True
+        models_response.json.return_value = {
+            "data": [
+                {"id": "model-with-context", "context_length": 32768},
+                {"id": "gemini/gemini-3-flash-preview", "name": "Gemini Flash"},
+            ]
+        }
+
+        model_info_response = MagicMock()
+        model_info_response.ok = True
+        model_info_response.json.return_value = {
+            "data": [{
+                "model_name": "gemini/gemini-3-flash-preview",
+                "model_info": {"max_input_tokens": 1048576},
+            }]
+        }
+
+        mock_get.side_effect = [models_response, model_info_response]
+
+        result = fetch_endpoint_model_metadata("http://litellm:4000/v1", force_refresh=True)
+
+        assert result["model-with-context"]["context_length"] == 32768
+        assert result["gemini/gemini-3-flash-preview"]["context_length"] == 1048576
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

This fixes LiteLLM-backed custom providers failing to report the correct context window in Hermes.

Today `agent/model_metadata.py` reads OpenAI-compatible `/models` metadata for custom endpoints, but LiteLLM deployments may expose the real context limit under LiteLLM-specific fields such as `model_info.max_input_tokens`, or only expose it via `/model/info`. When Hermes misses that metadata, it falls back to the 128k probe-down default, which is wrong for large-context models like `gemini/gemini-3-flash-preview`.

This PR updates endpoint metadata parsing to understand LiteLLM's response shape, merges `/model/info` data back into `/models` results when per-model context is missing, and keeps custom providers on the existing model-family fallback path before dropping to the 128k default.

## Related Issue

Fixes #8465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/model_metadata.py` to parse LiteLLM-specific context metadata from `model_info`, including `max_input_tokens`, `context_window`, and `max_tokens`
- Added endpoint metadata merging so `/model/info` can backfill missing context lengths from `/models`
- Fixed the edge case where `/model/info` was skipped if some models had context metadata but the target model did not
- Changed custom endpoint resolution to continue through existing model-family fallback heuristics before probe-down when endpoint metadata is incomplete
- Added regression tests in `tests/agent/test_model_metadata.py` for LiteLLM `/model/info` parsing and mixed `/models` + `/model/info` enrichment behavior

## How to Test

1. Run `D:\hermes-agent\hermes-agent\venv\Scripts\python.exe -m pytest tests/agent/test_model_metadata.py -q -n 0`
2. Run `D:\hermes-agent\hermes-agent\venv\Scripts\python.exe -m pytest tests/agent/test_model_metadata_local_ctx.py -q -n 0`
3. Run `D:\hermes-agent\hermes-agent\venv\Scripts\python.exe -m pytest tests/agent/test_usage_pricing.py -q -n 0`
4. Reproduce against a LiteLLM custom provider serving `gemini/gemini-3-flash-preview` and verify Hermes no longer falls back to `128,000` tokens when LiteLLM exposes `max_input_tokens`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows (PowerShell)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant failure mode before this change:

```text
INFO agent.model_metadata: Could not detect context length for model 'gemini/gemini-3-flash-preview' at http://litellm:4000 defaulting to 128,000 tokens (probe-down).
```
