### PR TITLE
feat: native multimodal vision routing for vision-capable models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -786,15 +786,21 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
         if not or_key:
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
+        logger.debug("Auxiliary client: OpenRouter via pool (base_url=%s)", base_url)
         return OpenAI(api_key=or_key, base_url=base_url,
                        default_headers=_OR_HEADERS), _OPENROUTER_MODEL
 
     or_key = os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
-    logger.debug("Auxiliary client: OpenRouter")
-    return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
+    # Respect OPENROUTER_BASE_URL env override the same way the main agent
+    # path does. Without this, users who route their OpenRouter key through
+    # an alternate endpoint (Nous Portal, custom proxy, OR-compatible mirror)
+    # see the auxiliary client silently call the canonical openrouter.ai
+    # endpoint with the wrong key, get 401, and exhaust the credential pool.
+    or_base_url = os.getenv("OPENROUTER_BASE_URL") or OPENROUTER_BASE_URL
+    logger.debug("Auxiliary client: OpenRouter (base_url=%s)", or_base_url)
+    return OpenAI(api_key=or_key, base_url=or_base_url,
                    default_headers=_OR_HEADERS), _OPENROUTER_MODEL
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1193,6 +1193,15 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         if token:
             source = "env:OPENROUTER_API_KEY"
             active_sources.add(source)
+            # Honor OPENROUTER_BASE_URL env override the same way the
+            # generic seeding path below honors per-provider base URL env
+            # vars.  Without this, users who route their OpenRouter API
+            # key through an alternate endpoint (Nous Portal, custom
+            # OR-compatible proxy) get a pool entry with a Nous key but
+            # the canonical openrouter.ai URL — every auxiliary call then
+            # returns 401 ``Missing Authentication header``.
+            env_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip().rstrip("/")
+            base_url = env_base_url or OPENROUTER_BASE_URL
             changed |= _upsert_entry(
                 entries,
                 provider,
@@ -1201,7 +1210,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
                     "source": source,
                     "auth_type": AUTH_TYPE_API_KEY,
                     "access_token": token,
-                    "base_url": OPENROUTER_BASE_URL,
+                    "base_url": base_url,
                     "label": "OPENROUTER_API_KEY",
                 },
             )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1065,6 +1065,17 @@ _IMAGE_CONTENT_CHARS = 6000
 _AUDIO_CONTENT_CHARS = 2000
 
 
+# Approximate dict serialization overhead (braces, quotes, field name
+# wrappers, separators). Empirically derived from comparing
+# ``len(str(msg))`` against our field-by-field count for typical chat
+# messages — averages to ~30 chars for a user turn and ~40 chars per
+# tool call. Without this overhead the new estimator under-reports
+# tool-heavy conversations by 60-75% compared to the legacy formula,
+# making preflight compression and budget checks fire far too late.
+_MESSAGE_DICT_OVERHEAD_CHARS = 30
+_TOOL_CALL_WRAPPER_CHARS = 40
+
+
 def count_message_chars(msg: Any) -> int:
     """Count characters in a message, skipping base64 image/audio payloads.
 
@@ -1075,8 +1086,10 @@ def count_message_chars(msg: Any) -> int:
     or trip false context-overflow checks.
 
     Walks the structure: counts text fields directly, applies fixed
-    per-image / per-audio budgets, and falls back to ``len(str(value))``
-    for unrecognized scalar fields.
+    per-image / per-audio budgets for media blocks, and includes dict
+    serialization overhead so non-image messages stay approximately
+    in line with the legacy ``len(str(msg))`` behaviour the compressor
+    and preflight checks were calibrated against.
     """
     if msg is None:
         return 0
@@ -1085,7 +1098,10 @@ def count_message_chars(msg: Any) -> int:
     if not isinstance(msg, dict):
         return len(str(msg))
 
-    total = 0
+    # Start with a small per-message overhead to account for the dict
+    # braces, quoted field names, and separators that the legacy
+    # ``len(str(msg))`` formula implicitly counted.
+    total = _MESSAGE_DICT_OVERHEAD_CHARS
     content = msg.get("content")
     if isinstance(content, str):
         total += len(content)
@@ -1127,6 +1143,7 @@ def count_message_chars(msg: Any) -> int:
         for tc in tool_calls:
             if not isinstance(tc, dict):
                 continue
+            total += _TOOL_CALL_WRAPPER_CHARS
             fn = tc.get("function", {})
             if isinstance(fn, dict):
                 total += len(str(fn.get("name", "")))

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1056,9 +1056,88 @@ def estimate_tokens_rough(text: str) -> int:
     return (len(text) + 3) // 4
 
 
+# Approximate character budgets for non-text content blocks. Expressed
+# in characters because the rough estimator divides by 4 to get tokens.
+# - Image: ~1500 tokens average across providers (Anthropic ~1500,
+#   OpenAI ~85-1500 per tile, Gemini ~258). 6000 chars ≈ 1500 tokens.
+# - Audio: ~500 tokens per segment is a sane upper bound for most STT.
+_IMAGE_CONTENT_CHARS = 6000
+_AUDIO_CONTENT_CHARS = 2000
+
+
+def count_message_chars(msg: Any) -> int:
+    """Count characters in a message, skipping base64 image/audio payloads.
+
+    Multimodal messages can carry data: URLs that contain hundreds of
+    KB of base64. ``len(str(msg))`` would count every base64 character
+    as a billable text character, which inflates the token estimate by
+    100-300x and causes the compressor to wipe vision turns immediately
+    or trip false context-overflow checks.
+
+    Walks the structure: counts text fields directly, applies fixed
+    per-image / per-audio budgets, and falls back to ``len(str(value))``
+    for unrecognized scalar fields.
+    """
+    if msg is None:
+        return 0
+    if isinstance(msg, str):
+        return len(msg)
+    if not isinstance(msg, dict):
+        return len(str(msg))
+
+    total = 0
+    content = msg.get("content")
+    if isinstance(content, str):
+        total += len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, str):
+                total += len(block)
+                continue
+            if not isinstance(block, dict):
+                total += len(str(block))
+                continue
+            btype = str(block.get("type", "") or "")
+            if btype in ("text", "input_text"):
+                text = block.get("text", "")
+                if isinstance(text, str):
+                    total += len(text)
+            elif btype in ("image_url", "input_image", "image"):
+                total += _IMAGE_CONTENT_CHARS
+            elif btype in ("input_audio", "audio"):
+                total += _AUDIO_CONTENT_CHARS
+            else:
+                # Unknown block — count its serialized form, but skip
+                # any data: URL payloads to stay safe.
+                total += sum(
+                    len(str(v)) for k, v in block.items()
+                    if k != "image_url" and not (
+                        isinstance(v, str) and v.startswith("data:")
+                    )
+                )
+
+    # Account for role + tool plumbing fields (small but non-zero).
+    for key in ("role", "tool_call_id", "tool_name", "name"):
+        v = msg.get(key)
+        if isinstance(v, str):
+            total += len(v)
+
+    tool_calls = msg.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function", {})
+            if isinstance(fn, dict):
+                total += len(str(fn.get("name", "")))
+                total += len(str(fn.get("arguments", "")))
+
+    return total
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only)."""
-    total_chars = sum(len(str(msg)) for msg in messages)
+    total_chars = sum(count_message_chars(msg) for msg in messages)
     return (total_chars + 3) // 4
 
 
@@ -1079,7 +1158,7 @@ def estimate_request_tokens_rough(
     if system_prompt:
         total_chars += len(system_prompt)
     if messages:
-        total_chars += sum(len(str(msg)) for msg in messages)
+        total_chars += sum(count_message_chars(msg) for msg in messages)
     if tools:
         total_chars += len(str(tools))
     return (total_chars + 3) // 4

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -347,7 +347,16 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
 
 
 def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry by exact match, then case-insensitive fallback."""
+    """Find a model entry by exact match, then case-insensitive fallback,
+    then dot/hyphen-normalized match.
+
+    Different catalogs use different conventions for version separators:
+    Anthropic's catalog spells the latest Sonnet as ``claude-sonnet-4-6``
+    (hyphens) while OpenRouter's catalog uses ``anthropic/claude-sonnet-4.6``
+    (dots).  Users typing either form should resolve to the same entry,
+    so we try a normalized version where dots and hyphens are
+    interchangeable.
+    """
     # Exact match
     entry = models.get(model)
     if isinstance(entry, dict):
@@ -357,6 +366,17 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
     model_lower = model.lower()
     for mid, mdata in models.items():
         if mid.lower() == model_lower and isinstance(mdata, dict):
+            return mdata
+
+    # Dot/hyphen normalized match: collapse both dots and hyphens to a
+    # single separator and compare. ``claude-sonnet-4.6`` and
+    # ``claude-sonnet-4-6`` both normalize to ``claude_sonnet_4_6``.
+    def _norm(s: str) -> str:
+        return s.lower().replace(".", "_").replace("-", "_")
+
+    target = _norm(model)
+    for mid, mdata in models.items():
+        if _norm(mid) == target and isinstance(mdata, dict):
             return mdata
 
     return None

--- a/cli.py
+++ b/cli.py
@@ -3422,14 +3422,53 @@ class HermesCLI:
         elif _is_termux_environment():
             _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {_termux_example_image_path(image_path.name)} \"What do you see?\"{_RST}")
 
+    def _build_native_vision_content_cli(self, text: str, images: list) -> list:
+        """Build a multimodal content list (text + image_url blocks) for vision-capable models.
+
+        Used in place of ``_preprocess_images_with_vision`` when the active
+        model declares native vision support.  Reads each image into a
+        base64 data URL via the existing helper and emits OpenAI-style
+        ``image_url`` content blocks.  The provider adapter converts these
+        into the right native format (Anthropic image blocks, OpenAI
+        image_url, Codex input_image, etc.).
+
+        Bad image paths are skipped with a warning rather than failing the
+        whole submission.
+        """
+        from tools.vision_tools import _image_to_base64_data_url
+
+        blocks: list = []
+        if isinstance(text, str) and text:
+            blocks.append({"type": "text", "text": text})
+
+        for img_path in images:
+            if not img_path.exists():
+                _cprint(f"  {_DIM}⚠ image not found, skipping: {img_path.name}{_RST}")
+                continue
+            try:
+                data_url = _image_to_base64_data_url(img_path)
+            except Exception as exc:
+                _cprint(f"  {_DIM}⚠ failed to encode {img_path.name}: {exc}{_RST}")
+                continue
+            blocks.append({
+                "type": "image_url",
+                "image_url": {"url": data_url},
+            })
+
+        # If no images encoded successfully and no caption, fall back to a
+        # placeholder so the model isn't sent an empty message.
+        if not blocks:
+            return text or "What do you see in this image?"
+        return blocks
+
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 
-        Instead of embedding raw base64 ``image_url`` content parts in the
-        conversation (which only works with vision-capable models), this
-        pre-processes each image through the auxiliary vision model (Gemini
-        Flash) and prepends the descriptions to the user's message — the
-        same approach the messaging gateway uses.
+        Legacy fallback for non-vision models: each image goes through the
+        auxiliary vision model (Gemini Flash) and the resulting text
+        description gets prepended to the user's message.  Vision-capable
+        models should use ``_build_native_vision_content_cli`` instead so
+        the actual pixels reach the model.
 
         The local file path is included so the agent can re-examine the
         image later with ``vision_analyze`` if needed.
@@ -7467,13 +7506,24 @@ class HermesCLI:
         ):
             return None
         
-        # Pre-process images through the vision tool (Gemini Flash) so the
-        # main model receives text descriptions instead of raw base64 image
-        # content — works with any model, not just vision-capable ones.
+        # Image handling: vision-capable models get native multimodal
+        # content blocks (actual pixels reach the model); other models
+        # fall back to the vision_analyze text-description path.
         if images:
-            message = self._preprocess_images_with_vision(
-                message if isinstance(message, str) else "", images
-            )
+            _use_native = False
+            try:
+                if self.agent is not None:
+                    _use_native = self.agent._model_supports_native_vision()
+            except Exception as _exc:
+                logging.debug("CLI native vision capability check failed: %s", _exc)
+            if _use_native:
+                message = self._build_native_vision_content_cli(
+                    message if isinstance(message, str) else "", images
+                )
+            else:
+                message = self._preprocess_images_with_vision(
+                    message if isinstance(message, str) else "", images
+                )
 
         # Expand @ context references (e.g. @file:main.py, @diff, @folder:src/)
         if isinstance(message, str) and "@" in message:

--- a/cli.py
+++ b/cli.py
@@ -3422,42 +3422,49 @@ class HermesCLI:
         elif _is_termux_environment():
             _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {_termux_example_image_path(image_path.name)} \"What do you see?\"{_RST}")
 
-    def _build_native_vision_content_cli(self, text: str, images: list) -> list:
+    def _build_native_vision_content_cli(self, text: str, images: list):
         """Build a multimodal content list (text + image_url blocks) for vision-capable models.
 
         Used in place of ``_preprocess_images_with_vision`` when the active
-        model declares native vision support.  Reads each image into a
-        base64 data URL via the existing helper and emits OpenAI-style
-        ``image_url`` content blocks.  The provider adapter converts these
-        into the right native format (Anthropic image blocks, OpenAI
-        image_url, Codex input_image, etc.).
+        model declares native vision support.  Auto-resizes each image
+        if the encoded size would exceed the standard vision budget,
+        then emits OpenAI-style ``image_url`` content blocks with
+        ``detail: "auto"`` set explicitly so providers don't silently
+        default to "high" on large screenshots.  The provider adapter
+        converts these into the right native format (Anthropic image
+        blocks, OpenAI image_url, Codex input_image, etc.).
 
         Bad image paths are skipped with a warning rather than failing the
-        whole submission.
+        whole submission.  Returns a list of content blocks, or a plain
+        string (caption or placeholder) if every image fails.
         """
-        from tools.vision_tools import _image_to_base64_data_url
+        from tools.vision_tools import _resize_image_for_vision
 
         blocks: list = []
         if isinstance(text, str) and text:
             blocks.append({"type": "text", "text": text})
 
+        encoded_count = 0
         for img_path in images:
             if not img_path.exists():
                 _cprint(f"  {_DIM}⚠ image not found, skipping: {img_path.name}{_RST}")
                 continue
             try:
-                data_url = _image_to_base64_data_url(img_path)
+                # Auto-resizes if the encoded size exceeds the standard
+                # ~5MB budget. Returns a ready-to-send data URL.
+                data_url = _resize_image_for_vision(img_path)
             except Exception as exc:
                 _cprint(f"  {_DIM}⚠ failed to encode {img_path.name}: {exc}{_RST}")
                 continue
             blocks.append({
                 "type": "image_url",
-                "image_url": {"url": data_url},
+                "image_url": {"url": data_url, "detail": "auto"},
             })
+            encoded_count += 1
 
-        # If no images encoded successfully and no caption, fall back to a
-        # placeholder so the model isn't sent an empty message.
-        if not blocks:
+        # If no images encoded successfully, fall back to the caption
+        # text or a placeholder so the model isn't sent an empty message.
+        if encoded_count == 0:
             return text or "What do you see in this image?"
         return blocks
 
@@ -7517,10 +7524,18 @@ class HermesCLI:
             except Exception as _exc:
                 logging.debug("CLI native vision capability check failed: %s", _exc)
             if _use_native:
+                logging.info(
+                    "[vision] route=native model=%s images=%d",
+                    self.model, len(images),
+                )
                 message = self._build_native_vision_content_cli(
                     message if isinstance(message, str) else "", images
                 )
             else:
