### PR TITLE
fix(gateway): clarify home-channel setup notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3494,11 +3494,7 @@ class GatewayRunner:
                 if adapter:
                     await adapter.send(
                         source.chat_id,
-                        f"📬 No home channel is set for {platform_name.title()}. "
-                        f"A home channel is where Hermes delivers cron job results "
-                        f"and cross-platform messages.\n\n"
-                        f"Type /sethome to make this chat your home channel, "
-                        f"or ignore to skip."
+                        self._build_home_channel_notice(platform_name),
                     )
         
         # -----------------------------------------------------------------
@@ -4738,7 +4734,17 @@ class GatewayRunner:
         
         preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
         return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
-    
+
+    @staticmethod
+    def _build_home_channel_notice(platform_name: str) -> str:
+        """Return the setup notice for missing home-channel configuration."""
+        platform_title = platform_name.title()
+        return (
+            f"⚙️ Setup notice: {platform_title} home channel is not set yet. "
+            f"Hermes uses a home channel to deliver cron job results and cross-platform messages.\n\n"
+            f"Run /sethome in the chat you want to use, or ignore this notice to skip."
+        )
+
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
         source = event.source

--- a/tests/gateway/test_home_channel_notice.py
+++ b/tests/gateway/test_home_channel_notice.py
@@ -1,0 +1,12 @@
+from gateway.run import GatewayRunner
+
+
+def test_home_channel_notice_reads_like_setup_copy():
+    notice = GatewayRunner._build_home_channel_notice("telegram")
+
+    assert notice.startswith("⚙️ Setup notice:")
+    assert "Telegram home channel is not set yet." in notice
+    assert "/sethome" in notice
+    assert "cron job results" in notice
+    assert "cross-platform messages" in notice
+    assert "No home channel is set" not in notice


### PR DESCRIPTION
## Summary
- extract the missing-home-channel message into a dedicated helper
- rewrite the Telegram home-channel notice so it reads like setup guidance instead of an assistant reply
- add a regression test that locks in the new setup-oriented wording

## Root Cause
The first-run home-channel notice was phrased like a normal assistant message (`"No home channel is set..."`). In Telegram DMs that made the onboarding copy look like part of the conversation instead of a one-time setup notice.

This PR addresses the home-channel setup-notice portion of #7921 only. The separate interrupt-status leakage mentioned in that issue should stay tracked independently until it is fixed.

## Validation
- `python3 -m py_compile gateway/run.py tests/gateway/test_home_channel_notice.py`
- `uv run --extra dev pytest tests/gateway/test_home_channel_notice.py -q`
- `uv run --extra dev pytest tests/gateway/test_internal_event_bypass_pairing.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
