### PR TITLE
chore: sync missing skills into repo

### DIFF
--- a/skills/devops/cifs-mount-watchdog/SKILL.md
+++ b/skills/devops/cifs-mount-watchdog/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: cifs-mount-watchdog
+description: Diagnose and fix CIFS/SMB mounts that fail on boot due to Tailscale/network race conditions, and install a systemd watchdog timer to auto-recover. Use when a service (e.g. Ollama) crashes with permission denied on a network-mounted path.
+tags: [cifs, smb, mount, systemd, tailscale, ollama, watchdog, race-condition]
+---
+
+# CIFS Mount Watchdog
+
+## When to use
+- A service crashes with `permission denied` or `no such file` on a path under `/mnt/`
+- `mount | grep cifs` shows the share is not mounted despite being in `/etc/fstab`
+- fstab uses `_netdev` + `x-systemd.requires=tailscaled.service` (Tailscale-dependent mounts)
+- You want automatic recovery without manual intervention after reboot or Tailscale reconnect
+
+---
+
+## Step 1 — Diagnose
+
+```bash
+journalctl -u <service>.service -n 50 --no-pager
+```
+
+Look for: `mkdir /mnt/xxx: permission denied` or `no such file or directory`
+
+Then check mount status:
+```bash
+mount | grep cifs           # is the share actually mounted?
+findmnt -t cifs             # cleaner view
+ls -la /mnt/                # does the mountpoint directory exist?
+ping <truenas-ip>           # is the NAS reachable?
+```
+
+If mount is missing but NAS is reachable → race condition on boot.
+
+---
+
+## Step 2 — Immediate fix (manual remount)
+
+```bash
+sudo mount /mnt/ssd_llm     # uses fstab entry
+sudo systemctl restart ollama
+systemctl is-active ollama
+```
+
+---
+
+## Step 3 — Install watchdog script
+
+Create `/usr/local/bin/mount-watchdog.sh`:
+
+```bash
+sudo tee /usr/local/bin/mount-watchdog.sh > /dev/null << 'EOF'
+#!/bin/bash
+LOGFILE="/var/log/mount-watchdog.log"
+MOUNTS=("/mnt/ssd_llm" "/mnt/ssd_vm")
+REMOUNTED=0
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOGFILE"
+}
+
+for MOUNTPOINT in "${MOUNTS[@]}"; do
+    if ! findmnt -t cifs "$MOUNTPOINT" > /dev/null 2>&1; then
+        log "WARN: $MOUNTPOINT niet gemount, probeer te mounten..."
+        if mount "$MOUNTPOINT" >> "$LOGFILE" 2>&1; then
+            log "OK: $MOUNTPOINT succesvol gemount"
+            REMOUNTED=1
+        else
+            log "ERROR: mounten van $MOUNTPOINT mislukt"
+        fi
+    fi
+done
+
+if [ "$REMOUNTED" -eq 1 ]; then
+    if findmnt -t cifs /mnt/ssd_llm > /dev/null 2>&1; then
+        log "INFO: ssd_llm hersteld, Ollama herstarten..."
+        systemctl restart ollama
+        log "INFO: Ollama herstart"
+    fi
+fi
+EOF
+sudo chmod +x /usr/local/bin/mount-watchdog.sh
+```
+
+---
+
+## Step 4 — systemd service unit
+
+```bash
+sudo tee /etc/systemd/system/mount-watchdog.service > /dev/null << 'EOF'
+[Unit]
+Description=CIFS Mount Watchdog (ssd_llm / ssd_vm)
+After=tailscaled.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mount-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+EOF
+```
+
+---
+
+## Step 5 — systemd timer unit (every 1 minute)
+
+```bash
+sudo tee /etc/systemd/system/mount-watchdog.timer > /dev/null << 'EOF'
+[Unit]
+Description=Run CIFS Mount Watchdog every minute
+Requires=tailscaled.service
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+Unit=mount-watchdog.service
+
+[Install]
+WantedBy=timers.target
+EOF
+```
+
+---
+
+## Step 6 — Enable and verify
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now mount-watchdog.timer
+systemctl list-timers mount-watchdog.timer --no-pager
+# Wait ~1 minute, then:
+journalctl -u mount-watchdog -n 10 --no-pager
+```
+
+Expected: `Finished mount-watchdog.service` every minute. If a mount was restored, log shows `OK: ... succesvol gemount` and `Ollama herstart`.
+
+---
+
+## Alternatief scenario: OLLAMA_MODELS pad corrupt (mount aanwezig, modellen kapot)
+
+Soms is de mount wél aanwezig maar bevat de modellen-map corrupte of ontbrekende manifests. Symptoom: `curl http://127.0.0.1:11434/api/tags` geeft `{"models":[]}` of modellen worden niet gevonden (404). De echte modellen staan dan lokaal op `/usr/share/ollama/.ollama`.
+
+**Diagnose:**
+```bash
+curl -s http://127.0.0.1:11434/api/tags           # {"models":[]} = probleem
+ls /usr/share/ollama/.ollama/models/manifests/     # echte modellen hier?
+cat /etc/systemd/system/ollama.service.d/override.conf  # welk pad?
+ls /mnt/ssd_llm/ollama/                            # kapote inhoud?
+```
+
+**Fix: override naar lokaal pad redirecten:**
+```bash
+# sudo -n tee werkt als sudoers tee/systemctl toestaat zonder wachtwoord
+sudo -n tee /etc/systemd/system/ollama.service.d/override.conf > /dev/null << 'EOF'
+[Service]
+Environment="OLLAMA_MODELS=/usr/share/ollama/.ollama/models"
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+EOF
+
+sudo -n systemctl daemon-reload
+sudo -n systemctl restart ollama
+sleep 4
+curl -s http://127.0.0.1:11434/api/tags   # verwacht: modellen zichtbaar
+```
+
+**Kapotte SSD-map veilig hernoemen (als file owner, geen sudo nodig):**
+```bash
+mv /mnt/ssd_llm/ollama /mnt/ssd_llm/ollama.broken-backup
+```
+
+**Let op:** `sudo -n` (non-interactive) werkt alleen voor specifieke commands die via sudoers NOPASSWD zijn toegestaan (bijv. `tee`, `systemctl`). `sudo -n mv` of `sudo -n ls` op willekeurige paden werkt mogelijk niet — check dan eerst of de user eigenaar is van de map.
+
+---
+
+## Pitfalls
+
+- **sudo via SSH heredoc**: gebruik `sudo -n tee /path > /dev/null << 'EOF'` — niet `sudo bash -c "cat > /path" << 'EOF'` (dat werkt niet betrouwbaar over SSH)
+- **sudo -n vs interactief**: `sudo -n` faalt met exit code 1 als het wachtwoord vereist is. Test eerst met `sudo -n systemctl status ollama` — als dat werkt, werken systemctl/tee ook.
+- **Ollama models path**: in `/etc/systemd/system/ollama.service.d/override.conf` als `OLLAMA_MODELS=`. Kan naar SSD wijzen terwijl echte modellen lokaal staan.
+- **nofail in fstab**: zorgt dat boot niet blokkeert als mount faalt — goed voor uptime, maar betekent dat de service soms start zonder mount. De watchdog compenseert dit.
+- **ssd_vm zonder CIFS**: ssd_vm kan lokale content hebben (bijv. `pluto/` map) zonder actieve CIFS mount — dit is normaal als die share niet nodig is voor actieve services.
+- **Rechten watchdog script**: de systemd service draait als root (geen `User=` opgegeven), dus `mount` en `systemctl restart` werken zonder sudo.

--- a/skills/devops/discord-multi-agent-control-plane/SKILL.md
+++ b/skills/devops/discord-multi-agent-control-plane/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: discord-multi-agent-control-plane
+description: Use Discord as transparency/control plane for multi-agent systems while keeping agent logic and detailed state outside Discord.
+---
+
+# Discord multi-agent control plane
+
+Use this when a user wants Discord integrated with Hermes/OpenClaw/Pluto for visibility, coordination, or lightweight human-in-the-loop control.
+
+## Core rule
+Discord is the UI/event layer, not the internal agent bus.
+
+Recommended split:
+1. Discord = alerts, task intake, handoffs, approvals, short summaries
+2. Mission Control / internal services = status detail, logs, dashboards, run state
+3. Internal queue/protocol/router = agent-to-agent communication
+4. Obsidian = durable decisions, architecture notes, runbooks
+
+## Why
+- Prevents bot reply loops
+- Keeps routing deterministic
+- Improves security and auditability
+- Avoids flooding Discord with machine chatter
+- Makes human oversight simple
+
+## Recommended architecture
+1. User posts command/task in Discord or Telegram
+2. Hermes gateway normalizes the event
+3. Router chooses the right agent/system
+4. Agents execute through internal tools/protocols
+5. Only relevant summaries, alerts, and requests-for-input are posted back to Discord
+6. Detailed progress stays in Mission Control
+
+## Channel design pattern
+- #inbox or #tasks: new requests
+- #alerts: failures, escalations, important completions
+- #agents: cross-agent summaries and handoffs
+- #builds or #ops: deploy/build notifications
+- #memory: extracted durable facts and decisions
+- #study / #sales / domain channels: project-specific summaries
+
+## Routing rules
+- Prefer explicit routing by channel, thread, role, or mention
+- One orchestrator decides what to fan out to specialist agents
+- Agents should ignore messages not addressed to their route
+- Never let agents auto-reply to each other broadly in the same channel
+
+## What to post to Discord
+Post:
+- concise task status
+- blockers
+- escalations
+- handoff summaries
+- final outcome summaries
+
+Do not post:
+- verbose logs
+- token-level reasoning
+- repeated heartbeat/status spam
+- unrestricted bot-to-bot chatter
+
+## Implementation guidance
+- Use Discord bot/webhook outputs for notifications and controlled commands
+- Keep state outside Discord
+- Link back to Mission Control for details
+- Save final architecture/runbooks in Obsidian
+
+## Decision heuristic
+If the message helps a human notice, steer, approve, or understand a task quickly, Discord is a good destination.
+If it is long-lived state, detailed telemetry, or internal machine coordination, keep it outside Discord.
+
+## Pitfalls
+- Feedback loops between bots
+- Overloading one channel with every event
+- Letting Discord become the only system of record
+- Mixing human discussion, internal telemetry, and agent routing in one place
+
+## Default recommendation
+Choose: Discord as control/visibility layer + Mission Control as source of detail + internal router/protocol for agent execution.