+                logging.info(
+                    "[vision] route=legacy_analyze model=%s images=%d",
+                    self.model, len(images),
+                )
                 message = self._preprocess_images_with_vision(
                     message if isinstance(message, str) else "", images
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6898,10 +6898,9 @@ class GatewayRunner:
         Resolution order:
         1. ``HERMES_FORCE_NATIVE_VISION=1`` → always True.
         2. Direct lookup ``(provider, model)`` in models.dev catalog.
-        3. Provider-prefix fallback: when the model name has a vendor
-           prefix (``"anthropic/claude-sonnet-4.6"``) and the provider
-           itself isn't catalogued (Nous, custom proxies), split on
-           ``/`` and try the upstream vendor's catalog.
+        3. Upstream vendor catalog fallback when model has a vendor slug.
+        4. OpenRouter aggregator catalog fallback (Nous and most custom
+           proxies share the OpenRouter slug format).
         """
         if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
             return True
@@ -6916,13 +6915,15 @@ class GatewayRunner:
         try:
             from agent.models_dev import get_model_capabilities
             caps = get_model_capabilities(provider, model)
-            if caps is not None:
-                return bool(caps.supports_vision)
-            if "/" in model:
+            if caps is None and "/" in model:
+                # Upstream vendor fallback
                 vendor, vendor_model = model.split("/", 1)
                 caps = get_model_capabilities(vendor, vendor_model)
-                if caps is not None:
-                    return bool(caps.supports_vision)
+            if caps is None and "/" in model and provider != "openrouter":
+                # OpenRouter aggregator catalog fallback
+                caps = get_model_capabilities("openrouter", model)
+            if caps is not None:
+                return bool(caps.supports_vision)
             return False
         except Exception as exc:
             logger.debug("native_vision: capability lookup failed for %s/%s: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26,7 +26,7 @@ import threading
 import time
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Union
 
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
@@ -2973,10 +2973,20 @@ class GatewayRunner:
                     # actual pixels reach the model instead of a lossy text
                     # description.  Models that don't declare native vision
                     # support fall through to the legacy text-flatten path.
+                    logger.info(
+                        "[vision] route=native platform=%s images=%d",
+                        source.platform.value if source.platform else "?",
+                        len(image_paths),
+                    )
                     message_text = self._build_native_vision_content(
                         message_text, image_paths,
                     )
                 else:
+                    logger.info(
+                        "[vision] route=legacy_analyze platform=%s images=%d",
+                        source.platform.value if source.platform else "?",
+                        len(image_paths),
+                    )
                     message_text = await self._enrich_message_with_vision(
                         message_text,
                         image_paths,
@@ -6934,18 +6944,22 @@ class GatewayRunner:
         self,
         user_text: str,
         image_paths: List[str],
-    ) -> List[Dict[str, Any]]:
+    ) -> Union[str, List[Dict[str, Any]]]:
         """Build a multimodal content list for vision-capable models.
 
-        Reads each image into a base64 data URL and emits an OpenAI-style
-        ``image_url`` content block.  The agent's provider adapter
-        converts these into the right native format (Anthropic image
-        blocks, OpenAI image_url, Codex input_image, etc.).
+        Reads each image into a base64 data URL (auto-resizing if the
+        encoded size would exceed the vision tool's standard budget)
+        and emits an OpenAI-style ``image_url`` content block with
+        ``detail: "auto"`` set explicitly so providers don't silently
+        default to "high" for large screenshots and balloon the bill.
 
         The user's caption text is included as the first block when
         non-empty so the model has a prompt alongside the images.
+
+        Returns a list of content blocks normally, or a plain string
+        (the caption, or empty) when every image fails to encode.
         """
-        from tools.vision_tools import _image_to_base64_data_url
+        from tools.vision_tools import _resize_image_for_vision
 
         blocks: List[Dict[str, Any]] = []
         if user_text:
@@ -6953,7 +6967,9 @@ class GatewayRunner:
 
         for path in image_paths:
             try:
-                data_url = _image_to_base64_data_url(Path(path))
+                # Auto-resizes if the encoded size exceeds the standard
+                # ~5MB budget. Returns a ready-to-send data URL.
+                data_url = _resize_image_for_vision(Path(path))
             except Exception as exc:
                 logger.warning(
                     "native_vision: failed to encode %s, skipping image: %s",
@@ -6962,13 +6978,13 @@ class GatewayRunner:
                 continue
             blocks.append({
                 "type": "image_url",
-                "image_url": {"url": data_url},
+                "image_url": {"url": data_url, "detail": "auto"},
             })
 
-        # If no images encoded successfully and no caption, fall back to
-        # an empty string so downstream callers handle it normally.
-        if not blocks:
-            return ""  # type: ignore[return-value]
+        # If no images encoded successfully, fall back to the caption
+        # text (or empty string) so downstream callers handle it normally.
+        if len(blocks) <= (1 if user_text else 0):
+            return user_text or ""
         return blocks
 
     async def _enrich_message_with_vision(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2934,12 +2934,17 @@ class GatewayRunner:
         event: MessageEvent,
         source: SessionSource,
         history: List[Dict[str, Any]],
-    ) -> Optional[str]:
+    ) -> Optional[Any]:
         """Prepare inbound event text for the agent.
 
         Keep the normal inbound path and the queued follow-up path on the same
         preprocessing pipeline so sender attribution, image enrichment, STT,
         document notes, reply context, and @ references all behave the same.
+
+        Returns either a plain ``str`` (legacy text-only path) or a ``list``
+        of multimodal content blocks (text + image_url) when the active model
+        supports native vision and the event includes image attachments.
+        Both shapes flow through ``_run_agent → run_conversation`` unchanged.
         """
         history = history or []
         message_text = event.text or ""
@@ -2963,10 +2968,19 @@ class GatewayRunner:
                     audio_paths.append(path)
 
             if image_paths:
-                message_text = await self._enrich_message_with_vision(
-                    message_text,
-                    image_paths,
-                )
+                if self._should_use_native_vision_for_source(source):
+                    # Native multimodal: build typed content blocks so the
+                    # actual pixels reach the model instead of a lossy text
+                    # description.  Models that don't declare native vision
+                    # support fall through to the legacy text-flatten path.
+                    message_text = self._build_native_vision_content(
+                        message_text, image_paths,
+                    )
+                else:
+                    message_text = await self._enrich_message_with_vision(
+                        message_text,
+                        image_paths,
+                    )
 
             if audio_paths:
                 message_text = await self._enrich_message_with_transcription(
@@ -3534,11 +3548,12 @@ class GatewayRunner:
 
         try:
             # Emit agent:start hook
+            _msg_preview = self._message_preview_for_hook(message_text)
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
-                "message": message_text[:500],
+                "message": _msg_preview[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
@@ -6845,6 +6860,104 @@ class GatewayRunner:
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
     
+    @staticmethod
+    def _message_preview_for_hook(message: Any) -> str:
+        """Flatten str-or-multimodal-list message to a hook-safe text preview."""
+        if message is None:
+            return ""
+        if isinstance(message, str):
+            return message
+        if not isinstance(message, list):
+            return str(message)
+        parts: List[str] = []
+        for block in message:
+            if isinstance(block, str):
+                if block:
+                    parts.append(block)
+                continue
+            if not isinstance(block, dict):
+                continue
+            btype = str(block.get("type", "") or "")
+            if btype in ("text", "input_text"):
+                t = block.get("text", "")
+                if isinstance(t, str) and t:
+                    parts.append(t)
+            elif btype in ("image_url", "input_image", "image"):
+                parts.append("[image]")
+            elif btype in ("input_audio", "audio"):
+                parts.append("[audio]")
+        return " ".join(parts).strip()
+
+    def _should_use_native_vision_for_source(self, source: SessionSource) -> bool:
+        """True if the model selected for this source declares native vision.
+
+        Honors the same per-session model overrides as the actual agent
+        runtime so the gateway routes images consistently with the model
+        the agent will use for this turn.
+
+        ``HERMES_FORCE_NATIVE_VISION=1`` forces True for users on
+        self-hosted vision models that aren't catalogued in models.dev.
+        """
+        if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
+            return True
+        try:
+            model, runtime_kwargs = self._resolve_session_agent_runtime(source=source)
+        except Exception as exc:
+            logger.debug("native_vision: runtime resolution failed: %s", exc)
+            return False
+        provider = (runtime_kwargs.get("provider") or "") if runtime_kwargs else ""
+        if not model:
+            return False
+        try:
+            from agent.models_dev import get_model_capabilities
+            caps = get_model_capabilities(provider, model)
+            return bool(caps and caps.supports_vision)
+        except Exception as exc:
+            logger.debug("native_vision: capability lookup failed for %s/%s: %s",
+                         provider, model, exc)
+            return False
+
+    def _build_native_vision_content(
+        self,
+        user_text: str,
+        image_paths: List[str],
+    ) -> List[Dict[str, Any]]:
+        """Build a multimodal content list for vision-capable models.
+
+        Reads each image into a base64 data URL and emits an OpenAI-style
+        ``image_url`` content block.  The agent's provider adapter
+        converts these into the right native format (Anthropic image
+        blocks, OpenAI image_url, Codex input_image, etc.).
+
+        The user's caption text is included as the first block when
+        non-empty so the model has a prompt alongside the images.
+        """
+        from tools.vision_tools import _image_to_base64_data_url
+
+        blocks: List[Dict[str, Any]] = []
+        if user_text:
+            blocks.append({"type": "text", "text": user_text})
+
+        for path in image_paths:
+            try:
+                data_url = _image_to_base64_data_url(Path(path))
+            except Exception as exc:
+                logger.warning(
+                    "native_vision: failed to encode %s, skipping image: %s",
+                    path, exc,
+                )
+                continue
+            blocks.append({
+                "type": "image_url",
+                "image_url": {"url": data_url},
+            })
+
+        # If no images encoded successfully and no caption, fall back to
+        # an empty string so downstream callers handle it normally.
+        if not blocks:
+            return ""  # type: ignore[return-value]
+        return blocks
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -7251,7 +7364,7 @@ class GatewayRunner:
 
     async def _run_agent(
         self,
-        message: str,
+        message: Any,
         context_prompt: str,
         history: List[Dict[str, Any]],
         source: SessionSource,
@@ -7262,6 +7375,11 @@ class GatewayRunner:
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
+
+        ``message`` may be a plain string OR a list of multimodal content
+        blocks (text + image_url) when the active model declares native
+        vision support and the source platform attached an image. Both
+        shapes flow through to ``run_conversation`` unchanged.
         
         Returns the full result dict from run_conversation, including:
           - "final_response": str (the text to send back)
@@ -7930,7 +8048,12 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                if isinstance(message, list):
+                    # Multimodal: prepend the note as a text block so the
+                    # image content blocks remain intact
+                    message = [{"type": "text", "text": _msn + "\n\n"}] + list(message)
+                else:
+                    message = _msn + "\n\n" + message
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
@@ -8040,10 +8163,13 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
+                    # Title generator expects a plain text user_message;
+                    # flatten multimodal content to its text preview.
+                    _title_user_msg = self._message_preview_for_hook(message)
                     maybe_auto_title(
                         self._session_db,
                         effective_session_id,
-                        message,
+                        _title_user_msg,
                         final_response,
                         all_msgs,
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6895,8 +6895,13 @@ class GatewayRunner:
         runtime so the gateway routes images consistently with the model
         the agent will use for this turn.
 
-        ``HERMES_FORCE_NATIVE_VISION=1`` forces True for users on
-        self-hosted vision models that aren't catalogued in models.dev.
+        Resolution order:
+        1. ``HERMES_FORCE_NATIVE_VISION=1`` → always True.
+        2. Direct lookup ``(provider, model)`` in models.dev catalog.
+        3. Provider-prefix fallback: when the model name has a vendor
+           prefix (``"anthropic/claude-sonnet-4.6"``) and the provider
+           itself isn't catalogued (Nous, custom proxies), split on
+           ``/`` and try the upstream vendor's catalog.
         """
         if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
             return True
@@ -6911,7 +6916,14 @@ class GatewayRunner:
         try:
             from agent.models_dev import get_model_capabilities
             caps = get_model_capabilities(provider, model)
-            return bool(caps and caps.supports_vision)
+            if caps is not None:
+                return bool(caps.supports_vision)
+            if "/" in model:
+                vendor, vendor_model = model.split("/", 1)
+                caps = get_model_capabilities(vendor, vendor_model)
+                if caps is not None:
+                    return bool(caps.supports_vision)
+            return False
         except Exception as exc:
             logger.debug("native_vision: capability lookup failed for %s/%s: %s",
                          provider, model, exc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,67 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
+
+
+def _extract_searchable_text(content: Any) -> str:
+    """Flatten multimodal content to a plain text representation.
+
+    Used for the legacy ``content`` TEXT column so FTS5 search keeps
+    working when a message carries image/audio blocks alongside text.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: List[str] = []
+    for block in content:
+        if isinstance(block, str):
+            if block:
+                parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type", "") or "")
+        if btype in ("text", "input_text"):
+            text = block.get("text", "")
+            if isinstance(text, str) and text:
+                parts.append(text)
+        elif btype in ("image_url", "input_image", "image"):
+            parts.append("[image]")
+        elif btype in ("input_audio", "audio"):
+            parts.append("[audio]")
+    return " ".join(parts).strip()
+
+
+def _serialize_message_content(content: Any) -> tuple:
+    """Convert message content to a (text, blocks_json) DB tuple.
+
+    Plain string content is stored as-is in ``content`` for backwards
+    compat and FTS5 searchability.  Multimodal list/dict content is
+    stored both as a flattened searchable text in ``content`` AND as
+    JSON-serialized structure in ``content_blocks`` so it round-trips
+    losslessly on reload.
+    """
+    if content is None:
+        return None, None
+    if isinstance(content, str):
+        return content, None
+    if isinstance(content, (list, dict)):
+        return _extract_searchable_text(content), json.dumps(content)
+    return str(content), None
+
+
+def _deserialize_message_content(content_text: Any, content_blocks: Any) -> Any:
+    """Restore message content from DB row, preferring multimodal blocks."""
+    if content_blocks:
+        try:
+            return json.loads(content_blocks)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Failed to deserialize content_blocks, falling back to text")
+    return content_text
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -81,7 +141,8 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT,
     reasoning TEXT,
     reasoning_details TEXT,
-    codex_reasoning_items TEXT
+    codex_reasoning_items TEXT,
+    content_blocks TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -329,6 +390,18 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add content_blocks column to messages — stores
+                # JSON-serialized multimodal content (image_url/input_image
+                # blocks) so vision-capable models can round-trip native
+                # image content through session reload.  The plain text
+                # `content` column keeps a flattened representation for
+                # FTS5 searchability and backwards compat.
+                try:
+                    cursor.execute("ALTER TABLE messages ADD COLUMN content_blocks TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -792,7 +865,7 @@ class SessionDB:
         self,
         session_id: str,
         role: str,
-        content: str = None,
+        content: Any = None,
         tool_name: str = None,
         tool_calls: Any = None,
         tool_call_id: str = None,
@@ -804,6 +877,11 @@ class SessionDB:
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
+
+        Content may be a plain string or a multimodal list of content
+        blocks (text + image_url/input_image).  Multimodal content is
+        stored both as a flattened text in `content` (for FTS5 search)
+        and as JSON in `content_blocks` (for lossless round-trip).
 
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
@@ -819,6 +897,9 @@ class SessionDB:
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
 
+        # Split multimodal content into searchable text + JSON blocks
+        content_text, content_blocks_json = _serialize_message_content(content)
+
         # Pre-compute tool call count
         num_tool_calls = 0
         if tool_calls is not None:
@@ -828,12 +909,12 @@ class SessionDB:
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_details, codex_reasoning_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   reasoning, reasoning_details, codex_reasoning_items, content_blocks)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
-                    content,
+                    content_text,
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
@@ -843,6 +924,7 @@ class SessionDB:
                     reasoning,
                     reasoning_details_json,
                     codex_items_json,
+                    content_blocks_json,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -880,6 +962,9 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            # Restore multimodal content from content_blocks if present
+            content_blocks = msg.pop("content_blocks", None)
+            msg["content"] = _deserialize_message_content(msg.get("content"), content_blocks)
             result.append(msg)
         return result
 
@@ -891,14 +976,17 @@ class SessionDB:
         with self._lock:
             cursor = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
-                "reasoning, reasoning_details, codex_reasoning_items "
+                "reasoning, reasoning_details, codex_reasoning_items, content_blocks "
                 "FROM messages WHERE session_id = ? ORDER BY timestamp, id",
                 (session_id,),
             )
             rows = cursor.fetchall()
         messages = []
         for row in rows:
-            msg = {"role": row["role"], "content": row["content"]}
+            msg = {
+                "role": row["role"],
+                "content": _deserialize_message_content(row["content"], row["content_blocks"]),
+            }
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5967,8 +5967,15 @@ class AIAgent:
         2. Direct lookup ``(provider, model)`` in models.dev catalog.
         3. Provider-prefix fallback: when the model name has a vendor
            prefix (``"anthropic/claude-sonnet-4.6"``) and the provider
-           itself isn't in the catalog (Nous, custom proxies, etc.),
-           split on ``/`` and try the upstream vendor's catalog instead.
+           itself isn't in the catalog, split on ``/`` and try the
+           upstream vendor's catalog instead.  Works for custom proxies
+           that pass through the direct vendor model name.
+        4. OpenRouter aggregator fallback: when the other paths fail
+           and the model name has a slash prefix, try the OpenRouter
+           catalog with the full slug.  Nous, custom OpenAI-compatible
+           proxies, and most aggregators use the same OpenRouter slug
+           format (``moonshotai/kimi-k2.5``, ``mistralai/mistral-small``)
+           so the OpenRouter catalog is a strong catch-all.
         """
         if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
             return True
@@ -5983,18 +5990,17 @@ class AIAgent:
         try:
             from agent.models_dev import get_model_capabilities
             caps = get_model_capabilities(provider, model)
-            if caps is not None:
-                result = bool(caps.supports_vision)
-            elif "/" in model:
-                # Provider-prefix fallback: aggregator routes (Nous,
-                # OpenRouter-style proxies) often pass through the
-                # upstream vendor name in the model slug.  Try resolving
-                # against the underlying vendor catalog so vision-capable
-                # upstream models still get the native path.
+            if caps is None and "/" in model:
+                # Fallback 1: upstream vendor catalog (for custom proxies
+                # where the model name already matches the vendor catalog).
                 vendor, vendor_model = model.split("/", 1)
                 caps = get_model_capabilities(vendor, vendor_model)
-                if caps is not None:
-                    result = bool(caps.supports_vision)
+            if caps is None and "/" in model and provider != "openrouter":
+                # Fallback 2: OpenRouter aggregator catalog. Nous and most
+                # custom proxies use OpenRouter-compatible slug format.
+                caps = get_model_capabilities("openrouter", model)
+            if caps is not None:
+                result = bool(caps.supports_vision)
         except Exception as exc:
             logger.debug("Native vision capability lookup failed: %s", exc)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -86,6 +86,7 @@ from agent.prompt_builder import (
 from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
+    count_message_chars,
     get_next_probe_tier, parse_context_limit_from_error,
     parse_available_output_tokens_from_error,
     save_context_length, is_local_endpoint,
@@ -8024,8 +8025,10 @@ class AIAgent:
                     new_tcs.append(tc)
                 am["tool_calls"] = new_tcs
 
-            # Calculate approximate request size for logging
-            total_chars = sum(len(str(msg)) for msg in api_messages)
+            # Calculate approximate request size for logging.  Skips
+            # base64 image/audio payloads so multimodal turns don't
+            # report inflated char counts.
+            total_chars = sum(count_message_chars(msg) for msg in api_messages)
             approx_tokens = estimate_messages_tokens_rough(api_messages)
             
             # Thinking spinner for quiet mode (animated during API call)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3457,6 +3457,79 @@ class AIAgent:
         digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:24]
         return f"fc_{digest}"
 
+    @staticmethod
+    def _chat_content_to_responses_content(content: Any, role: str) -> Any:
+        """Convert chat-style content to Codex Responses input format.
+
+        The Responses API accepts ``content`` as either a plain string
+        or a list of typed content items. ``str(content)`` would coerce
+        a multimodal list into Python repr (``[{'type': ...}]``) which
+        the API rejects as text. This walks the structure and emits the
+        right shape so vision-capable Codex/OpenAI Responses models can
+        receive native image input.
+
+        For user/tool roles, text blocks become ``input_text`` and image
+        blocks become ``input_image``. For assistant roles, text blocks
+        become ``output_text`` to match the Responses output format.
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return str(content)
+
+        text_type = "output_text" if role == "assistant" else "input_text"
+        out: List[Dict[str, Any]] = []
+        for block in content:
+            if isinstance(block, str):
+                if block:
+                    out.append({"type": text_type, "text": block})
+                continue
+            if not isinstance(block, dict):
+                continue
+            btype = str(block.get("type", "") or "")
+            if btype in ("text", "input_text", "output_text"):
+                text = block.get("text", "")
+                if isinstance(text, str) and text:
+                    out.append({"type": text_type, "text": text})
+            elif btype in ("image_url", "input_image"):
+                image_value = block.get("image_url", {})
+                if isinstance(image_value, dict):
+                    url = str(image_value.get("url", "") or "")
+                else:
+                    url = str(image_value or "")
+                if url:
+                    out.append({"type": "input_image", "image_url": url})
+            elif btype == "image":
+                # Anthropic-native block shape: source.type=base64|url
+                src = block.get("source")
+                if isinstance(src, dict):
+                    if src.get("type") == "base64":
+                        media_type = str(src.get("media_type", "image/jpeg") or "image/jpeg")
+                        data = str(src.get("data", "") or "")
+                        if data:
+                            out.append({
+                                "type": "input_image",
+                                "image_url": f"data:{media_type};base64,{data}",
+                            })
+                    elif src.get("type") == "url":
+                        url = str(src.get("url", "") or "")
+                        if url:
+                            out.append({"type": "input_image", "image_url": url})
+        return out
+
+    @staticmethod
+    def _responses_content_is_empty(content: Any) -> bool:
+        """True if Responses-API content has no user-visible text or media."""
+        if content is None:
+            return True
+        if isinstance(content, str):
+            return not content.strip()
+        if isinstance(content, list):
+            return len(content) == 0
+        return False
+
     def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
@@ -3471,7 +3544,7 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                converted_content = self._chat_content_to_responses_content(content, role)
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -3489,8 +3562,8 @@ class AIAgent:
                                     seen_item_ids.add(item_id)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
-                        items.append({"role": "assistant", "content": content_text})
+                    if not self._responses_content_is_empty(converted_content):
+                        items.append({"role": "assistant", "content": converted_content})
                     elif has_codex_reasoning:
                         # The Responses API requires a following item after each
                         # reasoning item (otherwise: missing_following_item error).
@@ -3542,7 +3615,7 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                items.append({"role": role, "content": converted_content})
                 continue
 
             if role == "tool":

--- a/run_agent.py
+++ b/run_agent.py
@@ -5962,9 +5962,13 @@ class AIAgent:
         Result is cached on the agent for the lifetime of the (provider,
         model) tuple to avoid repeated cache lookups across turns.
 
-        ``HERMES_FORCE_NATIVE_VISION=1`` forces True for users whose
-        model is not catalogued in models.dev but is known to support
-        vision (e.g. self-hosted vLLM serving Llama 3.2 Vision).
+        Resolution order:
+        1. ``HERMES_FORCE_NATIVE_VISION=1`` env var → always True.
+        2. Direct lookup ``(provider, model)`` in models.dev catalog.
+        3. Provider-prefix fallback: when the model name has a vendor
+           prefix (``"anthropic/claude-sonnet-4.6"``) and the provider
+           itself isn't in the catalog (Nous, custom proxies, etc.),
+           split on ``/`` and try the upstream vendor's catalog instead.
         """
         if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
             return True
@@ -5974,12 +5978,23 @@ class AIAgent:
         if cached is not None and cached.get("key") == cache_key:
             return cached["value"]
 
+        provider, model = cache_key
         result = False
         try:
             from agent.models_dev import get_model_capabilities
-            caps = get_model_capabilities(cache_key[0], cache_key[1])
+            caps = get_model_capabilities(provider, model)
             if caps is not None:
                 result = bool(caps.supports_vision)
+            elif "/" in model:
+                # Provider-prefix fallback: aggregator routes (Nous,
+                # OpenRouter-style proxies) often pass through the
+                # upstream vendor name in the model slug.  Try resolving
+                # against the underlying vendor catalog so vision-capable
+                # upstream models still get the native path.
+                vendor, vendor_model = model.split("/", 1)
+                caps = get_model_capabilities(vendor, vendor_model)
+                if caps is not None:
+                    result = bool(caps.supports_vision)
         except Exception as exc:
             logger.debug("Native vision capability lookup failed: %s", exc)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,7 +37,7 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -3456,6 +3456,69 @@ class AIAgent:
         seed = source or str(response_item_id or "") or uuid.uuid4().hex
         digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:24]
         return f"fc_{digest}"
+
+    @staticmethod
+    def _user_message_preview(user_message: Any, max_len: int = 80) -> str:
+        """Flatten a user message (str or multimodal list) to preview text.
+
+        Logging and display paths need a string, but ``user_message`` may
+        now be a list of typed content blocks.  Walks the list to extract
+        text fields and substitutes ``[image]``/``[audio]`` markers for
+        non-text blocks so the preview stays readable.
+        """
+        if user_message is None:
+            return ""
+        if isinstance(user_message, str):
+            return user_message[:max_len] + ("..." if len(user_message) > max_len else "")
+        if not isinstance(user_message, list):
+            text = str(user_message)
+            return text[:max_len] + ("..." if len(text) > max_len else "")
+        parts: List[str] = []
+        for block in user_message:
+            if isinstance(block, str):
+                if block:
+                    parts.append(block)
+                continue
+            if not isinstance(block, dict):
+                continue
+            btype = str(block.get("type", "") or "")
+            if btype in ("text", "input_text", "output_text"):
+                text = block.get("text", "")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif btype in ("image_url", "input_image", "image"):
+                parts.append("[image]")
+            elif btype in ("input_audio", "audio"):
+                parts.append("[audio]")
+        text = " ".join(parts)
+        return text[:max_len] + ("..." if len(text) > max_len else "")
+
+    @staticmethod
+    def _sanitize_user_message_in_place(user_message: Any) -> Any:
+        """Run surrogate sanitization across all text fields of a user message.
+
+        Plain strings get the legacy ``_sanitize_surrogates`` treatment.
+        For multimodal lists, walk the blocks and sanitize each text
+        field while leaving image/audio fields untouched.
+        """
+        if isinstance(user_message, str):
+            return _sanitize_surrogates(user_message)
+        if not isinstance(user_message, list):
+            return user_message
+        sanitized: List[Any] = []
+        for block in user_message:
+            if isinstance(block, str):
+                sanitized.append(_sanitize_surrogates(block))
+                continue
+            if not isinstance(block, dict):
+                sanitized.append(block)
+                continue
+            new_block = dict(block)
+            text = new_block.get("text")
+            if isinstance(text, str):
+                new_block["text"] = _sanitize_surrogates(text)
+            sanitized.append(new_block)
+        return sanitized
 
     @staticmethod
     def _chat_content_to_responses_content(content: Any, role: str) -> Any:
@@ -7600,7 +7663,7 @@ class AIAgent:
 
     def run_conversation(
         self,
-        user_message: str,
+        user_message: Union[str, List[Dict[str, Any]]],
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
@@ -7611,7 +7674,11 @@ class AIAgent:
         Run a complete conversation with tool calling until completion.
 
         Args:
-            user_message (str): The user's message/question
+            user_message (str | list): The user's message/question. May be a
+                plain string OR a list of multimodal content blocks (text +
+                image_url/input_image) for vision-capable models. The
+                gateway sends a list when the source platform attached an
+                image and the active model declares native vision support.
             system_message (str): Custom system message (optional, overrides ephemeral_system_prompt if provided)
             conversation_history (List[Dict]): Previous conversation messages (optional)
             task_id (str): Unique identifier for this task to isolate VMs between concurrent tasks (optional, auto-generated if not provided)
@@ -7643,8 +7710,8 @@ class AIAgent:
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates
         # that are invalid UTF-8 and crash JSON serialization in the OpenAI SDK.
-        if isinstance(user_message, str):
-            user_message = _sanitize_surrogates(user_message)
+        # Walks into multimodal blocks so image-bearing turns are also clean.
+        user_message = self._sanitize_user_message_in_place(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = _sanitize_surrogates(persist_user_message)
 
@@ -7692,7 +7759,7 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
+        _msg_preview = self._user_message_preview(user_message, max_len=80)
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
@@ -7719,7 +7786,16 @@ class AIAgent:
         self._user_turn_count += 1
 
         # Preserve the original user message (no nudge injection).
-        original_user_message = persist_user_message if persist_user_message is not None else user_message
+        # When user_message is multimodal, use a text preview so downstream
+        # string-only consumers (plugin hooks, trajectory saver, memory
+        # extraction) keep receiving a clean text representation while
+        # the API call still gets the full multimodal content.
+        if persist_user_message is not None:
+            original_user_message = persist_user_message
+        elif isinstance(user_message, str):
+            original_user_message = user_message
+        else:
+            original_user_message = self._user_message_preview(user_message, max_len=2_000_000)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -7740,7 +7816,7 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            self._safe_print(f"💬 Starting conversation: '{self._user_message_preview(user_message, max_len=60)}'")
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.
@@ -10057,7 +10133,7 @@ class AIAgent:
                         and self.valid_tool_names
                         and codex_ack_continuations < 2
                         and self._looks_like_codex_intermediate_ack(
-                            user_message=user_message,
+                            user_message=original_user_message,
                             assistant_content=final_response,
                             messages=messages,
                         )
@@ -10196,7 +10272,7 @@ class AIAgent:
         completed = final_response is not None and api_call_count < self.max_iterations
 
         # Save trajectory if enabled
-        self._save_trajectory(messages, user_message, completed)
+        self._save_trajectory(messages, original_user_message, completed)
 
         # Clean up VM and browser for this task after conversation completes
         self._cleanup_task_resources(effective_task_id)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5956,11 +5956,50 @@ class AIAgent:
             return suffix
         return "[A multimodal message was converted to text for Anthropic compatibility.]"
 
+    def _model_supports_native_vision(self) -> bool:
+        """Return True if the active model has native vision per models.dev.
+
+        Result is cached on the agent for the lifetime of the (provider,
+        model) tuple to avoid repeated cache lookups across turns.
+
+        ``HERMES_FORCE_NATIVE_VISION=1`` forces True for users whose
+        model is not catalogued in models.dev but is known to support
+        vision (e.g. self-hosted vLLM serving Llama 3.2 Vision).
+        """
+        if os.environ.get("HERMES_FORCE_NATIVE_VISION") == "1":
+            return True
+
+        cache_key = (getattr(self, "provider", "") or "", getattr(self, "model", "") or "")
+        cached = getattr(self, "_native_vision_cache", None)
+        if cached is not None and cached.get("key") == cache_key:
+            return cached["value"]
+
+        result = False
+        try:
+            from agent.models_dev import get_model_capabilities
+            caps = get_model_capabilities(cache_key[0], cache_key[1])
+            if caps is not None:
+                result = bool(caps.supports_vision)
+        except Exception as exc:
+            logger.debug("Native vision capability lookup failed: %s", exc)
+
+        self._native_vision_cache = {"key": cache_key, "value": result}
+        return result
+
     def _prepare_anthropic_messages_for_api(self, api_messages: list) -> list:
         if not any(
             isinstance(msg, dict) and self._content_has_image_parts(msg.get("content"))
             for msg in api_messages
         ):
+            return api_messages
+
+        # Vision-capable Anthropic models (Claude 3+, Opus 4.6, Sonnet 4.6,
+        # etc.) handle image content blocks natively. The anthropic_adapter
+        # already converts image_url/input_image blocks into Anthropic's
+        # native {"type": "image", "source": ...} format. Skip the legacy
+        # vision_analyze fallback path for these models so the actual pixels
+        # reach the model instead of a lossy text description.
+        if self._model_supports_native_vision():
             return api_messages
 
         transformed = copy.deepcopy(api_messages)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -705,6 +705,81 @@ class TestVisionClientFallback:
         assert model == "claude-haiku-4-5-20251001"
 
 
+class TestTryOpenRouterBaseUrlOverride:
+    """Tests that ``_try_openrouter`` respects ``OPENROUTER_BASE_URL`` env override.
+
+    Without this override, users who route their OpenRouter API key
+    through an alternate endpoint (Nous Portal, custom OR-compatible
+    proxy) would see the auxiliary client silently call the canonical
+    openrouter.ai endpoint with the wrong key, get 401, and exhaust
+    the credential pool — eventually leading to vision_analyze being
+    silently de-registered from the agent's toolset.
+    """
+
+    def test_uses_env_base_url_override(self, monkeypatch):
+        """When OPENROUTER_BASE_URL is set, the constructed client uses it."""
+        from agent.auxiliary_client import _try_openrouter
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "https://custom.example.com/v1")
+        # Avoid the credential pool path by ensuring the pool is empty
+        monkeypatch.setattr(
+            "agent.auxiliary_client._select_pool_entry",
+            lambda provider: (False, None),
+        )
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = _try_openrouter()
+        assert client is not None
+        # The OpenAI client should have been built with the env override base URL
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["base_url"] == "https://custom.example.com/v1"
+        assert call_kwargs["api_key"] == "sk-test-key"
+
+    def test_falls_back_to_hardcoded_default(self, monkeypatch):
+        """When OPENROUTER_BASE_URL is not set, the canonical endpoint is used."""
+        from agent.auxiliary_client import _try_openrouter
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._select_pool_entry",
+            lambda provider: (False, None),
+        )
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = _try_openrouter()
+        assert client is not None
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["base_url"] == "https://openrouter.ai/api/v1"
+
+    def test_no_api_key_returns_none(self, monkeypatch):
+        """No OPENROUTER_API_KEY → return (None, None) regardless of base URL."""
+        from agent.auxiliary_client import _try_openrouter
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "https://anything.example/v1")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._select_pool_entry",
+            lambda provider: (False, None),
+        )
+        client, model = _try_openrouter()
+        assert client is None
+        assert model is None
+
+    def test_empty_env_base_url_falls_back_to_default(self, monkeypatch):
+        """Explicit empty OPENROUTER_BASE_URL='' should fall through to default."""
+        from agent.auxiliary_client import _try_openrouter
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-key")
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._select_pool_entry",
+            lambda provider: (False, None),
+        )
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = _try_openrouter()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["base_url"] == "https://openrouter.ai/api/v1"
+
+
 class TestAuxiliaryPoolAwareness:
     def test_try_nous_uses_pool_entry(self):
         class _Entry:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -391,6 +391,7 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
 
     from agent.credential_pool import load_pool
