### PR TITLE
fix(codex): tighten runtime and auxiliary token handling

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -638,44 +638,36 @@ def _nous_base_url() -> str:
 def _read_codex_access_token() -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
-    If a credential pool exists but currently has no selectable runtime entry
-    (for example all pool slots are marked exhausted), fall back to the
-    profile's auth.json token instead of hard-failing. This keeps explicit
-    fallback-to-Codex working when the pool state is stale but the stored OAuth
-    token is still valid.
-    """
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        token = _pool_runtime_api_key(entry)
-        if token:
-            return token
+    Prefer the explicit auth store for the active HERMES_HOME so auxiliary
+    fallback respects the current profile even when a credential pool was
+    seeded from another source. Only fall back to the credential pool when the
+    active auth store has no usable Codex token at all.
 
+    If the explicit auth store contains an expired JWT, return ``None`` so the
+    auxiliary auto chain can continue to the next provider instead of reviving
+    Codex from a stale pool entry.
+    """
     try:
-        from hermes_cli.auth import _read_codex_tokens
+        from hermes_cli.auth import _codex_access_token_is_expiring, _read_codex_tokens
         data = _read_codex_tokens()
         tokens = data.get("tokens", {})
         access_token = tokens.get("access_token")
         if not isinstance(access_token, str) or not access_token.strip():
             return None
-
-        # Check JWT expiry — expired tokens block the auto chain and
-        # prevent fallback to working providers (e.g. Anthropic).
-        try:
-            import base64
-            payload = access_token.split(".")[1]
-            payload += "=" * (-len(payload) % 4)
-            claims = json.loads(base64.urlsafe_b64decode(payload))
-            exp = claims.get("exp", 0)
-            if exp and time.time() > exp:
-                logger.debug("Codex access token expired (exp=%s), skipping", exp)
-                return None
-        except Exception:
-            pass  # Non-JWT token or decode error — use as-is
-
-        return access_token.strip()
+        access_token = access_token.strip()
+        if _codex_access_token_is_expiring(access_token, 0):
+            logger.debug("Codex access token expired in active auth store, skipping auxiliary Codex fallback")
+            return None
+        return access_token
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
-        return None
+
+    pool_present, entry = _select_pool_entry("openai-codex")
+    if pool_present:
+        token = _pool_runtime_api_key(entry)
+        if token:
+            return token
+    return None
 
 
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -943,20 +935,14 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
+    codex_token = _read_codex_access_token()
+    if not codex_token:
+        return None, None
+
     pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
-        else:
-            codex_token = _read_codex_access_token()
-            if not codex_token:
-                return None, None
-            base_url = _CODEX_AUX_BASE_URL
+    if pool_present and _pool_runtime_api_key(entry) == codex_token:
+        base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
     else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
         base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
     real_client = OpenAI(api_key=codex_token, base_url=base_url)
@@ -998,7 +984,9 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
         pass
 
     from agent.anthropic_adapter import _is_oauth_token
-    is_oauth = _is_oauth_token(token)
+    is_oauth = _is_oauth_token(token) or (
+        isinstance(token, str) and bool(token) and not token.startswith("sk-ant-api")
+    )
     model = _API_KEY_PROVIDER_AUX_MODELS.get("anthropic", "claude-haiku-4-5-20251001")
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
@@ -1676,6 +1664,25 @@ def get_available_vision_backends() -> List[str]:
         if p not in available and _strict_vision_backend_available(p):
             available.append(p)
     return available
