### PR TITLE
fix(gateway): discard orphaned execute_code responses after reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3572,6 +3572,16 @@ class GatewayRunner:
                 _response_time, _api_calls, _resp_len,
             )
 
+            _discard_reason = (
+                agent_result.get("discarded") and "discarded"
+            ) or self._discard_turn_result_reason(session_key, session_entry.session_id)
+            if _discard_reason:
+                logger.info(
+                    "Ignoring orphaned agent response for session %s after reset/stop (%s)",
+                    session_key[:20], _discard_reason,
+                )
+                return None
+
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
                 error_detail = agent_result.get("error", "unknown error")
@@ -3921,6 +3931,28 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    def _discard_turn_result_reason(
+        self,
+        session_key: Optional[str],
+        session_id: Optional[str],
+    ) -> Optional[str]:
+        """Return a reason when a finished turn no longer belongs to the live session."""
+        if not session_key or not session_id:
+            return None
+
+        try:
+            current_entry = self.session_store.get_session_entry(session_key)
+        except Exception:
+            return None
+
+        if current_entry is None:
+            return "missing"
+        if getattr(current_entry, "suspended", False):
+            return "suspended"
+        if current_entry.session_id != session_id:
+            return "reset"
+        return None
 
     async def _handle_reset_command(self, event: MessageEvent) -> str:
         """Handle /new or /reset command."""
@@ -8375,6 +8407,24 @@ class GatewayRunner:
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.
                     self._evict_cached_agent(session_key)
+
+            _discard_reason = self._discard_turn_result_reason(session_key, session_id)
+            if _discard_reason:
+                logger.info(
+                    "Discarding completed agent result for session %s (%s)",
+                    session_key[:20] if session_key else "?",
+                    _discard_reason,
+                )
+                _discard_source = response if isinstance(response, dict) else {}
+                if not _discard_source and isinstance(result_holder[0], dict):
+                    _discard_source = result_holder[0]
+                return {
+                    "discarded": True,
+                    "final_response": "",
+                    "messages": _discard_source.get("messages", history),
+                    "api_calls": _discard_source.get("api_calls", 0),
+                    "already_sent": True,
+                }
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -783,6 +783,12 @@ class SessionStore:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
 
+    def get_session_entry(self, session_key: str) -> Optional[SessionEntry]:
+        """Return the current entry for ``session_key`` without creating one."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
 

--- a/tests/gateway/test_orphaned_reset_response.py
+++ b/tests/gateway/test_orphaned_reset_response.py
@@ -1,0 +1,135 @@
+"""Regression tests for orphaned agent responses after /reset or /stop."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_event(text: str = "hello") -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="mid-1",
+    )
+
+
+def _make_runner(tmp_path):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_typing = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    adapter.get_pending_message = MagicMock(return_value=None)
+    adapter.has_pending_interrupt = MagicMock(return_value=False)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._pending_messages = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._show_reasoning = False
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._MAX_INTERRUPT_DEPTH = 3
+    runner._async_flush_memories = AsyncMock()
+    runner._deliver_media_from_response = AsyncMock()
+    runner._send_voice_reply = AsyncMock()
+    runner._inject_watch_notification = AsyncMock()
+    runner._should_send_voice_reply = lambda *args, **kwargs: False
+    runner._format_session_info = lambda: ""
+    runner._set_session_env = lambda context: []
+    runner._clear_session_env = lambda tokens: None
+    runner._load_reasoning_config = lambda: None
+    runner._load_service_tier = lambda: None
+    runner._is_intentional_model_switch = lambda *args, **kwargs: False
+    runner._evict_cached_agent = lambda *args, **kwargs: None
+    runner._status_action_label = lambda: "restart"
+    runner._status_action_gerund = lambda: "restarting"
+    runner._queue_during_drain_enabled = lambda: False
+    runner._update_runtime_status = lambda *args, **kwargs: None
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        loaded_hooks=False,
+    )
+    runner.config = GatewayConfig()
+    runner.session_store = SessionStore(tmp_path / "sessions.json", runner.config)
+    runner._handle_message_with_agent = GatewayRunner._handle_message_with_agent.__get__(runner, GatewayRunner)
+    runner._discard_turn_result_reason = GatewayRunner._discard_turn_result_reason.__get__(runner, GatewayRunner)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_discards_orphaned_result(tmp_path):
+    runner = _make_runner(tmp_path)
+    event = _make_event()
+    source = event.source
+    session_entry = runner.session_store.get_or_create_session(source)
+    session_key = session_entry.session_key
+
+    runner._prepare_inbound_message_text = AsyncMock(return_value="hello")
+    runner._run_agent = AsyncMock(return_value={
+        "discarded": True,
+        "final_response": "",
+        "messages": [],
+        "api_calls": 1,
+    })
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    old_home = os.environ.get("TELEGRAM_HOME_CHANNEL")
+    os.environ["TELEGRAM_HOME_CHANNEL"] = "set"
+    try:
+        result = await runner._handle_message_with_agent(event, source, session_key)
+    finally:
+        if old_home is None:
+            os.environ.pop("TELEGRAM_HOME_CHANNEL", None)
+        else:
+            os.environ["TELEGRAM_HOME_CHANNEL"] = old_home
+
+    assert result is None
+    runner._run_agent.assert_awaited_once()
+    runner.adapters[Platform.TELEGRAM].send.assert_not_awaited()
+    runner.session_store.append_to_transcript.assert_not_called()
+    runner.session_store.update_session.assert_not_called()
+
+
+def test_discard_turn_result_reason_detects_reset_and_suspension(tmp_path):
+    runner = _make_runner(tmp_path)
+    source = _make_event().source
+    entry = runner.session_store.get_or_create_session(source)
+    session_key = entry.session_key
+    old_session_id = entry.session_id
+
+    assert runner._discard_turn_result_reason(session_key, old_session_id) is None
+
+    runner.session_store.reset_session(session_key)
+    assert runner._discard_turn_result_reason(session_key, old_session_id) == "reset"
+
+    refreshed = runner.session_store.get_session_entry(session_key)
+    runner.session_store.suspend_session(session_key)
+    assert runner._discard_turn_result_reason(session_key, refreshed.session_id) == "suspended"

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -811,6 +811,42 @@ class TestInterruptHandling(unittest.TestCase):
             set_interrupt(False, main_tid)
             t.join(timeout=3)
 
