### PR TITLE
fix: queue busy gateway messages and preserve auto-reset continuity

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -518,7 +518,7 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -812,6 +812,66 @@ class GatewayRunner:
             old_session_id,
             session_key,
         )
+
+    async def _prepare_auto_reset_boundary(
+        self,
+        *,
+        source: SessionSource,
+        session_key: str,
+    ) -> None:
+        """Flush durable memory hooks before an automatic session reset.
+
+        Auto-resets can happen after crashes, interrupts, or idle expiry. If a
+        cached agent still exists for the old session, give its memory provider
+        one last chance to extract durable facts from the persisted transcript
+        before the active session pointer rolls over to a new session id.
+        """
+        old_entry = None
+        try:
+            with self.session_store._lock:
+                self.session_store._ensure_loaded_locked()
+                old_entry = self.session_store._entries.get(session_key)
+        except Exception:
+            old_entry = None
+        if not old_entry:
+            return
+
+        reset_reason = "suspended" if getattr(old_entry, "suspended", False) else None
+        if reset_reason is None:
+            try:
+                reset_reason = self.session_store._should_reset(old_entry, source)
+            except Exception:
+                reset_reason = None
+        if not reset_reason:
+            return
+
+        cached_agent = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache_lock is not None and _cache is not None:
+            with _cache_lock:
+                cached = _cache.get(session_key)
+            cached_agent = cached[0] if isinstance(cached, tuple) else cached if cached else None
+
+        if cached_agent is not None and cached_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                history = self.session_store.load_transcript(old_entry.session_id)
+                if history and hasattr(cached_agent, "shutdown_memory_provider"):
+                    cached_agent.shutdown_memory_provider(history)
+            except Exception as e:
+                logger.debug("Auto-reset memory provider flush failed for %s: %s", old_entry.session_id, e)
+
+        if not getattr(old_entry, "memory_flushed", False):
+            try:
+                await self._async_flush_memories(old_entry.session_id, session_key)
+                with self.session_store._lock:
+                    self.session_store._ensure_loaded_locked()
+                    refreshed_entry = self.session_store._entries.get(session_key)
+                    if refreshed_entry and refreshed_entry.session_id == old_entry.session_id:
+                        refreshed_entry.memory_flushed = True
+                        self.session_store._save()
+            except Exception as e:
+                logger.debug("Auto-reset async memory flush failed for %s: %s", old_entry.session_id, e)
 
     @property
     def should_exit_cleanly(self) -> bool:
@@ -1189,7 +1249,12 @@ class GatewayRunner:
 
     @staticmethod
     def _load_busy_input_mode() -> str:
-        """Load gateway drain-time busy-input behavior from config/env."""
+        """Load gateway busy-input behavior from config/env.
+
+        Modes:
+          - ``queue``     — queue follow-up user messages while the current turn runs
+          - ``interrupt`` — interrupt the current turn when a follow-up arrives
+        """
         mode = os.getenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "").strip().lower()
         if not mode:
             try:
@@ -1201,7 +1266,7 @@ class GatewayRunner:
                     mode = str(cfg.get("display", {}).get("busy_input_mode", "") or "").strip().lower()
             except Exception:
                 pass
-        return "queue" if mode == "queue" else "interrupt"
+        return "interrupt" if mode == "interrupt" else "queue"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -1326,24 +1391,59 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
-    async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
-        if not self._draining:
+    @staticmethod
+    def _is_explicit_interrupt_message(event: MessageEvent) -> bool:
+        text = (getattr(event, "text", "") or "").strip().lower()
+        if not text:
             return False
+        explicit = {
+            "interrupt",
+            "interrupt current task",
+            "stop",
+            "stop current task",
+            "cancel",
+            "cancel current task",
+            "abort",
+            "中断",
+            "中断当前任务",
+            "停止",
+            "停止当前任务",
+            "取消",
+            "取消当前任务",
+            "打断",
+            "打断当前任务",
+        }
+        return text in explicit
 
+    async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return True
 
         thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-        if self._queue_during_drain_enabled():
