### PR TITLE
fix(compression): pass configured context_length to feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1748,10 +1748,25 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+
+            # Read user-configured context_length for the compression model.
+            # Custom endpoints often don't support /models API queries so
+            # get_model_context_length() falls through to the 128K default,
+            # ignoring the explicit config value.  Pass it as the highest-
+            # priority hint so the configured value is always respected.
+            _aux_cfg = (self.config or {}).get("auxiliary", {}).get("compression", {})
+            _aux_context_config = _aux_cfg.get("context_length") if isinstance(_aux_cfg, dict) else None
+            if _aux_context_config is not None:
+                try:
+                    _aux_context_config = int(_aux_context_config)
+                except (TypeError, ValueError):
+                    _aux_context_config = None
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
+                config_context_length=_aux_context_config,
             )
 
             threshold = self.context_compressor.threshold_tokens


### PR DESCRIPTION
## Problem

Closes #8499

`_check_compression_model_feasibility()` called `get_model_context_length()` without passing `config_context_length`. Custom endpoints that do not support `/models` API queries always fell through to the 128K default, ignoring `auxiliary.compression.context_length` in `config.yaml`.

## Root Cause

`get_model_context_length()` resolution order: Step 0 is `config_context_length` (highest priority), but it was never passed from the feasibility check.

## Fix

Read `auxiliary.compression.context_length` from config and pass it as `config_context_length`:

```python
_aux_cfg = (self.config or {}).get("auxiliary", {}).get("compression", {})
_aux_context_config = _aux_cfg.get("context_length")

aux_context = get_model_context_length(
    aux_model,
    base_url=aux_base_url,
    api_key=aux_api_key,
    config_context_length=_aux_context_config,  # now respected
)
```

## Before / After

**Before:** `context_length: 1000000` in config → ignored → 128K default → spurious warning

**After:** `context_length: 1000000` in config → passed as hint → correct value used