### PR TITLE
fix(agent): gate summary provider hints to OpenRouter

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7445,7 +7445,7 @@ class AIAgent:
                     provider_preferences["order"] = self.providers_order
                 if self.provider_sort:
                     provider_preferences["sort"] = self.provider_sort
-                if provider_preferences:
+                if provider_preferences and self._is_openrouter_url():
                     summary_extra_body["provider"] = provider_preferences
 
                 if summary_extra_body:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1587,6 +1587,36 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_includes_provider_preferences_for_openrouter(self, agent):
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.providers_allowed = ["Anthropic"]
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"]["only"] == ["Anthropic"]
+
+    def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.base_url = "https://api.openai.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.providers_allowed = ["Anthropic"]
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "provider" not in kwargs.get("extra_body", {})
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.


### PR DESCRIPTION
## Summary
- only pass provider routing hints during max-iteration summary requests when the configured API target is OpenRouter
- keep summary-time behavior aligned with the normal request path in `_build_api_kwargs()`
- add regression tests covering both OpenRouter and non-OpenRouter summary requests

## Root Cause
`_handle_max_iterations()` always injected `extra_body.provider` whenever provider preferences were configured. That field is OpenRouter-specific, so non-OpenRouter providers could receive an unexpected payload and reject the request.

Closes #8591.

## Validation
- `uv run --extra dev pytest tests/run_agent/test_run_agent.py -k 'HandleMaxIterations or provider_preferences_injected'`
- `python3 -m py_compile run_agent.py tests/run_agent/test_run_agent.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
