### PR TITLE
fix(gateway): respect streaming.enabled: false even when display.streaming is true (fixes #8338)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7652,10 +7652,11 @@ class GatewayRunner:
                 user_config, platform_key, "streaming"
             )
             # None = no per-platform override → follow global config
+            _global_streaming = _scfg.enabled and _scfg.transport != "off"
             _streaming_enabled = (
-                _scfg.enabled and _scfg.transport != "off"
+                _global_streaming
                 if _plat_streaming is None
-                else bool(_plat_streaming)
+                else _global_streaming and bool(_plat_streaming)
             )
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -353,3 +353,37 @@ class TestStreamingPerPlatform:
             }
         }
         assert resolve_display_setting(config, "email", "streaming") is True
+
+
+class TestStreamingGateGlobalOverride:
+    """display.streaming must not override streaming.enabled: false (issue #8338)."""
+
+    @staticmethod
+    def _gate(_scfg_enabled, _scfg_transport, _plat_streaming):
+        """Replicate the streaming gate logic from gateway/run.py."""
+        _global_streaming = _scfg_enabled and _scfg_transport != "off"
+        return (
+            _global_streaming
+            if _plat_streaming is None
+            else _global_streaming and bool(_plat_streaming)
+        )
+
+    def test_display_true_but_global_off_means_disabled(self):
+        """display.streaming=True should NOT enable streaming when
+        streaming.enabled=False."""
+        assert self._gate(False, "sse", True) is False
+
+    def test_both_on_means_enabled(self):
+        assert self._gate(True, "sse", True) is True
+
+    def test_global_on_no_override_means_enabled(self):
+        assert self._gate(True, "sse", None) is True
+
+    def test_global_off_no_override_means_disabled(self):
+        assert self._gate(False, "sse", None) is False
+
+    def test_global_on_override_false_means_disabled(self):
+        assert self._gate(True, "sse", False) is False
+
+    def test_transport_off_means_disabled(self):
+        assert self._gate(True, "off", True) is False


### PR DESCRIPTION
## Summary
- The streaming gate in `gateway/run.py` now respects `streaming.enabled: false` even when `display.streaming: true` is set
- `_scfg.enabled` remains a hard prerequisite — per-platform display overrides can only *disable* streaming, not re-enable it when the global config has disabled it

## Root cause
The ternary expression:
```python
_streaming_enabled = (
    _scfg.enabled and _scfg.transport != "off"
    if _plat_streaming is None
    else bool(_plat_streaming)
)
```
When `_plat_streaming` was not None (display override existed), the global `_scfg.enabled` check was completely bypassed.

## Fix
```python
_global_streaming = _scfg.enabled and _scfg.transport != "off"
_streaming_enabled = (
    _global_streaming
    if _plat_streaming is None
    else _global_streaming and bool(_plat_streaming)
)
```

## Testing
- New tests: `tests/gateway/test_display_config.py::TestStreamingGateGlobalOverride` (6 test cases)
- Full suite: `pytest tests/gateway/test_display_config.py -q` → 33 passed

Fixes #8338