### PR TITLE
fix(auxiliary): honor configured OpenRouter model in auto-routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1255,6 +1255,21 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                         main_provider, resolved or main_model)
             return client, resolved or main_model
 
+    # OpenRouter is an aggregator, but when it is the configured primary
+    # provider we should still honor the saved model slug rather than
+    # swapping to the hardcoded auxiliary default.  That keeps side-task
+    # calls aligned with the user's selected OpenRouter model.
+    if main_provider == "openrouter" and main_model:
+        client, resolved = resolve_provider_client(
+            "openrouter",
+            main_model,
+            api_mode=runtime_api_mode or None,
+        )
+        if client is not None:
+            logger.info("Auxiliary auto-detect: using configured OpenRouter model %s",
+                        resolved or main_model)
+            return client, resolved or main_model
+
     # ── Step 2: aggregator / fallback chain ──────────────────────────────
     tried = []
     for label, try_fn in _get_provider_chain():

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2160,6 +2160,10 @@ def _resolve_task_provider_model(
     cfg_base_url = None
     cfg_api_key = None
     cfg_api_mode = None
+    env_provider = None
+    env_model = None
+    env_base_url = None
+    env_api_key = None
 
     if task:
         try:
@@ -2178,7 +2182,13 @@ def _resolve_task_provider_model(
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
-    resolved_model = model or cfg_model
+        env_prefix = f"AUXILIARY_{str(task).strip().upper()}"
+        env_provider = os.getenv(f"{env_prefix}_PROVIDER", "").strip() or None
+        env_model = os.getenv(f"{env_prefix}_MODEL", "").strip() or None
+        env_base_url = os.getenv(f"{env_prefix}_BASE_URL", "").strip() or None
+        env_api_key = os.getenv(f"{env_prefix}_API_KEY", "").strip() or None
+
+    resolved_model = model or cfg_model or env_model
     resolved_api_mode = cfg_api_mode
 
     if base_url:
@@ -2192,6 +2202,12 @@ def _resolve_task_provider_model(
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode
+        # Legacy env vars still work as a fallback when config.yaml does not
+        # provide a task-specific route.
+        if env_base_url:
+            return "custom", resolved_model, env_base_url, env_api_key, resolved_api_mode
+        if env_provider and env_provider != "auto":
+            return env_provider, resolved_model, None, None, resolved_api_mode
 
         return "auto", resolved_model, None, None, resolved_api_mode
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -450,6 +450,121 @@ class TestExplicitProviderRouting:
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 
+    def test_openrouter_takes_priority(self, monkeypatch, codex_auth_dir):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client()
+        assert model == "google/gemini-3-flash-preview"
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args
+        assert call_kwargs.kwargs["api_key"] == "or-key"
+
+    def test_openrouter_auto_uses_configured_main_model(self):
+        """Configured OpenRouter main models should not be replaced by the aux default."""
+        calls = []
+
+        def _fake_resolve(provider, model=None, *args, **kwargs):
+            calls.append((provider, model, kwargs))
+            return MagicMock(), model
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", side_effect=_fake_resolve),
+        ):
+            client, model = _resolve_auto(
+                main_runtime={
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-sonnet-4.6",
+                }
+            )
+
+        assert client is not None
+        assert model == "anthropic/claude-sonnet-4.6"
+        assert calls == [("openrouter", "anthropic/claude-sonnet-4.6", {"api_mode": None})]
+
+    def test_nous_takes_priority_over_codex(self, monkeypatch, codex_auth_dir):
+        with patch("agent.auxiliary_client._read_nous_auth") as mock_nous, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_nous.return_value = {"access_token": "nous-tok"}
+            client, model = get_text_auxiliary_client()
+        assert model == "google/gemini-3-flash-preview"
+
+    def test_custom_endpoint_over_codex(self, monkeypatch, codex_auth_dir):
+        config = {
+            "model": {
+                "provider": "custom",
+                "base_url": "http://localhost:1234/v1",
+                "default": "my-local-model",
+            }
+        }
+        monkeypatch.setenv("OPENAI_API_KEY", "lm-studio-key")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: config)
+        # Override the autouse monkeypatch for codex
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_codex_access_token",
+            lambda: "codex-test-token-abc123",
+        )
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client()
+        assert model == "my-local-model"
+        call_kwargs = mock_openai.call_args
+        assert call_kwargs.kwargs["base_url"] == "http://localhost:1234/v1"
+
+    def test_task_direct_endpoint_override(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_BASE_URL", "http://localhost:2345/v1")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_KEY", "task-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_MODEL", "task-model")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client("web_extract")
+        assert model == "task-model"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:2345/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "task-key"
+
+    def test_task_direct_endpoint_without_openai_key_uses_placeholder(self, monkeypatch):
+        """Local endpoints without an API key should use 'no-key-required' placeholder."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_BASE_URL", "http://localhost:2345/v1")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_MODEL", "task-model")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client("web_extract")
+        assert client is not None
+        assert model == "task-model"
+        assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:2345/v1"
+
+    def test_custom_endpoint_uses_config_saved_base_url(self, monkeypatch):
+        config = {
+            "model": {
+                "provider": "custom",
+                "base_url": "http://localhost:1234/v1",
+                "default": "my-local-model",
+            }
+        }
+        monkeypatch.setenv("OPENAI_API_KEY", "lm-studio-key")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: config)
+
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client()
+
+        assert client is not None
+        assert model == "my-local-model"
+        call_kwargs = mock_openai.call_args
+        assert call_kwargs.kwargs["base_url"] == "http://localhost:1234/v1"
+
+    def test_codex_fallback_when_nothing_else(self, codex_auth_dir):
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client()
+        assert model == "gpt-5.2-codex"
+        # Returns a CodexAuxiliaryClient wrapper, not a raw OpenAI client
+        from agent.auxiliary_client import CodexAuxiliaryClient
+        assert isinstance(client, CodexAuxiliaryClient)
     def test_codex_pool_entry_takes_priority_over_auth_store(self):
         class _Entry:
             access_token = "pooled-codex-token"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -534,6 +534,29 @@ class TestGetTextAuxiliaryClient:
         assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
         assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:2345/v1"
 
+    def test_task_config_override_beats_legacy_env(self, monkeypatch):
+        config = {
+            "auxiliary": {
+                "web_extract": {
+                    "base_url": "http://config-endpoint:2345/v1",
+                    "api_key": "config-key",
+                    "model": "config-model",
+                }
+            }
+        }
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_BASE_URL", "http://env-endpoint:2345/v1")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_KEY", "env-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_MODEL", "env-model")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client("web_extract")
+
+        assert client is not None
+        assert model == "config-model"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://config-endpoint:2345/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "config-key"
+
     def test_custom_endpoint_uses_config_saved_base_url(self, monkeypatch):
         config = {
             "model": {


### PR DESCRIPTION
## Summary
- honor the configured OpenRouter main model during auxiliary auto-routing instead of always falling back to the hardcoded auxiliary default
- preserve task-specific direct endpoint overrides and legacy `AUXILIARY_<TASK>_*` environment variables so web-extract/vision routes still win over the OpenRouter main-model shortcut
- add regression coverage for both the configured OpenRouter path and task-override precedence

## Root Cause
Auxiliary auto-routing always treated OpenRouter as an aggregator and swapped to the generic auxiliary default model, even when the user had explicitly selected a different OpenRouter model for their main runtime. Fixing that exposed an adjacent gap: legacy task-level direct endpoint overrides were documented and tested but not actually read from the auxiliary routing resolver, so they could be bypassed by the broader auto-routing path.

## Validation
- `python3 -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `uv run --extra dev pytest -o addopts='' tests/agent/test_auxiliary_client.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
