### PR TITLE
feat: add /feishu_auth and /feishu_diagnose slash commands

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -972,6 +972,9 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
+        # Bypass macOS system proxy for Feishu WebSocket
+        if "proxy" not in kwargs:
+            kwargs["proxy"] = None
         return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2776,6 +2776,12 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "feishu_auth":
+            return await self._handle_feishu_auth(event)
+
+        if canonical == "feishu_diagnose":
+            return await self._handle_feishu_diagnose(event)
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
@@ -4937,6 +4943,109 @@ class GatewayRunner:
         self._save_voice_modes()
         adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+
+    # =========================================================================
+    # Feishu/Lark commands
+    # =========================================================================
+
+    async def _handle_feishu_auth(self, event: MessageEvent) -> str:
+        """Handle /feishu_auth — trigger OAuth device flow for the calling user."""
+        try:
+            import sys
+            from pathlib import Path
+
+            # Try to load hermes-lark plugin bridge
+            plugin_dir = Path.home() / ".hermes" / "plugins" / "hermes-lark"
+            if not (plugin_dir / "bridge.py").exists():
+                plugin_dir = Path.home() / "projects" / "openclaw-lark-hermes" / "package"
+
+            bridge_dir = str(plugin_dir)
+            if bridge_dir not in sys.path:
+                sys.path.insert(0, bridge_dir)
+
+            from bridge import HermesLarkBridge
+
+            bridge = HermesLarkBridge()
+            bridge.initialize(
+                app_id=os.getenv("FEISHU_APP_ID", ""),
+                app_secret=os.getenv("FEISHU_APP_SECRET", ""),
+                domain=os.getenv("FEISHU_DOMAIN", "feishu"),
+                owner_policy=os.getenv("FEISHU_OWNER_POLICY", "multiUser"),
+            )
+
+            result = bridge.call_tool("feishu_oauth", {"action": "authorize"})
+            bridge.close()
+
+            if isinstance(result, dict) and "content" in result:
+                texts = []
+                for c in result["content"]:
+                    texts.append(c.get("text", ""))
+                return "\n".join(texts)
+            return json.dumps(result, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            return f"❌ Feishu OAuth failed: {e}"
+
+    async def _handle_feishu_diagnose(self, event: MessageEvent) -> str:
+        """Handle /feishu_diagnose — show Feishu connection and OAuth status."""
+        import os as _os
+        lines = []
+        lines.append("🔍 **Feishu/Lark Diagnostics**\n")
+
+        # Check env vars
+        app_id = _os.getenv("FEISHU_APP_ID", "")
+        app_secret = _os.getenv("FEISHU_APP_SECRET", "")
+        lines.append(f"**FEISHU_APP_ID**: {'✅ ' + app_id[:8] + '...' if app_id else '❌ Not set'}")
+        lines.append(f"**FEISHU_APP_SECRET**: {'✅ Set (' + str(len(app_secret)) + ' chars)' if app_secret and app_secret != '***' else '❌ Not set or placeholder'}")
+
+        # Check plugin
+        from pathlib import Path
+        plugin_dir = Path.home() / ".hermes" / "plugins" / "hermes-lark"
+        has_plugin = (plugin_dir / "__init__.py").exists()
+        lines.append(f"**hermes-lark plugin**: {'✅ Installed' if has_plugin else '❌ Not found'}")
+
+        # Check bridge
+        has_bridge = (plugin_dir / "bridge.py").exists() or (Path.home() / "projects" / "openclaw-lark-hermes" / "package" / "bridge.py").exists()
+        lines.append(f"**bridge.py**: {'✅ Found' if has_bridge else '❌ Not found'}")
+
+        # Check hermes-lark repo
+        has_repo = (Path.home() / "projects" / "openclaw-lark-hermes").is_dir()
+        lines.append(f"**hermes-lark repo**: {'✅ Present' if has_repo else '⚠️ Not cloned'}")
+
+        # Try a quick bridge test
+        if app_id and app_secret and app_secret != "***" and has_bridge:
+            try:
+                import sys
+                bd = str(plugin_dir) if (plugin_dir / "bridge.py").exists() else str(Path.home() / "projects" / "openclaw-lark-hermes" / "package")
+                if bd not in sys.path:
+                    sys.path.insert(0, bd)
+                from bridge import HermesLarkBridge
+                b = HermesLarkBridge()
+                b.initialize(app_id=app_id, app_secret=app_secret,
+                           domain=_os.getenv("FEISHU_DOMAIN", "feishu"),
+                           owner_policy=_os.getenv("FEISHU_OWNER_POLICY", "multiUser"))
+                tools = b.list_tools()
+                lines.append(f"\n**Bridge test**: ✅ {len(tools)} tools loaded")
+
+                # Test a quick API call
+                r = b.call_tool("feishu_chat", {"action": "list"})
+                if r is None:
+                    lines.append("**API test**: ✅ Connected (no chats, expected)")
+                elif isinstance(r, dict) and isinstance(r.get("error"), str):
+                    err = r["error"]
+                    if "need_user_authorization" in err:
+                        lines.append("**API test**: ⚠️ Connected but needs OAuth (use /feishu_auth)")
+                    else:
+                        lines.append(f"**API test**: ⚠️ {err[:80]}")
+                else:
+                    lines.append("**API test**: ✅ Working")
+                b.close()
+            except Exception as e:
+                lines.append(f"\n**Bridge test**: ❌ {e}")
+        else:
+            lines.append(f"\n**Bridge test**: ⏭️ Skipped (missing credentials)")
+
+        return "\n".join(lines)
 
     async def _handle_voice_channel_input(
         self, guild_id: int, user_id: int, transcript: str

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -155,6 +155,16 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
 
+    # Feishu/Lark integration
+    CommandDef("feishu_auth", "Trigger Feishu OAuth device flow for user authorization",
+               "Tools & Skills",
+               aliases=("lark_auth", "fa"),
+               gateway_config_gate="plugins.feishu_auth.enabled"),
+    CommandDef("feishu_diagnose", "Diagnose Feishu connection and OAuth status",
+               "Tools & Skills",
+               aliases=("lark_diagnose", "fd"),
+               gateway_config_gate="plugins.feishu_auth.enabled"),
+
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",
                cli_only=True, aliases=("exit", "q")),


### PR DESCRIPTION
## Summary

Add slash commands for Feishu/Lark OAuth integration, enabling gateway users to trigger the OAuth device flow and diagnose connection issues directly from chat.

### Changes

**hermes_cli/commands.py:**
- Add `feishu_auth` command (aliases: `lark_auth`, `fa`) — triggers Feishu OAuth device flow
- Add `feishu_diagnose` command (aliases: `lark_diagnose`, `fd`) — shows Feishu connection and OAuth status
- Both commands are gated behind `plugins.feishu_auth.enabled` config key

**gateway/run.py:**
- Add `_handle_feishu_auth()` — async handler that loads hermes-lark bridge, calls `feishu_oauth` tool with `action: authorize`
- Add `_handle_feishu_diagnose()` — async handler that checks env vars, plugin installation, bridge connectivity, and runs a quick API test
- Bridge loaded lazily from `~/.hermes/plugins/hermes-lark/` or `~/projects/openclaw-lark-hermes/package/`

**gateway/platforms/feishu.py:**
- Bypass macOS system proxy for Feishu WebSocket connections (`proxy: None`)

### Context

These commands complement the [hermes-lark plugin](https://github.com/eggyrooch-blip/hermes-lark), which adapts the official openclaw-lark Feishu plugin for Hermes Agent. The plugin provides 36 Feishu tools (calendar, IM, drive, wiki, sheets, tasks, bitable, OAuth) via a Node.js bridge.

### Testing
- `python3 -m py_compile` passes on all modified files
- `ast.parse()` passes on gateway/run.py
- Commands appear in `GATEWAY_KNOWN_COMMANDS` when config gate is enabled
- `resolve_command("feishu_auth")` resolves correctly including alias `"fa"`
- Compatible with existing command dispatch in gateway/run.py

### Configuration

Enable in `~/.hermes/config.yaml`:
```yaml
plugins:
  feishu_auth:
    enabled: true
```

Set in `~/.hermes/.env`:
```
FEISHU_APP_ID=cli_xxxxx
FEISHU_APP_SECRET=your_secret
```