### PR TITLE
fix(hindsight): propagate local CPU env on macOS

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -22,7 +22,10 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import threading
+from contextlib import contextmanager
+from pathlib import Path
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List
@@ -37,6 +40,10 @@ _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.4.22"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_LOCAL_DAEMON_FORCE_CPU_ENV_VARS = (
+    "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU",
+    "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU",
+)
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -82,6 +89,28 @@ def _run_sync(coro, timeout: float = 120.0):
     loop = _get_loop()
     future = asyncio.run_coroutine_threadsafe(coro, loop)
     return future.result(timeout=timeout)
+
+
+@contextmanager
+def _temporary_env_overrides(overrides: Dict[str, str]):
+    """Temporarily apply env var overrides for daemon startup."""
+    if not overrides:
+        yield
+        return
+
+    sentinel = object()
+    previous: Dict[str, object] = {}
+    try:
+        for key, value in overrides.items():
+            previous[key] = os.environ.get(key, sentinel)
+            os.environ[key] = value
+        yield
+    finally:
+        for key, old_value in previous.items():
+            if old_value is sentinel:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = str(old_value)
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +495,101 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
+    def _build_embedded_daemon_env(self, saved_env: Dict[str, str]) -> Dict[str, str]:
+        """Collect startup-only env vars needed by the embedded daemon."""
+        env: Dict[str, str] = {}
+        cfg = self._config if isinstance(self._config, dict) else {}
+
+        for key in _LOCAL_DAEMON_FORCE_CPU_ENV_VARS:
+            value = ""
+            for cfg_key in (key, key.lower(), key.removeprefix("HINDSIGHT_API_").lower()):
+                raw = cfg.get(cfg_key)
+                if raw is not None and str(raw).strip():
+                    value = str(raw).strip()
+                    break
+            if not value:
+                value = str(os.environ.get(key, "") or "").strip()
+            if not value:
+                value = str(saved_env.get(key, "") or "").strip()
+            if not value and sys.platform == "darwin":
+                value = "true"
+            if value:
+                env[key] = value
+
+        return env
+
+    def _start_embedded_daemon(self) -> None:
+        """Start the embedded Hindsight daemon with the correct startup env."""
+        import traceback
+        import hindsight_embed.daemon_embed_manager as dem
+        from rich.console import Console
+
+        log_dir = get_hermes_home() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "hindsight-embed.log"
+
+        try:
+            # Redirect the daemon manager's Rich console to our log file
+            # instead of stderr. This avoids global fd redirects that
+            # would capture output from other threads.
+            dem.console = Console(file=open(log_path, "a"), force_terminal=False)
+
+            client = self._get_client()
+            profile = self._config.get("profile", "hermes")
+
+            # Update the profile .env to match our current config so
+            # the daemon always starts with the right settings.
+            # If the config changed and the daemon is running, stop it.
+            profile_env = Path.home() / ".hindsight" / "profiles" / f"{profile}.env"
+            current_key = self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+            current_provider = self._config.get("llm_provider", "")
+            current_model = self._config.get("llm_model", "")
+            current_base_url = self._config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+            # Map openai_compatible/openrouter → openai for the daemon (OpenAI wire format)
+            daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
+
+            # Read saved profile config
+            saved: Dict[str, str] = {}
+            if profile_env.exists():
+                for line in profile_env.read_text().splitlines():
+                    if "=" in line and not line.startswith("#"):
+                        k, v = line.split("=", 1)
+                        saved[k.strip()] = v.strip()
+
+            daemon_start_env = self._build_embedded_daemon_env(saved)
+            desired_env = dict(saved)
+            desired_env.update(
+                {
+                    "HINDSIGHT_API_LLM_PROVIDER": daemon_provider,
+                    "HINDSIGHT_API_LLM_API_KEY": current_key,
+                    "HINDSIGHT_API_LLM_MODEL": current_model,
+                    "HINDSIGHT_API_LOG_LEVEL": "info",
+                }
+            )
+            if current_base_url:
+                desired_env["HINDSIGHT_API_LLM_BASE_URL"] = current_base_url
+            else:
+                desired_env.pop("HINDSIGHT_API_LLM_BASE_URL", None)
+            desired_env.update(daemon_start_env)
+
+            if saved != desired_env:
+                profile_env.parent.mkdir(parents=True, exist_ok=True)
+                env_lines = "".join(f"{key}={value}\n" for key, value in desired_env.items())
+                profile_env.write_text(env_lines)
+                if client._manager.is_running(profile):
+                    with open(log_path, "a") as f:
+                        f.write("\n=== Config changed, restarting daemon ===\n")
+                    client._manager.stop(profile)
+
+            with _temporary_env_overrides(daemon_start_env):
+                client._ensure_started()
+            with open(log_path, "a") as f:
+                f.write("\n=== Daemon started successfully ===\n")
+        except Exception as e:
+            with open(log_path, "a") as f:
+                f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                traceback.print_exc(file=f)
+
     def initialize(self, session_id: str, **kwargs) -> None:
         self._session_id = session_id
 
@@ -558,75 +682,11 @@ class HindsightMemoryProvider(MemoryProvider):
         # doesn't block the chat. Redirect stdout/stderr to a log file to
         # prevent rich startup output from spamming the terminal.
         if self._mode == "local_embedded":
