### PR TITLE
fix(claw): warn and prompt if OpenClaw is still running before archival (fixes #8502)

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -161,6 +161,34 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
     return findings
 
 
+def _check_openclaw_running() -> list:
+    """Check if any OpenClaw processes or services are still running."""
+    import subprocess
+    running = []
+    # Check systemd service
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "is-active", "openclaw-gateway.service"],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.stdout.strip() == "active":
+            running.append("systemd service: openclaw-gateway.service")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    # Check running processes
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "openclaw"],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            pids = result.stdout.strip().split()
+            running.append(f"openclaw process(es) running (PIDs: {', '.join(pids)})")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return running
+
+
 def _archive_directory(source_dir: Path, dry_run: bool = False) -> Path:
     """Rename an OpenClaw directory to .pre-migration.
 
@@ -429,6 +457,21 @@ def _cmd_cleanup(args):
         print()
         print_success("No OpenClaw directories found. Nothing to clean up.")
         return
+    # Warn if OpenClaw is still running
+    running = _check_openclaw_running()
+    if running:
+        print()
+        print_warning("OpenClaw appears to be still running:")
+        for proc in running:
+            print_warning(f"  • {proc}")
+        print_warning("Archiving .openclaw/ while the service is active may cause it to")
+        print_warning("immediately recreate an empty skeleton directory, destroying your config.")
+        print_warning("Stop OpenClaw first: systemctl --user stop openclaw-gateway.service")
+        print()
+        if not auto_yes:
+            if not prompt_yes_no("Proceed anyway?", default=False):
+                print_info("Aborted. Stop OpenClaw first, then re-run: hermes claw cleanup")
+                return
 
     total_archived = 0
 


### PR DESCRIPTION
## Problem
`hermes claw cleanup` renames `.openclaw/` to `.openclaw.pre-migration/` 
without checking if the OpenClaw gateway service is still running. If it is, 
the service immediately recreates an empty skeleton `.openclaw/` directory, 
destroying all agents, skills, memories, and config.

Reported in #8502 — user lost a 2.2GB OpenClaw installation this way.

## Fix
Before archiving, `_cmd_cleanup` now:
1. Checks if `openclaw-gateway.service` is active via `systemctl --user is-active`
2. Checks for running `openclaw` processes via `pgrep`
3. If either is found, prints a clear warning with the exact stop command
4. Prompts "Proceed anyway?" (default: No) unless `--yes` is passed

## Testing
All 36 existing `test_claw.py` tests pass.

Fixes #8502