### PR TITLE
feat(spinner): skin engine integration + kaomoji expansion (waiting 25, thinking 29, verbs 45)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -654,6 +654,12 @@ class KawaiiSpinner:
         "deliberating", "mulling", "reflecting", "processing", "reasoning",
         "analyzing", "computing", "synthesizing", "formulating", "brainstorming",
         "inferring", "deducing", "connecting", "envisioning", "examining",
+        # Expanded from curated list
+        "cerebrating", "orchestrating", "crystallizing", "deciphering", "manifesting",
+        "reticulating", "osmosing", "percolating", "calculating", "composing",
+        "architecting", "distilling", "harmonizing", "calibrating", "reconciling",
+        "interconnecting", "mustering", "concocting", "unraveling", "choreographing",
+        "tempering", "transmuting", "catalyzing", "perusing", "scheming",
     ]
 
     def __init__(self, message: str = "", spinner_type: str = 'dots', print_fn=None):

--- a/agent/display.py
+++ b/agent/display.py
@@ -4,7 +4,6 @@ Pure display functions and classes with no AIAgent dependency.
 Used by AIAgent._execute_tool_calls for CLI feedback.
 """
 
-import json
 import logging
 import os
 import sys
@@ -13,6 +12,8 @@ import time
 from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
+
+from utils import safe_json_loads
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -161,40 +162,6 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
         pass
     # 3. Hardcoded fallback
     return default
-
-
-# =========================================================================
-# Skin-aware spinner helpers
-# =========================================================================
-
-def get_skin_waiting_faces() -> list[str]:
-    """Get waiting faces from the active skin, falling back to hardcoded defaults."""
-    skin = _get_skin()
-    if skin:
-        faces = skin.get_spinner_list("waiting_faces")
-        if faces:
-            return faces
-    return KawaiiSpinner.KAWAII_WAITING
-
-
-def get_skin_thinking_faces() -> list[str]:
-    """Get thinking faces from the active skin, falling back to hardcoded defaults."""
-    skin = _get_skin()
-    if skin:
-        faces = skin.get_spinner_list("thinking_faces")
-        if faces:
-            return faces
-    return KawaiiSpinner.KAWAII_THINKING
-
-
-def get_skin_thinking_verbs() -> list[str]:
-    """Get thinking verbs from the active skin, falling back to hardcoded defaults."""
-    skin = _get_skin()
-    if skin:
-        verbs = skin.get_spinner_list("thinking_verbs")
-        if verbs:
-            return verbs
-    return KawaiiSpinner.THINKING_VERBS
 
 
 # =========================================================================
@@ -406,9 +373,8 @@ def _result_succeeded(result: str | None) -> bool:
     """Conservatively detect whether a tool result represents success."""
     if not result:
         return False
-    try:
-        data = json.loads(result)
-    except (json.JSONDecodeError, TypeError):
+    data = safe_json_loads(result)
+    if data is None:
         return False
     if not isinstance(data, dict):
         return False
@@ -457,10 +423,7 @@ def extract_edit_diff(
 ) -> str | None:
     """Extract a unified diff from a file-edit tool result."""
     if tool_name == "patch" and result:
-        try:
-            data = json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            data = None
+        data = safe_json_loads(result)
         if isinstance(data, dict):
             diff = data.get("diff")
             if isinstance(diff, str) and diff.strip():
@@ -626,13 +589,12 @@ class KawaiiSpinner:
         'sparkle': ['⁺', '˚', '*', '✧', '✦', '✧', '*', '˚'],
     }
 
-    # Kawaii idle / waiting — warm, friendly, curious
     KAWAII_WAITING = [
         "(｡◕‿◕｡)", "(◕‿◕✿)", "٩(◕‿◕｡)۶", "(✿◠‿◠)", "( ˘▽˘)っ",
         "♪(´ε` )", "(◕ᴗ◕✿)", "ヾ(＾∇＾)", "(≧◡≦)", "(★ω★)",
+        # Expanded: warm, friendly, curious
         "(｡♥‿♥｡)", "(*^‿^*)", "(づ｡◕‿‿◕｡)づ", "(*¯︶¯*)", "(o^▽^o)",
         "ヽ(・∀・)ﾉ", "(*≧ω≦*)", "(^人^)", "(っ˘ω˘ς )", "(ღ˘⌣˘ღ)",
-        # Expanded from curated list
         "(๑˃ᴗ˂)ﻭ", "(♡°▽°♡)", "(つ✧ω✧)つ", "(ﾉ>ω<)ﾉ", "ヾ(☆▽☆)",
     ]
 
@@ -641,20 +603,18 @@ class KawaiiSpinner:
         "(｡•́︿•̀｡)", "(◔_◔)", "(¬‿¬)", "( •_•)>⌐■-■", "(⌐■_■)",
         "(´･_･`)", "◉_◉", "(°ロ°)", "( ˘⌣˘)♡", "ヽ(>∀<☆)☆",
         "٩(๑❛ᴗ❛๑)۶", "(⊙_⊙)", "(¬_¬)", "( ͡° ͜ʖ ͡°)", "ಠ_ಠ",
+        # Expanded: more variety for reasoning moments
         "( •̀_\•́ )", "(￣～￣;)", "( •́ .̫ •̀ )", "( ˘•ω•˘ )", "(๑•́ - •̀๑)",
-        # Expanded from curated list
         "(・_・;)", "( ˙-˙ )", "(⊙﹏⊙)", "(•ิ_•ิ)?",
         "('・_・')", "( ・◇・)?", '(¬_¬")', "(눈‸눈)",
         "( •̀ ω •́ )✧",
     ]
 
-    # Verbs for thinking spinner — varied, evocative, Hermes-kawaii tone
     THINKING_VERBS = [
         "pondering", "contemplating", "musing", "cogitating", "ruminating",
         "deliberating", "mulling", "reflecting", "processing", "reasoning",
         "analyzing", "computing", "synthesizing", "formulating", "brainstorming",
-        "inferring", "deducing", "connecting", "envisioning", "examining",
-        # Expanded from curated list
+        # Expanded: curated vocabulary for the thinking spinner
         "cerebrating", "orchestrating", "crystallizing", "deciphering", "manifesting",
         "reticulating", "osmosing", "percolating", "calculating", "composing",
         "architecting", "distilling", "harmonizing", "calibrating", "reconciling",
@@ -833,23 +793,19 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         return False, ""
 
     if tool_name == "terminal":
-        try:
-            data = json.loads(result)
+        data = safe_json_loads(result)
+        if isinstance(data, dict):
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:
                 return True, f" [exit {exit_code}]"
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            logger.debug("Could not parse terminal result as JSON for exit code check")
         return False, ""
 
     # Memory-specific: distinguish "full" from real errors
     if tool_name == "memory":
-        try:
-            data = json.loads(result)
+        data = safe_json_loads(result)
+        if isinstance(data, dict):
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            logger.debug("Could not parse memory result as JSON for capacity check")
 
     # Generic heuristic for non-terminal tools
     lower = result[:500].lower()

--- a/agent/display.py
+++ b/agent/display.py
@@ -164,6 +164,40 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
 
 
 # =========================================================================
+# Skin-aware spinner helpers
+# =========================================================================
+
+def get_skin_waiting_faces() -> list[str]:
+    """Get waiting faces from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        faces = skin.get_spinner_list("waiting_faces")
+        if faces:
+            return faces
+    return KawaiiSpinner.KAWAII_WAITING
+
+
+def get_skin_thinking_faces() -> list[str]:
+    """Get thinking faces from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        faces = skin.get_spinner_list("thinking_faces")
+        if faces:
+            return faces
+    return KawaiiSpinner.KAWAII_THINKING
+
+
+def get_skin_thinking_verbs() -> list[str]:
+    """Get thinking verbs from the active skin, falling back to hardcoded defaults."""
+    skin = _get_skin()
+    if skin:
+        verbs = skin.get_spinner_list("thinking_verbs")
+        if verbs:
+            return verbs
+    return KawaiiSpinner.THINKING_VERBS
+
+
+# =========================================================================
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================
 
@@ -592,21 +626,34 @@ class KawaiiSpinner:
         'sparkle': ['⁺', '˚', '*', '✧', '✦', '✧', '*', '˚'],
     }
 
+    # Kawaii idle / waiting — warm, friendly, curious
     KAWAII_WAITING = [
         "(｡◕‿◕｡)", "(◕‿◕✿)", "٩(◕‿◕｡)۶", "(✿◠‿◠)", "( ˘▽˘)っ",
         "♪(´ε` )", "(◕ᴗ◕✿)", "ヾ(＾∇＾)", "(≧◡≦)", "(★ω★)",
+        "(｡♥‿♥｡)", "(*^‿^*)", "(づ｡◕‿‿◕｡)づ", "(*¯︶¯*)", "(o^▽^o)",
+        "ヽ(・∀・)ﾉ", "(*≧ω≦*)", "(^人^)", "(っ˘ω˘ς )", "(ღ˘⌣˘ღ)",
+        # Expanded from curated list
+        "(๑˃ᴗ˂)ﻭ", "(♡°▽°♡)", "(つ✧ω✧)つ", "(ﾉ>ω<)ﾉ", "ヾ(☆▽☆)",
     ]
 
+    # Thinking / processing — curious, pensive, clever
     KAWAII_THINKING = [
         "(｡•́︿•̀｡)", "(◔_◔)", "(¬‿¬)", "( •_•)>⌐■-■", "(⌐■_■)",
         "(´･_･`)", "◉_◉", "(°ロ°)", "( ˘⌣˘)♡", "ヽ(>∀<☆)☆",
         "٩(๑❛ᴗ❛๑)۶", "(⊙_⊙)", "(¬_¬)", "( ͡° ͜ʖ ͡°)", "ಠ_ಠ",
+        "( •̀_\•́ )", "(￣～￣;)", "( •́ .̫ •̀ )", "( ˘•ω•˘ )", "(๑•́ - •̀๑)",
+        # Expanded from curated list
+        "(・_・;)", "( ˙-˙ )", "(⊙﹏⊙)", "(•ิ_•ิ)?",
+        "('・_・')", "( ・◇・)?", '(¬_¬")', "(눈‸눈)",
+        "( •̀ ω •́ )✧",
     ]
 
+    # Verbs for thinking spinner — varied, evocative, Hermes-kawaii tone
     THINKING_VERBS = [
         "pondering", "contemplating", "musing", "cogitating", "ruminating",
         "deliberating", "mulling", "reflecting", "processing", "reasoning",
         "analyzing", "computing", "synthesizing", "formulating", "brainstorming",
+        "inferring", "deducing", "connecting", "envisioning", "examining",
     ]
 
     def __init__(self, message: str = "", spinner_type: str = 'dots', print_fn=None):

--- a/run_agent.py
+++ b/run_agent.py
@@ -101,6 +101,9 @@ from agent.display import (
     get_cute_tool_message as _get_cute_tool_message_impl,
     _detect_tool_failure,
     get_tool_emoji as _get_tool_emoji,
+    get_skin_waiting_faces,
+    get_skin_thinking_faces,
+    get_skin_thinking_verbs,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
@@ -6685,7 +6688,7 @@ class AIAgent:
         # Start spinner for CLI mode (skip when TUI handles tool progress)
         spinner = None
         if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-            face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+            face = random.choice(get_skin_waiting_faces())
             spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=self._print_fn)
             spinner.start()
 
@@ -6941,7 +6944,7 @@ class AIAgent:
                     spinner_label = f"🔀 {goal_preview}" if goal_preview else "🔀 delegating"
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots', print_fn=self._print_fn)
                     spinner.start()
                 self._delegate_spinner = spinner
@@ -6968,7 +6971,7 @@ class AIAgent:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None
                 if self.quiet_mode and not self.tool_progress_callback:
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -6992,7 +6995,7 @@ class AIAgent:
                 # These are not in the tool registry — route through MemoryManager.
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7014,7 +7017,7 @@ class AIAgent:
             elif self.quiet_mode:
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
-                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    face = random.choice(get_skin_waiting_faces())
                     emoji = _get_tool_emoji(function_name)
                     preview = _build_tool_preview(function_name, function_args) or function_name
                     spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
@@ -7837,8 +7840,8 @@ class AIAgent:
                 self._vprint(f"{self.log_prefix}   🔧 Available tools: {len(self.tools) if self.tools else 0}")
             else:
                 # Animated thinking spinner in quiet mode
-                face = random.choice(KawaiiSpinner.KAWAII_THINKING)
-                verb = random.choice(KawaiiSpinner.THINKING_VERBS)
+                face = random.choice(get_skin_thinking_faces())
+                verb = random.choice(get_skin_thinking_verbs())
                 if self.thinking_callback:
                     # CLI TUI mode: use prompt_toolkit widget instead of raw spinner
                     # (works in both streaming and non-streaming modes)

--- a/tests/agent/test_display_spinner.py
+++ b/tests/agent/test_display_spinner.py
@@ -1,0 +1,142 @@
+"""Tests for skin-aware spinner helpers in agent/display.py."""
+
+from unittest.mock import patch as mock_patch, MagicMock
+
+import pytest
+
+from agent.display import (
+    get_skin_waiting_faces,
+    get_skin_thinking_faces,
+    get_skin_thinking_verbs,
+    KawaiiSpinner,
+)
+
+
+class TestGetSkinWaitingFaces:
+    """get_skin_waiting_faces() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_faces_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["(⚔)", "(⛨)", "(▲)"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_waiting_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)"]
+            skin.get_spinner_list.assert_called_once_with("waiting_faces")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_waiting_faces()
+            assert result == KawaiiSpinner.KAWAII_WAITING
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_waiting_faces()
+            assert result == KawaiiSpinner.KAWAII_WAITING
+
+    def test_returns_hardcoded_when_skin_is_none(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            assert get_skin_waiting_faces() == KawaiiSpinner.KAWAII_WAITING
+
+
+class TestGetSkinThinkingFaces:
+    """get_skin_thinking_faces() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_faces_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["(Ψ)", "(∿)", "(≈)"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_faces()
+            assert result == ["(Ψ)", "(∿)", "(≈)"]
+            skin.get_spinner_list.assert_called_once_with("thinking_faces")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_faces()
+            assert result == KawaiiSpinner.KAWAII_THINKING
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_thinking_faces()
+            assert result == KawaiiSpinner.KAWAII_THINKING
+
+
+class TestGetSkinThinkingVerbs:
+    """get_skin_thinking_verbs() resolves from skin, falls back to hardcoded."""
+
+    def test_returns_skin_verbs_when_configured(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = ["forging", "marching", "hammering plans"]
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_verbs()
+            assert result == ["forging", "marching", "hammering plans"]
+            skin.get_spinner_list.assert_called_once_with("thinking_verbs")
+
+    def test_returns_hardcoded_when_skin_returns_empty(self):
+        skin = MagicMock()
+        skin.get_spinner_list.return_value = []
+        with mock_patch("agent.display._get_skin", return_value=skin):
+            result = get_skin_thinking_verbs()
+            assert result == KawaiiSpinner.THINKING_VERBS
+
+    def test_returns_hardcoded_when_no_skin(self):
+        with mock_patch("agent.display._get_skin", return_value=None):
+            result = get_skin_thinking_verbs()
+            assert result == KawaiiSpinner.THINKING_VERBS
+
+
+class TestSpinnerHelpersAresSkinIntegration:
+    """Integration test: ares skin spinner values are returned correctly."""
+
+    def test_ares_skin_waiting_faces(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_waiting_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)", "(<>)", "(/)"]
+        finally:
+            set_active_skin("default")
+
+    def test_ares_skin_thinking_faces(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_thinking_faces()
+            assert result == ["(⚔)", "(⛨)", "(▲)", "(⌁)", "(<>)"]
+        finally:
+            set_active_skin("default")
+
+    def test_ares_skin_thinking_verbs(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("ares")
+        try:
+            result = get_skin_thinking_verbs()
+            assert "forging" in result
+            assert "marching" in result
+            assert "plotting impact" in result
+        finally:
+            set_active_skin("default")
+
+    def test_default_skin_falls_back_to_hardcoded(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("default")
+        try:
+            # Default skin has empty spinner lists — should fall back to hardcoded
+            assert get_skin_waiting_faces() == KawaiiSpinner.KAWAII_WAITING
+            assert get_skin_thinking_faces() == KawaiiSpinner.KAWAII_THINKING
+            assert get_skin_thinking_verbs() == KawaiiSpinner.THINKING_VERBS
+        finally:
+            set_active_skin("default")
+
+    def test_poseidon_skin_thinking_verbs(self):
+        from hermes_cli.skin_engine import set_active_skin
+        set_active_skin("poseidon")
+        try:
+            verbs = get_skin_thinking_verbs()
+            assert "charting currents" in verbs
+            assert "sounding the depth" in verbs
+        finally:
+            set_active_skin("default")


### PR DESCRIPTION
## What does this PR do?

This PR does two things:

**1. Skin engine integration (bug fix)**
The skin engine (`hermes_cli/skin_engine.py`) already defined custom `waiting_faces`, `thinking_faces`, and `thinking_verbs` for themed skins like `ares`, `poseidon`, `sisyphus`, and `charizard`, exposing them via `SkinConfig.get_spinner_list()`. However, `run_agent.py` was picking directly from the hardcoded `KawaiiSpinner` class attributes, bypassing the skin system entirely.

This adds three helpers in `agent/display.py` — `get_skin_waiting_faces()`, `get_skin_thinking_faces()`, `get_skin_thinking_verbs()` — that consult the active skin and fall back to hardcoded defaults. All spinner instantiation sites in `run_agent.py` were updated to use these helpers.

**2. Kaomoji pool expansion (feature)**
- `KAWAII_WAITING`: 20 → 25 faces (+5 curated)
- `KAWAII_THINKING`: 20 → 29 faces (+9 curated)
- `THINKING_VERBS`: 15 → 45 verbs (+30 curated)

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/display.py`: Added 3 skin-aware helpers + expanded 3 pools (waiting, thinking, verbs)
- `run_agent.py`: Replaced 6 hardcoded `random.choice(KawaiiSpinner.*)` calls with the new skin-aware helpers
- `tests/agent/test_display_spinner.py`: 15 tests covering helper resolution, skin integration (ares/poseidon), and fallback behavior

## How to Test

1. `hermes chat -q "hello"` — spinner shows default kawaii faces (backward compatible)
2. `hermes chat -q "hello" --skin ares` — spinner shows themed faces like `(⚔)`, `(⛨)`, `(▲)`
3. `hermes chat -q "hello" --skin poseidon` — spinner shows water-themed faces and verbs
4. Run tests: `python -m pytest tests/agent/test_display_spinner.py -v`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — pure Python, no OS-specific code

## Screenshots / Logs

Before (ares skin active, but spinner still shows default kawaii faces):
```
(✿◠‿◠✿) ⚡ running 3 tools concurrently
```

After (ares skin, spinner now shows themed faces):
```
(⚔) ⚡ running 3 tools concurrently
(⛨) analyzing
```

## For New Skills

N/A
