### PR TITLE
feat(setup): add STT wizard + ElevenLabs STT provider support

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -618,7 +618,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral) | "elevenlabs"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -628,6 +628,9 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "elevenlabs": {
+            "model": "scribe_v1",  # scribe_v1, scribe_v1_experimental
         },
     },
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6703,12 +6703,12 @@ For more help on a command:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent",
+        "Run a specific section: hermes setup model|tts|stt|terminal|gateway|tools|agent",
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "tts", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "tts", "stt", "terminal", "gateway", "tools", "agent"],
         default=None,
         help="Run a specific setup section instead of the full wizard",
     )

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1074,6 +1074,97 @@ def setup_tts(config: dict):
     _setup_tts_provider(config)
 
 
+def _setup_stt_provider(config: dict):
+    """Interactive STT provider selection."""
+    stt_config = config.get("stt", {})
+    current_provider = stt_config.get("provider", "local")
+
+    provider_labels = {
+        "local": "Local (faster-whisper)",
+        "groq": "Groq",
+        "openai": "OpenAI",
+        "mistral": "Mistral",
+        "elevenlabs": "ElevenLabs",
+    }
+    current_label = provider_labels.get(current_provider, current_provider)
+
+    print()
+    print_header("Speech-to-Text Provider")
+    print_info(f"Current: {current_label}")
+    print()
+
+    choices = [
+        "Local (free, on-device faster-whisper)",
+        "Groq (free tier available, needs API key)",
+        "OpenAI Whisper (needs API key)",
+        "Mistral Voxtral (needs API key)",
+        "ElevenLabs STT (needs API key)",
+        f"Keep current ({current_label})",
+    ]
+    providers = ["local", "groq", "openai", "mistral", "elevenlabs"]
+    keep_current_idx = len(choices) - 1
+    idx = prompt_choice("Select STT provider:", choices, keep_current_idx)
+
+    if idx == keep_current_idx:
+        return
+
+    selected = providers[idx]
+
+    if selected == "groq":
+        existing = get_env_value("GROQ_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Groq API key for STT", password=True)
+            if api_key:
+                save_env_value("GROQ_API_KEY", api_key)
+                print_success("Groq API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "openai":
+        existing = get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("OpenAI API key for STT", password=True)
+            if api_key:
+                save_env_value("VOICE_TOOLS_OPENAI_KEY", api_key)
+                print_success("OpenAI STT API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "mistral":
+        existing = get_env_value("MISTRAL_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Mistral API key for STT", password=True)
+            if api_key:
+                save_env_value("MISTRAL_API_KEY", api_key)
+                print_success("Mistral API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "elevenlabs":
+        existing = get_env_value("ELEVENLABS_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("ElevenLabs API key for STT", password=True)
+            if api_key:
+                save_env_value("ELEVENLABS_API_KEY", api_key)
+                print_success("ElevenLabs API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+
+    config.setdefault("stt", {})["provider"] = selected
+    save_config(config)
+    print_success(f"STT provider set to: {provider_labels.get(selected, selected)}")
+
+
+def setup_stt(config: dict):
+    """Standalone STT setup (for 'hermes setup stt')."""
+    _setup_stt_provider(config)
+
+
 # =============================================================================
 # Section 2: Terminal Backend Configuration
 # =============================================================================
@@ -2724,6 +2815,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
 SETUP_SECTIONS = [
     ("model", "Model & Provider", setup_model_provider),
     ("tts", "Text-to-Speech", setup_tts),
+    ("stt", "Speech-to-Text", setup_stt),
     ("terminal", "Terminal Backend", setup_terminal_backend),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
@@ -2749,6 +2841,7 @@ def run_setup_wizard(args):
       hermes setup           — full or quick (auto-detected)
       hermes setup model     — just model/provider
       hermes setup tts       — just text-to-speech
+      hermes setup stt       — just speech-to-text provider
       hermes setup terminal  — just terminal backend
       hermes setup gateway   — just messaging platforms
       hermes setup tools     — just tool configuration

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -492,3 +492,33 @@ def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys
 
     captured = capsys.readouterr()
     assert "Run 'hermes chat' manually" in captured.out
+
+
+def test_setup_sections_include_stt():
+    from hermes_cli.setup import SETUP_SECTIONS
+
+    section_keys = [key for key, _label, _func in SETUP_SECTIONS]
+    assert "stt" in section_keys
+
+
+def test_setup_stt_provider_elevenlabs_saves_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.setup import setup_stt
+
+    config = {"stt": {"provider": "local"}}
+    saved_env = {}
+
+    def fake_prompt_choice(question, choices, default=0):
+        assert question == "Select STT provider:"
+        return choices.index("ElevenLabs STT (needs API key)")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *_a, **_kw: "el-test-key")
+    monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda _k: "")
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda k, v: saved_env.setdefault(k, v))
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda _cfg: None)
+
+    setup_stt(config)
+
+    assert config["stt"]["provider"] == "elevenlabs"
+    assert saved_env.get("ELEVENLABS_API_KEY") == "el-test-key"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -49,6 +49,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -995,3 +996,74 @@ class TestTranscribeAudioMistralDispatch:
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+# ============================================================================
+# _get_provider — ElevenLabs
+# ============================================================================
+
+class TestGetProviderElevenLabs:
+    """ElevenLabs-specific provider selection tests."""
+
+    def test_elevenlabs_when_key_and_sdk_available(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "elevenlabs"
+
+    def test_elevenlabs_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "none"
+
+    def test_elevenlabs_explicit_no_sdk_returns_none(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_ELEVENLABS", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "elevenlabs"}) == "none"
+
+
+# ============================================================================
+# transcribe_audio — ElevenLabs dispatch
+# ============================================================================
+
+class TestTranscribeAudioElevenLabsDispatch:
+    def test_dispatches_to_elevenlabs(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "elevenlabs"}), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi", "provider": "elevenlabs"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "elevenlabs"
+        mock_eleven.assert_called_once()
+
+    def test_config_elevenlabs_model_used(self, sample_ogg):
+        config = {"provider": "elevenlabs", "elevenlabs": {"model": "scribe_v1_experimental"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_eleven.call_args[0][1] == "scribe_v1_experimental"
+
+    def test_model_override_passed_to_elevenlabs(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="elevenlabs"), \
+             patch(
+                 "tools.transcription_tools._transcribe_elevenlabs",
+                 return_value={"success": True, "transcript": "hi"},
+             ) as mock_eleven:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="scribe_v1")
+
+        assert mock_eleven.call_args[0][1] == "scribe_v1"

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1232,3 +1232,46 @@ class TestRefreshLevelLock:
         t.join(timeout=1)
         assert not t.is_alive(), "Refresh thread did not stop"
         assert iterations > 0, "Refresh thread never ran"
+
+
+# ============================================================================
+# ElevenLabs API key resolution (config fallback)
+# ============================================================================
+
+class TestElevenLabsApiKeyResolution:
+    def test_generate_elevenlabs_uses_config_api_key_when_env_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = [b"audio-bytes"]
+        mock_elevenlabs_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_elevenlabs", return_value=mock_elevenlabs_cls):
+            from tools.tts_tool import _generate_elevenlabs
+
+            output_path = tmp_path / "tts.mp3"
+            _generate_elevenlabs(
+                "hello",
+                str(output_path),
+                {
+                    "elevenlabs": {
+                        "api_key": "cfg-el-key",
+                        "voice_id": "voice-id",
+                        "model_id": "model-id",
+                    }
+                },
+            )
+
+        assert output_path.exists()
+        assert output_path.read_bytes() == b"audio-bytes"
+        assert mock_elevenlabs_cls.call_args.kwargs["api_key"] == "cfg-el-key"
+
+    def test_check_tts_requirements_accepts_config_api_key(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError("no edge")), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock()), \
+             patch("tools.tts_tool._load_tts_config", return_value={"elevenlabs": {"api_key": "cfg-el-key"}}), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError("no openai")), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False):
+            from tools.tts_tool import check_tts_requirements
+            assert check_tts_requirements() is True

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,15 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **mistral** (paid) — Mistral Voxtral API, requires ``MISTRAL_API_KEY``.
+  - **elevenlabs** (paid) — ElevenLabs STT API, requires ``ELEVENLABS_API_KEY`` or ``stt.elevenlabs.api_key`` in config.
+  - **naga** (paid) — Naga.ac STT API, requires ``NAGA_API_KEY`` or ``stt.naga.api_key`` in config.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -576,7 +579,8 @@ def _resolve_elevenlabs_stt_api_key(stt_config: Optional[dict] = None) -> str:
     if isinstance(config, dict):
         eleven_cfg = config.get("elevenlabs", {})
         if isinstance(eleven_cfg, dict):
-            cfg_key = str(eleven_cfg.get("api_key", "")).strip()
+            _val = eleven_cfg.get("api_key")
+            cfg_key = _val.strip() if isinstance(_val, str) else ""
             if cfg_key:
                 return cfg_key
     return os.getenv("ELEVENLABS_API_KEY", "").strip()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -56,6 +56,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_ELEVENLABS = _safe_find_spec("elevenlabs")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,6 +68,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -220,6 +222,15 @@ def _get_provider(stt_config: dict) -> str:
             logger.warning(
                 "STT provider 'mistral' configured but mistralai package "
                 "not installed or MISTRAL_API_KEY not set"
+            )
+            return "none"
+
+        if provider == "elevenlabs":
+            if _HAS_ELEVENLABS and _resolve_elevenlabs_stt_api_key(stt_config):
+                return "elevenlabs"
+            logger.warning(
+                "STT provider 'elevenlabs' configured but elevenlabs package "
+                "not installed or no API key available"
             )
             return "none"
 
@@ -555,6 +566,62 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: elevenlabs (Speech-to-Text API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_elevenlabs_stt_api_key(stt_config: Optional[dict] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then env."""
+    config = stt_config if stt_config is not None else _load_stt_config()
+    if isinstance(config, dict):
+        eleven_cfg = config.get("elevenlabs", {})
+        if isinstance(eleven_cfg, dict):
+            cfg_key = str(eleven_cfg.get("api_key", "")).strip()
+            if cfg_key:
+                return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
+def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using ElevenLabs Speech-to-Text API."""
+    if not _HAS_ELEVENLABS:
+        return {"success": False, "transcript": "", "error": "elevenlabs package not installed"}
+
+    stt_config = _load_stt_config()
+    api_key = _resolve_elevenlabs_stt_api_key(stt_config)
+    if not api_key:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Neither stt.elevenlabs.api_key in config nor ELEVENLABS_API_KEY is set",
+        }
+
+    try:
+        from elevenlabs.client import ElevenLabs
+        client = ElevenLabs(api_key=api_key)
+        with open(file_path, "rb") as audio_file:
+            transcription = client.speech_to_text.convert(
+                model_id=model_name,
+                file=audio_file,
+            )
+
+        transcript_text = _extract_transcript_text(transcription)
+        logger.info(
+            "Transcribed %s via ElevenLabs API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "elevenlabs"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("ElevenLabs transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"ElevenLabs transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -620,6 +687,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "elevenlabs":
+        eleven_cfg = stt_config.get("elevenlabs", {})
+        model_name = model or eleven_cfg.get("model", DEFAULT_ELEVENLABS_STT_MODEL)
+        return _transcribe_elevenlabs(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -628,7 +700,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set ELEVENLABS_API_KEY for ElevenLabs STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -148,7 +148,8 @@ def _resolve_elevenlabs_api_key(tts_config: Optional[Dict[str, Any]] = None) -> 
     cfg = tts_config if tts_config is not None else _load_tts_config()
     el_cfg = cfg.get("elevenlabs", {}) if isinstance(cfg, dict) else {}
     if isinstance(el_cfg, dict):
-        cfg_key = str(el_cfg.get("api_key", "")).strip()
+        _val = el_cfg.get("api_key")
+        cfg_key = _val.strip() if isinstance(_val, str) else ""
         if cfg_key:
             return cfg_key
     return os.getenv("ELEVENLABS_API_KEY", "").strip()
@@ -244,7 +245,10 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     """
     api_key = _resolve_elevenlabs_api_key(tts_config)
     if not api_key:
-        raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
+        raise ValueError(
+            "ElevenLabs API key not set. Set ELEVENLABS_API_KEY env var or "
+            "tts.elevenlabs.api_key in config. Get one at https://elevenlabs.io/"
+        )
 
     el_config = tts_config.get("elevenlabs", {})
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
@@ -1111,7 +1115,7 @@ def stream_tts_to_speaker(
 
         api_key = _resolve_elevenlabs_api_key(tts_config)
         if not api_key:
-            logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
+            logger.warning("Neither tts.elevenlabs.api_key nor ELEVENLABS_API_KEY set; streaming TTS audio disabled")
         else:
             try:
                 ElevenLabs = _import_elevenlabs()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -143,6 +143,17 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
 
 
+def _resolve_elevenlabs_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then environment."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    el_cfg = cfg.get("elevenlabs", {}) if isinstance(cfg, dict) else {}
+    if isinstance(el_cfg, dict):
+        cfg_key = str(el_cfg.get("api_key", "")).strip()
+        if cfg_key:
+            return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
 # ===========================================================================
 # ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
 # ===========================================================================
@@ -231,7 +242,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     Returns:
         Path to the saved audio file.
     """
-    api_key = os.getenv("ELEVENLABS_API_KEY", "")
+    api_key = _resolve_elevenlabs_api_key(tts_config)
     if not api_key:
         raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
 
@@ -976,8 +987,9 @@ def check_tts_requirements() -> bool:
     except ImportError:
         pass
     try:
+        tts_config = _load_tts_config()
         _import_elevenlabs()
-        if os.getenv("ELEVENLABS_API_KEY"):
+        if _resolve_elevenlabs_api_key(tts_config):
             return True
     except ImportError:
         pass
@@ -1097,7 +1109,7 @@ def stream_tts_to_speaker(
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
 
-        api_key = os.getenv("ELEVENLABS_API_KEY", "")
+        api_key = _resolve_elevenlabs_api_key(tts_config)
         if not api_key:
             logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
         else:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -963,10 +963,12 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "elevenlabs":
+        details_parts.append("STT provider: OK (ElevenLabs)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
+            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / ELEVENLABS_API_KEY)"
         )
 
     for warning in env_check["warnings"]:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -965,10 +965,15 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (OpenAI)")
     elif stt_provider == "elevenlabs":
         details_parts.append("STT provider: OK (ElevenLabs)")
+    elif stt_provider == "mistral":
+        details_parts.append("STT provider: OK (Mistral)")
+    elif stt_provider in ("local_command", "local-command"):
+        details_parts.append("STT provider: OK (local command)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / ELEVENLABS_API_KEY)"
+            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / MISTRAL_API_KEY, "
+            "or configure stt.elevenlabs.api_key in config)"
         )
 
     for warning in env_check["warnings"]:


### PR DESCRIPTION
## What does this PR do?

Adds interactive STT provider selection to `hermes setup` and ElevenLabs as a speech-to-text provider.

## Changes Made

- Add `hermes setup stt` wizard with providers: local, groq, openai, mistral, elevenlabs
- Add ElevenLabs STT provider (`_transcribe_elevenlabs`) in transcription_tools
- Refactor ElevenLabs API key resolution to support config-based keys (config first, then env var)
- Add `stt.elevenlabs` config defaults (model: scribe_v1)
- Update parser to accept `tts|stt` sections
- Add tests for STT wizard, ElevenLabs provider selection, dispatch, and config key resolution

## How to Test

1. `hermes setup stt` -> choose ElevenLabs
2. Set ELEVENLABS_API_KEY and send an audio message
3. Run: `pytest tests/hermes_cli/test_setup.py tests/tools/test_transcription_tools.py tests/tools/test_voice_cli_integration.py -q`