### PR TITLE
fix(memory): persist nudge counter across agent cache misses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -546,6 +546,12 @@ class GatewayRunner:
         self._fallback_model = self._load_fallback_model()
         self._smart_model_routing = self._load_smart_model_routing()
 
+        # Per-session memory nudge counters — persisted across agent cache
+        # misses (e.g. when smart routing switches between cheap/strong model).
+        # Without this, _turns_since_memory resets to 0 on every new AIAgent
+        # and the background memory review never triggers.
+        self._session_nudge_counters: Dict[str, int] = {}
+
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
         self.session_store = SessionStore(
@@ -7675,6 +7681,12 @@ class GatewayRunner:
                         _cache[session_key] = (agent, _sig)
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 
+            # Restore memory nudge counter from gateway-level storage so it
+            # survives agent cache misses (smart routing model switches).
+            _saved_nudge = self._session_nudge_counters.get(session_key, 0)
+            if hasattr(agent, '_turns_since_memory'):
+                agent._turns_since_memory = _saved_nudge
+
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
@@ -7863,6 +7875,11 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+
+            # Save memory nudge counter back to gateway for persistence
+            # across agent cache misses (smart routing model switches).
+            if hasattr(agent, '_turns_since_memory'):
+                self._session_nudge_counters[session_key] = agent._turns_since_memory
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/tests/gateway/test_nudge_counter_persistence.py
+++ b/tests/gateway/test_nudge_counter_persistence.py
@@ -1,0 +1,128 @@
+"""Tests for memory nudge counter persistence across agent cache misses.
+
+When smart model routing switches between cheap and strong models per turn,
+the agent cache misses and creates a fresh AIAgent whose __init__ resets
+_turns_since_memory to 0. The gateway-level _session_nudge_counters dict
+must preserve and restore this counter so that background memory review
+actually triggers after nudge_interval turns.
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_runner():
+    """Create a minimal GatewayRunner with nudge counter infrastructure."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_nudge_counters = {}
+    return runner
+
+
+class TestNudgeCounterPersistence:
+    """Verify _session_nudge_counters preserves counters across cache misses."""
+
+    def test_runner_has_nudge_counters_dict(self):
+        runner = _make_runner()
+        assert isinstance(runner._session_nudge_counters, dict)
+        assert len(runner._session_nudge_counters) == 0
+
+    def test_save_and_restore_counter(self):
+        """Counter saved after one turn is restored for the next."""
+        runner = _make_runner()
+        session_key = "bb:iMessage;-;+1234"
+
+        # Simulate: agent runs, counter increments to 2
+        runner._session_nudge_counters[session_key] = 2
+
+        # Simulate: new agent created (cache miss), restore counter
+        restored = runner._session_nudge_counters.get(session_key, 0)
+        assert restored == 2
+
+    def test_missing_session_defaults_to_zero(self):
+        """Unknown session key returns 0 (first message)."""
+        runner = _make_runner()
+        assert runner._session_nudge_counters.get("unknown-session", 0) == 0
+
+    def test_counter_accumulates_across_turns(self):
+        """Counter should grow: 0→1→2→3 across multiple cache misses."""
+        runner = _make_runner()
+        session_key = "bb:iMessage;-;+1234"
+
+        for expected in range(1, 5):
+            # Restore
+            counter = runner._session_nudge_counters.get(session_key, 0)
+            # Simulate run_conversation incrementing
+            counter += 1
+            # Save
+            runner._session_nudge_counters[session_key] = counter
+            assert runner._session_nudge_counters[session_key] == expected
+
+    def test_counter_resets_after_trigger(self):
+        """Counter resets to 0 when nudge triggers (simulating the agent reset)."""
+        runner = _make_runner()
+        session_key = "bb:iMessage;-;+1234"
+        nudge_interval = 3
+
+        # Accumulate to trigger point
+        for _ in range(nudge_interval):
+            counter = runner._session_nudge_counters.get(session_key, 0)
+            counter += 1
+            runner._session_nudge_counters[session_key] = counter
+
+        assert runner._session_nudge_counters[session_key] == nudge_interval
+
+        # Agent triggers nudge and resets counter
+        runner._session_nudge_counters[session_key] = 0
+        assert runner._session_nudge_counters[session_key] == 0
+
+        # Next turn starts from 0
+        counter = runner._session_nudge_counters.get(session_key, 0)
+        counter += 1
+        runner._session_nudge_counters[session_key] = counter
+        assert runner._session_nudge_counters[session_key] == 1
+
+    def test_independent_sessions(self):
+        """Different sessions have independent counters."""
+        runner = _make_runner()
+        runner._session_nudge_counters["session-A"] = 3
+        runner._session_nudge_counters["session-B"] = 1
+
+        assert runner._session_nudge_counters["session-A"] == 3
+        assert runner._session_nudge_counters["session-B"] == 1
+
+    def test_agent_attribute_restore(self):
+        """Verify the hasattr + restore pattern used in run.py."""
+        runner = _make_runner()
+        session_key = "bb:test"
+        runner._session_nudge_counters[session_key] = 5
+
+        # Simulate a mock agent with the attribute
+        agent = MagicMock()
+        agent._turns_since_memory = 0  # fresh agent
+
+        # Restore pattern from gateway/run.py
+        _saved = runner._session_nudge_counters.get(session_key, 0)
+        if hasattr(agent, '_turns_since_memory'):
+            agent._turns_since_memory = _saved
+
+        assert agent._turns_since_memory == 5
+
+    def test_agent_attribute_save(self):
+        """Verify the save pattern used in run.py after run_conversation."""
+        runner = _make_runner()
+        session_key = "bb:test"
+
+        agent = MagicMock()
+        agent._turns_since_memory = 3  # after run_conversation
+
+        # Save pattern from gateway/run.py
+        if hasattr(agent, '_turns_since_memory'):
+            runner._session_nudge_counters[session_key] = agent._turns_since_memory
+
+        assert runner._session_nudge_counters[session_key] == 3


### PR DESCRIPTION
## What does this PR do?

When smart model routing is enabled, the gateway alternates between cheap and strong models per turn. Each model switch changes the agent config signature, causing an agent cache miss and creating a fresh `AIAgent`. The new agent's `__init__` resets `_turns_since_memory = 0`, so the nudge counter never reaches `nudge_interval` and `_spawn_background_review` never triggers.

**Result:** Memory nudge is completely broken when smart routing is active. The agent appears to remember but never actually calls the memory tool.

Fix: persist `_turns_since_memory` at the `GatewayRunner` level in a per-session-key dict (`_session_nudge_counters`). After agent creation, restore the counter; after `run_conversation`, save it back.

```
Turn 1 (cheap, cache miss): restore 0, run +1=1, save 1
Turn 2 (strong, cache miss): restore 1, run +1=2, save 2
Turn 3 (cheap, cache miss): restore 2, run +1=3 >= interval → TRIGGER!
```

## Related Issue

Fixes #8506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`:
  - Added `_session_nudge_counters: Dict[str, int]` to `GatewayRunner.__init__`
  - Restore counter after agent creation (~L7681)
  - Save counter after `run_conversation` (~L7876)
- `tests/gateway/test_nudge_counter_persistence.py`: New test file with 8 tests covering save/restore, accumulation, trigger reset, independent sessions, and the hasattr guard pattern

## How to Test

1. Enable smart routing with `nudge_interval: 3`
2. Send 4 messages alternating cheap/strong models
3. Verify nudge triggers at message 3 (counter reaches interval)
4. Verify `USER.md` is updated with conversation data
5. Verify counter resets and resumes counting for next cycle

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Sequoia), Apple Silicon

### Documentation & Housekeeping

- [x] N/A - no config keys or docs changed
- [x] Cross-platform: all platforms affected equally, fix is platform-independent