### PR TITLE
feat(gateway): auto_thread only creates threads on @mention

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2280,21 +2280,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 if self._client.user not in message.mentions:
                     return
 
-            if self._client.user and self._client.user in message.mentions:
+            was_mentioned = self._client.user and self._client.user in message.mentions
+            if was_mentioned:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
 
-        # Auto-thread: when enabled, automatically create a thread for every
-        # @mention in a text channel so each conversation is isolated (like Slack).
+        # Auto-thread: when enabled, automatically create a thread for @mentions
+        # in text channels so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        # Only creates a thread when the bot was actually @mentioned, so that
+        # with require_mention=false, non-mentioned messages stay in-channel.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
             skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            if auto_thread and not skip_thread:
+            if auto_thread and not skip_thread and was_mentioned:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     is_thread = True

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -225,7 +225,7 @@ async def test_no_thread_channel_skips_auto_thread(adapter, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
-    """Channels NOT in no_thread_channels still get auto-threading."""
+    """Channels NOT in no_thread_channels still get auto-threading when @mentioned."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
     monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "800")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
@@ -235,7 +235,12 @@ async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
     fake_thread = FakeThread(channel_id=999, name="auto-thread")
     adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
 
-    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=900),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
     await adapter._handle_message(message)
 
     adapter._auto_create_thread.assert_awaited_once()

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -265,7 +265,12 @@ async def test_discord_auto_thread_enabled_by_default(adapter, monkeypatch):
     fake_thread = FakeThread(channel_id=999, name="auto-thread")
     adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
 
-    message = make_message(channel=FakeTextChannel(channel_id=123), content="hello")
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
 
     await adapter._handle_message(message)
 
@@ -340,7 +345,12 @@ async def test_discord_auto_thread_tracks_participation(adapter, monkeypatch):
     fake_thread = FakeThread(channel_id=555, name="auto-thread")
     adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
 
-    message = make_message(channel=FakeTextChannel(channel_id=123), content="start a thread")
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123),
+        content=f"<@{bot_user.id}> start a thread",
+        mentions=[bot_user],
+    )
 
     await adapter._handle_message(message)
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -358,13 +358,13 @@ class _FakeThreadChannel(_discord_mod.Thread):
         self.parent = SimpleNamespace(id=parent_id, name="general", guild=SimpleNamespace(name=guild_name, id=1))
 
 
-def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza"):
+def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza", mentions=None):
     return SimpleNamespace(
         author=SimpleNamespace(id=author_id, display_name=display_name, bot=False),
         content=content,
         channel=channel,
         attachments=[],
-        mentions=[],
+        mentions=list(mentions or []),
         reference=None,
         created_at=None,
         id=12345,
@@ -373,7 +373,7 @@ def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza
 
 @pytest.mark.asyncio
 async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
-    """When DISCORD_AUTO_THREAD=true, a new thread is created and the event routes there."""
+    """When DISCORD_AUTO_THREAD=true and bot is @mentioned, a new thread is created."""
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
 
@@ -387,7 +387,12 @@ async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
 
     adapter.handle_message = capture_handle
 
-    msg = _fake_message(_FakeTextChannel(), content="Hello world")
+    bot_user = adapter._client.user
+    msg = _fake_message(
+        _FakeTextChannel(),
+        content=f"<@{bot_user.id}> Hello world",
+        mentions=[bot_user],
+    )
 
     await adapter._handle_message(msg)
 
@@ -401,7 +406,7 @@ async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_auto_thread_enabled_by_default_slash_commands(adapter, monkeypatch):
-    """Without DISCORD_AUTO_THREAD env var, auto-threading is enabled (default: true)."""
+    """Without DISCORD_AUTO_THREAD env var, auto-threading is enabled on @mention (default: true)."""
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
 
@@ -415,7 +420,8 @@ async def test_auto_thread_enabled_by_default_slash_commands(adapter, monkeypatc
 
     adapter.handle_message = capture_handle
 
-    msg = _fake_message(_FakeTextChannel())
+    bot_user = adapter._client.user
+    msg = _fake_message(_FakeTextChannel(), mentions=[bot_user], content=f"<@{bot_user.id}> Hello")
 
     await adapter._handle_message(msg)
 


### PR DESCRIPTION
## What

`auto_thread` currently creates a thread for every message that triggers a response, regardless of whether the bot was @mentioned. This makes it impossible to use `require_mention=false` + `auto_thread=true` without getting a thread for every single message.

This PR adds mention-awareness to `auto_thread`: threads are only created when the bot was actually `@mentioned`. Non-mentioned messages reply directly in the channel.

## Why

Users want flexible Discord channel usage: casual conversation flows naturally in the channel without creating unnecessary thread partitions, while @mentions signal a need for organized tracking — like following up on a specific project or topic — and should automatically spawn a thread.

Currently there's no way to achieve this. The only options are:
- `auto_thread: true` → every message creates a thread (noisy)
- `auto_thread: false` → no threads at all (no organization)

The documentation already describes the intended behavior as "every @mention automatically creates a new thread", but the implementation didn't distinguish between mentioned and non-mentioned messages.

## How to test

1. Set in `config.yaml`:
   ```yaml
   discord:
     require_mention: false
     auto_thread: true
   ```
2. Send a message **without** @mention → bot replies directly in channel
3. Send a message **with** @mention → bot creates a thread and replies there

## Test results

Full test suite on both main and feature branch:
- main: 78 failed, 10868 passed, 35 skipped
- feature branch: 71 failed, 10875 passed, 35 skipped

All 71 failures on the feature branch are pre-existing (voice, approval, provider parity, etc.) — none are related to this change. The 7 additional passes are from fixing existing broken Discord tests to match the new behavior.

Discord-specific tests: **207 passed, 0 failed** — verified on two independent systems.

| System | OS | Python | Result |
|--------|-----|--------|--------|
| CachyOS | Arch-based | 3.11 | 207 passed |
| MX Linux | Debian GNU/Linux 13 (trixie) | 3.13 | 207 passed |

## Demo

![auto-thread-on-mention-demo](https://github.com/user-attachments/assets/78906803-95a6-4879-a21d-f48c91bb7321)

- **Top**: Non-@mentioned message ("Hi! Hermes") → bot replies directly in channel
- **Bottom**: @mentioned message ("Hi! Let's do a auto thread test @Hermes") → bot auto-creates a thread and replies there

## Platforms tested

- CachyOS (Arch-based), Python 3.11, Discord gateway
- Debian GNU/Linux 13 (trixie), Python 3.13, Discord gateway