### PR TITLE
fix(whatsapp): normalize bare phone targets to JIDs

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -30,6 +30,7 @@ from typing import Dict, Optional, Any
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
+_WHATSAPP_BARE_PHONE_RE = re.compile(r"^\+?[\d\s().-]+$")
 
 
 def _kill_port_process(port: int) -> None:
@@ -98,6 +99,26 @@ def check_whatsapp_requirements() -> bool:
         return result.returncode == 0
     except Exception:
         return False
+
+
+def _normalize_outbound_whatsapp_chat_id(value: Optional[str]) -> str:
+    """Normalize outbound WhatsApp targets to bridge-safe JID format."""
+    if not value:
+        return ""
+
+    normalized = str(value).strip()
+    if ":" in normalized and "@" in normalized:
+        normalized = normalized.replace(":", "@", 1)
+
+    if "@" in normalized:
+        return normalized
+
+    if _WHATSAPP_BARE_PHONE_RE.fullmatch(normalized):
+        digits = re.sub(r"\D+", "", normalized)
+        if digits:
+            return f"{digits}@s.whatsapp.net"
+
+    return normalized
 
 
 class WhatsAppAdapter(BasePlatformAdapter):
@@ -195,12 +216,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _normalize_whatsapp_id(value: Optional[str]) -> str:
-        if not value:
-            return ""
-        normalized = str(value).strip()
-        if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
-        return normalized
+        return _normalize_outbound_whatsapp_chat_id(value)
 
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
         bot_ids = set()
@@ -548,8 +564,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
+            normalized_chat_id = _normalize_outbound_whatsapp_chat_id(chat_id)
             payload = {
-                "chatId": chat_id,
+                "chatId": normalized_chat_id,
                 "message": content,
             }
             if reply_to:
@@ -624,8 +641,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
+            normalized_chat_id = _normalize_outbound_whatsapp_chat_id(chat_id)
             payload: Dict[str, Any] = {
-                "chatId": chat_id,
+                "chatId": normalized_chat_id,
                 "filePath": file_path,
                 "mediaType": media_type,
             }
@@ -714,9 +732,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
+            normalized_chat_id = _normalize_outbound_whatsapp_chat_id(chat_id)
             await self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
+                json={"chatId": normalized_chat_id},
                 timeout=aiohttp.ClientTimeout(total=5)
             )
         except Exception:
@@ -732,8 +751,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
+            normalized_chat_id = _normalize_outbound_whatsapp_chat_id(chat_id)
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                f"http://127.0.0.1:{self._bridge_port}/chat/{normalized_chat_id}",
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -239,6 +239,24 @@ class TestBridgeRuntimeFailure:
         assert adapter._bridge_log_fh is None
 
     @pytest.mark.asyncio
+    async def test_send_normalizes_bare_phone_numbers_to_jid(self):
+        adapter = _make_adapter()
+        adapter._running = True
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"messageId": "msg-1"})
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=_AsyncCM(mock_resp))
+        adapter._http_session = mock_session
+
+        result = await adapter.send("+50766715226", "hello")
+
+        assert result.success is True
+        payload = mock_session.post.call_args.kwargs["json"]
+        assert payload["chatId"] == "50766715226@s.whatsapp.net"
+
+    @pytest.mark.asyncio
     async def test_poll_messages_marks_retryable_fatal_when_managed_bridge_exits(self):
         adapter = _make_adapter()
         fatal_handler = AsyncMock()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -13,6 +13,7 @@ from tools.send_message_tool import (
     _parse_target_ref,
     _send_discord,
     _send_telegram,
+    _send_whatsapp,
     _send_to_platform,
     send_message_tool,
 )
@@ -617,6 +618,33 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+
+class TestSendWhatsapp:
+    @staticmethod
+    def _build_mock(response_status, response_data=None, response_text="error body"):
+        mock_resp = MagicMock()
+        mock_resp.status = response_status
+        mock_resp.json = AsyncMock(return_value=response_data or {"messageId": "msg123"})
+        mock_resp.text = AsyncMock(return_value=response_text)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        return mock_session
+
+    def test_send_whatsapp_normalizes_bare_phone_to_jid(self):
+        mock_session = self._build_mock(200, response_data={"messageId": "wa-123"})
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_whatsapp({"bridge_port": 3000}, "+50766715226", "hi"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "50766715226@s.whatsapp.net"
+        assert mock_session.post.call_args.kwargs["json"]["chatId"] == "50766715226@s.whatsapp.net"
 
 
 class TestSendTelegramHtmlDetection:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -626,11 +626,14 @@ async def _send_whatsapp(extra, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
+        from gateway.platforms.whatsapp import _normalize_outbound_whatsapp_chat_id
+
         bridge_port = extra.get("bridge_port", 3000)
+        normalized_chat_id = _normalize_outbound_whatsapp_chat_id(chat_id)
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
-                json={"chatId": chat_id, "message": message},
+                json={"chatId": normalized_chat_id, "message": message},
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 if resp.status == 200:
@@ -638,7 +641,7 @@ async def _send_whatsapp(extra, chat_id, message):
                     return {
                         "success": True,
                         "platform": "whatsapp",
-                        "chat_id": chat_id,
+                        "chat_id": normalized_chat_id,
                         "message_id": data.get("messageId"),
                     }
                 body = await resp.text()


### PR DESCRIPTION
## Summary
- normalize bare WhatsApp phone numbers to `@s.whatsapp.net` JIDs before sending them to the local bridge
- apply the normalization in both the gateway adapter and the `send_message` tool path
- add regression tests covering bare-phone normalization for both direct bridge sends and adapter sends

## Root Cause
Both `tools/send_message_tool.py` and `gateway/platforms/whatsapp.py` passed raw phone numbers directly to the Baileys bridge. Baileys expects a WhatsApp JID like `50766715226@s.whatsapp.net`, so bare numbers caused `jidDecode(...)` to return `undefined` and the bridge crashed with HTTP 500.

Closes #8637.

## Testing
- `python3 -m py_compile gateway/platforms/whatsapp.py tools/send_message_tool.py tests/gateway/test_whatsapp_connect.py tests/tools/test_send_message_tool.py`
- `uv run --extra dev pytest tests/gateway/test_whatsapp_connect.py -q`
- `uv run --extra dev pytest tests/tools/test_send_message_tool.py -q -k 'whatsapp'`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
