### PR TITLE
fix(runtime): reuse session credentials in background helpers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2119,10 +2119,14 @@ class AIAgent:
                      contextlib.redirect_stderr(_devnull):
                     review_agent = AIAgent(
                         model=self.model,
+                        base_url=self.base_url,
+                        api_key=self.api_key,
                         max_iterations=8,
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        api_mode=self.api_mode,
+                        credential_pool=self._credential_pool,
                     )
                     review_agent._memory_store = self._memory_store
                     review_agent._memory_enabled = self._memory_enabled
@@ -6488,6 +6492,7 @@ class AIAgent:
                     tools=[memory_tool_def],
                     temperature=0.3,
                     max_tokens=5120,
+                    main_runtime=self._current_main_runtime(),
                     # timeout resolved from auxiliary.flush_memories.timeout config
                 )
             except RuntimeError:

--- a/tests/run_agent/test_background_review_runtime.py
+++ b/tests/run_agent/test_background_review_runtime.py
@@ -1,0 +1,66 @@
+"""Tests for background review agent runtime propagation."""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+def test_spawn_background_review_reuses_parent_runtime():
+    parent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    parent.model = "MiniMax-M2.7"
+    parent.base_url = "https://api.minimax.io/anthropic"
+    parent.api_key = "mm-key"
+    parent.platform = "telegram"
+    parent.provider = "minimax"
+    parent.api_mode = "anthropic_messages"
+    parent._credential_pool = object()
+    parent._memory_store = MagicMock()
+    parent._memory_enabled = True
+    parent._user_profile_enabled = True
+    parent.background_review_callback = None
+    parent._safe_print = lambda *args, **kwargs: None
+
+    child = SimpleNamespace(
+        _session_messages=[],
+        run_conversation=MagicMock(),
+        close=MagicMock(),
+    )
+    child_kwargs = {}
+
+    def _fake_agent(**kwargs):
+        child_kwargs.update(kwargs)
+        return child
+
+    with (
+        patch("run_agent.AIAgent", side_effect=_fake_agent),
+        patch("threading.Thread", _ImmediateThread),
+    ):
+        parent._spawn_background_review(
+            messages_snapshot=[{"role": "user", "content": "remember this"}],
+            review_memory=True,
+        )
+
+    assert child_kwargs["model"] == parent.model
+    assert child_kwargs["base_url"] == parent.base_url
+    assert child_kwargs["api_key"] == parent.api_key
+    assert child_kwargs["provider"] == parent.provider
+    assert child_kwargs["api_mode"] == parent.api_mode
+    assert child_kwargs["credential_pool"] is parent._credential_pool
+    child.run_conversation.assert_called_once()
+    child.close.assert_called_once()

--- a/tests/run_agent/test_flush_memories_codex.py
+++ b/tests/run_agent/test_flush_memories_codex.py
@@ -167,6 +167,7 @@ class TestFlushMemoriesUsesAuxiliaryClient:
         mock_call.assert_called_once()
         call_kwargs = mock_call.call_args
         assert call_kwargs.kwargs.get("task") == "flush_memories"
+        assert call_kwargs.kwargs.get("main_runtime") == agent._current_main_runtime()
 
     def test_flush_uses_main_client_when_no_auxiliary(self, monkeypatch):
         """Non-Codex mode with no auxiliary falls back to self.client."""


### PR DESCRIPTION
## Summary
- pass the current session runtime into `flush_memories()` auxiliary calls instead of re-resolving credentials from env/pool
- propagate `base_url`, `api_key`, `api_mode`, and `credential_pool` into background review agents
- add regression coverage for both helper paths

Fixes #8283

## Testing
- python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-8283/run_agent.py /Users/stephenyu/Documents/hermes-agent-wt-8283/tests/run_agent/test_flush_memories_codex.py /Users/stephenyu/Documents/hermes-agent-wt-8283/tests/run_agent/test_background_review_runtime.py
- uv run --extra dev pytest -o addopts= /Users/stephenyu/Documents/hermes-agent-wt-8283/tests/run_agent/test_flush_memories_codex.py /Users/stephenyu/Documents/hermes-agent-wt-8283/tests/run_agent/test_background_review_runtime.py -q

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
