### PR TITLE
fix(agent): enable prompt caching on Anthropic-compatible endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -91,7 +91,6 @@ from agent.model_metadata import (
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
 )
-from agent.auxiliary_client import _is_anthropic_compat_endpoint
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
@@ -740,7 +739,7 @@ class AIAgent:
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
         # Anthropic prompt caching: auto-enabled for Claude models on native
-        # Anthropic, OpenRouter, and Anthropic-compatible /anthropic endpoints.
+        # Anthropic, OpenRouter, and other Anthropic Messages transports.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
         # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
         self._use_prompt_caching = self._supports_anthropic_prompt_caching()
@@ -5865,20 +5864,36 @@ class AIAgent:
         effective_provider = (provider if provider is not None else self.provider or "").lower()
         effective_base_url = base_url if base_url is not None else self.base_url
         effective_model = (model if model is not None else self.model or "").lower()
+        base_url_lower = (effective_base_url or "").lower()
 
-        if (base_url is None and self._is_openrouter_url()) or "openrouter" in (effective_base_url or "").lower():
+        if (base_url is None and self._is_openrouter_url()) or "openrouter" in base_url_lower:
             return "claude" in effective_model
 
         if effective_api_mode != "anthropic_messages":
             return False
 
+        if effective_provider == "anthropic" or "api.anthropic.com" in base_url_lower:
+            return True
+
+        return "claude" in effective_model
+
+    def _uses_native_anthropic_prompt_cache_layout(
+        self,
+        provider: str | None = None,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+    ) -> bool:
+        """Return True only for native Anthropic transports that support tool-level markers."""
+        effective_api_mode = api_mode if api_mode is not None else self.api_mode
+        if effective_api_mode != "anthropic_messages":
+            return False
+
+        effective_provider = (provider if provider is not None else self.provider or "").lower()
         if effective_provider == "anthropic":
             return True
 
-        return "claude" in effective_model and _is_anthropic_compat_endpoint(
-            effective_provider,
-            effective_base_url,
-        )
+        effective_base_url = (base_url if base_url is not None else self.base_url or "").lower()
+        return "api.anthropic.com" in effective_base_url
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""
@@ -8015,13 +8030,13 @@ class AIAgent:
                 for idx, pfm in enumerate(self.prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
-            # Apply Anthropic prompt caching for Claude models on Anthropic-compatible
-            # endpoints (native Anthropic, OpenRouter, and /anthropic proxies).
+            # Apply Anthropic prompt caching for Claude models when the active
+            # transport supports Anthropic cache_control markers.
             if self._use_prompt_caching:
                 api_messages = apply_anthropic_cache_control(
                     api_messages,
                     cache_ttl=self._cache_ttl,
-                    native_anthropic=self._supports_anthropic_prompt_caching(),
+                    native_anthropic=self._uses_native_anthropic_prompt_cache_layout(),
                 )
 
             # Safety net: strip orphaned tool results / add stubs for missing

--- a/run_agent.py
+++ b/run_agent.py
@@ -91,6 +91,7 @@ from agent.model_metadata import (
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
 )
+from agent.auxiliary_client import _is_anthropic_compat_endpoint
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
@@ -738,13 +739,11 @@ class AIAgent:
         self.request_overrides = dict(request_overrides or {})
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         
-        # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
+        # Anthropic prompt caching: auto-enabled for Claude models on native
+        # Anthropic, OpenRouter, and Anthropic-compatible /anthropic endpoints.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
         # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
-        is_openrouter = self._is_openrouter_url()
-        is_claude = "claude" in self.model.lower()
-        is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
-        self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
+        self._use_prompt_caching = self._supports_anthropic_prompt_caching()
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
         # Iteration budget: the LLM is only notified when it actually exhausts
@@ -1013,7 +1012,12 @@ class AIAgent:
         
         # Show prompt caching status
         if self._use_prompt_caching and not self.quiet_mode:
-            source = "native Anthropic" if is_native_anthropic else "Claude via OpenRouter"
+            if self.provider == "anthropic":
+                source = "native Anthropic"
+            elif self._is_openrouter_url():
+                source = "Claude via OpenRouter"
+            else:
+                source = "Anthropic-compatible endpoint"
             print(f"💾 Prompt caching: ENABLED ({source}, {self._cache_ttl} TTL)")
         
         # Session logging setup - auto-save conversation trajectories for debugging
@@ -1542,10 +1546,11 @@ class AIAgent:
             )
 
         # ── Re-evaluate prompt caching ──
