### PR TITLE
fix: bound delegate task wall-clock runtime

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -739,11 +739,13 @@ code_execution:
 # Supports single tasks and batch mode (up to 3 parallel).
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
+  max_duration_seconds: 1800                  # Max wall-clock runtime per child (default: 1800, <=0 disables)
   default_toolsets: ["terminal", "file", "web"]  # Default toolsets for subagents
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  #                                           # Env override: DELEGATION_MAX_DURATION_SECONDS
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2843,7 +2843,11 @@ class AIAgent:
         # Signal all tools to abort any in-flight operations immediately.
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.
-        _set_interrupt(True, self._execution_thread_id)
+        # Bare agents constructed via __new__ in tests/debug helpers may not
+        # have _execution_thread_id populated yet; treat that the same as None
+        # so tools fall back to the current thread instead of raising.
+        execution_thread_id = getattr(self, "_execution_thread_id", None)
+        _set_interrupt(True, execution_thread_id)
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -2859,7 +2863,8 @@ class AIAgent:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
-        _set_interrupt(False, self._execution_thread_id)
+        execution_thread_id = getattr(self, "_execution_thread_id", None)
+        _set_interrupt(False, execution_thread_id)
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -81,6 +81,16 @@ class TestDelegationDurationConfig(unittest.TestCase):
         with patch("tools.delegate_tool._load_config", return_value={"max_duration_seconds": 0}):
             self.assertIsNone(_get_max_duration_seconds())
 