@@ -401,6 +402,65 @@ def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     assert entry is not None
     assert entry.source == "env:OPENROUTER_API_KEY"
     assert entry.access_token == "sk-or-seeded"
+    # No env override → falls back to canonical OpenRouter endpoint
+    assert entry.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_load_pool_openrouter_seed_honors_base_url_env_override(tmp_path, monkeypatch):
+    """OPENROUTER_BASE_URL env override must propagate into the pool entry.
+
+    Without this, users routing their OpenRouter API key through an
+    alternate endpoint (Nous Portal, custom proxy, OR-compatible mirror)
+    end up with a pool entry that pairs the alt-endpoint key with the
+    canonical openrouter.ai URL, causing every auxiliary call to return
+    401 ``Missing Authentication header``.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-nous-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://inference-api.nousresearch.com/v1")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.access_token == "sk-nous-key"
+    assert entry.base_url == "https://inference-api.nousresearch.com/v1"
+
+
+def test_load_pool_openrouter_seed_strips_trailing_slash(tmp_path, monkeypatch):
+    """Trailing slash in OPENROUTER_BASE_URL must be normalized away."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://custom.example.com/v1/")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    entry = pool.select()
+
+    assert entry is not None
+    # Trailing slash stripped to match canonical form
+    assert entry.base_url == "https://custom.example.com/v1"
+
+
+def test_load_pool_openrouter_empty_base_url_falls_back_to_default(tmp_path, monkeypatch):
+    """Explicit empty OPENROUTER_BASE_URL should fall through to default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.base_url == "https://openrouter.ai/api/v1"
 
 
 def test_load_pool_removes_stale_seeded_env_entry(tmp_path, monkeypatch):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -67,15 +67,22 @@ class TestEstimateTokensRough:
 
 
 class TestEstimateMessagesTokensRough:
+    # Per-message dict overhead and per-tool-call wrapper overhead.
+    # Match the constants in agent/model_metadata.py so these tests
+    # stay correct if the overhead is tuned.
+    _MSG_OVERHEAD = 30
+    _TOOL_OVERHEAD = 40
+
     def test_empty_list(self):
         assert estimate_messages_tokens_rough([]) == 0
 
     def test_single_message_plain_text(self):
-        """Plain text content: ≈ len(content) + len(role)."""
+        """Plain text content: overhead + len(content) + len(role)."""
         msg = {"role": "user", "content": "a" * 400}
         result = estimate_messages_tokens_rough([msg])
-        # Counts content (400) + role ("user", 4) = 404 chars → ~101 tokens
-        assert result == (404 + 3) // 4
+        # overhead(30) + content(400) + role(4) = 434 chars
+        expected_chars = self._MSG_OVERHEAD + 400 + 4
+        assert result == (expected_chars + 3) // 4
 
     def test_multiple_messages_additive(self):
         msgs = [
@@ -83,8 +90,10 @@ class TestEstimateMessagesTokensRough:
             {"role": "assistant", "content": "Hi there, how can I help?"},
         ]
         result = estimate_messages_tokens_rough(msgs)
-        # user(4) + Hello(5) + assistant(9) + Hi there...(25) = 43
-        assert result == (43 + 3) // 4
+        # msg1: overhead(30) + user(4) + Hello(5) = 39
+        # msg2: overhead(30) + assistant(9) + 25 = 64
+        expected_chars = (self._MSG_OVERHEAD + 4 + 5) + (self._MSG_OVERHEAD + 9 + 25)
+        assert result == (expected_chars + 3) // 4
 
     def test_tool_call_message(self):
         """Tool call messages with no 'content' key still contribute tokens."""
@@ -92,8 +101,9 @@ class TestEstimateMessagesTokensRough:
                "tool_calls": [{"id": "1", "function": {"name": "terminal", "arguments": "{}"}}]}
         result = estimate_messages_tokens_rough([msg])
         assert result > 0
-        # role(9) + name(8) + args(2) = 19 chars → 5 tokens
-        assert result == (19 + 3) // 4
+        # overhead(30) + role(9) + tool_wrapper(40) + name(8) + args(2) = 89
+        expected_chars = self._MSG_OVERHEAD + 9 + self._TOOL_OVERHEAD + 8 + 2
+        assert result == (expected_chars + 3) // 4
 
     def test_message_with_text_only_list_content(self):
         """List content with only text blocks should count just the text."""
@@ -101,8 +111,9 @@ class TestEstimateMessagesTokensRough:
             {"type": "text", "text": "describe this"},
         ]}
         result = estimate_messages_tokens_rough([msg])
-        # role(4) + text(13) = 17 chars → 5 tokens
-        assert result == (17 + 3) // 4
+        # overhead(30) + role(4) + text(13) = 47
+        expected_chars = self._MSG_OVERHEAD + 4 + 13
+        assert result == (expected_chars + 3) // 4
 
 
 class TestCountMessageCharsMultimodal:
@@ -161,28 +172,32 @@ class TestCountMessageCharsMultimodal:
         assert chars < 5000
         assert chars >= 2000
 
+    _MSG_OVERHEAD = 30
+    _TOOL_OVERHEAD = 40
+
     def test_text_only_list_content(self):
-        """Pure text list content counts just the text fields."""
+        """Pure text list content counts just the text fields + overhead."""
         msg = {"role": "user", "content": [
             {"type": "text", "text": "Hello"},
             {"type": "text", "text": "World"},
         ]}
-        # role(4) + Hello(5) + World(5) = 14
-        assert count_message_chars(msg) == 14
+        # overhead(30) + role(4) + Hello(5) + World(5) = 44
+        assert count_message_chars(msg) == self._MSG_OVERHEAD + 4 + 5 + 5
 
     def test_plain_string_content(self):
-        """Plain string content counts directly + role."""
+        """Plain string content counts directly + role + overhead."""
         msg = {"role": "user", "content": "Just a question"}
-        # role(4) + content(15) = 19
-        assert count_message_chars(msg) == 19
+        # overhead(30) + role(4) + content(15) = 49
+        assert count_message_chars(msg) == self._MSG_OVERHEAD + 4 + 15
 
     def test_none_content(self):
         """None content (e.g. tool-only assistant turn) handled gracefully."""
         msg = {"role": "assistant", "content": None}
-        assert count_message_chars(msg) == len("assistant")
+        # overhead(30) + role(9) = 39
+        assert count_message_chars(msg) == self._MSG_OVERHEAD + len("assistant")
 
     def test_tool_calls_in_message(self):
-        """Tool calls contribute name + arguments to char count."""
+        """Tool calls contribute name + arguments + wrapper overhead."""
         msg = {
             "role": "assistant",
             "content": None,
@@ -190,8 +205,9 @@ class TestCountMessageCharsMultimodal:
                 {"id": "c1", "function": {"name": "search", "arguments": '{"q":"hello"}'}}
             ],
         }
-        # role(9) + name(6) + args(13) = 28
-        assert count_message_chars(msg) == 28
+        # overhead(30) + role(9) + tool_wrapper(40) + name(6) + args(13) = 98
+        expected = self._MSG_OVERHEAD + 9 + self._TOOL_OVERHEAD + 6 + 13
+        assert count_message_chars(msg) == expected
 
     def test_multimodal_estimate_does_not_explode_with_huge_image(self):
         """End-to-end: estimate_messages_tokens_rough must not blow up on big images."""

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -23,8 +23,10 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     _strip_provider_prefix,
+    count_message_chars,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
+    estimate_request_tokens_rough,
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
@@ -68,13 +70,12 @@ class TestEstimateMessagesTokensRough:
     def test_empty_list(self):
         assert estimate_messages_tokens_rough([]) == 0
 
-    def test_single_message_concrete_value(self):
-        """Verify against known str(msg) length (ceiling division)."""
+    def test_single_message_plain_text(self):
+        """Plain text content: ≈ len(content) + len(role)."""
         msg = {"role": "user", "content": "a" * 400}
         result = estimate_messages_tokens_rough([msg])
-        n = len(str(msg))
-        expected = (n + 3) // 4
-        assert result == expected
+        # Counts content (400) + role ("user", 4) = 404 chars → ~101 tokens
+        assert result == (404 + 3) // 4
 
     def test_multiple_messages_additive(self):
         msgs = [
@@ -82,9 +83,8 @@ class TestEstimateMessagesTokensRough:
             {"role": "assistant", "content": "Hi there, how can I help?"},
         ]
         result = estimate_messages_tokens_rough(msgs)
-        n = sum(len(str(m)) for m in msgs)
-        expected = (n + 3) // 4
-        assert result == expected
+        # user(4) + Hello(5) + assistant(9) + Hi there...(25) = 43
+        assert result == (43 + 3) // 4
 
     def test_tool_call_message(self):
         """Tool call messages with no 'content' key still contribute tokens."""
@@ -92,16 +92,134 @@ class TestEstimateMessagesTokensRough:
                "tool_calls": [{"id": "1", "function": {"name": "terminal", "arguments": "{}"}}]}
         result = estimate_messages_tokens_rough([msg])
         assert result > 0
-        assert result == (len(str(msg)) + 3) // 4
+        # role(9) + name(8) + args(2) = 19 chars → 5 tokens
+        assert result == (19 + 3) // 4
 
-    def test_message_with_list_content(self):
-        """Vision messages with multimodal content arrays."""
+    def test_message_with_text_only_list_content(self):
+        """List content with only text blocks should count just the text."""
         msg = {"role": "user", "content": [
-            {"type": "text", "text": "describe"},
-            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+            {"type": "text", "text": "describe this"},
         ]}
         result = estimate_messages_tokens_rough([msg])
-        assert result == (len(str(msg)) + 3) // 4
+        # role(4) + text(13) = 17 chars → 5 tokens
+        assert result == (17 + 3) // 4
+
+
+class TestCountMessageCharsMultimodal:
+    """Tests for the multimodal-aware char counter (Bug fix #2).
+
+    Before the fix, ``len(str(msg))`` counted base64 image data as text,
+    which inflated token estimates by 100-300x for vision turns and
+    caused the context compressor to wipe images aggressively or trip
+    false context-overflow checks.
+    """
+
+    def test_image_url_block_uses_fixed_budget_not_base64_length(self):
+        """A 1MB base64 image should not contribute >6KB to the char count."""
+        # Simulate a 1MB base64 image payload (roughly real-world)
+        big_base64 = "A" * (1024 * 1024)
+        msg = {"role": "user", "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{big_base64}"}},
+        ]}
+        chars = count_message_chars(msg)
+        # Plain text counter would give ~1M+ chars → ~262K tokens
+        # With per-image budget, we should be far smaller
+        assert chars < 10_000, (
+            f"image_url block should not count base64 data; got {chars} chars"
+        )
+        # Sanity: should still include the text + image budget
+        assert chars > 6000  # at least the image budget
+
+    def test_input_image_block_uses_fixed_budget(self):
+        """input_image type (Codex/OpenAI Responses API) also gets budget."""
+        big_base64 = "A" * 500_000
+        msg = {"role": "user", "content": [
+            {"type": "input_image", "image_url": {"url": f"data:image/jpeg;base64,{big_base64}"}},
+        ]}
+        chars = count_message_chars(msg)
+        assert chars < 10_000
+        assert chars >= 6000
+
+    def test_anthropic_image_block(self):
+        """Anthropic-native ``image`` block type also gets budget."""
+        msg = {"role": "user", "content": [
+            {"type": "image", "source": {"type": "base64", "data": "X" * 200_000}},
+        ]}
+        chars = count_message_chars(msg)
+        # We don't walk source.data — it's covered by the image budget
+        assert chars < 10_000
+        assert chars >= 6000
+
+    def test_audio_block_uses_fixed_budget(self):
+        """input_audio block uses a separate audio budget."""
+        msg = {"role": "user", "content": [
+            {"type": "input_audio", "audio_url": {"url": "data:audio/wav;base64," + "Z" * 100_000}},
+        ]}
+        chars = count_message_chars(msg)
+        # Audio budget is ~2000 chars
+        assert chars < 5000
+        assert chars >= 2000
+
+    def test_text_only_list_content(self):
+        """Pure text list content counts just the text fields."""
+        msg = {"role": "user", "content": [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": "World"},
+        ]}
+        # role(4) + Hello(5) + World(5) = 14
+        assert count_message_chars(msg) == 14
+
+    def test_plain_string_content(self):
+        """Plain string content counts directly + role."""
+        msg = {"role": "user", "content": "Just a question"}
+        # role(4) + content(15) = 19
+        assert count_message_chars(msg) == 19
+
+    def test_none_content(self):
+        """None content (e.g. tool-only assistant turn) handled gracefully."""
+        msg = {"role": "assistant", "content": None}
+        assert count_message_chars(msg) == len("assistant")
+
+    def test_tool_calls_in_message(self):
+        """Tool calls contribute name + arguments to char count."""
+        msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "search", "arguments": '{"q":"hello"}'}}
+            ],
+        }
+        # role(9) + name(6) + args(13) = 28
+        assert count_message_chars(msg) == 28
+
+    def test_multimodal_estimate_does_not_explode_with_huge_image(self):
+        """End-to-end: estimate_messages_tokens_rough must not blow up on big images."""
+        big_base64 = "A" * (2 * 1024 * 1024)  # 2MB image
+        msgs = [{"role": "user", "content": [
+            {"type": "text", "text": "Debug this"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{big_base64}"}},
+        ]}]
+        tokens = estimate_messages_tokens_rough(msgs)
+        # Old: ~524K tokens. New: should be well under 5000.
+        assert tokens < 5000, f"Expected reasonable token count, got {tokens}"
+        assert tokens > 1000  # but not zero
+
+    def test_request_tokens_includes_multimodal_correctly(self):
+        """estimate_request_tokens_rough must use the same path."""
+        big_base64 = "A" * (1024 * 1024)
+        msgs = [{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{big_base64}"}},
+        ]}]
+        tokens = estimate_request_tokens_rough(msgs, system_prompt="You are helpful")
+        # System prompt(15 chars) + image(6000) ≈ 6015 chars → ~1504 tokens
+        assert tokens < 3000
+        assert tokens > 1000
+
+    def test_string_message_passes_through(self):
+        """Non-dict messages should still be counted."""
+        assert count_message_chars("hello") == 5
+        assert count_message_chars(None) == 0
 
 
 # =========================================================================

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -284,3 +284,60 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+
+class TestModelNameDotHyphenNormalization:
+    """Tests for dot/hyphen-tolerant model name matching.
+
+    Different catalogs use different separators between model name and
+    version: Anthropic stores ``claude-sonnet-4-6`` (hyphens) while
+    OpenRouter stores ``anthropic/claude-sonnet-4.6`` (dots). Users
+    should be able to query either form and resolve to the same entry.
+    """
+
+    REGISTRY = {
+        "anthropic": {
+            "id": "anthropic",
+            "models": {
+                "claude-sonnet-4-6": {
+                    "id": "claude-sonnet-4-6",
+                    "attachment": True,
+                    "tool_call": True,
+                    "limit": {"context": 200000, "output": 64000},
+                },
+                "claude-opus-4-6": {
+                    "id": "claude-opus-4-6",
+                    "attachment": True,
+                    "tool_call": True,
+                    "limit": {"context": 200000, "output": 32000},
+                },
+            },
+        },
+    }
+
+    def test_dot_query_matches_hyphen_catalog(self):
+        """``claude-sonnet-4.6`` should match ``claude-sonnet-4-6``."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            caps = get_model_capabilities("anthropic", "claude-sonnet-4.6")
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    def test_hyphen_query_still_works(self):
+        """Backwards compat: existing ``claude-sonnet-4-6`` queries unchanged."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            caps = get_model_capabilities("anthropic", "claude-sonnet-4-6")
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    def test_uppercase_dot_query_matches(self):
+        """Case-insensitive normalization combines with dot/hyphen handling."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            caps = get_model_capabilities("anthropic", "Claude-Opus-4.6")
+        assert caps is not None
+        assert caps.supports_vision is True
+
+    def test_unrelated_model_still_returns_none(self):
+        """Normalization shouldn't cause spurious matches across families."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            caps = get_model_capabilities("anthropic", "claude-haiku-3.5")
+        assert caps is None

--- a/tests/cli/test_cli_native_vision.py
+++ b/tests/cli/test_cli_native_vision.py
@@ -67,14 +67,14 @@ class TestBuildNativeVisionContentCli:
         assert len(image_blocks) == 3
 
     def test_skips_missing_image(self, tmp_path):
+        """Bad image path is skipped; caption-only fallback returns a
+        plain string rather than a list with only a text block."""
         cli_obj = _make_cli()
         bad = tmp_path / "missing.png"
         with patch("cli._cprint"):
             result = cli_obj._build_native_vision_content_cli("hi", [bad])
-        # No image block, but text remains as a list with the text block
-        assert isinstance(result, list)
-        assert any(b.get("type") == "text" for b in result)
-        assert not any(b.get("type") == "image_url" for b in result)
+        # No images encoded → fall back to plain string
+        assert result == "hi"
 
     def test_falls_back_to_string_when_nothing_to_send(self, tmp_path):
         """Empty caption + all-bad images returns a placeholder string."""
@@ -85,6 +85,15 @@ class TestBuildNativeVisionContentCli:
         # Falls back to placeholder text rather than empty list
         assert isinstance(result, str)
         assert "image" in result.lower()
+
+    def test_image_url_includes_detail_auto(self, png_file):
+        """CLI must also set ``detail: "auto"`` on image_url blocks."""
+        cli_obj = _make_cli()
+        result = cli_obj._build_native_vision_content_cli("look", [png_file])
+        assert isinstance(result, list)
+        image_blocks = [b for b in result if b.get("type") == "image_url"]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image_url"]["detail"] == "auto"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_native_vision.py
+++ b/tests/cli/test_cli_native_vision.py
@@ -1,0 +1,210 @@
+"""Tests for the CLI's native vision content routing.
+
+When the active model declares native vision support, the CLI should
+build a list of typed content blocks (text + image_url) instead of
+calling _preprocess_images_with_vision to flatten images via the
+auxiliary vision model. Models without native vision still get the
+legacy text-flatten path.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._attached_images = []
+    return cli_obj
+
+
+@pytest.fixture()
+def png_file(tmp_path):
+    """Tiny valid PNG file for base64-encoding tests."""
+    png_bytes = bytes.fromhex(
+        "89504e470d0a1a0a0000000d4948445200000001000000010806000000"
+        "1f15c4890000000d49444154789c6300010000000500010d0a2db40000"
+        "000049454e44ae426082"
+    )
+    path = tmp_path / "test.png"
+    path.write_bytes(png_bytes)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _build_native_vision_content_cli
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNativeVisionContentCli:
+    def test_text_and_one_image(self, png_file):
+        cli_obj = _make_cli()
+        result = cli_obj._build_native_vision_content_cli("Look at this", [png_file])
+        assert isinstance(result, list)
+        assert result[0] == {"type": "text", "text": "Look at this"}
+        assert result[1]["type"] == "image_url"
+        assert result[1]["image_url"]["url"].startswith("data:image/")
+        assert "base64," in result[1]["image_url"]["url"]
+
+    def test_image_only_no_caption(self, png_file):
+        cli_obj = _make_cli()
+        result = cli_obj._build_native_vision_content_cli("", [png_file])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["type"] == "image_url"
+
+    def test_multiple_images(self, png_file):
+        cli_obj = _make_cli()
+        result = cli_obj._build_native_vision_content_cli(
+            "compare", [png_file, png_file, png_file]
+        )
+        text_blocks = [b for b in result if b.get("type") == "text"]
+        image_blocks = [b for b in result if b.get("type") == "image_url"]
+        assert len(text_blocks) == 1
+        assert len(image_blocks) == 3
+
+    def test_skips_missing_image(self, tmp_path):
+        cli_obj = _make_cli()
+        bad = tmp_path / "missing.png"
+        with patch("cli._cprint"):
+            result = cli_obj._build_native_vision_content_cli("hi", [bad])
+        # No image block, but text remains as a list with the text block
+        assert isinstance(result, list)
+        assert any(b.get("type") == "text" for b in result)
+        assert not any(b.get("type") == "image_url" for b in result)
+
+    def test_falls_back_to_string_when_nothing_to_send(self, tmp_path):
+        """Empty caption + all-bad images returns a placeholder string."""
+        cli_obj = _make_cli()
+        bad = tmp_path / "missing.png"
+        with patch("cli._cprint"):
+            result = cli_obj._build_native_vision_content_cli("", [bad])
+        # Falls back to placeholder text rather than empty list
+        assert isinstance(result, str)
+        assert "image" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# chat() routing — vision-capable vs non-vision models
+# ---------------------------------------------------------------------------
+
+
+class TestChatVisionRouting:
+    def test_chat_uses_native_vision_when_capable(self, png_file):
+        """When agent reports native vision, chat() builds content blocks
+        instead of calling _preprocess_images_with_vision."""
+        cli_obj = _make_cli()
+        cli_obj.agent = MagicMock()
+        cli_obj.agent._model_supports_native_vision.return_value = True
+
+        # Just test the image-handling branch in isolation by replicating
+        # the chat() preprocessing logic
+        message = "describe"
+        images = [png_file]
+
+        if images:
+            _use_native = False
+            try:
+                if cli_obj.agent is not None:
+                    _use_native = cli_obj.agent._model_supports_native_vision()
+            except Exception:
+                pass
+            if _use_native:
+                message = cli_obj._build_native_vision_content_cli(message, images)
+            else:
+                message = cli_obj._preprocess_images_with_vision(message, images)
+
+        assert isinstance(message, list)
+        assert any(b.get("type") == "image_url" for b in message)
+        cli_obj.agent._model_supports_native_vision.assert_called_once()
+
+    def test_chat_uses_legacy_flatten_when_not_capable(self, png_file):
+        """When agent reports no native vision, chat() falls back to
+        _preprocess_images_with_vision (legacy text-flatten path)."""
+        cli_obj = _make_cli()
+        cli_obj.agent = MagicMock()
+        cli_obj.agent._model_supports_native_vision.return_value = False
+
+        message = "describe"
+        images = [png_file]
+
+        with patch.object(
+            cli_obj,
+            "_preprocess_images_with_vision",
+            return_value="[The user attached an image. Description: a cat]",
+        ) as mock_preprocess:
+            if images:
+                _use_native = False
+                try:
+                    if cli_obj.agent is not None:
+                        _use_native = cli_obj.agent._model_supports_native_vision()
+                except Exception:
+                    pass
+                if _use_native:
+                    message = cli_obj._build_native_vision_content_cli(message, images)
+                else:
+                    message = cli_obj._preprocess_images_with_vision(message, images)
+
+        assert isinstance(message, str)
+        assert "Description: a cat" in message
+        mock_preprocess.assert_called_once()
+
+    def test_chat_handles_capability_check_exception(self, png_file):
+        """If _model_supports_native_vision raises, fall back to legacy."""
+        cli_obj = _make_cli()
+        cli_obj.agent = MagicMock()
+        cli_obj.agent._model_supports_native_vision.side_effect = RuntimeError("boom")
+
+        message = "describe"
+        images = [png_file]
+
+        with patch.object(
+            cli_obj,
+            "_preprocess_images_with_vision",
+            return_value="[fallback text]",
+        ) as mock_preprocess:
+            if images:
+                _use_native = False
+                try:
+                    if cli_obj.agent is not None:
+                        _use_native = cli_obj.agent._model_supports_native_vision()
+                except Exception:
+                    pass
+                if _use_native:
+                    message = cli_obj._build_native_vision_content_cli(message, images)
+                else:
+                    message = cli_obj._preprocess_images_with_vision(message, images)
+
+        assert isinstance(message, str)
+        assert "[fallback text]" in message
+        mock_preprocess.assert_called_once()
+
+    def test_chat_handles_no_agent(self, png_file):
+        """When self.agent is None, fall back to legacy without crashing."""
+        cli_obj = _make_cli()
+        cli_obj.agent = None
+
+        message = "describe"
+        images = [png_file]
+
+        with patch.object(
+            cli_obj,
+            "_preprocess_images_with_vision",
+            return_value="[fallback text]",
+        ) as mock_preprocess:
+            if images:
+                _use_native = False
+                try:
+                    if cli_obj.agent is not None:
+                        _use_native = cli_obj.agent._model_supports_native_vision()
+                except Exception:
+                    pass
+                if _use_native:
+                    message = cli_obj._build_native_vision_content_cli(message, images)
+                else:
+                    message = cli_obj._preprocess_images_with_vision(message, images)
+
+        mock_preprocess.assert_called_once()

--- a/tests/gateway/test_native_vision_routing.py
+++ b/tests/gateway/test_native_vision_routing.py
@@ -157,6 +157,24 @@ class TestShouldUseNativeVision:
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert runner._should_use_native_vision_for_source(MagicMock()) is False
 
+    def test_openrouter_catalog_fallback(self, runner, monkeypatch):
+        """When the direct and vendor-prefix lookups both fail, fall back
+        to querying the OpenRouter catalog with the full slug. Required
+        for aggregators where the upstream vendor catalog is empty (e.g.
+        moonshotai in models.dev) but the model is catalogued in OR."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("moonshotai/kimi-k2.5", {"provider": "nous"})
+        )
+
+        def fake_caps(provider, model):
+            if provider == "openrouter" and model == "moonshotai/kimi-k2.5":
+                return MagicMock(supports_vision=True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            assert runner._should_use_native_vision_for_source(MagicMock()) is True
+
 
 # ---------------------------------------------------------------------------
 # _build_native_vision_content

--- a/tests/gateway/test_native_vision_routing.py
+++ b/tests/gateway/test_native_vision_routing.py
@@ -206,12 +206,20 @@ class TestBuildNativeVisionContent:
         assert len(image_blocks) == 2
 
     def test_skips_unreadable_images(self, runner, tmp_path):
-        """Bad image path is skipped, doesn't crash the build."""
+        """Bad image path is skipped; caption-only fallback returns a string
+        rather than a list with a single text block (a list with no images
+        has no reason to exist as a list)."""
         bad_path = tmp_path / "nonexistent.png"
         result = runner._build_native_vision_content("hi", [str(bad_path)])
-        # Text block remains, no image block
+        # No images encoded → fall back to plain string caption
+        assert result == "hi"
+
+    def test_image_url_includes_detail_auto(self, runner, png_file):
+        """Emitted image_url blocks must set ``detail: "auto"`` explicitly
+        so providers don't silently default to "high" on large screenshots
+        and inflate the bill."""
+        result = runner._build_native_vision_content("what's this?", [str(png_file)])
         assert isinstance(result, list)
-        text_blocks = [b for b in result if b.get("type") == "text"]
-        assert len(text_blocks) == 1
         image_blocks = [b for b in result if b.get("type") == "image_url"]
-        assert len(image_blocks) == 0
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["image_url"]["detail"] == "auto"

--- a/tests/gateway/test_native_vision_routing.py
+++ b/tests/gateway/test_native_vision_routing.py
@@ -1,0 +1,169 @@
+"""Tests for the gateway's native vision content routing.
+
+When the active model declares native vision support, the gateway
+should build a list of typed content blocks (text + image_url) instead
+of calling vision_analyze_tool to flatten images to a text description.
+Models without native vision still get the legacy text-flatten path.
+"""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+@pytest.fixture()
+def runner():
+    """Bare GatewayRunner without full init — fine for unit-testing helpers."""
+    r = object.__new__(GatewayRunner)
+    return r
+
+
+@pytest.fixture()
+def png_file(tmp_path):
+    """Tiny valid PNG file for base64-encoding tests."""
+    # 1x1 transparent PNG
+    png_bytes = bytes.fromhex(
+        "89504e470d0a1a0a0000000d4948445200000001000000010806000000"
+        "1f15c4890000000d49444154789c6300010000000500010d0a2db40000"
+        "000049454e44ae426082"
+    )
+    path = tmp_path / "test.png"
+    path.write_bytes(png_bytes)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _message_preview_for_hook
+# ---------------------------------------------------------------------------
+
+
+class TestMessagePreviewForHook:
+    def test_string_message(self):
+        assert GatewayRunner._message_preview_for_hook("hello") == "hello"
+
+    def test_none_message(self):
+        assert GatewayRunner._message_preview_for_hook(None) == ""
+
+    def test_text_only_list(self):
+        content = [{"type": "text", "text": "Look at this"}]
+        assert GatewayRunner._message_preview_for_hook(content) == "Look at this"
+
+    def test_multimodal_list(self):
+        content = [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": "https://x.com/y.png"}},
+        ]
+        result = GatewayRunner._message_preview_for_hook(content)
+        assert "What is this?" in result
+        assert "[image]" in result
+
+    def test_audio_block(self):
+        content = [
+            {"type": "text", "text": "Listen:"},
+            {"type": "input_audio", "audio_url": {"url": "data:audio/wav;base64,X"}},
+        ]
+        result = GatewayRunner._message_preview_for_hook(content)
+        assert "Listen:" in result
+        assert "[audio]" in result
+
+
+# ---------------------------------------------------------------------------
+# _should_use_native_vision_for_source
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseNativeVision:
+    def test_force_env_var_returns_true(self, runner, monkeypatch):
+        """HERMES_FORCE_NATIVE_VISION=1 short-circuits the lookup."""
+        monkeypatch.setenv("HERMES_FORCE_NATIVE_VISION", "1")
+        # No need to mock _resolve_session_agent_runtime — should not be called
+        assert runner._should_use_native_vision_for_source(MagicMock()) is True
+
+    def test_returns_true_when_capability_says_vision(self, runner, monkeypatch):
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("claude-opus-4-6", {"provider": "anthropic"})
+        )
+        with patch("agent.models_dev.get_model_capabilities") as mock_caps:
+            mock_caps.return_value = MagicMock(supports_vision=True)
+            assert runner._should_use_native_vision_for_source(MagicMock()) is True
+            mock_caps.assert_called_once_with("anthropic", "claude-opus-4-6")
+
+    def test_returns_false_when_capability_says_no_vision(self, runner, monkeypatch):
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("plain-text-model", {"provider": "custom"})
+        )
+        with patch("agent.models_dev.get_model_capabilities") as mock_caps:
+            mock_caps.return_value = MagicMock(supports_vision=False)
+            assert runner._should_use_native_vision_for_source(MagicMock()) is False
+
+    def test_returns_false_when_capability_lookup_returns_none(self, runner, monkeypatch):
+        """Unknown model defaults to safe legacy fallback."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("unknown-model", {"provider": "custom"})
+        )
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert runner._should_use_native_vision_for_source(MagicMock()) is False
+
+    def test_returns_false_when_no_model(self, runner, monkeypatch):
+        """Empty model name returns False without lookup."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("", {"provider": "anthropic"})
+        )
+        assert runner._should_use_native_vision_for_source(MagicMock()) is False
+
+    def test_returns_false_when_runtime_resolution_fails(self, runner, monkeypatch):
+        """Exception in resolver is caught and we fall back to legacy."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(side_effect=RuntimeError("boom"))
+        assert runner._should_use_native_vision_for_source(MagicMock()) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_native_vision_content
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNativeVisionContent:
+    def test_builds_text_and_image_blocks(self, runner, png_file):
+        result = runner._build_native_vision_content("What's this?", [str(png_file)])
+        assert isinstance(result, list)
+        # First block: user text
+        assert result[0]["type"] == "text"
+        assert result[0]["text"] == "What's this?"
+        # Second block: image as data URL
+        assert result[1]["type"] == "image_url"
+        assert result[1]["image_url"]["url"].startswith("data:image/")
+        assert "base64," in result[1]["image_url"]["url"]
+
+    def test_skips_text_block_when_caption_empty(self, runner, png_file):
+        result = runner._build_native_vision_content("", [str(png_file)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["type"] == "image_url"
+
+    def test_handles_multiple_images(self, runner, png_file):
+        result = runner._build_native_vision_content("two pics", [str(png_file), str(png_file)])
+        assert len(result) == 3  # 1 text + 2 images
+        image_blocks = [b for b in result if b.get("type") == "image_url"]
+        assert len(image_blocks) == 2
+
+    def test_skips_unreadable_images(self, runner, tmp_path):
+        """Bad image path is skipped, doesn't crash the build."""
+        bad_path = tmp_path / "nonexistent.png"
+        result = runner._build_native_vision_content("hi", [str(bad_path)])
+        # Text block remains, no image block
+        assert isinstance(result, list)
+        text_blocks = [b for b in result if b.get("type") == "text"]
+        assert len(text_blocks) == 1
+        image_blocks = [b for b in result if b.get("type") == "image_url"]
+        assert len(image_blocks) == 0

