### PR TITLE
fix(gateway): preserve symlinked venv python in systemd system unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -613,14 +613,28 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
 
       /root/.hermes/hermes-agent  -> /home/alice/.hermes/hermes-agent
       /opt/hermes                 -> /opt/hermes  (kept as-is)
+
+    The lexical (unresolved) form of *path* is preferred so that symlinks
+    pointing outside of $HOME — notably the interpreter inside a uv-managed
+    venv, whose ``venv/bin/python`` is a symlink into uv's shared Python
+    store — are preserved verbatim. Resolving those would emit the bare
+    interpreter in ExecStart and bypass the venv's site-packages at runtime.
     """
-    current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    source = Path(path)
+    current_home = Path.home()
+    for home_candidate in (current_home, current_home.resolve()):
+        try:
+            relative = source.relative_to(home_candidate)
+            return str(Path(target_home_dir) / relative)
+        except ValueError:
+            continue
+    # Fallback: compare resolved forms so a symlinked $HOME
+    # (e.g. /home/alice -> /mnt/users/alice) still remaps cleanly.
     try:
-        relative = resolved.relative_to(current_home)
+        relative = source.resolve().relative_to(current_home.resolve())
         return str(Path(target_home_dir) / relative)
     except ValueError:
-        return str(resolved)
+        return path
 
 
 def _hermes_home_for_target_user(target_home_dir: str) -> str:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -843,6 +843,30 @@ class TestRemapPathForUser:
         result = gateway_cli._remap_path_for_user(original, str(tmp_path / "alice"))
         assert result == original
 
+    def test_preserves_symlink_pointing_outside_home(self, monkeypatch, tmp_path):
+        """Regression: uv-managed venv has venv/bin/python as a symlink to an
+        interpreter outside $HOME. _remap_path_for_user must preserve the
+        lexical path so ExecStart points at the venv interpreter — resolving
+        the symlink would emit the bare python and bypass site-packages.
+        """
+        root_home = tmp_path / "root"
+        root_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: root_home)
+
+        # Simulate a uv-style venv: venv/bin/python -> external interpreter
+        venv_bin = root_home / "src" / "hermes-agent" / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        external_python = tmp_path / "uv-store" / "python3.11"
+        external_python.parent.mkdir(parents=True)
+        external_python.write_text("")
+        venv_python = venv_bin / "python"
+        venv_python.symlink_to(external_python)
+
+        result = gateway_cli._remap_path_for_user(str(venv_python), "/home/alice")
+
+        assert result == "/home/alice/src/hermes-agent/venv/bin/python"
+        assert "uv-store" not in result
+
 
 class TestSystemUnitPathRemapping:
     """System units must remap ALL paths from the caller's home to the target user."""


### PR DESCRIPTION
## What

`_remap_path_for_user()` in `hermes_cli/gateway.py` called `Path.resolve()` on its input, which follows symlinks. In **uv-managed venvs**, `venv/bin/python` is a symlink into uv's shared Python store:

```
venv/bin/python -> ~/.local/share/uv/python/cpython-3.11.x-linux-x86_64-gnu/bin/python3.11
```

`get_python_path()` correctly returns `.../venv/bin/python`, but when `generate_systemd_unit(system=True)` runs that path through `_remap_path_for_user`, `.resolve()` swaps it for the bare uv interpreter. The generated unit's `ExecStart=` then launches Python **outside** the venv, so none of the venv's site-packages are importable and the service crash-loops on import:

```
ModuleNotFoundError: No module named 'yaml'
```

`hermes gateway start --system` reports success (systemd accepted the start request) but `systemctl status hermes-gateway` shows `activating (auto-restart)` briefly before settling into `failed`. The CLI and the actual state disagree, which makes it genuinely confusing to diagnose.

Only affects uv-managed venvs combined with `--system` installs — a traditional `python -m venv` copies the interpreter, so `.resolve()` stays inside the venv and the bug is invisible. User-scoped installs skip `_remap_path_for_user` entirely and are unaffected.

## Fix

Prefer the lexical (unresolved) form of the path for the remap, and only fall back to resolving when `$HOME` itself is a symlink (e.g. `/home/alice -> /mnt/users/alice`). System paths like `/opt/hermes` continue to round-trip unchanged. In the unreachable-by-remap fallback branch, return the original path rather than the resolved form — otherwise we'd still leak resolved symlinks for paths outside `$HOME`.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_service.py` — 58 passed, including new regression test `test_preserves_symlink_pointing_outside_home`
- [x] Existing `_remap_path_for_user` tests (`test_remaps_path_under_current_home`, `test_keeps_system_path_unchanged`, `test_noop_when_same_user`) still pass
- [x] Reproduced end-to-end on Linux with a uv-managed venv: before the fix, `systemctl cat hermes-gateway` showed `ExecStart=<uv-store-path>/python3.11 ...` and the service crash-looped on `ModuleNotFoundError: yaml`. After the fix, `ExecStart=<project>/venv/bin/python ...` and the service runs cleanly (`Active: active (running)`).
- [ ] Not tested on macOS/Windows — change is path-handling only and uses `pathlib`, so cross-platform impact should be minimal.

## Platforms

Tested on Linux (systemd).