### PR TITLE
docs: add community plugins section with hermes-music

### DIFF
--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -201,3 +201,13 @@ This enables plugins like remote control viewers, messaging bridges, or webhook 
 :::
 
 See the **[full guide](/docs/guides/build-a-hermes-plugin)** for handler contracts, schema format, hook behavior, error handling, and common mistakes.
+
+## Community plugins
+
+Plugins built by the community and distributed via pip. Install any of these and the tools appear automatically in your next session.
+
+| Plugin | Install | What it does | Author |
+|--------|---------|-------------|--------|
+| **[hermes-music](https://github.com/buckster123/hermes-music-plugin)** | `pip install hermes-music` | AI music generation via Suno, MIDI composition, music library management (10 tools) | [@buckster123](https://github.com/buckster123) |
+
+Have a plugin to share? Open a PR adding it to this table.


### PR DESCRIPTION
## What

Adds a **Community Plugins** section to the [Plugins documentation page](https://hermes-agent.nousresearch.com/docs/user-guide/features/plugins) — a table where community-contributed plugins can be listed.

### First entry: hermes-music

**[hermes-music](https://github.com/buckster123/hermes-music-plugin)** — AI music generation plugin for Hermes Agent.

- **PyPI:** `pip install hermes-music`
- **10 tools** in the `music` toolset:
  - `music_generate`, `music_status`, `music_result`, `music_list` (Suno AI pipeline)
  - `music_favorite`, `music_library`, `music_search`, `music_play` (library/curation)
  - `midi_create`, `music_compose` (MIDI composition → AI generation)
- **Entry-point discovery** — installs via pip, auto-detected by Hermes plugin system
- **64 tests passing** across Python 3.10-3.12
- Requires `SUNO_API_KEY` (from sunoapi.org)

### Why a community plugins table?

Hermes has a great plugin system but no central place to discover community plugins. This table in the docs gives plugin authors a way to get discovered and gives users a place to browse. The table invites others to open PRs adding their own plugins.

### Change

One file changed: `website/docs/user-guide/features/plugins.md` — 10 lines added at the bottom.