### PR TITLE
fix(honcho): extend local client timeout

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -553,6 +553,10 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     }
     if resolved_base_url:
         kwargs["base_url"] = resolved_base_url
+        if _is_local:
+            # Local workstation models can take well over 60s for dialectic calls.
+            # Use a longer SDK timeout so Hermes doesn't give up before Honcho responds.
+            kwargs["timeout"] = 300.0
 
     _honcho_client = Honcho(**kwargs)
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -542,6 +542,31 @@ class TestInitOnSessionStart:
         assert cfg.init_on_session_start is False
 
 
+class TestGetHonchoClient:
+    def test_local_base_url_uses_longer_timeout(self):
+        import plugins.memory.honcho.client as mod
+
+        reset_honcho_client()
+        config = HonchoClientConfig(
+            workspace_id="local-ws",
+            base_url="http://127.0.0.1:8000",
+            enabled=True,
+            raw={},
+        )
+
+        with patch("honcho.Honcho") as mock_honcho:
+            mock_client = MagicMock()
+            mock_honcho.return_value = mock_client
+
+            result = get_honcho_client(config)
+
+        assert result is mock_client
+        _, kwargs = mock_honcho.call_args
+        assert kwargs["base_url"] == "http://127.0.0.1:8000"
+        assert kwargs["api_key"] == "local"
+        assert kwargs["timeout"] == 300.0
+
+
 class TestResetHonchoClient:
     def test_reset_clears_singleton(self):
         import plugins.memory.honcho.client as mod


### PR DESCRIPTION
## Summary
- increase the Honcho SDK timeout to 300 seconds for local/self-hosted Honcho base URLs only
- keep the existing default timeout behavior for cloud Honcho unchanged
- add a focused unit test covering the local timeout override

## Why
Local/self-hosted Honcho deployments can take longer than the SDK's default 60 second HTTP timeout for dialectic-style calls. When Hermes is pointed at a localhost/127.0.0.1 Honcho instance, this can cause Hermes to give up before Honcho responds even though the local server is still working.

This change keeps the scope narrow:
- only applies when Hermes has already classified the resolved Honcho base URL as local
- does not change cloud Honcho behavior
- uses the Honcho SDK's existing `timeout=` parameter rather than introducing Hermes-specific retry logic

## Test Plan
- `/Users/dgrieco/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/memory/honcho/client.py tests/honcho_plugin/test_client.py`
- `/Users/dgrieco/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin/test_client.py -q`
