### PR TITLE
fix(slack): use Block Kit markdown block type instead of legacy mrkdwn

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -261,11 +261,15 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            # Convert standard markdown → Slack mrkdwn
-            formatted = self.format_message(content)
+            # Use raw content for the Block Kit markdown block type which
+            # natively renders standard markdown (tables, bold, links, etc.).
+            # format_message() converts to legacy mrkdwn and is only used for
+            # the plain-text fallback (notifications, search, accessibility).
+            fallback = self.format_message(content)
 
             # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+            fallback_chunks = self.truncate_message(fallback, self.MAX_MESSAGE_LENGTH)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
@@ -275,10 +279,11 @@ class SlackAdapter(BasePlatformAdapter):
             broadcast = self.config.extra.get("reply_broadcast", False)
 
             for i, chunk in enumerate(chunks):
+                fallback_chunk = fallback_chunks[i] if i < len(fallback_chunks) else chunk
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
-                    "mrkdwn": True,
+                    "text": fallback_chunk,
+                    "blocks": [{"type": "markdown", "text": chunk}],
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
@@ -321,11 +326,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
-            formatted = self.format_message(content)
+            # Use raw content for the markdown block; mrkdwn fallback for text field.
+            fallback = self.format_message(content)
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,
-                text=formatted,
+                text=fallback,
+                blocks=[{"type": "markdown", "text": content}],
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -336,12 +336,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     media_files = media_files or []
 
-    if platform == Platform.SLACK and message:
-        try:
-            slack_adapter = SlackAdapter.__new__(SlackAdapter)
-            message = slack_adapter.format_message(message)
-        except Exception:
-            logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
+    # NOTE: Do NOT call format_message() for Slack here.
+    # The _send_slack() function uses the `markdown` block type which requires
+    # raw standard markdown — format_message() converts to legacy mrkdwn and
+    # corrupts table syntax, bold, and links before they reach the block.
 
     # Platform message length limits (from adapter class attributes)
     _MAX_LENGTHS = {
@@ -609,7 +607,7 @@ async def _send_slack(token, chat_id, message):
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
-            payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            payload = {"channel": chat_id, "text": message, "blocks": [{"type": "markdown", "text": message}]}
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary

- Use Block Kit `markdown` block type for Slack message rendering instead of legacy `mrkdwn`
- Keep `format_message()` output only as `text` fallback for notifications/search
- Fix `edit_message()` to include `blocks` in `chat_update` (streaming responses were bypassing the fix)
- Remove `format_message()` pre-conversion in `send_message_tool.py` for Slack

## Problem

`format_message()` converts standard markdown to Slack's legacy `mrkdwn` format before sending:
- `**bold**` → `*bold*`
- `[text](url)` → `<url|text>`
- `| table | rows |` → stripped/broken
- Headers → `*bold*`

The legacy `mrkdwn` format does not support tables. The `markdown` block type in Block Kit natively renders standard markdown including tables.

The critical issue was that `edit_message()` (used by the stream consumer to update responses in-place) was sending only `text` with no `blocks`, so even after fixing `send()`, the final streamed response reverted to legacy rendering.

## Changes

| File | Change |
|------|--------|
| `gateway/platforms/slack.py` `send()` | Raw content → `blocks`, `format_message()` → `text` fallback only |
| `gateway/platforms/slack.py` `edit_message()` | Added `blocks=[{type: "markdown", text: content}]` to `chat_update` |
| `tools/send_message_tool.py` `_send_to_platform()` | Removed `format_message()` call for Slack |
| `tools/send_message_tool.py` `_send_slack()` | `mrkdwn: True` → `blocks: [{type: "markdown", text: message}]` |

## Test plan

- [x] Tables render as native Slack table blocks
- [x] Bold, italic, links, code blocks render correctly
- [x] Thread replies work with `thread_ts` in blocks payload
- [x] Streaming responses render correctly via `edit_message()`
- [x] Notifications and search still work via `text` fallback

Fixes #8552

🤖 Generated with [Claude Code](https://claude.com/claude-code)