### PR TITLE
fix: preserve venv symlink in systemd service ExecStart path

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -753,10 +753,22 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
     current_home = Path.home().resolve()
+    target_home = Path(target_home_dir)
+    abs_path = Path(path) if Path(path).is_absolute() else Path(path).absolute()
+    # If the path is already under the target home, return it as-is to
+    # preserve symlinks (e.g. venv/bin/python should not be resolved to
+    # the underlying interpreter which lacks venv site-packages).
+    try:
+        abs_path.relative_to(target_home)
+        return str(abs_path)
+    except ValueError:
+        pass
+    # Fall back to fully resolved path for cross-home remapping (e.g.
+    # /root/.hermes -> /home/alice/.hermes when running under sudo).
     resolved = Path(path).resolve()
     try:
         relative = resolved.relative_to(current_home)
-        return str(Path(target_home_dir) / relative)
+        return str(target_home / relative)
     except ValueError:
         return str(resolved)
 


### PR DESCRIPTION
## Summary

- Fix `_remap_path_for_user()` in `hermes_cli/gateway.py` to preserve virtualenv symlinks when generating systemd service files
- When the path is already under the target user's home, return it as-is instead of resolving symlinks
- This prevents the venv `bin/python` from being resolved to the raw uv interpreter which lacks venv `site-packages`

## Problem

When generating the systemd unit via `sudo hermes gateway start --system`, `_remap_path_for_user()` calls `Path.resolve()` on the Python path. This follows the symlink chain:

```
venv/bin/python
  → ~/.local/share/uv/python/cpython-3.11-.../bin/python3.11   (symlink)
    → ~/.local/share/uv/python/cpython-3.11.15-.../bin/python3.11  (real file)
```

The resolved raw interpreter doesn't have access to the venv's `site-packages`, so the gateway fails on startup with:

```
ModuleNotFoundError: No module named 'yaml'
```

Under `sudo`, `Path.home()` returns `/root`, so the path (under `/home/user/`) fails the `relative_to(current_home)` check, and the function returns the fully resolved path — the raw uv Python.

## Fix

Before attempting symlink resolution, check if the path is already under `target_home_dir`. If so, return it unchanged to preserve the venv symlink structure.

Fixes #8519

## Test plan

- [ ] Run `sudo hermes gateway restart --system` and verify `ExecStart` in the generated service file points to `venv/bin/python`, not the resolved uv interpreter
- [ ] Verify `systemctl status hermes-gateway` shows `active (running)`
- [ ] Verify the fix also works for the original `/root` → `/home/user` remapping case (install via `sudo` from root shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)