### PR TITLE
fix(backup): correct marker filenames in _validate_backup_zip

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -201,7 +201,7 @@ def _validate_backup_zip(zf: zipfile.ZipFile) -> tuple[bool, str]:
         return False, "zip archive is empty"
 
     # Look for telltale files that a hermes home would have
-    markers = {"config.yaml", ".env", "hermes_state.db", "memory_store.db"}
+    markers = {"config.yaml", ".env", "state.db"}
     found = set()
     for n in names:
         # Could be at the root or one level deep (if someone zipped the directory)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -233,6 +233,44 @@ class TestBackup:
 
 
 # ---------------------------------------------------------------------------
+# _validate_backup_zip tests
+# ---------------------------------------------------------------------------
+
+class TestValidateBackupZip:
+    def _make_zip(self, zip_path: Path, filenames: list[str]) -> None:
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for name in filenames:
+                zf.writestr(name, "dummy")
+
+    def test_state_db_passes(self, tmp_path):
+        """A zip containing state.db is accepted as a valid Hermes backup."""
+        from hermes_cli.backup import _validate_backup_zip
+        zip_path = tmp_path / "backup.zip"
+        self._make_zip(zip_path, ["state.db", "sessions/abc.json"])
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            ok, reason = _validate_backup_zip(zf)
+        assert ok, reason
+
+    def test_old_wrong_db_name_fails(self, tmp_path):
+        """A zip with only hermes_state.db (old wrong name) is rejected."""
+        from hermes_cli.backup import _validate_backup_zip
+        zip_path = tmp_path / "old.zip"
+        self._make_zip(zip_path, ["hermes_state.db", "memory_store.db"])
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            ok, reason = _validate_backup_zip(zf)
+        assert not ok
+
+    def test_config_yaml_passes(self, tmp_path):
+        """A zip containing config.yaml is accepted (existing behaviour preserved)."""
+        from hermes_cli.backup import _validate_backup_zip
+        zip_path = tmp_path / "backup.zip"
+        self._make_zip(zip_path, ["config.yaml", "skills/x/SKILL.md"])
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            ok, reason = _validate_backup_zip(zf)
+        assert ok, reason
+
+
+# ---------------------------------------------------------------------------
 # Import tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `hermes_cli/backup.py` where `_validate_backup_zip` checked for database filenames that do not exist in a real Hermes installation, causing valid backups to be silently rejected on import.

## Type of Change
- [x] Bug fix

## Changes Made

`_validate_backup_zip` used these marker filenames to detect a valid Hermes backup:
```python
# Before
markers = {"config.yaml", ".env", "hermes_state.db", "memory_store.db"}
```

Neither `hermes_state.db` nor `memory_store.db` exist in a real installation. The actual database file is `state.db` (confirmed in `hermes_state.py`):
```python
DEFAULT_DB_PATH = get_hermes_home() / "state.db"
```

A fresh Hermes installation produces:
```
~/.hermes/state.db        ← actual name
~/.hermes/config.yaml
~/.hermes/.env
```

Because the marker set never matched `state.db`, a backup zip containing only `state.db` + `config.yaml` would fail validation:
```
Error: zip does not appear to be a Hermes backup
       (no config.yaml, .env, or state databases found)
```
...and `hermes import` would exit with `sys.exit(1)`, silently rejecting a perfectly valid backup.

Fix:
```python
# After
markers = {"config.yaml", ".env", "state.db"}
```

## How to Test

```bash
# Create a minimal backup zip with only state.db
python3 -c "
import zipfile, io
buf = io.BytesIO()
with zipfile.ZipFile(buf, 'w') as zf:
    zf.writestr('state.db', 'dummy')
buf.seek(0)
import zipfile as zf2
with zf2.ZipFile(buf) as zf:
    from hermes_cli.backup import _validate_backup_zip
    ok, reason = _validate_backup_zip(zf)
    print('ok:', ok, 'reason:', reason)
"
# Before fix: ok: False reason: zip does not appear to be a Hermes backup
# After fix:  ok: True  reason:
```

## Checklist
- [x] My changes follow the project code style
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass

## Screenshots/Logs
```
tests/hermes_cli/test_backup.py::TestValidateBackupZip
  PASSED test_state_db_passes
  PASSED test_old_wrong_db_name_fails
  PASSED test_config_yaml_passes
```