--- a/tests/gateway/test_native_vision_routing.py
+++ b/tests/gateway/test_native_vision_routing.py
@@ -127,6 +127,36 @@ class TestShouldUseNativeVision:
         runner._resolve_session_agent_runtime = MagicMock(side_effect=RuntimeError("boom"))
         assert runner._should_use_native_vision_for_source(MagicMock()) is False
 
+    def test_provider_prefix_fallback_for_aggregator_provider(self, runner, monkeypatch):
+        """Aggregator providers (Nous, custom proxies) not in models.dev
+        should still resolve via the upstream vendor in the model slug."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("anthropic/claude-sonnet-4.6", {"provider": "nous"})
+        )
+
+        def fake_caps(provider, model):
+            # First call: provider=nous → not catalogued
+            if provider == "nous":
+                return None
+            # Second call: provider=anthropic + dotted model → vision-capable
+            if provider == "anthropic" and model == "claude-sonnet-4.6":
+                return MagicMock(supports_vision=True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            assert runner._should_use_native_vision_for_source(MagicMock()) is True
+
+    def test_provider_prefix_fallback_unknown_vendor(self, runner, monkeypatch):
+        """If both the aggregator AND the upstream vendor are unknown,
+        return False (safe legacy fallback)."""
+        monkeypatch.delenv("HERMES_FORCE_NATIVE_VISION", raising=False)
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("fictional/never-heard-of-it", {"provider": "custom"})
+        )
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert runner._should_use_native_vision_for_source(MagicMock()) is False
+
 
 # ---------------------------------------------------------------------------
 # _build_native_vision_content

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3213,6 +3213,47 @@ class TestAnthropicNativeVision:
         assert isinstance(result[0]["content"], str)
         assert "A cat." in result[0]["content"]
 
+    def test_provider_prefix_fallback_for_unmapped_provider(self, agent):
+        """Aggregator providers (Nous, custom proxies) that aren't in
+        models.dev should still resolve via the upstream vendor when the
+        model name has a vendor prefix like ``anthropic/claude-sonnet-4.6``.
+        """
+        agent.provider = "nous"
+        agent.model = "anthropic/claude-sonnet-4.6"
+        agent._native_vision_cache = None
+
+        # First call (provider="nous") returns None — provider not catalogued.
+        # Second call (provider="anthropic", model="claude-sonnet-4.6") returns vision-capable.
+        def fake_caps(provider, model):
+            if provider == "anthropic" and model == "claude-sonnet-4.6":
+                return MagicMock(supports_vision=True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            assert agent._model_supports_native_vision() is True
+
+    def test_provider_prefix_fallback_no_slash_returns_false(self, agent):
+        """If model has no slash prefix, fallback shouldn't trigger."""
+        agent.provider = "unknown"
+        agent.model = "plain-model-name"
+        agent._native_vision_cache = None
+
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_native_vision() is False
+
+    def test_provider_prefix_fallback_unknown_vendor_returns_false(self):
+        """If both the provider AND the upstream vendor are unknown,
+        the result is False (safe legacy fallback)."""
+        from run_agent import AIAgent
+        # Use object.__new__ to skip __init__ side effects
+        agent = object.__new__(AIAgent)
+        agent.provider = "nous"
+        agent.model = "fictional/never-heard-of-it"
+        agent._native_vision_cache = None
+
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_native_vision() is False
+
 
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2198,6 +2198,159 @@ class TestRunConversation:
         mock_handle_function_call.assert_not_called()
 
 
