### PR TITLE
fix(execute_code): register subprocess with process_registry for immediate kill on /reset

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -379,8 +379,9 @@ class TestStubSchemaDrift(unittest.TestCase):
 
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
-    # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete"}
+    # Parameters intentionally blocked in the sandbox (must stay in sync with
+    # _TERMINAL_BLOCKED_PARAMS in tools/code_execution_tool.py)
+    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -951,6 +951,7 @@ def execute_code(
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
     server_sock = None
+    _reg_session_id: Optional[str] = None  # process_registry handle for this subprocess
 
     try:
         # Write the auto-generated hermes_tools module
@@ -1036,6 +1037,20 @@ def execute_code(
             stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
         )
+
+        # Register with process_registry so that agent.close() / kill_all() can
+        # terminate this subprocess immediately when /reset is issued mid-execution
+        # instead of waiting up to 0.2 s for the poll loop to notice the interrupt.
+        try:
+            from tools.process_registry import process_registry as _proc_reg
+            _reg_session = _proc_reg.register_proc(
+                proc,
+                task_id=task_id or "",
+                command="execute_code",
+            )
+            _reg_session_id = _reg_session.id
+        except Exception:
+            pass
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
         deadline = time.monotonic() + timeout
@@ -1205,6 +1220,15 @@ def execute_code(
         }, ensure_ascii=False)
 
     finally:
+        # Remove from process_registry now that the subprocess has exited (or was
+        # killed).  Safe to call even if kill_all() already removed it.
+        if _reg_session_id is not None:
+            try:
+                from tools.process_registry import process_registry as _proc_reg
+                _proc_reg.deregister_proc(_reg_session_id)
+            except Exception:
+                pass
+
         # Cleanup temp dir and socket
         if server_sock is not None:
             try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -475,6 +475,49 @@ class ProcessRegistry:
         self._write_checkpoint()
         return session
 
+    def register_proc(
+        self,
+        proc: subprocess.Popen,
+        task_id: str = "",
+        command: str = "execute_code",
+        session_key: str = "",
+    ) -> "ProcessSession":
+        """Register an externally-spawned Popen so kill_all() can terminate it.
+
+        Unlike spawn_local(), this does not start reader threads or write a
+        checkpoint — it only tracks the Popen handle so that agent.close() /
+        kill_all(task_id=...) can reach the subprocess immediately on /reset.
+        Call deregister_proc() once the process has exited naturally.
+        """
+        session = ProcessSession(
+            id=f"proc_{uuid.uuid4().hex[:12]}",
+            command=command,
+            task_id=task_id,
+            session_key=session_key,
+            pid=proc.pid,
+            process=proc,
+            started_at=time.time(),
+        )
+        with self._lock:
+            self._prune_if_needed()
+            self._running[session.id] = session
+        return session
+
+    def deregister_proc(self, session_id: str) -> None:
+        """Remove a process registered via register_proc() after it has exited.
+
+        Safe to call even if the process was already removed by kill_all() or
+        kill_process() — the call is a no-op in that case.
+        """
+        with self._lock:
+            session = self._running.get(session_id)
+            if session is None:
+                return  # already removed by kill_all / kill_process
+            session.exited = True
+            if session.process is not None:
+                session.exit_code = session.process.returncode
+        self._move_to_finished(session)
+
     # ----- Reader / Poller Threads -----
 
     def _reader_loop(self, session: ProcessSession):


### PR DESCRIPTION
## Problem

When `/reset` is issued during an active `execute_code` run, `agent.close()` calls `process_registry.kill_all(task_id=session_id)` to terminate background processes. However, the `execute_code` subprocess was spawned via a bare `subprocess.Popen` and **never registered** with `process_registry` — so it was unreachable by `kill_all()`.

As a result the subprocess kept running until the poll loop’s next 0.2 s tick noticed the interrupt flag, and the partially-collected tool result was still written to the agent’s response stream after the session had already been reset, producing orphaned output.

Closes #8523

## Fix

Adds two lightweight methods to `ProcessRegistry`:

- **`register_proc(proc, task_id, ...)`** — registers an existing `Popen` handle in `_running` under the given `task_id` without starting reader threads or writing a checkpoint.
- **`deregister_proc(session_id)`** — removes the entry once the process exits naturally; a no-op if `kill_all()` already removed it.

`execute_code` now:
1. Calls `register_proc` immediately after `subprocess.Popen(...)`, keyed by `task_id`.
2. Calls `deregister_proc` in its `finally` block so the registry stays clean on normal exit.

With this change, `process_registry.kill_all(task_id=session_id)` reaches and SIGTERMs the sandbox subprocess immediately on `/reset`, consistent with how `terminal(background=true)` processes are handled.

## Files changed

| File | Change |
|------|--------|
| `tools/process_registry.py` | Add `register_proc` / `deregister_proc` methods |
| `tools/code_execution_tool.py` | Register subprocess after spawn; deregister in `finally` |