### PR TITLE
fix(feishu): include audio duration in uploads

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -26,8 +26,11 @@ import logging
 import mimetypes
 import os
 import re
+import shutil
+import subprocess
 import threading
 import time
+import wave
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -3199,11 +3202,15 @@ class FeishuAdapter(BasePlatformAdapter):
             requested_message_type=outbound_message_type,
         )
         try:
+            duration_ms: Optional[int] = None
+            if resolved_message_type == "audio":
+                duration_ms = self._probe_audio_duration_ms(file_path)
             with open(file_path, "rb") as file_obj:
                 body = self._build_file_upload_body(
                     file_type=upload_file_type,
                     file_name=display_name,
                     file=file_obj,
+                    duration=duration_ms,
                 )
                 request = self._build_file_upload_request(body)
                 upload_response = await asyncio.to_thread(self._client.im.v1.file.create, request)
@@ -3590,16 +3597,30 @@ class FeishuAdapter(BasePlatformAdapter):
         return SimpleNamespace(request_body=request_body)
 
     @staticmethod
-    def _build_file_upload_body(*, file_type: str, file_name: str, file: Any) -> Any:
+    def _build_file_upload_body(
+        *,
+        file_type: str,
+        file_name: str,
+        file: Any,
+        duration: Optional[int] = None,
+    ) -> Any:
         if "CreateFileRequestBody" in globals():
-            return (
+            builder = (
                 CreateFileRequestBody.builder()
                 .file_type(file_type)
                 .file_name(file_name)
                 .file(file)
-                .build()
             )
-        return SimpleNamespace(file_type=file_type, file_name=file_name, file=file)
+            if duration is not None:
+                try:
+                    builder = builder.duration(duration)
+                except AttributeError:
+                    pass
+            return builder.build()
+        payload = SimpleNamespace(file_type=file_type, file_name=file_name, file=file)
+        if duration is not None:
+            payload.duration = duration
+        return payload
 
     @staticmethod
     def _build_file_upload_request(request_body: Any) -> Any:
@@ -3615,6 +3636,57 @@ class FeishuAdapter(BasePlatformAdapter):
         content = payload.setdefault("zh_cn", {}).setdefault("content", [])
         content.append([media_tag])
         return json.dumps(payload, ensure_ascii=False)
+
+    @staticmethod
+    def _probe_audio_duration_ms(file_path: str) -> Optional[int]:
+        """Best-effort audio duration probe for Feishu upload metadata."""
+        ext = Path(file_path).suffix.lower()
+
+        if ext == ".wav":
+            try:
+                with wave.open(file_path, "rb") as wav_file:
+                    frame_rate = wav_file.getframerate()
+                    if frame_rate > 0:
+                        duration_ms = round(wav_file.getnframes() * 1000 / frame_rate)
+                        return max(1, int(duration_ms))
+            except Exception:
+                pass
+
+        ffprobe = shutil.which("ffprobe")
+        if ffprobe:
+            try:
+                proc = subprocess.run(
+                    [
+                        ffprobe,
+                        "-v",
+                        "error",
+                        "-show_entries",
+                        "format=duration",
+                        "-of",
+                        "default=noprint_wrappers=1:nokey=1",
+                        file_path,
+                    ],
+                    capture_output=True,
+                    check=True,
+                    text=True,
+                )
+                duration_s = float((proc.stdout or "").strip())
+                if duration_s > 0:
+                    return max(1, int(round(duration_s * 1000)))
+            except Exception:
+                pass
+
+        try:
+            from mutagen import File as _mutagen_file  # type: ignore
+
+            audio = _mutagen_file(file_path)
+            duration_s = getattr(getattr(audio, "info", None), "length", None)
+            if duration_s and duration_s > 0:
+                return max(1, int(round(float(duration_s) * 1000)))
+        except Exception:
+            pass
+
+        return None
 
     @staticmethod
     def _resolve_outbound_file_routing(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 import time
+import wave
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -2370,15 +2371,42 @@ class TestAdapterBehavior(unittest.TestCase):
             audio_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_probe_audio_duration_ms", return_value=1234),
+            ):
                 result = asyncio.run(adapter.send_voice(chat_id="oc_chat", audio_path=audio_path))
         finally:
             os.unlink(audio_path)
 
         self.assertTrue(result.success)
         self.assertEqual(captured["upload_request"].request_body.file_type, "opus")
+        self.assertEqual(captured["upload_request"].request_body.duration, 1234)
         self.assertEqual(captured["message_request"].request_body.msg_type, "audio")
         self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_audio_123"}')
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_probe_audio_duration_uses_wav_header(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".wav", delete=False) as tmp:
+            wav_path = tmp.name
+
+        try:
+            with wave.open(wav_path, "wb") as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(8000)
+                wf.writeframes(b"\x00\x00" * 800)
+
+            duration_ms = adapter._probe_audio_duration_ms(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertEqual(duration_ms, 100)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_extracts_title_and_links(self):


### PR DESCRIPTION
## Summary
- attach best-effort audio duration metadata when Feishu uploads voice messages
- probe duration from WAV headers first, then fall back to `ffprobe` or `mutagen` when available
- add regression tests for both upload-body duration plumbing and WAV duration probing

## Root Cause
`send_voice()` reused the generic Feishu file-upload path, but the upload body never included audio duration metadata. Feishu's native audio message rendering depends on that field, so successful uploads could still display with missing or incorrect duration.

Closes #8300.

## Validation
- `python3 -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py`
- `uv run --extra dev pytest tests/gateway/test_feishu.py -q -k 'send_voice_uploads_opus_and_sends_audio_message or probe_audio_duration_uses_wav_header'`
- `uv run --extra dev pytest tests/gateway/test_feishu.py -q -k 'not test_build_event_handler_registers_reaction_and_card_processors'`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
