### PR TITLE
fix: improve profile creation UX — seed SOUL.md + credential warning

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4243,18 +4243,24 @@ def cmd_profile(args):
                             print(f'  Add to your shell config (~/.bashrc or ~/.zshrc):')
                             print(f'    export PATH="$HOME/.local/bin:$PATH"')
 
+            # Profile dir for display
+            try:
+                profile_dir_display = "~/" + str(profile_dir.relative_to(Path.home()))
+            except ValueError:
+                profile_dir_display = str(profile_dir)
+
             # Next steps
             print(f"\nNext steps:")
             print(f"  {name} setup              Configure API keys and model")
             print(f"  {name} chat               Start chatting")
             print(f"  {name} gateway start      Start the messaging gateway")
             if clone or clone_all:
-                try:
-                    profile_dir_display = "~/" + str(profile_dir.relative_to(Path.home()))
-                except ValueError:
-                    profile_dir_display = str(profile_dir)
                 print(f"\n  Edit {profile_dir_display}/.env for different API keys")
                 print(f"  Edit {profile_dir_display}/SOUL.md for different personality")
+            else:
+                print(f"\n  ⚠ This profile has no API keys yet. Run '{name} setup' first,")
+                print(f"    or it will inherit keys from your shell environment.")
+                print(f"  Edit {profile_dir_display}/SOUL.md to customize personality")
             print()
 
         except (ValueError, FileExistsError, FileNotFoundError) as e:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -459,6 +459,16 @@ def create_profile(
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, dst)
 
+    # Seed a default SOUL.md so the user has a file to customize immediately.
+    # Skipped when the profile already has one (from --clone / --clone-all).
+    soul_path = profile_dir / "SOUL.md"
+    if not soul_path.exists():
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+            soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
+        except Exception:
+            pass  # best-effort — don't fail profile creation over this
+
     return profile_dir
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -177,7 +177,8 @@ class TestCreateProfile:
         # No error; optional files just not copied
         assert not (profile_dir / "config.yaml").exists()
         assert not (profile_dir / ".env").exists()
-        assert not (profile_dir / "SOUL.md").exists()
+        # SOUL.md is always seeded with the default even when clone source lacks it
+        assert (profile_dir / "SOUL.md").exists()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Addresses user confusion reported in Discord about:
1. New profiles using the wrong model/plan tokens (root cause: no separate API keys)
2. SOUL.md not being read consistently (root cause: no SOUL.md in fresh profiles until first use)

## What changed

**`hermes_cli/profiles.py`** — `create_profile()` now seeds a default SOUL.md immediately after creating the directory structure. Skipped when the profile already has one (from `--clone` / `--clone-all`).

**`hermes_cli/main.py`** — Post-creation output for fresh profiles (no `--clone`) now:
- Warns that the profile has no API keys and will inherit from the shell environment
- Shows the SOUL.md path for personality customization
- Moved `profile_dir_display` computation to cover both clone and non-clone paths

## Before
```
Profile 'mybot' created at ~/.hermes/profiles/mybot
42 bundled skills synced.

Next steps:
  mybot setup              Configure API keys and model
  mybot chat               Start chatting
  mybot gateway start      Start the messaging gateway
```

## After
```
Profile 'mybot' created at ~/.hermes/profiles/mybot
42 bundled skills synced.

Next steps:
  mybot setup              Configure API keys and model
  mybot chat               Start chatting
  mybot gateway start      Start the messaging gateway

  ⚠ This profile has no API keys yet. Run 'mybot setup' first,
    or it will inherit keys from your shell environment.
  Edit ~/.hermes/profiles/mybot/SOUL.md to customize personality
```

## Investigation findings (issue #8093)

E2E verified that `load_soul_md()` correctly reads from the profile's HERMES_HOME. The code path is:
- `_apply_profile_override()` sets `HERMES_HOME` before module imports
- `load_soul_md()` calls `get_hermes_home() / "SOUL.md"` which reads the env var
- Both CLI and gateway paths resolve correctly

Issue #8093's reporter showed identical files in both locations (diff produces no output), so their "cross-contamination" conclusion was unsupported by evidence. Closed with detailed analysis.

## Test plan
- `python3 -m pytest tests/hermes_cli/test_profiles.py -o "addopts=" -q` — 87 passed
- Updated `test_clone_config_missing_files_skipped` to reflect that SOUL.md is now always seeded
- E2E verified: fresh profile seeds SOUL.md, cloned profile preserves source SOUL.md