### PR TITLE
fix: use model-specific context window after /model switch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1230,6 +1230,9 @@ class AIAgent:
 
         # Store for reuse in switch_model (so config override persists across model switches)
         self._config_context_length = _config_context_length
+        # Remember the default model so switch_model can decide whether to apply
+        # _config_context_length after a /model switch (only applies to the default model).
+        self._default_model = self.model
 
         # Check custom_providers per-model context_length
         if _config_context_length is None:
@@ -1551,12 +1554,22 @@ class AIAgent:
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
+            # Only apply the config.yaml model.context_length override when the
+            # new model matches the default model it was set for.  Switching to a
+            # different model (e.g. from opus-4-6 to sonnet-4-6, or to a 1M-tier
+            # model) should use that model's true context window so the statusline
+            # bar accurately reflects the new ceiling rather than the old clamp.
+            _default_model = getattr(self, "_default_model", None) or self.model
+            _cfg_ctx = getattr(self, "_config_context_length", None)
+            _effective_cfg_ctx = _cfg_ctx if (
+                _cfg_ctx and new_model.rstrip("/").split("/")[-1] == _default_model.rstrip("/").split("/")[-1]
+            ) else None
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=_effective_cfg_ctx,
             )
             self.context_compressor.update_model(
                 model=self.model,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2207,6 +2207,9 @@ class AIAgent:
         # Store for reuse by _check_compression_model_feasibility (auxiliary
         # compression model context-length detection needs the same list).
         self._custom_providers = _custom_providers
+        # Remember the default model so switch_model can decide whether to apply
+        # _config_context_length after a /model switch (only applies to the default model).
+        self._default_model = self.model
 
         # Check custom_providers per-model context_length
         if _config_context_length is None and _custom_providers:
@@ -2648,10 +2651,12 @@ class AIAgent:
         old_model = self.model
         old_provider = self.provider
 
-        # Clear the per-config context_length override so the new model's
-        # actual context window is resolved via get_model_context_length()
-        # instead of inheriting the stale value from the previous model.
-        self._config_context_length = None
+        # NB: do NOT clear self._config_context_length here.  The default model's
+        # config.yaml clamp must persist so round-tripping back to it
+        # (opus → sonnet → opus) re-applies the clamp.  The _effective_cfg_ctx
+        # guard further down (see _default_model check) makes sure the clamp is
+        # only forwarded to get_model_context_length() when the new model
+        # matches the default.
 
         # ── Swap core runtime fields ──
         self.model = new_model
@@ -2734,12 +2739,22 @@ class AIAgent:
                 _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
             except Exception:
                 _sm_custom_providers = None
+            # Only apply the config.yaml model.context_length override when the
+            # new model matches the default model it was set for.  Switching to a
+            # different model (e.g. from opus-4-6 to sonnet-4-6, or to a 1M-tier
+            # model) should use that model's true context window so the statusline
+            # bar accurately reflects the new ceiling rather than the old clamp.
+            _default_model = getattr(self, "_default_model", None) or self.model
+            _cfg_ctx = getattr(self, "_config_context_length", None)
+            _effective_cfg_ctx = _cfg_ctx if (
+                _cfg_ctx and new_model.rstrip("/").split("/")[-1] == _default_model.rstrip("/").split("/")[-1]
+            ) else None
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=_effective_cfg_ctx,
                 custom_providers=_sm_custom_providers,
             )
             self.context_compressor.update_model(


### PR DESCRIPTION
## TL;DR

Upstream PR ([`8ac351407`](https://github.com/NousResearch/hermes-agent/commit/8ac351407), Closes #21509) fixes the same bug but **drops the clamp permanently on the first `/model` switch**. This PR proposes a more conservative alternative: keep the clamp pinned to the *default model only*, so round-tripping back to it restores the clamp instead of losing it for the session.

If maintainers prefer the simpler "clear once and forget" semantic, please close this PR — `8ac351407` is sufficient and this PR can be discarded.

## Problem

`config.yaml` `model.context_length` is a per-default-model clamp (e.g. 200K for `claude-opus-4-6` on Claude Max which lacks the 1M tier). Currently this clamp was passed blindly to every subsequent `/model` switch, so switching to any other model still showed the clamped value in the statusline instead of the new model's true context window.

## Related upstream fix vs. this PR

Both PRs address `AIAgent.switch_model()` leaking `_config_context_length` to the new model. The behavioural difference is what happens on **round-trip back to the default model**:

| Scenario (default `opus` w/ `context_length: 200000`) | Before either fix | Upstream `8ac351407` | **This PR** |
|---|---|---|---|
| Default `opus` | 200K ✓ | 200K ✓ | 200K ✓ |
| Switch to `sonnet` | 200K ✗ | 1M ✓ | 1M ✓ |
| Switch to `gpt-4o` | 200K ✗ | 128K ✓ | 128K ✓ |
| **Switch back to `opus`** | 200K ✓ (by accident) | **1M ✗** (clamp gone) | **200K ✓** (clamp re-applied) |

Upstream sets `self._config_context_length = None` once at the start of `switch_model()`, which is simple but throws the user's config away permanently. This PR keeps the attribute pinned to the default model and gates its application via a model-ID comparison.

## Approach

1. Store `self._default_model = self.model` at `AIAgent` init time so `switch_model()` knows which model the clamp belongs to.
2. In `switch_model()`, drop the `self._config_context_length = None` line from `8ac351407` and instead compute `_effective_cfg_ctx`:
   ```python
   _default_model = getattr(self, "_default_model", None) or self.model
   _cfg_ctx = getattr(self, "_config_context_length", None)
   _effective_cfg_ctx = _cfg_ctx if (
       _cfg_ctx and new_model.rstrip("/").split("/")[-1] == _default_model.rstrip("/").split("/")[-1]
   ) else None
   ```
3. Pass `_effective_cfg_ctx` into `get_model_context_length()` instead of the raw attribute, so the full resolution chain (custom_providers per-model → endpoint probe → models.dev) runs for non-default models.

The `_sm_custom_providers` re-read introduced by `8ac351407`'s neighbour (#15779 fix) is preserved — per-model overrides under `custom_providers` still flow through correctly.

## Behaviour after fix

### Default `claude-opus-4-6` with `context_length: 200000`

| Scenario | Before | After |
|---|---|---|
| Default `claude-opus-4-6` | 200K ✓ | 200K ✓ |
| Switch to `claude-sonnet-4-6` | 200K ✗ | 1M ✓ |
| Switch to `gemini-2.5-pro` | 200K ✗ | 1M ✓ |
| Switch to `gpt-4o` | 200K ✗ | 128K ✓ |
| Switch back to `claude-opus-4-6` | 200K ✓ | 200K ✓ |

### Default `gpt-4o` with `context_length: 64000`

| Scenario | Before | After |
|---|---|---|
| Default `gpt-4o` | 64K ✓ | 64K ✓ |
| Switch to `claude-sonnet-4-6` | 64K ✗ | 1M ✓ |
| Switch to `gemini-2.5-pro` | 64K ✗ | 1M ✓ |
| Switch back to `gpt-4o` | 64K ✓ | 64K ✓ |

## Out of scope

The fallback path (`_config_context_length = None` at the failover handler around `run_agent.py:8837`) is untouched. Falling back is automatic and not user-initiated, so "clamp belongs to default model" is harder to argue there; happy to address it as a follow-up if maintainers want consistency.

## Testing

Not yet re-run after the rebase onto current `main`. Reviewer/author should run `pytest tests/run_agent/` locally to confirm the existing `AIAgent.__init__` / `switch_model` suite still passes with the `_default_model` + `_effective_cfg_ctx` changes. Manual smoke test: launch with `model.context_length: 200000` and verify the statusline context bar updates across `/model` switches per the tables above.