+    def test_env_override_takes_precedence_over_config(self):
+        with patch.dict(os.environ, {"DELEGATION_MAX_DURATION_SECONDS": "12"}, clear=False):
+            with patch("tools.delegate_tool._load_config", return_value={"max_duration_seconds": 34}):
+                self.assertEqual(_get_max_duration_seconds(), 12.0)
+
+    def test_env_override_can_disable_duration_even_when_config_is_set(self):
+        with patch.dict(os.environ, {"DELEGATION_MAX_DURATION_SECONDS": "0"}, clear=False):
+            with patch("tools.delegate_tool._load_config", return_value={"max_duration_seconds": 34}):
+                self.assertIsNone(_get_max_duration_seconds())
+
 
 class TestChildSystemPrompt(unittest.TestCase):
     def test_goal_only(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -21,6 +21,8 @@ from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
     _get_max_concurrent_children,
+    _get_max_duration_seconds,
+    _run_single_child,
     MAX_DEPTH,
     check_delegate_requirements,
     delegate_task,
@@ -68,6 +70,16 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+
+
+class TestDelegationDurationConfig(unittest.TestCase):
+    def test_default_max_duration_seconds(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertEqual(_get_max_duration_seconds(), 900.0)
+
+    def test_zero_disables_max_duration(self):
+        with patch("tools.delegate_tool._load_config", return_value={"max_duration_seconds": 0}):
+            self.assertIsNone(_get_max_duration_seconds())
 
 
 class TestChildSystemPrompt(unittest.TestCase):
@@ -232,6 +244,64 @@ class TestDelegateTask(unittest.TestCase):
 
             delegate_task(goal="Test tracking", parent_agent=parent)
             self.assertEqual(len(parent._active_children), 0)
+
+    def test_run_single_child_times_out(self):
+        parent = _make_mock_parent(depth=0)
+        parent._touch_activity = MagicMock()
+
+        class SlowChild:
+            def __init__(self):
+                self.tool_progress_callback = None
+                self._delegate_saved_tool_names = []
+                self._credential_pool = None
+                self._interrupt_requested = False
+                self._interrupt_message = None
+                self.model = "test/model"
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+
+            def get_activity_summary(self):
+                return {
+                    "current_tool": None,
+                    "api_call_count": 0,
+                    "max_iterations": 20,
+                    "last_activity_desc": "waiting for model response",
+                }
+
+            def interrupt(self, message=None):
+                self._interrupt_requested = True
+                self._interrupt_message = message
+
+            def run_conversation(self, user_message=None, **kwargs):
+                start = time.monotonic()
+                while not self._interrupt_requested and (time.monotonic() - start) < 5:
+                    time.sleep(0.02)
+                return {
+                    "final_response": "Operation interrupted by timeout.",
+                    "messages": [],
+                    "api_calls": 1,
+                    "completed": False,
+                    "interrupted": self._interrupt_requested,
+                    "interrupt_message": self._interrupt_message,
+                }
+
+            def close(self):
+                return None
+
+        child = SlowChild()
+        with patch("tools.delegate_tool._get_max_duration_seconds", return_value=0.1):
+            result = _run_single_child(
+                task_index=0,
+                goal="Review this diff",
+                child=child,
+                parent_agent=parent,
+            )
+        self.assertEqual(result["status"], "timeout")
+        self.assertEqual(result["exit_reason"], "timeout")
+        self.assertIn("max_duration_seconds", result["error"])
+        self.assertLess(result["duration_seconds"], 3.0)
+        self.assertTrue(child._interrupt_requested)
+        parent._touch_activity.assert_called()
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -303,6 +303,58 @@ class TestDelegateTask(unittest.TestCase):
         self.assertTrue(child._interrupt_requested)
         parent._touch_activity.assert_called()
 
+    def test_run_single_child_does_not_mark_completed_child_as_timeout_during_flush(self):
+        parent = _make_mock_parent(depth=0)
+
+        class FlushBarrier:
+            def _flush(self):
+                time.sleep(0.05)
+
+        class FastChild:
+            def __init__(self):
+                self.tool_progress_callback = FlushBarrier()
+                self._delegate_saved_tool_names = []
+                self._credential_pool = None
+                self.model = "test/model"
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+
+            def get_activity_summary(self):
+                return {
+                    "current_tool": None,
+                    "api_call_count": 1,
+                    "max_iterations": 20,
+                    "last_activity_desc": "completed",
+                }
+
+            def interrupt(self, message=None):
+                raise AssertionError("completed child should not be interrupted after return")
+
+            def run_conversation(self, user_message=None, **kwargs):
+                return {
+                    "final_response": "Finished successfully.",
+                    "messages": [],
+                    "api_calls": 1,
+                    "completed": True,
+                    "interrupted": False,
+                }
+
+            def close(self):
+                return None
+
+        child = FastChild()
+        with patch("tools.delegate_tool._get_max_duration_seconds", return_value=0.01):
+            result = _run_single_child(
+                task_index=0,
+                goal="Review this diff",
+                child=child,
+                parent_agent=parent,
+            )
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["exit_reason"], "completed")
+        self.assertEqual(result["summary"], "Finished successfully.")
+        self.assertNotIn("error", result)
+
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -75,7 +75,7 @@ class TestDelegateRequirements(unittest.TestCase):
 class TestDelegationDurationConfig(unittest.TestCase):
     def test_default_max_duration_seconds(self):
         with patch("tools.delegate_tool._load_config", return_value={}):
-            self.assertEqual(_get_max_duration_seconds(), 900.0)
+            self.assertEqual(_get_max_duration_seconds(), 1800.0)
 
     def test_zero_disables_max_duration(self):
         with patch("tools.delegate_tool._load_config", return_value={"max_duration_seconds": 0}):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -530,6 +530,12 @@ def _run_single_child(
     try:
         result = child.run_conversation(user_message=goal)
 
+        # Stop the timeout watchdog before post-processing the result so a child
+        # that completed just under the wall-clock limit cannot be reclassified
+        # as timed out while we flush progress or inspect the returned payload.
+        _timeout_stop.set()
+        _timeout_thread.join(timeout=5)
+
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, '_flush'):
             try:
@@ -543,7 +549,10 @@ def _run_single_child(
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
         interrupt_message = result.get("interrupt_message") or ""
-        timed_out = _timeout_triggered.is_set() or str(interrupt_message).startswith(_TIMEOUT_INTERRUPT_PREFIX)
+        timed_out = (
+            str(interrupt_message).startswith(_TIMEOUT_INTERRUPT_PREFIX)
+            or (_timeout_triggered.is_set() and interrupted and not completed)
+        )
         api_calls = result.get("api_calls", 0)
 
         if timed_out:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -50,7 +50,9 @@ _SUBAGENT_TOOLSETS = sorted(
 _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
+_DEFAULT_MAX_DURATION_SECONDS = 900
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
+_TIMEOUT_INTERRUPT_PREFIX = "[delegate-timeout]"
 
 
 def _get_max_concurrent_children() -> int:
@@ -77,6 +79,34 @@ def _get_max_concurrent_children() -> int:
         except (TypeError, ValueError):
             pass
     return _DEFAULT_MAX_CONCURRENT_CHILDREN
+
+
+def _get_max_duration_seconds() -> Optional[float]:
+    """Read delegation.max_duration_seconds with env override and sane coercion.
+
+    Returns None when explicitly disabled with 0/negative values.
+    """
+    cfg = _load_config()
+    val = cfg.get("max_duration_seconds")
+    if val is not None:
+        try:
+            seconds = float(val)
+            return seconds if seconds > 0 else None
+        except (TypeError, ValueError):
+            logger.warning(
+                "delegation.max_duration_seconds=%r is not a valid number; using default %s",
+                val,
+                _DEFAULT_MAX_DURATION_SECONDS,
+            )
+    env_val = os.getenv("DELEGATION_MAX_DURATION_SECONDS")
+    if env_val:
+        try:
+            seconds = float(env_val)
+            return seconds if seconds > 0 else None
+        except (TypeError, ValueError):
+            pass
+    return float(_DEFAULT_MAX_DURATION_SECONDS)
+
 DEFAULT_MAX_ITERATIONS = 50
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
@@ -468,6 +498,35 @@ def _run_single_child(
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
     _heartbeat_thread.start()
 
+    max_duration_seconds = _get_max_duration_seconds()
+    _timeout_stop = threading.Event()
+    _timeout_triggered = threading.Event()
+
+    def _timeout_loop():
+        if max_duration_seconds is None:
+            return
+        if _timeout_stop.wait(max_duration_seconds):
+            return
+        _timeout_triggered.set()
+        timeout_msg = (
+            f"{_TIMEOUT_INTERRUPT_PREFIX} subagent exceeded max_duration_seconds="
+            f"{max_duration_seconds:g}"
+        )
+        try:
+            child.interrupt(timeout_msg)
+        except Exception as exc:
+            logger.debug("Failed to interrupt timed-out child agent: %s", exc)
+        if parent_agent is not None:
+            touch = getattr(parent_agent, '_touch_activity', None)
+            if touch:
+                try:
+                    touch(f"delegate_task: timing out subagent {task_index}")
+                except Exception:
+                    pass
+
+    _timeout_thread = threading.Thread(target=_timeout_loop, daemon=True)
+    _timeout_thread.start()
+
     try:
         result = child.run_conversation(user_message=goal)
 
@@ -483,9 +542,13 @@ def _run_single_child(
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
+        interrupt_message = result.get("interrupt_message") or ""
+        timed_out = _timeout_triggered.is_set() or str(interrupt_message).startswith(_TIMEOUT_INTERRUPT_PREFIX)
         api_calls = result.get("api_calls", 0)
 
-        if interrupted:
+        if timed_out:
+            status = "timeout"
+        elif interrupted:
             status = "interrupted"
         elif summary:
             # A summary means the subagent produced usable output.
@@ -534,7 +597,9 @@ def _run_single_child(
                         tool_trace[-1].update(result_meta)
 
         # Determine exit reason
-        if interrupted:
+        if timed_out:
+            exit_reason = "timeout"
+        elif interrupted:
             exit_reason = "interrupted"
         elif completed:
             exit_reason = "completed"
@@ -560,7 +625,13 @@ def _run_single_child(
             },
             "tool_trace": tool_trace,
         }
-        if status == "failed":
+        if timed_out:
+            entry["error"] = (
+                f"Subagent exceeded max_duration_seconds={max_duration_seconds:g}"
+                if max_duration_seconds is not None else
+                "Subagent exceeded max duration"
+            )
+        elif status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
         return entry
@@ -578,10 +649,12 @@ def _run_single_child(
         }
 
     finally:
-        # Stop the heartbeat thread so it doesn't keep touching parent activity
-        # after the child has finished (or failed).
+        # Stop the heartbeat and timeout watchdog threads so they don't keep
+        # touching parent activity or firing after the child has finished.
         _heartbeat_stop.set()
+        _timeout_stop.set()
         _heartbeat_thread.join(timeout=5)
+        _timeout_thread.join(timeout=5)
 
         if child_pool is not None and leased_cred_id is not None:
             try:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -51,7 +51,7 @@ _SUBAGENT_TOOLSETS = sorted(
 _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
-_DEFAULT_MAX_DURATION_SECONDS = 900
+_DEFAULT_MAX_DURATION_SECONDS = 1800
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 _TIMEOUT_INTERRUPT_PREFIX = "[delegate-timeout]"
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -87,6 +87,17 @@ def _get_max_duration_seconds() -> Optional[float]:
 
     Returns None when explicitly disabled with 0/negative values.
     """
+    env_val = os.getenv("DELEGATION_MAX_DURATION_SECONDS")
+    if env_val:
+        try:
+            seconds = float(env_val)
+            return seconds if seconds > 0 else None
+        except (TypeError, ValueError):
+            logger.warning(
+                "DELEGATION_MAX_DURATION_SECONDS=%r is not a valid number; falling back to config/default",
+                env_val,
+            )
+
     cfg = _load_config()
     val = cfg.get("max_duration_seconds")
     if val is not None:
@@ -99,13 +110,6 @@ def _get_max_duration_seconds() -> Optional[float]:
                 val,
                 _DEFAULT_MAX_DURATION_SECONDS,
             )
-    env_val = os.getenv("DELEGATION_MAX_DURATION_SECONDS")
-    if env_val:
-        try:
-            seconds = float(env_val)
-            return seconds if seconds > 0 else None
-        except (TypeError, ValueError):
-            pass
     return float(_DEFAULT_MAX_DURATION_SECONDS)
 
 DEFAULT_MAX_ITERATIONS = 50

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,6 +20,7 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -442,11 +443,10 @@ def _run_single_child(
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
 
-    # Restore parent tool names using the value saved before child construction
-    # mutated the global. This is the correct parent toolset, not the child's.
-    import model_tools
-    _saved_tool_names = getattr(child, "_delegate_saved_tool_names",
-                                list(model_tools._last_resolved_tool_names))
+    # Avoid importing model_tools on cold synthetic/test paths here.
+    # The child already carries the parent's saved tool names when delegation
+    # was constructed normally, and a fresh model_tools import can dominate the
+    # measured runtime for timeout-sensitive watchdog tests.
 
     child_pool = getattr(child, '_credential_pool', None)
     leased_cred_id = None
@@ -664,11 +664,10 @@ def _run_single_child(
 
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
-        import model_tools
-
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
-        if isinstance(saved_tool_names, list):
-            model_tools._last_resolved_tool_names = list(saved_tool_names)
+        model_tools_mod = sys.modules.get("model_tools")
+        if isinstance(saved_tool_names, list) and model_tools_mod is not None:
+            model_tools_mod._last_resolved_tool_names = list(saved_tool_names)
 
         # Remove child from active tracking
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1234,6 +1234,7 @@ delegation:
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
+  # max_duration_seconds: 900                # Wall-clock cap per subagent (0 disables the watchdog)
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
@@ -1243,6 +1244,8 @@ delegation:
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
 **Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+
+**Runtime watchdog:** `delegation.max_duration_seconds` caps each subagent by wall-clock time. When the limit is reached, Hermes interrupts the child, returns a `timeout` result, and includes an error like `Subagent exceeded max_duration_seconds=...`. Set it to `0` or a negative value to disable the watchdog.
 
 ## Clarify
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1234,7 +1234,6 @@ delegation:
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
-  # max_duration_seconds: 900                # Wall-clock cap per subagent (0 disables the watchdog)
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
@@ -1244,8 +1243,6 @@ delegation:
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
 **Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
-
-**Runtime watchdog:** `delegation.max_duration_seconds` caps each subagent by wall-clock time. When the limit is reached, Hermes interrupts the child, returns a `timeout` result, and includes an error like `Subagent exceeded max_duration_seconds=...`. Set it to `0` or a negative value to disable the watchdog.
 
 ## Clarify
 


### PR DESCRIPTION
## What changed
- add a wall-clock watchdog for `delegate_task` subagents
- interrupt and classify children as `timeout` when they exceed `delegation.max_duration_seconds`
- set the default delegate watchdog to `1800` seconds (30 minutes)
- add regression coverage for the new delegation watchdog
- avoid a cold `model_tools` import in `_run_single_child`, which was stretching timeout-path wall-clock duration during tests
- document `delegation.max_duration_seconds` in `cli-config.yaml.example`, including the disable behavior and env override

## Why
I observed several delegate-task runs lasting 20–75 minutes, including one session that looked hung for a long time before being interrupted by a new user message. The current delegate flow bounds subagents by tool-call iterations but not by wall-clock runtime, so slow delegation workers can appear stuck indefinitely.

A 30-minute default is a better operator tradeoff than 15 minutes for real coding/research delegates: it still bounds apparent hangs, but it is less likely to cut off legitimate longer-running subagents by default.

## How to test
- `python -m pytest tests/tools/test_delegate.py -q`
- `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
- Manual smoke exercise of the timeout path:
  - run `_run_single_child(...)` with `DELEGATION_MAX_DURATION_SECONDS=0.1`
  - verify the child is interrupted and returns `status: timeout` / `exit_reason: timeout`

## Platforms tested
- macOS

## Notes
- This keeps the change focused on the delegate timeout/runtime slice.
- The branch was rebased onto current `main` before opening the upstream PR.
