### PR TITLE
test(dev): make optional-dependency suites work in plain dev installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "agent-client-protocol>=0.9.0,<1.0"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -6,7 +6,9 @@ dispatch.  All external dependencies (faster_whisper, openai) are mocked.
 
 import json
 import os
+import sys
 import tempfile
+from types import ModuleType
 from pathlib import Path
 from unittest.mock import MagicMock, patch, mock_open
 
@@ -23,6 +25,15 @@ def _clear_openai_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
+@pytest.fixture
+def stub_faster_whisper(monkeypatch):
+    module = ModuleType("faster_whisper")
+    whisper_model = MagicMock(name="WhisperModel")
+    module.WhisperModel = whisper_model
+    monkeypatch.setitem(sys.modules, "faster_whisper", module)
+    return whisper_model
+
+
 class TestGetProvider:
     """_get_provider() picks the right backend based on config + availability."""
 
@@ -36,6 +47,7 @@ class TestGetProvider:
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
              patch("tools.transcription_tools._HAS_OPENAI", True):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "local"}) == "none"
@@ -43,6 +55,7 @@ class TestGetProvider:
     def test_local_nothing_available(self, monkeypatch):
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
              patch("tools.transcription_tools._HAS_OPENAI", False):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "local"}) == "none"
@@ -122,7 +135,7 @@ class TestValidateAudioFile:
 
 class TestTranscribeLocal:
 
-    def test_successful_transcription(self, tmp_path):
+    def test_successful_transcription(self, tmp_path, stub_faster_whisper):
         audio_file = tmp_path / "test.ogg"
         audio_file.write_bytes(b"fake audio")
 
@@ -135,8 +148,9 @@ class TestTranscribeLocal:
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
 
+        stub_faster_whisper.return_value = mock_model
+
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", return_value=mock_model), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio_file), "base")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -8,7 +8,9 @@ end-to-end dispatch.  All external dependencies are mocked.
 import os
 import struct
 import subprocess
+import sys
 import wave
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +53,15 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+
+
+@pytest.fixture
+def stub_faster_whisper(monkeypatch):
+    module = ModuleType("faster_whisper")
+    whisper_model = MagicMock(name="WhisperModel")
+    module.WhisperModel = whisper_model
+    monkeypatch.setitem(sys.modules, "faster_whisper", module)
+    return whisper_model
 
 
 # ============================================================================
@@ -415,7 +426,7 @@ class TestTranscribeLocalCommand:
 # ============================================================================
 
 class TestTranscribeLocalExtended:
-    def test_model_reuse_on_second_call(self, tmp_path):
+    def test_model_reuse_on_second_call(self, tmp_path, stub_faster_whisper):
         """Second call with same model should NOT reload the model."""
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")
@@ -428,10 +439,9 @@ class TestTranscribeLocalExtended:
 
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
-        mock_whisper_cls = MagicMock(return_value=mock_model)
+        stub_faster_whisper.return_value = mock_model
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None):
             from tools.transcription_tools import _transcribe_local
@@ -439,9 +449,9 @@ class TestTranscribeLocalExtended:
             _transcribe_local(str(audio), "base")
 
         # WhisperModel should be created only once
-        assert mock_whisper_cls.call_count == 1
+        assert stub_faster_whisper.call_count == 1
 
-    def test_model_reloaded_on_change(self, tmp_path):
+    def test_model_reloaded_on_change(self, tmp_path, stub_faster_whisper):
         """Switching model name should reload the model."""
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")
@@ -454,26 +464,24 @@ class TestTranscribeLocalExtended:
 
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
-        mock_whisper_cls = MagicMock(return_value=mock_model)
+        stub_faster_whisper.return_value = mock_model
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None):
             from tools.transcription_tools import _transcribe_local
             _transcribe_local(str(audio), "base")
             _transcribe_local(str(audio), "small")
 
-        assert mock_whisper_cls.call_count == 2
+        assert stub_faster_whisper.call_count == 2
 
-    def test_exception_returns_failure(self, tmp_path):
+    def test_exception_returns_failure(self, tmp_path, stub_faster_whisper):
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")
 
-        mock_whisper_cls = MagicMock(side_effect=RuntimeError("CUDA out of memory"))
+        stub_faster_whisper.side_effect = RuntimeError("CUDA out of memory")
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "large-v3")
@@ -481,7 +489,7 @@ class TestTranscribeLocalExtended:
         assert result["success"] is False
         assert "CUDA out of memory" in result["error"]
 
-    def test_multiple_segments_joined(self, tmp_path):
+    def test_multiple_segments_joined(self, tmp_path, stub_faster_whisper):
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")
 
@@ -496,8 +504,9 @@ class TestTranscribeLocalExtended:
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([seg1, seg2], mock_info)
 
+        stub_faster_whisper.return_value = mock_model
+
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", return_value=mock_model), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "base")


### PR DESCRIPTION
## What does this PR do?

Removes two concrete plain-`.[dev]` blockers from the test environment without pulling the full voice extra into `dev`.

This partially overlaps #6375 on the faster_whisper test-stubbing piece, but this PR specifically targets plain-.[dev] optional-dependency blockers by adding ACP to dev and keeping unrelated Python 3.14 and gateway-restart test fixes out of scope.

This branch:
- adds ACP support to the `dev` extra in `pyproject.toml`
- keeps `voice` out of `dev`
- updates the transcription tests to stub `faster_whisper` locally so Hermes-side logic can still be tested in a plain dev install

This is a narrow follow-up to the faster_whisper test-stubbing part of #6375 rather than a full replacement for that PR.

## Related Issue

No dedicated issue. Partial overlap with #6375.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent-client-protocol` to the `dev` extra in `pyproject.toml`
- Stubbed `faster_whisper` inside `tests/tools/test_transcription.py` and `tests/tools/test_transcription_tools.py`

## How to Test

1. Create a fresh plain-dev env and install `uv pip install -e ".[dev]"`.
2. Run `python -m pytest tests/acp/test_entry.py tests/acp/test_events.py -q -o addopts=''`.
3. Run `python -m pytest tests/tools/test_transcription.py tests/tools/test_transcription_tools.py -q -o addopts=''`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification in a fresh `.[dev]` env:
- `python -m pytest tests/acp/test_entry.py tests/acp/test_events.py -q -o addopts=''`: `15 passed` (with existing warnings)
- `python -m pytest tests/tools/test_transcription.py tests/tools/test_transcription_tools.py -q -o addopts=''`: `97 passed`

Note: a full plain-`.[dev]` run on current `main` is still broadly red in unrelated areas (`89 failed, 10787 passed, 92 skipped`). This PR intentionally fixes only the two confirmed optional-dependency blockers above.
