### PR TITLE
fix(spinner): connect skin engine to run_agent spinner faces and verbs

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -164,6 +164,40 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
 
 
 # =========================================================================
+# Skin-aware spinner helpers
+# =========================================================================
+
+def get_skin_waiting_faces() -> list[str]:
+    """Get waiting faces from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        faces = skin.get_spinner_list("waiting_faces")
+        if faces:
+            return faces
+    return KawaiiSpinner.KAWAII_WAITING
+
+
+def get_skin_thinking_faces() -> list[str]:
+    """Get thinking faces from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        faces = skin.get_spinner_list("thinking_faces")
+        if faces:
+            return faces
+    return KawaiiSpinner.KAWAII_THINKING
+
+
+def get_skin_thinking_verbs() -> list[str]:
+    """Get thinking verbs from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        verbs = skin.get_spinner_list("thinking_verbs")
+        if verbs:
+            return verbs
+    return KawaiiSpinner.THINKING_VERBS
+
+
+# =========================================================================
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -101,6 +101,9 @@ from agent.display import (
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
+    get_skin_waiting_faces,
+    get_skin_thinking_faces,
+    get_skin_thinking_verbs,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
@@ -6685,7 +6688,7 @@ class AIAgent:
         # Start spinner for CLI mode (skip when TUI handles tool progress)
         spinner = None
         if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-            face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+            face = random.choice(get_skin_waiting_faces())
             spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=self._print_fn)
             spinner.start()
 
@@ -6941,7 +6944,7 @@ class AIAgent:
                     spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots', print_fn=self._print_fn)
                     spinner.start()
                 self._delegate_spinner = spinner
@@ -6968,7 +6971,7 @@ class AIAgent:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None
                 if self.quiet_mode and not self.tool_progress_callback:
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -6992,7 +6995,7 @@ class AIAgent:
                 # These are not in the tool registry — route through MemoryManager.
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7014,7 +7017,7 @@ class AIAgent:
             elif self.quiet_mode:
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7837,8 +7840,8 @@ class AIAgent:
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
                 # Animated thinking spinner in quiet mode
-                face = random.choice(KawaiiSpinner.KAWAII_THINKING)
-                verb = random.choice(KawaiiSpinner.THINKING_VERBS)
+                face = random.choice(get_skin_thinking_faces())
+                verb = random.choice(get_skin_thinking_verbs())
                 if self.thinking_callback:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     # (works in both streaming and non-streaming modes)

--- a/tests/agent/test_display_spinner.py
+++ b/tests/agent/test_display_spinner.py
@@ -1,0 +1,142 @@
+"""Tests for skin-aware spinner helpers in agent/display.py."""
+
+from unittest.mock import patch as mock_patch, MagicMock
+
+import pytest
+
+from agent.display import (
+    get_skin_waiting_faces,
+    get_skin_thinking_faces,
+    get_skin_thinking_verbs,
+    KawaiiSpinner,
+)
+
+
+class TestGetSkinWaitingFaces:
+    """get_skin_waiting_faces() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_faces_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["(⚔)", "(⛨)", "(▲)"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_waiting_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)"]
+            skin.get_spinner_list.assert_called_once_with("waiting_faces")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_waiting_faces()
+            assert result == KawaiiSpinner.KAWAII_WAITING
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_waiting_faces()
+            assert result == KawaiiSpinner.KAWAII_WAITING
+
+    def test_returns_hardcoded_when_skin_is_none(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            assert get_skin_waiting_faces() == KawaiiSpinner.KAWAII_WAITING
+
+
+class TestGetSkinThinkingFaces:
+    """get_skin_thinking_faces() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_faces_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["(Ψ)", "(∿)", "(≈)"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_faces()
+            assert result == ["(Ψ)", "(∿)", "(≈)"]
+            skin.get_spinner_list.assert_called_once_with("thinking_faces")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_faces()
+            assert result == KawaiiSpinner.KAWAII_THINKING
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_thinking_faces()
+            assert result == KawaiiSpinner.KAWAII_THINKING
+
+
+class TestGetSkinThinkingVerbs:
+    """get_skin_thinking_verbs() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_verbs_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["forging", "marching", "hammering plans"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_verbs()
+            assert result == ["forging", "marching", "hammering plans"]
+            skin.get_spinner_list.assert_called_once_with("thinking_verbs")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_verbs()
+            assert result == KawaiiSpinner.THINKING_VERBS
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_thinking_verbs()
+            assert result == KawaiiSpinner.THINKING_VERBS
+
+
+class TestSpinnerHelpersAresSkinIntegration:
+    """Integration test: ares skin spinner values are returned correctly."""
+
+    def test_ares_skin_waiting_faces(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_waiting_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)", "(<>)", "(/)"]
+        finally:
+            set_active_skin("default")
+
+    def test_ares_skin_thinking_faces(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_thinking_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)", "(⌁)", "(<>)"]
+        finally:
+            set_active_skin("default")
+
+    def test_ares_skin_thinking_verbs(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_thinking_verbs()
+            assert "forging" in result
+            assert "marching" in result
+            assert "plotting impact" in result
+        finally:
+            set_active_skin("default")
+
+    def test_default_skin_falls_back_to_hardcoded(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("default")
+        try:
+            # Default skin has empty spinner lists — should fall back to hardcoded
+            assert get_skin_waiting_faces() == KawaiiSpinner.KAWAII_WAITING
+            assert get_skin_thinking_faces() == KawaiiSpinner.KAWAII_THINKING
+            assert get_skin_thinking_verbs() == KawaiiSpinner.THINKING_VERBS
+        finally:
+            set_active_skin("default")
+
+    def test_poseidon_skin_thinking_verbs(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("poseidon")
+        try:
+            verbs = get_skin_thinking_verbs()
+            assert "charting currents" in verbs
+            assert "sounding the depth" in verbs
+        finally:
+            set_active_skin("default")


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where the skin engine's spinner customization was completely ignored at runtime. The skin engine (`hermes_cli/skin_engine.py`) already defined custom `waiting_faces`, `thinking_faces`, and `thinking_verbs` for themed skins like `ares`, `poseidon`, `sisyphus`, and `charizard`, exposing them via `SkinConfig.get_spinner_list()`. However, `run_agent.py` was picking directly from the hardcoded `KawaiiSpinner.KAWAII_WAITING`, `KawaiiSpinner.KAWAII_THINKING`, and `KawaiiSpinner.THINKING_VERBS` class attributes, bypassing the skin system entirely.

The result: all four themed skins had custom themed faces and verbs defined but never displayed — users saw the default kawaii faces regardless of which skin was active.

**What changed:**

- `agent/display.py`: Added three helpers — `get_skin_waiting_faces()`, `get_skin_thinking_faces()`, `get_skin_thinking_verbs()` — that consult the active skin and fall back to hardcoded defaults when no skin value is configured.
- `run_agent.py`: Replaced 6 hardcoded `random.choice(KawaiiSpinner.*)` calls with the new helpers (5 for waiting faces during tool execution, 1 combined call for thinking face+verb during API response).
- `tests/agent/test_display_spinner.py`: 15 unit/integration tests covering the helper resolution chain and ares/poseidon skin integration.

## Related Issue

N/A — no pre-existing issue for this bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/display.py`: Added `get_skin_waiting_faces()`, `get_skin_thinking_faces()`, `get_skin_thinking_verbs()` helpers (+34 lines)
- `run_agent.py`: Replaced 6 hardcoded `random.choice(KawaiiSpinner.*)` calls with the new skin-aware helpers — affects tool execution spinner and thinking spinner paths (+10/-7 lines net)
- `tests/agent/test_display_spinner.py`: 15 tests covering helper resolution, empty-skin fallback, default skin fallback, and ares/poseidon integration (+142 lines)

## How to Test

1. `hermes chat -q 'hello' --skin ares` — spinner should show themed faces like `(⚔)`, `(⛨)`, `(▲)` instead of default kawaii faces
2. `hermes chat -q 'hello' --skin poseidon` — spinner should show water-themed faces and verbs like "charting currents"
3. `hermes chat -q 'hello'` (no skin flag) — default kawaii behavior unchanged, verifies backward compatibility
4. Run the new tests: `python -m pytest tests/agent/test_display_spinner.py -v`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Before (ares skin active, but spinner still shows default kawaii faces):
```
(✿◠‿◠✿) ⚡ running 3 tools concurrently
```

After (ares skin, spinner now shows themed faces):
```
(⚔) ⚡ running 3 tools concurrently
(⛨) analyzing
```