### PR TITLE
fix: intercept long sleep commands that block agent and prevent user interaction

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1372,6 +1372,24 @@ def terminal_tool(
                 "EOF."
             )
 
+        # Intercept long sleep commands that block the agent and prevent
+        # user interaction. The interrupt flag is checked between tool calls,
+        # not during subprocess execution, so a 6-minute sleep cannot be interrupted.
+        _sleep_match = re.match(r"^\s*sleep\s+(\d+)", command)
+        if _sleep_match and int(_sleep_match.group(1)) > 30 and not background:
+            _sleep_secs = int(_sleep_match.group(1))
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    f"Rejected: 'sleep {_sleep_secs}' would block the agent for "
+                    f"{_sleep_secs}s, preventing user interaction. "
+                    "Instead: run your long process with background=true, then "
+                    "use process(action='poll', session_id=...) to check progress. "
+                    "For short waits, use sleep values <= 30."
+                ),
+            }, ensure_ascii=False)
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.


### PR DESCRIPTION
Reject foreground `sleep N` commands where N > 30 seconds. These block the entire agent — the interrupt flag is checked between tool calls, not during subprocess execution, so a multi-minute sleep cannot be interrupted. Users report the agent 'goes into a sleep+tail loop and completely hangs.'

The error message guides the model toward `background=true` + `process(action='poll')`. Short sleeps (<=30s) and background sleeps are still allowed.

18 lines in `tools/terminal_tool.py`. Closes #4162. Supersedes #4164 (stale conflicts).