### PR TITLE
fix(matrix): disable streaming cursor decoration on Matrix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7666,7 +7666,10 @@ class GatewayRunner:
                         _consumer_cfg = StreamConsumerConfig(
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
-                            cursor=_scfg.cursor,
+                            # Some Matrix clients render the streaming cursor
+                            # as a visible tofu/white-box artifact. Keep
+                            # streaming text on Matrix, but suppress the cursor.
+                            cursor="" if source.platform == Platform.MATRIX else _scfg.cursor,
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -491,6 +491,13 @@ class GatewayStreamConsumer:
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
         text = self._clean_for_display(text)
+        # A bare streaming cursor is not meaningful user-visible content and
+        # can render as a stray tofu/white-box message on some clients.
+        visible_without_cursor = text
+        if self.cfg.cursor:
+            visible_without_cursor = visible_without_cursor.replace(self.cfg.cursor, "")
+        if not visible_without_cursor.strip():
+            return True  # cursor-only / whitespace-only update
         if not text.strip():
             return True  # nothing to send is "success"
         try:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -378,6 +378,25 @@ class PreviewedResponseAgent:
         }
 
 
+class StreamingRefineAgent:
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("Continuing to refine:")
+        time.sleep(0.1)
+        if self.stream_delta_callback:
+            self.stream_delta_callback(" Final answer.")
+        return {
+            "final_response": "Continuing to refine: Final answer.",
+            "response_previewed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedCommentaryAgent:
     calls = 0
 
@@ -404,6 +423,10 @@ async def _run_with_agent(
     session_id,
     pending_text=None,
     config_data=None,
+    platform=Platform.TELEGRAM,
+    chat_id="-1001",
+    chat_type="group",
+    thread_id="17585",
 ):
     if config_data:
         import yaml
@@ -418,7 +441,7 @@ async def _run_with_agent(
     fake_run_agent.AIAgent = agent_cls
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
-    adapter = ProgressCaptureAdapter()
+    adapter = ProgressCaptureAdapter(platform=platform)
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
@@ -426,12 +449,14 @@ async def _run_with_agent(
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
     source = SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id="-1001",
-        chat_type="group",
-        thread_id="17585",
+        platform=platform,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
     )
-    session_key = "agent:main:telegram:group:-1001:17585"
+    session_key = f"agent:main:{platform.value}:{chat_type}:{chat_id}"
+    if thread_id:
+        session_key = f"{session_key}:{thread_id}"
     if pending_text is not None:
         adapter._pending_messages[session_key] = MessageEvent(
             text=pending_text,
@@ -557,6 +582,30 @@ async def test_run_agent_previewed_final_marks_already_sent(monkeypatch, tmp_pat
 
     assert result.get("already_sent") is True
     assert [call["content"] for call in adapter.sent] == ["You're welcome."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-matrix-streaming",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+    assert result.get("already_sent") is True
+    all_text = [call["content"] for call in adapter.sent] + [call["content"] for call in adapter.edits]
+    assert all_text, "expected streamed Matrix content to be sent or edited"
+    assert all("▉" not in text for text in all_text)
+    assert any("Continuing to refine:" in text for text in all_text)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -139,6 +139,22 @@ class TestSendOrEditMediaStripping:
 
         adapter.send.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_cursor_only_update_skips_send(self):
+        """A bare streaming cursor should not be sent as its own message."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(cursor=" ▉"),
+        )
+        await consumer._send_or_edit(" ▉")
+
+        adapter.send.assert_not_called()
+
 
 # ── Integration: full stream run ─────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes from sending Matrix streaming messages with the trailing cursor decoration that shows up as visible white-box / tofu artifacts in Element.

A Matrix user reported white blocks after a recent update. Looking at the Element event source showed Hermes was sometimes emitting content like:

```json
{
  "body": "\n\n\n ▉",
  "format": "org.matrix.custom.html",
  "formatted_body": "▉",
  "msgtype": "m.text"
}
```

and also edited messages like:

```json
{
  "formatted_body": "Continuing to refine:<br />\n ▉"
}
```

So the real issue was broader than cursor-only placeholder messages: Matrix clients were getting the stream cursor itself as visible content.

This PR keeps streaming text on Matrix, but disables the cursor decoration for Matrix specifically.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `gateway/run.py` so the `GatewayStreamConsumer` is instantiated with `cursor=""` on Matrix
- kept the existing stream-consumer guard that skips cursor-only / whitespace-only updates
- added a regression test in `tests/gateway/test_run_progress_topics.py` to verify streamed Matrix content does not include `▉`
- kept the change scoped to Matrix rather than changing streaming cursor behavior globally

## How to Test

1. Reproduce the bug on Matrix with streamed/interim output.
2. Verify Hermes no longer sends Matrix messages whose visible content contains the trailing cursor decoration `▉`.
3. Run:
   `venv/bin/python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py -q -n0`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification run:

- `venv/bin/python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py -q -n0` → `44 passed in 16.55s`

The full `pytest tests/ -q` checklist item is intentionally left unchecked here.
