### PR TITLE
fix(bluebubbles): recover chat identity when chatGuid is missing

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -857,12 +857,29 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             text = "(attachment)"
         # --- End attachment handling ---
 
+        record_chat_guid = None
+        record_chats = record.get("chats")
+        if isinstance(record_chats, list):
+            for chat in record_chats:
+                if isinstance(chat, dict) and chat.get("guid"):
+                    record_chat_guid = chat.get("guid")
+                    break
+
+        payload_chat_guid = None
+        payload_chats = payload.get("chats")
+        if isinstance(payload_chats, list):
+            for chat in payload_chats:
+                if isinstance(chat, dict) and chat.get("guid"):
+                    payload_chat_guid = chat.get("guid")
+                    break
+
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
             record.get("chat_guid"),
             payload.get("chat_guid"),
-            payload.get("guid"),
+            record_chat_guid,
+            payload_chat_guid,
         )
         chat_identifier = self._value(
             record.get("chatIdentifier"),
@@ -923,4 +940,3 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             asyncio.create_task(self.mark_read(session_chat_id))
 
         return web.Response(text="ok")
-

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -167,6 +167,29 @@ class TestBlueBubblesWebhookParsing:
             chat_identifier = sender
         assert chat_identifier == "user@example.com"
 
+    def test_webhook_uses_chat_guid_from_chats_array(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        payload = {
+            "data": {
+                "guid": "MESSAGE-GUID",
+                "text": "hello",
+                "chats": [{"guid": "iMessage;-;+1234"}],
+            }
+        }
+        record = adapter._extract_payload_record(payload) or {}
+        record_chat_guid = None
+        if isinstance(record.get("chats"), list):
+            record_chat_guid = record["chats"][0].get("guid")
+
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            payload.get("chatGuid"),
+            record.get("chat_guid"),
+            payload.get("chat_guid"),
+            record_chat_guid,
+        )
+        assert chat_guid == "iMessage;-;+1234"
+
     def test_extract_payload_record_accepts_list_data(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {


### PR DESCRIPTION
## What does this PR do?

This fixes BlueBubbles webhook parsing when `chatGuid` is null by recovering the conversation GUID from the `chats` array instead of falling back to the message GUID.

That keeps replies routed to the correct DM or group thread while preserving existing behavior for payloads that already include `chatGuid`.

## Related Issue

Fixes #8514

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated webhook payload parsing in `gateway/platforms/bluebubbles.py` to recover chat identity from `chats[].guid` when `chatGuid` is missing.
- Removed the incorrect fallback from chat identity to the message GUID.
- Added regression coverage in `tests/gateway/test_bluebubbles.py` for null-`chatGuid` webhook payloads.

## Overlap Note

This overlaps with #8295.

Relative to #8295, this branch makes the fallback slightly more defensive in the main parser path: it searches the available `record["chats"]` and `payload["chats"]` entries until it finds a usable GUID, instead of only checking the first `_chats[0]` entry after direct fields fail. That means malformed or partially populated leading entries do not block recovery of the real chat GUID.

`#8295` already has broader standalone regression coverage, so the strongest end state would be either to merge that PR with this more defensive lookup shape, or to fold the same extra fallback behavior into its branch.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_bluebubbles.py -q`
2. Send a BlueBubbles webhook payload with `chatGuid: null` and `chats[0].guid` set
3. Confirm Hermes routes replies using the conversation GUID instead of the message GUID

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/gateway/test_bluebubbles.py -q` → `46 passed, 15 warnings in 2.52s`
