### PR TITLE
fix(model): coerce custom provider config fields to str before strip()

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1097,17 +1097,19 @@ def select_provider_and_model(args=None):
         for entry in custom_providers_cfg:
             if not isinstance(entry, dict):
                 continue
-            name = (entry.get("name") or "").strip()
-            base_url = (entry.get("base_url") or "").strip()
+            # Coerce all fields to str — a config.yaml value like `name: 123`
+            # is parsed as int by PyYAML, causing AttributeError on .strip().
+            name = str(entry.get("name") or "").strip()
+            base_url = str(entry.get("base_url") or "").strip()
             if not name or not base_url:
                 continue
             key = "custom:" + name.lower().replace(" ", "-")
             custom_provider_map[key] = {
                 "name": name,
                 "base_url": base_url,
-                "api_key": entry.get("api_key", ""),
-                "model": entry.get("model", ""),
-                "api_mode": entry.get("api_mode", ""),
+                "api_key": str(entry.get("api_key") or ""),
+                "model": str(entry.get("model") or ""),
+                "api_mode": str(entry.get("api_mode") or ""),
             }
         return custom_provider_map
 


### PR DESCRIPTION
## Problem

Closes #8503

PyYAML parses unquoted numeric values (e.g. `name: 123`) as `int`. Calling `.strip()` on an `int` raises `AttributeError: int object has no attribute strip`, crashing `hermes model`.

## Fix

Wrap all `entry.get()` calls with `str()` before `.strip()` so any scalar type (int, float, bool) is safely coerced to a string.

## Example

```yaml
custom_providers:
  - name: 123
    base_url: https://api.example.com
```

Before: crash. After: provider name treated as string 123, works normally.