--- a/skills/devops/github-agent-account-setup/SKILL.md
+++ b/skills/devops/github-agent-account-setup/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: github-agent-account-setup
+description: Set up a GitHub account for an autonomous agent (e.g. CodyPlutoRocks), including org membership, PAT creation, and Gmail App Password for IMAP verification. Use when onboarding a new agent identity to GitHub and email.
+tags: [github, gmail, agent, pat, imap, verification, openclaw]
+---
+
+# GitHub Agent Account Setup
+
+Use when creating a GitHub account for an autonomous agent and wiring up email access so verification codes can be read automatically.
+
+## The Core Problem
+
+GitHub requires device verification via email on every new login from an unknown browser/IP. Google blocks IMAP with plain passwords. This creates a manual bottleneck unless you set up a Gmail App Password BEFORE the first GitHub login attempt.
+
+## Correct Order of Operations
+
+### PHASE 1 — Gmail App Password first (before GitHub login)
+
+Do this BEFORE attempting any GitHub browser login:
+
+1. Have Sander open Gmail for the agent account (e.g. codyplutorocks@gmail.com)
+2. Navigate to: myaccount.google.com/apppasswords
+3. Create App Password with name: Hermes-IMAP
+4. Copy the 16-character app password (shown only once)
+5. Store it immediately:
+
+```bash
+ssh sander@100.108.223.25 "echo 'CODY_GMAIL_APP_PASSWORD=xxxx xxxx xxxx xxxx' >> ~/.hermes/.env"
+```
+
+6. Test IMAP access with himalaya or python imaplib before proceeding
+
+### PHASE 2 — GitHub account creation
+
+- CAPTCHA on signup requires Sander to do it manually
+- Username convention: [AgentName]PlutoRocks (e.g. CodyPlutoRocks)
+- Password convention: Pluto0s[Name]!2026
+- Email: [agentname]plutorocks@gmail.com
+
+### PHASE 3 — GitHub login + device verification
+
+Now that Gmail App Password is set up, read the verification code automatically:
+
+```python
+import imaplib, email, re
+
+def get_github_code(gmail_user, app_password):
+    mail = imaplib.IMAP4_SSL('imap.gmail.com')
+    mail.login(gmail_user, app_password)
+    mail.select('inbox')
+    _, data = mail.search(None, 'FROM', 'noreply@github.com', 'UNSEEN')
+    for num in data[0].split()[-3:]:  # check last 3 unread
+        _, msg_data = mail.fetch(num, '(RFC822)')
+        msg = email.message_from_bytes(msg_data[0][1])
+        body = str(msg.get_payload())
+        match = re.search(r'Verification code:\s*(\d{6})', body)
+        if match:
+            return match.group(1)
+    return None
+```
+
+### PHASE 4 — PAT creation
+
+After login:
+1. Navigate to: https://github.com/settings/tokens/new
+2. Token name: OpenClaw-[AgentName]
+3. Expiration: No expiration
+4. Scopes: repo, workflow, write:packages, admin:org, user
+5. Generate and store:
+
+```bash
+ssh sander@100.108.223.25 "echo 'CODY_GITHUB_PAT=ghp_xxxx' >> ~/.hermes/.env"
+ssh sander@100.108.223.25 "echo 'github_pat: ghp_xxxx' >> ~/.openclaw/.cody-credentials"
+```
+
+### PHASE 5 — Org membership
+
+From Sander's main GitHub account (AlexanderWatersOxygen):
+- Org name: Alexander-waters-oxygen
+- Invite the agent account as Owner role
+- Agent account: accept the invite (can be done via browser as agent)
+
+Verify with:
+```bash
+export PATH=$HOME/.local/bin:$PATH && gh api orgs/Alexander-waters-oxygen/members --jq '.[].login'
+```
+
+## Pitfalls
+
+- Google blocks browser login to Gmail from automated browsers ("This browser may not be secure") — use IMAP with App Password instead, never browser
+- GitHub sends a NEW code each login attempt — old codes expire immediately when a new one is sent
+- The App Password must be set up BEFORE the first GitHub login, not after
+- Browser sessions time out — type verification codes within 2 minutes of receiving them
+- Org name on GitHub may differ from account name: AlexanderWatersOxygen → org is Alexander-waters-oxygen (check with `gh api user/orgs`)
+- IMAP plain password login is blocked by Google since 2022 — always use App Password
+
+## Credentials Storage Convention
+
+```
+~/.hermes/.env:
+  CODY_GITHUB_PAT=ghp_...
+  CODY_GMAIL_APP_PASSWORD=xxxx xxxx xxxx xxxx
+
+~/.openclaw/.cody-credentials:
+  github_pat: ghp_...
+  gmail_app_password: xxxx xxxx xxxx xxxx
+```
+
+## Credential Rotation (when password changes)
+
+When Sander drops a new password/token in a file on the SSD (e.g. /mnt/ssd_vm/pluto/Exports/secret.txt),
+follow this exact sequence:
+
+### 1 — Read the file over SSH
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'base64 /mnt/ssd_vm/pluto/Exports/secret.txt'
+```
+Use base64 to avoid shell escaping issues with special characters in tokens.
+Decode in Python: `base64.b64decode(output).decode()`
+
+### 2 — Store credentials securely on Pluto
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'mkdir -p ~/.openclaw/credentials && chmod 700 ~/.openclaw/credentials && \
+   printf "GITHUB_USER=CodyPlutoRocks\nGITHUB_TOKEN=ghp_xxx\n" \
+   > ~/.openclaw/credentials/github_cody.env && \
+   chmod 600 ~/.openclaw/credentials/github_cody.env'
+```
+
+### 3 — Re-configure gh CLI with the new token
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'export PATH=$HOME/.local/bin:$PATH && \
+   echo "ghp_xxx" | gh auth login --hostname github.com --with-token && \
+   gh auth status'
+```
+
+### 4 — Securely destroy the plaintext file
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'shred -u /mnt/ssd_vm/pluto/Exports/secret.txt && \
+   ls /mnt/ssd_vm/pluto/Exports/'
+```
+Use `shred -u` (not `rm`) — overwrites before unlinking so recovery is impossible.
+
+### 5 — Update agent's MEMORY.md
+Note the rotation date but do NOT write the new password in plaintext:
+```
+## GitHub Account (Cody)
+Username: CodyPlutoRocks
+Wachtwoord: GEWIJZIGD op DD-MM-YYYY - staat opgeslagen in ~/.openclaw/credentials/github_cody.env
+Token: PAT geconfigureerd via gh CLI
+```
+
+## Pitfalls (credential rotation)
+
+- Token in a text file may be truncated visually but full in the file — always use base64 to read, don't trust cat output
+- `shred` requires the filesystem to support overwrite (ext4/xfs OK; COW filesystems like btrfs/ZFS may not fully overwrite — warn Sander if on such FS)
+- Never write the actual password into agent markdown files (MEMORY.md, IDENTITY.md) — only reference the credentials store path
+- gh CLI keyring caching: after `gh auth login --with-token`, verify with `gh auth status` to confirm active account switched correctly

--- a/skills/devops/hermes-hybrid-sync-lock-recovery/SKILL.md
+++ b/skills/devops/hermes-hybrid-sync-lock-recovery/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: hermes-hybrid-sync-lock-recovery
+description: Stabilize a Hermes hybrid watcher + scheduled Git sync when concurrent runs cause index.lock or overlapping git failures. Use when local-first sync must stay enabled and you need proof that the locking fix actually works.
+---
+
+# Hermes hybrid sync lock recovery
+
+Use this when a local Hermes/Git sync setup has both:
+- a watcher/event-driven trigger, and
+- a periodic scheduled sync,
+
+and you see failures caused by overlap, such as `index.lock`, concurrent `git add/commit/push`, or stale lock behavior.
+
+## Goal
+Keep the repository local-first, retain both fast watcher-based sync and scheduled catch-up sync, and eliminate overlap failures without disabling the hybrid design.
+
+## Approach
+1. Keep the repo/model/data local if capacity allows; do not move to shared/network storage just to work around a locking bug.
+2. Serialize all sync executions with a single lock mechanism shared by both watcher and scheduler.
+3. Verify not only by reading logs, but by forcing overlapping runs and confirming both exit cleanly.
+4. Treat old failures in logs as historical until a fresh overlap test disproves the fix.
+
+## Implementation pattern
+
+### 1) Identify both entrypoints
+Find every way the sync can start, typically:
+- systemd service running a watcher
+- systemd timer / cron invoking the sync script directly
+- manual force-sync command
+
+All of them must funnel through the same guarded script or wrapper.
+
+### 2) Add a non-blocking lock around the critical section
+Preferred pattern in bash:
+
+```bash
+LOCKFILE="${LOCKFILE:-/path/to/repo/.sync.lock}"
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  echo "sync already running; exiting"
+  exit 0
+fi
+```
+
+Important:
+- Put the lock before any `git add`, `git commit`, `git pull`, `git push`, or index mutation.
+- Make overlapping invocations exit successfully (`0`) when skipping is acceptable. This prevents watchdog noise and proves serialization instead of failure.
+- Use one shared lock path for watcher, timer, and manual force-sync.
+
+### 3) Keep the critical section narrow but complete
+Inside the lock, perform the full mutation flow, for example:
+- refresh repo state
+- stage files
+- commit if needed
+- pull/rebase if your workflow requires it
+- push
+
+Do not release the lock between git subcommands.
+
+### 4) Make the service call the guarded script
+Do not duplicate git logic in multiple places. The watcher and schedule should both call the same script or wrapper so the lock behavior stays identical.
+
+### 5) Validate script syntax before restart
+For shell scripts:
+
+```bash
+bash -n /path/to/script.sh
+```
+
+Only restart the service after syntax passes.
+
+### 6) Restart and inspect service health
+Typical checks:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart <service>
+systemctl --user status <service> --no-pager
+journalctl --user -u <service> -n 100 --no-pager
+```
+
+### 7) Run a deliberate overlap test
+This is the key verification step. Launch two near-simultaneous force-sync runs and confirm both return cleanly.
+
+Example pattern:
+
+```bash
+(<force-sync-command>; echo first:$?) &
+(<force-sync-command>; echo second:$?) &
+wait
+```
+
+Success criteria:
+- both commands return `0`
+- no fresh `index.lock` or concurrent git mutation error appears
+- logs show one run performed the work and the other skipped or serialized safely
+
+## How to interpret logs correctly
+- A prior failure in logs does **not** mean the new fix failed.
+- If the failure timestamp predates the patch/restart, treat it as historical.
+- Prefer fresh evidence:
+  - current service status healthy
+  - no new lock errors after restart
+  - explicit overlap stress test passed
+
+## Recommended decision rule
+If models/data fit locally and the issue is sync overlap, prefer:
+- local storage/modelstore
+- hybrid watcher + scheduled sync
+- proper serialization with flock
+
+Avoid switching to shared/network storage unless capacity or architecture truly requires it.
+
+## Pitfalls
+- Using separate lock files for watcher and timer: this does not prevent overlap.
+- Locking only `git push` and not `git add/commit`: `index.lock` can still happen earlier.
+- Returning non-zero on benign overlap: causes false alerts and noisy watchdog behavior.
+- Verifying only through old journal output instead of a new forced overlap test.
+
+## Verification checklist
+- `bash -n` passes
+- service restarts successfully
+- service status is healthy
+- no fresh lock errors appear in logs
+- two simultaneous force-sync invocations both exit `0`
+- repository behavior remains local-first and hybrid sync remains enabled

--- a/skills/devops/hermes-rate-limit-prevention/SKILL.md
+++ b/skills/devops/hermes-rate-limit-prevention/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: hermes-rate-limit-prevention
+description: Configure Hermes to prevent API rate limit failures using a fallback model chain, smart routing, and local Ollama as a free provider. Use when rate limits (HTTP 429) are being hit, or to proactively avoid them in high-usage setups.
+tags: [hermes, rate-limit, fallback, model-routing, ollama, minimax, gpt, config]
+---
+
+# Hermes Rate Limit Prevention
+
+## When to use
+- HTTP 429 errors appear in Hermes responses or cron job logs
+- Multiple concurrent sessions/cron jobs hit the same API simultaneously
+- You want cron jobs or monitoring tasks to use cheap/free models instead of expensive ones
+- You want automatic failover when a provider is overloaded
+
+---
+
+## Config location
+
+```
+~/.hermes/config.yaml
+```
+
+---
+
+## Step 1 — Set primary model
+
+Switch from default to preferred primary (e.g. gpt-5.4 via openai-codex):
+
+```yaml
+model:
+  default: gpt-5.4
+  provider: openai-codex
+```
+
+---
+
+## Step 2 — Add local Ollama as free provider
+
+If Ollama runs on a remote machine accessible via Tailscale/LAN, register it as an OpenAI-compatible provider:
+
+```yaml
+providers:
+  ollama-pluto:
+    type: openai_compatible
+    base_url: http://100.108.223.25:11434/v1
+    api_key: ollama
+```
+
+For local Ollama (same machine):
+```yaml
+providers:
+  ollama-local:
+    type: openai_compatible
+    base_url: http://127.0.0.1:11434/v1
+    api_key: ollama
+```
+
+---
+
+## Step 3 — Configure fallback model
+
+Uncomment and set the `fallback_model` block (at the bottom of config.yaml, in the comments section):
+
+```yaml
+fallback_model:
+  provider: minimax
+  model: MiniMax-Text-01
+```
+
+MiniMax has a 200k context window and is well-suited as fallback. Triggers automatically on 429, 503, 529, or connection failures from the primary.
+
+---
+
+## Step 4 — Enable smart model routing
+
+Routes short/simple messages to a cheap model, saves the primary for complex work:
+
+```yaml
+smart_model_routing:
+  enabled: true
+  max_simple_chars: 300
+  max_simple_words: 50
+  cheap_model:
+    provider: minimax
+    model: MiniMax-Text-01
+```
+
+Tune `max_simple_chars` / `max_simple_words` based on what counts as "simple" for your use case.
+
+---
+
+## Step 5 — Set cron jobs to lightweight models
+
+When creating cron jobs (especially monitoring/health checks), explicitly assign a cheap model:
+
+```python
+mcp_cronjob(action="update", job_id="...", model="MiniMax-Text-01", provider="minimax")
+```
+
+Or at creation time:
+```python
+mcp_cronjob(action="create", ..., model="MiniMax-Text-01", provider="minimax")
+```
+
+Health-check crons never need a powerful model — use minimax or a local Ollama model.
+
+---
+
+## Full config snippet (combined)
+
+```yaml
+model:
+  default: gpt-5.4
+  provider: openai-codex
+
+providers:
+  ollama-pluto:
+    type: openai_compatible
+    base_url: http://100.108.223.25:11434/v1
+    api_key: ollama
+
+fallback_model:
+  provider: minimax
+  model: MiniMax-Text-01
+
+smart_model_routing:
+  enabled: true
+  max_simple_chars: 300
+  max_simple_words: 50
+  cheap_model:
+    provider: minimax
+    model: MiniMax-Text-01
+```
+
+---
+
+## Pitfalls
+
+- **fallback_model is commented out by default**: it lives at the bottom of config.yaml inside a large comment block. You must uncomment it (remove the `#` prefix) for it to take effect.
+- **smart_model_routing default is off**: `enabled: false` by default. Must be explicitly set to `true`.
+- **Cron jobs inherit default model**: unless you specify `model`/`provider` at creation or update, cron jobs use the config default — which burns rate-limit quota.
+- **Ollama provider needs the service running**: if Ollama is down, calls to `ollama-pluto` will fail. The fallback chain doesn't cover this automatically — keep a health-check cron running.
+- **MiniMax-Text-01 context window**: 200k tokens, good for large context tasks as fallback.
+- **Compression model**: if `compression.summary_model` is set to a paid provider (e.g. `google/gemini-3-flash-preview`), it will still burn quota during long sessions. Consider pointing it at a cheap/local model too.
+- **Always verify Ollama model names before writing config**: do NOT guess model names. Query the live API first:
+  `curl -s http://<host>:11434/api/tags | python3 -c "import json,sys; [print(m['name']) for m in json.load(sys.stdin)['models']]"`
+  Use the exact name returned. Wrong model names silently fail at fallback time — the worst moment to discover it.
+- **MiniMax fallback may route internally through Anthropic**: if MiniMax is configured and Anthropic is also rate-limited, the fallback achieves nothing. Use ollama-pluto as fallback instead — it has no API rate limits.
+- **Credential pool exhaustion is a silent failure mode**: logs show "credential pool: no available entries (all exhausted or empty)" before every retry. When the pool is empty, Hermes silently bypasses the configured primary model and falls back to whatever auth it can find — often Anthropic. If Anthropic is also rate-limited, the whole chain collapses. Symptom: unexpected model appears in logs despite different config default.
+- **"response.output is empty" for gpt-5.4 means Hermes is outdated**: this error indicates an API shape mismatch between the installed Hermes version and the gpt-5.4 response format. Fix: run `hermes update`. Check version with `hermes --version` — if it shows "X commits behind", update immediately before debugging further.
+- **Hermes version staleness breaks entire model categories**: running `hermes update` is the first diagnostic step when a model that should work gives shape errors. New models (gpt-5.4, claude-sonnet-4-6, etc.) require up-to-date Hermes to parse responses correctly.

