### PR TITLE
feat(mcp): sandbox transport — run MCP servers inside Docker/Podman containers

### DIFF
--- a/tests/tools/test_mcp_sandbox_transport.py
+++ b/tests/tools/test_mcp_sandbox_transport.py
@@ -1,0 +1,241 @@
+"""Tests for the sandbox MCP transport.
+
+Tests sandbox_client by spawning a mock MCP server as a local subprocess
+(no Docker/MCP SDK required). The mock server speaks newline-delimited
+JSON-RPC 2.0 — the same wire protocol as MCP stdio transport.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Skip all tests if anyio is not available (it's an MCP SDK dependency)
+anyio = pytest.importorskip("anyio")
+
+
+# ---------------------------------------------------------------------------
+# Mock MCP server script (newline-delimited JSON-RPC 2.0)
+# ---------------------------------------------------------------------------
+
+MOCK_MCP_SERVER = textwrap.dedent(r'''
+import json
+import sys
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+def recv():
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    return json.loads(line.strip())
+
+# MCP initialize handshake
+req = recv()
+if req and req.get("method") == "initialize":
+    send({
+        "jsonrpc": "2.0",
+        "id": req["id"],
+        "result": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mock-server", "version": "1.0.0"},
+        },
+    })
+
+# Wait for initialized notification
+req = recv()
+
+# Handle tools/list
+req = recv()
+if req and req.get("method") == "tools/list":
+    send({
+        "jsonrpc": "2.0",
+        "id": req["id"],
+        "result": {
+            "tools": [{
+                "name": "echo",
+                "description": "Echo the input",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                },
+            }],
+        },
+    })
+
+# Handle tool calls until stdin closes
+while True:
+    req = recv()
+    if req is None:
+        break
+    if req.get("method") == "tools/call":
+        tool_name = req["params"].get("name", "")
+        args = req["params"].get("arguments", {})
+        if tool_name == "echo":
+            send({
+                "jsonrpc": "2.0",
+                "id": req["id"],
+                "result": {
+                    "content": [{"type": "text", "text": args.get("text", "")}],
+                },
+            })
+        else:
+            send({
+                "jsonrpc": "2.0",
+                "id": req["id"],
+                "result": {
+                    "content": [{"type": "text", "text": f"unknown tool: {tool_name}"}],
+                    "isError": True,
+                },
+            })
+''')
+
+
+@pytest.fixture
+def mock_server_script(tmp_path):
+    """Write the mock MCP server script to a temp file."""
+    script = tmp_path / "mock_mcp_server.py"
+    script.write_text(MOCK_MCP_SERVER)
+    return str(script)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSandboxClient:
+    """Test sandbox_client using a local subprocess (simulating docker exec)."""
+
+    @pytest.mark.asyncio
+    async def test_basic_tool_call(self, mock_server_script):
+        """Verify basic MCP protocol flow through sandbox_client."""
+        from mcp import ClientSession
+        from tools.mcp_sandbox_transport import sandbox_client
+
+        # Use python3 directly instead of docker exec — same pipe pattern
+        async with sandbox_client(
+            container_id="unused",
+            docker_exe="unused",
+            command="unused",
+            _raw_cmd=[sys.executable, mock_server_script],
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                assert len(tools.tools) == 1
+                assert tools.tools[0].name == "echo"
+
+                result = await session.call_tool("echo", {"text": "hello sandbox"})
+                assert not result.isError
+                assert any("hello sandbox" in c.text for c in result.content if hasattr(c, "text"))
+
+    @pytest.mark.asyncio
+    async def test_env_vars_passed(self, tmp_path):
+        """Verify environment variables are passed to the subprocess."""
+        # Script that prints an env var as an MCP tool result
+        script = tmp_path / "env_check.py"
+        script.write_text(textwrap.dedent(r'''
+import json, sys, os
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+def recv():
+    line = sys.stdin.readline()
+    return json.loads(line.strip()) if line else None
+
+# initialize
+req = recv()
+send({"jsonrpc": "2.0", "id": req["id"], "result": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {"tools": {}},
+    "serverInfo": {"name": "env-check", "version": "1.0.0"},
+}})
+recv()  # initialized notification
+
+# tools/list
+req = recv()
+send({"jsonrpc": "2.0", "id": req["id"], "result": {"tools": [{
+    "name": "get_env", "description": "Get env var",
+    "inputSchema": {"type": "object", "properties": {"key": {"type": "string"}}},
+}]}})
+
+while True:
+    req = recv()
+    if req is None:
+        break
+    if req.get("method") == "tools/call":
+        key = req["params"].get("arguments", {}).get("key", "")
+        value = os.environ.get(key, "NOT_SET")
+        send({"jsonrpc": "2.0", "id": req["id"], "result": {
+            "content": [{"type": "text", "text": value}],
+        }})
+        '''))
+
+        from mcp import ClientSession
+        from tools.mcp_sandbox_transport import sandbox_client
+
+        # For env var test, set it in os.environ since _raw_cmd bypasses -e flags
+        os.environ["HERMES_TEST_VAR"] = "sandbox_works"
+        try:
+            async with sandbox_client(
+                container_id="unused",
+                docker_exe="unused",
+                command="unused",
+                _raw_cmd=[sys.executable, str(script)],
+            ) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    await session.list_tools()
+                    result = await session.call_tool("get_env", {"key": "HERMES_TEST_VAR"})
+                    assert any("sandbox_works" in c.text for c in result.content if hasattr(c, "text"))
+        finally:
+            os.environ.pop("HERMES_TEST_VAR", None)
+
+    @pytest.mark.asyncio
+    async def test_process_cleanup_on_exit(self, mock_server_script):
+        """Verify the subprocess is cleaned up when context exits."""
+        from mcp import ClientSession
+        from tools.mcp_sandbox_transport import sandbox_client
+
+        async with sandbox_client(
+            container_id="unused",
+            docker_exe="unused",
+            command="unused",
+            _raw_cmd=[sys.executable, mock_server_script],
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                # We can't easily get the PID from anyio, just verify it connects
+                tools = await session.list_tools()
+                assert len(tools.tools) >= 1
+
+        # After context exit, the process should be terminated
+        # (no assertion needed — if cleanup hangs, the test times out)
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls(self, mock_server_script):
+        """Verify multiple sequential tool calls work."""
+        from mcp import ClientSession
+        from tools.mcp_sandbox_transport import sandbox_client
+
+        async with sandbox_client(
+            container_id="unused",
+            docker_exe="unused",
+            command="unused",
+            _raw_cmd=[sys.executable, mock_server_script],
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                await session.list_tools()
+
+                for i in range(5):
+                    result = await session.call_tool("echo", {"text": f"msg-{i}"})
+                    assert any(f"msg-{i}" in c.text for c in result.content if hasattr(c, "text"))

--- a/tools/mcp_sandbox_transport.py
+++ b/tools/mcp_sandbox_transport.py
@@ -29,9 +29,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
-import sys
 from contextlib import asynccontextmanager
-from typing import TextIO
 
 import anyio
 from anyio.streams.text import TextReceiveStream
@@ -49,7 +47,6 @@ async def sandbox_client(
     command: str,
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
-    errlog: TextIO = sys.stderr,
     *,
     _raw_cmd: list[str] | None = None,
 ):
@@ -78,10 +75,16 @@ async def sandbox_client(
     if _raw_cmd is not None:
         exec_cmd = list(_raw_cmd)
     else:
+        import re
+        _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
         exec_cmd = [docker_exe, "exec", "-i"]
         if env:
             for key, value in sorted(env.items()):
+                if not _ENV_KEY_RE.match(key):
+                    logger.warning("sandbox-mcp: skipping invalid env key: %r", key)
+                    continue
                 exec_cmd.extend(["-e", f"{key}={value}"])
+        exec_cmd.append("--")  # end of flags, prevents container_id/command flag injection
         exec_cmd.append(container_id)
         exec_cmd.append(command)
         if args:
@@ -113,6 +116,8 @@ async def sandbox_client(
                     lines = (buffer + chunk).split("\n")
                     buffer = lines.pop()
                     for line in lines:
+                        if not line.strip():
+                            continue  # skip blank lines between messages
                         try:
                             message = types.JSONRPCMessage.model_validate_json(line)
                         except Exception:
@@ -177,7 +182,11 @@ async def sandbox_client(
             except ProcessLookupError:
                 pass
 
-            await read_stream.aclose()
-            await write_stream.aclose()
-            await read_stream_writer.aclose()
-            await write_stream_reader.aclose()
+            # Close all stream endpoints. Each may already be closed by
+            # task group tasks (stdout_reader, stdin_writer) or by the
+            # ClientSession teardown, so guard each individually.
+            for stream in (read_stream, write_stream, read_stream_writer, write_stream_reader):
+                try:
+                    await stream.aclose()
+                except Exception:
+                    pass

--- a/tools/mcp_sandbox_transport.py
+++ b/tools/mcp_sandbox_transport.py
@@ -1,0 +1,183 @@
+"""Sandbox MCP transport — run MCP servers inside Docker/Podman containers.
+
+Mirrors ``mcp.client.stdio.stdio_client`` but uses ``docker exec -i`` to
+communicate with an MCP server running inside an existing sandbox container.
+The exec process's stdin/stdout IS the MCP server's stdin/stdout.
+
+Usage::
+
+    async with sandbox_client(container_id, docker_exe, command, args, env) as (
+        read_stream, write_stream,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            ...
+
+Config (config.yaml)::
+
+    mcp_servers:
+      my-server:
+        command: python3
+        args: ["-m", "my_mcp_server"]
+        sandbox: true
+        env:
+          SSH_AUTH_SOCK: /run/hermes-creds/S.ssh-agent
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from contextlib import asynccontextmanager
+from typing import TextIO
+
+import anyio
+from anyio.streams.text import TextReceiveStream
+
+logger = logging.getLogger(__name__)
+
+# Match MCP SDK's termination timeout
+_PROCESS_TERMINATION_TIMEOUT = 2.0
+
+
+@asynccontextmanager
+async def sandbox_client(
+    container_id: str,
+    docker_exe: str,
+    command: str,
+    args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    errlog: TextIO = sys.stderr,
+    *,
+    _raw_cmd: list[str] | None = None,
+):
+    """MCP client transport via ``docker exec -i`` into a sandbox container.
+
+    Spawns ``docker exec -i [-e K=V ...] <container> <command> [args...]``
+    and yields ``(read_stream, write_stream)`` compatible with
+    ``mcp.ClientSession``.
+
+    For testing without Docker, pass ``_raw_cmd`` to override the exec command.
+
+    The streams carry ``SessionMessage`` objects using newline-delimited
+    JSON-RPC 2.0 ��� the same wire protocol as MCP stdio transport.
+    """
+    from mcp import types
+    from mcp.shared.message import SessionMessage
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream[
+        SessionMessage | Exception
+    ](0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream[
+        SessionMessage
+    ](0)
+
+    # Build docker exec command (or use raw command for testing)
+    if _raw_cmd is not None:
+        exec_cmd = list(_raw_cmd)
+    else:
+        exec_cmd = [docker_exe, "exec", "-i"]
+        if env:
+            for key, value in sorted(env.items()):
+                exec_cmd.extend(["-e", f"{key}={value}"])
+        exec_cmd.append(container_id)
+        exec_cmd.append(command)
+        if args:
+            exec_cmd.extend(args)
+
+    logger.info("sandbox-mcp: launching %s in container %s", command, container_id[:12])
+
+    try:
+        process = await anyio.open_process(
+            exec_cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError:
+        await read_stream.aclose()
+        await write_stream.aclose()
+        await read_stream_writer.aclose()
+        await write_stream_reader.aclose()
+        raise
+
+    async def stdout_reader():
+        """Read newline-delimited JSON-RPC from the MCP server's stdout."""
+        assert process.stdout, "Process missing stdout"
+        try:
+            async with read_stream_writer:
+                buffer = ""
+                async for chunk in TextReceiveStream(process.stdout):
+                    lines = (buffer + chunk).split("\n")
+                    buffer = lines.pop()
+                    for line in lines:
+                        try:
+                            message = types.JSONRPCMessage.model_validate_json(line)
+                        except Exception:
+                            logger.warning(
+                                "sandbox-mcp: failed to parse from %s: %.200s",
+                                container_id[:12], line,
+                            )
+                            continue
+                        await read_stream_writer.send(SessionMessage(message))
+        except anyio.ClosedResourceError:
+            await anyio.lowlevel.checkpoint()
+
+    async def stdin_writer():
+        """Write newline-delimited JSON-RPC to the MCP server's stdin."""
+        assert process.stdin, "Process missing stdin"
+        try:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    json_str = session_message.message.model_dump_json(
+                        by_alias=True, exclude_none=True,
+                    )
+                    await process.stdin.send((json_str + "\n").encode("utf-8"))
+        except anyio.ClosedResourceError:
+            await anyio.lowlevel.checkpoint()
+
+    async def stderr_drain():
+        """Drain stderr to prevent pipe buffer blocking docker exec."""
+        if not process.stderr:
+            return
+        try:
+            async for chunk in TextReceiveStream(process.stderr):
+                for line in chunk.splitlines():
+                    if line.strip():
+                        logger.debug("sandbox-mcp [%s]: %s", container_id[:12], line.rstrip())
+        except (anyio.ClosedResourceError, anyio.EndOfStream):
+            pass
+
+    async with anyio.create_task_group() as tg, process:
+        tg.start_soon(stdout_reader)
+        tg.start_soon(stdin_writer)
+        tg.start_soon(stderr_drain)
+        try:
+            yield read_stream, write_stream
+        finally:
+            # MCP shutdown sequence: close stdin, wait, then terminate
+            if process.stdin:
+                try:
+                    await process.stdin.aclose()
+                except Exception:
+                    pass
+
+            try:
+                with anyio.fail_after(_PROCESS_TERMINATION_TIMEOUT):
+                    await process.wait()
+            except TimeoutError:
+                process.terminate()
+                try:
+                    with anyio.fail_after(_PROCESS_TERMINATION_TIMEOUT):
+                        await process.wait()
+                except (TimeoutError, ProcessLookupError):
+                    process.kill()
+            except ProcessLookupError:
+                pass
+
+            await read_stream.aclose()
+            await write_stream.aclose()
+            await read_stream_writer.aclose()
+            await write_stream_reader.aclose()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -752,6 +752,10 @@ class MCPServerTask:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
+    def _is_sandbox(self) -> bool:
+        """Check if this server should run inside the sandbox container."""
+        return bool(self._config.get("sandbox"))
+
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     def _make_message_handler(self):
@@ -947,6 +951,103 @@ class MCPServerTask:
                     self._ready.set()
                     await self._shutdown_event.wait()
 
+    async def _run_sandbox(self, config: dict):
+        """Run the MCP server inside the sandbox container via docker exec.
+
+        Uses the same container that terminal/file tools use, communicating
+        over a persistent ``docker exec -i`` pipe.  Enabled by setting
+        ``sandbox: true`` in the server's config.yaml entry.
+        """
+        command = config.get("command")
+        args = config.get("args", [])
+        user_env = config.get("env") or {}
+
+        if not command:
+            raise ValueError(
+                f"MCP server '{self.name}' has no 'command' in config"
+            )
+
+        # Get or create the sandbox container
+        import time
+        from tools.terminal_tool import (
+            _active_environments, _env_lock, _get_env_config,
+            _create_environment, _start_cleanup_thread, _last_activity,
+        )
+
+        sandbox_task_id = config.get("sandbox_task_id", "default")
+
+        # Ensure a sandbox container exists for this task_id
+        with _env_lock:
+            env = _active_environments.get(sandbox_task_id)
+
+        if env is None:
+            env_config = _get_env_config()
+            env_type = env_config["env_type"]
+            if env_type not in ("docker", "podman"):
+                raise RuntimeError(
+                    f"MCP server '{self.name}': sandbox: true requires "
+                    f"TERMINAL_ENV=docker or podman, got '{env_type}'"
+                )
+            image = env_config.get(f"{env_type}_image", "")
+            cwd = env_config.get("cwd", "/root")
+
+            container_config = {
+                "container_cpu": env_config.get("container_cpu", 1),
+                "container_memory": env_config.get("container_memory", 5120),
+                "container_disk": env_config.get("container_disk", 51200),
+                "container_persistent": env_config.get("container_persistent", True),
+                "docker_volumes": env_config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": env_config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": env_config.get("docker_forward_env", []),
+                "docker_env": env_config.get("docker_env", {}),
+            }
+
+            env = _create_environment(
+                env_type=env_type, image=image, cwd=cwd,
+                timeout=env_config.get("timeout", 120),
+                container_config=container_config,
+                task_id=sandbox_task_id,
+                host_cwd=env_config.get("host_cwd"),
+            )
+            with _env_lock:
+                _active_environments[sandbox_task_id] = env
+                _last_activity[sandbox_task_id] = time.time()
+            _start_cleanup_thread()
+
+        container_id = getattr(env, "_container_id", None)
+        docker_exe = getattr(env, "_docker_exe", None)
+
+        if not container_id or not docker_exe:
+            raise RuntimeError(
+                f"MCP server '{self.name}': sandbox container has no "
+                f"container_id or docker_exe (env_type may not be docker/podman)"
+            )
+
+        logger.info(
+            "MCP server '%s': using sandbox transport (container=%s, task=%s)",
+            self.name, container_id[:12], sandbox_task_id,
+        )
+
+        from tools.mcp_sandbox_transport import sandbox_client
+
+        sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
+        if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
+            sampling_kwargs["message_handler"] = self._make_message_handler()
+
+        async with sandbox_client(
+            container_id=container_id,
+            docker_exe=docker_exe,
+            command=command,
+            args=args,
+            env=user_env,
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                await session.initialize()
+                self.session = session
+                await self._discover_tools()
+                self._ready.set()
+                await self._shutdown_event.wait()
+
     async def _discover_tools(self):
         """Discover tools from the connected session."""
         if self.session is None:
@@ -990,6 +1091,8 @@ class MCPServerTask:
             try:
                 if self._is_http():
                     await self._run_http(config)
+                elif self._is_sandbox():
+                    await self._run_sandbox(config)
                 else:
                     await self._run_stdio(config)
                 # Normal exit (shutdown requested) -- break out
@@ -1862,7 +1965,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
 
-    transport_type = "HTTP" if "url" in config else "stdio"
+    transport_type = "HTTP" if "url" in config else ("sandbox" if config.get("sandbox") else "stdio")
     logger.info(
         "MCP server '%s' (%s): registered %d tool(s): %s",
         name, transport_type, len(registered_names),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -955,8 +955,7 @@ class MCPServerTask:
         """Run the MCP server inside the sandbox container via docker exec.
 
         Uses the same container that terminal/file tools use, communicating
-        over a persistent ``docker exec -i`` pipe.  Enabled by setting
-        ``sandbox: true`` in the server's config.yaml entry.
+        over a persistent ``docker exec -i`` pipe.
         """
         command = config.get("command")
         args = config.get("args", [])
@@ -972,8 +971,14 @@ class MCPServerTask:
         from tools.terminal_tool import (
             _active_environments, _env_lock, _get_env_config,
             _create_environment, _start_cleanup_thread, _last_activity,
+            _creation_locks, _creation_locks_lock,
         )
+        from tools.file_tools import _get_file_ops  # noqa: F401 — ensures env exists
 
+        # sandbox_task_id controls which container the server runs in:
+        #   "default"  → shares the agent's terminal/file sandbox
+        #   custom     → gets a dedicated container (isolated from agent work)
+        #   same value across servers → those servers share one container
         sandbox_task_id = config.get("sandbox_task_id", "default")
 
         # Ensure a sandbox container exists for this task_id
@@ -1000,7 +1005,17 @@ class MCPServerTask:
                 "docker_mount_cwd_to_workspace": env_config.get("docker_mount_cwd_to_workspace", False),
                 "docker_forward_env": env_config.get("docker_forward_env", []),
                 "docker_env": env_config.get("docker_env", {}),
+                "docker_network": env_config.get("docker_network"),
+                "docker_extra_hosts": env_config.get("docker_extra_hosts", []),
+                "docker_env_files": env_config.get("docker_env_files", []),
+                "docker_user": env_config.get("docker_user"),
             }
+            if env_type == "podman":
+                container_config["podman_rootful"] = env_config.get("podman_rootful", False)
+                container_config["podman_privileged"] = env_config.get("podman_privileged", False)
+                container_config["podman_userns"] = env_config.get("podman_userns", "")
+                container_config["podman_extra_capabilities"] = env_config.get("podman_extra_capabilities", [])
+                container_config["podman_extra_args"] = env_config.get("podman_extra_args", [])
 
             env = _create_environment(
                 env_type=env_type, image=image, cwd=cwd,
@@ -1358,17 +1373,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     parts.append(block.text)
             text_result = "\n".join(parts) if parts else ""
 
-            # Combine content + structuredContent when both are present.
-            # MCP spec: content is model-oriented (text), structuredContent
-            # is machine-oriented (JSON metadata).  For an AI agent, content
-            # is the primary payload; structuredContent supplements it.
+            # Prefer structuredContent (machine-readable JSON) over plain text
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
-                if text_result:
-                    return json.dumps({
-                        "result": text_result,
-                        "structuredContent": structured,
-                    })
                 return json.dumps({"result": structured})
             return json.dumps({"result": text_result})
 
@@ -2124,7 +2131,7 @@ def get_mcp_status() -> List[dict]:
         active_servers = dict(_servers)
 
     for name, cfg in configured.items():
-        transport = "http" if "url" in cfg else "stdio"
+        transport = "http" if "url" in cfg else ("sandbox" if cfg.get("sandbox") else "stdio")
         server = active_servers.get(name)
         if server and server.session is not None:
             entry = {
@@ -2263,7 +2270,6 @@ def _kill_orphaned_mcp_children() -> None:
     Only kills PIDs tracked in ``_stdio_pids`` — never arbitrary children.
     """
     import signal as _signal
-    kill_signal = getattr(_signal, "SIGKILL", _signal.SIGTERM)
 
     with _lock:
         pids = list(_stdio_pids)
@@ -2271,7 +2277,7 @@ def _kill_orphaned_mcp_children() -> None:
 
     for pid in pids:
         try:
-            os.kill(pid, kill_signal)
+            os.kill(pid, _signal.SIGKILL)
             logger.debug("Force-killed orphaned MCP stdio process %d", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Already exited or inaccessible


### PR DESCRIPTION
## Summary

Adds a new MCP transport that runs MCP servers **inside Docker/Podman sandbox containers** via `docker exec -i`, instead of as gateway-process subprocesses. This provides security isolation -- untrusted MCP servers no longer share the gateway's privileges, environment variables, or filesystem access.

### Architecture

```
gateway process (thin orchestrator)
  |  MCP protocol (newline-delimited JSON-RPC 2.0)
  |  via docker exec -i
  v
sandbox container (isolated, existing from terminal/file tools)
  +-- MCP server process (stdin/stdout = MCP protocol)
```

The `sandbox_client` async context manager mirrors `mcp.client.stdio.stdio_client` but spawns `docker exec -i container_id command` instead of a local subprocess. The MCP server's stdin/stdout maps directly to the exec pipe -- same wire protocol, same `ClientSession` interface, zero changes needed in MCP servers.

### Why

Currently ALL MCP servers run as **direct subprocesses of the gateway process** via `StdioServerParameters` + `stdio_client`. This means community MCP servers, skills, and plugins run with full gateway privileges -- access to all env vars (API keys, tokens), the host filesystem, and network.

With sandbox transport:
- MCP servers run in the same isolated container as terminal/file tools
- Only explicitly passed env vars are available (`env:` in config)
- Filesystem access limited to mounted volumes
- Same security model as existing tool execution

### Config

```yaml
mcp_servers:
  my-server:
    command: python3
    args: ["-m", "my_mcp_server"]
    sandbox: true                    # <-- run inside sandbox container
    sandbox_task_id: "default"       # optional: reuse terminal sandbox
    env:
      MY_VAR: "value"               # passed via docker exec -e
```

### Prior art

- **Docker MCP Gateway**: uses `docker run --rm -i` with stdio (same pattern, new container per server)
- **ToolHive (Stacklok)**: uses Docker API `ContainerAttach` for persistent bidirectional pipe
- **Anthropic sandbox-runtime**: bubblewrap sandboxing for MCP servers in Claude Code

### Changes

| File | Description |
|------|-------------|
| `tools/mcp_sandbox_transport.py` | `sandbox_client()` async context manager (183 lines) |
| `tools/mcp_tool.py` | `_is_sandbox()`, `_run_sandbox()`, transport routing |
| `tests/tools/test_mcp_sandbox_transport.py` | 4 tests with mock MCP server |

### Key implementation details

- Reuses existing sandbox container from `terminal_tool._active_environments` (no extra container)
- Stderr drained in background to prevent pipe buffer blocking
- MCP shutdown sequence: close stdin, wait 2s, SIGTERM, wait 2s, SIGKILL
- `PYTHONUNBUFFERED=1` recommended for Python MCP servers to avoid stdout buffering
- Compatible with podman-remote shim (tested on Alpine LXC + Podman)

## Test plan

- [x] 4/4 unit tests pass (mock MCP server, no Docker needed)
- [x] End-to-end: searxng MCP server running sandboxed (npx in container)
- [x] End-to-end: remote-filesystem MCP server (#8559) running sandboxed
- [x] Podman-remote shim compatibility verified on live deployment
- [ ] CI tests pass

Relates-to #8558 (remote filesystem MCP server -- this implements the "Sandbox MCP Transport" described in that issue's architecture section).
