### PR TITLE
feat: add live CLI session messaging

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3627,8 +3627,36 @@ class HermesCLI:
                 preview = preview[:117] + "..."
             _cprint(f"  ↪ live message from {sender}: {preview}")
             if body and hasattr(self, "_pending_input"):
-                self._pending_input.put(body)
+                self._pending_input.put({"type": "live_message", "body": body, "event": event})
         return events
+
+    def _maybe_send_live_completion(self, live_event: dict | None, response: str, result: dict | None) -> None:
+        self._ensure_live_session_state()
+        if not live_event or not self._session_db:
+            return
+        if getattr(self, "_live_role", None) != "executor":
+            return
+        target_session_id = live_event.get("sender_session_id")
+        if not target_session_id:
+            return
+        if result and result.get("interrupted"):
+            return
+
+        sender_label = getattr(self, "_live_role", None) or self.session_id
+        status = "failed" if result and result.get("failed") else "completed"
+        response_text = (response or "").strip() or "(no response)"
+        outbound = (
+            f"[Live task {status} by {sender_label}]\n"
+            f"From prompt: {(live_event.get('body') or '').strip()}\n\n"
+            f"Result:\n{response_text}"
+        )
+        self._session_db.queue_live_message(
+            target_session_id=target_session_id,
+            body=outbound,
+            sender_session_id=self.session_id,
+            sender_label=sender_label,
+            sender_model=getattr(self, "model", None),
+        )
 
     def _list_live_sessions(self, cmd_original: str) -> None:
         self._ensure_live_session_state()
@@ -7839,6 +7867,11 @@ class HermesCLI:
                     self._voice_continuous = False
                     _cprint(f"\n{_DIM}Continuous voice mode stopped due to error.{_RST}")
 
+            try:
+                self._maybe_send_live_completion(live_event, response, result)
+            except Exception:
+                logger.debug("Failed to send live completion", exc_info=True)
+
             # Handle interrupt - check if we were interrupted
             pending_message = None
             if result and result.get("interrupted"):
@@ -9529,7 +9562,11 @@ class HermesCLI:
 
                     # Unpack image payload: (text, [Path, ...]) or plain str
                     submit_images = []
-                    if isinstance(user_input, tuple):
+                    live_event = None
+                    if isinstance(user_input, dict) and user_input.get("type") == "live_message":
+                        live_event = user_input.get("event")
+                        user_input = user_input.get("body", "")
+                    elif isinstance(user_input, tuple):
                         user_input, submit_images = user_input
                     
                     # Check for commands — but detect dragged/pasted file paths first.

--- a/cli.py
+++ b/cli.py
@@ -3603,7 +3603,110 @@ class HermesCLI:
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
         self.console.print("\n".join(lines), highlight=False, markup=False)
