### PR TITLE
fix(voice): expose AudioRecorder recording state

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -418,6 +418,10 @@ class AudioRecorder:
     # -- public properties ---------------------------------------------------
 
     @property
+    def is_recording(self) -> bool:
+        return self._recording
+
+    @property
     def elapsed_seconds(self) -> float:
         if not self._recording:
             return 0.0


### PR DESCRIPTION
## What does this PR do?

Restores the public recorder interface expected by the voice-mode tests and by the other recorder backend.

This branch adds `AudioRecorder.is_recording` as a read-only property over the existing `_recording` flag, matching `TermuxAudioRecorder.is_recording` without changing any stream or silence-detection behavior.

This supersedes the stale earlier PR #7271 with a fresh branch from current `main`.

## Related Issue

No dedicated issue. Supersedes #7271.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `AudioRecorder.is_recording` in `tools/voice_mode.py`

## How to Test

1. Run `uv run --extra dev python -m pytest tests/tools/test_voice_mode.py -q -o addopts=''`.
2. Confirm the suite passes and the recorder lifecycle assertions no longer raise `AttributeError`.
3. Optionally exercise `/voice on` in the CLI to confirm no runtime behavior changed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification:
- `uv run --extra dev python -m pytest tests/tools/test_voice_mode.py -q -o addopts=''`: `45 passed, 15 skipped, 1 warning`
