### PR TITLE
fix: route CJK-heavy messages to primary model in smart routing (#8516)

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -95,6 +95,14 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if _URL_RE.search(text):
         return None
 
+    # CJK text has no whitespace-separated "words", so word-count based
+    # heuristics fail badly.  A 160-char Chinese sentence looks like a
+    # single "word" and slips through as 'simple'.  Detect CJK density
+    # and treat CJK-heavy messages as complex (#8516).
+    cjk_chars = len(_CJK_RE.findall(text))
+    if cjk_chars > 0 and cjk_chars / max(len(text), 1) > 0.2:
+        return None
+
     lowered = text.lower()
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
     if words & _COMPLEX_KEYWORDS:


### PR DESCRIPTION
## Problem

CJK (Chinese, Japanese, Korean) text lacks whitespace-separated words, so the word-count based heuristics in `choose_cheap_model_route` incorrectly classify CJK messages as 'simple'. A 160-char Chinese sentence appears as a single 'word' and slips through to the cheap model.

## Fix

Add CJK density detection using the existing `_CJK_RE` regex. When >20% of characters are CJK, treat the message as complex and route to the primary model.

## Test
- `你好世界` → routed to primary (was: cheap model)
- `hi` → routed to cheap model (unchanged)
- `what time is it` → routed to cheap model (unchanged)