-            def _start_daemon():
-                import traceback
-                log_dir = get_hermes_home() / "logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-                log_path = log_dir / "hindsight-embed.log"
-                try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a"), force_terminal=False)
-
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
-
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    from pathlib import Path as _Path
-                    profile_env = _Path.home() / ".hindsight" / "profiles" / f"{profile}.env"
-                    current_key = self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
-                    current_provider = self._config.get("llm_provider", "")
-                    current_model = self._config.get("llm_model", "")
-                    current_base_url = self._config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
-                    # Map openai_compatible/openrouter → openai for the daemon (OpenAI wire format)
-                    daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
-
-                    # Read saved profile config
-                    saved = {}
-                    if profile_env.exists():
-                        for line in profile_env.read_text().splitlines():
-                            if "=" in line and not line.startswith("#"):
-                                k, v = line.split("=", 1)
-                                saved[k.strip()] = v.strip()
-
-                    config_changed = (
-                        saved.get("HINDSIGHT_API_LLM_PROVIDER") != daemon_provider or
-                        saved.get("HINDSIGHT_API_LLM_MODEL") != current_model or
-                        saved.get("HINDSIGHT_API_LLM_API_KEY") != current_key or
-                        saved.get("HINDSIGHT_API_LLM_BASE_URL", "") != current_base_url
-                    )
-
-                    if config_changed:
-                        # Write updated profile .env
-                        profile_env.parent.mkdir(parents=True, exist_ok=True)
-                        env_lines = (
-                            f"HINDSIGHT_API_LLM_PROVIDER={daemon_provider}\n"
-                            f"HINDSIGHT_API_LLM_API_KEY={current_key}\n"
-                            f"HINDSIGHT_API_LLM_MODEL={current_model}\n"
-                            f"HINDSIGHT_API_LOG_LEVEL=info\n"
-                        )
-                        if current_base_url:
-                            env_lines += f"HINDSIGHT_API_LLM_BASE_URL={current_base_url}\n"
-                        profile_env.write_text(env_lines)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
-
-                    client._ensure_started()
-                    with open(log_path, "a") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
-
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=self._start_embedded_daemon,
+                daemon=True,
+                name="hindsight-daemon-start",
+            )
             t.start()
 
     def system_prompt_block(self) -> str:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,7 +6,10 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import os
+import sys
 import threading
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -203,6 +206,110 @@ class TestConfig:
         assert cfg["apiKey"] == "env-key"
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
+
+
+class TestEmbeddedDaemonStartup:
+    def test_build_embedded_daemon_env_defaults_force_cpu_on_darwin(self, monkeypatch):
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"mode": "local_embedded", "llm_provider": "openai", "llm_model": "gpt-4o-mini"}
+        monkeypatch.setattr("plugins.memory.hindsight.sys.platform", "darwin")
+        monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", raising=False)
+
+        env = p._build_embedded_daemon_env({})
+
+        assert env == {
+            "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU": "true",
+            "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU": "true",
+        }
+
+    def test_embedded_daemon_startup_exports_force_cpu_env_and_restores_it(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "local_embedded",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "llm_api_key": "test-llm-key",
+            "bank_id": "test-bank",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("plugins.memory.hindsight.sys.platform", "darwin")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU", raising=False)
+
+        ensure_env = {}
+        fake_client = SimpleNamespace(
+            _manager=SimpleNamespace(
+                is_running=lambda _profile: False,
+                stop=lambda _profile: None,
+            )
+        )
+
+        def _ensure_started():
+            ensure_env["embeddings"] = os.environ.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU")
+            ensure_env["reranker"] = os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU")
+
+        fake_client._ensure_started = _ensure_started
+
+        fake_hindsight_embed = types.ModuleType("hindsight_embed")
+        fake_dem = types.ModuleType("hindsight_embed.daemon_embed_manager")
+        fake_dem.console = None
+        fake_hindsight_embed.daemon_embed_manager = fake_dem
+
+        fake_rich = types.ModuleType("rich")
+        fake_rich_console = types.ModuleType("rich.console")
+        fake_rich_console.Console = lambda **_kwargs: object()
+        fake_rich.console = fake_rich_console
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None, name=None):
+                self._target = target
+
+            def start(self):
+                if self._target:
+                    self._target()
+
+        with (
+            patch("plugins.memory.hindsight.HindsightMemoryProvider._get_client", return_value=fake_client),
+            patch("plugins.memory.hindsight.threading.Thread", _ImmediateThread),
+            patch.dict(
+                sys.modules,
+                {
+                    "hindsight_embed": fake_hindsight_embed,
+                    "hindsight_embed.daemon_embed_manager": fake_dem,
+                    "rich": fake_rich,
+                    "rich.console": fake_rich_console,
+                },
+            ),
+        ):
+            p = HindsightMemoryProvider()
+            p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert ensure_env == {"embeddings": "true", "reranker": "true"}
+        assert os.environ.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU") is None
+        assert os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU") is None
+
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        contents = profile_env.read_text()
+        assert "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true" in contents
+        assert "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true" in contents
+
+    def test_embedded_daemon_env_honors_explicit_override(self, monkeypatch):
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"mode": "local_embedded", "llm_provider": "openai", "llm_model": "gpt-4o-mini"}
+        monkeypatch.setattr("plugins.memory.hindsight.sys.platform", "darwin")
+        monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU", "false")
+
+        env = p._build_embedded_daemon_env({})
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "false"
+        assert env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] == "true"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- propagate embedded Hindsight daemon CPU-force env vars into the actual startup environment
- preserve those vars in the generated profile `.env` file and default them on macOS when unset
- add regression coverage for Darwin startup env propagation and env restoration

Fixes #7135

## Testing
- python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-7135/plugins/memory/hindsight/__init__.py /Users/stephenyu/Documents/hermes-agent-wt-7135/tests/plugins/memory/test_hindsight_provider.py
- uv run --extra dev pytest -o addopts= /Users/stephenyu/Documents/hermes-agent-wt-7135/tests/plugins/memory/test_hindsight_provider.py -q

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