-            self._queue_or_replace_pending_event(session_key, event)
-            message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
-        else:
-            message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
+        if self._draining:
+            if self._queue_during_drain_enabled():
+                self._queue_or_replace_pending_event(session_key, event)
+                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+            else:
+                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+
+            await adapter._send_with_retry(
+                chat_id=event.source.chat_id,
+                content=message,
+                reply_to=event.message_id,
+                metadata=thread_meta,
+            )
+            return True
+
+        if self._busy_input_mode != "queue" or self._is_explicit_interrupt_message(event):
+            return False
+
+        self._queue_or_replace_pending_event(session_key, event)
         await adapter._send_with_retry(
             chat_id=event.source.chat_id,
-            content=message,
+            content="⏳ I’m still working on your previous message — queued this for the next turn. Send /stop to interrupt.",
             reply_to=event.message_id,
             metadata=thread_meta,
         )
@@ -2543,7 +2643,7 @@ class GatewayRunner:
                     del self._running_agents[_quick_key]
                 # Mark session suspended so the next message starts fresh
                 # instead of resuming the stuck context (#7536).
-                self.session_store.suspend_session(_quick_key)
+                self.session_store.suspend_session(_quick_key, reason="manual_stop")
                 logger.info("HARD STOP for session %s — suspended, session lock released", _quick_key[:20])
                 return "⚡ Force-stopped. The session is suspended — your next message will start fresh."
 
@@ -2634,6 +2734,10 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
+            if self._busy_input_mode == "queue" and not self._is_explicit_interrupt_message(event):
+                logger.debug("PRIORITY queue for session %s", _quick_key[:20])
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return "⏳ I’m still working on your previous message — queued this for the next turn. Send /stop to interrupt."
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
             running_agent.interrupt(event.text)
             if _quick_key in self._pending_messages:
@@ -3096,6 +3200,8 @@ class GatewayRunner:
         )
 
         # Get or create session
+        initial_session_key = self._session_key_for_source(source)
+        await self._prepare_auto_reset_boundary(source=source, session_key=initial_session_key)
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         
@@ -3136,11 +3242,21 @@ class GatewayRunner:
         if getattr(session_entry, 'was_auto_reset', False):
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
-                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
+                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation.]"
             elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation.]"
             else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
+                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation.]"
+
+            reset_summary = (getattr(session_entry, 'reset_context_summary', '') or '').strip()
+            if reset_summary:
+                context_note += (
+                    "\n[System note: A brief carryover summary from the previous session is included below so "
+                    "the user does not lose continuity.]\n"
+                    f"{reset_summary}"
+                )
+            else:
+                context_note += "\n[System note: No carryover summary was available from the previous session.]"
             context_prompt = context_note + "\n\n" + context_prompt
 
             # Send a user-facing notification explaining the reset, unless:
@@ -3173,9 +3289,15 @@ class GatewayRunner:
                             mins = policy.idle_minutes % 60
                             duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
                             reason_text = f"inactive for {duration}"
+                        carryover_text = (
+                            "A brief summary from the previous session was carried into this new session."
+                            if reset_summary else
+                            "No carryover summary was available from the previous session."
+                        )
                         notice = (
                             f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
+                            f"Conversation history cleared from the active session.\n"
+                            f"{carryover_text}\n"
                             f"Use /resume to browse and restore a previous session.\n"
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
@@ -3194,6 +3316,7 @@ class GatewayRunner:
 
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
+            session_entry.reset_context_summary = ""
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -360,8 +360,9 @@ class SessionEntry:
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
     was_auto_reset: bool = False
-    auto_reset_reason: Optional[str] = None  # "idle" or "daily"
+    auto_reset_reason: Optional[str] = None  # "idle", "daily", or "suspended"
     reset_had_activity: bool = False  # whether the expired session had any messages
+    reset_context_summary: str = ""  # compact carryover injected into the next session
     
     # Set by the background expiry watcher after it successfully flushes
     # memories for this session.  Persisted to sessions.json so the flag
@@ -373,6 +374,7 @@ class SessionEntry:
     # this session (create a new session_id) so the user starts fresh.
     # Set by /stop to break stuck-resume loops (#7536).
     suspended: bool = False
+    suspended_reason: str = ""
     
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -393,6 +395,8 @@ class SessionEntry:
             "cost_status": self.cost_status,
             "memory_flushed": self.memory_flushed,
             "suspended": self.suspended,
+            "suspended_reason": self.suspended_reason,
+            "reset_context_summary": self.reset_context_summary,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -430,6 +434,8 @@ class SessionEntry:
             cost_status=data.get("cost_status", "unknown"),
             memory_flushed=data.get("memory_flushed", False),
             suspended=data.get("suspended", False),
+            suspended_reason=data.get("suspended_reason", "") or "",
+            reset_context_summary=data.get("reset_context_summary", "") or "",
         )
 
 