+
+
+def get_vision_auxiliary_client(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    async_mode: bool = False,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Backward-compatible wrapper returning only ``(client, model)`` for vision."""
+    _, client, final_model = resolve_vision_provider_client(
+        provider,
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        async_mode=async_mode,
+    )
+    return client, final_model
 
 
 def resolve_vision_provider_client(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.auxiliary_client import (
     get_text_auxiliary_client,
+    get_vision_auxiliary_client,
     get_available_vision_backends,
     resolve_vision_provider_client,
     resolve_provider_client,
@@ -91,12 +92,48 @@ class TestReadCodexAccessToken:
 
         assert result == valid_jwt
 
+    def test_explicit_auth_store_takes_priority_over_pool(self):
+        with (
+            patch("hermes_cli.auth._read_codex_tokens", return_value={
+                "tokens": {"access_token": "explicit-auth-token", "refresh_token": "refresh"}
+            }),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, object())),
+            patch("agent.auxiliary_client._pool_runtime_api_key", return_value="pooled-codex-token"),
+        ):
+            result = _read_codex_access_token()
+
+        assert result == "explicit-auth-token"
+
+    def test_missing_auth_store_falls_back_to_pool(self):
+        with (
+            patch("hermes_cli.auth._read_codex_tokens", side_effect=RuntimeError("no auth store token")),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, object())),
+            patch("agent.auxiliary_client._pool_runtime_api_key", return_value="pooled-codex-token"),
+        ):
+            result = _read_codex_access_token()
+
+        assert result == "pooled-codex-token"
+
+    def test_expired_explicit_auth_store_token_skips_pool(self):
+        expired_jwt = "eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjF9.sig"
+        with (
+            patch("hermes_cli.auth._read_codex_tokens", return_value={
+                "tokens": {"access_token": expired_jwt, "refresh_token": "refresh"}
+            }),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, object())),
+            patch("agent.auxiliary_client._pool_runtime_api_key", return_value="pooled-codex-token"),
+        ):
+            result = _read_codex_access_token()
+
+        assert result is None
+
     def test_missing_returns_none(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        result = _read_codex_access_token()
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            result = _read_codex_access_token()
         assert result is None
 
     def test_empty_token_returns_none(self, tmp_path, monkeypatch):
@@ -114,19 +151,26 @@ class TestReadCodexAccessToken:
         result = _read_codex_access_token()
         assert result is None
 
-    def test_malformed_json_returns_none(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "auth.json").write_text("{bad json")
-        with patch("agent.auxiliary_client.Path.home", return_value=tmp_path):
+    def test_malformed_auth_store_falls_back_to_pool(self):
+        with (
+            patch("hermes_cli.auth._read_codex_tokens", side_effect=ValueError("bad auth")),
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, object())),
+            patch("agent.auxiliary_client._pool_runtime_api_key", return_value="pooled-codex-token"),
+        ):
             result = _read_codex_access_token()
-        assert result is None
+        assert result == "pooled-codex-token"
 
-    def test_missing_tokens_key_returns_none(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "auth.json").write_text(json.dumps({"other": "data"}))
-        with patch("agent.auxiliary_client.Path.home", return_value=tmp_path):
+    def test_missing_tokens_key_returns_none(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {"other": "data"},
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
             result = _read_codex_access_token()
         assert result is None
 
@@ -623,7 +667,7 @@ class TestGetTextAuxiliaryClient:
         from agent.auxiliary_client import CodexAuxiliaryClient
         assert isinstance(client, CodexAuxiliaryClient)
 
-    def test_codex_pool_entry_takes_priority_over_auth_store(self):
+    def test_codex_auth_store_takes_priority_over_pool_entry(self):
         class _Entry:
             access_token = "pooled-codex-token"
             base_url = "https://chatgpt.com/backend-api/codex"
@@ -637,8 +681,10 @@ class TestGetTextAuxiliaryClient:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
-            patch("agent.auxiliary_client.OpenAI"),
-            patch("hermes_cli.auth._read_codex_tokens", side_effect=AssertionError("legacy codex store should not run")),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            patch("hermes_cli.auth._read_codex_tokens", return_value={
+                "tokens": {"access_token": "explicit-auth-token", "refresh_token": "refresh"}
+            }),
         ):
             from agent.auxiliary_client import _try_codex
 
@@ -648,6 +694,7 @@ class TestGetTextAuxiliaryClient:
 
         assert isinstance(client, CodexAuxiliaryClient)
         assert model == "gpt-5.2-codex"
+        assert mock_openai.call_args.kwargs["api_key"] == "explicit-auth-token"
 
     def test_returns_none_when_nothing_available(self, monkeypatch):
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -655,6 +702,7 @@ class TestGetTextAuxiliaryClient:
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime", return_value=(None, None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
             client, model = get_text_auxiliary_client()
         assert client is None


### PR DESCRIPTION
## What does this PR do?

Tightens the Codex auxiliary token path so it respects the active Hermes auth store before falling back to pooled credentials, and stops reviving Codex from a stale pool entry when the explicit auth-store JWT is expired.

This branch also restores two auxiliary-client compatibility expectations that were already red in the same test file on current `main`:
- a backward-compatible `get_vision_auxiliary_client()` wrapper
- auxiliary Anthropic OAuth/setup-token classification for non-`sk-ant-api*` token sources

This is the fresh replacement for #8594 rather than a dependency on it.

## Related Issue

No dedicated issue. Supersedes #8594.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Refactored `_read_codex_access_token()` in `agent/auxiliary_client.py`
- Added compatibility coverage and precedence/expiry assertions in `tests/agent/test_auxiliary_client.py`

## How to Test

1. Run `uv run --extra dev python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts=''`.
2. Run `uv run --extra dev python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o addopts=''`.
3. Confirm expired explicit auth-store JWTs return `None` instead of silently taking a pooled Codex token.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification:
- `uv run --extra dev python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts=''`: `113 passed, 1 warning`
- `uv run --extra dev python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o addopts=''`: `15 passed, 1 warning`
