### PR TITLE
feat: make gateway 'still working' notification interval configurable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -186,6 +186,8 @@ if _config_path.exists():
                 os.environ["HERMES_AGENT_TIMEOUT"] = str(_agent_cfg["gateway_timeout"])
             if "gateway_timeout_warning" in _agent_cfg and "HERMES_AGENT_TIMEOUT_WARNING" not in os.environ:
                 os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
+            if "gateway_notify_interval" in _agent_cfg and "HERMES_AGENT_NOTIFY_INTERVAL" not in os.environ:
+                os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = str(_agent_cfg["gateway_notify_interval"])
             if "restart_drain_timeout" in _agent_cfg and "HERMES_RESTART_DRAIN_TIMEOUT" not in os.environ:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
         _display_cfg = _cfg.get("display", {})
@@ -8137,11 +8139,17 @@ class GatewayRunner:
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
 
         # Periodic "still working" notifications for long-running tasks.
-        # Fires every 10 minutes so the user knows the agent hasn't died.
-        _NOTIFY_INTERVAL = 600  # 10 minutes
+        # Fires every N seconds so the user knows the agent hasn't died.
+        # Config: agent.gateway_notify_interval in config.yaml, or
+        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 600s (10 min).
+        # 0 = disable notifications.
+        _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 600))
+        _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
 
         async def _notify_long_running():
+            if _NOTIFY_INTERVAL is None:
+                return  # Notifications disabled (gateway_notify_interval: 0)
             _notify_adapter = self.adapters.get(source.platform)
             if not _notify_adapter:
                 return

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -355,6 +355,10 @@ DEFAULT_CONFIG = {
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.
         "gateway_timeout_warning": 900,
+        # Periodic "still working" notification interval (seconds).
+        # Sends a status message every N seconds so the user knows the
+        # agent hasn't died during long tasks.  0 = disable notifications.
+        "gateway_notify_interval": 600,
     },
     
     "terminal": {


### PR DESCRIPTION
## Summary
Adds `agent.gateway_notify_interval` to config.yaml (default 600s / 10 min). Set to 0 to disable the periodic "⏳ Still working..." notifications during long-running gateway tasks.

Follows the same pattern as the existing `gateway_timeout` and `gateway_timeout_warning` settings — bridged to `HERMES_AGENT_NOTIFY_INTERVAL` env var, env var takes precedence over config.yaml.

### Config example
```yaml
agent:
  gateway_notify_interval: 0      # disable 'still working' pings
  gateway_timeout_warning: 0      # disable inactivity warning
  gateway_timeout: 0              # disable inactivity kill
```

## Files changed
- `hermes_cli/config.py` — added `gateway_notify_interval: 600` to DEFAULT_CONFIG
- `gateway/run.py` — bridge config→env var, read env var instead of hardcoded 600, early return when disabled

## Test plan
- 650/651 gateway tests pass (1 pre-existing failure in test_email.py unrelated to this change)