### PR TITLE
fix: clear stale api_key when switching custom providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1956,6 +1956,8 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    else:
+        model.pop("api_key", None)
     # Apply api_mode from custom_providers entry, or clear stale value
     custom_api_mode = provider_info.get("api_mode", "")
     if custom_api_mode:

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -148,18 +148,19 @@ class TestCustomProviderModelSwitch:
         assert model.get("api_mode") == "anthropic_messages"
 
     def test_api_mode_cleared_when_not_specified(self, config_home):
-        """When custom_providers entry has no api_mode, stale api_mode is removed."""
+        """When custom_providers entry has no api_mode or api_key, stale values are removed."""
         import yaml
         from hermes_cli.main import _model_flow_named_custom
 
-        # Pre-seed a stale api_mode in config
+        # Pre-seed stale transport/auth fields in config
         config_path = config_home / "config.yaml"
-        config_path.write_text(yaml.dump({"model": {"api_mode": "anthropic_messages"}}))
+        config_path.write_text(
+            yaml.dump({"model": {"api_mode": "anthropic_messages", "api_key": "stale-key"}})
+        )
 
         provider_info = {
             "name": "My vLLM",
             "base_url": "https://vllm.example.com/v1",
-            "api_key": "***",
             "model": "llama-3",
         }
 
@@ -173,3 +174,4 @@ class TestCustomProviderModelSwitch:
         model = config.get("model")
         assert isinstance(model, dict)
         assert "api_mode" not in model, "Stale api_mode should be removed"
+        assert "api_key" not in model, "Stale api_key should be removed"


### PR DESCRIPTION
## Summary
- clear `model.api_key` when switching to a saved custom provider that does not define an API key
- keep the existing `api_mode` behavior intact
- extend the named custom-provider regression test to cover stale auth cleanup

## Problem
`_model_flow_named_custom()` already clears stale `api_mode` when the selected `custom_providers` entry does not specify one, but it leaves a stale `model.api_key` behind.

That means switching from an authenticated custom endpoint to a no-key local endpoint can preserve the old key in `config.yaml`, which is incorrect state and can affect subsequent requests.

## Testing
- `/Users/yiminglin/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_custom_provider_model_switch.py`
- manual temp-`HERMES_HOME` reproducer showing `model.api_key` is removed when selecting a no-key provider
