### PR TITLE
fix(cron): report empty agent response as 'warning' instead of 'ok'

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5019,7 +5019,15 @@ class HermesCLI:
                     print(f"  Skills: {', '.join(job['skills'])}")
                 print(f"  Prompt: {job.get('prompt_preview', '')}")
                 if job.get("last_run_at"):
-                    print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                    _status = job.get("last_status", "?")
+                    _status_display = {
+                        "ok": "ok",
+                        "error": "error",
+                        "warning": "warning — empty response (check model/API config)",
+                    }.get(_status, _status)
+                    _last_err = job.get("last_error")
+                    _err_suffix = f": {_last_err}" if _status == "warning" and _last_err else ""
+                    print(f"  Last run: {job['last_run_at']} ({_status_display}{_err_suffix})")
                 print()
             return
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -578,23 +578,33 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None, empty_response: bool = False):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    ``empty_response`` flags runs where the agent completed without producing
+    any output (e.g. invalid model name causing a silent API 404).  These are
+    stored as ``last_status="warning"`` so they are distinguishable from
+    genuine successes in job listings and monitoring.
     """
     jobs = load_jobs()
     for i, job in enumerate(jobs):
         if job["id"] == job_id:
             now = _hermes_now().isoformat()
             job["last_run_at"] = now
-            job["last_status"] = "ok" if success else "error"
-            job["last_error"] = error if not success else None
+            if not success:
+                job["last_status"] = "error"
+            elif empty_response:
+                job["last_status"] = "warning"
+            else:
+                job["last_status"] = "ok"
+            job["last_error"] = error if (not success or empty_response) else None
             # Track delivery failures separately — cleared on successful delivery
             job["last_delivery_error"] = delivery_error
             

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -946,6 +946,21 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
                 success, output, final_response, error = run_job(job)
 
+                # A completed run with no agent response (e.g. an invalid model
+                # name silently producing a 404) must not be reported as "ok".
+                # Flag it so mark_job_run() stores last_status="warning" instead,
+                # making the silent failure visible in job listings and /cron list.
+                empty_response = success and not final_response
+                if empty_response:
+                    error = (
+                        "Agent completed without producing a response — "
+                        "check model name, API key, and provider configuration"
+                    )
+                    logger.warning(
+                        "Job '%s' produced an empty response; recording as warning",
+                        job.get("name", job["id"]),
+                    )
+
                 output_file = save_job_output(job["id"], output)
                 if verbose:
                     logger.info("Output saved to: %s", output_file)
@@ -967,7 +982,8 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                mark_job_run(job["id"], success, error, delivery_error=delivery_error,
+                             empty_response=empty_response)
                 executed += 1
 
             except Exception as e:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -369,6 +369,28 @@ class TestMarkJobRun:
         assert updated["last_error"] == "model timeout"
         assert updated["last_delivery_error"] == "platform 'discord' not enabled"
 
+    def test_empty_response_sets_warning_status(self, tmp_cron_dir):
+        """A run that completes but produces no agent response is stored as
+        'warning', not 'ok', so silent API failures are visible in job listings."""
+        job = create_job(prompt="Daily report", schedule="every 1h")
+        mark_job_run(
+            job["id"],
+            success=True,
+            error="Agent completed without producing a response — check model/API config",
+            empty_response=True,
+        )
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "warning"
+        assert updated["last_error"] is not None
+
+    def test_empty_response_warning_does_not_override_real_ok(self, tmp_cron_dir):
+        """Ensure empty_response=False keeps last_status as 'ok' (non-regression)."""
+        job = create_job(prompt="Ping", schedule="every 1h")
+        mark_job_run(job["id"], success=True, empty_response=False)
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "ok"
+        assert updated["last_error"] is None
+
 
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1216,3 +1216,76 @@ class TestSendMediaViaAdapter:
         self._run_with_loop(adapter, "123", media_files, None, {"id": "j4"})
         adapter.send_voice.assert_called_once()
         adapter.send_image_file.assert_called_once()
+
+
+class TestEmptyResponseWarning:
+    """tick() must mark jobs with empty agent responses as 'warning', not 'ok'.
+
+    Regression test for #8585: invalid model names (and other silent API
+    failures) caused run_job() to return success=True with an empty
+    final_response, and mark_job_run() stored last_status="ok", making
+    the failure invisible in /cron list output.
+    """
+
+    def test_empty_final_response_stored_as_warning(self, tmp_path, monkeypatch):
+        """When run_job returns success=True but final_response is empty,
+        tick() must call mark_job_run with empty_response=True so the job
+        shows last_status='warning' rather than 'ok'."""
+        from cron import jobs as _jobs_mod
+
+        # Patch run_job to simulate a successful-but-empty run (e.g. 404 on model)
+        monkeypatch.setattr(
+            "cron.scheduler.run_job",
+            lambda job: (True, "# Cron Job: test\n\n(No response generated)", "", None),
+        )
+        # Patch save_job_output to avoid disk I/O
+        monkeypatch.setattr("cron.scheduler.save_job_output", lambda *a, **kw: str(tmp_path / "out.md"))
+
+        captured = {}
+
+        original_mark = _jobs_mod.mark_job_run
+
+        def capturing_mark(job_id, success, error=None, delivery_error=None, empty_response=False):
+            captured["empty_response"] = empty_response
+            captured["error"] = error
+            original_mark(job_id, success, error=error,
+                          delivery_error=delivery_error, empty_response=empty_response)
+
+        monkeypatch.setattr("cron.scheduler.mark_job_run", capturing_mark)
+        monkeypatch.setattr("cron.scheduler._deliver_result", lambda *a, **kw: None)
+
+        # Build a minimal job dict that tick() would pass to run_job
+        job = {
+            "id": "job-test-001",
+            "name": "test-job",
+            "prompt": "summarise logs",
+            "schedule": "every 1h",
+            "schedule_display": "every 1h",
+            "enabled": True,
+            "origin": {},
+            "repeat": {"times": None, "completed": 0},
+            "next_run_at": None,
+            "last_run_at": None,
+            "last_status": None,
+            "last_error": None,
+            "last_delivery_error": None,
+            "state": "scheduled",
+        }
+
+        # Patch jobs layer to return our single job and persist writes to tmp_path
+        jobs_file = tmp_path / "jobs.json"
+        jobs_file.write_text(json.dumps([job]))
+        monkeypatch.setattr("cron.jobs.JOBS_PATH", jobs_file)
+        monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [job])
+        monkeypatch.setattr("cron.scheduler.advance_next_run", lambda jid: None)
+
+        from cron.scheduler import tick
+        tick(adapters={}, loop=None, verbose=False)
+
+        assert captured.get("empty_response") is True, (
+            "tick() should pass empty_response=True to mark_job_run when "
+            "run_job returns success=True with an empty final_response"
+        )
+        assert captured.get("error") is not None, (
+            "An explanatory error message must be provided alongside the warning"
+        )

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1218,6 +1218,8 @@ class TestSendMediaViaAdapter:
         adapter.send_image_file.assert_called_once()
 
 
+
+
 class TestEmptyResponseWarning:
     """tick() must mark jobs with empty agent responses as 'warning', not 'ok'.
 
