### PR TITLE
feat(cli): show elapsed time in the prompt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1774,6 +1774,7 @@ class HermesCLI:
         # Conversation state
         self.conversation_history: List[Dict[str, Any]] = []
         self.session_start = datetime.now()
+        self._last_user_message_at: Optional[datetime] = None
         self._resumed = False
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
@@ -7504,6 +7505,8 @@ class HermesCLI:
             from run_agent import _sanitize_surrogates
             message = _sanitize_surrogates(message)
 
+        self._last_user_message_at = datetime.now()
+
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
 
@@ -7953,6 +7956,30 @@ class HermesCLI:
         level = min(rms, 8000) * 7 // 8000
         return _LEVEL_BARS[level]
 
+    def _format_last_user_message_elapsed(self, *, compact: bool, now: Optional[datetime] = None) -> str:
+        """Return an elapsed-time badge for the most recent user turn."""
+        last_user_message_at = getattr(self, "_last_user_message_at", None)
+        if not isinstance(last_user_message_at, datetime):
+            return ""
+
+        if now is None:
+            now = datetime.now()
+
+        elapsed_seconds = max(0, int((now - last_user_message_at).total_seconds()))
+        hours, remainder = divmod(elapsed_seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        if hours > 0:
+            elapsed_label = f"{hours}h {minutes}m"
+        elif minutes > 0:
+            elapsed_label = f"{minutes}m {seconds}s"
+        else:
+            elapsed_label = f"{seconds}s"
+
+        if compact:
+            return f"[{elapsed_label}]"
+        return f"[{elapsed_label} since last user message]"
+
     def _get_tui_prompt_fragments(self):
         """Return the prompt_toolkit fragments for the current interactive state."""
         symbol, state_suffix = self._get_tui_prompt_symbols()
@@ -7989,6 +8016,12 @@ class HermesCLI:
             return _state_fragment("class:prompt-working", "⚕")
         if self._voice_mode:
             return _state_fragment("class:voice-prompt", "🎤")
+        elapsed_badge = self._format_last_user_message_elapsed(compact=compact)
+        if elapsed_badge:
+            return [
+                ("class:prompt", symbol),
+                ("class:prompt-working", f"{elapsed_badge} "),
+            ]
         return [("class:prompt", symbol)]
 
     def _get_tui_prompt_text(self) -> str:

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -92,6 +92,16 @@ class TestCliSkinPromptIntegration:
             ("class:prompt-working", "[1m 15s] "),
         ]
 
+    def test_elapsed_badge_rolls_over_to_hours(self):
+        cli = _make_cli_stub()
+        cli._last_user_message_at = datetime.now() - timedelta(seconds=3_665)
+
+        set_active_skin("default")
+        frags = cli._get_tui_prompt_fragments()
+
+        assert frags[0] == ("class:prompt", "❯ ")
+        assert frags[1] == ("class:prompt-working", "[1h 1m since last user message] ")
+
     def test_icon_only_skin_symbol_still_visible_in_special_states(self):
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}

--- a/tests/cli/test_cli_skin_integration.py
+++ b/tests/cli/test_cli_skin_integration.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -42,6 +43,17 @@ class TestCliSkinPromptIntegration:
         set_active_skin("ares")
         assert cli._get_tui_prompt_fragments() == [("class:prompt", "⚔ ❯ ")]
 
+    def test_prompt_fragments_include_elapsed_badge_after_user_message(self):
+        cli = _make_cli_stub()
+        cli._last_user_message_at = datetime.now() - timedelta(seconds=12)
+
+        set_active_skin("default")
+        frags = cli._get_tui_prompt_fragments()
+
+        assert frags[0] == ("class:prompt", "❯ ")
+        assert frags[1][0] == "class:prompt-working"
+        assert "[12s since last user message]" in frags[1][1]
+
     def test_secret_prompt_fragments_preserve_secret_state(self):
         cli = _make_cli_stub()
         cli._secret_state = {"response_queue": object()}
@@ -67,6 +79,18 @@ class TestCliSkinPromptIntegration:
         assert frags[0][0] == "class:voice-recording"
         assert frags[0][1].startswith("●")
         assert "❯" not in frags[0][1]
+
+    def test_narrow_terminals_compact_elapsed_badge(self):
+        cli = _make_cli_stub()
+        cli._last_user_message_at = datetime.now() - timedelta(seconds=75)
+
+        with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=50):
+            frags = cli._get_tui_prompt_fragments()
+
+        assert frags == [
+            ("class:prompt", "❯ "),
+            ("class:prompt-working", "[1m 15s] "),
+        ]
 
     def test_icon_only_skin_symbol_still_visible_in_special_states(self):
         cli = _make_cli_stub()


### PR DESCRIPTION
## What does this PR do?

This adds an elapsed-time badge to the interactive CLI prompt so Hermes shows how long it has been since the last user message.

The badge stays compact on narrow terminals, uses a longer label when there is room, and leaves non-interactive output and special prompt states unchanged.

## Related Issue

Fixes #8541

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added last-user-message timestamp tracking in `cli.py`.
- Added elapsed badge formatting for the idle interactive prompt with compact and wide variants.
- Added CLI prompt integration tests covering elapsed rendering and narrow-terminal compaction.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/cli/test_cli_skin_integration.py tests/cli/test_cli_status_bar.py -q`
2. Start Hermes CLI chat and send a message
3. Wait a few seconds and confirm the prompt shows an elapsed badge since the last user message

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/cli/test_cli_skin_integration.py tests/cli/test_cli_status_bar.py -q` → `34 passed, 15 warnings in 5.79s`
