### PR TITLE
fix: strip API keys from request debug dumps (#8518)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2729,6 +2729,10 @@ class AIAgent:
         try:
             body = copy.deepcopy(api_kwargs)
             body.pop("timeout", None)
+            # Never persist raw secrets in debug dump files — the API key
+            # may be present in api_kwargs for some SDK/client combinations (#8518).
+            for _secret_key in ("api_key", "x_api_key", "api_token"):
+                body.pop(_secret_key, None)
             body = {k: v for k, v in body.items() if v is not None}
 
             api_key = None


### PR DESCRIPTION
## Problem

`_dump_api_request_debug` persists raw `api_kwargs` into JSON files on disk. While the Authorization header is masked via `_mask_api_key_for_logs()`, the request body may contain `api_key`, `x_api_key`, or `api_token` as raw values (depending on SDK/client combination). These get written unredacted to `logs_dir/request_dump_*.json`.

## Fix

Strip known secret keys from the body before writing:
- `api_key`
- `x_api_key`
- `api_token`

## Affected code
- `run_agent.py`: `_dump_api_request_debug()`