### PR TITLE
fix(cli): strip gemma thought tags from visible output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2454,9 +2454,9 @@ def extract_content_or_reasoning(response) -> str:
     if content:
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
         cleaned = re.sub(
-            r"<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>"
+            r"<(?:think|thinking|thought|reasoning|REASONING_SCRATCHPAD)>"
             r".*?"
-            r"</(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>",
+            r"</(?:think|thinking|thought|reasoning|REASONING_SCRATCHPAD)>",
             "", content, flags=re.DOTALL | re.IGNORECASE,
         ).strip()
         if cleaned:

--- a/cli.py
+++ b/cli.py
@@ -2420,8 +2420,8 @@ class HermesCLI:
         # suppress them during streaming too — unless show_reasoning is
         # enabled, in which case we route the inner content to the
         # reasoning display box instead of discarding it.
-        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>")
-        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>")
+        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<thought>", "<THINKING>", "<thinking>", "<THOUGHT>")
+        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</thought>", "</THINKING>", "</thinking>", "</THOUGHT>")
 
         # Append to a pre-filter buffer first
         self._stream_prefilt = getattr(self, "_stream_prefilt", "") + text
@@ -3098,16 +3098,16 @@ class HermesCLI:
         MAX_ASST_LINES = 3           # max lines of assistant text
 
         def _strip_reasoning(text: str) -> str:
-            """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
+            """Remove reasoning tag blocks from displayed text
             from displayed text (reasoning model internal thoughts)."""
             import re
             cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
+                r"<(?:REASONING_SCRATCHPAD|think|thinking|thought|reasoning)>.*?</(?:REASONING_SCRATCHPAD|think|thinking|thought|reasoning)>\s*",
                 "", text, flags=re.DOTALL,
             )
             # Also strip unclosed reasoning tags at the end
             cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*$",
+                r"<(?:REASONING_SCRATCHPAD|think|thinking|thought|reasoning)>.*$",
                 "", cleaned, flags=re.DOTALL,
             )
             return cleaned.strip()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1871,13 +1871,14 @@ class AIAgent:
         """Remove reasoning/thinking blocks from content, returning only visible text."""
         if not content:
             return ""
-        # Strip all reasoning tag variants: <think>, <thinking>, <THINKING>,
+        # Strip all reasoning tag variants: <think>, <thinking>, <thought>,
         # <reasoning>, <REASONING_SCRATCHPAD>
         content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
         content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
+        content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
         content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL)
         content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL)
-        content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
+        content = re.sub(r'</?(?:think|thinking|thought|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
     def _looks_like_codex_intermediate_ack(
@@ -2002,6 +2003,7 @@ class AIAgent:
             inline_patterns = (
                 r"<think>(.*?)</think>",
                 r"<thinking>(.*?)</thinking>",
+                r"<thought>(.*?)</thought>",
                 r"<reasoning>(.*?)</reasoning>",
                 r"<REASONING_SCRATCHPAD>(.*?)</REASONING_SCRATCHPAD>",
             )
@@ -8358,7 +8360,7 @@ class AIAgent:
                         # thinking-budget exhaustion.
                         _has_think_tags = bool(
                             _trunc_content and re.search(
-                                r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
+                                r'<(?:think|thinking|thought|reasoning|REASONING_SCRATCHPAD)[^>]*>',
                                 _trunc_content,
                                 re.IGNORECASE,
                             )
@@ -9415,7 +9417,7 @@ class AIAgent:
                     _think_text = assistant_message.content.strip()
                     # Strip reasoning XML tags that shouldn't leak to parent display
                     _think_text = re.sub(
-                        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                        r'</?(?:REASONING_SCRATCHPAD|think|thinking|thought|reasoning)>', '', _think_text
                     ).strip()
                     # For subagents: relay first line to parent display (existing behaviour).
                     # For all agents with a structured callback: emit reasoning.available event.

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -230,7 +230,7 @@ class TestThinkingCallback:
         if (content and callback and delegate_depth > 0):
             _think_text = content.strip()
             _think_text = re.sub(
-                r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                r'</?(?:REASONING_SCRATCHPAD|think|thinking|thought|reasoning)>', '', _think_text
             ).strip()
             first_line = _think_text.split('\n')[0][:80] if _think_text else ""
             if first_line:
@@ -303,6 +303,17 @@ class TestThinkingCallback:
         assert "<think>" not in calls[0][1]
         assert "think about this problem" in calls[0][1]
 
+    def test_thinking_callback_strips_thought_tags(self):
+        """<thought> tags should be stripped before display."""
+        calls = []
+        self._simulate_thinking_callback(
+            "<thought>Keep this internal</thought>",
+            lambda name, preview=None: calls.append((name, preview))
+        )
+        assert len(calls) == 1
+        assert "<thought>" not in calls[0][1]
+        assert "Keep this internal" in calls[0][1]
+
     def test_thinking_callback_empty_after_strip(self):
         """Should not fire when content is only XML tags."""
         calls = []
@@ -371,4 +382,3 @@ class TestBatchFlush:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -290,6 +290,22 @@ class TestDisplayResumedHistory:
         assert "Let me think step by step" not in output
         assert "The answer is 42" in output
 
+    def test_thought_tags_stripped(self):
+        """<thought> blocks should be stripped from display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "<thought>Hidden reasoning</thought>\n\nVisible answer.",
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<thought>" not in output
+        assert "Hidden reasoning" not in output
+        assert "Visible answer." in output
+
     def test_pure_reasoning_message_skipped(self):
         """Assistant messages that are only reasoning should be skipped."""
         cli = _make_cli()

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -111,6 +111,19 @@ class TestRealReasoningBlock:
         cli._stream_delta("   <think>")
         assert cli._in_reasoning_block
 
