### PR TITLE
fix: reuse main context for auto compression feasibility

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1708,6 +1708,89 @@ class AIAgent:
             "api_mode": getattr(self, "api_mode", "") or "",
         }
 
+    def _compression_has_explicit_override(self) -> bool:
+        """Return True when compression routing is explicitly configured.
+
+        Reusing the main model's configured context length is only safe when
+        compression is still in full auto mode and resolves back to the live main
+        runtime. Any explicit provider/model/base URL/API override means the
+        auxiliary route may intentionally differ and must be re-measured.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_agent_config
+            from agent.auxiliary_client import (
+                _get_auxiliary_env_override,
+                _get_auxiliary_provider,
+            )
+        except Exception:
+            return True
+
+        try:
+            _agent_cfg = _load_agent_config()
+        except Exception:
+            _agent_cfg = {}
+
+        if not isinstance(_agent_cfg, dict):
+            _agent_cfg = {}
+
+        _compression_cfg = _agent_cfg.get("compression", {})
+        if not isinstance(_compression_cfg, dict):
+            _compression_cfg = {}
+
+        _aux_cfg = _agent_cfg.get("auxiliary", {})
+        if not isinstance(_aux_cfg, dict):
+            _aux_cfg = {}
+        _aux_compression_cfg = _aux_cfg.get("compression", {})
+        if not isinstance(_aux_compression_cfg, dict):
+            _aux_compression_cfg = {}
+
+        _aux_provider = str(_aux_compression_cfg.get("provider") or "").strip().lower()
+        if _aux_provider and _aux_provider != "auto":
+            return True
+        for _key in ("model", "base_url", "api_key", "api_mode"):
+            if str(_aux_compression_cfg.get(_key) or "").strip():
+                return True
+
+        _summary_provider = str(_compression_cfg.get("summary_provider") or "").strip().lower()
+        if _summary_provider and _summary_provider != "auto":
+            return True
+        for _key in ("summary_model", "summary_base_url"):
+            if str(_compression_cfg.get(_key) or "").strip():
+                return True
+
+        if _get_auxiliary_provider("compression") != "auto":
+            return True
+        for _suffix in ("MODEL", "BASE_URL", "API_KEY", "API_MODE"):
+            if _get_auxiliary_env_override("compression", _suffix):
+                return True
+
+        return False
+
+    def _compression_can_reuse_main_context(
+        self,
+        aux_model: str,
+        aux_base_url: str,
+        aux_api_key: str,
+    ) -> bool:
+        """Return True when auto compression resolves back to the live main runtime."""
+        _config_context_length = getattr(self, "_config_context_length", None)
+        if not isinstance(_config_context_length, int) or _config_context_length <= 0:
+            return False
+        if self._compression_has_explicit_override():
+            return False
+
+        _main_model = str(getattr(self, "model", "") or "")
+        _main_base_url = str(getattr(self, "base_url", "") or "")
+        _main_api_key = str(getattr(self, "api_key", "") or "")
+
+        if str(aux_model or "") != _main_model:
+            return False
+        if str(aux_base_url or "").rstrip("/") != _main_base_url.rstrip("/"):
+            return False
+        if str(aux_api_key or "") != _main_api_key:
+            return False
+        return True
+
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
         window is smaller than the main model's compression threshold.
@@ -1748,11 +1831,18 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
-            aux_context = get_model_context_length(
+            if self._compression_can_reuse_main_context(
                 aux_model,
-                base_url=aux_base_url,
-                api_key=aux_api_key,
-            )
+                aux_base_url,
+                aux_api_key,
+            ):
+                aux_context = int(self._config_context_length)
+            else:
+                aux_context = get_model_context_length(
+                    aux_model,
+                    base_url=aux_base_url,
+                    api_key=aux_api_key,
+                )
 
             threshold = self.context_compressor.threshold_tokens
             if aux_context < threshold:

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -19,6 +19,7 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    config_context_length: int | None = None,
 ) -> AIAgent:
     """Build a minimal AIAgent with a compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
