### PR TITLE
fix(auxiliary): forward codex adapter timeout and output token caps

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -269,6 +269,7 @@ class _CodexCompletionsAdapter:
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
+        timeout = kwargs.get("timeout")
 
         # Separate system/instructions from conversation messages.
         # Convert chat.completions multimodal content blocks to Responses
@@ -293,8 +294,20 @@ class _CodexCompletionsAdapter:
             "store": False,
         }
 
+        # Responses API expects max_output_tokens, while auxiliary callers
+        # use chat.completions-style token params.
+        max_output_tokens = (
+            kwargs.get("max_output_tokens")
+            or kwargs.get("max_completion_tokens")
+            or kwargs.get("max_tokens")
+        )
+        if max_output_tokens is not None:
+            resp_kwargs["max_output_tokens"] = max_output_tokens
+        if timeout is not None:
+            resp_kwargs["timeout"] = timeout
+
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
-        # support max_output_tokens or temperature — omit to avoid 400 errors.
+        # support temperature — omit to avoid 400 errors.
 
         # Tools support for flush_memories and similar callers
         tools = kwargs.get("tools")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -1699,3 +1700,58 @@ class TestAnthropicCompatImageConversion:
         }]
         result = _convert_openai_images_to_anthropic(messages)
         assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+
+class TestCodexAuxiliaryAdapter:
+    @staticmethod
+    def _make_streaming_client():
+        final = SimpleNamespace(output=[], usage=None)
+
+        class _StreamCtx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return final
+
+        stream_mock = MagicMock(return_value=_StreamCtx())
+        client = SimpleNamespace(
+            responses=SimpleNamespace(stream=stream_mock)
+        )
+        return client, stream_mock
+
+    def test_codex_adapter_maps_max_tokens_to_max_output_tokens(self):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        client, stream_mock = self._make_streaming_client()
+        adapter = _CodexCompletionsAdapter(client, "gpt-5.4")
+
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1234,
+        )
+
+        kwargs = stream_mock.call_args.kwargs
+        assert kwargs["max_output_tokens"] == 1234
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_codex_adapter_forwards_timeout_to_responses_stream(self):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        client, stream_mock = self._make_streaming_client()
+        adapter = _CodexCompletionsAdapter(client, "gpt-5.4")
+
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=900,
+        )
+
+        kwargs = stream_mock.call_args.kwargs
+        assert kwargs["timeout"] == 900


### PR DESCRIPTION
## What does this PR do?

Bridges chat.completions-style kwargs more completely through `_CodexCompletionsAdapter.create()` when auxiliary calls are routed through the Responses API. Specifically, it forwards `timeout` and normalizes `max_output_tokens` / `max_completion_tokens` / `max_tokens` into Responses API `max_output_tokens`.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Read `timeout = kwargs.get("timeout")` in `agent/auxiliary_client.py`
- Map `max_output_tokens`, `max_completion_tokens`, and `max_tokens` to `resp_kwargs["max_output_tokens"]`
- Forward `timeout` to `resp_kwargs["timeout"]`
- Add regression tests in `tests/agent/test_auxiliary_client.py` covering token-cap forwarding and timeout forwarding

## How to Test

1. `source venv/bin/activate`
2. `pytest -q tests/agent/test_auxiliary_client.py -k 'codex_adapter or copilot'`
3. Verify the new adapter tests pass and confirm `responses.stream()` receives `max_output_tokens` / `timeout`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 5.15.0-119-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest -q tests/agent/test_auxiliary_client.py -k 'codex_adapter or copilot'`
- Result: `5 passed`
