### PR TITLE
fix(cli): add messaging to configurable toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
+    ("messaging",       "💬 Messaging",                 "send_message"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
+    CONFIGURABLE_TOOLSETS,
     _configure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
@@ -20,6 +21,19 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled
+
+
+def test_configurable_toolsets_include_messaging():
+    configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    assert "messaging" in configurable_keys
+
+
+def test_get_platform_tools_infers_messaging_from_default_telegram_toolset():
+    config = {}
+
+    enabled = _get_platform_tools(config, "telegram")
+
+    assert "messaging" in enabled
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():


### PR DESCRIPTION
## Summary
- add the missing `messaging` entry to `CONFIGURABLE_TOOLSETS`
- keep `send_message` visible when gateway platforms resolve composite toolsets like `hermes-telegram`
- add regression tests for the configurable toolset registry and Telegram default platform resolution

## Root Cause
Issue #8616 came from `_get_platform_tools()` reverse-mapping composite platform toolsets back through `CONFIGURABLE_TOOLSETS`. The runtime `messaging` toolset already exists in `toolsets.py`, but because it was missing from the configurable registry, gateway platforms never re-enabled it and `send_message` was silently dropped from platform sessions.

Fixes #8616.

## Testing
- `uv run --extra dev pytest tests/hermes_cli/test_tools_config.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
