### PR TITLE
fix: suppress Authorization: Bearer for Gemini provider to prevent HT…

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -725,6 +725,15 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
+            elif "generativelanguage.googleapis.com" in base_url.lower():
+                # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
+                # Passing api_key= causes the SDK to inject Authorization: Bearer,
+                # which Google rejects with HTTP 400 "Multiple authentication
+                # credentials received". Use a placeholder for api_key and pass
+                # the real key via x-goog-api-key header instead.
+                # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
+                extra["default_headers"] = {"x-goog-api-key": api_key}
+                api_key = "not-used"
             return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -746,6 +755,15 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
+        elif "generativelanguage.googleapis.com" in base_url.lower():
+            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
+            # Passing api_key= causes the SDK to inject Authorization: Bearer,
+            # which Google rejects with HTTP 400 "Multiple authentication
+            # credentials received". Use a placeholder for api_key and pass
+            # the real key via x-goog-api-key header instead.
+            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
+            extra["default_headers"] = {"x-goog-api-key": api_key}
+            api_key = "not-used"
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -1533,6 +1551,15 @@ def resolve_provider_client(
             from hermes_cli.models import copilot_default_headers
 
             headers.update(copilot_default_headers())
+        elif "generativelanguage.googleapis.com" in base_url.lower():
+            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
+            # Passing api_key= causes the OpenAI SDK to inject Authorization: Bearer,
+            # which Google rejects with HTTP 400 "Multiple authentication credentials
+            # received". Use a placeholder for api_key and pass the real key via
+            # x-goog-api-key header instead.
+            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
+            headers["x-goog-api-key"] = api_key
+            api_key = "not-used"
 
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))

--- a/run_agent.py
+++ b/run_agent.py
@@ -875,6 +875,16 @@ class AIAgent:
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
+                elif "generativelanguage.googleapis.com" in effective_base.lower():
+                    # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
+                    # The OpenAI SDK auto-injects Authorization: Bearer when api_key= is
+                    # set to a real value, causing HTTP 400 "Multiple authentication
+                    # credentials received".  Pass a placeholder so the SDK does not
+                    # emit Bearer, and carry the real key via x-goog-api-key instead.
+                    # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
+                    real_key = client_kwargs["api_key"]
+                    client_kwargs["api_key"] = "not-used"
+                    client_kwargs["default_headers"] = {"x-goog-api-key": real_key}
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -4561,6 +4571,17 @@ class AIAgent:
             self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
+        elif "generativelanguage.googleapis.com" in normalized:
+            # Google's endpoint rejects Bearer tokens; use x-goog-api-key instead.
+            # Swap the real key out of api_key and into the header so the OpenAI
+            # SDK does not emit Authorization: Bearer.
+            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
+            real_key = self._client_kwargs.get("api_key", "")
+            if real_key and real_key != "not-used":
+                self._client_kwargs["api_key"] = "not-used"
+            self._client_kwargs["default_headers"] = {
+                "x-goog-api-key": real_key or self._client_kwargs.get("api_key", ""),
+            }
         else:
             self._client_kwargs.pop("default_headers", None)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -504,7 +504,12 @@ class TestExplicitProviderRouting:
             assert client is not None
 
     def test_explicit_google_alias_uses_gemini_credentials(self):
