### PR TITLE
Add api_key_env support for custom providers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1586,12 +1586,12 @@ _KNOWN_ROOT_KEYS = {
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
+    "name", "base_url", "api_key", "api_key_env", "api_mode", "model", "models",
     "context_length", "rate_limit_delay",
 }
 
 # Fields that look like they should be inside custom_providers, not at root
-_CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+_CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "api_key_env", "rate_limit_delay", "api_mode"}
 
 
 @dataclass

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -301,6 +301,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
+        api_key_env = str(entry.get("api_key_env", "") or "").strip()
+        if api_key_env:
+            result["api_key_env"] = api_key_env
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
@@ -339,9 +342,15 @@ def _resolve_named_custom_runtime(
             pool_result["model"] = model_name
         return pool_result
 
+    api_key_env_var = str(custom_provider.get("api_key_env", "") or "").strip()
+    api_key_from_env = os.getenv(api_key_env_var, "").strip() if api_key_env_var else ""
+    is_ollama_url = "ollama.com" in base_url.lower()
+
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
+        api_key_from_env,
+        (os.getenv("OLLAMA_API_KEY", "").strip() if is_ollama_url else ""),
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -64,6 +64,20 @@ class TestCustomProvidersValidation:
         })
         assert len(issues) == 0
 
+    def test_valid_list_with_api_key_env_no_issues(self):
+        """custom_providers entries may specify api_key_env for env-based auth."""
+        issues = validate_config_structure({
+            "custom_providers": [
+                {
+                    "name": "ollama-cloud",
+                    "base_url": "https://ollama.com/v1",
+                    "api_key_env": "OLLAMA_API_KEY",
+                },
+            ],
+            "model": {"provider": "custom:ollama-cloud", "default": "minimax-m2.7"},
+        })
+        assert len(issues) == 0
+
     def test_list_entry_missing_name(self):
         """List entry without name should warn."""
         issues = validate_config_structure({

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -599,6 +599,73 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     assert resolved["requested_provider"] == "custom:local-llm"
 
 
+def test_named_custom_provider_uses_api_key_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_API_KEY", "env-ollama-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Ollama Cloud",
+                    "base_url": "https://ollama.com/v1",
+                    "api_key_env": "OLLAMA_API_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:ollama-cloud")
+
+    assert resolved["base_url"] == "https://ollama.com/v1"
+    assert resolved["api_key"] == "env-ollama-key"
+    assert resolved["requested_provider"] == "custom:ollama-cloud"
+
+
+def test_named_custom_provider_prefers_api_key_over_api_key_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_API_KEY", "env-ollama-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Ollama Cloud",
+                    "base_url": "https://ollama.com/v1",
+                    "api_key": "explicit-custom-key",
+                    "api_key_env": "OLLAMA_API_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:ollama-cloud")
+
+    assert resolved["api_key"] == "explicit-custom-key"
+
+
 def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):
     monkeypatch.setattr(
         rp,
@@ -1236,6 +1303,21 @@ def test_get_named_custom_provider_includes_model(monkeypatch):
     result = rp._get_named_custom_provider("my-dashscope")
     assert result is not None
     assert result["model"] == "qwen3.6-plus"
+
+
+def test_get_named_custom_provider_includes_api_key_env(monkeypatch):
+    """_get_named_custom_provider should include api_key_env from config."""
+    monkeypatch.setattr(rp, "load_config", lambda: {
+        "custom_providers": [{
+            "name": "my-ollama",
+            "base_url": "https://ollama.com/v1",
+            "api_key_env": "OLLAMA_API_KEY",
+        }],
+    })
+
+    result = rp._get_named_custom_provider("my-ollama")
+    assert result is not None
+    assert result["api_key_env"] == "OLLAMA_API_KEY"
 
 
 def test_get_named_custom_provider_excludes_empty_model(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds support for `api_key_env` in customer providers like top level `model` config to avoid requiring api keys in config.yaml.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. use `api_key_env` in a custom provider entry 
2. set the api key env var in .env file
3. confirm access works as expected

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