+    def test_thought_at_start_of_stream(self):
+        """'<thought>reasoning</thought>answer' should suppress reasoning."""
+        cli = _make_cli_stub()
+        cli._stream_delta("<thought>")
+        assert cli._in_reasoning_block
+        cli._stream_delta("Keep this internal")
+        cli._stream_delta("</thought>")
+        assert not cli._in_reasoning_block
+        cli._stream_delta("Visible answer")
+        full = "".join(cli._emitted)
+        assert "Visible answer" in full
+        assert "Keep this internal" not in full
+
 
 class TestFlushRecovery:
     """_flush_stream should recover content from false-positive reasoning blocks."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -291,6 +291,12 @@ class TestStripThinkBlocks:
         assert "</thinking>" not in result
         assert "answer" in result
 
+    def test_thought_tag_removed(self, agent):
+        result = agent._strip_think_blocks("<thought>private chain of thought</thought>answer")
+        assert "<thought>" not in result
+        assert "private chain of thought" not in result
+        assert "answer" in result
+
     def test_orphaned_opening_think_tag(self, agent):
         result = agent._strip_think_blocks("<think>orphaned reasoning without close")
         assert "<think>" not in result
@@ -344,6 +350,7 @@ class TestExtractReasoning:
         [
             ("<think>thinking hard</think>", "thinking hard"),
             ("<thinking>step by step</thinking>", "step by step"),
+            ("<thought>quiet deliberation</thought>", "quiet deliberation"),
             (
                 "<REASONING_SCRATCHPAD>scratch analysis</REASONING_SCRATCHPAD>",
                 "scratch analysis",


### PR DESCRIPTION
## What does this PR do?

This hardens Hermes against Gemma-style `<thought>...</thought>` reasoning tags leaking into visible output.

There is already an open PR in this area (`#6149`), but that one is narrower. This patch covers the other places where `<thought>` still leaked through: CLI streaming suppression, resumed-history display cleanup, auxiliary-client content cleanup, reasoning extraction, subagent progress relay, and the think-tag detection path used during truncation/retry handling.

That keeps the behavior consistent with the other reasoning-tag variants Hermes already strips.

## Related Issue

Fixes #6148

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- added `<thought>` handling to `run_agent.py` reasoning-tag cleanup and extraction paths
- added `<thought>` suppression to the CLI streaming and resumed-history display paths in `cli.py`
- added `<thought>` cleanup to `agent/auxiliary_client.py`
- added regression coverage in `tests/run_agent/test_run_agent.py`
- added regression coverage in `tests/cli/test_stream_delta_think_tag.py`
- added regression coverage in `tests/cli/test_resume_display.py`
- added regression coverage in `tests/agent/test_subagent_progress.py`

## How to Test

1. Configure a Gemma 4 model that emits `<thought>...</thought>` in responses.
2. Send a prompt that triggers reasoning in the CLI and confirm the `<thought>` block does not appear in visible output.
3. Resume a session or stream output through the CLI and confirm `<thought>` content is still hidden there as well.

Focused tests:

```bash
source venv/bin/activate
python -m pytest tests/run_agent/test_run_agent.py -q -k "think or reasoning"
python -m pytest tests/cli/test_stream_delta_think_tag.py tests/cli/test_resume_display.py tests/agent/test_subagent_progress.py -q
```

Results:
- `41 passed`
- `59 passed`

Full suite:

```bash
source venv/bin/activate
python -m pytest tests/ -q
```

Result:
- `95 failed, 10874 passed, 33 skipped`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