+class TestMultimodalUserMessage:
+    """Tests for run_conversation accepting list user_message (vision turns).
+
+    The gateway sends a list of typed content blocks (text + image_url)
+    when the source platform attached an image and the active model
+    supports native vision.  These tests verify the plumbing accepts
+    that shape end-to-end without coercing to text.
+    """
+
+    # ---- Helper: _user_message_preview ----
+
+    def test_user_message_preview_string(self):
+        assert AIAgent._user_message_preview("hello world") == "hello world"
+
+    def test_user_message_preview_string_truncates(self):
+        assert AIAgent._user_message_preview("a" * 200, max_len=10) == "aaaaaaaaaa..."
+
+    def test_user_message_preview_none(self):
+        assert AIAgent._user_message_preview(None) == ""
+
+    def test_user_message_preview_text_only_list(self):
+        content = [{"type": "text", "text": "Hello world"}]
+        assert AIAgent._user_message_preview(content) == "Hello world"
+
+    def test_user_message_preview_multimodal_list(self):
+        content = [
+            {"type": "text", "text": "Look at this:"},
+            {"type": "image_url", "image_url": {"url": "https://x.com/y.png"}},
+        ]
+        result = AIAgent._user_message_preview(content)
+        assert "Look at this:" in result
+        assert "[image]" in result
+
+    def test_user_message_preview_image_only(self):
+        content = [{"type": "image_url", "image_url": {"url": "https://x.com/y.png"}}]
+        result = AIAgent._user_message_preview(content)
+        assert "[image]" in result
+
+    def test_user_message_preview_audio_block(self):
+        content = [
+            {"type": "text", "text": "Listen:"},
+            {"type": "input_audio", "audio_url": {"url": "data:audio/wav;base64,X"}},
+        ]
+        result = AIAgent._user_message_preview(content)
+        assert "Listen:" in result
+        assert "[audio]" in result
+
+    def test_user_message_preview_anthropic_image_block(self):
+        content = [{"type": "image", "source": {"type": "url", "url": "https://x.com/y.png"}}]
+        result = AIAgent._user_message_preview(content)
+        assert "[image]" in result
+
+    # ---- Helper: _sanitize_user_message_in_place ----
+
+    def test_sanitize_string_passes_through(self):
+        result = AIAgent._sanitize_user_message_in_place("clean text")
+        assert result == "clean text"
+
+    def test_sanitize_string_strips_surrogates(self):
+        # Lone high surrogate (invalid UTF-8)
+        dirty = "hello\ud83d world"
+        result = AIAgent._sanitize_user_message_in_place(dirty)
+        assert "\ud83d" not in result
+
+    def test_sanitize_list_walks_blocks(self):
+        content = [
+            {"type": "text", "text": "hello\ud83d world"},
+            {"type": "image_url", "image_url": {"url": "https://x.com/y.png"}},
+        ]
+        result = AIAgent._sanitize_user_message_in_place(content)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        # Text block sanitized
+        assert "\ud83d" not in result[0]["text"]
+        # Image block untouched
+        assert result[1]["type"] == "image_url"
+        assert result[1]["image_url"]["url"] == "https://x.com/y.png"
+
+    def test_sanitize_list_does_not_mutate_input(self):
+        original = [{"type": "text", "text": "hello"}]
+        result = AIAgent._sanitize_user_message_in_place(original)
+        # Result is a new list with new dicts
+        assert result is not original
+        assert result[0] is not original[0]
+
+    # ---- run_conversation accepts list ----
+
+    def test_run_conversation_accepts_list_content(self, agent):
+        """End-to-end: passing a list user_message should produce a
+        multimodal user message in the API call."""
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        resp = _mock_response(content="I see a cat", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        content = [
+            {"type": "text", "text": "What's in this photo?"},
+            {"type": "image_url", "image_url": {"url": "https://x.com/cat.png"}},
+        ]
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(content)
+
+        # Result should be successful
+        assert result["completed"] is True
+
+        # The API call should have received the multimodal content as a list
+        call_kwargs = agent.client.chat.completions.create.call_args.kwargs
+        api_messages = call_kwargs["messages"]
+        user_msgs = [m for m in api_messages if m.get("role") == "user"]
+        assert len(user_msgs) >= 1
+        last_user = user_msgs[-1]
+        assert isinstance(last_user["content"], list), (
+            "user message content was coerced to string — multimodal lost"
+        )
+        # Both blocks should still be there
+        block_types = [b.get("type") for b in last_user["content"]]
+        assert "text" in block_types or "input_text" in block_types
+        assert "image_url" in block_types or "input_image" in block_types
+
+    def test_run_conversation_string_still_works(self, agent):
+        """Backwards compat: passing a plain string still produces a string content."""
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        resp = _mock_response(content="Hello back", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Hello")
+
+        assert result["completed"] is True
+        call_kwargs = agent.client.chat.completions.create.call_args.kwargs
+        api_messages = call_kwargs["messages"]
+        user_msgs = [m for m in api_messages if m.get("role") == "user"]
+        assert isinstance(user_msgs[-1]["content"], str)
+        assert user_msgs[-1]["content"] == "Hello"
+
+
 class TestRetryExhaustion:
     """Regression: retry_count > max_retries was dead code (off-by-one).
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3110,6 +3110,110 @@ class TestAnthropicImageFallback:
         assert mock_vision.await_count == 1
 
 
+class TestAnthropicNativeVision:
+    """Tests for capability-aware skip of the vision_analyze fallback.
+
+    When the active model has native vision support, the Anthropic
+    adapter handles image content blocks directly (line 829 in
+    anthropic_adapter.py).  The legacy preprocess that flattens images
+    to text descriptions should be skipped so the actual pixels reach
+    the model.
+    """
+
+    def test_model_supports_native_vision_caches_lookup(self, agent):
+        """Result is cached per (provider, model) tuple."""
+        agent.provider = "anthropic"
+        agent.model = "claude-opus-4-6"
+
+        with patch("agent.models_dev.get_model_capabilities") as mock_caps:
+            mock_caps.return_value = MagicMock(supports_vision=True)
+
+            assert agent._model_supports_native_vision() is True
+            assert agent._model_supports_native_vision() is True
+            # Lookup should only happen once
+            assert mock_caps.call_count == 1
+
+    def test_model_supports_native_vision_returns_false_when_unknown(self, agent):
+        """Unknown models default to False (safe legacy fallback)."""
+        agent.provider = "unknown"
+        agent.model = "fictional-model"
+        # Reset cache from any previous test
+        agent._native_vision_cache = None
+
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_native_vision() is False
+
+    def test_model_supports_native_vision_force_env_var(self, agent, monkeypatch):
+        """HERMES_FORCE_NATIVE_VISION=1 forces True regardless of lookup."""
+        monkeypatch.setenv("HERMES_FORCE_NATIVE_VISION", "1")
+        agent._native_vision_cache = None
+
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_native_vision() is True
+
+    def test_model_supports_native_vision_lookup_exception_safe(self, agent):
+        """If the capability lookup raises, return False (don't crash)."""
+        agent._native_vision_cache = None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=RuntimeError("boom")):
+            assert agent._model_supports_native_vision() is False
+
+    def test_prepare_anthropic_skips_flatten_for_vision_capable_model(self, agent):
+        """Vision-capable models pass image blocks through unchanged."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.model = "claude-opus-4-6"
+        agent._native_vision_cache = None
+
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's this?"},
+                {"type": "image_url", "image_url": {"url": "https://x.com/y.png"}},
+            ],
+        }]
+
+        with (
+            patch("agent.models_dev.get_model_capabilities",
+                  return_value=MagicMock(supports_vision=True)),
+            patch("tools.vision_tools.vision_analyze_tool") as mock_vision,
+        ):
+            result = agent._prepare_anthropic_messages_for_api(api_messages)
+
+        # vision_analyze_tool should NOT have been called
+        mock_vision.assert_not_called()
+        # Image content blocks should be preserved
+        assert isinstance(result[0]["content"], list)
+        assert any(b.get("type") in ("image_url", "input_image") for b in result[0]["content"])
+
+    def test_prepare_anthropic_still_flattens_when_no_vision(self, agent):
+        """Non-vision models still get the legacy text-flatten fallback."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.model = "claude-old-no-vision"
+        agent._native_vision_cache = None
+
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's this?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ],
+        }]
+
+        with (
+            patch("agent.models_dev.get_model_capabilities",
+                  return_value=MagicMock(supports_vision=False)),
+            patch("tools.vision_tools.vision_analyze_tool",
+                  new=AsyncMock(return_value=json.dumps({"success": True, "analysis": "A cat."}))),
+        ):
+            result = agent._prepare_anthropic_messages_for_api(api_messages)
+
+        # Content should now be a string (flattened)
+        assert isinstance(result[0]["content"], str)
+        assert "A cat." in result[0]["content"]
+
+
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3254,6 +3254,61 @@ class TestAnthropicNativeVision:
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_native_vision() is False
 
