### PR TITLE
fix: make agent_thread daemon to prevent orphan CLI processes on tab close

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7617,8 +7617,10 @@ class HermesCLI:
                         "error": _summary,
                     }
 
-            # Start agent in background thread
-            agent_thread = threading.Thread(target=run_agent)
+            # Start agent in background thread (daemon so it cannot keep the
+            # process alive when the user closes the terminal tab — SIGHUP
+            # exits the main thread and daemon threads are reaped automatically).
+            agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
 
             # Monitor the dedicated interrupt queue while the agent runs.
@@ -9595,6 +9597,15 @@ class HermesCLI:
             pass
         finally:
             self._should_exit = True
+            # Interrupt the agent immediately so its daemon thread stops making
+            # API calls and exits promptly (agent_thread is daemon, so the
+            # process will exit once the main thread finishes, but interrupting
+            # avoids wasted API calls and lets run_conversation clean up).
+            if self.agent and getattr(self, '_agent_running', False):
+                try:
+                    self.agent.interrupt()
+                except Exception:
+                    pass
             # Flush memories before exit (only for substantial conversations)
             if self.agent and self.conversation_history:
                 try:


### PR DESCRIPTION
## Summary

Fixes orphan Hermes CLI processes that survive after closing a terminal tab, causing massive swap usage over time.

**Reported by:** Jaxasaurous (Discord) — 77GB swap on a 32GB M1 Pro MacBook after many conversations.

## Root Cause

`agent_thread` (cli.py line 7621) was the only non-daemon thread in the CLI. When a user closes a terminal tab:

1. SIGHUP → signal handler → KeyboardInterrupt on main thread
2. Main thread exits through finally/atexit cleanup
3. Python waits for non-daemon threads before exiting the process
4. `agent_thread` is still alive (blocked on API call in `_interruptible_api_call`)
5. Nobody sets `_interrupt_requested` during SIGHUP, so the agent loop keeps going
6. Entire Python process stays alive until the API call/conversation naturally finishes

Each orphaned process holds the full conversation history, loaded modules, httpx clients, etc. Over many conversations closed mid-turn, these accumulate.

## Changes

- **`daemon=True` on agent_thread** — the process now exits when the main thread finishes cleanup. Under normal operation this changes nothing; the main thread already waits on `agent_thread.is_alive()` in a polling loop.
- **Interrupt agent in finally block** — calls `self.agent.interrupt()` so the daemon thread stops making API calls promptly rather than being killed mid-flight.

## Test

- `py_compile` clean
- `tests/cli/` — 419 passed (19 pre-existing failures in `test_reasoning_command.py` from test pollution, pass in isolation)