### PR TITLE
fix(feishu): ack card-action callbacks without a response body

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1863,9 +1863,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 loop,
             )
             future.add_done_callback(self._log_background_failure)
-        if P2CardActionTriggerResponse is None:
-            return None
-        return P2CardActionTriggerResponse()
+        # Feishu accepts a no-op callback response here; returning an empty
+        # P2CardActionTriggerResponse() can serialize to a malformed body and
+        # surface 200340 on button clicks.
+        return None
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -806,6 +806,35 @@ class TestAdapterBehavior(unittest.TestCase):
         run_threadsafe.assert_not_called()
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_card_action_trigger_ack_returns_none(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _Loop:
+            def is_closed(self):
+                return False
+
+        adapter._loop = _Loop()
+        data = SimpleNamespace(event=SimpleNamespace(token="tok_1"))
+
+        future = SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+        def _submit(coro, _loop):
+            coro.close()
+            return future
+
+        with patch(
+            "gateway.platforms.feishu.asyncio.run_coroutine_threadsafe",
+            side_effect=_submit,
+        ) as submit:
+            result = adapter._on_card_action_trigger(data)
+
+        self.assertIsNone(result)
+        self.assertTrue(submit.called)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_normalize_inbound_text_strips_feishu_mentions(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- return a no-op card-action acknowledgement from Feishu instead of fabricating an empty `P2CardActionTriggerResponse()`
- add a regression test that the card-action trigger still schedules work but returns `None`

## Root Cause
Feishu approval button clicks were getting an empty callback response body from `_on_card_action_trigger()`, which can be rejected as malformed and surface as error 200340 on button clicks.

Fixes #8246.

## Testing
- `python3 -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py tests/gateway/test_feishu_approval_buttons.py`
- `uv run --extra dev pytest tests/gateway/test_feishu.py -k "card_action_trigger_ack_returns_none or ack_reaction_events_are_ignored_to_avoid_feedback_loops"`
- `uv run --extra dev pytest tests/gateway/test_feishu_approval_buttons.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
