### PR TITLE
fix(test): remove implicit xdist auto from local pytest runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,10 @@ hermes chat -q "Hello"
 pytest tests/ -v
 ```
 
+Local `pytest` runs are serial by default. If you want xdist locally, prefer
+an explicit worker count like `-n 4`, or set `PYTEST_XDIST_AUTO_NUM_WORKERS=4`
+before using `-n auto`. CI can still use full `-n auto`.
+
 ---
 
 ## Project Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,4 +125,4 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
-addopts = "-m 'not integration' -n auto"
+addopts = "-m 'not integration'"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,37 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
+_LOCAL_XDIST_AUTO_WORKER_CAP = 4
+
+
+def _parse_positive_int(value: str | None) -> int | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def pytest_xdist_auto_num_workers(config) -> int | None:
+    """Bound local ``-n auto`` runs to a sane default worker count.
+
+    The suite is fairly I/O-heavy and ``-n auto`` can overwhelm WSL/local
+    developer machines by spawning one worker per reported CPU.  Keep local
+    ``auto`` runs bounded while leaving CI and explicit overrides alone.
+    """
+    override = _parse_positive_int(os.getenv("PYTEST_XDIST_AUTO_NUM_WORKERS"))
+    if override is not None:
+        return override
+
+    cpu_count = os.cpu_count() or 1
+    if os.getenv("CI"):
+        return cpu_count
+    return min(cpu_count, _LOCAL_XDIST_AUTO_WORKER_CAP)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_hermes_home(tmp_path, monkeypatch):
     """Redirect HERMES_HOME to a temp dir so tests never write to ~/.hermes/."""

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -84,6 +84,10 @@ hermes chat -q "Hello"
 pytest tests/ -v
 ```
 
+Local `pytest` runs are serial by default. If you want xdist locally, prefer
+an explicit worker count like `-n 4`, or set `PYTEST_XDIST_AUTO_NUM_WORKERS=4`
+before using `-n auto`. CI can still use full `-n auto`.
+
 ## Code Style
 
 - **PEP 8** with practical exceptions (no strict line length enforcement)


### PR DESCRIPTION
## What does this PR do?

Removes implicit `-n auto` inheritance from local `pytest` runs and adds a bounded local worker cap for explicit `-n auto` usage.

This fixes a bad local-dev failure mode where a plain `pytest` inherited xdist parallelism from `pyproject.toml`, spawned one worker per reported CPU, and could peg CPU/disk hard on WSL for this I/O-heavy suite.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- removed `-n auto` from `pyproject.toml` pytest `addopts` so local `pytest` runs are serial by default
- added `pytest_xdist_auto_num_workers()` in `tests/conftest.py` to cap local explicit `-n auto` runs at 4 workers by default
- preserved CI behavior by returning full CPU count when `CI` is set
- respected `PYTEST_XDIST_AUTO_NUM_WORKERS` as an explicit override
- updated `CONTRIBUTING.md` and `website/docs/developer-guide/contributing.md` to document the new local testing guidance

## How to Test

1. Run a normal local test command and verify it does **not** inherit xdist automatically:
   `venv/bin/python -m pytest tests/gateway/test_stream_consumer.py -q`
2. Run an explicit xdist auto command with a safe override and verify it still works:
   `PYTEST_XDIST_AUTO_NUM_WORKERS=2 venv/bin/python -m pytest tests/gateway/test_stream_consumer.py -q -n auto`
3. Optional: confirm the auto-worker hook behavior directly in the venv:
   local `-n auto` resolves to 4 workers, env override resolves to the override, and `CI=true` resolves to full CPU count

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verification run locally:

- `venv/bin/python -m pytest tests/gateway/test_stream_consumer.py -q` → `28 passed in 1.73s`
- `PYTEST_XDIST_AUTO_NUM_WORKERS=2 venv/bin/python -m pytest tests/gateway/test_stream_consumer.py -q -n auto` → `28 passed in 1.32s`
- hook check in venv reported:
  - local auto workers = 4
  - env override workers = 2
  - CI auto workers = 16

A full serial `venv/bin/python -m pytest tests/ -q -n0` run was started to verify the broader suite, but the suite surfaced multiple unrelated failures early and was stopped rather than continuing to churn through the entire tree.