-    
+
+    def _ensure_live_session_state(self):
+        if not hasattr(self, "_live_role"):
+            self._live_role = None
+        if not hasattr(self, "_live_runtime"):
+            from hermes_cli.live_sessions import LiveRuntimeState
+            self._live_runtime = LiveRuntimeState()
+
+    def _drain_live_session_messages(self):
+        self._ensure_live_session_state()
+        if not self._session_db:
+            return []
+        events = self._session_db.claim_live_messages(self.session_id)
+        if not events:
+            return []
+
+        for event in events:
+            sender = event.get("sender_label") or event.get("sender_session_id") or "unknown"
+            body = (event.get("body") or "").strip()
+            preview = body.replace("\n", " ")
+            if len(preview) > 120:
+                preview = preview[:117] + "..."
+            _cprint(f"  ↪ live message from {sender}: {preview}")
+            if body and hasattr(self, "_pending_input"):
+                self._pending_input.put(body)
+        return events
+
+    def _list_live_sessions(self, cmd_original: str) -> None:
+        self._ensure_live_session_state()
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        include_stale = cmd_original.strip().lower().endswith(" all")
+        sessions = self._session_db.list_live_sessions(include_stale=include_stale, limit=100)
+        if not sessions:
+            _cprint("  No live CLI sessions found.")
+            return
+
+        self_id = getattr(self, "session_id", None)
+        _cprint("  Live CLI sessions:")
+        for row in sessions:
+            sid = row.get("session_id", "")
+            me = " *" if sid == self_id else "  "
+            role = row.get("role") or "-"
+            name = row.get("display_name") or sid
+            model = row.get("model") or "unknown"
+            provider = row.get("provider") or "auto"
+            status = "busy" if row.get("agent_running") else ("live" if row.get("is_active") else "stale")
+            age = int(row.get("age_seconds") or 0)
+            cwd = Path(row.get("cwd") or ".").name
+            _cprint(f"{me} {sid} [{role}] {status} {age}s {cwd} {model} ({provider}) — {name}")
+
+    def _handle_live_role_command(self, cmd_original: str) -> None:
+        self._ensure_live_session_state()
+        parts = cmd_original.split(None, 1)
+        if len(parts) == 1 or not parts[1].strip():
+            current = getattr(self, "_live_role", None)
+            _cprint(f"  Live role: {current or '(unset)'}")
+            return
+
+        value = parts[1].strip()
+        self._live_role = None if value == "-" else value
+        try:
+            from hermes_cli.live_sessions import refresh_live_registration
+            refresh_live_registration(self)
+        except Exception:
+            pass
+        _cprint(f"  Live role set: {self._live_role or '(cleared)'}")
+
+    def _handle_live_send_command(self, cmd_original: str) -> None:
+        self._ensure_live_session_state()
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        parts = cmd_original.split(None, 2)
+        if len(parts) < 3 or not parts[1].strip() or not parts[2].strip():
+            _cprint("  Usage: /send <target> <message>")
+            _cprint("  Example: /send executor Implement issue-first PR workflow for ...")
+            return
+
+        target, body = parts[1].strip(), parts[2].strip()
+        resolved, error = self._session_db.resolve_live_session(
+            target,
+            exclude_session_id=self.session_id,
+        )
+        if error or not resolved:
+            _cprint(f"  {error or 'target not found'}")
+            return
+
+        sender_label = getattr(self, "_live_role", None) or self.session_id
+        self._session_db.queue_live_message(
+            target_session_id=resolved["session_id"],
+            body=body,
+            sender_session_id=self.session_id,
+            sender_label=sender_label,
+            sender_model=getattr(self, "model", None),
+        )
+        _cprint(
+            f"  Sent live message to {resolved['session_id']}"
+            f" [{resolved.get('role') or '-'}]"
+        )
+
     def _fast_command_available(self) -> bool:
         try:
             from hermes_cli.models import model_supports_fast_mode
@@ -5373,6 +5476,12 @@ class HermesCLI:
             self._show_gateway_status()
         elif canonical == "status":
             self._show_session_status()
+        elif canonical == "sessions":
+            self._list_live_sessions(cmd_original)
+        elif canonical == "role":
+            self._handle_live_role_command(cmd_original)
+        elif canonical == "send":
+            self._handle_live_send_command(cmd_original)
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
@@ -9552,7 +9661,14 @@ class HermesCLI:
         # Start processing thread
         process_thread = threading.Thread(target=process_loop, daemon=True)
         process_thread.start()
-        
+
+        self._ensure_live_session_state()
+        try:
+            from hermes_cli.live_sessions import start_live_runtime
+            start_live_runtime(self)
+        except Exception:
+            logger.debug("Failed to start live CLI session runtime", exc_info=True)
+
         # Register atexit cleanup so resources are freed even on unexpected exit
         atexit.register(_run_cleanup)
         
@@ -9666,6 +9782,11 @@ class HermesCLI:
                     self._session_db.end_session(self.agent.session_id, "cli_close")
                 except (Exception, KeyboardInterrupt) as e:
                     logger.debug("Could not close session in DB: %s", e)