@@ -43,6 +44,7 @@ def _make_agent(
     compressor.context_length = main_context
     compressor.threshold_tokens = int(main_context * threshold_percent)
     agent.context_compressor = compressor
+    agent._config_context_length = config_context_length
 
     return agent
 
@@ -127,6 +129,86 @@ def test_feasibility_check_passes_live_main_runtime():
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         },
+    )
+
+
+@patch("agent.auxiliary_client._get_auxiliary_env_override", return_value=None)
+@patch("agent.auxiliary_client._get_auxiliary_provider", return_value="auto")
+@patch("hermes_cli.config.load_config", return_value={"compression": {"summary_model": "", "summary_provider": "auto", "summary_base_url": None}, "auxiliary": {"compression": {"provider": "auto", "model": "", "base_url": "", "api_key": "", "api_mode": ""}}})
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_auto_mode_reuses_main_config_context_when_aux_matches_main_runtime(
+    mock_get_client,
+    mock_ctx_len,
+    mock_load_config,
+    mock_get_provider,
+    mock_get_env_override,
+):
+    """Auto compression should reuse the main config context when routing back to the live main runtime."""
+    agent = _make_agent(
+        main_context=1_050_000,
+        threshold_percent=0.50,
+        config_context_length=1_050_000,
+    )
+    agent.model = "gpt-5.4"
+    agent.provider = "custom"
+    agent.base_url = "https://llm.mics.tw/v1"
+    agent.api_key = "sk-main"
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://llm.mics.tw/v1"
+    mock_client.api_key = "sk-main"
+    mock_get_client.return_value = (mock_client, "gpt-5.4")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert messages == []
+    assert agent._compression_warning is None
+    mock_ctx_len.assert_not_called()
+
+
+@patch("agent.auxiliary_client._get_auxiliary_env_override", return_value=None)
+@patch("agent.auxiliary_client._get_auxiliary_provider", return_value="auto")
+@patch("hermes_cli.config.load_config", return_value={"compression": {"summary_model": "gpt-5.4", "summary_provider": "auto", "summary_base_url": None}, "auxiliary": {"compression": {"provider": "auto", "model": "", "base_url": "", "api_key": "", "api_mode": ""}}})
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_explicit_summary_model_does_not_reuse_main_config_context(
+    mock_get_client,
+    mock_ctx_len,
+    mock_load_config,
+    mock_get_provider,
+    mock_get_env_override,
+):
+    """Any explicit compression model override disables main-context reuse."""
+    agent = _make_agent(
+        main_context=1_050_000,
+        threshold_percent=0.50,
+        config_context_length=1_050_000,
+    )
+    agent.model = "gpt-5.4"
+    agent.provider = "custom"
+    agent.base_url = "https://llm.mics.tw/v1"
+    agent.api_key = "sk-main"
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://llm.mics.tw/v1"
+    mock_client.api_key = "sk-main"
+    mock_get_client.return_value = (mock_client, "gpt-5.4")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "128,000" in messages[0]
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.4",
+        base_url="https://llm.mics.tw/v1",
+        api_key="sk-main",
     )
 
 


### PR DESCRIPTION
## Summary
- reuse the configured main context length during compression feasibility checks only when auxiliary compression is still in full auto mode and resolves back to the live main runtime
- keep explicit auxiliary/summary provider, model, base URL, API key, API mode, and env overrides on the old re-measurement path
- add regression tests covering both auto reuse and explicit override behavior

## Problem we hit
We hit this with a custom OpenAI-compatible deployment where the main model had an explicit `model.context_length` override of `1050000`, `compression.threshold` was `0.5`, and compression was still configured in auto mode.

In that setup, compression auto-routing correctly resolved back to the same main runtime. However, the feasibility warning path in `run_agent.py` re-measured the auxiliary context via `get_model_context_length(...)` instead of reusing the already-configured main context length.

For custom endpoints where Hermes cannot recover the true context window from endpoint metadata, that re-measurement can fall back to a much smaller inferred window (for us, `128000`). Hermes then warns that compression would be impossible because it compares:
- main threshold: `525000`
- inferred auxiliary context: `128000`

The important nuance is that Hermes was not choosing a different compression model here — it was still auto-routing to the same main model/runtime, but the feasibility check was re-inferring context length and losing the configured `1050000` override.

## Behavior after this patch
- If compression is still fully `auto` and resolves back to the same live main runtime, the feasibility check reuses the configured main context length.
- If compression is explicitly configured in any way, Hermes keeps the old behavior and re-measures the auxiliary route instead of inheriting the main context.

## Testing
- pytest -q tests/run_agent/test_compression_feasibility.py