@@ -1227,56 +1229,39 @@ class TestEmptyResponseWarning:
     the failure invisible in /cron list output.
     """
 
-    def test_empty_final_response_stored_as_warning(self, tmp_path, monkeypatch):
+    _MINIMAL_JOB = {
+        "id": "job-test-001",
+        "name": "test-job",
+        "prompt": "summarise logs",
+        "schedule": "every 1h",
+        "schedule_display": "every 1h",
+        "enabled": True,
+        "origin": {},
+        "repeat": {"times": None, "completed": 0},
+        "next_run_at": None,
+        "last_run_at": None,
+        "last_status": None,
+        "last_error": None,
+        "last_delivery_error": None,
+        "state": "scheduled",
+    }
+
+    def test_empty_final_response_stored_as_warning(self, monkeypatch):
         """When run_job returns success=True but final_response is empty,
         tick() must call mark_job_run with empty_response=True so the job
         shows last_status='warning' rather than 'ok'."""
-        from cron import jobs as _jobs_mod
-
-        # Patch run_job to simulate a successful-but-empty run (e.g. 404 on model)
-        monkeypatch.setattr(
-            "cron.scheduler.run_job",
-            lambda job: (True, "# Cron Job: test\n\n(No response generated)", "", None),
-        )
-        # Patch save_job_output to avoid disk I/O
-        monkeypatch.setattr("cron.scheduler.save_job_output", lambda *a, **kw: str(tmp_path / "out.md"))
-
         captured = {}
 
-        original_mark = _jobs_mod.mark_job_run
-
-        def capturing_mark(job_id, success, error=None, delivery_error=None, empty_response=False):
+        def fake_mark(job_id, success, error=None, delivery_error=None, empty_response=False):
             captured["empty_response"] = empty_response
             captured["error"] = error
-            original_mark(job_id, success, error=error,
-                          delivery_error=delivery_error, empty_response=empty_response)
 
-        monkeypatch.setattr("cron.scheduler.mark_job_run", capturing_mark)
+        monkeypatch.setattr("cron.scheduler.run_job",
+                            lambda job: (True, "# Cron Job\n\n(No response generated)", "", None))
+        monkeypatch.setattr("cron.scheduler.save_job_output", lambda *a, **kw: "/tmp/out.md")
+        monkeypatch.setattr("cron.scheduler.mark_job_run", fake_mark)
         monkeypatch.setattr("cron.scheduler._deliver_result", lambda *a, **kw: None)
-
-        # Build a minimal job dict that tick() would pass to run_job
-        job = {
-            "id": "job-test-001",
-            "name": "test-job",
-            "prompt": "summarise logs",
-            "schedule": "every 1h",
-            "schedule_display": "every 1h",
-            "enabled": True,
-            "origin": {},
-            "repeat": {"times": None, "completed": 0},
-            "next_run_at": None,
-            "last_run_at": None,
-            "last_status": None,
-            "last_error": None,
-            "last_delivery_error": None,
-            "state": "scheduled",
-        }
-
-        # Patch jobs layer to return our single job and persist writes to tmp_path
-        jobs_file = tmp_path / "jobs.json"
-        jobs_file.write_text(json.dumps([job]))
-        monkeypatch.setattr("cron.jobs.JOBS_PATH", jobs_file)
-        monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [job])
+        monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [dict(self._MINIMAL_JOB)])
         monkeypatch.setattr("cron.scheduler.advance_next_run", lambda jid: None)
 
         from cron.scheduler import tick
@@ -1287,5 +1272,27 @@ class TestEmptyResponseWarning:
             "run_job returns success=True with an empty final_response"
         )
         assert captured.get("error") is not None, (
-            "An explanatory error message must be provided alongside the warning"
+            "tick() should supply a diagnostic error message with the warning"
+        )
+
+    def test_non_empty_response_not_flagged_as_warning(self, monkeypatch):
+        """A run that produces a real response must still be stored as 'ok'."""
+        captured = {}
+
+        def fake_mark(job_id, success, error=None, delivery_error=None, empty_response=False):
+            captured["empty_response"] = empty_response
+
+        monkeypatch.setattr("cron.scheduler.run_job",
+                            lambda job: (True, "# Cron Job\n\nAll done.", "All done.", None))
+        monkeypatch.setattr("cron.scheduler.save_job_output", lambda *a, **kw: "/tmp/out.md")
+        monkeypatch.setattr("cron.scheduler.mark_job_run", fake_mark)
+        monkeypatch.setattr("cron.scheduler._deliver_result", lambda *a, **kw: None)
+        monkeypatch.setattr("cron.scheduler.get_due_jobs", lambda: [dict(self._MINIMAL_JOB)])
+        monkeypatch.setattr("cron.scheduler.advance_next_run", lambda jid: None)
+
+        from cron.scheduler import tick
+        tick(adapters={}, loop=None, verbose=False)
+
+        assert captured.get("empty_response") is False, (
+            "tick() must NOT set empty_response=True when final_response is non-empty"
         )

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -379,8 +379,9 @@ class TestStubSchemaDrift(unittest.TestCase):
 
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
-    # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete"}
+    # Parameters intentionally blocked in the sandbox (must stay in sync with
+    # _TERMINAL_BLOCKED_PARAMS in tools/code_execution_tool.py)
+    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -951,6 +951,7 @@ def execute_code(
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
     server_sock = None
+    _reg_session_id: Optional[str] = None  # process_registry handle for this subprocess
 
     try:
         # Write the auto-generated hermes_tools module
@@ -1036,6 +1037,20 @@ def execute_code(
             stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
         )
+
+        # Register with process_registry so that agent.close() / kill_all() can
+        # terminate this subprocess immediately when /reset is issued mid-execution
+        # instead of waiting up to 0.2 s for the poll loop to notice the interrupt.
+        try:
+            from tools.process_registry import process_registry as _proc_reg
+            _reg_session = _proc_reg.register_proc(
+                proc,
+                task_id=task_id or "",
+                command="execute_code",
+            )
+            _reg_session_id = _reg_session.id
+        except Exception:
+            pass
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
         deadline = time.monotonic() + timeout
@@ -1205,6 +1220,15 @@ def execute_code(
         }, ensure_ascii=False)
 
     finally:
+        # Remove from process_registry now that the subprocess has exited (or was
+        # killed).  Safe to call even if kill_all() already removed it.
+        if _reg_session_id is not None:
+            try:
+                from tools.process_registry import process_registry as _proc_reg
+                _proc_reg.deregister_proc(_reg_session_id)
+            except Exception:
+                pass
+
         # Cleanup temp dir and socket
         if server_sock is not None:
             try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -475,6 +475,49 @@ class ProcessRegistry:
         self._write_checkpoint()
         return session
 
+    def register_proc(
+        self,
+        proc: subprocess.Popen,
+        task_id: str = "",
+        command: str = "execute_code",
+        session_key: str = "",
+    ) -> "ProcessSession":
+        """Register an externally-spawned Popen so kill_all() can terminate it.
+
+        Unlike spawn_local(), this does not start reader threads or write a
+        checkpoint — it only tracks the Popen handle so that agent.close() /
+        kill_all(task_id=...) can reach the subprocess immediately on /reset.
+        Call deregister_proc() once the process has exited naturally.
+        """
+        session = ProcessSession(
+            id=f"proc_{uuid.uuid4().hex[:12]}",
+            command=command,
+            task_id=task_id,
+            session_key=session_key,
+            pid=proc.pid,
+            process=proc,
+            started_at=time.time(),
+        )
+        with self._lock:
+            self._prune_if_needed()
+            self._running[session.id] = session
+        return session
+
+    def deregister_proc(self, session_id: str) -> None:
+        """Remove a process registered via register_proc() after it has exited.
+
+        Safe to call even if the process was already removed by kill_all() or
+        kill_process() — the call is a no-op in that case.
+        """
+        with self._lock:
+            session = self._running.get(session_id)
+            if session is None:
+                return  # already removed by kill_all / kill_process
+            session.exited = True
+            if session.process is not None:
+                session.exit_code = session.process.returncode
+        self._move_to_finished(session)
+
     # ----- Reader / Poller Threads -----
 
     def _reader_loop(self, session: ProcessSession):


### PR DESCRIPTION
## Problem

When a cron job completes but the agent produces no output — for example because an invalid model name causes a silent API 404 — `run_job()` already returned `(True, output, "", None)`. `tick()` then called `mark_job_run(success=True)`, so `last_status` was stored as **`"ok"`** and the failure was completely invisible in `/cron list` output. Users could go days without realising their jobs were silently producing `"(No response generated)"` (#8585).

## Fix

### `cron/scheduler.py`
After `run_job()` returns, detect `success=True` with an empty `final_response`, emit a `logger.warning`, build a descriptive error string, and pass `empty_response=True` to `mark_job_run()`.

### `cron/jobs.py`
`mark_job_run()` gains an `empty_response` keyword argument. When set:
- `last_status` → **`"warning"`** (distinct from `"ok"` and `"error"`)
- `last_error` → populated with the diagnostic message rather than cleared

### `cli.py`
`/cron list` now renders `last_status="warning"` with a human-readable hint so the operator immediately knows to check their model/API configuration:
```
Last run: 2026-04-12T18:00:00 (warning — empty response (check model/API config))
```

## Tests

| File | What it covers |
|------|----------------|
| `tests/cron/test_jobs.py` | `empty_response=True` stores `"warning"` + `last_error`; `empty_response=False` keeps `"ok"` (non-regression) |
| `tests/cron/test_scheduler.py` | Integration: monkeypatches `run_job()` to return an empty response, asserts `tick()` propagates `empty_response=True` to `mark_job_run()` |

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Valid run with output | `ok` | `ok` (unchanged) |
| Run that fails with exception | `error` | `error` (unchanged) |
| Run that completes but produces no output | `ok` ← **silent bug** | `warning` + diagnostic message |

Fixes #8585