+            try:
+                from hermes_cli.live_sessions import stop_live_runtime
+                stop_live_runtime(self)
+            except Exception:
+                logger.debug("Failed to stop live CLI session runtime", exc_info=True)
             # Plugin hook: on_session_end — safety net for interrupted exits.
             # run_conversation() already fires this per-turn on normal completion,
             # so only fire here if the agent was mid-turn (_agent_running) when

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -90,6 +90,12 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("sessions", "List live CLI sessions available for coordination", "Session",
+               args_hint="[all]", cli_only=True),
+    CommandDef("role", "Set or show the current live session role label", "Session",
+               args_hint="[name|-]", cli_only=True),
+    CommandDef("send", "Send a live message to another active CLI session", "Session",
+               aliases=("msg",), args_hint="<target> <message>", cli_only=True),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/hermes_cli/live_sessions.py
+++ b/hermes_cli/live_sessions.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from hermes_cli.profiles import get_active_profile_name
+
+if TYPE_CHECKING:
+    from cli import HermesCLI
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LiveRuntimeState:
+    thread: Optional[threading.Thread] = None
+    stop_event: Optional[threading.Event] = None
+    registered_session_id: Optional[str] = None
+
+
+def _display_name(cli: "HermesCLI") -> str:
+    title = None
+    try:
+        if getattr(cli, "_session_db", None):
+            title = cli._session_db.get_session_title(cli.session_id)
+    except Exception:
+        title = None
+    if title:
+        return title
+    role = getattr(cli, "_live_role", None)
+    if role:
+        return role
+    return cli.session_id
+
+
+def _build_payload(cli: "HermesCLI") -> dict:
+    cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+    provider = getattr(cli, "provider", None) or getattr(cli, "requested_provider", None) or "auto"
+    return {
+        "session_id": cli.session_id,
+        "source": "cli",
+        "display_name": _display_name(cli),
+        "role": getattr(cli, "_live_role", None),
+        "model": getattr(cli, "model", None),
+        "provider": provider,
+        "profile": get_active_profile_name(),
+        "cwd": cwd,
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "agent_running": bool(getattr(cli, "_agent_running", False)),
+        "accepts_messages": True,
+        "started_at": getattr(cli, "session_start", None).timestamp() if getattr(cli, "session_start", None) else time.time(),
+    }
+
+
+def refresh_live_registration(cli: "HermesCLI") -> None:
+    db = getattr(cli, "_session_db", None)
+    state = getattr(cli, "_live_runtime", None)
+    if not db or not state:
+        return
+
+    payload = _build_payload(cli)
+    current_session_id = payload["session_id"]
+    previous = state.registered_session_id
+    if previous and previous != current_session_id:
+        try:
+            db.remove_live_session(previous)
+        except Exception:
+            logger.debug("Failed removing old live session row for %s", previous, exc_info=True)
+    db.upsert_live_session(**payload)
+    state.registered_session_id = current_session_id
+    try:
+        db.prune_live_sessions()
+    except Exception:
+        logger.debug("Live session prune failed", exc_info=True)
+
+
+def stop_live_runtime(cli: "HermesCLI") -> None:
+    state = getattr(cli, "_live_runtime", None)
+    db = getattr(cli, "_session_db", None)
+    if state and state.stop_event:
+        state.stop_event.set()
+    if state and state.thread and state.thread.is_alive():
+        state.thread.join(timeout=1.5)
+    if db and state and state.registered_session_id:
+        try:
+            db.remove_live_session(state.registered_session_id)
+        except Exception:
+            logger.debug("Failed removing live session row during shutdown", exc_info=True)
+    if state:
+        state.registered_session_id = None
+
+
+def start_live_runtime(cli: "HermesCLI", *, interval_seconds: float = 0.75) -> None:
+    state = getattr(cli, "_live_runtime", None)
+    if not state or not getattr(cli, "_session_db", None):
+        return
+    if state.thread and state.thread.is_alive():
+        return
+
+    stop_event = threading.Event()
+    state.stop_event = stop_event
+
+    def _loop() -> None:
+        while not stop_event.is_set() and not getattr(cli, "_should_exit", False):
+            try:
+                refresh_live_registration(cli)
+                cli._drain_live_session_messages()
+            except Exception:
+                logger.debug("Live CLI heartbeat loop error", exc_info=True)
+            stop_event.wait(interval_seconds)
+
+    state.thread = threading.Thread(target=_loop, daemon=True, name="hermes-live-sessions")
+    state.thread.start()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -84,10 +84,41 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT
 );
 