--- a/skills/devops/openclaw-multi-node-audit/SKILL.md
+++ b/skills/devops/openclaw-multi-node-audit/SKILL.md
@@ -1,0 +1,572 @@
+---
+name: openclaw-multi-node-audit
+description: Audit and onboard multi-node OpenClaw infrastructure over SSH, verify access, inventory storage/services/cron, and identify architecture issues like mixed interaction-execution state and scattered exports.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [openclaw, ssh, audit, infrastructure, multi-agent, storage, discord, gdrive]
+---
+
+# OpenClaw Multi-Node Audit
+
+Use this when a user wants Hermes to take over management of Pluto/Henry-style OpenClaw systems, especially when they complain that:
+- tasks get interrupted when they ask a new question
+- exports/logs are hard to find
+- Discord/Drive/storage are fragmented
+- they want autonomous system management with proof
+
+## Goal
+
+Quickly establish trusted SSH access, inventory both nodes in parallel, and produce a grounded architecture recommendation.
+
+## Core Principles
+
+1. Verify access with real SSH commands before claiming success.
+2. Inventory nodes in parallel when possible.
+3. Prefer evidence over assumptions: report actual paths, services, cronjobs, mounts, and binaries.
+4. Treat secrets as sensitive: never save webhook tokens/bot tokens in memory/skills.
+5. Separate interaction from execution in recommendations.
+
+## Recommended Flow
+
+### 1) Create a dedicated SSH key for Hermes
+
+Run locally:
+
+```bash
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+if [ ! -f ~/.ssh/hermes_access_ed25519 ]; then
+  ssh-keygen -t ed25519 -f ~/.ssh/hermes_access_ed25519 -N '' -C 'hermes-access'
+fi
+chmod 600 ~/.ssh/hermes_access_ed25519
+chmod 644 ~/.ssh/hermes_access_ed25519.pub
+cat ~/.ssh/hermes_access_ed25519.pub
+```
+
+Give the user only the public key and have them append it to `~/.ssh/authorized_keys` on each node.
+
+### 2) Verify SSH access immediately
+
+Test each node with the dedicated key:
+
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=12 user@host 'printf "HOST: "; hostname; printf "USER: "; whoami'
+```
+
+Do this for every node. Only after successful output should access be considered confirmed.
+
+### 3) Inventory nodes in parallel
+
+For each node, gather:
+- hostname, user, pwd
+- OS/kernel
+- `command -v openclaw`
+- top-level OpenClaw dirs
+- sessions, cron, logs, memory, workspace paths
+- mounts and `df -h`
+- user/system services
+- crontab
+- recent session/log files
+- Ollama API availability if relevant
+
+Useful audit command template:
+
+```bash
+set -e
+printf "=== BASIC ===\n"; hostname; whoami; pwd
+printf "\n=== OS ===\n"; uname -a
+printf "\n=== OPENCLAW BIN ===\n"; command -v openclaw || true
+printf "\n=== OPENCLAW DIRS ===\n"; find ~/.openclaw -maxdepth 3 \( -type d -o -type f \) 2>/dev/null | sed "s#^$HOME#~#" | sort | head -n 200 || true
+printf "\n=== MOUNTS ===\n"; mount | egrep "/mnt|/srv|/media|/home|truenas|zfs|virtio|ext4|xfs|overlay" || true
+printf "\n=== DISKS ===\n"; df -h | sed -n "1,120p"
+printf "\n=== CRON ===\n"; crontab -l 2>/dev/null || true
+printf "\n=== SYSTEMD ===\n"; systemctl --user list-unit-files --type=service --no-pager 2>/dev/null | sed -n "1,120p" || systemctl list-unit-files --type=service --no-pager 2>/dev/null | sed -n "1,120p" || true
+printf "\n=== OLLAMA ===\n"; curl -s http://127.0.0.1:11434/api/tags | head -c 3000 || true
+printf "\n=== RECENT LOG/SESSION FILES ===\n"; find ~/.openclaw ~/.local ~/.config ~/hermes ~/memory -type f 2>/dev/null | egrep "(log|session|memory|hook|openclaw)" | xargs -r ls -lt 2>/dev/null | head -n 60 || true
+```
+
+For root-based nodes, adapt paths from `~` to `/root` if needed.
+
+### 4) Deep-check mounts, Git state, and security posture before drawing conclusions
+
+#### Mount verification is mandatory
+Don’t stop at `mount`/`df -h`. A node can have storage configured in `fstab` while the live mount is actually failed. Explicitly check:
+
+```bash
+findmnt -o TARGET,SOURCE,FSTYPE,OPTIONS | sed -n '1,160p'
+lsblk -o NAME,SIZE,FSTYPE,TYPE,MOUNTPOINTS,UUID | sed -n '1,120p'
+cat /etc/fstab
+systemctl list-units --type=mount --all --no-pager | sed -n '1,120p'
+find /mnt /media /srv -maxdepth 3 2>/dev/null
+```
+
+Important interpretation rule:
+- if a share appears in `/etc/fstab` but the corresponding `*.mount` unit is `failed`, treat storage as broken/unavailable
+- do not describe such mounts as "working" or "present" in runtime
+
+#### Inventory Git repos and config governance
+Check whether changes are already partially Git-managed:
+
+```bash
+find ~ -maxdepth 4 -type d -name .git 2>/dev/null | sort
+```
+
+Look for repos around:
+- `~/.openclaw/workspace`
+- router/dashboard code
+- dedicated infra repos like `~/pluto-os`
+
+If Git repos exist but GitHub/auth is unverified, explicitly report: "Git exists locally; GitHub access not yet confirmed."
+
+For repo-governance audits, don't stop at finding `.git` directories. For each important repo (`~/.openclaw/workspace`, Hermes source, or named repos like `hermes-core`, `openclaw-pluto`, `openclaw-henry`), explicitly capture:
+
+```bash
+git -C <repo> remote -v || true
+git -C <repo> branch --show-current || true
+git -C <repo> status --short || true
+```
+
+Interpretation rules:
+- local git repo + no remote = work exists but cannot be reaching GitHub from that node
+- upstream remote points to a third-party/original project = user-owned private repo flow is not actually wired yet
+- many modified/untracked files = do not recommend blind first push; require curation, `.gitignore`, and secret review first
+- if the intended architecture mentions a separate state/config repo, verify the export path actually exists (for example `~/.hermes/git-sync`, a curated export directory, or similar). If no such path exists, report that the state-export layer was designed but not operationalized
+
+Special case: Hermes local snapshot sync
+- Check for a local snapshot/export pipeline under paths like:
+  - `~/.local/share/hermes-local-sync/snapshot`
+  - `~/.local/bin/hermes-local-sync.py`
+  - `~/.local/share/hermes-local-sync/state.json`
+  - `~/.local/share/hermes-local-sync/snapshot/manifest.json`
+- Read `manifest.json` to see what is being exported. In practice this may include curated copies of:
+  - `~/.hermes/hermes-agent`
+  - `~/.hermes/skills`
+  - `~/.hermes/config.yaml`
+  - `~/.hermes/SOUL.md`
+  - `~/.config/systemd/user`
+- Then inspect the snapshot repo directly:
+
+```bash
+git -C ~/.local/share/hermes-local-sync/snapshot log --oneline -n 10 || true
+git -C ~/.local/share/hermes-local-sync/snapshot remote -v || true
+```
+
+Interpretation rules for this pattern:
+- recent local commits + empty `remote -v` = configs/skills/code are being versioned locally only, not pushed anywhere
+- that means "GitHub is empty" is usually not a GitHub failure; it is an unfinished export-to-remote step
+- be explicit that a local snapshot repo is a backup/versioning layer, not the same thing as the promised repo split (`hermes-core`, `openclaw-pluto`, `openclaw-henry`)
+- IMPORTANT: a configured remote + active commits does NOT mean all intended repos are being synced. Check which repos the sync script actually knows about. Common failure: hermes-core is wired and actively synced, but openclaw-pluto and openclaw-henry are never mentioned in the sync script's SOURCES list — so they remain at the initial skeleton commit forever.
+
+To diagnose this specifically:
+```bash
+grep -n "hermes-core\|openclaw-pluto\|openclaw-henry\|SOURCES\|label\|path" ~/.local/bin/hermes-local-sync.py | head -40
+```
+Then cross-check each repo's last commit date:
+```bash
+export PATH=$HOME/.local/bin:$PATH
+for repo in hermes-core openclaw-pluto openclaw-henry; do
+  gh api repos/AlexanderWatersOxygen/$repo/commits?per_page=1 --jq "\"$repo: \" + .[0].commit.committer.date + \" \" + (.[0].commit.message | split(\"\n\")[0])" 2>&1
+done
+```
+If openclaw-pluto/henry show only a single init commit while hermes-core has recent syncs, the sync script covers only hermes-core.
+
+Additional finding: the sync script may inadvertently include the full hermes-agent source code (the upstream NousResearch codebase) inside hermes-core. Check whether `hermes-agent/` is a SOURCES entry and whether that was intended — personal config repos should not contain upstream source code.
+
+When the user says "nothing is on GitHub" or asks why repos are empty, distinguish clearly between:
+1. design agreement existed
+2. local repos/workspaces exist
+3. local snapshot/export exists
+4. remotes/export/sync/push pipeline were never fully connected
+
+That distinction prevents falsely blaming GitHub when the real failure is unfinished repo wiring.
+
+#### Remote deployment caveat: long SSH build commands may hang in tooling even when SSH itself works
+When deploying to Pluto/Henry through Hermes tooling, don't assume a long `ssh 'cd app && npm run build && restart'` one-liner is the best approach. In practice, direct SSH verification can work perfectly while long remote build/deploy commands get blocked or time out at the tool layer.
+
+Preferred deployment method for remote UI/apps:
+1. Verify the target app path, service name, current port listener, and systemd unit first.
+2. Sync or patch files separately.
+3. Write a small deploy script locally with exact steps (`build`, `restart`, `curl` checks).
+4. Copy that script to the remote node.
+5. Start it remotely in a way that survives the tool call.
+6. Read back log files and HTTP markers to confirm success.
+
+Example verification steps before touching anything:
+
+```bash
+find ~/.openclaw/workspace -maxdepth 3 \( -type d -o -type f \) | egrep 'mission-control($|/)'
+ss -ltnp | egrep ':3000\b' || true
+systemctl --user status mission-control.service --no-pager -l | sed -n '1,120p' || true
+```
+
+Important interpretation rule:
+- if source files on the node changed but the service HTML/headers still look old, the new build likely was not completed/restarted yet
+- do not claim deployment success until both the service restarted and the served HTML contains expected markers from the new build
+
+#### Don’t confuse direct SSH management with Pluto’s own OpenClaw exec approvals
+If Hermes is connecting via direct SSH from its own environment, Pluto/OpenClaw approval rules are usually not the immediate cause of a blocked tool call. Check `~/.openclaw/openclaw.json` anyway, but distinguish these cases clearly:
+
+- Direct Hermes SSH path problem:
+  - SSH login works
+  - long remote build/deploy tool call hangs or gets blocked
+  - solve with smaller steps, remote scripts, background execution, and log verification
+
+- Pluto OpenClaw autonomy problem:
+  - Pluto itself gets stuck on `exec` approvals for `ssh` or shell actions
+  - solve by configuring safe bins / allowlist / per-agent approvals
+
+On audit, inspect `tools.exec` in `~/.openclaw/openclaw.json` and report whether it is empty or configured.
+
+#### Inventory security-relevant files
+On execution nodes especially, check for sprawl of secrets/config state:
+
+```bash
+find ~/.openclaw -maxdepth 3 -type f | egrep '(secrets|credentials|pairing|allowFrom|exec-approvals|device-auth|device.json|\.env|env_vars)'
+```
+
+Report this as security/config drift, not just as trivia.
+
+### 5) Look specifically for these findings
+
+#### On primary/front-end nodes (like Pluto)
+- Telegram/OpenClaw gateway service
+- session storage under `~/.openclaw/agents/main/sessions`
+- Hermes scripts like `~/hermes/hermes.py`
+- memory index like `~/memory/index.md`
+- watchdogs and reboot scripts
+- whether extra SSD storage is actually mounted (don’t assume)
+- whether `openclaw` is in PATH even if systemd services exist
+
+#### On execution/back-office nodes (like Henry)
+- OpenClaw binary in PATH
+- many specialized agent directories under `~/.openclaw/agents`
+- Drive mounts via rclone
+- NAS/backup mounts via CIFS/NFS
+- dense cron-based automation
+- evidence of fragmented backups/secrets/exports
+
+### 5) Diagnose architecture problems
+
+Common root cause when “everything stops when I ask another question”:
+- interaction, execution, memory, and exports all share one live chat/process
+- long-running work is not externalized to queue/run state
+- outputs are spread across nodes and ad hoc folders
+
+State this clearly: this is an architecture flaw, not user error.
+
+### 6) Recommend a 3-layer operating model
+
+Also include governance and knowledge-layer recommendations when the user wants long-term autonomy:
+- GitHub-first for configs/scripts/docs so branches, rollbacks, and audit history are easy
+- secrets stay outside Git
+- start with a markdown/Obsidian-style knowledge base (docs + memory + runbooks) before proposing a heavier RAG/vector stack
+- treat unsupported document flows (`.html`, `.mht`) as a data-pipeline problem: normalize exports to `.md`, `.pdf`, `.txt`, or `.zip`
+
+If the user complains that prior agents misunderstood design mockups literally, state clearly that responsive UI mockups are illustrative and should not be implemented as split-screen static copies; phone should see mobile UI and desktop should see desktop UI.
+
+Recommended pattern:
+- Hermes = control plane / governance / memory / architecture
+- Pluto = intake + local interaction + lightweight local execution
+- Henry = execution/back-office/batch pipelines
+
+Also recommend one canonical run structure per node, e.g.:
+
+```text
+/srv/pluto/
+  inbox/
+  queue/
+  runs/
+  exports/
+  logs/
+  memory/
+  snapshots/
+  config/
+
+/srv/henry/
+  queue/
+  runs/
+  exports/
+  logs/
+  snapshots/
+  workers/
+```
+
+Per run:
+
+```text
+run_id/
+  task.json
+  status.json
+  stdout.log
+  artifacts/
+  result.md
+```
+
+### 7) Recommend solutions to the interruption problem
+
+Always offer concrete options such as:
+1. Separate chat/intake from long-running execution.
+2. Add a dedicated orchestrator/queue worker.
+3. Centralize state, logs, and exports with fixed paths.
+
+Default recommendation: implement all three, with separated interaction/execution as the first step.
+
+## Reporting Format
+
+When done, report:
+- whether SSH access is confirmed on each node
+- what actually exists on each node
+- the top architecture risks
+- one clear recommendation for the next step
+
+Keep the final message non-jargony for the user, but grounded in observed evidence.
+
+## Hermes→Pluto Renaming (naming hygiene)
+
+When Sander reports confusion about things being named "hermes" on Pluto, it means Pluto's own operational scripts/services are named after the AI assistant (Hermes) instead of the node (Pluto). This is a naming collision that should be cleaned up proactively.
+
+### What to check
+
+Run on Pluto to find everything named "hermes" that belongs to Pluto's own logic:
+
+```bash
+# Files in home dir
+find /home/sander -maxdepth 4 -iname "*hermes*" 2>/dev/null | grep -v .git | grep -v __pycache__
+# Dirs on SSD
+find /mnt/ssd_vm -maxdepth 2 -iname "*hermes*" 2>/dev/null
+# Env var names in .env files
+grep -r "HERMES_" /home/sander/pluto-os/ 2>/dev/null | grep "\.env"
+```
+
+### Naming rules
+
+| Pattern | What it means | Action |
+|---------|--------------|--------|
+| `~/pluto-os/pluto-agent/` | Pluto's operational scripts | Keep name |
+| `~/pluto-os/pluto-agent/.env` `HERMES_WEBHOOK_*` | Pluto owns these webhooks | Rename to `PLUTO_WEBHOOK_*` |
+| `pluto.py`, `pluto_final.py` | Pluto's brain scripts | Correct names — keep |
+| `.bashrc.pre-hermes.bak` | Auto-generated backup suffixes | Leave alone |
+| `SecondBrain/01_INBOX/from-hermes/` | Inbox FROM me (Hermes) | Semantically correct — keep |
+| `Design Pluto OS/workspace_files/hermes/` | My identity MD files | Correct — keep |
+| `/mnt/ssd_vm/Hermes/` (empty catch-all dir) | Was created for me, not Pluto | Rename to `OpenClaw-Agent` |
+| `SecondBrain/03_OPERATIONS/hermes/` | Pluto-managed ops folder | Rename to `pluto-agent` |
+
+### Rename procedure
+
+```bash
+SSH="ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25"
+
+# .env vars: HERMES_WEBHOOK_ → PLUTO_WEBHOOK_
+$SSH "sed -i 's/HERMES_WEBHOOK_/PLUTO_WEBHOOK_/g' ~/pluto-os/pluto-agent/.env"
+$SSH "sed -i 's/HERMES_WEBHOOK_/PLUTO_WEBHOOK_/g' ~/pluto-os/pluto-agent/.env.example"
+
+# Update any Python scripts that read those vars
+$SSH "sed -i 's/HERMES_WEBHOOK_/PLUTO_WEBHOOK_/g' ~/pluto-os/pluto-agent/pluto.py ~/pluto-os/pluto-agent/pluto_final.py"
+
+# Rename empty/catch-all dirs on SSD
+$SSH "mv /mnt/ssd_vm/Hermes /mnt/ssd_vm/OpenClaw-Agent 2>/dev/null || true"
+$SSH "mv /mnt/ssd_vm/OpenClaw-SecondBrain/03_OPERATIONS/hermes /mnt/ssd_vm/OpenClaw-SecondBrain/03_OPERATIONS/pluto-agent 2>/dev/null || true"
+```
+
+Always verify with:
+```bash
+$SSH "cat ~/pluto-os/pluto-agent/.env | sed 's/=.*/=[REDACTED]/g'"
+$SSH "grep -n HERMES ~/pluto-os/pluto-agent/pluto.py pluto_final.py 2>/dev/null | head -5"
+```
+
+---
+
+## OpenClaw SecondBrain — Access Governance
+
+When the SecondBrain folder hierarchy is set up, classify each folder and assign governance:
+
+| Map | Rol | Lezen | Schrijven | Beheer |
+|-----|-----|-------|-----------|--------|
+| 00_CANON/ | CANON | Alle agents | Alleen Hermes | Hermes |
+| 01_INBOX/from-hermes/ | INBOX | Pluto | Hermes | Hermes |
+| 01_INBOX/from-henry/ | INBOX | Pluto, Hermes | Henry | Pluto |
+| 01_INBOX/from-pluto/ | INBOX | Hermes | Pluto | Pluto |
+| 01_INBOX/to-review/ | INBOX | Hermes, Sander | Pluto, Henry | Hermes |
+| 02_PROJECTS/ | SHARED | Alle agents | Pluto, Hermes | Hermes |
+| 03_OPERATIONS/pluto/ | NODE_LOCAL | Hermes, Pluto | Pluto | Pluto |
+| 03_OPERATIONS/henry/ | NODE_LOCAL | Hermes, Henry | Henry | Henry |
+| 03_OPERATIONS/pluto-agent/ | NODE_LOCAL | Pluto | Pluto | Pluto |
+| 04_KNOWLEDGE/ | SHARED | Alle agents | Hermes, Pluto | Hermes |
+| 05_VAULT/ | CANON | Alle agents | Alleen Hermes | Hermes |
+| 06_EXPORTS/ | ARCHIVE | Alle agents | Pluto, Henry | Pluto |
+| 07_ARCHIVE/ | ARCHIVE | Alle agents | Alleen Hermes | Hermes |
+| 99_ADMIN/ | CANON | Alle agents | Alleen Hermes | Hermes |
+
+Key rule: CANON folders (00, 99, Vault) only written by Hermes. INBOX folders: each agent writes only to its own inbox. NODE_LOCAL: only the node itself writes there.
+
+---
+
+## OpenClaw Agent Model Routing
+
+### Where routing actually lives
+
+The real model routing for each agent is in `~/.openclaw/openclaw.json` under `agents.list[].model`, NOT in the agent markdown files (IDENTITY.md, MEMORY.md, SOUL.md). Those markdowns are behavioral guidance only — they do not control which model the OpenClaw runtime uses.
+
+Structure in `openclaw.json`:
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": { "primary": "ollama/qwen3.5:9b" }
+    },
+    "list": [
+      {
+        "id": "main",
+        "model": {
+          "primary": "anthropic/claude-sonnet-4-6",
+          "fallbacks": ["google/gemini-2.5-flash"]
+        }
+      },
+      {
+        "id": "cody",
+        "model": {
+          "primary": "openai-codex/gpt-5.4",
+          "fallbacks": ["google/gemini-2.5-flash"]
+        }
+      }
+    ]
+  }
+}
+```
+
+### Subagents inherit main agent routing, not spawning agent routing
+
+Critical pitfall: when Cody spawns a subagent, that subagent uses the **global defaults or main agent config**, not Cody's own model config. This means:
+- Changing Cody's live config doesn't fix subagents Cody spawns
+- The fallback chain `Anthropic → Gemini` hitting errors came from main agent config, not Cody's
+
+**The only fix** is to update both:
+1. The spawning agent's own `agents.list[]` entry (so the agent itself runs on the right model)
+2. The `agents.defaults.model` (so subagents spawned by any agent also use the right model)
+
+### Markdown files (IDENTITY.md, MEMORY.md, SOUL.md) do NOT control routing
+
+This is a recurring confusion. Pluto agents will update these files thinking they've changed the live routing. They have not. These files are behavioral guidance text. Only `openclaw.json` controls which model is invoked at runtime.
+
+If Pluto reports "I've updated Cody's model config" but the error persists, assume Pluto edited the markdowns, not `openclaw.json`. Fix by SSH-editing `openclaw.json` directly from Hermes.
+
+### Inspecting live routing quickly
+
+```python
+import json
+with open('/home/sander/.openclaw/openclaw.json') as f:
+    d = json.load(f)
+agents = d.get('agents', {})
+print(json.dumps(agents.get('defaults', {}), indent=2))
+for a in agents.get('list', []):
+    print(a.get('id'), '→', a.get('model', 'inherits default'))
+```
+
+Or via SSH:
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  "python3 -c \"import json; d=json.load(open('/home/sander/.openclaw/openclaw.json')); [print(a['id'], a.get('model','default')) for a in d['agents']['list']]\""
+```
+
+### OpenAI OAuth vs full OpenAI API catalog
+
+When setting up models via the OpenClaw onboarding/model-setup menu:
+- **OAuth / onboard route** → gives only `openai-codex/gpt-5.4` (or similar codex-namespaced models)
+- **Full OpenAI API provider** → gives the entire `openai/*` catalog (gpt-4o, gpt-4.1, o3, o4-mini, etc.)
+
+These are separate. Selecting a model via OAuth does not automatically make the full model catalog available. If you want both codex models AND the full OpenAI catalog, you need both providers configured.
+
+Practical recommendation:
+- For Cody: use `openai-codex/gpt-5.4` as primary (OAuth route)
+- For budget fallback: use `google/gemini-2.5-flash` (separate provider)
+- Do NOT copy one provider model to another agent as-is; the OAuth route is agent/session-bound
+
+### Checking auth-state for disabled/cooldown providers
+
+If an agent keeps failing with a provider despite config changes, check whether that provider is disabled or in cooldown in the auth state:
+```bash
+find ~/.openclaw -name "auth-state*" -o -name "provider-state*" 2>/dev/null
+# Also check for agent-level state files
+find ~/.openclaw/agents -name "*.json" | xargs grep -l "fallback\|cooldown\|disabled\|provider" 2>/dev/null
+```
+
+Common failure pattern:
+- `anthropic:default` → DISABLED (billing error)
+- `google:default` → COOLDOWN (rate_limit)
+- Both are set globally, so all agents — including subagents — hit those blocks
+
+**Critical pattern observed in the field:**
+
+When Pluto reports "I updated Cody's model config" but errors persist in this sequence:
+1. Pluto edits IDENTITY.md/MEMORY.md → does NOT fix routing (wrong layer)
+2. Pluto edits `openclaw.json` agent entry → fixes Cody's own calls, but NOT subagent calls
+3. Subagents Cody spawns still go to `agents.defaults.model`, which may still include Anthropic
+4. Anthropic hits billing error → tries Gemini fallback → Gemini hits rate limit → crash
+
+Diagnosis order when this happens:
+1. Read `openclaw.json` — check both `agents.defaults.model` AND the per-agent entry
+2. Check `agents.defaults.fallbacks` — this is what subagents inherit
+3. Check for auth-state files showing provider cooldowns
+4. Only if all three look clean, suspect runtime bootstrap or cached config
+
+Full fix requires updating both the agent entry AND the defaults:
+```python
+import json
+path = '/home/sander/.openclaw/openclaw.json'
+with open(path) as f:
+    d = json.load(f)
+# Fix agent-level
+for agent in d['agents']['list']:
+    if agent['id'] == 'cody':
+        agent['model'] = {
+            'primary': 'openai-codex/gpt-5.4',
+            'fallbacks': ['google/gemini-2.5-flash']
+        }
+# Fix defaults so subagents Cody spawns also avoid Anthropic
+if 'defaults' not in d['agents']:
+    d['agents']['defaults'] = {}
+d['agents']['defaults']['model'] = {
+    'primary': 'openai-codex/gpt-5.4',
+    'fallbacks': ['google/gemini-2.5-flash']
+}
+with open(path, 'w') as f:
+    json.dump(d, f, indent=2)
+```
+
+Note: changing defaults affects ALL agents. Only do this if you want a system-wide default change, not just a per-agent change.
+
+### Modifying live routing
+
+To change a specific agent's model, edit `openclaw.json` directly. For the fallback:
+```python
+import json
+path = '/home/sander/.openclaw/openclaw.json'
+with open(path) as f:
+    d = json.load(f)
+for agent in d['agents']['list']:
+    if agent['id'] == 'cody':
+        agent['model'] = {
+            'primary': 'openai-codex/gpt-5.4',
+            'fallbacks': ['google/gemini-2.5-flash']
+        }
+with open(path, 'w') as f:
+    json.dump(d, f, indent=2)
+```
+
+Note: changing an agent's config does NOT automatically propagate to subagents it spawns. Subagent model routing may need a separate global default change.
+
+---
+
+## Pitfalls
+
+- Don't claim SSD/shared storage exists until mount output proves it.
+- Don't assume Pluto and Henry use the same user/path layout.
+- Don't store raw webhook or bot tokens in memory or skills.
+- Don't stop at "I can access it" — inventory the system immediately.
+- Don't recommend reading Discord via webhook; reading requires a bot.
+- When renaming env vars, also update any Python scripts that os.getenv() those vars.
+- `.pre-hermes.bak` backup suffixes are auto-generated — leave them, don't rename.
+- `from-hermes/` inbox dirs are semantically correct (inbox FROM Hermes) — don't rename.
+- `workspace_files/hermes/` holds Hermes identity/agent definition files — don't rename.

--- a/skills/devops/python313-pip-setup/SKILL.md
+++ b/skills/devops/python313-pip-setup/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: python313-pip-setup
+description: Fix broken pip, distutils, and setuptools on Ubuntu with Python 3.13. Use when pip3 is missing, `python3 -m pip` fails, or packages fail to build due to missing distutils or setuptools.
+tags: [python, pip, ubuntu, distutils, setuptools, python3.13, devops]
+---
+
+# Python 3.13 pip/distutils Setup on Ubuntu
+
+## When to use
+
+- `pip3: command not found` on Ubuntu with Python 3.13
+- `python3 -m pip` fails with "No module named pip"
+- Package build fails: `ModuleNotFoundError: No module named 'distutils'`
+- `ImportError: cannot import name 'setup' from 'setuptools'`
+- Installing packages like twikit, or anything with legacy `setup.py`
+
+## Root cause
+
+Python 3.13 on Ubuntu ships WITHOUT pip and WITHOUT distutils by default.
+- `pip3` binary may not exist at all
+- `distutils` was removed from stdlib in Python 3.12+
+- Many legacy packages use `setup.py` with `from distutils.core import setup` — this breaks
+
+## Fix (in order)
+
+```bash
+# Step 1: Install pip + dev headers
+sudo apt install -y python3-pip python3-dev
+
+# Step 2: Install setuptools + distutils compatibility layer
+sudo apt install -y python3-setuptools python3-distutils-extra
+
+# Step 3: Verify
+python3 -m pip --version
+pip3 --version
+```
+
+## Install packages after fix
+
+```bash
+# Use --break-system-packages on Ubuntu 24+ (PEP 668 enforced)
+python3 -m pip install <package> --break-system-packages
+
+# Or install to user space (no flag needed)
+pip3 install --user <package>
+```
+
+## sudoers for agent (Cody/subagents)
+
+If a subagent needs to install packages without password:
+
+```bash
+# Write to /tmp/agent-sudoers first, then:
+sudo tee /etc/sudoers.d/agent-name < /tmp/agent-sudoers
+sudo chmod 440 /etc/sudoers.d/agent-name
+```
+
+Content of the sudoers file (use scp + tee — avoid heredoc over SSH due to shell escaping):
+```
+# Agent - limited NOPASSWD
+sander ALL=(ALL) NOPASSWD: /usr/bin/python3
+sander ALL=(ALL) NOPASSWD: /usr/bin/pip3
+sander ALL=(ALL) NOPASSWD: /usr/local/bin/pip3
+```
+
+**Pattern**: write file locally → `scp` to remote → `sudo tee /etc/sudoers.d/` on remote.
+Do NOT try to write sudoers content via heredoc or inline SSH strings — shell escaping breaks.
+
+## Pitfalls
+
+- `sudo tee` requires tee to already be in NOPASSWD — check existing sudoers first with `sudo -l`
+- `sudo visudo -c` may not be in NOPASSWD; skip it or use `cat` to verify file content
+- `pip3` binary lands in `/home/sander/.local/bin` when installed with `--break-system-packages` — PATH may need updating for scripts
+- Do NOT try inline Python heredoc over SSH with complex quoting — write locally, scp, then execute
+- `python3-distutils-extra` is the correct apt package name (not `python3-distutils` alone)

--- a/skills/devops/remote-file-patch-via-scp/SKILL.md
+++ b/skills/devops/remote-file-patch-via-scp/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: remote-file-patch-via-scp
+description: Patch files on a remote host (e.g. Pluto over SSH) without shell-escaping hell. Write a Python patch script locally, scp it, then execute it remotely. Use when inline SSH string manipulation fails due to quotes, special chars, or multi-line replacements.
+tags: [ssh, scp, pluto, remote, patch, file-edit]
+---
+
+# Remote File Patch via SCP
+
+## When to Use
+
+- You need to edit a file on Pluto (or any SSH host) with complex string replacements
+- Inline `ssh host 'sed ...'` or `ssh host \"python3 -c '...'\"` fails due to escaping
+- The replacement contains quotes, newlines, special characters, or is multi-line
+- You want reliable, auditable, idempotent edits on remote files
+
+## Two Patterns
+
+### Pattern A: Inline SSH heredoc (faster, no temp files)
+
+Use when the replacement logic is moderate and doesn't need local file references.
+
+```bash
+ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 "
+python3 << 'EOF'
+with open('/remote/path/file.js') as f:
+    content = f.read()
+
+block = '''
+// new block to insert
+const FOO = 'bar';
+'''
+
+marker = 'const PORT = ...'  # exact string from file
+if 'const FOO' not in content and marker in content:
+    content = content.replace(marker, marker + block)
+    with open('/remote/path/file.js', 'w') as f:
+        f.write(content)
+    print('Inserted block')
+else:
+    print('Skipped: already present or marker not found')
+EOF
+"
+```
+
+**When heredoc fails** (special chars in the block or exit code 255 from SSH), fall back to Pattern B.
+
+### Pattern B: SCP then execute (most reliable, use for complex cases)
+
+**Do NOT try to inline Python or sed over SSH for complex replacements — it always fails.**
+
+1. Write a `.py` patch script locally using `write_file`
+2. `scp` it to the remote host
+3. `ssh` to execute it
+4. Print result and check exit code
+
+## Template
+
+```python
+# /tmp/patch_<target>.py
+path = '/remote/path/to/file.md'
+with open(path, 'r') as f:
+    content = f.read()
+
+old = "exact string to find"
+new = "replacement string"
+
+if old in content:
+    content = content.replace(old, new)
+    with open(path, 'w') as f:
+        f.write(content)
+    print('Patched successfully')
+else:
+    print('String not found — no changes made')
+    print('Expected:', repr(old[:80]))
+```
+
+Then execute:
+
+```bash
+scp -i ~/.ssh/hermes_access_ed25519 /tmp/patch_target.py sander@100.108.223.25:/tmp/patch_target.py \
+  && ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 'python3 /tmp/patch_target.py'
+```
+
+Or combined via execute_code:
+
+```python
+from hermes_tools import terminal
+
+result = terminal(
+    "scp -i ~/.ssh/hermes_access_ed25519 /tmp/patch_target.py sander@100.108.223.25:/tmp/patch_target.py "
+    "&& ssh -i ~/.ssh/hermes_access_ed25519 sander@100.108.223.25 'python3 /tmp/patch_target.py'"
+)
+print(result['output'])
+```
+
+## Pluto SSH Details
+
+- Host: sander@100.108.223.25 (Tailscale)
+- Key: ~/.ssh/hermes_access_ed25519
+
+## Multi-block Replacement
+
+For multiple replacements in one file, use a list of (old, new) tuples:
+
+```python
+path = '/remote/path/to/file.md'
+with open(path, 'r') as f:
+    content = f.read()
+
+patches = [
+    ("old string 1", "new string 1"),
+    ("old string 2", "new string 2"),
+]
+
+applied = []
+for old, new in patches:
+    if old in content:
+        content = content.replace(old, new)
+        applied.append(old[:40])
+    else:
+        print(f'NOT FOUND: {repr(old[:60])}')
+
+with open(path, 'w') as f:
+    f.write(content)
+
+print(f'Applied {len(applied)} patches:', applied)
+```
+
+## Pitfalls
+
+- Always print the first 80 chars of the expected string when not found — helps debug whitespace/indent mismatches
+- Use `repr()` in debug output so hidden characters (tabs, \\r, trailing spaces) are visible
+- For YAML/JSON files, prefer loading and re-serializing instead of string replacement — avoids corrupting structure
+- Clean up /tmp/*.py after use if the script contained sensitive data
+- `scp` and `ssh` must be in separate steps if you need the exit code of the patch script itself
+- If the file uses Windows line endings (\\r\\n), `old` must include \\r or the match will fail — check with `repr(content[:200])`
+
+## Idempotency Guard: Be Specific
+
+When checking if a block is already present, use the **declaration string**, not a substring that may appear elsewhere:
+
+```python
+# WRONG: 'OLLAMA_FALLBACK' appears in references even before the const is declared
+if 'OLLAMA_FALLBACK' not in content:
+    ...  # skipped even though const block was never inserted
+
+# CORRECT: check for the exact declaration
+if 'const OLLAMA_FALLBACK' not in content:
+    ...  # only skipped if the actual declaration exists
+```
+
+This catches the case where a variable name is used in the file (e.g. in function calls) before the declaration block is inserted.
+
+## SSH Heredoc: exit code 255
+
+If `ssh ... "python3 << 'EOF' ... EOF"` returns exit_code 255, the SSH connection itself failed (timeout, key issue, or the heredoc confuses the shell quoting). Switch to Pattern B (SCP) immediately — don't retry the heredoc.

--- a/skills/devops/safe-live-service-changes/SKILL.md
+++ b/skills/devops/safe-live-service-changes/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: safe-live-service-changes
+description: >
+  Mandatory safety protocol before making any changes to live services, running
+  processes, or production infrastructure (Pluto, Henry, Mission Control, routers,
+  Ollama, systemd services). Use whenever modifying files, configs, or crons that
+  touch a running service.
+tags: [devops, safety, pluto, infrastructure, rollback, git]
+---
+
+# Safe Live Service Changes
+
+## When to apply this skill
+
+- Modifying any file that a running process reads (server.js, config.json, data.ts, .env)
+- Creating crons that restart, kill, or modify running services
+- Changing systemd unit files or starting/stopping services
+- Any `pkill`, `kill`, or process restart on Pluto/Henry
+- Modifying Mission Control, iblai-router, Ollama config, pluto-agent
+
+---
+
+## Mandatory pre-change checklist
+
+Before touching anything:
+
+1. **Verify current state works**
+   ```bash
+   curl -s -o /dev/null -w 'HTTP %{http_code}' http://127.0.0.1:3000
+   # Document the result — is it 200? If not, note why.
+   ```
+
+2. **Create a Git branch** (if repo exists)
+   ```bash
+   cd /path/to/repo
+   git checkout -b fix/description-$(date +%Y%m%d)
+   git status
+   ```
+
+3. **Create a timestamped file backup** (always, even if git exists)
+   ```bash
+   cp target_file target_file.backup_$(date +%Y%m%d_%H%M%S)
+   ```
+
+4. **Note which PID / systemd unit owns the service**
+   ```bash
+   ps aux | grep service_name
+   systemctl status service_name 2>/dev/null
+   ```
+
+---
+
+## Cron safety rules
+
+NEVER create a cron that:
+- Does `pkill`, `kill -9`, or `killall` on a Next.js / node / Python service
+- Does unconditional `pkill next dev` — this will kill the running process and the replacement may bind to a different port
+- Restarts a service without first checking if it's actually down
+- Writes to files that a running process hot-reloads (data.ts, config.json)
+
+SAFE cron pattern:
+```bash
+# Check first, act only if down
+if ! curl -sf http://127.0.0.1:PORT/health > /dev/null; then
+  # Service is down — restart safe
+  systemctl restart service_name || nohup node server.js &
+fi
+# Otherwise: do nothing, report only
+```
+
+---
+
+## Change workflow
+
+1. Make the change on the **backup copy** first, verify it looks right
+2. Apply to real file
+3. Test immediately (curl, HTTP check, log tail)
+4. If test passes → commit to Git branch
+5. Only merge to main / enable cron after confirmed working
+6. If test fails → restore from backup immediately:
+   ```bash
+   cp target_file.backup_TIMESTAMP target_file
+   ```
+
+---
+
+## Rollback commands (Pluto)
+
+```bash
+# Mission Control
+pkill -f 'next dev'  # kill stray processes
+cd ~/.openclaw/workspace/mission-control && nohup npm run dev > /tmp/mc.log 2>&1 &
+curl -s -o /dev/null -w 'MC: HTTP %{http_code}\n' http://127.0.0.1:3000
+
+# Restore a file from backup
+cp file.backup_20260412_161336 file
+
+# Systemd service (requires sudo — instruct user to run manually)
+# sudo systemctl disable --now service_name
+```
+
+---
+
+## Pitfalls learned (from incident 2026-04-12)
+
+- **pkill next dev in a cron** killed the running Mission Control process; Next.js restarted on port 3001 instead of 3000, breaking the URL
+- **Backup was made AFTER patches** — the "pre-patch" backup already contained changes. Always make backup BEFORE the first edit
+- **sudo systemctl stop** hangs in non-PTY SSH sessions — cannot be done via Hermes terminal; must be done by user interactively or via a sudoers NOPASSWD entry for specific commands
+- **iblai-router ran as root** via systemd — Hermes SSH user (sander) could not kill it
+- **config.json was not in git** — no version history to restore from; always check `git ls-files` before assuming git covers a file
+
+---
+
+## Verification after any change
+
+```bash
+# Always end with a 3-point check:
+curl -s -o /dev/null -w 'Service: HTTP %{http_code}\n' http://127.0.0.1:PORT
+pgrep -a node | head -5           # confirm correct process running
+tail -5 /tmp/service.log          # no errors in recent log
+```

--- a/skills/devops/truthful-model-selection/SKILL.md
+++ b/skills/devops/truthful-model-selection/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: truthful-model-selection
+description: Diagnose and harden Hermes model selection so the chosen model is truly executed, fallbacks are explicit, and Telegram model switching remains honest under rate limits.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [model-routing, fallback, telegram, rate-limits, hermes]
+    related_skills: [systematic-debugging, hermes-agent]
+---
+
+# Truthful Model Selection
+
+Use this when Hermes appears to "switch models" in UI or Telegram, but runtime behavior still follows hidden fallback chains or stale provider config.
+
+## Goal
+
+Guarantee that:
+1. selected_model is the user's requested truth
+2. executed_model is what actually ran
+3. fallback only happens when policy explicitly allows it
+4. Telegram `/model` always changes control state honestly, even during rate limits
+5. background jobs keep running independently from chat/provider turbulence
+
+## Root problem pattern
+
+Typical symptom cluster:
+- UI says "Model switched to X"
+- runtime still prints "switching to fallback provider"
+- retries hit a stale model like `MiniMax-Text-01`
+- user correctly experiences this as a lie
+
+Common architectural cause:
+- global `fallback_model` / `fallback_providers` are loaded automatically at boot
+- session `/model` changes visible state but does not clear or override runtime fallback chain
+- selected model and executed model are not tracked separately
+- stale fallback entries survive in config or caches
+
+## Investigation checklist
+
+1. Inspect where fallback chain is built.
+   - Search for `_fallback_chain`, `_fallback_model`, `_load_fallback_model`, `fallback_providers`, `fallback_model`.
+2. Confirm whether gateway boot loads global fallback config automatically.
+3. Confirm whether `/model` changes only display/session metadata or also runtime execution state.
+4. Search logs for these strings:
+   - `Rate limited — switching to fallback provider`
+   - `Non-retryable error (HTTP 404)`
+   - stale model names (for example `MiniMax-Text-01`)
+5. Verify whether rate-limit handling and model-selection messaging are handled by different code paths.
+6. Inspect provider list sources used by Telegram, TUI, setup, and runtime.
+   - In Hermes, check whether the picker reads `providers` while runtime resolution still reads `custom_providers`.
+   - A real failure mode observed in production: `~/.hermes/config.yaml` stores named local endpoints under `providers:` (for example `ollama-pluto`, `ollama-elibook`), but `runtime_provider.py` still does `config.get("custom_providers")` and returns `None` when that key is absent or not a list.
+   - When these structures diverge, local endpoints can appear in menus yet fail at execution time, forcing manual `ssh` + `hermes setup model` repair.
+7. Verify the provider picker and resolver use one canonical schema.
+   - Backward-compatible migration is fine, but UI, setup wizard, Telegram `/model`, and runtime execution must all read the same effective provider list.
+   - If the codebase is mid-migration, add an adapter layer instead of maintaining parallel code paths.
+8. Audit provider-menu omissions separately from runtime support.
+   - A provider may already exist in `providers.py` overlays yet still be absent from the switch menu.
+   - Concrete case: `openai-codex` existed as a provider overlay with `transport="codex_responses"`, but the picker/fallback tables did not expose the expected OpenAI Codex model family.
+   - When users report a missing provider group, inspect both overlay registration and the picker/setup fallback model tables.
+9. For local OpenAI-compatible endpoints, verify model discovery order:
+   - explicit `models`
+   - `default_model` or `model`
+   - full probe of `/v1/models` to collect all advertised model ids
+   - only then a single-model auto-detect fallback
+   - if the backend is local/Ollama-compatible, allow a non-empty placeholder API key such as `ollama` instead of treating empty remote-provider credentials as a reason to fall back to OpenRouter
+   - important production finding: relying on auto-detect only when exactly one model is exposed breaks Telegram/TUI switching for multi-model Ollama endpoints and leaves provider groups showing `0` models
+10. When a switch targets a local provider, ensure runtime does not silently re-enter remote credential resolution.
+   - If the chosen provider is `ollama-pluto` or `ollama-elibook`, the executor should pin `base_url` to that endpoint and skip OpenRouter/OpenAI API-key fallback logic.
+   - after a manual `/model` switch, explicitly clear any stale gateway/session fallback state such as `_effective_model`, `_effective_provider`, and cached agent `_fallback_model`; otherwise the UI can report a successful switch while execution still follows an earlier degraded route and keeps surfacing rate-limit behavior
+11. Audit picker visibility separately from raw credential detection.
+   - Hermes-only providers like `openai-codex` should remain visible when they are the current provider or configured provider, even if one credential-detection path fails.
+   - keep the configured/current model visible in the picker even when the curated catalog is stale or incomplete, so users can still reselect known-good runtimes from Telegram/TUI.
+
+## Design rules to enforce
+
+### 1. Separate selected and executed model
+Every response or task execution should carry:
+- `selected_model`
+- `selected_provider`
+- `executed_model`
+- `executed_provider`
+- `execution_reason` = `direct | degrade | override | resume`
+
+If executed != selected, surface it explicitly.
+
+### 2. Make fallback policy explicit
+Support a small policy surface:
+- `strict`: never fallback
+- `degrade`: may fallback only within approved ladder
+- `override`: system may temporarily reroute, but must report it clearly
+
+Never allow hidden fallback when policy is `strict`.
+
+### 3. Quarantine dead fallback entries
+If a model returns `404 not_found`, mark it unusable for the current session/job immediately.
+Do not retry it again in the same execution path.
+
+### 4. Health-gate the fallback ladder
+Before using fallback providers/models:
+- validate config entries at boot
+- probe model availability where feasible
+- disable invalid entries before runtime
+
+A safe Telegram ladder is:
+1. requested model/provider
+2. approved same-provider sibling (only if policy allows)
+3. approved remote fallback
+4. local Pluto Ollama
+5. local Elitebook Ollama
+
+### 5. Separate control plane from worker plane
+Telegram chat should set execution policy, not host long-running execution.
+Long-running tasks must run as background jobs/subagents with pinned model policy and notify status back to chat.
+
+## Implementation outline
+
+1. Add a canonical execution policy object per session/job.
+   Include:
+   - preferred provider/model
+   - fallback policy
+   - allowed fallbacks
+   - retry budget
+   - local escape hatch list
+2. Ensure `/model` updates that policy object.
+3. On each turn/job start, resolve executor from policy.
+4. Before sending user-facing "switched" messages, verify the runtime executor actually changed.
+5. Emit one truthful status line when degradation occurs.
+6. If no healthy executor exists, fail honestly:
+   - `Switch failed; no healthy fallback available`
+   rather than pretending success.
+
+## Acceptance criteria
+
+A fix is not done until all five pass:
+1. `/model` in Telegram always changes `selected_model` state.
+2. `executed_model` is logged or surfaced for every answer/job.
+3. Silent fallback is impossible.
+4. Stale/404 models do not remain in active fallback chains.
+5. Active tasks continue as background jobs despite chat/provider issues.
+
+## Pitfalls
+
+- Do not treat UI confirmation as evidence that runtime switched.
+- Do not keep a global fallback chain active after a user explicitly picked a model unless policy allows it.
+- Do not retry a provider/model that already returned 404.
+- Do not bind task survival to the Telegram request/response lifecycle.
+
+## Useful searches
+
+Use Hermes file search instead of grep:
+- `_fallback_chain`
+- `_fallback_model`
+- `_load_fallback_model`
+- `fallback_providers`
+- `fallback_model`
+- `Rate limited — switching to fallback provider`
+- stale model identifiers such as `MiniMax-Text-01`
+
+## Outcome
+
+A truthful system may still degrade under rate limits, but it never lies about what happened. That distinction is critical when users depend on model guarantees and uninterrupted task execution.

--- a/skills/devops/windows-openssh-wsl-setup/SKILL.md
+++ b/skills/devops/windows-openssh-wsl-setup/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: windows-openssh-wsl-setup
+description: Set up OpenSSH Server on Windows 10/11 and configure WSL Ubuntu autostart at login. Use when remotely managing a Windows machine via SSH, or setting up WSL as an always-on Linux environment on a Windows host.
+tags: [windows, ssh, wsl, openssh, tailscale, devops]
+---
+
+# Windows OpenSSH + WSL Autostart Setup
+
+## Trigger
+Use when:
+- Need SSH access into a Windows 10/11 machine
+- Want WSL to start automatically at boot/login
+- Setting up a Windows laptop as a remote execution node
+
+## Key Findings (from trial and error)
+
+### WSL + Tailscale
+WSL2 on Windows automatically shares the Windows host Tailscale network.
+No separate Tailscale install needed inside WSL — Tailscale IPs are directly reachable from WSL.
+Test with: `ping <tailscale-ip>` from inside WSL.
+
+### PowerShell pitfall
+Users often copy terminal output including "PS C:\Users\...>" prompts into a new PowerShell session.
+This causes cascade parse errors. Always instruct: copy commands only, one line at a time.
+
+### Elevation required
+All OpenSSH and service commands require an elevated PowerShell session.
+Instruct: Windows key -> type "PowerShell" -> right-click -> "Run as administrator"
+
+## Steps
+
+### 1. Install and Start OpenSSH Server (admin PowerShell)
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+```
+Run each line separately. `Add-WindowsCapability` can take 30-60 seconds.
+
+### 2. Enable Password Authentication (for initial access)
+```powershell
+(Get-Content "C:\ProgramData\ssh\sshd_config") -replace '#PasswordAuthentication yes','PasswordAuthentication yes' | Set-Content "C:\ProgramData\ssh\sshd_config"
+Restart-Service sshd
+```
+
+### 3. Add SSH Public Key (passwordless access)
+```powershell
+$key = "<paste public key here>"
+$authFile = "C:\Users\sander\.ssh\authorized_keys"
+New-Item -ItemType Directory -Force -Path "C:\Users\sander\.ssh"
+Add-Content -Path $authFile -Value $key
+```
+Then fix permissions (Windows OpenSSH requires strict ACL):
+```powershell
+icacls "C:\Users\sander\.ssh\authorized_keys" /inheritance:r /grant "sander:(R)" /grant "SYSTEM:(R)"
+```
+
+### 4. WSL Autostart at Login (admin PowerShell)
+```powershell
+$action = New-ScheduledTaskAction -Execute "wsl.exe" -Argument "-d Ubuntu"
+$trigger = New-ScheduledTaskTrigger -AtLogon
+Register-ScheduledTask -TaskName "WSL Autostart" -Action $action -Trigger $trigger -RunLevel Highest
+```
+
+### 5. Test SSH from remote
+```bash
+ssh -o StrictHostKeyChecking=no sander@<tailscale-ip> "echo SSH_OK && whoami"
+```
+
+## Pitfalls
+- authorized_keys permissions: Windows OpenSSH ignores keys if ACL is wrong. Always run icacls after creating the file.
+- Run PowerShell as Administrator or ALL service/capability commands fail silently or with "elevation required".
+- Do NOT paste multi-line output back into PowerShell — only paste the command itself.
+- If sshd won't start after Add-WindowsCapability, reboot once then retry Start-Service.
+- WSL default distro name matters in -Argument: check with `wsl --list` if Ubuntu doesn't start.
+
+## Verification
+```bash
+# From Pluto/Hermes (WSL side):
+ssh sander@100.116.48.49 "echo OK"
+# Should return: OK
+```

--- a/skills/note-taking/pluto-obsidian-remote-note/SKILL.md
+++ b/skills/note-taking/pluto-obsidian-remote-note/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pluto-obsidian-remote-note
+description: Save a note into Sander's Obsidian vault on Pluto over SSH and verify the write.
+---
+
+# Pluto remote Obsidian note
+
+Use this when a result should be persisted in Sander's central Obsidian vault on Pluto instead of only being returned in chat.
+
+## Environment facts
+- Pluto SSH endpoint: `sander@100.108.223.25`
+- Preferred SSH key: `/home/sanderubuntu/.ssh/hermes_access_ed25519`
+- Obsidian vault root: `/mnt/ssd_vm/pluto/vault/`
+
+## Recommended workflow
+1. Draft the markdown note locally first.
+2. Choose the final vault folder and filename before copying.
+3. Create the remote directory with `mkdir -p` over SSH.
+4. Copy the file with `scp`.
+5. Verify success remotely with both file size and a short preview.
+6. In the user reply, report the exact final path.
+
+## Example pattern
+```bash
+ssh -i /home/sanderubuntu/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'mkdir -p "/mnt/ssd_vm/pluto/vault/04_Technologie/OpenClaw/Discord"'
+
+scp -i /home/sanderubuntu/.ssh/hermes_access_ed25519 /tmp/note.md \
+  sander@100.108.223.25:'/mnt/ssd_vm/pluto/vault/04_Technologie/OpenClaw/Discord/2026-04-08 Example.md'
+
+ssh -i /home/sanderubuntu/.ssh/hermes_access_ed25519 sander@100.108.223.25 \
+  'wc -c "/mnt/ssd_vm/pluto/vault/04_Technologie/OpenClaw/Discord/2026-04-08 Example.md" && printf "\n---\n" && head -n 8 "/mnt/ssd_vm/pluto/vault/04_Technologie/OpenClaw/Discord/2026-04-08 Example.md"'
+```
+
+## Verification standard
+Treat the note as saved only after:
+- `scp` succeeds, and
+- remote verification shows the expected file exists and contains the expected opening lines.
+
+## Optional follow-up
+If the user expected confirmation in Discord but the current chat is Telegram, schedule or send a short Discord confirmation that includes:
+- what was saved,
+- the exact Obsidian path,
+- the one-line operational summary.
+
+## Pitfalls
+- Always quote vault paths; they may contain spaces in other folders.
+- Do not claim completion before remote verification.
+- Prefer Obsidian for durable plans/runbooks; keep Discord messages brief and non-repetitive.
+- If using a prewritten local temp file, make sure the final user message reflects the remote path, not the temp path.

--- a/skills/productivity/onedrive-shared-links/SKILL.md
+++ b/skills/productivity/onedrive-shared-links/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: onedrive-shared-links
+description: Inspect and work with publicly shared OneDrive folders/files, extract useful metadata, and avoid dead ends with large folders or auth redirects.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [onedrive, shared-links, browser, file-access, troubleshooting]
+---
+
+# OneDrive Shared Links
+
+Use this skill when the user provides a public OneDrive/1drv.ms shared link and wants you to inspect files or retrieve specific documents.
+
+## What this skill is for
+
+This is best for:
+- Confirming whether a shared OneDrive link is accessible
+- Listing visible files/folders in a shared folder
+- Finding specific filenames in the shared page
+- Extracting useful internal metadata (item ids, api root hints) from the page
+- Determining the fastest next step when the folder is very large
+
+This is **not** a guarantee that every file can be downloaded directly through browser automation. OneDrive often allows listing/preview while making deep navigation or large-file retrieval awkward.
+
+## Core findings from experience
+
+1. `browser_navigate()` usually opens public OneDrive shared links successfully.
+2. `browser_snapshot(full=true)` can expose visible filenames, sizes, and folder structure in the page.
+3. Clicking deeper into large folders can be slow or time out.
+4. Direct navigation to inferred OneDrive child-folder URLs can redirect to sign-in even when the parent share is public.
+5. Useful file metadata may be embedded in HTML attributes such as `data-drop-target-key` or `data-drag-source-key`.
+6. Direct API fetching from `my.microsoftpersonalcontent.com/_api/v2.0/...` may fail from browser context due to CORS/session constraints.
+7. For large exports, it is often faster to ask the user for a narrower subfolder link or direct file links instead of crawling the whole share.
+
+## Recommended workflow
+
+### Step 1: Open the shared link
+Use browser navigation first.
+
+```json
+browser_navigate({"url":"<shared onedrive url>"})
+```
+
+### Step 2: Inspect visible items
+Take a full snapshot.
+
+```json
+browser_snapshot({"full":true})
+```
+
+Look for:
+- folder names
+- filenames
+- sizes
+- whether the user’s target file is already visible
+
+### Step 3: If the target file is visible, inspect the page state
+Use `browser_console()` to inspect DOM text and nearby metadata.
+
+Useful expressions:
+
+```js
+document.title
+```
+
+```js
+document.body.innerText.includes('target-file-name')
+```
+
+```js
+(() => {
+  const html = document.documentElement.outerHTML;
+  const idx = html.indexOf('target-file-name');
+  return idx === -1 ? null : html.slice(Math.max(0, idx - 1500), idx + 5000);
+})()
+```
+
+This can reveal internal ids like:
+- drive id
+- item id
+- API root hints
+
+## Practical heuristics
+
+### If the shared folder is large
+Do **not** spend many retries clicking through a huge export tree.
+Instead:
+- confirm access works
+- identify the visible relevant files/folders
+- ask the user for a direct link to the specific subfolder or file
+- prioritize the exact course/project folder over full history exports
+
+### If the user wants specific study/work documents
+Prefer this order:
+1. direct file link
+2. direct subfolder link
+3. top-level share crawl
+
+### If a file is huge
+For very large `.md`, `.zip`, or export files:
+- do not promise full download immediately
+- first locate the exact relevant course folder or smaller files
+- work with the minimum needed subset
+
+## Reliable outputs you can provide
+
+Even when full download is awkward, you can still provide:
+- whether the share is accessible
+- the names/sizes of visible files
+- whether a target file is present
+- which next link/request from the user would unblock efficient analysis
+
+## Good response pattern
+
+Use a grounded answer like:
+- “Ja, de OneDrive-link werkt voor mij.”
+- “Ik zie map X en bestand Y.”
+- “De snelste route is nu een directe link naar subfolder Z of naar bestand A.”
+
+Avoid claiming that you have fully downloaded or parsed a file unless you actually have.
+
+## Anti-patterns
+
+Do not:
+- assume public parent-share access means all child URLs can be navigated directly
+- promise recursive crawling of huge OneDrive exports without checking page behavior
+- claim a direct API route works just because item ids were visible in HTML
+- waste many turns brute-forcing OneDrive navigation when a narrower link would solve it faster
+
+## Escalation rule
+
+If OneDrive browsing becomes slow, redirects to sign-in, or blocks deeper retrieval:
+- stop brute force
+- report exactly what you can already see
+- request a direct subfolder/file link
+- continue from there
+
+## Best-fit use case discovered
+
+For academic or project support, shared OneDrive works best when the user gives:
+- a direct subfolder like `05_opleiding`
+- or direct links to the exact documents for the current task
+
+That is faster and more reliable than mining a full chat/export archive first.

--- a/skills/social-media/discord-webhook-validation/SKILL.md
+++ b/skills/social-media/discord-webhook-validation/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: discord-webhook-validation
+description: Safely validate a Discord webhook by fetching its metadata first, confirm whether it can post, and avoid storing leaked webhook secrets.
+---
+
+# Discord webhook validation
+
+Use this when a user shares a Discord webhook and wants to know whether the setup is correct.
+
+## Goals
+- Verify whether the webhook is valid without sending a message yet.
+- Distinguish clearly between posting capability and read capability.
+- Treat the webhook URL/token as sensitive and avoid persisting it.
+
+## Procedure
+1. **Do not store the raw webhook URL or token in memory.**
+   - Webhook URLs are secrets.
+   - If the user pasted one in chat, treat it as potentially leaked.
+
+2. **Validate by GET request first, not POST.**
+   - Use a simple HTTP GET against the webhook URL.
+   - A valid webhook usually returns HTTP 200 and JSON metadata including:
+     - `id`
+     - `name`
+     - `channel_id`
+     - `guild_id`
+     - `type`
+   - This confirms the webhook exists and can be used for posting to that bound channel.
+
+3. **Explain the result in plain language.**
+   - If GET returns 200: tell the user the webhook is valid and identify the webhook name/channel/server IDs if available.
+   - If unauthorized / not found: tell the user the webhook is invalid, deleted, malformed, or revoked.
+
+4. **Clarify the capability boundary.**
+   - Discord webhook = can post to a specific channel.
+   - Discord webhook != read existing channel messages.
+   - Reading requires a bot/integration with channel permissions.
+
+5. **Recommend secret rotation after exposure.**
+   - If a webhook was pasted into chat, advise the user to regenerate/rotate it in Discord.
+   - Explain briefly that anyone with the URL can post to that channel.
+
+6. **Only send a test message if the user explicitly wants that.**
+   - Default to non-posting validation first.
+   - If posting, make the message clearly labeled as a test.
+
+## Example validation command
+Use terminal or equivalent HTTP tooling:
+
+```bash
+python - <<'PY'
+import urllib.request
+url='https://discord.com/api/webhooks/...'
+req=urllib.request.Request(url, headers={'User-Agent':'Hermes'})
+with urllib.request.urlopen(req, timeout=20) as r:
+    print(r.status)
+    print(r.read().decode('utf-8','replace'))
+PY
+```
+
+## Response template
+- “Ja — deze webhook werkt.”
+- Mention `name`, `guild_id`, and `channel_id` if returned.
+- Add: “Belangrijk: deze URL is een geheim; omdat hij gedeeld is, raad ik aan hem te regenereren.”
+- Add: “Met deze webhook kan ik posten, niet lezen.”
+
+## Pitfalls
+- Do not claim read access from webhook validation.
+- Do not save raw webhook secrets in memory or skills.
+- Do not send a test post unless the user asked for it.

--- a/skills/software-development/session-recovery-and-state-validation/SKILL.md
+++ b/skills/software-development/session-recovery-and-state-validation/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: session-recovery-and-state-validation
+description: Recover an exact prior user prompt or intent from Hermes session history, then validate the present filesystem/host state so you can distinguish lost context from lost implementation.
+tags: [sessions, recall, recovery, validation, ssh, git, mission-control]
+---
+
+# Session recovery and state validation
+
+Use this when:
+- The user says a PC/server reboot or crash may have lost prior instructions
+- The user asks "can you still see my prompt?" or references earlier work that may be missing
+- You need to confirm whether only chat context was interrupted, or whether scripts/config/repos were actually lost
+- You need to recover a Mission Control / UI intent that another agent implemented incorrectly
+
+## Goal
+Recover the exact instruction or closest authoritative wording from prior sessions, then verify the current machine/repo state so the answer is grounded in evidence rather than memory alone.
+
+## Recommended workflow
+
+1. Search cross-session history first
+- Use `session_search` with broad OR queries combining nouns from the user’s request.
+- Example patterns:
+  - `Pluto OR Henry OR scripts OR configwijzigingen OR prompt`
+  - `"Mission Control" OR mission-control OR responsive OR device OR split mockup OR Cursor`
+- Prefer `role_filter=user,assistant` when you only need human/assistant narrative.
+
+2. Find the exact quoted prompt in raw session files
+- If the summary is not precise enough, inspect `~/.hermes/sessions/session_*.json` directly.
+- Use `search_files` on the session JSONs to find distinctive fragments.
+- Then use `read_file` around the matching line range to recover the exact user wording.
+- This is the most reliable way to answer “can you still see my prompt?” with proof.
+
+3. Distinguish intent recovery from implementation recovery
+- After recovering the prompt, explicitly separate:
+  - recovered instruction/intent
+  - current implementation state on disk/hosts
+- Do not assume that because the prompt exists, the implementation was completed.
+
+4. Validate the current host state with live checks
+- For local/WSL state, use `terminal`.
+- For remote Pluto/Henry state, use SSH via the known Hermes key.
+- Check the exact folders/repos named in the recovered prompt.
+- For Mission Control-style tasks, inspect:
+  - repo presence
+  - current branch
+  - remotes
+  - tracked/untracked changes
+  - key source files (`page.tsx`, layout files, config files, package.json)
+
+5. When checking whether an editor/tool is really installed, verify multiple signals
+- Don’t rely on one signal.
+- For Cursor on Linux/Pluto, check:
+  - `command -v cursor`
+  - desktop entries (`~/.local/share/applications`, `/usr/share/applications`)
+  - install directories (`~/.local/opt/cursor`, `/usr/share/cursor`)
+- For Windows from WSL, query PowerShell for:
+  - `Get-Command`
+  - installed app registry entries
+  - expected EXE paths
+- Report absence clearly if all checks are empty.
+
+6. For UI misimplementation claims, inspect the code before concluding
+- If the user says another agent misunderstood a responsive mockup/example, open the real UI source files.
+- Look for evidence like:
+  - manual layout toggles
+  - separate layout variants (A / C / A+C)
+  - literal split-screen rendering
+  - missing device-aware breakpoints
+- Then restate the intended behavior in plain language:
+  - one responsive app
+  - mobile shows mobile experience
+  - desktop shows desktop experience
+  - experimental variants are UX modes, not literal side-by-side mockups
+
+7. Answer in three parts
+Structure the response as:
+- What I recovered from your prior prompt
+- What I verified in the current environment
+- My single recommendation / next action
+
+## Useful command patterns
+
+Recover exact prior prompt from session JSON:
+- `search_files(pattern="Mission Control|telefon|desktop versie|split test", target="content", path="~/.hermes/sessions", file_glob="session_*.json")`
+- `read_file(path="~/.hermes/sessions/session_<id>.json", offset=<near-match>, limit=40)`
+
+Check Pluto Mission Control repo state:
+- `ssh -i ~/.ssh/hermes_access_ed25519 -o BatchMode=yes sander@100.108.223.25 'cd ~/.openclaw/workspace/mission-control && git rev-parse --is-inside-work-tree && git status --short && git remote -v && git branch --show-current'`
+
+Check Cursor on Pluto:
+- `ssh -i ~/.ssh/hermes_access_ed25519 -o BatchMode=yes sander@100.108.223.25 'command -v cursor || true; find ~/.local/share/applications /usr/share/applications -maxdepth 1 -iname "*cursor*.desktop" 2>/dev/null; find ~/.local /opt /usr/share -maxdepth 3 \( -iname "*cursor*" -o -iname cursor \) 2>/dev/null | sed -n "1,40p"'`
+
+Check Windows-side Cursor from WSL:
+- `powershell.exe -NoProfile -Command '$cursor = Get-Command cursor -ErrorAction SilentlyContinue; $cursorExe = Get-ChildItem "$env:LOCALAPPDATA\Programs\Cursor\Cursor.exe" -ErrorAction SilentlyContinue; $cursorApp = Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*" -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -like "*Cursor*" } | Select-Object DisplayName, DisplayVersion, InstallLocation; ...'`
+
+## Pitfalls
+- `session_search` summaries are excellent for orientation, but not enough when the user asks for the exact prompt text.
+- Session JSON grep results can be noisy because tool schemas also contain words like `prompt`; narrow to distinctive user phrases when possible.
+- `printf '---'` over SSH can fail because leading dashes are parsed as options in some shells; prefer `echo` for separators.
+- A repo can be a git worktree but still have no remote configured. Always check both `git status` and `git remote -v`.
+- When checking Windows apps from WSL, empty PowerShell output usually means “not detected”, not tool failure, if the exit code is 0.
+
+## Success criteria
+You should end with evidence-backed statements such as:
+- the exact recovered user prompt
+- whether the current implementation exists on disk
+- whether the target tool/editor is actually installed
+- whether the repo is properly connected to GitHub or still only local
+- whether the current code matches the user’s intended outcome or reflects a misunderstanding


### PR DESCRIPTION
Samenvatting:
- voeg 15 lokale skills toe die wel in ~/.hermes/skills staan maar nog niet in de repo stonden
- houdt repo en lokale skill-catalogus beter in sync

Herkomst:
- vergeleken repo skills/ met ~/.hermes/skills
- index/cache-bestanden bewust niet meegenomen

Validatie:
- vergeleken sets opnieuw: geen inhoudelijke skill-bestanden meer missing in repo