### PR TITLE
fix(model): respect explicit context_length override

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1315,7 +1315,11 @@ class AIAgent:
         # for reliable tool-calling workflows (64K tokens).
         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
         _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+        if (
+            _ctx
+            and _ctx < MINIMUM_CONTEXT_LENGTH
+            and self._config_context_length is None
+        ):
             raise ValueError(
                 f"Model {self.model} has a context window of {_ctx:,} tokens, "
                 f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -84,6 +84,64 @@ def agent_with_memory_tool():
         return a
 
 
+def _make_mock_context_compressor(context_length: int) -> MagicMock:
+    """Build a minimal compressor stub for AIAgent.__init__ tests."""
+    compressor = MagicMock()
+    compressor.context_length = context_length
+    compressor.threshold_tokens = int(context_length * 0.50)
+    compressor.get_tool_schemas.return_value = []
+    compressor.on_session_start.return_value = None
+    return compressor
+
+
+def test_aiagent_allows_explicit_context_length_override_below_minimum():
+    compressor = _make_mock_context_compressor(32_768)
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.ContextCompressor", return_value=compressor),
+        patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 32_768}}),
+        patch.object(AIAgent, "_check_compression_model_feasibility", return_value=None),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._config_context_length == 32_768
+    assert agent.context_compressor.context_length == 32_768
+
+
+def test_aiagent_rejects_sub_minimum_context_without_override():
+    compressor = _make_mock_context_compressor(32_768)
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.ContextCompressor", return_value=compressor),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch.object(AIAgent, "_check_compression_model_feasibility", return_value=None),
+    ):
+        with pytest.raises(ValueError, match="32,768 tokens"):
+            AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()


### PR DESCRIPTION
## What does this PR do?

This fixes the startup context-length guard so an explicit `model.context_length` override is respected even when it is below the default 64K minimum.

The default safety check still applies when no override is configured, and the PR adds constructor-level regression coverage for both paths.

## Related Issue

Fixes #8430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `run_agent.py` to skip the minimum-context startup rejection when `model.context_length` is explicitly configured.
- Preserved the existing rejection for sub-64K context windows when no override is set.
- Added regression tests in `tests/run_agent/test_run_agent.py` covering both the override-allowed and default-rejected constructor paths.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/run_agent/test_run_agent.py -q -k "explicit_context_length_override_below_minimum or sub_minimum_context_without_override"`
2. Run `uv run --extra dev python -m pytest tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py -q`
3. Set `model.context_length: 32768` in config and confirm Hermes starts without the minimum context error

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/run_agent/test_run_agent.py -q -k "explicit_context_length_override_below_minimum or sub_minimum_context_without_override"` → `2 passed, 2 warnings in 5.41s`
- `uv run --extra dev python -m pytest tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py -q` → `14 passed, 14 warnings in 2.14s`