+CREATE TABLE IF NOT EXISTS live_sessions (
+    session_id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    display_name TEXT,
+    role TEXT,
+    model TEXT,
+    provider TEXT,
+    profile TEXT,
+    cwd TEXT,
+    pid INTEGER,
+    host TEXT,
+    agent_running INTEGER DEFAULT 0,
+    accepts_messages INTEGER DEFAULT 1,
+    started_at REAL NOT NULL,
+    last_seen REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS live_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_session_id TEXT NOT NULL,
+    sender_session_id TEXT,
+    sender_label TEXT,
+    sender_model TEXT,
+    body TEXT NOT NULL,
+    delivery_mode TEXT NOT NULL DEFAULT 'enqueue',
+    created_at REAL NOT NULL,
+    consumed_at REAL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_live_sessions_last_seen ON live_sessions(last_seen DESC);
+CREATE INDEX IF NOT EXISTS idx_live_messages_target_pending ON live_messages(target_session_id, consumed_at, created_at);
 """
 
 FTS_SQL = """
@@ -329,6 +360,43 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS live_sessions (
+                        session_id TEXT PRIMARY KEY,
+                        source TEXT NOT NULL,
+                        display_name TEXT,
+                        role TEXT,
+                        model TEXT,
+                        provider TEXT,
+                        profile TEXT,
+                        cwd TEXT,
+                        pid INTEGER,
+                        host TEXT,
+                        agent_running INTEGER DEFAULT 0,
+                        accepts_messages INTEGER DEFAULT 1,
+                        started_at REAL NOT NULL,
+                        last_seen REAL NOT NULL
+                    )
+                    """
+                )
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS live_messages (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        target_session_id TEXT NOT NULL,
+                        sender_session_id TEXT,
+                        sender_label TEXT,
+                        sender_model TEXT,
+                        body TEXT NOT NULL,
+                        delivery_mode TEXT NOT NULL DEFAULT 'enqueue',
+                        created_at REAL NOT NULL,
+                        consumed_at REAL
+                    )
+                    """
+                )
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -339,6 +407,18 @@ class SessionDB:
             )
         except sqlite3.OperationalError:
             pass  # Index already exists
+
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_live_sessions_last_seen "
+                "ON live_sessions(last_seen DESC)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_live_messages_target_pending "
+                "ON live_messages(target_session_id, consumed_at, created_at)"
+            )
+        except sqlite3.OperationalError:
+            pass
 
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
@@ -1109,6 +1189,245 @@ class SessionDB:
                     (limit, offset),
                 )
             return [dict(row) for row in cursor.fetchall()]
