### PR TITLE
feat(compaction): preserve recent user messages during compression (Codex-style)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -41,6 +41,11 @@ SUMMARY_PREFIX = (
     "config, etc.) may reflect work described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
+_LEGACY_COMPACTION_PREFIX = "[CONTEXT COMPACTION]"
+
+# Maximum tokens of preserved user messages from the summarized region.
+# Inspired by OpenAI Codex's COMPACT_USER_MESSAGE_MAX_TOKENS.
+_USER_MESSAGE_MAX_TOKENS = 20000
 
 # Minimum tokens for the summary output
 _MIN_SUMMARY_TOKENS = 2000
@@ -114,6 +119,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        user_message_max_tokens: int = _USER_MESSAGE_MAX_TOKENS,
     ):
         self.model = model
         self.base_url = base_url
@@ -125,6 +131,7 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+        self.user_message_max_tokens = user_message_max_tokens
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -660,6 +667,63 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         return max(cut_idx, head_end + 1)
 
     # ------------------------------------------------------------------
+    # User message preservation (Codex-style)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _collect_user_messages(
+        messages: List[Dict[str, Any]],
+        max_tokens: int = _USER_MESSAGE_MAX_TOKENS,
+    ) -> List[Dict[str, Any]]:
+        """Extract real user messages from a message slice, newest-first up to a token budget.
+
+        Filters out previous compaction summaries (identified by SUMMARY_PREFIX,
+        LEGACY_SUMMARY_PREFIX, and _LEGACY_COMPACTION_PREFIX).  Returns messages
+        in chronological order, ready for insertion into the compressed history.
+
+        Inspired by OpenAI Codex's ``collect_user_messages`` +
+        ``build_compacted_history_with_limit`` logic.
+        """
+        # Gather candidates in original order
+        candidates: List[Dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") != "user":
+                continue
+            content = (msg.get("content") or "").strip()
+            if not content:
+                continue
+            # Skip previous summaries
+            if (content.startswith(SUMMARY_PREFIX)
+                    or content.startswith(LEGACY_SUMMARY_PREFIX)
+                    or content.startswith(_LEGACY_COMPACTION_PREFIX)):
+                continue
+            candidates.append(msg)
+
+        if not candidates or max_tokens <= 0:
+            return []
+
+        # Select newest-first up to the token budget
+        selected: List[Dict[str, Any]] = []
+        remaining = max_tokens
+        for msg in reversed(candidates):
+            content = msg.get("content") or ""
+            tokens = len(content) // _CHARS_PER_TOKEN + 10
+            if tokens <= remaining:
+                selected.append(msg.copy())
+                remaining -= tokens
+            else:
+                # Truncate the message to fit the remaining budget
+                chars_budget = remaining * _CHARS_PER_TOKEN
+                if chars_budget > 100:  # only include if meaningful
+                    truncated = {**msg, "content": content[:chars_budget] + "\n...[truncated]"}
+                    selected.append(truncated)
+                break
+
+        # Reverse back to chronological order
+        selected.reverse()
+        return selected
+
+    # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
 
@@ -671,7 +735,9 @@ The user has requested that this compaction PRIORITISE preserving all informatio
           2. Protect head messages (system prompt + first exchange)
           3. Find tail boundary by token budget (~20K tokens of recent context)
           4. Summarize middle turns with structured LLM prompt
-          5. On re-compression, iteratively update the previous summary
+          5. Preserve recent user messages from the summarized region (Codex-style)
+          6. Assemble: head → preserved user messages → summary → tail
+          7. On re-compression, iteratively update the previous summary
 
         After compression, orphaned tool_call / tool_result pairs are cleaned
         up so the API never receives mismatched IDs.
@@ -740,7 +806,20 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Phase 3: Generate structured summary
         summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
+        # Phase 3b: Extract real user messages from the summarized region.
+        # These are placed before the summary so the model sees the user's actual
+        # asks as the primary signal, with the summary as supplementary context.
+        preserved_user_msgs = self._collect_user_messages(
+            turns_to_summarize, max_tokens=self.user_message_max_tokens
+        )
+        if preserved_user_msgs and not self.quiet_mode:
+            logger.info(
+                "Preserved %d user message(s) from summarized region",
+                len(preserved_user_msgs),
+            )
+
         # Phase 4: Assemble compressed message list
+        # Order: [head] → [preserved user messages] → [summary] → [tail]
         compressed = []
         for i in range(compress_start):
             msg = messages[i].copy()
@@ -750,6 +829,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
                 )
             compressed.append(msg)
+
+        # Insert preserved user messages from the summarized region.
+        # These come before the summary so the model sees user intent first.
+        for umsg in preserved_user_msgs:
+            compressed.append(umsg)
 
         # If LLM summary failed, insert a static fallback so the model
         # knows context was lost rather than silently dropping everything.

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -30,6 +30,7 @@ def _make_compressor():
     compressor.base_url = "http://localhost"
     compressor.api_key = "test-key"
     compressor.api_mode = "chat_completions"
