### PR TITLE
feat(voice): add Naga.ac TTS/STT provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -584,7 +584,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "naga" | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -592,6 +592,11 @@ DEFAULT_CONFIG = {
         "elevenlabs": {
             "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam
             "model_id": "eleven_multilingual_v2",
+        },
+        "naga": {
+            "model": "eleven-multilingual-v2:free",
+            "voice": "jsCqWAovK2LkecY7zXl4",
+            "base_url": "https://api.naga.ac/v1",
         },
         "openai": {
             "model": "gpt-4o-mini-tts",
@@ -618,7 +623,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral) | "elevenlabs" | "naga"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -628,6 +633,13 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "elevenlabs": {
+            "model": "scribe_v1",  # scribe_v1, scribe_v1_experimental
+        },
+        "naga": {
+            "model": "whisper-large-v3:free",
+            "base_url": "https://api.naga.ac/v1",
         },
     },
 
@@ -1327,6 +1339,13 @@ OPTIONAL_ENV_VARS = {
         "description": "ElevenLabs API key for premium text-to-speech voices",
         "prompt": "ElevenLabs API key",
         "url": "https://elevenlabs.io/",
+        "password": True,
+        "category": "tool",
+    },
+    "NAGA_API_KEY": {
+        "description": "Naga.ac API key for TTS and STT",
+        "prompt": "Naga.ac API key",
+        "url": "https://naga.ac/",
         "password": True,
         "category": "tool",
     },