+    def test_openrouter_catalog_fallback(self, agent):
+        """When the direct provider lookup and the vendor prefix strip
+        both fail, fall back to querying the OpenRouter catalog with the
+        full slug. Nous and most aggregators use OpenRouter-compatible
+        slugs so the OR catalog is a strong catch-all.
+        """
+        agent.provider = "nous"
+        agent.model = "moonshotai/kimi-k2.5"
+        agent._native_vision_cache = None
+
+        # Simulate the real situation: nous not mapped, moonshotai catalog
+        # empty, but openrouter catalog has the entry with vision=True.
+        def fake_caps(provider, model):
+            if provider == "openrouter" and model == "moonshotai/kimi-k2.5":
+                return MagicMock(supports_vision=True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            assert agent._model_supports_native_vision() is True
+
+    def test_openrouter_fallback_respects_non_vision_model(self, agent):
+        """If OpenRouter catalog says the model has no vision, return False."""
+        agent.provider = "nous"
+        agent.model = "moonshotai/kimi-k2"  # text-only variant
+        agent._native_vision_cache = None
+
+        def fake_caps(provider, model):
+            if provider == "openrouter" and model == "moonshotai/kimi-k2":
+                return MagicMock(supports_vision=False)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            assert agent._model_supports_native_vision() is False
+
+    def test_openrouter_fallback_skipped_when_provider_is_openrouter(self, agent):
+        """If the provider is already 'openrouter', skip the redundant
+        second lookup — avoid infinite loop / wasted call."""
+        agent.provider = "openrouter"
+        agent.model = "moonshotai/kimi-k2.5"
+        agent._native_vision_cache = None
+
+        call_count = [0]
+        def fake_caps(provider, model):
+            call_count[0] += 1
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            agent._model_supports_native_vision()
+
+        # Exactly 2 calls: direct ("openrouter", "moonshotai/kimi-k2.5"),
+        # and the vendor prefix fallback ("moonshotai", "kimi-k2.5").
+        # The OpenRouter fallback must be skipped because provider is
+        # already openrouter.
+        assert call_count[0] == 2
+
 
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -589,6 +589,153 @@ def test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids(monkeypatch):
     assert function_output["call_id"] == "call_pair123"
 
 
+# =========================================================================
+# Multimodal content (image_url / input_image / Anthropic image blocks)
+# =========================================================================
+
+def test_chat_content_to_responses_content_plain_string():
+    """Plain string content passes through unchanged."""
+    from run_agent import AIAgent
+    result = AIAgent._chat_content_to_responses_content("Hello world", "user")
+    assert result == "Hello world"
+
+
+def test_chat_content_to_responses_content_none_becomes_empty():
+    """None content becomes empty string."""
+    from run_agent import AIAgent
+    assert AIAgent._chat_content_to_responses_content(None, "user") == ""
+    assert AIAgent._chat_content_to_responses_content(None, "assistant") == ""
+
+
+def test_chat_content_to_responses_content_text_block():
+    """Text-only list content emits input_text items."""
+    from run_agent import AIAgent
+    content = [{"type": "text", "text": "Hello"}]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [{"type": "input_text", "text": "Hello"}]
+
+
+def test_chat_content_to_responses_content_assistant_uses_output_text():
+    """Assistant text blocks use output_text type."""
+    from run_agent import AIAgent
+    content = [{"type": "text", "text": "Reply"}]
+    result = AIAgent._chat_content_to_responses_content(content, "assistant")
+    assert result == [{"type": "output_text", "text": "Reply"}]
+
+
+def test_chat_content_to_responses_content_image_url_dict():
+    """OpenAI-style image_url dict converts to input_image string URL."""
+    from run_agent import AIAgent
+    content = [
+        {"type": "text", "text": "What's in this?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+    ]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [
+        {"type": "input_text", "text": "What's in this?"},
+        {"type": "input_image", "image_url": "https://example.com/x.png"},
+    ]
+
+
+def test_chat_content_to_responses_content_image_url_string():
+    """image_url as plain string (legacy form) also works."""
+    from run_agent import AIAgent
+    content = [{"type": "image_url", "image_url": "https://example.com/y.jpg"}]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [{"type": "input_image", "image_url": "https://example.com/y.jpg"}]
+
+
+def test_chat_content_to_responses_content_input_image_passthrough():
+    """input_image block (already Responses-shaped) round-trips."""
+    from run_agent import AIAgent
+    content = [{"type": "input_image", "image_url": {"url": "data:image/png;base64,iVBOR"}}]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [{"type": "input_image", "image_url": "data:image/png;base64,iVBOR"}]
+
+
+def test_chat_content_to_responses_content_anthropic_image_base64():
+    """Anthropic-native image block (base64 source) becomes a data URL."""
+    from run_agent import AIAgent
+    content = [{
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "AAAA",
+        },
+    }]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [{"type": "input_image", "image_url": "data:image/jpeg;base64,AAAA"}]
+
+
+def test_chat_content_to_responses_content_anthropic_image_url():
+    """Anthropic-native image block (url source) converts directly."""
+    from run_agent import AIAgent
+    content = [{
+        "type": "image",
+        "source": {"type": "url", "url": "https://cdn.example.com/z.png"},
+    }]
+    result = AIAgent._chat_content_to_responses_content(content, "user")
+    assert result == [{"type": "input_image", "image_url": "https://cdn.example.com/z.png"}]
+
+
+def test_chat_messages_to_responses_input_preserves_user_image(monkeypatch):
+    """End-to-end: a user message with image content should yield an
+    input_image item in the Responses input list.
+
+    Before this fix, ``str(content)`` produced a Python repr of the
+    list, which the API rejected as an opaque text blob and the model
+    never saw the image.
+    """
+    agent = _build_agent(monkeypatch)
+    items = agent._chat_messages_to_responses_input([
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this screenshot"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/shot.png"}},
+            ],
+        },
+    ])
+    assert len(items) == 1
+    assert items[0]["role"] == "user"
+    assert isinstance(items[0]["content"], list)
+    text_blocks = [b for b in items[0]["content"] if b["type"] == "input_text"]
+    image_blocks = [b for b in items[0]["content"] if b["type"] == "input_image"]
+    assert len(text_blocks) == 1
+    assert text_blocks[0]["text"] == "Describe this screenshot"
+    assert len(image_blocks) == 1
+    assert image_blocks[0]["image_url"] == "https://example.com/shot.png"
+
+
+def test_chat_messages_to_responses_input_does_not_stringify_list(monkeypatch):
+    """Regression: list content must NOT be coerced via str().
+
+    The old behavior used ``str(content)`` which converted a list of
+    dicts to its Python repr (``"[{'type': 'text', ...}]"``) and sent
+    that as a text blob to the Responses API.  The model never saw any
+    image and the API treated the literal repr as user text.
+    """
+    agent = _build_agent(monkeypatch)
+    items = agent._chat_messages_to_responses_input([
+        {"role": "user", "content": [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "https://x.com/img.png"}},
+        ]},
+    ])
+    user_item = items[0]
+    # The fix produces a list of typed blocks; the bug produced a str.
+    assert isinstance(user_item["content"], list), (
+        "user content was stringified — multimodal blocks lost"
+    )
+    # Each block must be a properly-shaped dict, not a string fragment
+    assert all(isinstance(b, dict) for b in user_item["content"])
+    # The image URL must round-trip without escaping/repr quoting
+    image_blocks = [b for b in user_item["content"] if b.get("type") == "input_image"]
+    assert len(image_blocks) == 1
+    assert image_blocks[0]["image_url"] == "https://x.com/img.png"
+
+
 def test_preflight_codex_api_kwargs_strips_optional_function_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     preflight = agent._preflight_codex_api_kwargs(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -264,6 +264,111 @@ class TestMessageStorage:
 
 
 # =========================================================================
+# Multimodal content storage (text + image_url blocks)
+# =========================================================================
+
+class TestMultimodalContent:
+    """Tests for storing and round-tripping multimodal content blocks.
+
+    Vision-capable models receive content as a list of typed blocks
+    (text, image_url, input_image).  These tests verify that the DB
+    can persist and restore the structure losslessly while keeping
+    legacy plain-text content paths intact.
+    """
+
+    def test_multimodal_list_round_trips(self, db):
+        """A list of content blocks should survive write+read unchanged."""
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "What's wrong with this UI?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/screenshot.png"}},
+        ]
+        db.append_message("s1", role="user", content=content)
+
+        conv = db.get_messages_as_conversation("s1")
+        assert len(conv) == 1
+        assert conv[0]["role"] == "user"
+        assert conv[0]["content"] == content
+
+    def test_multimodal_get_messages_round_trips(self, db):
+        """get_messages() must also restore multimodal content (not just _as_conversation)."""
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "Inspect this image:"},
+            {"type": "input_image", "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}},
+        ]
+        db.append_message("s1", role="user", content=content)
+
+        msgs = db.get_messages("s1")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == content
+
+    def test_plain_string_content_unchanged(self, db):
+        """Plain string content path must remain identical to legacy behavior."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Just text, no images")
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["content"] == "Just text, no images"
+
+        msgs = db.get_messages("s1")
+        assert msgs[0]["content"] == "Just text, no images"
+
+    def test_multimodal_searchable_text_in_fts5(self, db):
+        """FTS5 must still find text from inside multimodal blocks."""
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "Help me debug this CSS layout"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+        ]
+        db.append_message("s1", role="user", content=content)
+
+        results = db.search_messages("CSS")
+        assert len(results) >= 1, "FTS5 should find 'CSS' even when content is multimodal"
+
+    def test_legacy_text_row_still_reads(self, db, tmp_path):
+        """A row inserted with raw TEXT content (no content_blocks) must still read correctly.
+
+        Simulates the migration case where existing DBs have plain-text
+        rows but no content_blocks column population.
+        """
+        db.create_session(session_id="s1", source="cli")
+        # Bypass append_message and insert directly as a "legacy" row
+        with db._lock:
+            db._conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, content_blocks) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("s1", "user", "Legacy plain text", time.time(), None),
+            )
+            db._conn.commit()
+
+        conv = db.get_messages_as_conversation("s1")
+        assert len(conv) == 1
+        assert conv[0]["content"] == "Legacy plain text"
+
+    def test_multimodal_with_audio_block(self, db):
+        """Audio blocks should be flattened to [audio] in searchable text."""
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "Listen to this:"},
+            {"type": "input_audio", "audio_url": {"url": "data:audio/wav;base64,UklGRg=="}},
+        ]
+        db.append_message("s1", role="user", content=content)
+
+        msgs = db.get_messages("s1")
+        assert msgs[0]["content"] == content
+
+    def test_none_content_round_trips(self, db):
+        """None content (e.g. assistant tool-only message) must round-trip as None."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="assistant", content=None,
+                          tool_calls=[{"id": "c1", "function": {"name": "x", "arguments": "{}"}}])
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["content"] is None
+
+
+# =========================================================================
 # FTS5 search
 # =========================================================================
 
