### PR TITLE
fix(cli): improve default skin contrast on light terminals

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -96,6 +96,7 @@ Activate with ``/skin <name>`` in the CLI or ``display.skin: <name>`` in config.
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -105,22 +106,89 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_LIGHT_TERMINAL_COLORS: Dict[str, str] = {
+    "banner_border": "#8C5A15",
+    "banner_title": "#8A5B00",
+    "banner_accent": "#9A6700",
+    "banner_dim": "#6B5B38",
+    "banner_text": "#2B2110",
+    "ui_accent": "#9A6700",
+    "ui_label": "#0F6D7A",
+    "ui_ok": "#2E7D32",
+    "ui_error": "#B42318",
+    "ui_warn": "#B45309",
+    "prompt": "#2B2110",
+    "input_rule": "#8C5A15",
+    "response_border": "#8A5B00",
+    "session_label": "#8A5B00",
+    "session_border": "#8C8173",
+}
+
+
+def _terminal_looks_light() -> bool:
+    """Best-effort detection for terminals with a light default background."""
+    raw = (os.environ.get("COLORFGBG") or "").strip()
+    if not raw:
+        return False
+
+    parts = raw.replace(",", ";").split(";")
+    try:
+        background = int(next(part for part in reversed(parts) if part.strip()))
+    except (StopIteration, ValueError):
+        return False
+
+    return background in {7, 15} or background >= 10
+
+
+def _default_light_banner_logo() -> str:
+    """Return contrast-safe default banner art for light terminals."""
+    return """[bold #8A5B00]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗       █████╗  ██████╗ ███████╗███╗   ██╗████████╗[/]
+[bold #8A5B00]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝      ██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝[/]
+[#9A6700]███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗█████╗███████║██║  ███╗█████╗  ██╔██╗ ██║   ██║[/]
+[#9A6700]██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║╚════╝██╔══██║██║   ██║██╔══╝  ██║╚██╗██║   ██║[/]
+[#8C5A15]██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║      ██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║[/]
+[#8C5A15]╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝      ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝[/]"""
+
+
+def _default_light_banner_hero() -> str:
+    """Return contrast-safe default caduceus art for light terminals."""
+    return """[#8C5A15]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀⠀⢀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#8C5A15]⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣇⠸⣿⣿⠇⣸⣿⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⠀[/]
+[#9A6700]⠀⢀⣠⣴⣶⠿⠋⣩⡿⣿⡿⠻⣿⡇⢠⡄⢸⣿⠟⢿⣿⢿⣍⠙⠿⣶⣦⣄⡀⠀[/]
+[#9A6700]⠀⠀⠉⠉⠁⠶⠟⠋⠀⠉⠀⢀⣈⣁⡈⢁⣈⣁⡀⠀⠉⠀⠙⠻⠶⠈⠉⠉⠀⠀[/]
+[#8A5B00]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⡿⠛⢁⡈⠛⢿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#8A5B00]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⣿⣦⣤⣈⠁⢠⣴⣿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#9A6700]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠻⢿⣿⣦⡉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#9A6700]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢷⣦⣈⠛⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#8C5A15]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣴⠦⠈⠙⠿⣦⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#8C5A15]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿⣤⡈⠁⢤⣿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#6B5B38]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠷⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#6B5B38]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠑⢶⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#6B5B38]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠁⢰⡆⠈⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#6B5B38]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠳⠈⣡⠞⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#6B5B38]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]"""
+
+
 # =============================================================================
 # Skin data structure
 # =============================================================================
 
+
 @dataclass
 class SkinConfig:
     """Complete skin configuration."""
+
     name: str
     description: str = ""
     colors: Dict[str, str] = field(default_factory=dict)
     spinner: Dict[str, Any] = field(default_factory=dict)
     branding: Dict[str, str] = field(default_factory=dict)
     tool_prefix: str = "┊"
-    tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
-    banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
-    banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    tool_emojis: Dict[str, str] = field(
+        default_factory=dict
+    )  # per-tool emoji overrides
+    banner_logo: str = ""  # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
+    banner_hero: str = ""  # Rich-markup hero art (replaces HERMES_CADUCEUS)
 
     def get_color(self, key: str, fallback: str = "") -> str:
         """Get a color value with fallback."""