@@ -615,8 +621,7 @@ class SessionStore:
         return False
 
     def _should_reset(self, entry: SessionEntry, source: SessionSource) -> Optional[str]:
-        """
-        Check if a session should be reset based on policy.
+        """Determine whether a session should be reset.
         
         Returns the reset reason ("idle" or "daily") if a reset is needed,
         or None if the session is still valid.
@@ -657,7 +662,53 @@ class SessionStore:
                 return "daily"
         
         return None
-    
+
+    @staticmethod
+    def _normalize_reset_summary_text(value: Any, *, limit: int = 220) -> str:
+        text = re.sub(r"\s+", " ", str(value or "")).strip()
+        if not text:
+            return ""
+        if len(text) <= limit:
+            return text
+        return text[: limit - 1].rstrip() + "…"
+
+    def _build_reset_context_summary(self, session_id: str, *, max_items: int = 6) -> str:
+        """Build a compact carryover summary from the previous transcript.
+
+        This is an extractive fallback used when an auto-reset creates a fresh
+        session. It preserves the most recent user/assistant turns so the next
+        session does not feel like an abrupt amnesia event, even if the old
+        agent was interrupted before durable memory extraction completed.
+        """
+        try:
+            history = self.load_transcript(session_id)
+        except Exception as e:
+            logger.debug("Failed to load transcript for reset summary %s: %s", session_id, e)
+            return ""
+
+        convo = []
+        for msg in history:
+            role = msg.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            content = self._normalize_reset_summary_text(msg.get("content"))
+            if not content:
+                continue
+            convo.append((role, content))
+
+        if not convo:
+            return ""
+
+        convo = convo[-max_items:]
+        lines = [
+            "Carryover from the previous auto-reset session:",
+            "- Treat this as summarized prior context, not a verbatim transcript.",
+        ]
+        for role, content in convo:
+            label = "User" if role == "user" else "Assistant"
+            lines.append(f"- {label}: {content}")
+        return "\n".join(lines)
+
     def has_any_sessions(self) -> bool:
         """Check if any sessions have ever been created (across all platforms).
 
@@ -698,6 +749,7 @@ class SessionStore:
         # All _entries / _loaded mutations are protected by self._lock.
         db_end_session_id = None
         db_create_kwargs = None
+        reset_context_summary = ""
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -709,8 +761,10 @@ class SessionStore:
                 # broke a stuck loop — #7536).
                 if entry.suspended:
                     reset_reason = "suspended"
+                    suspended_reason = getattr(entry, "suspended_reason", "") or "manual_stop"
                 else:
                     reset_reason = self._should_reset(entry, source)
+                    suspended_reason = ""
                 if not reset_reason:
                     entry.updated_at = now
                     self._save()
@@ -719,8 +773,10 @@ class SessionStore:
                     # Session is being auto-reset.
                     was_auto_reset = True
                     auto_reset_reason = reset_reason
-                    # Track whether the expired session had any real conversation
-                    reset_had_activity = entry.total_tokens > 0
+                    if reset_reason != "suspended" or suspended_reason != "manual_stop":
+                        reset_context_summary = self._build_reset_context_summary(entry.session_id)
+                    # Track whether the expired session had any real conversation.
+                    reset_had_activity = bool(reset_context_summary) or entry.total_tokens > 0
                     db_end_session_id = entry.session_id
             else:
                 was_auto_reset = False
@@ -742,6 +798,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                reset_context_summary=reset_context_summary,
             )
 
             self._entries[session_key] = entry
@@ -783,17 +840,18 @@ class SessionStore:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
 
-    def suspend_session(self, session_key: str) -> bool:
+    def suspend_session(self, session_key: str, reason: str = "manual_stop") -> bool:
         """Mark a session as suspended so it auto-resets on next access.
 
         Used by ``/stop`` to prevent stuck sessions from being resumed