-        is_native_anthropic = api_mode == "anthropic_messages" and new_provider == "anthropic"
-        self._use_prompt_caching = (
-            ("openrouter" in (self.base_url or "").lower() and "claude" in new_model.lower())
-            or is_native_anthropic
+        self._use_prompt_caching = self._supports_anthropic_prompt_caching(
+            provider=new_provider,
+            base_url=self.base_url,
+            api_mode=api_mode,
+            model=new_model,
         )
 
         # ── Update context compressor ──
@@ -5504,10 +5509,11 @@ class AIAgent:
                 }
 
             # Re-evaluate prompt caching for the new provider/model
-            is_native_anthropic = fb_api_mode == "anthropic_messages" and fb_provider == "anthropic"
-            self._use_prompt_caching = (
-                ("openrouter" in fb_base_url.lower() and "claude" in fb_model.lower())
-                or is_native_anthropic
+            self._use_prompt_caching = self._supports_anthropic_prompt_caching(
+                provider=fb_provider,
+                base_url=fb_base_url,
+                api_mode=fb_api_mode,
+                model=fb_model,
             )
 
             # Update context compressor limits for the fallback model.
@@ -5846,6 +5852,33 @@ class AIAgent:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+
+    def _supports_anthropic_prompt_caching(
+        self,
+        provider: str | None = None,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+        model: str | None = None,
+    ) -> bool:
+        """Return True when Anthropic cache_control markers are safe to enable."""
+        effective_api_mode = api_mode if api_mode is not None else self.api_mode
+        effective_provider = (provider if provider is not None else self.provider or "").lower()
+        effective_base_url = base_url if base_url is not None else self.base_url
+        effective_model = (model if model is not None else self.model or "").lower()
+
+        if (base_url is None and self._is_openrouter_url()) or "openrouter" in (effective_base_url or "").lower():
+            return "claude" in effective_model
+
+        if effective_api_mode != "anthropic_messages":
+            return False
+
+        if effective_provider == "anthropic":
+            return True
+
+        return "claude" in effective_model and _is_anthropic_compat_endpoint(
+            effective_provider,
+            effective_base_url,
+        )
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""
@@ -7982,12 +8015,14 @@ class AIAgent:
                 for idx, pfm in enumerate(self.prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
-            # Apply Anthropic prompt caching for Claude models via OpenRouter.
-            # Auto-detected: if model name contains "claude" and base_url is OpenRouter,
-            # inject cache_control breakpoints (system + last 3 messages) to reduce
-            # input token costs by ~75% on multi-turn conversations.
+            # Apply Anthropic prompt caching for Claude models on Anthropic-compatible
+            # endpoints (native Anthropic, OpenRouter, and /anthropic proxies).
             if self._use_prompt_caching:
-                api_messages = apply_anthropic_cache_control(api_messages, cache_ttl=self._cache_ttl, native_anthropic=(self.api_mode == 'anthropic_messages'))
+                api_messages = apply_anthropic_cache_control(
+                    api_messages,
+                    cache_ttl=self._cache_ttl,
+                    native_anthropic=self._supports_anthropic_prompt_caching(),
+                )
 
             # Safety net: strip orphaned tool results / add stubs for missing
             # results before sending to the API.  Runs unconditionally — not

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -203,6 +203,23 @@ class TestRestorePrimaryRuntime:
 
         assert agent._use_prompt_caching == original_caching
 
+    def test_fallback_enables_prompt_caching_for_anthropic_compatible_endpoint(self):
+        agent = _make_agent(
+            fallback_model={"provider": "zenmux-anthropic", "model": "anthropic/claude-sonnet-4.6"},
+        )
+
+        mock_client = _mock_resolve(base_url="https://zenmux.ai/api/anthropic")
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+            patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent._fallback_activated is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._use_prompt_caching is True
+
     def test_restore_survives_exception(self):
         """If client rebuild fails, the method returns False gracefully."""
         agent = _make_agent()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -551,6 +551,26 @@ class TestInit:
             assert a.api_mode == "anthropic_messages"
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_custom_anthropic_messages_provider_without_anthropic_path(self):
+        """Explicit anthropic_messages custom providers should not need /anthropic in the URL."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="litellm-proxy",
+                model="claude-sonnet-4-20250514",
+                base_url="https://api.example.com/v1/messages",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is True
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")
@@ -982,6 +1002,14 @@ class TestBuildApiKwargs:
         # Should not crash even without a system message
         assert kwargs["messages"][0]["content"][0]["text"] == "hi"
         assert "cache_control" not in kwargs["messages"][0]["content"][0]
+
+    def test_custom_anthropic_messages_provider_uses_non_native_cache_layout(self, agent):
+        agent.provider = "litellm-proxy"
+        agent.base_url = "https://api.example.com/v1/messages"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.api_mode = "anthropic_messages"
+        agent.model = "claude-sonnet-4-20250514"
+        assert agent._uses_native_anthropic_prompt_cache_layout() is False
 
     def test_qwen_portal_sends_explicit_max_tokens(self, agent):
         """When the user explicitly sets max_tokens, it should be sent to Qwen Portal."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -532,6 +532,25 @@ class TestInit:
             assert a.api_mode == "anthropic_messages"
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_custom_anthropic_compatible_provider(self):
+        """Anthropic-compatible /anthropic endpoints should also enable prompt caching."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter._anthropic_sdk"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="zenmux-anthropic",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://zenmux.ai/api/anthropic",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is True
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -94,3 +94,25 @@ def test_switch_model_enables_prompt_caching_for_anthropic_compatible_provider(m
     assert agent.api_mode == "anthropic_messages"
     assert agent._use_prompt_caching is True
     mock_ctx_len.assert_called_once()
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=400_000)
+def test_switch_model_enables_prompt_caching_for_custom_anthropic_messages_provider(mock_ctx_len):
+    """Explicit anthropic_messages custom providers should not rely on /anthropic URLs."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    with (
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
+    ):
+        agent.switch_model(
+            "claude-sonnet-4-20250514",
+            "litellm-proxy",
+            api_key="sk-anthropic",
+            base_url="https://api.example.com/v1/messages",
+            api_mode="anthropic_messages",
+        )
+
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._use_prompt_caching is True
+    mock_ctx_len.assert_called_once()

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -72,3 +72,25 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=400_000)
+def test_switch_model_enables_prompt_caching_for_anthropic_compatible_provider(mock_ctx_len):
+    """Switching to an Anthropic-compatible /anthropic endpoint should enable caching."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    with (
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        patch("agent.anthropic_adapter._is_oauth_token", return_value=False),
+    ):
+        agent.switch_model(
+            "anthropic/claude-sonnet-4-20250514",
+            "zenmux-anthropic",
+            api_key="sk-anthropic",
+            base_url="https://zenmux.ai/api/anthropic",
+            api_mode="anthropic_messages",
+        )
+
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._use_prompt_caching is True
+    mock_ctx_len.assert_called_once()


### PR DESCRIPTION
## Summary
- make Anthropic prompt caching transport-aware instead of relying on provider-name or `/anthropic` URL heuristics alone
- enable cache-control markers for custom `api_mode: anthropic_messages` providers that expose Claude models on plain `/v1/messages` endpoints
- keep tool-level cache layout native-Anthropic-only so third-party proxies are not over-classified
- add regression coverage for init, `switch_model`, and the non-native cache-layout guard

## Root Cause
Prompt caching was still tied to provider-name and URL-shape heuristics. That missed custom Anthropic-compatible providers using `api_mode: anthropic_messages` when their endpoint did not contain `/anthropic`, and it also conflated “eligible for cache markers” with “native Anthropic tool-result cache layout.”

Closes #8294.

## Validation
- `python3 -m py_compile run_agent.py tests/run_agent/test_run_agent.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_primary_runtime_restore.py`
- `uv run --extra dev pytest tests/run_agent/test_run_agent.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_primary_runtime_restore.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