@@ -206,8 +274,14 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "waiting_faces": ["(⚔)", "(⛨)", "(▲)", "(<>)", "(/)"],
             "thinking_faces": ["(⚔)", "(⛨)", "(▲)", "(⌁)", "(<>)"],
             "thinking_verbs": [
-                "forging", "marching", "sizing the field", "holding the line",
-                "hammering plans", "tempering steel", "plotting impact", "raising the shield",
+                "forging",
+                "marching",
+                "sizing the field",
+                "holding the line",
+                "hammering plans",
+                "tempering steel",
+                "plotting impact",
+                "raising the shield",
             ],
             "wings": [
                 ["⟪⚔", "⚔⟫"],
@@ -332,9 +406,14 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "waiting_faces": ["(≈)", "(Ψ)", "(∿)", "(◌)", "(◠)"],
             "thinking_faces": ["(Ψ)", "(∿)", "(≈)", "(⌁)", "(◌)"],
             "thinking_verbs": [
-                "charting currents", "sounding the depth", "reading foam lines",
-                "steering the trident", "tracking undertow", "plotting sea lanes",
-                "calling the swell", "measuring pressure",
+                "charting currents",
+                "sounding the depth",
+                "reading foam lines",
+                "steering the trident",
+                "tracking undertow",
+                "plotting sea lanes",
+                "calling the swell",
+                "measuring pressure",
             ],
             "wings": [
                 ["⟪≈", "≈⟫"],
@@ -396,9 +475,14 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "waiting_faces": ["(◉)", "(◌)", "(◬)", "(⬤)", "(::)"],
             "thinking_faces": ["(◉)", "(◬)", "(◌)", "(○)", "(●)"],
             "thinking_verbs": [
-                "finding traction", "measuring the grade", "resetting the boulder",
-                "counting the ascent", "testing leverage", "setting the shoulder",
-                "pushing uphill", "enduring the loop",
+                "finding traction",
+                "measuring the grade",
+                "resetting the boulder",
+                "counting the ascent",
+                "testing leverage",
+                "setting the shoulder",
+                "pushing uphill",
+                "enduring the loop",
             ],
             "wings": [
                 ["⟪◉", "◉⟫"],
@@ -461,9 +545,14 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
             "waiting_faces": ["(✦)", "(▲)", "(◇)", "(<>)", "(🔥)"],
             "thinking_faces": ["(✦)", "(▲)", "(◇)", "(⌁)", "(🔥)"],
             "thinking_verbs": [
-                "banking into the draft", "measuring burn", "reading the updraft",
-                "tracking ember fall", "setting wing angle", "holding the flame core",
-                "plotting a hot landing", "coiling for lift",
+                "banking into the draft",
+                "measuring burn",
+                "reading the updraft",
+                "tracking ember fall",
+                "setting wing angle",
+                "holding the flame core",
+                "plotting a hot landing",
+                "coiling for lift",
             ],
             "wings": [
                 ["⟪✦", "✦⟫"],
@@ -521,6 +610,7 @@ def _load_skin_from_yaml(path: Path) -> Optional[Dict[str, Any]]:
     """Load a skin definition from a YAML file."""
     try:
         import yaml
+
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
         if isinstance(data, dict) and "name" in data:
@@ -541,6 +631,14 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
     branding = dict(default.get("branding", {}))
     branding.update(data.get("branding", {}))
 
+    banner_logo = data.get("banner_logo", "")
+    banner_hero = data.get("banner_hero", "")
+
+    if data is _BUILTIN_SKINS["default"] and _terminal_looks_light():
+        colors.update(_DEFAULT_LIGHT_TERMINAL_COLORS)
+        banner_logo = _default_light_banner_logo()
+        banner_hero = _default_light_banner_hero()
+
     return SkinConfig(
         name=data.get("name", "unknown"),
         description=data.get("description", ""),
@@ -549,8 +647,8 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         branding=branding,
         tool_prefix=data.get("tool_prefix", default.get("tool_prefix", "┊")),
         tool_emojis=data.get("tool_emojis", {}),
-        banner_logo=data.get("banner_logo", ""),
-        banner_hero=data.get("banner_hero", ""),
+        banner_logo=banner_logo,
+        banner_hero=banner_hero,
     )
 
 
@@ -561,11 +659,13 @@ def list_skins() -> List[Dict[str, str]]:
     """
     result = []
     for name, data in _BUILTIN_SKINS.items():
-        result.append({
-            "name": name,
-            "description": data.get("description", ""),
-            "source": "builtin",
-        })
+        result.append(
+            {
+                "name": name,
+                "description": data.get("description", ""),
+                "source": "builtin",
+            }
+        )
 
     skins_path = _skins_dir()
     if skins_path.is_dir():
@@ -576,11 +676,13 @@ def list_skins() -> List[Dict[str, str]]:
                 # Skip if it shadows a built-in
                 if any(s["name"] == skin_name for s in result):
                     continue
-                result.append({
-                    "name": skin_name,
-                    "description": data.get("description", ""),
-                    "source": "user",
-                })
+                result.append(
+                    {
+                        "name": skin_name,
+                        "description": data.get("description", ""),
+                        "source": "user",
+                    }
+                )
 
     return result
 
@@ -651,7 +753,6 @@ def get_active_prompt_symbol(fallback: str = "❯ ") -> str:
         return fallback
 
 
-
 def get_active_help_header(fallback: str = "(^_^)? Available Commands") -> str:
     """Get the /help header from the active skin."""
     try:
@@ -660,14 +761,12 @@ def get_active_help_header(fallback: str = "(^_^)? Available Commands") -> str:
         return fallback
 
 
-
 def get_active_goodbye(fallback: str = "Goodbye! ⚕") -> str:
     """Get the goodbye line from the active skin."""
     try:
         return get_active_skin().get_branding("goodbye", fallback)
     except Exception:
         return fallback
-
 
 
 def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
@@ -690,6 +789,12 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     warn = skin.get_color("ui_warn", "#FF8C00")
     error = skin.get_color("ui_error", "#FF6B6B")
 
+    completion_bg = "#1a1a2e"
+    completion_current_bg = "#333355"
+    if skin.name == "default" and _terminal_looks_light():
+        completion_bg = "#f7f1e3"
+        completion_current_bg = "#eadfbe"
+
     return {
         "input-area": prompt,
         "placeholder": f"{dim} italic",
@@ -698,11 +803,11 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "hint": f"{dim} italic",
         "input-rule": input_rule,
         "image-badge": f"{label} bold",
-        "completion-menu": f"bg:#1a1a2e {text}",
-        "completion-menu.completion": f"bg:#1a1a2e {text}",
-        "completion-menu.completion.current": f"bg:#333355 {title}",
-        "completion-menu.meta.completion": f"bg:#1a1a2e {dim}",
-        "completion-menu.meta.completion.current": f"bg:#333355 {label}",
+        "completion-menu": f"bg:{completion_bg} {text}",
+        "completion-menu.completion": f"bg:{completion_bg} {text}",
+        "completion-menu.completion.current": f"bg:{completion_current_bg} {title}",
+        "completion-menu.meta.completion": f"bg:{completion_bg} {dim}",
+        "completion-menu.meta.completion.current": f"bg:{completion_current_bg} {label}",
         "clarify-border": input_rule,
         "clarify-title": f"{title} bold",
         "clarify-question": f"{text} bold",

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 def reset_skin_state():
     """Reset skin engine state between tests."""
     from hermes_cli import skin_engine
+
     skin_engine._active_skin = None
     skin_engine._active_skin_name = "default"
     yield
@@ -21,6 +22,7 @@ def reset_skin_state():
 class TestSkinConfig:
     def test_default_skin_has_required_fields(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("default")
         assert skin.name == "default"
         assert skin.tool_prefix == "┊"
@@ -30,18 +32,21 @@ class TestSkinConfig:
 
     def test_get_color_with_fallback(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("default")
         assert skin.get_color("banner_title") == "#FFD700"
         assert skin.get_color("nonexistent", "#000") == "#000"
 
     def test_get_branding_with_fallback(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("default")
         assert skin.get_branding("agent_name") == "Hermes Agent"
         assert skin.get_branding("nonexistent", "fallback") == "fallback"
 
     def test_get_spinner_list_empty_for_default(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("default")
         # Default skin has no custom spinner config
         assert skin.get_spinner_list("waiting_faces") == []
@@ -49,6 +54,7 @@ class TestSkinConfig:
 
     def test_get_spinner_wings_empty_for_default(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("default")
         assert skin.get_spinner_wings() == []
 
@@ -56,6 +62,7 @@ class TestSkinConfig:
 class TestBuiltinSkins:
     def test_ares_skin_loads(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("ares")
         assert skin.name == "ares"
         assert skin.tool_prefix == "╎"
@@ -67,6 +74,7 @@ class TestBuiltinSkins:
 
     def test_ares_has_spinner_customization(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("ares")
         assert len(skin.get_spinner_list("waiting_faces")) > 0
         assert len(skin.get_spinner_list("thinking_faces")) > 0
@@ -78,25 +86,58 @@ class TestBuiltinSkins:
 
     def test_mono_skin_loads(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("mono")
         assert skin.name == "mono"
         assert skin.get_color("banner_title") == "#e6edf3"
 
     def test_slate_skin_loads(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("slate")
         assert skin.name == "slate"
         assert skin.get_color("banner_title") == "#7eb8f6"
 
     def test_unknown_skin_falls_back_to_default(self):
         from hermes_cli.skin_engine import load_skin
+
         skin = load_skin("nonexistent_skin_xyz")
         assert skin.name == "default"
 
+    def test_default_skin_adapts_for_light_terminals(self, monkeypatch):
+        from hermes_cli.skin_engine import load_skin
+
+        monkeypatch.setenv("COLORFGBG", "15;7")
+        skin = load_skin("default")
+
+        assert skin.get_color("banner_text") == "#2B2110"
+        assert skin.get_color("prompt") == "#2B2110"
+        assert "#8A5B00" in skin.banner_logo
+        assert "#6B5B38" in skin.banner_hero
+
+    def test_default_skin_keeps_dark_terminal_palette_without_colorfgbg(
+        self, monkeypatch
+    ):
+        from hermes_cli.skin_engine import load_skin
+
+        monkeypatch.delenv("COLORFGBG", raising=False)
+        skin = load_skin("default")
+
+        assert skin.get_color("banner_text") == "#FFF8DC"
+        assert skin.banner_logo == ""
+        assert skin.banner_hero == ""
+
     def test_all_builtin_skins_have_complete_colors(self):
         from hermes_cli.skin_engine import _BUILTIN_SKINS, _build_skin_config
-        required_keys = ["banner_border", "banner_title", "banner_accent",
-                         "banner_dim", "banner_text", "ui_accent"]
+
+        required_keys = [
+            "banner_border",
+            "banner_title",
+            "banner_accent",
+            "banner_dim",
+            "banner_text",
+            "ui_accent",
+        ]
         for name, data in _BUILTIN_SKINS.items():
             skin = _build_skin_config(data)
             for key in required_keys:
@@ -105,7 +146,12 @@ class TestBuiltinSkins:
 
 class TestSkinManagement:
     def test_set_active_skin(self):
-        from hermes_cli.skin_engine import set_active_skin, get_active_skin, get_active_skin_name
+        from hermes_cli.skin_engine import (
+            set_active_skin,
+            get_active_skin,
+            get_active_skin_name,
+        )
+
         skin = set_active_skin("ares")
         assert skin.name == "ares"
         assert get_active_skin_name() == "ares"
@@ -113,11 +159,13 @@ class TestSkinManagement:
 
     def test_get_active_skin_defaults(self):
         from hermes_cli.skin_engine import get_active_skin
+
         skin = get_active_skin()
         assert skin.name == "default"
 
     def test_list_skins_includes_builtins(self):
         from hermes_cli.skin_engine import list_skins
+
         skins = list_skins()
         names = [s["name"] for s in skins]
         assert "default" in names
@@ -130,18 +178,35 @@ class TestSkinManagement:
 
     def test_init_skin_from_config(self):
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
         init_skin_from_config({"display": {"skin": "ares"}})
         assert get_active_skin_name() == "ares"
 
     def test_init_skin_from_empty_config(self):
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
         init_skin_from_config({})
         assert get_active_skin_name() == "default"
+
+    def test_prompt_toolkit_overrides_use_light_completion_palette(self, monkeypatch):
+        from hermes_cli.skin_engine import (
+            get_prompt_toolkit_style_overrides,
+            set_active_skin,
+        )
+
+        monkeypatch.setenv("COLORFGBG", "15;7")
+        set_active_skin("default")
+        styles = get_prompt_toolkit_style_overrides()
+
+        assert styles["prompt"] == "#2B2110"
+        assert styles["completion-menu"].startswith("bg:#f7f1e3 ")
+        assert styles["completion-menu.completion.current"].startswith("bg:#eadfbe ")
 
 
 class TestUserSkins:
     def test_load_user_skin_from_yaml(self, tmp_path, monkeypatch):
         from hermes_cli.skin_engine import load_skin, _skins_dir
+
         # Create a user skin YAML
         skins_dir = tmp_path / "skins"
         skins_dir.mkdir()
@@ -154,6 +219,7 @@ class TestUserSkins:
             "tool_prefix": "▸",
         }
         import yaml
+
         skin_file.write_text(yaml.dump(skin_data))
 
         # Patch skins dir
@@ -169,13 +235,19 @@ class TestUserSkins:
 
     def test_list_skins_includes_user_skins(self, tmp_path, monkeypatch):
         from hermes_cli.skin_engine import list_skins
+
         skins_dir = tmp_path / "skins"
         skins_dir.mkdir()
         import yaml
-        (skins_dir / "pirate.yaml").write_text(yaml.dump({
-            "name": "pirate",
-            "description": "Arr matey",
-        }))
+
+        (skins_dir / "pirate.yaml").write_text(
+            yaml.dump(
+                {
+                    "name": "pirate",
+                    "description": "Arr matey",
+                }
+            )
+        )
         monkeypatch.setattr("hermes_cli.skin_engine._skins_dir", lambda: skins_dir)
 
         skins = list_skins()
@@ -188,17 +260,20 @@ class TestUserSkins:
 class TestDisplayIntegration:
     def test_get_skin_tool_prefix_default(self):
         from agent.display import get_skin_tool_prefix
+
         assert get_skin_tool_prefix() == "┊"
 
     def test_get_skin_tool_prefix_custom(self):
         from hermes_cli.skin_engine import set_active_skin
         from agent.display import get_skin_tool_prefix
+
         set_active_skin("ares")
         assert get_skin_tool_prefix() == "╎"
 
     def test_tool_message_uses_skin_prefix(self):
         from hermes_cli.skin_engine import set_active_skin
         from agent.display import get_cute_tool_message
+
         set_active_skin("ares")
         msg = get_cute_tool_message("terminal", {"command": "ls"}, 0.5)
         assert msg.startswith("╎")
@@ -206,6 +281,7 @@ class TestDisplayIntegration:
 
     def test_tool_message_default_prefix(self):
         from agent.display import get_cute_tool_message
+
         msg = get_cute_tool_message("terminal", {"command": "ls"}, 0.5)
         assert msg.startswith("┊")
 
@@ -235,7 +311,10 @@ class TestCliBrandingHelpers:
         assert get_active_goodbye() == "Farewell, warrior! ⚔"
 
     def test_prompt_toolkit_style_overrides_cover_tui_classes(self):
-        from hermes_cli.skin_engine import set_active_skin, get_prompt_toolkit_style_overrides
+        from hermes_cli.skin_engine import (
+            set_active_skin,
+            get_prompt_toolkit_style_overrides,
+        )
 
         set_active_skin("ares")
         overrides = get_prompt_toolkit_style_overrides()


### PR DESCRIPTION
## Summary
- detect light terminals for the built-in `default` skin using `COLORFGBG` and swap in a higher-contrast palette
- keep the existing dark-terminal defaults intact while also giving the default ASCII banner art and prompt-toolkit completion menu a light-safe variant
- add regression coverage for both light and dark terminal behavior in the skin engine tests

## Testing
- `uv run --extra dev python -m pytest tests/hermes_cli/test_skin_engine.py -q`
- `uv run --extra dev python -m pytest tests/test_cli_skin_integration.py -q`

## Notes
- Fixes #8526