-        after a gateway restart (#7536).  Returns True if the session
+        after a gateway restart (#7536). Returns True if the session
         existed and was marked.
         """
         with self._lock:
             self._ensure_loaded_locked()
             if session_key in self._entries:
                 self._entries[session_key].suspended = True
+                self._entries[session_key].suspended_reason = reason or "manual_stop"
                 self._save()
                 return True
         return False
@@ -816,6 +874,7 @@ class SessionStore:
             for entry in self._entries.values():
                 if not entry.suspended and entry.updated_at >= cutoff:
                     entry.suspended = True
+                    entry.suspended_reason = "startup_recovery"
                     count += 1
             if count:
                 self._save()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -509,7 +509,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
-        "busy_input_mode": "interrupt",
+        "busy_input_mode": "queue",
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -35,6 +35,7 @@ def make_restart_source(chat_id: str = "123456", chat_type: str = "dm") -> Sessi
         platform=Platform.TELEGRAM,
         chat_id=chat_id,
         chat_type=chat_type,
+        user_id="u-restart",
     )
 
 
@@ -62,7 +63,7 @@ def make_restart_runner(
     runner._restart_via_service = False
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     runner._stop_task = None
-    runner._busy_input_mode = "interrupt"
+    runner._busy_input_mode = "queue"
     runner._update_prompt_pending = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
@@ -71,6 +72,7 @@ def make_restart_runner(
     runner._queue_or_replace_pending_event = GatewayRunner._queue_or_replace_pending_event.__get__(
         runner, GatewayRunner
     )
+    runner._is_explicit_interrupt_message = GatewayRunner._is_explicit_interrupt_message
     runner._session_key_for_source = GatewayRunner._session_key_for_source.__get__(
         runner, GatewayRunner
     )

--- a/tests/gateway/test_async_memory_flush.py
+++ b/tests/gateway/test_async_memory_flush.py
@@ -10,9 +10,10 @@ Verifies that:
 import pytest
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from gateway.config import Platform, GatewayConfig, SessionResetPolicy
+from gateway.run import GatewayRunner
 from gateway.session import SessionSource, SessionStore, SessionEntry
 
 
@@ -114,6 +115,34 @@ class TestIsSessionExpired:
 
 class TestGetOrCreateSessionNoCallback:
     """get_or_create_session should NOT call a sync flush callback."""
+
+    @pytest.mark.asyncio
+    async def test_prepare_auto_reset_boundary_loads_persisted_session_on_cold_start(self, idle_store):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+        )
+        session_key = idle_store._generate_session_key(source)
+        entry = idle_store.get_or_create_session(source)
+        idle_store.append_to_transcript(entry.session_id, {"role": "user", "content": "keep this context"})
+        entry.suspended = True
+        idle_store._save()
+
+        # Simulate a cold-start runner before SessionStore has loaded _entries.
+        idle_store._entries.clear()
+        idle_store._loaded = False
+
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = idle_store
+        runner._async_flush_memories = AsyncMock()
+        runner._agent_cache_lock = None
+        runner._agent_cache = None
+        runner._prepare_auto_reset_boundary = GatewayRunner._prepare_auto_reset_boundary.__get__(runner, GatewayRunner)
+
+        await runner._prepare_auto_reset_boundary(source=source, session_key=session_key)
+
+        runner._async_flush_memories.assert_awaited_once_with(entry.session_id, session_key)
 
     def test_auto_reset_creates_new_session_after_flush(self, idle_store):
         """When a flushed session auto-resets, a new session_id is created."""

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -58,6 +58,50 @@ async def test_drain_queue_mode_queues_follow_up_without_interrupt():
 
 
 @pytest.mark.asyncio
+async def test_busy_queue_mode_queues_follow_up_without_interrupt():
+    runner, adapter = make_restart_runner()
+    runner._busy_input_mode = "queue"
+
+    event = MessageEvent(
+        text="follow up while busy",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m2b",
+    )
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter.handle_message(event)
+
+    assert session_key in adapter._pending_messages
+    assert adapter._pending_messages[session_key].text == "follow up while busy"
+    assert not adapter._active_sessions[session_key].is_set()
+    assert any("queued this for the next turn" in message for message in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_explicit_interrupt_message_bypasses_queue_mode():
+    runner, adapter = make_restart_runner()
+    runner._busy_input_mode = "queue"
+
+    event = MessageEvent(
+        text="中断当前任务",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m2c",
+    )
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter.handle_message(event)
+
+    assert session_key in adapter._pending_messages
+    assert adapter._pending_messages[session_key].text == "中断当前任务"
+    assert adapter._active_sessions[session_key].is_set()
+    assert not adapter.sent
+
+
+@pytest.mark.asyncio
 async def test_draining_rejects_new_session_messages():
     runner, _adapter = make_restart_runner()
     runner._draining = True
@@ -79,7 +123,7 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_input_mode: queue\n", encoding="utf-8"

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -60,7 +60,7 @@ def _make_runner():
 
 def _make_event(text="hello", chat_id="12345"):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm", user_id="u-race"
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
 
@@ -268,7 +268,7 @@ async def test_stop_hard_kills_running_agent():
     forever — showing 'writing...' but never producing output."""
     runner = _make_runner()
     session_key = build_session_key(
-        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="u-race")
     )
 
     # Simulate a running (possibly hung) agent
@@ -301,7 +301,7 @@ async def test_stop_clears_pending_messages():
     queued during the run must be discarded."""
     runner = _make_runner()
     session_key = build_session_key(
-        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="u-race")
     )
 
     fake_agent = MagicMock()

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -165,6 +165,44 @@ class TestSessionEntryReason:
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
 
+    def test_auto_reset_carries_forward_extract_summary(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        store.append_to_transcript(entry1.session_id, {"role": "user", "content": "继续刚才那个 PR，别丢上下文"})
+        store.append_to_transcript(entry1.session_id, {"role": "assistant", "content": "好的，我会保留重点并继续处理。"})
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+
+        assert entry2.was_auto_reset is True
+        assert "Carryover from the previous auto-reset session" in entry2.reset_context_summary
+        assert "继续刚才那个 PR" in entry2.reset_context_summary
+        assert "保留重点并继续处理" in entry2.reset_context_summary
+        assert entry2.reset_had_activity is True
+
+    def test_manual_stop_suspension_starts_fresh_without_carryover_summary(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        store.append_to_transcript(entry1.session_id, {"role": "user", "content": "这段上下文有问题，别继续带着它"})
+        store.suspend_session(entry1.session_key, reason="manual_stop")
+
+        entry2 = store.get_or_create_session(source)
+
+        assert entry2.was_auto_reset is True
+        assert entry2.auto_reset_reason == "suspended"
+        assert entry2.reset_context_summary == ""
+
 
 # ---------------------------------------------------------------------------
 # SessionResetPolicy notify config


### PR DESCRIPTION
## Summary
- change gateway busy-input handling so the default behavior is to queue follow-up user messages instead of interrupting the active turn
- preserve continuity across automatic session resets by extracting a compact carryover summary from the previous transcript and injecting it into the next session when appropriate
- flush memory hooks before auto-reset boundaries and keep `/stop` semantics fresh by suppressing carryover for manual-stop suspensions

## Problem / user-visible failures
This fixes two UX failures in the gateway:

1. **Incoming follow-up messages interrupted active work too aggressively**
   - A user asking for progress, sending a quick follow-up, or receiving a media echo during an active turn could interrupt the model call mid-flight.
   - The gateway already had `display.busy_input_mode: queue`, but that behavior only applied during restart/stop drain mode, not during ordinary busy turns.
   - Result: users could accidentally cancel the very task they were waiting on.

2. **Automatic session reset felt like sudden amnesia**
   - After a crash/interruption or other auto-reset boundary, the gateway would open a new session and tell the user the previous conversation history was cleared.
   - If the old session had not yet been distilled into durable memory, the next turn lost continuity even though the user expected the agent to keep going.
   - Result: the agent felt like it “forgot” what it had just been doing.

## What changed
### Busy-session behavior
- `busy_input_mode` now governs **normal active-session follow-ups**, not only restart drain mode.
- Default behavior is now `queue`, while explicit `interrupt` config/env still restores the old behavior.
- Added an explicit interrupt phrase allowlist for busy turns so users can still deliberately interrupt without using `/stop`.
- Kept restart/drain queueing behavior intact.

### Auto-reset continuity
- Added `reset_context_summary` to `SessionEntry`.
- On auto-reset, `SessionStore` builds an extractive carryover summary from recent user/assistant transcript turns.
- The next session injects that summary into the system context and updates the user-facing reset notice so it’s clear continuity was preserved.
- Added pre-reset boundary handling to flush memory hooks before the session rolls over.
- Manual `/stop` suspensions still start truly fresh: no carryover summary is injected for `manual_stop` suspensions.

## Tests
Targeted tests run locally:
- `python -m pytest tests/gateway/test_restart_drain.py tests/gateway/test_session_reset_notify.py tests/gateway/test_session_race_guard.py tests/gateway/test_session_model_reset.py tests/gateway/test_async_memory_flush.py tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_command_bypass_active_session.py -q -o addopts=''`

Result:
- `74 passed`

## Notes
- I intentionally did **not** stage an unrelated local `package-lock.json` modification.
- The carryover summary is transcript-derived and only used for auto-reset continuity, not for explicit `/new` resets.