-        """provider='google' should route through the gemini API-key provider."""
+        """provider='google' should route through the gemini API-key provider.
+
+        Updated for issue #7893: the OpenAI client must receive api_key='not-used'
+        and default_headers={'x-goog-api-key': real_key} so the SDK does not emit
+        Authorization: Bearer, which Google's endpoint rejects with HTTP 400.
+        """
         with (
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
                 "api_key": "gemini-key",
@@ -517,8 +522,11 @@ class TestExplicitProviderRouting:
 
         assert client is not None
         assert model == "gemini-3.1-pro-preview"
-        assert mock_openai.call_args.kwargs["api_key"] == "gemini-key"
+        # api_key must be placeholder to suppress Authorization: Bearer (issue #7893)
+        assert mock_openai.call_args.kwargs["api_key"] == "not-used"
         assert mock_openai.call_args.kwargs["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+        # real key must be in x-goog-api-key header
+        assert mock_openai.call_args.kwargs.get("default_headers", {}).get("x-goog-api-key") == "gemini-key"
 
     def test_explicit_unknown_returns_none(self, monkeypatch):
         """Unknown provider should return None."""
@@ -853,6 +861,7 @@ class TestAuxiliaryPoolAwareness:
         assert provider == "custom:local"
 
     def test_vision_config_google_provider_uses_gemini_credentials(self, monkeypatch):
+        """Updated for issue #7893: Gemini vision client must use x-goog-api-key."""
         config = {
             "auxiliary": {
                 "vision": {
@@ -874,8 +883,11 @@ class TestAuxiliaryPoolAwareness:
         assert resolved_provider == "gemini"
         assert client is not None
         assert model == "gemini-3.1-pro-preview"
-        assert mock_openai.call_args.kwargs["api_key"] == "gemini-key"
+        # api_key must be placeholder to suppress Authorization: Bearer (issue #7893)
+        assert mock_openai.call_args.kwargs["api_key"] == "not-used"
         assert mock_openai.call_args.kwargs["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+        # real key must be in x-goog-api-key header
+        assert mock_openai.call_args.kwargs.get("default_headers", {}).get("x-goog-api-key") == "gemini-key"
 
 
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -211,6 +211,58 @@ class TestGeminiAgentInit:
             assert agent.api_mode == "chat_completions"
             assert agent.provider == "gemini"
 
+    def test_gemini_uses_x_goog_api_key_not_bearer(self, monkeypatch):
+        """Regression test for issue #7893.
+
+        When provider=gemini, the OpenAI client must be constructed with
+        api_key='not-used' and default_headers={'x-goog-api-key': real_key}.
+        This prevents the SDK from injecting Authorization: Bearer, which
+        Google's endpoint rejects with HTTP 400.
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy_REAL_KEY")
+        real_key = "AIzaSy_REAL_KEY"
+        with patch("run_agent.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from run_agent import AIAgent
+            AIAgent(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                api_key=real_key,
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+        call_kwargs = mock_openai.call_args[1]
+        # The SDK must NOT receive the real key as api_key (which would emit Bearer)
+        assert call_kwargs.get("api_key") == "not-used", (
+            "api_key must be 'not-used' to suppress Authorization: Bearer for Gemini"
+        )
+        # The real key must be in x-goog-api-key header
+        headers = call_kwargs.get("default_headers", {})
+        assert headers.get("x-goog-api-key") == real_key, (
+            "x-goog-api-key header must carry the real Gemini API key"
+        )
+
+    def test_gemini_resolve_provider_client_auth(self, monkeypatch):
+        """Regression test for issue #7893 — resolve_provider_client path.
+
+        When resolve_provider_client('gemini') is called, the returned OpenAI
+        client must use x-goog-api-key header, not Authorization: Bearer.
+        """
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy_TEST_KEY")
+        real_key = "AIzaSy_TEST_KEY"
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            mock_openai.return_value.api_key = "not-used"
+            from agent.auxiliary_client import resolve_provider_client
+            resolve_provider_client("gemini")
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("api_key") == "not-used", (
+            "api_key must be 'not-used' to prevent Bearer injection for Gemini"
+        )
+        headers = call_kwargs.get("default_headers", {})
+        assert headers.get("x-goog-api-key") == real_key, (
+            "x-goog-api-key header must carry the real Gemini API key"
+        )
+
 
 # ── models.dev Integration ──
 


### PR DESCRIPTION
Fixes #7893

## Root Cause

Google's OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai`)
does not accept `Authorization: Bearer` for AIzaSy API keys. The OpenAI Python SDK
automatically injects this header whenever a real key is passed as `api_key=`, causing:

    HTTP 400: Multiple authentication credentials received. Please pass only one.

## Fix

When `base_url` targets `generativelanguage.googleapis.com`, the OpenAI client is
now constructed with `api_key="not-used"` (suppresses Bearer injection) and the real
key is passed via `default_headers={"x-goog-api-key": real_key}` instead.

Applied to all 4 client construction paths:
- `run_agent.py` — primary agent client init
- `run_agent.py` — `_apply_client_headers_for_base_url()` (provider swap/recovery)
- `agent/auxiliary_client.py` — `_resolve_api_key_provider()` pool + main paths
- `agent/auxiliary_client.py` — `resolve_provider_client()` API-key branch

## Tests

Added 2 regression tests asserting `api_key == "not-used"` and
`x-goog-api-key == real_key`. Updated 2 existing tests that were
asserting the old broken auth behavior.