### PR TITLE
fix(cron): treat empty agent response as error in last_status (fixes #8585)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -967,6 +967,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)
 
+                # Treat empty final_response as a soft failure so last_status
+                # is not "ok" — the agent ran but produced nothing useful.
+                # (issue #8585)
+                if success and not final_response:
+                    success = False
+                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 executed += 1
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -672,7 +672,7 @@ class TestRunJobSessionPersistence:
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).
-        
+
         The placeholder '(No response generated)' should only appear in the
         output log, not in the returned final_response that's used for delivery.
         """
@@ -690,7 +690,7 @@ class TestRunJobSessionPersistence:
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value={
-                     "api_key": "test-key",
+                     "api_key": "***",
                      "base_url": "https://example.invalid/v1",
                      "provider": "openrouter",
                      "api_mode": "chat_completions",
@@ -710,6 +710,43 @@ class TestRunJobSessionPersistence:
         assert final_response == ""
         # But the output log should show the placeholder
         assert "(No response generated)" in output
+
+    def test_tick_marks_empty_response_as_error(self, tmp_path):
+        """When run_job returns success=True but final_response is empty,
+        tick() should mark the job as error so last_status != 'ok'.
+        (issue #8585)
+        """
+        from cron.scheduler import tick
+        from cron.jobs import load_jobs, save_jobs
+
+        job = {
+            "id": "empty-job",
+            "name": "empty-test",
+            "prompt": "do something",
+            "schedule": "every 1h",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+            "last_status": None,
+        }
+
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
+            tick(verbose=False)
+
+        # Should be called with success=False because final_response is empty
+        mock_mark.assert_called_once()
+        call_args = mock_mark.call_args
+        assert call_args[0][0] == "empty-job"
+        assert call_args[0][1] is False  # success should be False
+        assert "empty" in call_args[0][2].lower()  # error should mention empty
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {


### PR DESCRIPTION
## Summary
- Treats empty `final_response` from agent as a soft failure in `tick()` so `last_status` is `"error"` instead of `"ok"`
- When a cron job's agent run completes but produces no output (e.g. API 404 from invalid model name), the failure is now visible in job listings
- Adds regression test `test_tick_marks_empty_response_as_error`

## Root cause
`scheduler.py:tick()` passed `success=True` to `mark_job_run` regardless of whether `final_response` was empty. The `mark_job_run` function then set `last_status = "ok"` unconditionally.

## Fix
In `tick()`, after `run_job()` returns, check if `final_response` is empty. If so, override `success=False` with a descriptive error message before calling `mark_job_run`.

## Testing
- New test: `tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_tick_marks_empty_response_as_error`
- Full suite: `pytest tests/cron/test_scheduler.py -q` → 62 passed

Fixes #8585