+
+    def upsert_live_session(
+        self,
+        session_id: str,
+        *,
+        source: str,
+        display_name: Optional[str] = None,
+        role: Optional[str] = None,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        profile: Optional[str] = None,
+        cwd: Optional[str] = None,
+        pid: Optional[int] = None,
+        host: Optional[str] = None,
+        agent_running: bool = False,
+        accepts_messages: bool = True,
+        started_at: Optional[float] = None,
+    ) -> None:
+        """Insert or refresh a live CLI session row."""
+        now = time.time()
+        started = started_at or now
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO live_sessions (
+                    session_id, source, display_name, role, model, provider,
+                    profile, cwd, pid, host, agent_running, accepts_messages,
+                    started_at, last_seen
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    source = excluded.source,
+                    display_name = excluded.display_name,
+                    role = excluded.role,
+                    model = excluded.model,
+                    provider = excluded.provider,
+                    profile = excluded.profile,
+                    cwd = excluded.cwd,
+                    pid = excluded.pid,
+                    host = excluded.host,
+                    agent_running = excluded.agent_running,
+                    accepts_messages = excluded.accepts_messages,
+                    started_at = COALESCE(live_sessions.started_at, excluded.started_at),
+                    last_seen = excluded.last_seen
+                """,
+                (
+                    session_id,
+                    source,
+                    display_name,
+                    role,
+                    model,
+                    provider,
+                    profile,
+                    cwd,
+                    pid,
+                    host,
+                    1 if agent_running else 0,
+                    1 if accepts_messages else 0,
+                    started,
+                    now,
+                ),
+            )
+        self._execute_write(_do)
+
+    def remove_live_session(self, session_id: str) -> None:
+        """Delete a live session row when a CLI exits cleanly."""
+        def _do(conn):
+            conn.execute("DELETE FROM live_sessions WHERE session_id = ?", (session_id,))
+        self._execute_write(_do)
+
+    def set_live_session_role(self, session_id: str, role: Optional[str]) -> bool:
+        """Set or clear the current session's live role label."""
+        cleaned = role.strip() if role else None
+        if cleaned == "-":
+            cleaned = None
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE live_sessions SET role = ? WHERE session_id = ?",
+                (cleaned, session_id),
+            )
+            return cursor.rowcount
+        return self._execute_write(_do) > 0
+
+    def list_live_sessions(
+        self,
+        *,
+        active_within_seconds: int = 15,
+        include_stale: bool = False,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """List live sessions ordered by most recently seen heartbeat."""
+        cutoff = time.time() - max(active_within_seconds, 1)
+        query = (
+            "SELECT * FROM live_sessions "
+            "WHERE (? = 1 OR last_seen >= ?) "
+            "ORDER BY last_seen DESC LIMIT ?"
+        )
+        with self._lock:
+            cursor = self._conn.execute(
+                query,
+                (1 if include_stale else 0, cutoff, limit),
+            )
+            rows = cursor.fetchall()
+        sessions = []
+        now = time.time()
+        for row in rows:
+            item = dict(row)
+            item["is_active"] = bool(item.get("last_seen") and item["last_seen"] >= cutoff)
+            item["age_seconds"] = max(0.0, now - float(item.get("last_seen") or now))
+            item["agent_running"] = bool(item.get("agent_running"))
+            item["accepts_messages"] = bool(item.get("accepts_messages", 1))
+            sessions.append(item)
+        return sessions
+
+    def resolve_live_session(
+        self,
+        target: str,
+        *,
+        active_within_seconds: int = 15,
+        exclude_session_id: Optional[str] = None,
+    ) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """Resolve a live session by exact ID, unique prefix, role, or label."""
+        needle = (target or "").strip()
+        if not needle:
+            return None, "empty target"
+
+        live = self.list_live_sessions(
+            active_within_seconds=active_within_seconds,
+            include_stale=True,
+            limit=200,
+        )
+        if exclude_session_id:
+            live = [row for row in live if row.get("session_id") != exclude_session_id]
+
+        exact_id = [row for row in live if row.get("session_id") == needle]
+        if len(exact_id) == 1:
+            return exact_id[0], None
+
+        prefix = [row for row in live if str(row.get("session_id", "")).startswith(needle)]
+        if len(prefix) == 1:
+            return prefix[0], None
+        if len(prefix) > 1:
+            return None, f"ambiguous target '{needle}' — matches {', '.join(row['session_id'] for row in prefix[:5])}"
+
+        lowered = needle.lower()
+        by_role = [row for row in live if str(row.get("role") or "").lower() == lowered]
+        if len(by_role) == 1:
+            return by_role[0], None
+        if len(by_role) > 1:
+            return None, f"ambiguous role '{needle}' — matches {', '.join(row['session_id'] for row in by_role[:5])}"
+
+        by_label = [
+            row for row in live
+            if str(row.get("display_name") or "").strip().lower() == lowered
+        ]
+        if len(by_label) == 1:
+            return by_label[0], None
+        if len(by_label) > 1:
+            return None, f"ambiguous label '{needle}' — matches {', '.join(row['session_id'] for row in by_label[:5])}"
+
+        return None, f"live session '{needle}' not found"
+
+    def queue_live_message(
+        self,
+        *,
+        target_session_id: str,
+        body: str,
+        sender_session_id: Optional[str] = None,
+        sender_label: Optional[str] = None,
+        sender_model: Optional[str] = None,
+        delivery_mode: str = "enqueue",
+    ) -> int:
+        """Append a live message for another CLI session."""
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                INSERT INTO live_messages (
+                    target_session_id, sender_session_id, sender_label,
+                    sender_model, body, delivery_mode, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    target_session_id,
+                    sender_session_id,
+                    sender_label,
+                    sender_model,
+                    body,
+                    delivery_mode,
+                    now,
+                ),
+            )
+            return int(cursor.lastrowid)
+        return self._execute_write(_do)
+
+    def claim_live_messages(
+        self,
+        session_id: str,
+        *,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Atomically claim pending live messages for a CLI session."""
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                SELECT * FROM live_messages
+                WHERE target_session_id = ? AND consumed_at IS NULL
+                ORDER BY created_at ASC, id ASC
+                LIMIT ?
+                """,
+                (session_id, limit),
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return []
+            ids = [row["id"] for row in rows]
+            placeholders = ",".join("?" for _ in ids)
+            conn.execute(
+                f"UPDATE live_messages SET consumed_at = ? WHERE id IN ({placeholders})",
+                (now, *ids),
+            )
+            return [dict(row) for row in rows]
+        return self._execute_write(_do)
+
+    def prune_live_sessions(self, *, stale_after_seconds: int = 86400) -> int:
+        """Best-effort cleanup for abandoned live session rows."""
+        cutoff = time.time() - max(stale_after_seconds, 1)
+
+        def _do(conn):
+            cursor = conn.execute(
+                "DELETE FROM live_sessions WHERE last_seen < ?",
+                (cutoff,),
+            )
+            return cursor.rowcount
+        return int(self._execute_write(_do) or 0)
 
     # =========================================================================
     # Utility

--- a/tests/cli/test_live_cli_sessions.py
+++ b/tests/cli/test_live_cli_sessions.py
@@ -1,0 +1,69 @@
+import queue
+import sys
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+from tests.cli.test_cli_new_session import _make_cli
+
+
+class TestLiveCliSessions:
+    def _make_cli(self, tmp_path, session_id="sess_sender"):
+        with patch.dict(sys.modules, {"fire": MagicMock()}):
+            cli = _make_cli()
+        cli.config = {"quick_commands": {}}
+        cli.console = MagicMock()
+        cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+        cli.session_id = session_id
+        cli.model = "gpt-5.4"
+        cli.provider = "openai"
+        cli._pending_input = queue.Queue()
+        cli._agent_running = False
+        cli.session_start = None
+        cli.agent = None
+        cli.conversation_history = []
+        cli._should_exit = False
+        return cli
+
+    def test_role_command_sets_live_role(self, tmp_path):
+        cli = self._make_cli(tmp_path)
+        cli._session_db.upsert_live_session(cli.session_id, source="cli")
+
+        with patch("cli._cprint"):
+            cli.process_command("/role orchestrator")
+
+        row, error = cli._session_db.resolve_live_session(cli.session_id)
+        assert error is None
+        assert row["role"] == "orchestrator"
+        assert cli._live_role == "orchestrator"
+
+    def test_send_command_queues_message_for_target(self, tmp_path):
+        sender = self._make_cli(tmp_path, session_id="sess_sender")
+        receiver = self._make_cli(tmp_path, session_id="sess_receiver")
+        sender._session_db.upsert_live_session(sender.session_id, source="cli", role="orchestrator")
+        sender._live_role = "orchestrator"
+        receiver._session_db.upsert_live_session(receiver.session_id, source="cli", role="executor")
+
+        with patch("cli._cprint"):
+            sender.process_command("/send executor Implement the feature")
+
+        claimed = receiver._session_db.claim_live_messages(receiver.session_id)
+        assert len(claimed) == 1
+        assert claimed[0]["body"] == "Implement the feature"
+        assert claimed[0]["sender_label"] == "orchestrator"
+
+    def test_drain_live_messages_enqueues_received_prompt(self, tmp_path):
+        receiver = self._make_cli(tmp_path, session_id="sess_receiver")
+        receiver._session_db.upsert_live_session(receiver.session_id, source="cli", role="executor")
+        receiver._session_db.queue_live_message(
+            target_session_id=receiver.session_id,
+            sender_session_id="sess_sender",
+            sender_label="orchestrator",
+            sender_model="gpt-5.4",
+            body="Do the implementation",
+        )
+
+        with patch("cli._cprint"):
+            events = receiver._drain_live_session_messages()
+
+        assert len(events) == 1
+        assert receiver._pending_input.get_nowait() == "Do the implementation"

--- a/tests/test_live_session_db.py
+++ b/tests/test_live_session_db.py
@@ -1,0 +1,63 @@
+from hermes_state import SessionDB
+
+
+def test_upsert_and_list_live_sessions(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.upsert_live_session(
+        "sess_a",
+        source="cli",
+        role="orchestrator",
+        display_name="planner",
+        model="gpt-5.4",
+        provider="openai",
+        cwd="/tmp/project",
+        pid=111,
+        host="box",
+        agent_running=True,
+    )
+
+    rows = db.list_live_sessions()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["session_id"] == "sess_a"
+    assert row["role"] == "orchestrator"
+    assert row["display_name"] == "planner"
+    assert row["agent_running"] is True
+    assert row["is_active"] is True
+
+
+def test_resolve_live_session_supports_prefix_role_and_label(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.upsert_live_session("20260412_aaaaaa", source="cli", role="orchestrator", display_name="planner")
+    db.upsert_live_session("20260412_bbbbbb", source="cli", role="executor", display_name="coder")
+
+    row, error = db.resolve_live_session("20260412_b")
+    assert error is None
+    assert row["session_id"] == "20260412_bbbbbb"
+
+    row, error = db.resolve_live_session("executor")
+    assert error is None
+    assert row["session_id"] == "20260412_bbbbbb"
+
+    row, error = db.resolve_live_session("planner")
+    assert error is None
+    assert row["session_id"] == "20260412_aaaaaa"
+
+
+def test_claim_live_messages_marks_them_consumed(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.upsert_live_session("receiver", source="cli")
+    msg_id = db.queue_live_message(
+        target_session_id="receiver",
+        sender_session_id="sender",
+        sender_label="orchestrator",
+        sender_model="gpt-5.4",
+        body="Implement the patch",
+    )
+
+    claimed = db.claim_live_messages("receiver")
+    assert [row["id"] for row in claimed] == [msg_id]
+    assert claimed[0]["body"] == "Implement the patch"
+    assert claimed[0]["sender_label"] == "orchestrator"
+
+    assert db.claim_live_messages("receiver") == []


### PR DESCRIPTION
## Summary
- add a shared live-session registry to `state.db` for active CLI discovery
- add `/sessions`, `/role`, and `/send` for orchestrator/executor workflows across live terminals
- add a CLI heartbeat/inbox loop so inbound messages appear live and enqueue directly into the recipient session

## Changes
- added `live_sessions` and `live_messages` tables plus SessionDB helpers for registration, lookup, delivery, and claiming
- added `hermes_cli/live_sessions.py` to manage live runtime heartbeat and cleanup
- wired the CLI run loop and slash-command dispatch into live session messaging
- added DB tests and CLI behavior tests for role assignment, send, and inbox draining

## Testing
- `python -m pytest tests/test_live_session_db.py -q -o addopts=''`
- `python -m py_compile cli.py hermes_state.py hermes_cli/commands.py hermes_cli/live_sessions.py tests/test_live_session_db.py tests/cli/test_live_cli_sessions.py`
- smoke-tested `/send executor ...` delivery with a stubbed CLI import in the worktree

## Notes
- `process_command` and `new_session` were high-risk GitNexus surfaces; changes were kept localized and the live runtime was isolated in a new module
- full CLI pytest coverage is limited in this environment because optional runtime deps like `prompt_toolkit`, `fire`, and `openai` are not installed
