### PR TITLE
fix(cli): render /tools list through prompt_toolkit

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -40,6 +40,8 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
     print_warning as _print_warning,
     prompt as _prompt,
 )
+from prompt_toolkit import print_formatted_text as _pt_print
+from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 
 # ─── Toolset Registry ─────────────────────────────────────────────────────────
 
@@ -1610,42 +1612,47 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
     return failed_servers
 
 
+def _pt_cprint(text: str):
+    """Print ANSI-colored text through prompt_toolkit's renderer."""
+    _pt_print(_PT_ANSI(text))
+
+
 def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective = _get_effective_configurable_toolsets()
     builtin_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
 
-    print(f"Built-in toolsets ({platform}):")
+    _pt_cprint(f"Built-in toolsets ({platform}):")
     for ts_key, label, _ in effective:
         if ts_key not in builtin_keys:
             continue
         status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                   else color("✗ disabled", Colors.RED))
-        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+        _pt_cprint(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     # Plugin toolsets
     plugin_entries = [(k, l) for k, l, _ in effective if k not in builtin_keys]
     if plugin_entries:
-        print()
-        print(f"Plugin toolsets ({platform}):")
+        _pt_cprint("")
+        _pt_cprint(f"Plugin toolsets ({platform}):")
         for ts_key, label in plugin_entries:
             status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                       else color("✗ disabled", Colors.RED))
-            print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+            _pt_cprint(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     if mcp_servers:
-        print()
-        print("MCP servers:")
+        _pt_cprint("")
+        _pt_cprint("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []
             include = tools_cfg.get("include") or []
             if include:
-                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+                _pt_cprint(f"  {srv_name}  [include only: {', '.join(include)}]")
             elif exclude:
-                _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
+                _pt_cprint(f"  {srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
             else:
-                _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+                _pt_cprint(f"  {srv_name}  {color('all tools enabled', Colors.DIM)}")
 
 
 def tools_disable_enable_command(args):

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -2,6 +2,7 @@
 from argparse import Namespace
 from unittest.mock import patch
 
+from hermes_cli.colors import Colors
 from hermes_cli.tools_config import tools_disable_enable_command
 
 
@@ -174,6 +175,32 @@ class TestToolsList:
         out = capsys.readouterr().out
         assert "github" in out
         assert "create_issue" in out
+
+    def test_list_routes_ansi_through_prompt_toolkit_renderer(self):
+        """/tools list should not leak raw ANSI escapes through plain print()."""
+        config = {
+            "platform_toolsets": {"cli": ["web"]},
+            "mcp_servers": {"github": {"tools": {"exclude": ["create_issue"]}}},
+        }
+        rendered = []
+
+        def fake_color(text, *codes):
+            if not codes:
+                return text
+            return f"{''.join(codes)}{text}{Colors.RESET}"
+
+        def fake_pt_print(text):
+            rendered.append(repr(text))
+
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.color", side_effect=fake_color), \
+             patch("hermes_cli.tools_config._pt_print", side_effect=fake_pt_print):
+            tools_disable_enable_command(Namespace(tools_action="list", platform="cli"))
+
+        output = "\n".join(rendered)
+        assert "Built-in toolsets (cli):" in output
+        assert "github" in output
+        assert any("\\x1b[32m" in chunk or "\\x1b[31m" in chunk for chunk in rendered)
 
 
 # ── Validation ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- route `/tools list` output through prompt_toolkit's ANSI renderer instead of plain `print()`
- keep built-in, plugin, and MCP sections using the same ANSI-safe output path
- add a regression test that verifies `/tools list` goes through the prompt_toolkit printer

## Root Cause
`/tools list` built colored status strings with ANSI escapes and sent them to plain `print()`. Inside the prompt_toolkit-backed CLI, those raw escape sequences could show up literally instead of rendering as styled output.

Closes #4128.

## Validation
- `uv run --extra dev pytest tests/hermes_cli/test_tools_disable_enable.py -k 'list'`
- `python3 -m py_compile hermes_cli/tools_config.py tests/hermes_cli/test_tools_disable_enable.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
