### PR TITLE
fix(stt): honor configured local whisper runtime settings

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -8,7 +8,9 @@ end-to-end dispatch.  All external dependencies are mocked.
 import os
 import struct
 import subprocess
+import sys
 import wave
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -431,9 +433,9 @@ class TestTranscribeLocalExtended:
         mock_whisper_cls = MagicMock(return_value=mock_model)
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
              patch("tools.transcription_tools._local_model", None), \
-             patch("tools.transcription_tools._local_model_name", None):
+             patch("tools.transcription_tools._local_model_signature", None):
             from tools.transcription_tools import _transcribe_local
             _transcribe_local(str(audio), "base")
             _transcribe_local(str(audio), "base")
@@ -457,9 +459,9 @@ class TestTranscribeLocalExtended:
         mock_whisper_cls = MagicMock(return_value=mock_model)
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
              patch("tools.transcription_tools._local_model", None), \
-             patch("tools.transcription_tools._local_model_name", None):
+             patch("tools.transcription_tools._local_model_signature", None):
             from tools.transcription_tools import _transcribe_local
             _transcribe_local(str(audio), "base")
             _transcribe_local(str(audio), "small")
@@ -473,7 +475,7 @@ class TestTranscribeLocalExtended:
         mock_whisper_cls = MagicMock(side_effect=RuntimeError("CUDA out of memory"))
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "large-v3")
@@ -497,13 +499,64 @@ class TestTranscribeLocalExtended:
         mock_model.transcribe.return_value = ([seg1, seg2], mock_info)
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=MagicMock(return_value=mock_model))}), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "base")
 
         assert result["success"] is True
         assert result["transcript"] == "Hello world"
+
+    def test_local_runtime_config_passed_to_whisper_model(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hi"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        mock_whisper_cls = MagicMock(return_value=mock_model)
+        config = {"local": {"device": "cpu", "compute_type": "float32"}}
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
+             patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_signature", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(str(audio), "base")
+
+        mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
+
+    def test_local_runtime_config_change_reloads_cached_model(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hi"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        mock_whisper_cls = MagicMock(return_value=mock_model)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_signature", None):
+            from tools.transcription_tools import _transcribe_local
+            with patch("tools.transcription_tools._load_stt_config", return_value={"local": {"device": "auto", "compute_type": "auto"}}):
+                _transcribe_local(str(audio), "base")
+            with patch("tools.transcription_tools._load_stt_config", return_value={"local": {"device": "cpu", "compute_type": "float32"}}):
+                _transcribe_local(str(audio), "base")
+
+        assert mock_whisper_cls.call_count == 2
 
 
 # ============================================================================

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -532,6 +532,30 @@ class TestTranscribeLocalExtended:
 
         mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
 
+    def test_local_runtime_defaults_to_auto_when_unset(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hi"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        mock_whisper_cls = MagicMock(return_value=mock_model)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch.dict(sys.modules, {"faster_whisper": SimpleNamespace(WhisperModel=mock_whisper_cls)}), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_signature", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(str(audio), "base")
+
+        mock_whisper_cls.assert_called_once_with("base", device="auto", compute_type="auto")
+
     def test_local_runtime_config_change_reloads_cached_model(self, tmp_path):
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -86,7 +86,7 @@ GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-lar
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
-_local_model_name: Optional[str] = None
+_local_model_signature: Optional[tuple[str, str, str]] = None
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -312,22 +312,28 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
-    global _local_model, _local_model_name
+    global _local_model, _local_model_signature
 
     if not _HAS_FASTER_WHISPER:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
         from faster_whisper import WhisperModel
+        local_cfg = _load_stt_config().get("local", {})
+        if not isinstance(local_cfg, dict):
+            local_cfg = {}
+        device = str(local_cfg.get("device") or "auto").strip() or "auto"
+        compute_type = str(local_cfg.get("compute_type") or "auto").strip() or "auto"
+        model_signature = (model_name, device, compute_type)
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')
-        if _local_model is None or _local_model_name != model_name:
+        if _local_model is None or _local_model_signature != model_signature:
             logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
-            _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
-            _local_model_name = model_name
+            _local_model = WhisperModel(model_name, device=device, compute_type=compute_type)
+            _local_model_signature = model_signature
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            local_cfg.get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )


### PR DESCRIPTION
## What does this PR do?

This fixes local faster-whisper initialization so Hermes honors explicit `stt.local.device` and `stt.local.compute_type` settings instead of always constructing `WhisperModel(..., device="auto", compute_type="auto")`.

It also reloads the cached local Whisper model when the runtime signature changes, and adds regression coverage for both explicit config passthrough and the default `auto` fallback.

## Related Issue

Fixes #8319

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/transcription_tools.py` to derive local Whisper `device` and `compute_type` from config with `auto` as the fallback.
- Reloaded the cached local Whisper model when the runtime signature changes instead of only when the model name changes.
- Added regression tests in `tests/tools/test_transcription_tools.py` for explicit runtime config passthrough and config-driven cache invalidation.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tools/test_transcription_tools.py -q`
2. Set `stt.local.device` and `stt.local.compute_type` in `~/.hermes/config.yaml`
3. Trigger local transcription and confirm Hermes uses the configured runtime values instead of always using `auto`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/tools/test_transcription_tools.py -q` → `79 passed, 15 warnings in 1.50s`