@@ -935,7 +1040,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -991,12 +1096,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to current version
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1007,6 +1112,97 @@ class TestSchemaInit:
         assert migrated_db.set_session_title("existing", "Migrated Title") is True
         session = migrated_db.get_session("existing")
         assert session["title"] == "Migrated Title"
+
+        migrated_db.close()
+
+    def test_migration_adds_content_blocks_column(self, tmp_path):
+        """v6→v7 migration should add the content_blocks column to messages."""
+        import sqlite3
+
+        db_path = tmp_path / "v6_db.db"
+        conn = sqlite3.connect(str(db_path))
+        # Create a v6 schema (no content_blocks column).  Includes the
+        # superset of columns required by SCHEMA_SQL (parent_session_id,
+        # title, etc.) so the IF NOT EXISTS create script doesn't trip
+        # the trigger pre-flight.
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                title TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("legacy", "cli", 1000.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("legacy", "user", "old plain text", 1001.0),
+        )
+        conn.commit()
+        conn.close()
+
+        # Open with SessionDB — should run v7 migration
+        migrated_db = SessionDB(db_path=db_path)
+
+        cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
+        assert cursor.fetchone()[0] == 7
+
+        # Verify content_blocks column exists
+        cursor = migrated_db._conn.execute("PRAGMA table_info(messages)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "content_blocks" in columns
+
+        # Legacy plain-text content must still read correctly
+        conv = migrated_db.get_messages_as_conversation("legacy")
+        assert len(conv) == 1
+        assert conv[0]["content"] == "old plain text"
+
+        # New multimodal content must work after migration
+        migrated_db.create_session("new", "cli")
+        migrated_db.append_message(
+            "new",
+            role="user",
+            content=[
+                {"type": "text", "text": "Hello"},
+                {"type": "image_url", "image_url": {"url": "https://x.com/y.png"}},
+            ],
+        )
+        conv2 = migrated_db.get_messages_as_conversation("new")
+        assert isinstance(conv2[0]["content"], list)
+        assert len(conv2[0]["content"]) == 2
 
         migrated_db.close()
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -347,6 +347,7 @@ compression:
 | `AUXILIARY_VISION_MODEL` | Override model for vision tasks |
 | `AUXILIARY_VISION_BASE_URL` | Direct OpenAI-compatible endpoint for vision tasks |
 | `AUXILIARY_VISION_API_KEY` | API key paired with `AUXILIARY_VISION_BASE_URL` |
+| `HERMES_FORCE_NATIVE_VISION` | Force the gateway to send images as native multimodal content blocks even when the active model is not catalogued in models.dev. Set to `1` for self-hosted vision models (e.g. vLLM serving Llama 3.2 Vision) or new models not yet in the catalog. When unset, the gateway auto-detects native vision support and falls back to the `vision_analyze` text-description path for unknown or non-vision models. |
 | `AUXILIARY_WEB_EXTRACT_PROVIDER` | Override provider for web extraction/summarization |
 | `AUXILIARY_WEB_EXTRACT_MODEL` | Override model for web extraction/summarization |
 | `AUXILIARY_WEB_EXTRACT_BASE_URL` | Direct OpenAI-compatible endpoint for web extraction/summarization |

--- a/website/docs/user-guide/features/vision.md
+++ b/website/docs/user-guide/features/vision.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 
 # Vision & Image Paste
 
-Hermes Agent supports **multimodal vision** — you can paste images from your clipboard directly into the CLI and ask the agent to analyze, describe, or work with them. Images are sent to the model as base64-encoded content blocks, so any vision-capable model can process them.
+Hermes Agent supports **multimodal vision** — you can paste images from your clipboard directly into the CLI and ask the agent to analyze, describe, or work with them. When the active model has native vision support, images are sent as base64-encoded content blocks so the model receives the actual pixels. Models without native vision automatically fall back to a text-description path that uses an auxiliary vision model to summarize each image.
 
 ## How It Works
 
@@ -15,11 +15,33 @@ Hermes Agent supports **multimodal vision** — you can paste images from your c
 2. Attach it using one of the methods below
 3. Type your question and press Enter
 4. The image appears as a `[📎 Image #1]` badge above the input
-5. On submit, the image is sent to the model as a vision content block
+5. On submit, Hermes checks the active model's capability:
+   - **Native vision** (Claude 3+, Opus 4.6, Sonnet 4.6, GPT-5.4, Gemini 2.5/3, Grok, Qwen-VL, Llava, etc.) → image sent as a typed content block
+   - **No native vision** → image goes through `vision_analyze` (auxiliary vision model produces a text description that gets prepended to your message)
 
 You can attach multiple images before sending — each gets its own badge. Press `Ctrl+C` to clear all attached images.
 
 Images are saved to `~/.hermes/images/` as PNG files with timestamped filenames.
+
+## Messaging Platforms (Telegram, Discord, Matrix, etc.)
+
+The same capability-aware routing applies when users send images to Hermes via messaging gateways:
+
+- Send a photo + caption to your Hermes bot on Telegram, Discord, Matrix, Signal, Feishu, Slack, WhatsApp, or any other supported platform
+- The gateway detects the active model for that session and either passes the image natively or falls back to the legacy text-description path
+- Image-bearing messages are persisted with their full multimodal structure so session reload preserves the visual context
+
+This means **webdev workflows work end-to-end through messaging**: drop a screenshot of a broken UI into Telegram, ask "what's wrong with this layout?", and Claude/GPT/Gemini sees the actual pixels — not a lossy text summary.
+
+## Self-Hosted & Uncatalogued Vision Models
+
+Capability detection uses [models.dev](https://models.dev) data. If you're running a self-hosted vision model (vLLM serving Llama 3.2 Vision, a custom multimodal model not yet in the catalog, etc.), set the env var to force native vision routing:
+
+```bash
+export HERMES_FORCE_NATIVE_VISION=1
+```
+
+When unset, Hermes auto-detects native support per model. When set to `1`, the gateway and CLI both treat the active model as vision-capable regardless of catalog state.
 
 ## Paste Methods
 
@@ -173,7 +195,11 @@ This is why Hermes uses a separate clipboard check — instead of receiving imag
 
 ## Supported Models
 
-Image paste works with any vision-capable model. The image is sent as a base64-encoded data URL in the OpenAI vision content format:
+Image input works with **any model** — Hermes routes the image differently based on the model's capability:
+
+### Native vision models (preferred path)
+
+Image is sent as an OpenAI-style `image_url` content block; the provider adapter converts to the right native format (Anthropic image blocks, OpenAI image_url, Codex input_image, etc.):
 
 ```json
 {
@@ -184,4 +210,10 @@ Image paste works with any vision-capable model. The image is sent as a base64-e
 }
 ```
 
-Most modern models support this format, including GPT-4 Vision, Claude (with vision), Gemini, and open-source multimodal models served through OpenRouter.
+Confirmed native vision support: Claude Opus 4.6, Sonnet 4.6, Haiku 4.5; GPT-5, GPT-5.4, GPT-4o; Gemini 2.5, Gemini 3 Flash; Grok 4; Qwen-VL; Llava and other open-source multimodal models served through OpenRouter or self-hosted endpoints.
+
+### Non-vision models (fallback path)
+
+For text-only models (older GPTs without vision, smaller open-source models, etc.), Hermes routes the image through the auxiliary vision model (default: Gemini Flash) to produce a text description. The description is prepended to your message so the main model can answer questions about the image, just less accurately than native vision and with the cost/latency of an extra LLM call.
+
+You can override the fallback vision model via `AUXILIARY_VISION_PROVIDER` / `AUXILIARY_VISION_MODEL` (see [environment variables](/docs/reference/environment-variables)).


### PR DESCRIPTION
## Summary

Hermes currently routes **every** image attachment through the auxiliary vision model (Gemini Flash by default) to produce a text description, regardless of whether the active model has native vision support. Claude Opus 4.6, GPT-5.4, Gemini 3 Flash, Xiaomi MiMo Omni and every other vision-capable model receives a lossy text summary instead of the actual pixels.

This PR makes the CLI, gateway, and agent loop **capability-aware**: when the active model declares native vision per models.dev, images flow through the API as typed content blocks (`image_url` / `input_image` / Anthropic `image`). Models without native vision keep the legacy `vision_analyze` fallback unchanged. Zero regressions for text-only or non-vision use cases.

## Why This Matters

Real webdev workflow today:
1. User drops a screenshot of a broken layout into Telegram
2. Gateway calls `vision_analyze` → Gemini Flash produces "I see a navbar at the top..."
3. That text description is prepended to the user's message
4. Claude Sonnet 4.6 receives **only the text description** and is asked "what's wrong?"
5. Claude cannot diagnose pixel-level issues because it never sees the pixels

After this PR:
1. Gateway detects Sonnet 4.6 has native vision
2. Builds a multimodal content list (`text` + `image_url`)
3. Sonnet 4.6 receives the actual pixels and diagnoses the 20px offset directly

Verified end-to-end against the Nous endpoint: models that previously saw text now read pixel-level content (see test matrix below).

## Problem Scope

The naive "just add a content list at the gateway" approach doesn't work because the pipeline has **five independent layers** that each flatten multimodal content to text:

1. **Persistence** (`hermes_state.py`): SQLite `content TEXT` column stores raw `str(content)` → lists become Python repr blobs → session reload corrupted
2. **Token estimation** (`agent/model_metadata.py`): `len(str(msg))` counts base64 as text → 1MB image reports as ~262K tokens → compression wipes the image immediately
3. **Codex Responses API path** (`run_agent.py`): `str(content)` coerces list to repr → API receives literal `"[{'type': 'image_url', ...}]"` as user text
4. **`run_conversation` signature** (`run_agent.py`): `user_message: str` → no way to pass multimodal through in the first place
5. **Anthropic preprocess** (`run_agent.py`): `_prepare_anthropic_messages_for_api` unconditionally converts image content blocks to text descriptions via `_describe_image_for_anthropic_fallback`, even when the model has native vision

Plus the gateway itself unconditionally called `_enrich_message_with_vision` for every image, and the CLI's `chat()` method did the same via `_preprocess_images_with_vision`.

Each layer needs its own targeted fix; bundling them would make the PR unreviewable. This PR is split into **12 logically-ordered commits** — 5 bug fixes, 4 feature commits, 2 docs, 1 regression fix discovered during testing.

## Commit Walkthrough

### Bug fixes (layer-by-layer correctness)

| # | Commit | What it fixes |
|---|---|---|
| 1 | `fix(hermes_state): persist multimodal content blocks for vision sessions` | Add schema v7 `content_blocks TEXT` column; round-trip list content losslessly while keeping flattened searchable text in `content` for FTS5 and legacy rows |
| 2 | `fix(model_metadata): image-aware token estimation for multimodal turns` | Replace `len(str(msg))` with `count_message_chars()` that skips base64 payloads; applies ~1500-token budget per image instead of ~262K |
| 3 | `fix(run_agent): preserve multimodal content in codex responses input` | `_chat_content_to_responses_content()` walks content lists and emits `input_text` / `input_image` items in the shape the Codex Responses API expects |

### Feature commits (native vision path)

| # | Commit | What it adds |
|---|---|---|
| 4 | `feat(run_agent): accept multimodal list user_message in run_conversation` | Widen type to `Union[str, List[Dict[str, Any]]]`; `_user_message_preview()` + `_sanitize_user_message_in_place()` helpers; flatten to text for string-only downstream consumers (plugins, memory, trajectory) |
| 5 | `feat(run_agent): skip anthropic image-to-text preprocess for vision-capable models` | `_model_supports_native_vision()` with result caching and `HERMES_FORCE_NATIVE_VISION` escape hatch; `_prepare_anthropic_messages_for_api` skips flatten when capability says yes |
| 6 | `feat(gateway): native multimodal routing for vision-capable models` | Capability check in `_prepare_inbound_message_text`; `_build_native_vision_content` reads local image files into base64 data URLs and emits OpenAI-style content blocks; both callers + `_run_agent` now accept `Union[str, list]` |
| 7 | `feat(cli): native multimodal routing for vision-capable models` | Mirror the gateway routing in the CLI's `chat()` method so `/paste` and drag-and-drop images get native vision too |

### Capability detection robustness (discovered during real-API testing)

| # | Commit | What it fixes |
|---|---|---|
| 8 | `fix(native_vision): catalog matching for dotted versions and aggregator providers` | `_find_model_entry` normalizes dots/hyphens (`claude-sonnet-4.6` ↔ `claude-sonnet-4-6`); provider-prefix strip fallback resolves `("nous", "anthropic/claude-sonnet-4.6")` → `("anthropic", "claude-sonnet-4.6")` |
| 9 | `fix(native_vision): OpenRouter catalog as aggregator catch-all fallback` | Third fallback layer: query `("openrouter", full_slug)` when direct + vendor-prefix both fail. Catches Kimi, Mistral-small, GLM-4.5v, etc. that use OR-compatible slugs but aren't in their native vendor catalog |
| 12 | `fix(model_metadata): add dict overhead to count_message_chars to avoid regression` | The rewrite in commit 2 was reporting ~26% of the legacy `len(str(msg))` for tool-heavy text messages. Add per-message (30 chars) and per-tool-call (40 chars) overhead to keep the estimator within ~10% of legacy for non-image cases |

### Docs

| # | Commit |
|---|---|
| 10 | `docs(env): document HERMES_FORCE_NATIVE_VISION env var` |
| 11 | `docs(vision): document capability-aware native vision routing` |

## End-to-End Verification (Nous endpoint)

Test script: create a PNG with a recognizable 4-digit number, send to each model via `chat.completions.create` with a native `image_url` content block, check whether the model reads the number back correctly.

| Model | API accepts vision | Hermes detects capability | Note |
|---|:---:|:---:|---|
| `anthropic/claude-sonnet-4.6` | ✅ | ✅ | |
| `anthropic/claude-opus-4.6` | ✅ | ✅ | |
| `openai/gpt-5.4-mini` | ✅ | ✅ | |
| `google/gemini-3-flash-preview` | ✅ | ✅ | |
| `google/gemma-4-31b-it` | ✅ | ✅ | |
| `google/gemma-4-26b-a4b-it` | ✅ | ✅ | |
| `google/gemma-3-4b-it` | ✅ | ✅ | |
| `moonshotai/kimi-k2.5` | ✅ | ✅ | Fixed by commit 9 (OpenRouter fallback — moonshotai catalog empty in models.dev) |
| `mistralai/mistral-small-2603` | ✅ | ✅ | Fixed by commit 9 (slug `mistralai/` vs catalog `mistral`) |
| `mistralai/mistral-small-3.2-24b-instruct` | ✅ | ✅ | Fixed by commit 9 |
| `z-ai/glm-4.5v` | ✅ | ✅ | Fixed by commit 9 (slug `z-ai/` vs catalog `zai`) |
| `xiaomi/mimo-v2-omni` | ✅ | ✅ | Described the blue background AND read the number |
| `mistralai/pixtral-large-2411` | ✅ | ❌ | Missing from models.dev OpenRouter catalog entirely; users hitting this model can set `HERMES_FORCE_NATIVE_VISION=1` |

**Before this PR**: 0/13 received native vision — every image was text-flattened regardless of model capability.
**After this PR**: 12/13 automatically routed to native vision; 1 edge case covered by the env var escape hatch.

## Backwards Compatibility

This is the section I want reviewers to scrutinize hardest, because image-handling touches so many layers.

### Text-only messages — zero behavior change

- `hermes_state.append_message(content="hello")` → `content_blocks` is NULL, `content` TEXT stores `"hello"` → read path returns `"hello"` unchanged
- `run_conversation(user_message="hello")` → `user_msg = {"role": "user", "content": "hello"}` (unchanged)
- `_prepare_anthropic_messages_for_api([...])` → early return `if not any(... has_image_parts ...)` (unchanged)
- `_chat_messages_to_responses_input([...])` → string input falls through the new helper and returns unchanged
- Gateway `_prepare_inbound_message_text` → the `if image_paths` branch is skipped entirely for text-only events

### Image messages + non-vision model — legacy path unchanged

- `_should_use_native_vision_for_source` returns False → `_enrich_message_with_vision` is called just like before
- `AIAgent._model_supports_native_vision` returns False → `_prepare_anthropic_messages_for_api` runs the legacy text-flatten path
- CLI `chat()` with no agent or non-vision model → falls through to `_preprocess_images_with_vision`

### Image messages + vision model — new native path

- Gateway builds content list, passes it through `_run_agent → run_conversation(list, ...)`
- `user_msg = {"role": "user", "content": [list]}` is sent to the provider adapter
- `anthropic_adapter.py:829` already handles `image_url` → Anthropic native image block (zero change)
- `chat_completions` path passes through (zero change)
- `codex_responses` path converts via the helper in commit 3

### Token estimator regression caught during testing

Commit 12 is important: the rewrite in commit 2 removed the implicit dict-serialization overhead that `len(str(msg))` included. For text/tool conversations, the new estimator was reporting ~26% of the legacy value — a 74% undercount that would make preflight compression fire far later than before and put 32K-context models at risk of hitting real overflow.

Comparison on a realistic 9-turn tool conversation (empirical):
- Legacy `len(str)`:  894 chars / 224 tokens
- After commit 2:     274 chars /  69 tokens  ← **74% undercount, regression**
- After commit 12:    809 chars / 203 tokens  ← **91% of legacy, within noise**

And on a 1MB base64 image message:
- Legacy `len(str)`:  1,048,728 chars / 262,182 tokens  ← **broken (the bug we're fixing)**
- After commit 12:         6,056 chars /   1,514 tokens  ← **correct (1500 tokens ≈ actual image cost)**

## Test Coverage

**~80 new tests across 5 files**:
- `tests/test_hermes_state.py` — 8 round-trip cases + 1 v6→v7 migration test
- `tests/agent/test_model_metadata.py` — 11 token estimation / multimodal char counting cases + 4 dot/hyphen normalization cases
- `tests/run_agent/test_run_agent.py` — 14 multimodal `run_conversation` + 6 native vision capability + 4 prefix fallback + 3 OpenRouter fallback
- `tests/run_agent/test_run_agent_codex_responses.py` — 11 content conversion + 2 end-to-end codex responses
- `tests/gateway/test_native_vision_routing.py` — 15 helper tests + 2 OpenRouter fallback (new file)
- `tests/cli/test_cli_native_vision.py` — 9 helper + chat() routing tests (new file)

All ~380 tests in the touched areas pass. 9 pre-existing failures in unrelated files (`test_auxiliary_client.py`, `test_session_race_guard.py`, etc.) remain unchanged by this branch — confirmed by running the same tests against `main` with the branch stashed.

## Known Limitations

1. **`mistralai/pixtral-large-2411`** — Missing from the models.dev OpenRouter catalog so capability detection returns False. Users can set `HERMES_FORCE_NATIVE_VISION=1` until the catalog is updated.
2. **Self-hosted vision models (vLLM + Llama 3.2 Vision, etc.)** — Not in models.dev, need `HERMES_FORCE_NATIVE_VISION=1`. Documented in `vision.md` and `environment-variables.md`.
3. **Tool-result images** — `function_call_output` in the Codex Responses API takes a string `output` field, so images in tool results still get flattened. Out of scope for this PR; would need a separate design for tool result multimodal.

## Env Vars Added

- `HERMES_FORCE_NATIVE_VISION=1` — Force native vision routing in both CLI and gateway regardless of capability lookup. Documented in `website/docs/reference/environment-variables.md`.

## Test plan

- [x] End-to-end: all 13 models from the Nous popular list tested against real API (test matrix above)
- [x] Unit tests: ~80 new tests, all pass
- [x] Regression: 9-turn tool conversation token estimate stays within 10% of legacy
- [x] Backwards compat: text-only messages exercise zero new code paths
- [x] CLI `/paste` with vision-capable model sends native `image_url` content block
- [x] Gateway routing from Telegram-style `MessageEvent` with `media_urls` → native content list when model has vision


---