@@ -3368,6 +3387,7 @@ def show_config():
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("NAGA_API_KEY", "Naga.ac (STT/TTS)"),
         ("EXA_API_KEY", "Exa"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6703,12 +6703,12 @@ For more help on a command:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent",
+        "Run a specific section: hermes setup model|tts|stt|terminal|gateway|tools|agent",
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "tts", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "tts", "stt", "terminal", "gateway", "tools", "agent"],
         default=None,
         help="Run a specific setup section instead of the full wizard",
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -142,6 +142,7 @@ def _tts_label(current_provider: str) -> str:
     mapping = {
         "openai": "OpenAI TTS",
         "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
         "edge": "Edge TTS",
         "xai": "xAI TTS",
         "mistral": "Mistral Voxtral TTS",
@@ -274,6 +275,7 @@ def get_nous_subscription_features(
     direct_fal = bool(get_env_value("FAL_KEY"))
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
+    direct_naga = bool(get_env_value("NAGA_API_KEY"))
     direct_camofox = bool(get_env_value("CAMOFOX_URL"))
     direct_browserbase = bool(get_env_value("BROWSERBASE_API_KEY") and get_env_value("BROWSERBASE_PROJECT_ID"))
     direct_browser_use = bool(get_env_value("BROWSER_USE_API_KEY"))
@@ -335,6 +337,7 @@ def get_nous_subscription_features(
         tts_current_provider in {"edge", "neutts"}
         or (tts_current_provider == "openai" and (managed_tts_available or direct_openai_tts))
         or (tts_current_provider == "elevenlabs" and direct_elevenlabs)
+        or (tts_current_provider == "naga" and direct_naga)
         or (tts_current_provider == "mistral" and bool(get_env_value("MISTRAL_API_KEY")))
     )
     tts_active = bool(tts_tool_enabled and tts_available)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2857,6 +2857,7 @@ SETUP_SECTIONS = [
 # configuration. Keep this list in the same order as the visible menu entries.
 RETURNING_USER_MENU_SECTION_KEYS = [
     "model",
+    "stt",
     "terminal",
     "gateway",
     "tools",
@@ -2988,6 +2989,7 @@ def run_setup_wizard(args):
             "Quick Setup - configure missing items only",
             "Full Setup - reconfigure everything",
             "Model & Provider",
+            "Speech-to-Text",
             "Terminal Backend",
             "Messaging Platforms (Gateway)",
             "Tools",
@@ -3003,10 +3005,10 @@ def run_setup_wizard(args):
         elif choice == 1:
             # Full setup — fall through to run all sections
             pass
-        elif choice == 7:
+        elif choice == 8:
             print_info("Exiting. Run 'hermes setup' again when ready.")
             return
-        elif 2 <= choice <= 6:
+        elif 2 <= choice <= 7:
             # Individual section — map by key, not by position.
             # SETUP_SECTIONS includes TTS but the returning-user menu skips it,
             # so positional indexing (choice - 2) would dispatch the wrong section.

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -421,6 +421,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (OpenAI via Nous subscription)", True, None))
     elif tts_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Text-to-Speech (ElevenLabs)", True, None))
+    elif tts_provider == "naga" and get_env_value("NAGA_API_KEY"):
+        tool_status.append(("Text-to-Speech (Naga.ac)", True, None))
     elif tts_provider == "openai" and (
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
@@ -910,6 +912,7 @@ def _setup_tts_provider(config: dict):
     provider_labels = {
         "edge": "Edge TTS",
         "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
         "openai": "OpenAI TTS",
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
@@ -933,6 +936,7 @@ def _setup_tts_provider(config: dict):
         [
             "Edge TTS (free, cloud-based, no setup needed)",
             "ElevenLabs (premium quality, needs API key)",
+            "Naga.ac (OpenAI-compatible TTS, needs API key)",
             "OpenAI TTS (good quality, needs API key)",
             "xAI TTS (Grok voices, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
@@ -941,7 +945,7 @@ def _setup_tts_provider(config: dict):
             "NeuTTS (local on-device, free, ~300MB model download)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts"])
+    providers.extend(["edge", "elevenlabs", "naga", "openai", "xai", "minimax", "mistral", "gemini", "neutts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -994,6 +998,19 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "naga":
+        existing = get_env_value("NAGA_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Naga.ac API key for TTS", password=True)
+            if api_key:
+                save_env_value("NAGA_API_KEY", api_key)
+                print_success("Naga.ac API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+        config.setdefault("tts", {}).setdefault("naga", {})["voice"] = "jsCqWAovK2LkecY7zXl4"
 
     elif selected == "openai" and not selected_via_nous:
         existing = get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
@@ -1072,6 +1089,110 @@ def _setup_tts_provider(config: dict):
 def setup_tts(config: dict):
     """Standalone TTS setup (for 'hermes setup tts')."""
     _setup_tts_provider(config)
+
+
+def _setup_stt_provider(config: dict):
+    """Interactive STT provider selection."""
+    stt_config = config.get("stt", {})
+    current_provider = stt_config.get("provider", "local")
+
+    provider_labels = {
+        "local": "Local (faster-whisper)",
+        "groq": "Groq",
+        "openai": "OpenAI",
+        "mistral": "Mistral",
+        "elevenlabs": "ElevenLabs",
+        "naga": "Naga.ac",
+    }
+    current_label = provider_labels.get(current_provider, current_provider)
+
+    print()
+    print_header("Speech-to-Text Provider")
+    print_info(f"Current: {current_label}")
+    print()
+
+    choices = [
+        "Local (free, on-device faster-whisper)",
+        "Groq (free tier available, needs API key)",
+        "OpenAI Whisper (needs API key)",
+        "Mistral Voxtral (needs API key)",
+        "ElevenLabs STT (needs API key)",
+        "Naga.ac (OpenAI-compatible STT, needs API key)",
+        f"Keep current ({current_label})",
+    ]
+    providers = ["local", "groq", "openai", "mistral", "elevenlabs", "naga"]
+    keep_current_idx = len(choices) - 1
+    idx = prompt_choice("Select STT provider:", choices, keep_current_idx)
+
+    if idx == keep_current_idx:
+        return
+
+    selected = providers[idx]
+
+    if selected == "groq":
+        existing = get_env_value("GROQ_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Groq API key for STT", password=True)
+            if api_key:
+                save_env_value("GROQ_API_KEY", api_key)
+                print_success("Groq API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "openai":
+        existing = get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("OpenAI API key for STT", password=True)
+            if api_key:
+                save_env_value("VOICE_TOOLS_OPENAI_KEY", api_key)
+                print_success("OpenAI STT API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "mistral":
+        existing = get_env_value("MISTRAL_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Mistral API key for STT", password=True)
+            if api_key:
+                save_env_value("MISTRAL_API_KEY", api_key)
+                print_success("Mistral API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "elevenlabs":
+        existing = get_env_value("ELEVENLABS_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("ElevenLabs API key for STT", password=True)
+            if api_key:
+                save_env_value("ELEVENLABS_API_KEY", api_key)
+                print_success("ElevenLabs API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+    elif selected == "naga":
+        existing = get_env_value("NAGA_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Naga.ac API key for STT", password=True)
+            if api_key:
+                save_env_value("NAGA_API_KEY", api_key)
+                print_success("Naga.ac API key saved")
+            else:
+                print_warning("No API key provided. Falling back to local STT.")
+                selected = "local"
+
+    config.setdefault("stt", {})["provider"] = selected
+    save_config(config)
+    print_success(f"STT provider set to: {provider_labels.get(selected, selected)}")
+
+
+def setup_stt(config: dict):
+    """Standalone STT setup (for 'hermes setup stt')."""
+    _setup_stt_provider(config)
 
 
 # =============================================================================
@@ -2724,6 +2845,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
 SETUP_SECTIONS = [
     ("model", "Model & Provider", setup_model_provider),
     ("tts", "Text-to-Speech", setup_tts),
+    ("stt", "Speech-to-Text", setup_stt),
     ("terminal", "Terminal Backend", setup_terminal_backend),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -157,11 +157,19 @@ TOOL_CATEGORIES = {
             {
                 "name": "ElevenLabs",
                 "badge": "paid",
-                "tag": "Most natural voices",
+                "tag": "Premium TTS + STT",
                 "env_vars": [
-                    {"key": "ELEVENLABS_API_KEY", "prompt": "ElevenLabs API key", "url": "https://elevenlabs.io/app/settings/api-keys"},
+                    {"key": "ELEVENLABS_API_KEY", "prompt": "ElevenLabs API key", "url": "https://elevenlabs.io/"},
                 ],
                 "tts_provider": "elevenlabs",
+            },
+            {
+                "name": "Naga.ac",
+                "tag": "OpenAI-compatible TTS/STT",
+                "env_vars": [
+                    {"key": "NAGA_API_KEY", "prompt": "Naga.ac API key", "url": "https://naga.ac/"},
+                ],
+                "tts_provider": "naga",
             },
             {
                 "name": "Mistral (Voxtral TTS)",

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -168,7 +168,7 @@ class TestNonInteractiveSetup:
                 side_effect=lambda key: "sk-test" if key == "OPENROUTER_API_KEY" else "",
             ),
             patch("hermes_cli.auth.get_active_provider", return_value=None),
-            patch.object(setup_mod, "prompt_choice", return_value=3),
+            patch.object(setup_mod, "prompt_choice", return_value=4),
             patch.object(
                 setup_mod,
                 "SETUP_SECTIONS",
@@ -222,6 +222,7 @@ class TestNonInteractiveSetup:
             "Quick Setup - configure missing items only",
             "Full Setup - reconfigure everything",
             "Model & Provider",
+            "Speech-to-Text",
             "Terminal Backend",
             "Messaging Platforms (Gateway)",
             "Tools",
@@ -244,3 +245,19 @@ class TestNonInteractiveSetup:
         main_mod.main()
 
         assert received["section"] == "tts"
+
+    def test_main_accepts_stt_setup_section(self, monkeypatch):
+        """`hermes setup stt` should parse and dispatch like other setup sections."""
+        from hermes_cli import main as main_mod
+
+        received = {}
+
+        def fake_cmd_setup(args):
+            received["section"] = args.section
+
+        monkeypatch.setattr(main_mod, "cmd_setup", fake_cmd_setup)
+        monkeypatch.setattr("sys.argv", ["hermes", "setup", "stt"])
+
+        main_mod.main()
+
+        assert received["section"] == "stt"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,15 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **mistral** (paid) — Mistral Voxtral API, requires ``MISTRAL_API_KEY``.
+  - **elevenlabs** (paid) — ElevenLabs STT API, requires ``ELEVENLABS_API_KEY`` or ``stt.elevenlabs.api_key`` in config.
+  - **naga** (paid) — Naga.ac STT API, requires ``NAGA_API_KEY`` or ``stt.naga.api_key`` in config.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -238,7 +241,14 @@ def _get_provider(stt_config: dict) -> str:
 
         if provider == "naga":
             if _resolve_naga_stt_api_key(stt_config):
-                return "naga"
+                try:
+                    import requests  # noqa: F401
+                    return "naga"
+                except ImportError:
+                    logger.warning(
+                        "STT provider 'naga' requires the 'requests' package (pip install requests)"
+                    )
+                    return "none"
             logger.warning(
                 "STT provider 'naga' configured but no NAGA_API_KEY available"
             )
@@ -586,7 +596,8 @@ def _resolve_elevenlabs_stt_api_key(stt_config: Optional[dict] = None) -> str:
     if isinstance(config, dict):
         eleven_cfg = config.get("elevenlabs", {})
         if isinstance(eleven_cfg, dict):
-            cfg_key = str(eleven_cfg.get("api_key", "")).strip()
+            _val = eleven_cfg.get("api_key")
+            cfg_key = _val.strip() if isinstance(_val, str) else ""
             if cfg_key:
                 return cfg_key
     return os.getenv("ELEVENLABS_API_KEY", "").strip()
@@ -642,7 +653,8 @@ def _resolve_naga_stt_api_key(stt_config: Optional[dict] = None) -> str:
     if isinstance(config, dict):
         naga_cfg = config.get("naga", {})
         if isinstance(naga_cfg, dict):
-            cfg_key = str(naga_cfg.get("api_key", "")).strip()
+            _val = naga_cfg.get("api_key")
+            cfg_key = _val.strip() if isinstance(_val, str) else ""
             if cfg_key:
                 return cfg_key
     return os.getenv("NAGA_API_KEY", "").strip()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -56,6 +56,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_ELEVENLABS = _safe_find_spec("elevenlabs")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,6 +68,9 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v1")
+DEFAULT_NAGA_STT_MODEL = os.getenv("STT_NAGA_MODEL", "whisper-large-v3:free")
+DEFAULT_NAGA_STT_BASE_URL = os.getenv("STT_NAGA_BASE_URL", "https://api.naga.ac/v1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -220,6 +224,23 @@ def _get_provider(stt_config: dict) -> str:
             logger.warning(
                 "STT provider 'mistral' configured but mistralai package "
                 "not installed or MISTRAL_API_KEY not set"
+            )
+            return "none"
+
+        if provider == "elevenlabs":
+            if _HAS_ELEVENLABS and _resolve_elevenlabs_stt_api_key(stt_config):
+                return "elevenlabs"
+            logger.warning(
+                "STT provider 'elevenlabs' configured but elevenlabs package "
+                "not installed or no API key available"
+            )
+            return "none"
+
+        if provider == "naga":
+            if _resolve_naga_stt_api_key(stt_config):
+                return "naga"
+            logger.warning(
+                "STT provider 'naga' configured but no NAGA_API_KEY available"
             )
             return "none"
 
@@ -555,6 +576,125 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: elevenlabs (Speech-to-Text API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_elevenlabs_stt_api_key(stt_config: Optional[dict] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then env."""
+    config = stt_config if stt_config is not None else _load_stt_config()
+    if isinstance(config, dict):
+        eleven_cfg = config.get("elevenlabs", {})
+        if isinstance(eleven_cfg, dict):
+            cfg_key = str(eleven_cfg.get("api_key", "")).strip()
+            if cfg_key:
+                return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
+def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using ElevenLabs Speech-to-Text API."""
+    if not _HAS_ELEVENLABS:
+        return {"success": False, "transcript": "", "error": "elevenlabs package not installed"}
+
+    stt_config = _load_stt_config()
+    api_key = _resolve_elevenlabs_stt_api_key(stt_config)
+    if not api_key:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Neither stt.elevenlabs.api_key in config nor ELEVENLABS_API_KEY is set",
+        }
+
+    try:
+        from elevenlabs.client import ElevenLabs
+        client = ElevenLabs(api_key=api_key)
+        with open(file_path, "rb") as audio_file:
+            transcription = client.speech_to_text.convert(
+                model_id=model_name,
+                file=audio_file,
+            )
+
+        transcript_text = _extract_transcript_text(transcription)
+        logger.info(
+            "Transcribed %s via ElevenLabs API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "elevenlabs"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("ElevenLabs transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"ElevenLabs transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
+# Provider: naga (OpenAI-compatible STT API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_naga_stt_api_key(stt_config: Optional[dict] = None) -> str:
+    """Resolve Naga API key from config first, then env."""
+    config = stt_config if stt_config is not None else _load_stt_config()
+    if isinstance(config, dict):
+        naga_cfg = config.get("naga", {})
+        if isinstance(naga_cfg, dict):
+            cfg_key = str(naga_cfg.get("api_key", "")).strip()
+            if cfg_key:
+                return cfg_key
+    return os.getenv("NAGA_API_KEY", "").strip()
+
+
+def _transcribe_naga(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Naga.ac STT API."""
+    stt_config = _load_stt_config()
+    api_key = _resolve_naga_stt_api_key(stt_config)
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "NAGA_API_KEY not set"}
+
+    naga_cfg = stt_config.get("naga", {}) if isinstance(stt_config, dict) else {}
+    base_url = str(naga_cfg.get("base_url") or DEFAULT_NAGA_STT_BASE_URL).strip().rstrip("/")
+    endpoint = f"{base_url}/audio/transcriptions"
+
+    try:
+        import requests
+    except ImportError:
+        return {"success": False, "transcript": "", "error": "requests package not installed"}
+
+    try:
+        headers = {"Authorization": f"Bearer {api_key}"}
+        data = {"model": model_name}
+        with open(file_path, "rb") as audio_file:
+            files = {
+                "file": (Path(file_path).name, audio_file, "application/octet-stream"),
+            }
+            response = requests.post(endpoint, headers=headers, files=files, data=data, timeout=60)
+        response.raise_for_status()
+
+        try:
+            payload = response.json()
+            transcript_text = _extract_transcript_text(payload)
+        except ValueError:
+            transcript_text = response.text.strip()
+
+        logger.info(
+            "Transcribed %s via Naga STT API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "naga"}
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Naga transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Naga transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -620,6 +760,16 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "elevenlabs":
+        eleven_cfg = stt_config.get("elevenlabs", {})
+        model_name = model or eleven_cfg.get("model", DEFAULT_ELEVENLABS_STT_MODEL)
+        return _transcribe_elevenlabs(file_path, model_name)
+
+    if provider == "naga":
+        naga_cfg = stt_config.get("naga", {})
+        model_name = model or naga_cfg.get("model", DEFAULT_NAGA_STT_MODEL)
+        return _transcribe_naga(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -628,7 +778,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set ELEVENLABS_API_KEY for ElevenLabs STT, set NAGA_API_KEY for Naga STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -152,7 +152,8 @@ def _resolve_elevenlabs_api_key(tts_config: Optional[Dict[str, Any]] = None) -> 
     cfg = tts_config if tts_config is not None else _load_tts_config()
     el_cfg = cfg.get("elevenlabs", {}) if isinstance(cfg, dict) else {}
     if isinstance(el_cfg, dict):
-        cfg_key = str(el_cfg.get("api_key", "")).strip()
+        _val = el_cfg.get("api_key")
+        cfg_key = _val.strip() if isinstance(_val, str) else ""
         if cfg_key:
             return cfg_key
     return os.getenv("ELEVENLABS_API_KEY", "").strip()
@@ -163,7 +164,8 @@ def _resolve_naga_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
     cfg = tts_config if tts_config is not None else _load_tts_config()
     naga_cfg = cfg.get("naga", {}) if isinstance(cfg, dict) else {}
     if isinstance(naga_cfg, dict):
-        cfg_key = str(naga_cfg.get("api_key", "")).strip()
+        _val = naga_cfg.get("api_key")
+        cfg_key = _val.strip() if isinstance(_val, str) else ""
         if cfg_key:
             return cfg_key
     return os.getenv("NAGA_API_KEY", "").strip()
@@ -259,7 +261,10 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     """
     api_key = os.getenv("ELEVENLABS_API_KEY", "")
     if not api_key:
-        raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
+        raise ValueError(
+            "ElevenLabs API key not set. Set ELEVENLABS_API_KEY env var or "
+            "tts.elevenlabs.api_key in config. Get one at https://elevenlabs.io/"
+        )
 
     el_config = tts_config.get("elevenlabs", {})
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
@@ -339,6 +344,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             close()
 
 
+# ===========================================================================
 # ===========================================================================
 # Provider: xAI TTS
 # ===========================================================================
@@ -1085,7 +1091,17 @@ def check_tts_requirements() -> bool:
         pass
     try:
         if _resolve_naga_api_key():
-            return True
+            # Naga needs openai SDK or requests as backend
+            try:
+                _import_openai_client()
+                return True
+            except ImportError:
+                pass
+            try:
+                import requests  # noqa: F401
+                return True
+            except ImportError:
+                pass
     except Exception:
         pass
     if os.getenv("MINIMAX_API_KEY"):
@@ -1200,7 +1216,7 @@ def stream_tts_to_speaker(
 
         api_key = _resolve_elevenlabs_api_key(tts_config)
         if not api_key:
-            logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
+            logger.warning("Neither tts.elevenlabs.api_key nor ELEVENLABS_API_KEY set; streaming TTS audio disabled")
         else:
             try:
                 ElevenLabs = _import_elevenlabs()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -5,6 +5,7 @@ Text-to-Speech Tool Module
 Supports seven TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
+- Naga.ac (OpenAI-compatible): needs NAGA_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
@@ -87,6 +88,9 @@ DEFAULT_EDGE_VOICE = "en-US-AriaNeural"
 DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
+DEFAULT_NAGA_MODEL = "eleven-multilingual-v2:free"
+DEFAULT_NAGA_VOICE = "jsCqWAovK2LkecY7zXl4"
+DEFAULT_NAGA_TTS_BASE_URL = "https://api.naga.ac/v1"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
@@ -141,6 +145,28 @@ def _load_tts_config() -> Dict[str, Any]:
 def _get_provider(tts_config: Dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+
+
+def _resolve_elevenlabs_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve ElevenLabs API key from config first, then environment."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    el_cfg = cfg.get("elevenlabs", {}) if isinstance(cfg, dict) else {}
+    if isinstance(el_cfg, dict):
+        cfg_key = str(el_cfg.get("api_key", "")).strip()
+        if cfg_key:
+            return cfg_key
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
+def _resolve_naga_api_key(tts_config: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve Naga API key from config first, then environment."""
+    cfg = tts_config if tts_config is not None else _load_tts_config()
+    naga_cfg = cfg.get("naga", {}) if isinstance(cfg, dict) else {}
+    if isinstance(naga_cfg, dict):
+        cfg_key = str(naga_cfg.get("api_key", "")).strip()
+        if cfg_key:
+            return cfg_key
+    return os.getenv("NAGA_API_KEY", "").strip()
 
 
 # ===========================================================================
@@ -376,6 +402,72 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         f.write(response.content)
 
     return output_path
+# ===========================================================================
+# Provider: Naga.ac TTS
+# ===========================================================================
+def _generate_naga_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Naga.ac TTS API."""
+    api_key = _resolve_naga_api_key(tts_config)
+    if not api_key:
+        raise ValueError(
+            "Naga API key not set. Set NAGA_API_KEY env var or "
+            "tts.naga.api_key in config. Get one at https://naga.ac/"
+        )
+
+    naga_config = tts_config.get("naga", {})
+    model = naga_config.get("model", DEFAULT_NAGA_MODEL)
+    voice = naga_config.get("voice", DEFAULT_NAGA_VOICE)
+    base_url = naga_config.get("base_url", DEFAULT_NAGA_TTS_BASE_URL)
+    normalized_base_url = str(base_url).rstrip("/")
+    if normalized_base_url.endswith("/audio/speech"):
+        normalized_base_url = normalized_base_url[: -len("/audio/speech")]
+
+    try:
+        OpenAIClient = _import_openai_client()
+        client = OpenAIClient(api_key=api_key, base_url=normalized_base_url)
+        try:
+            response = client.audio.speech.create(
+                model=model,
+                voice=voice,
+                input=text,
+                response_format="opus" if output_path.endswith(".ogg") else "mp3",
+                extra_headers={"x-idempotency-key": str(uuid.uuid4())},
+            )
+            response.stream_to_file(output_path)
+            return output_path
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+    except Exception as e:
+        try:
+            import requests
+
+            endpoint = normalized_base_url + "/audio/speech"
+            response_format = "opus" if output_path.endswith(".ogg") else "mp3"
+            payload = {"model": model, "voice": voice, "input": text, "response_format": response_format}
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            }
+            response = requests.post(endpoint, json=payload, headers=headers, timeout=60)
+            if response.status_code >= 400:
+                error_body = (response.text or "").strip()
+                if len(error_body) > 800:
+                    error_body = error_body[:800] + "... [truncated]"
+                detail = error_body or response.reason or "unknown error"
+                raise ValueError(
+                    f"Naga API error {response.status_code} (model={model}, voice={voice}): {detail}"
+                ) from e
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+            return output_path
+        except ValueError:
+            raise
+        except Exception as fallback_exc:
+            raise ValueError(
+                f"Naga TTS failed via OpenAI-compatible client and HTTP fallback (model={model}, voice={voice}): {fallback_exc}"
+            ) from e
 
 
 # ===========================================================================
@@ -832,6 +924,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with ElevenLabs...")
             _generate_elevenlabs(text, file_str, tts_config)
 
+        elif provider == "naga":
+            logger.info("Generating speech with Naga.ac TTS...")
+            _generate_naga_tts(text, file_str, tts_config)
+
         elif provider == "openai":
             try:
                 _import_openai_client()
@@ -916,7 +1012,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "naga") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -977,7 +1073,7 @@ def check_tts_requirements() -> bool:
         pass
     try:
         _import_elevenlabs()
-        if os.getenv("ELEVENLABS_API_KEY"):
+        if _resolve_elevenlabs_api_key():
             return True
     except ImportError:
         pass
@@ -986,6 +1082,11 @@ def check_tts_requirements() -> bool:
         if _has_openai_audio_backend():
             return True
     except ImportError:
+        pass
+    try:
+        if _resolve_naga_api_key():
+            return True
+    except Exception:
         pass
     if os.getenv("MINIMAX_API_KEY"):
         return True
@@ -1097,7 +1198,7 @@ def stream_tts_to_speaker(
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
 
-        api_key = os.getenv("ELEVENLABS_API_KEY", "")
+        api_key = _resolve_elevenlabs_api_key(tts_config)
         if not api_key:
             logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
         else:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -967,10 +967,15 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (ElevenLabs)")
     elif stt_provider == "naga":
         details_parts.append("STT provider: OK (Naga.ac)")
+    elif stt_provider == "mistral":
+        details_parts.append("STT provider: OK (Mistral)")
+    elif stt_provider in ("local_command", "local-command"):
+        details_parts.append("STT provider: OK (local command)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / ELEVENLABS_API_KEY / NAGA_API_KEY)"
+            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / MISTRAL_API_KEY, "
+            "or configure stt.elevenlabs.api_key / stt.naga.api_key in config)"
         )
 
     for warning in env_check["warnings"]:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -963,10 +963,14 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "elevenlabs":
+        details_parts.append("STT provider: OK (ElevenLabs)")
+    elif stt_provider == "naga":
+        details_parts.append("STT provider: OK (Naga.ac)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
+            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY / ELEVENLABS_API_KEY / NAGA_API_KEY)"
         )
 
     for warning in env_check["warnings"]:


### PR DESCRIPTION
## What does this PR do?

Adds Naga.ac as a TTS and STT provider with OpenAI-compatible API flow.

## Related

This PR complements #8605 (STT wizard + ElevenLabs). Both PRs are independently reviewable — this one includes the full STT wizard with all providers including naga.

## Changes Made

- Add Naga.ac TTS provider (`_generate_naga_tts`) — OpenAI SDK client with HTTP fallback
- Add Naga.ac STT provider (`_transcribe_naga`) — whisper-large-v3:free via requests
- Add STT wizard (`_setup_stt_provider`) with all providers (local/groq/openai/mistral/elevenlabs/naga)
- Add ElevenLabs STT support (`_transcribe_elevenlabs`)
- Refactor API key resolution for ElevenLabs and Naga (config-first, env-fallback)
- Add tts.naga, stt.naga, stt.elevenlabs config defaults
- Add NAGA_API_KEY to OPTIONAL_ENV_VARS
- Force validated Naga voice ID (`jsCqWAovK2LkecY7zXl4`) at runtime
- Include Naga OGG in opus conversion for Telegram compatibility

## How to Test

1. Set `NAGA_API_KEY` in `\~/.hermes/.env`
2. `hermes setup tts` -> choose Naga.ac
3. `hermes setup stt` -> choose Naga.ac
4. Trigger TTS response — confirm audio generates
5. Send audio message — confirm transcription via Naga