### PR TITLE
fix(cli): preserve named custom providers in /model switching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4591,21 +4591,19 @@ class HermesCLI:
 
         user_provs = None
         custom_provs = None
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            if isinstance(cfg, dict):
+                user_provs = cfg.get("providers")
+                custom_provs = cfg.get("custom_providers")
+        except Exception:
+            pass
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
             model_display = self.model or "unknown"
             provider_display = get_label(self.provider) if self.provider else "unknown"
-
-            user_provs = None
-            custom_provs = None
-            try:
-                from hermes_cli.config import load_config
-                cfg = load_config()
-                user_provs = cfg.get("providers")
-                custom_provs = cfg.get("custom_providers")
-            except Exception:
-                pass
 
             try:
                 providers = list_authenticated_providers(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -58,6 +58,188 @@ _HERMES_MODEL_WARNING = (
 )
 
 
+def _normalize_custom_provider_hint(value: str) -> str:
+    """Normalize a custom-provider hint for loose slash-syntax matching."""
+    return (value or "").strip().lower().replace(" ", "-")
+
+
+def _collect_custom_provider_models(entry: dict) -> list[str]:
+    """Collect configured model names from a custom_providers entry."""
+    models: list[str] = []
+    seen: set[str] = set()
+
+    default_model = str(entry.get("model") or "").strip()
+    if default_model:
+        models.append(default_model)
+        seen.add(default_model.lower())
+
+    configured_models = entry.get("models")
+    if isinstance(configured_models, dict):
+        raw_models = list(configured_models.keys())
+    elif isinstance(configured_models, list):
+        raw_models = configured_models
+    else:
+        raw_models = []
+
+    for raw_model in raw_models:
+        if isinstance(raw_model, dict):
+            model_name = str(
+                raw_model.get("id")
+                or raw_model.get("name")
+                or raw_model.get("model")
+                or ""
+            ).strip()
+        else:
+            model_name = str(raw_model or "").strip()
+        if not model_name or model_name.lower() in seen:
+            continue
+        models.append(model_name)
+        seen.add(model_name.lower())
+
+    return models
+
+
+def _match_named_custom_provider(
+    requested: str,
+    custom_providers: list | None,
+) -> Optional[str]:
+    """Map a provider hint like ``stepfun`` or ``custom:stepfun-plan`` to a saved custom slug."""
+    if not custom_providers or not isinstance(custom_providers, list):
+        return None
+
+    requested_raw = (requested or "").strip().lower()
+    requested_norm = _normalize_custom_provider_hint(requested)
+    if not requested_raw or not requested_norm:
+        return None
+
+    exact_matches: list[str] = []
+    prefix_matches: list[str] = []
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+
+        display_name = str(entry.get("name") or "").strip()
+        api_url = str(
+            entry.get("base_url", "")
+            or entry.get("url", "")
+            or entry.get("api", "")
+            or ""
+        ).strip()
+        if not display_name or not api_url:
+            continue
+
+        slug = custom_provider_slug(display_name)
+        bare_slug = slug.split(":", 1)[1]
+        exact_aliases = {
+            display_name.lower(),
+            _normalize_custom_provider_hint(display_name),
+            bare_slug,
+            slug,
+        }
+
+        if requested_raw in exact_aliases or requested_norm in exact_aliases:
+            exact_matches.append(slug)
+            continue
+
+        if requested_raw.startswith("custom:"):
+            continue
+
+        if bare_slug.startswith(f"{requested_norm}-"):
+            prefix_matches.append(slug)
+
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if exact_matches:
+        return None
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
+    return None
+
+
+def _resolve_custom_provider_shortcut(
+    raw_input: str,
+    current_provider: str,
+    user_providers: dict | None,
+    custom_providers: list | None,
+) -> Optional[tuple[str, str]]:
+    """Resolve ``provider/model`` inputs against saved custom_providers."""
+    stripped = raw_input.strip()
+    if "/" not in stripped:
+        return None
+
+    provider_hint, model_name = stripped.split("/", 1)
+    provider_hint = provider_hint.strip()
+    model_name = model_name.strip()
+    if not provider_hint or not model_name:
+        return None
+
+    matched = _match_named_custom_provider(provider_hint, custom_providers)
+    if matched is not None:
+        matched_bare = matched.split(":", 1)[1]
+        requested_norm = _normalize_custom_provider_hint(provider_hint.removeprefix("custom:"))
+        if (
+            matched == current_provider
+            or provider_hint.strip().lower().startswith("custom:")
+            or requested_norm == matched_bare
+            or _detect_custom_provider_for_model(model_name, matched, custom_providers) is not None
+        ):
+            return (matched, model_name)
+
+    # Don't hijack built-in or user-defined providers like anthropic/claude-*
+    if resolve_provider_full(provider_hint, user_providers, None) is not None:
+        return None
+
+    if current_provider.startswith("custom:"):
+        current_hint = current_provider.split(":", 1)[1]
+        requested_norm = _normalize_custom_provider_hint(provider_hint.removeprefix("custom:"))
+        if requested_norm and (
+            current_hint == requested_norm or current_hint.startswith(f"{requested_norm}-")
+        ):
+            return (current_provider, model_name)
+
+    return None
+
+
+def _detect_custom_provider_for_model(
+    model_name: str,
+    current_provider: str,
+    custom_providers: list | None,
+) -> Optional[tuple[str, str]]:
+    """Find a saved custom provider that explicitly lists *model_name* in config."""
+    requested = (model_name or "").strip()
+    if not requested or not custom_providers or not isinstance(custom_providers, list):
+        return None
+
+    requested_lower = requested.lower()
+    matches: list[str] = []
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        display_name = str(entry.get("name") or "").strip()
+        api_url = str(
+            entry.get("base_url", "")
+            or entry.get("url", "")
+            or entry.get("api", "")
+            or ""
+        ).strip()
+        if not display_name or not api_url:
+            continue
+
+        slug = custom_provider_slug(display_name)
+        models = _collect_custom_provider_models(entry)
+        if not any(requested_lower == model.lower() for model in models):
+            continue
+        if slug == current_provider:
+            return (slug, requested)
+        matches.append(slug)
+
+    if len(matches) == 1:
+        return (matches[0], requested)
+    return None
+
+
 def _check_hermes_model_warning(model_name: str) -> str:
     """Return a warning string if *model_name* looks like a Hermes LLM model."""
     if "hermes" in model_name.lower():
@@ -509,8 +691,21 @@ def switch_model(
     # PATH B: No explicit provider — resolve from model input
     # =================================================================
     else:
+        custom_shortcut = _resolve_custom_provider_shortcut(
+            raw_input,
+            current_provider,
+            user_providers,
+            custom_providers,
+        )
+        if custom_shortcut is not None:
+            target_provider, new_model = custom_shortcut
+            logger.debug(
+                "Resolved custom provider shortcut '%s' to %s on %s",
+                raw_input, new_model, target_provider,
+            )
+
         # --- Step a: Try alias resolution on current provider ---
-        alias_result = resolve_alias(raw_input, current_provider)
+        alias_result = None if custom_shortcut is not None else resolve_alias(raw_input, current_provider)
 
         if alias_result is not None:
             target_provider, new_model, resolved_alias = alias_result
@@ -562,6 +757,14 @@ def switch_model(
                             raw_input, new_model,
                         )
 
+        custom_model_match = _detect_custom_provider_for_model(
+            new_model,
+            current_provider,
+            custom_providers,
+        )
+        if custom_model_match is not None:
+            target_provider, new_model = custom_model_match
+
         # --- Step d: Aggregator catalog search ---
         if is_aggregator(target_provider) and not resolved_alias:
             catalog = list_provider_models(target_provider)
@@ -581,7 +784,7 @@ def switch_model(
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
-        is_custom = current_provider in ("custom", "local") or (
+        is_custom = current_provider in ("custom", "local") or current_provider.startswith("custom:") or (
             "localhost" in _base or "127.0.0.1" in _base
         )
 
@@ -954,17 +1157,14 @@ def list_authenticated_providers(
             if slug in seen_slugs:
                 continue
 
-            models_list = []
-            default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
+            models_list = _collect_custom_provider_models(entry)
 
             results.append({
                 "slug": slug,
                 "name": display_name,
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": models_list[:max_models],
                 "total_models": len(models_list),
                 "source": "user-config",
                 "api_url": api_url,
@@ -975,5 +1175,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
-

--- a/tests/hermes_cli/test_cli_model_picker.py
+++ b/tests/hermes_cli/test_cli_model_picker.py
@@ -204,6 +204,59 @@ def test_process_command_model_without_args_opens_modal_picker_and_captures_draf
     assert cli._app.current_buffer.text == ""
 
 
+def test_handle_model_switch_with_args_loads_custom_providers_from_config():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+    switch_result = SimpleNamespace(
+        success=True,
+        error_message=None,
+        new_model="step-3.5-flash",
+        target_provider="custom:stepfun-plan",
+        api_key="sk-stepfun",
+        base_url="https://api.stepfun.com/step_plan/v1",
+        api_mode="chat_completions",
+        provider_label="stepfun-plan",
+        model_info=None,
+        warning_message=None,
+        provider_changed=True,
+    )
+
+    with (
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "custom_providers": [
+                    {
+                        "name": "stepfun-plan",
+                        "base_url": "https://api.stepfun.com/step_plan/v1",
+                        "model": "step-3.5-flash",
+                    }
+                ]
+            },
+        ),
+        patch("hermes_cli.model_switch.switch_model", return_value=switch_result) as switch_mock,
+        patch("cli._cprint"),
+    ):
+        HermesCLI._handle_model_switch(
+            cli,
+            "/model step-3.5-flash --provider custom:stepfun-plan",
+        )
+
+    assert cli.model == "step-3.5-flash"
+    assert cli.provider == "custom:stepfun-plan"
+    assert cli.requested_provider == "custom:stepfun-plan"
+    assert cli.base_url == "https://api.stepfun.com/step_plan/v1"
+    assert cli.api_key == "sk-stepfun"
+    assert switch_mock.call_args.kwargs["custom_providers"] == [
+        {
+            "name": "stepfun-plan",
+            "base_url": "https://api.stepfun.com/step_plan/v1",
+            "model": "step-3.5-flash",
+        }
+    ]
+
+
 def test_model_picker_provider_then_model_selection_applies_switch_result_and_restores_draft():
     from cli import HermesCLI
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -31,6 +31,10 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
                 "name": "Local (127.0.0.1:4141)",
                 "base_url": "http://127.0.0.1:4141/v1",
                 "model": "rotator-openrouter-coding",
+                "models": {
+                    "rotator-openrouter-coding": {"context_length": 131072},
+                    "backup-model": {"context_length": 65536},
+                },
             }
         ],
         max_models=50,
@@ -39,7 +43,7 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     assert any(
         p["slug"] == "custom:local-(127.0.0.1:4141)"
         and p["name"] == "Local (127.0.0.1:4141)"
-        and p["models"] == ["rotator-openrouter-coding"]
+        and p["models"] == ["rotator-openrouter-coding", "backup-model"]
         and p["api_url"] == "http://127.0.0.1:4141/v1"
         for p in providers
     )
@@ -102,3 +106,120 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+def test_switch_model_keeps_named_custom_provider_for_direct_model(monkeypatch):
+    """Named custom providers should not auto-switch away for matching bare models."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "sk-stepfun",
+            "base_url": "https://api.stepfun.com/step_plan/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *a, **k: ("minimax-cn", "MiniMax-M2.7"),
+    )
+
+    result = switch_model(
+        raw_input="step-3.5-flash",
+        current_provider="custom:stepfun-plan",
+        current_model="step-3.5-flash",
+        current_base_url="https://api.stepfun.com/step_plan/v1",
+        current_api_key="sk-stepfun",
+        custom_providers=[
+            {
+                "name": "stepfun-plan",
+                "base_url": "https://api.stepfun.com/step_plan/v1",
+                "model": "step-3.5-flash",
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:stepfun-plan"
+    assert result.new_model == "step-3.5-flash"
+    assert result.base_url == "https://api.stepfun.com/step_plan/v1"
+
+
+def test_switch_model_resolves_named_custom_provider_from_slash_syntax(monkeypatch):
+    """provider/model shorthand should map unique custom-provider prefixes."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "sk-stepfun",
+            "base_url": "https://api.stepfun.com/step_plan/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="stepfun/step-3.5-flash",
+        current_provider="openrouter",
+        current_model="anthropic/claude-sonnet-4.5",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="sk-openrouter",
+        custom_providers=[
+            {
+                "name": "stepfun-plan",
+                "base_url": "https://api.stepfun.com/step_plan/v1",
+                "model": "step-3.5-flash",
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:stepfun-plan"
+    assert result.provider_label == "stepfun-plan"
+    assert result.new_model == "step-3.5-flash"
+    assert result.base_url == "https://api.stepfun.com/step_plan/v1"
+
+
+def test_switch_model_auto_detects_model_listed_under_named_custom_provider(monkeypatch):
+    """Configured custom-provider models should win before built-in auto-detection."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "sk-stepfun",
+            "base_url": "https://api.stepfun.com/step_plan/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *a, **k: ("minimax-cn", "MiniMax-M2.7"),
+    )
+
+    result = switch_model(
+        raw_input="step-3.5-flash",
+        current_provider="openrouter",
+        current_model="anthropic/claude-sonnet-4.5",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="sk-openrouter",
+        custom_providers=[
+            {
+                "name": "stepfun-plan",
+                "base_url": "https://api.stepfun.com/step_plan/v1",
+                "models": {
+                    "step-3.5-flash": {"context_length": 262144},
+                    "step-3.5v-mini": {"context_length": 131072},
+                },
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:stepfun-plan"
+    assert result.new_model == "step-3.5-flash"
+    assert result.base_url == "https://api.stepfun.com/step_plan/v1"


### PR DESCRIPTION
## Summary
- load `providers` and `custom_providers` for CLI `/model` switches even when arguments are provided
- teach `switch_model()` to keep named custom providers when a configured custom model is selected
- support `provider/model` shorthand for uniquely matched named custom providers and surface configured custom-model lists in the picker

## Root Cause
Issue #8470 came from two gaps in the shared `/model` flow:
1. `HermesCLI._handle_model_switch()` only loaded config-backed providers for the no-args picker path, so `/model ... --provider custom:...` lost access to `custom_providers`.
2. `switch_model()` treated `custom:stepfun-plan` like a normal remote provider during auto-detection, so bare custom-model names and `stepfun/model` shorthand could fall through to built-in provider detection instead of the configured custom endpoint.

Fixes #8470.

## Testing
- `uv run --extra dev pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_cli_model_picker.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_variant_tags.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