+    compressor.user_message_max_tokens = 20000  # Codex-style user message preservation
     return compressor
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -390,7 +390,8 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            # Disable user message preservation to test role alternation logic in isolation
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2, user_message_max_tokens=0)
 
         # Head ends with tool (index 1), tail starts with user (index 6).
         # Default: tool → summary_role="user" → collides with tail.
@@ -429,7 +430,8 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=3)
+            # Disable user message preservation to test role alternation logic in isolation
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=3, user_message_max_tokens=0)
 
         # Head: [system, user, assistant]  →  last head = assistant
         # Tail: [user, assistant, user]    →  first tail = user
@@ -468,7 +470,8 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            # Disable user message preservation to test role alternation logic in isolation
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2, user_message_max_tokens=0)
 
         # Head: [system, user]        → last head = user
         # Tail: [assistant, user, assistant] → first tail = assistant
@@ -781,3 +784,98 @@ class TestTokenBudgetTailProtection:
         # Tool at index 2 is outside the protected tail (last 3 = indices 2,3,4)
         # so it might or might not be pruned depending on boundary
         assert isinstance(pruned, int)
+
+
+class TestUserMessagePreservation:
+    """Tests for Codex-style user message preservation during compression."""
+
+    def test_collect_user_messages_basic(self):
+        """_collect_user_messages extracts user messages newest-first."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        msgs = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "response"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "response"},
+            {"role": "user", "content": "third"},
+        ]
+        result = c._collect_user_messages(msgs, max_tokens=10000)
+        assert len(result) == 3
+        assert result[0]["content"] == "first"
+        assert result[1]["content"] == "second"
+        assert result[2]["content"] == "third"
+
+    def test_collect_user_messages_filters_summaries(self):
+        """_collect_user_messages filters out previous compaction summaries."""
+        from agent.context_compressor import SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        msgs = [
+            {"role": "user", "content": "real message"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX} old summary"},
+            {"role": "user", "content": f"{LEGACY_SUMMARY_PREFIX} legacy summary"},
+            {"role": "user", "content": "[CONTEXT COMPACTION] another summary"},
+            {"role": "user", "content": "another real message"},
+        ]
+        result = c._collect_user_messages(msgs, max_tokens=10000)
+        assert len(result) == 2
+        assert result[0]["content"] == "real message"
+        assert result[1]["content"] == "another real message"
+
+    def test_collect_user_messages_respects_token_budget(self):
+        """_collect_user_messages respects token budget, newest-first."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        # Each message ~25 chars = ~6 tokens + 10 overhead = ~16 tokens
+        msgs = [
+            {"role": "user", "content": "a" * 25},  # oldest
+            {"role": "user", "content": "b" * 25},
+            {"role": "user", "content": "c" * 25},  # newest
+        ]
+        # With budget of 40 tokens, should get newest 2 messages
+        result = c._collect_user_messages(msgs, max_tokens=40)
+        assert len(result) == 2
+        assert result[0]["content"] == "b" * 25
+        assert result[1]["content"] == "c" * 25
+
+    def test_collect_user_messages_zero_disables(self):
+        """Setting max_tokens=0 disables user message preservation."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, user_message_max_tokens=0)
+
+        msgs = [{"role": "user", "content": "test"}]
+        result = c._collect_user_messages(msgs, max_tokens=0)
+        assert result == []
+
+    def test_preserved_messages_in_compress_output(self):
+        """Compressed output includes preserved user messages between head and summary."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "head user"},
+            {"role": "assistant", "content": "head response"},  # compressed region starts
+            {"role": "user", "content": "middle user 1"},      # should be preserved
+            {"role": "assistant", "content": "middle response"},
+            {"role": "user", "content": "middle user 2"},      # should be preserved
+            {"role": "assistant", "content": "tail response"},  # tail starts
+            {"role": "user", "content": "tail user"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        # Find preserved user messages in result
+        contents = [m.get("content", "") for m in result]
+        assert "middle user 1" in contents or "middle user 2" in contents, \
+            "Preserved user messages should appear in compressed output"


### PR DESCRIPTION
## Enhanced Compaction (Codex-style)

### Background

We studied [OpenAI Codex's `compact.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/compact.rs) to understand how they handle context compaction. Their key insight: don't just summarize — preserve the user's actual messages alongside the summary.

### The Codex Approach

Codex's compaction keeps real user messages from the compressed region (up to 20K tokens, newest-first) and places them *before* the summary. This ensures the model sees user intent as the primary signal, with the summary as supplementary context.

**Before:**
```
[head] → [summary] → [tail]
```

**After:**
```
[head] → [preserved user messages] → [summary] → [tail]
```

### Changes

- Add `user_message_max_tokens` constructor param (default 20K, matching Codex)
  - Configurable: set to 0 to disable user message preservation entirely
- Add `_collect_user_messages()` — extracts user messages from the compressed region, filtering out previous compaction summaries
- Modify `compress()` to insert preserved messages between head and summary
- Add tests for new functionality