### PR TITLE
fix(claw): change cleanup archive prompt to default=No and warn about OpenClaw breakage

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -483,7 +483,10 @@ def _cmd_cleanup(args):
             print_info(f"Non-interactive session — would archive: {source_dir}")
             print_info("To execute, re-run with: hermes claw cleanup --yes")
         else:
-            if auto_yes or prompt_yes_no(f"Archive {source_dir}?", default=True):
+            if auto_yes or prompt_yes_no(
+                f"Archive {source_dir}? (⚠ This will make OpenClaw unbootable until renamed back)",
+                default=False,
+            ):
                 try:
                     archive_path = _archive_directory(source_dir)
                     print_success(f"Archived: {source_dir} → {archive_path}")


### PR DESCRIPTION
The 'Archive .openclaw?' prompt at `claw.py:486` defaulted to Yes — pressing Enter renamed the directory and made OpenClaw unbootable. Users reported this as 'Hermes killed my OpenClaw.'

Changed default to No and added a warning to the prompt text: '⚠ This will make OpenClaw unbootable until renamed back.'

3 lines changed in `hermes_cli/claw.py`. Ref #7907