### PR TITLE
fix(gateway): avoid streaming cursor artifacts on no-edit platforms

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -935,6 +935,10 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    def supports_message_editing(self) -> bool:
+        """Return True when this adapter implements in-place message edits."""
+        return type(self).edit_message is not BasePlatformAdapter.edit_message
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
         Send a typing indicator.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -79,7 +79,8 @@ class GatewayStreamConsumer:
         self._accumulated = ""
         self._message_id: Optional[str] = None
         self._already_sent = False
-        self._edit_supported = True  # Disabled when progressive edits are no longer usable
+        self._native_edit_supported = self._adapter_supports_message_editing()
+        self._edit_supported = self._native_edit_supported  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
         self._fallback_final_send = False
@@ -132,6 +133,88 @@ class GatewayStreamConsumer:
         """Signal that the stream is complete."""
         self._queue.put(_DONE)
 
+    def _adapter_supports_message_editing(self) -> bool:
+        checker = getattr(self.adapter, "supports_message_editing", None)
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:
+                return True
+        return True
+
+    @staticmethod
+    def _extract_complete_markdown_blocks(text: str, final: bool = False) -> tuple[str, str]:
+        """Split text into a stable markdown prefix and an unsent remainder.
+
+        For platforms without edit support, streaming partial markdown with a
+        cursor creates artifacts and broken rendering. This helper only releases
+        complete blocks during the stream: paragraphs separated by blank lines
+        and fully closed fenced code blocks. The trailing incomplete block is
+        held until more content arrives or the stream finishes.
+        """
+        if not text:
+            return "", ""
+        if final:
+            return text.strip(), ""
+
+        lines = text.splitlines(keepends=True)
+        in_code_block = False
+        block_has_content = False
+        safe_end = 0
+        offset = 0
+
+        for raw_line in lines:
+            line = raw_line.rstrip("\r\n")
+            offset += len(raw_line)
+
+            if raw_line.endswith(("\n", "\r")):
+                has_line_break = True
+            else:
+                has_line_break = False
+
+            if re.match(r"^```([^\n`]*)\s*$", line.strip()):
+                block_has_content = True
+                in_code_block = not in_code_block
+                if not in_code_block:
+                    safe_end = offset
+                    block_has_content = False
+                continue
+
+            if in_code_block:
+                continue
+
+            if line.strip():
+                block_has_content = True
+                continue
+
+            if block_has_content and has_line_break:
+                safe_end = offset
+                block_has_content = False
+
+        if safe_end <= 0:
+            return "", text
+
+        ready = text[:safe_end].strip()
+        remainder = text[safe_end:].lstrip("\r\n")
+        return ready, remainder
+
+    async def _send_no_edit_chunk(self, text: str) -> None:
+        """Send a streaming chunk on platforms that cannot edit messages."""
+        text = self._clean_for_display(text)
+        if not text.strip():
+            return
+        try:
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=text,
+                metadata=self.metadata,
+            )
+            if result.success:
+                self._already_sent = True
+                self._last_sent_text = text
+        except Exception as e:
+            logger.error("Stream send error on no-edit adapter: %s", e)
+
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
         # Platform message length limit — leave room for cursor + formatting
@@ -173,7 +256,17 @@ class GatewayStreamConsumer:
                 )
 
                 current_update_visible = False
-                if should_edit and self._accumulated:
+                if should_edit and self._accumulated and not self._native_edit_supported:
+                    ready_text, remainder = self._extract_complete_markdown_blocks(
+                        self._accumulated,
+                        final=got_done or got_segment_break,
+                    )
+                    if ready_text:
+                        await self._send_no_edit_chunk(ready_text)
+                        self._accumulated = remainder
+                        self._last_edit_time = time.monotonic()
+
+                elif should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
@@ -237,7 +330,11 @@ class GatewayStreamConsumer:
                     # mid-stream, send a single continuation/fallback message
                     # here instead of letting the base gateway path send the
                     # full response again.
-                    if self._accumulated:
+                    if not self._native_edit_supported:
+                        if self._accumulated:
+                            await self._send_no_edit_chunk(self._accumulated)
+                        self._final_response_sent = self._already_sent
+                    elif self._accumulated:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
                         elif current_update_visible:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -179,6 +179,63 @@ class TestStreamRunMediaStripping:
         assert consumer.already_sent
 
 
+class _NoEditAdapter:
+    MAX_MESSAGE_LENGTH = 4096
+
+    def __init__(self):
+        self.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+            SimpleNamespace(success=True, message_id="msg_3"),
+        ])
+        self.edit_message = AsyncMock(return_value=SimpleNamespace(success=False, error="Not supported"))
+
+    def supports_message_editing(self):
+        return False
+
+
+class TestStreamRunWithoutEditSupport:
+    @pytest.mark.asyncio
+    async def test_no_edit_adapter_sends_complete_blocks_without_cursor(self):
+        adapter = _NoEditAdapter()
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("# Title\n\nBody starts")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(" here.\n\nFinal block.")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs["content"] for call in adapter.send.await_args_list]
+        assert sent_texts == ["# Title", "Body starts here.", "Final block."]
+        assert all("▉" not in text for text in sent_texts)
+        adapter.edit_message.assert_not_awaited()
+        assert consumer.already_sent
+
+    @pytest.mark.asyncio
+    async def test_no_edit_adapter_waits_for_closed_code_fence(self):
+        adapter = _NoEditAdapter()
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("```python\nprint('hi')")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        adapter.send.assert_not_awaited()
+
+        consumer.on_delta("\n```\n\nDone.")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs["content"] for call in adapter.send.await_args_list]
+        assert sent_texts == ["```python\nprint('hi')\n```", "Done."]
+        assert all("▉" not in text for text in sent_texts)
+
+
 # ── Segment break (tool boundary) tests ──────────────────────────────────
 
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                      
  Fixes #8326                                                                                                                                                                                 
  Fix streaming output on platforms that do not support message editing, such as Weixin.                                                                                          
                                                                                                                                                                                  
  The gateway stream consumer currently assumes that a successful initial send means later updates can be edited in place. For adapters without `edit_message()` support, that    
  leaves the streaming cursor in the already-sent message and can also break Markdown block rendering when follow-up content is delivered as separate fallback messages.          
                                                                                                                                                                                  
  This change makes the stream consumer detect adapters without edit support up front and use a no-edit streaming path that sends only stable Markdown blocks without appending   
  the cursor.                                                                                                                                                                     
                                                                                                                                                                                  
  ## Changes                                                                                                                                                                      
                                                                                                                                                                                  
  - add an explicit `supports_message_editing()` capability check on platform adapters                                                                                            
  - route no-edit adapters through a streaming path that never appends the cursor marker                                                                                          
  - hold incomplete Markdown blocks during streaming until they are stable enough to send                                                                                         
  - add regression coverage for no-edit streaming behavior, including fenced code blocks                                                                                          
                                                                                                                                                                                  
  ## Testing                                                                                                                                                                      
                                                                                                                                                                                  
  - `D:\hermes-agent\hermes-agent\venv\Scripts\python.exe -m pytest tests\gateway\test_stream_consumer.py -q -n 0`                                                                
  - `D:\hermes-agent\hermes-agent\venv\Scripts\python.exe -m pytest tests\gateway\test_weixin.py -q -n 0`