+    def test_execute_code_registers_child_process_for_kill_all(self):
+        """execute_code should be killable immediately via process_registry.kill_all()."""
+        code = "import time; time.sleep(60); print('should not reach')"
+        result_holder = {}
+
+        def run_code():
+            result_holder["value"] = json.loads(execute_code(
+                code,
+                task_id="test-kill-all",
+                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+            ))
+
+        worker = threading.Thread(target=run_code, daemon=True)
+        worker.start()
+
+        try:
+            from tools.process_registry import process_registry
+
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if process_registry.has_active_processes("test-kill-all"):
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail("execute_code child was not registered in process_registry")
+
+            killed = process_registry.kill_all(task_id="test-kill-all")
+            self.assertGreaterEqual(killed, 1)
+
+            worker.join(timeout=10)
+            self.assertFalse(worker.is_alive(), "execute_code did not stop after kill_all()")
+            self.assertEqual(result_holder["value"]["status"], "interrupted")
+        finally:
+            from tools.process_registry import process_registry
+            process_registry.kill_all(task_id="test-kill-all")
+
 
 class TestHeadTailTruncation(unittest.TestCase):
     """Tests for head+tail truncation of large stdout in execute_code."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -253,6 +253,28 @@ class TestActiveQueries:
         assert registry.has_active_processes("t1") is False
 
 
+class TestManualRegistration:
+    def test_register_and_unregister_process(self, registry):
+        proc = MagicMock()
+        proc.pid = 4321
+
+        session = registry.register_process(
+            proc,
+            "python script.py",
+            cwd="/tmp",
+            task_id="task-123",
+            persist_checkpoint=False,
+        )
+
+        assert registry.has_active_processes("task-123") is True
+        assert registry.get(session.id) is session
+        assert session.persist_checkpoint is False
+
+        assert registry.unregister_process(session.id) is True
+        assert registry.get(session.id) is None
+        assert registry.has_active_processes("task-123") is False
+
+
 # =========================================================================
 # Pruning
 # =========================================================================

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -951,6 +951,7 @@ def execute_code(
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
     server_sock = None
+    tracked_proc_session = None
 
     try:
         # Write the auto-generated hermes_tools module
@@ -1036,6 +1037,18 @@ def execute_code(
             stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
         )
+
+        try:
+            from tools.process_registry import process_registry
+            tracked_proc_session = process_registry.register_process(
+                proc,
+                f"{sys.executable} script.py",
+                cwd=tmpdir,
+                task_id=task_id or "",
+                persist_checkpoint=False,
+            )
+        except Exception as exc:
+            logger.debug("Failed to register execute_code child process: %s", exc)
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
         deadline = time.monotonic() + timeout
@@ -1147,6 +1160,9 @@ def execute_code(
         exit_code = proc.returncode if proc.returncode is not None else -1
         duration = round(time.monotonic() - exec_start, 2)
 
+        if status == "success" and exit_code != 0 and _is_interrupted():
+            status = "interrupted"
+
         # Wait for RPC thread to finish
         server_sock.close()  # break accept() so thread exits promptly
         server_sock = None  # prevent double close in finally
@@ -1205,6 +1221,12 @@ def execute_code(
         }, ensure_ascii=False)
 
     finally:
+        if tracked_proc_session is not None:
+            try:
+                from tools.process_registry import process_registry
+                process_registry.unregister_process(tracked_proc_session.id)
+            except Exception as exc:
+                logger.debug("Failed to unregister execute_code child process: %s", exc)
         # Cleanup temp dir and socket
         if server_sock is not None:
             try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -98,6 +98,7 @@ class ProcessSession:
     _watch_disabled: bool = field(default=False, repr=False) # permanently killed by overload
     _watch_window_hits: int = field(default=0, repr=False)   # hits in current rate window
     _watch_window_start: float = field(default=0.0, repr=False)
+    persist_checkpoint: bool = True               # False for ephemeral foreground tasks
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
@@ -474,6 +475,46 @@ class ProcessRegistry:
 
         self._write_checkpoint()
         return session
+
+    def register_process(
+        self,
+        process: subprocess.Popen,
+        command: str,
+        *,
+        cwd: str = None,
+        task_id: str = "",
+        session_key: str = "",
+        persist_checkpoint: bool = True,
+    ) -> ProcessSession:
+        """Track an already-spawned local process without creating reader threads."""
+        session = ProcessSession(
+            id=f"proc_{uuid.uuid4().hex[:12]}",
+            command=command,
+            task_id=task_id,
+            session_key=session_key,
+            pid=getattr(process, "pid", None),
+            process=process,
+            cwd=cwd or os.getcwd(),
+            started_at=time.time(),
+            persist_checkpoint=persist_checkpoint,
+        )
+        with self._lock:
+            self._prune_if_needed()
+            self._running[session.id] = session
+        self._write_checkpoint()
+        return session
+
+    def unregister_process(self, session_id: str) -> bool:
+        """Remove a tracked process session once the owner has fully cleaned it up."""
+        removed = False
+        with self._lock:
+            if self._running.pop(session_id, None) is not None:
+                removed = True
+            if self._finished.pop(session_id, None) is not None:
+                removed = True
+        if removed:
+            self._write_checkpoint()
+        return removed
 
     # ----- Reader / Poller Threads -----
 
@@ -973,7 +1014,7 @@ class ProcessRegistry:
             with self._lock:
                 entries = []
                 for s in self._running.values():
-                    if not s.exited:
+                    if not s.exited and s.persist_checkpoint:
                         entries.append({
                             "session_id": s.id,
                             "command": s.command,


### PR DESCRIPTION
## Summary

This fixes a race where `/reset` or `/new` could force-stop an in-flight `execute_code` turn, but the old agent thread would still finish and publish a late orphaned response into the fresh session.

**Fixes #8523**

## What changed

- discard completed agent results when the session was reset or suspended mid-flight
- add a session-state guard in gateway post-processing so orphaned results are ignored instead of being published
- register local `execute_code` child processes in `process_registry`
- unregister those child processes after execution finishes
- skip checkpoint persistence for these ephemeral foreground `execute_code` processes
- normalize externally-killed `execute_code` children to `interrupted` when an interrupt was already requested

## Why

Previously:
1. user sends `/reset` while `execute_code` is running
2. the running agent is interrupted and the session is reset
3. `execute_code` eventually exits, but the old `_run_agent` path still returns a result
4. that stale result is published into the new session

This patch ensures that once the session has been reset or suspended, the completed turn is discarded silently. It also makes `execute_code` subprocesses visible to `process_registry`, so `agent.close()` can terminate them immediately.

## Tests added
- regression test for orphaned responses being discarded after reset/stop
- test that `execute_code` registers its child process so `kill_all()` can stop it
- test for manual process registration/unregistration in `process_registry`