### PR TITLE
fix: use absolute() instead of resolve() in _remap_path_for_user to preserve venv symlinks

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -753,7 +753,7 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
     current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    resolved = Path(path).absolute()
     try:
         relative = resolved.relative_to(current_home)
         return str(Path(target_home_dir) / relative)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -351,18 +351,23 @@ def show_status(args):
             _gw_svc = get_service_name()
         except Exception:
             _gw_svc = "hermes-gateway"
-        try:
-            result = subprocess.run(
-                ["systemctl", "--user", "is-active", _gw_svc],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            is_active = result.stdout.strip() == "active"
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            is_active = False
+        # Check user service first, then system service
+        is_active = False
+        manager = "systemd (user)"
+        for _cmd, _label in [
+            (["systemctl", "--user", "is-active", _gw_svc], "systemd (user)"),
+            (["systemctl", "is-active", _gw_svc], "systemd (system)"),
+        ]:
+            try:
+                result = subprocess.run(_cmd, capture_output=True, text=True, timeout=5)
+                if result.stdout.strip() == "active":
+                    is_active = True
+                    manager = _label
+                    break
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
         print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-        print("  Manager:      systemd (user)")
+        print(f"  Manager:      {manager}")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label


### PR DESCRIPTION
## Problem

When installing a system gateway service via `sudo hermes gateway install --system`, the generated `ExecStart` points to the bare system Python instead of the venv Python. This causes `ModuleNotFoundError` (e.g. `No module named 'yaml'`) because the system Python doesn't have project dependencies installed.

## Root Cause

`_remap_path_for_user()` in `hermes_cli/gateway.py` uses `Path(path).resolve()` which follows symlinks. The venv Python (`venv/bin/python`) is typically a symlink to the system Python binary. After `resolve()`, the symlink target replaces the venv path. Since the resolved path lives under a different prefix than the current user's home, the remap returns it as-is — losing the venv context entirely.

Flow:
1. `get_python_path()` correctly detects `venv/bin/python`
2. `_remap_path_for_user(python_path, home_dir)` calls `Path(python_path).resolve()`
3. Symlink resolves to `/usr/local/share/uv/python/cpython-3.11-.../bin/python3.11`
4. Resolved path is NOT under `/root/`, so remap returns it unchanged
5. Service file gets the bare Python, not the venv Python

## Fix

`Path.absolute()` converts relative paths to absolute without following symlinks. This preserves the venv Python path through the remapping logic.

```diff
-    resolved = Path(path).resolve()
+    resolved = Path(path).absolute()
```

## Verification

After the fix, `sudo hermes gateway install --system` generates:
```
ExecStart=/home/user/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace
```
Instead of the previous broken output:
```
ExecStart=/home/user/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/bin/python3.11 -m hermes_cli.main gateway run --replace
```