### PR TITLE
feat(cli,gateway): show per-turn response timing and token metrics

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1822,6 +1822,8 @@ class HermesCLI:
         self._secret_deadline = 0
         self._spinner_text: str = ""  # thinking spinner text for TUI
         self._tool_start_time: float = 0.0  # monotonic timestamp when current tool started (for live elapsed)
+        self._last_user_message_at: Optional[datetime] = None
+        self._last_user_turn_token_baseline: int = 0
         self._pending_tool_info: dict = {}  # function_name -> list of (preview, args) for stacked scrollback
         self._last_scrollback_tool: str = ""  # last tool name printed to scrollback (for "new" dedup)
         self._command_running = False
@@ -1886,7 +1888,8 @@ class HermesCLI:
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
-        elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
+        now = datetime.now()
+        elapsed_seconds = max(0.0, (now - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
@@ -1903,6 +1906,10 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "last_user_message_elapsed_seconds": None,
+            "last_user_message_elapsed_label": None,
+            "last_user_turn_tokens": None,
+            "last_user_turn_tokens_label": None,
         }
 
         if not agent:
@@ -1916,6 +1923,16 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+
+        last_user_message_at = getattr(self, "_last_user_message_at", None)
+        if last_user_message_at is not None:
+            last_user_elapsed_seconds = max(0, int((now - last_user_message_at).total_seconds()))
+            snapshot["last_user_message_elapsed_seconds"] = last_user_elapsed_seconds
+            snapshot["last_user_message_elapsed_label"] = format_duration_compact(last_user_elapsed_seconds)
+            turn_token_baseline = max(0, int(getattr(self, "_last_user_turn_token_baseline", 0) or 0))
+            turn_tokens = max(0, snapshot["session_total_tokens"] - turn_token_baseline)
+            snapshot["last_user_turn_tokens"] = turn_tokens
+            snapshot["last_user_turn_tokens_label"] = format_token_count_compact(turn_tokens)
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -2038,14 +2055,16 @@ class HermesCLI:
                 width = self._get_tui_terminal_width()
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
+            elapsed_label = snapshot["last_user_message_elapsed_label"] or snapshot["duration"]
+            elapsed_label = f"Δt {elapsed_label}"
+            turn_tokens_label = snapshot["last_user_turn_tokens_label"]
             duration_label = snapshot["duration"]
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {snapshot['model_short']} · {elapsed_label} · {duration_label}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
-                parts.append(duration_label)
+                parts = [f"⚕ {snapshot['model_short']}", percent_label, elapsed_label, duration_label]
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
             if snapshot["context_length"]:
@@ -2055,11 +2074,19 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label, elapsed_label]
+            if width >= 100 and turn_tokens_label:
+                parts.append(f"Δtok {turn_tokens_label}")
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+
+    def _build_scrollback_status_snapshot(self, width: Optional[int] = None) -> Optional[str]:
+        """Return the previous turn's status metrics for scrollback persistence."""
+        if getattr(self, "_last_user_message_at", None) is None:
+            return None
+        return self._build_status_bar_text(width=width)
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
@@ -2072,12 +2099,17 @@ class HermesCLI:
             # actually renders, causing the fragments to overflow to a second
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
+            elapsed_label = snapshot["last_user_message_elapsed_label"] or snapshot["duration"]
+            elapsed_label = f"Δt {elapsed_label}"
+            turn_tokens_label = snapshot["last_user_turn_tokens_label"]
             duration_label = snapshot["duration"]
 
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                    ("class:status-bar-dim", " · "),
+                    ("class:status-bar-dim", elapsed_label),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                     ("class:status-bar", " "),
@@ -2091,6 +2123,8 @@ class HermesCLI:
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
+                        ("class:status-bar-dim", " · "),
+                        ("class:status-bar-dim", elapsed_label),
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
@@ -2114,9 +2148,18 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                         ("class:status-bar-dim", " │ "),
+                        ("class:status-bar-dim", elapsed_label),
+                    ]
+                    if width >= 100 and turn_tokens_label:
+                        frags.extend([
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-dim", f"Δtok {turn_tokens_label}"),
+                        ])
+                    frags.extend([
+                        ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
-                    ]
+                    ])
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
@@ -9451,6 +9494,9 @@ class HermesCLI:
                     import re as _re
                     _paste_ref_re = _re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
                     paste_refs = list(_paste_ref_re.finditer(user_input)) if isinstance(user_input, str) else []
+                    previous_status_snapshot = self._build_scrollback_status_snapshot()
+                    if previous_status_snapshot:
+                        ChatConsole().print(f"[dim]{_escape(previous_status_snapshot)}[/]")
                     if paste_refs:
                         def _expand_ref(m):
                             p = Path(m.group(1))
@@ -9499,6 +9545,10 @@ class HermesCLI:
 
                     # Regular chat - run agent
                     self._agent_running = True
+                    self._last_user_message_at = datetime.now()
+                    self._last_user_turn_token_baseline = int(
+                        getattr(self.agent, "session_total_tokens", 0) if self.agent else 0
+                    )
                     app.invalidate()  # Refresh status line
 
                     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,6 +77,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
 from utils import atomic_yaml_write, is_truthy_value
+from agent.usage_pricing import format_duration_compact, format_token_count_compact
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -3762,6 +3763,21 @@ class GatewayRunner:
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
+            try:
+                _metrics_enabled = bool(
+                    _load_gateway_config()
+                    .get("display", {})
+                    .get("response_metrics", False)
+                )
+            except Exception:
+                _metrics_enabled = False
+            metrics_summary = self._format_response_metrics_summary(
+                source=source,
+                agent_result=agent_result,
+                elapsed_seconds=_response_time,
+                enabled=_metrics_enabled,
+            )
+
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
             # sends raw text chunks that include MEDIA: tags — the normal
@@ -3780,7 +3796,16 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                        if metrics_summary:
+                            await self._send_response_metrics_followup(
+                                adapter=_media_adapter,
+                                source=source,
+                                metrics_summary=metrics_summary,
+                            )
                 return None
+
+            if response and metrics_summary:
+                response = f"{response}\n\n{metrics_summary}"
 
             return response
             
@@ -5097,8 +5122,57 @@ class GatewayRunner:
             for p in {audio_path, actual_path} - {None}:
                 try:
                     os.unlink(p)
-                except OSError:
+                except Exception:
                     pass
+
+    @staticmethod
+    def _response_metrics_supported_platform(platform: Optional[Platform]) -> bool:
+        return platform in {Platform.SLACK, Platform.TELEGRAM, Platform.DISCORD}
+
+    def _format_response_metrics_summary(
+        self,
+        source: SessionSource,
+        agent_result: Dict[str, Any],
+        elapsed_seconds: float,
+        enabled: bool = False,
+    ) -> Optional[str]:
+        if not enabled:
+            return None
+        if not self._response_metrics_supported_platform(getattr(source, "platform", None)):
+            return None
+
+        response = (agent_result.get("final_response") or "").strip()
+        if not response:
+            return None
+
+        elapsed_label = format_duration_compact(max(0, elapsed_seconds))
+        input_tokens = max(0, int(agent_result.get("input_tokens") or 0))
+        output_tokens = max(0, int(agent_result.get("output_tokens") or 0))
+        total_tokens = input_tokens + output_tokens
+        token_label = format_token_count_compact(total_tokens)
+
+        model_name = str(agent_result.get("model") or "").strip()
+        model_short = model_name.split("/")[-1] if "/" in model_name else model_name
+        if model_short.endswith(".gguf"):
+            model_short = model_short[:-5]
+        if len(model_short) > 26:
+            model_short = f"{model_short[:23]}..."
+
+        parts = [elapsed_label, f"{token_label} tok"]
+        if model_short:
+            parts.append(model_short)
+        return "— " + " · ".join(parts)
+
+    async def _send_response_metrics_followup(
+        self,
+        adapter: BasePlatformAdapter,
+        source: SessionSource,
+        metrics_summary: str,
+    ) -> None:
+        if not metrics_summary:
+            return
+        metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        await adapter.send(source.chat_id, metrics_summary, metadata=metadata)
 
     async def _deliver_media_from_response(
         self,

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -71,6 +71,8 @@ class TestCLIStatusBar:
             context_tokens=12_450,
             context_length=200_000,
         )
+        cli_obj._last_user_message_at = datetime.now() - timedelta(seconds=18)
+        cli_obj._last_user_turn_token_baseline = 50
 
         text = cli_obj._build_status_bar_text(width=120)
 
@@ -78,6 +80,8 @@ class TestCLIStatusBar:
         assert "12.4K/200K" in text
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
+        assert "Δt 18s" in text
+        assert "Δtok 12.4K" in text
         assert "15m" in text
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
@@ -190,13 +194,17 @@ class TestCLIStatusBar:
             context_tokens=12400,
             context_length=200_000,
         )
+        cli_obj._last_user_message_at = datetime.now() - timedelta(seconds=18)
+        cli_obj._last_user_turn_token_baseline = 0
 
         text = cli_obj._build_status_bar_text(width=60)
 
         assert "⚕" in text
         assert "$0.06" not in text  # cost hidden by default
+        assert "Δt 18s" in text
         assert "15m" in text
         assert "200K" not in text
+        assert "Δtok" not in text
 
     def test_build_status_bar_text_handles_missing_agent(self):
         cli_obj = _make_cli()
@@ -205,6 +213,83 @@ class TestCLIStatusBar:
 
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
+
+    def test_status_bar_snapshot_includes_last_user_elapsed_and_turn_tokens(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._last_user_message_at = datetime.now() - timedelta(seconds=18)
+        cli_obj._last_user_turn_token_baseline = 50
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["last_user_message_elapsed_seconds"] == 18
+        assert snapshot["last_user_message_elapsed_label"] == "18s"
+        assert snapshot["last_user_turn_tokens"] == 12_400
+        assert snapshot["last_user_turn_tokens_label"] == "12.4K"
+
+    def test_status_bar_snapshot_handles_missing_last_user_message(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._last_user_message_at = None
+        cli_obj._last_user_turn_token_baseline = 50
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["last_user_message_elapsed_seconds"] is None
+        assert snapshot["last_user_message_elapsed_label"] is None
+        assert snapshot["last_user_turn_tokens"] is None
+        assert snapshot["last_user_turn_tokens_label"] is None
+
+    def test_build_scrollback_status_snapshot_returns_previous_metrics(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._last_user_message_at = datetime.now() - timedelta(seconds=18)
+        cli_obj._last_user_turn_token_baseline = 50
+
+        text = cli_obj._build_scrollback_status_snapshot(width=140)
+
+        assert text is not None
+        assert "⚕" in text
+        assert "Δt 18s" in text
+        assert "Δtok 12.4K" in text
+        assert "15m" in text
+
+    def test_build_scrollback_status_snapshot_skips_without_previous_turn(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._last_user_message_at = None
+
+        text = cli_obj._build_scrollback_status_snapshot(width=140)
+
+        assert text is None
 
     def test_minimal_tui_chrome_threshold(self):
         cli_obj = _make_cli()

--- a/tests/gateway/test_response_metrics.py
+++ b/tests/gateway/test_response_metrics.py
@@ -1,0 +1,145 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class CaptureAdapter(BasePlatformAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="m-1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_runner():
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+def test_format_response_metrics_summary_for_supported_platform():
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="u1",
+        user_name="u1",
+        chat_type="dm",
+    )
+
+    summary = runner._format_response_metrics_summary(
+        source=source,
+        agent_result={
+            "final_response": "done",
+            "input_tokens": 10_000,
+            "output_tokens": 2_450,
+            "model": "openai/gpt-5.4",
+        },
+        elapsed_seconds=18,
+        enabled=True,
+    )
+
+    assert summary == "— 18s · 12.4K tok · gpt-5.4"
+
+
+def test_format_response_metrics_summary_skips_unsupported_platform():
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="chat-1",
+        user_id="u1",
+        user_name="u1",
+        chat_type="dm",
+    )
+
+    summary = runner._format_response_metrics_summary(
+        source=source,
+        agent_result={
+            "final_response": "done",
+            "input_tokens": 10_000,
+            "output_tokens": 2_450,
+            "model": "openai/gpt-5.4",
+        },
+        elapsed_seconds=18,
+        enabled=True,
+    )
+
+    assert summary is None
+
+
+def test_format_response_metrics_summary_skips_when_gate_disabled():
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="u1",
+        user_name="u1",
+        chat_type="dm",
+    )
+
+    summary = runner._format_response_metrics_summary(
+        source=source,
+        agent_result={
+            "final_response": "done",
+            "input_tokens": 10_000,
+            "output_tokens": 2_450,
+            "model": "openai/gpt-5.4",
+        },
+        elapsed_seconds=18,
+    )
+
+    assert summary is None
+
+
+@pytest.mark.asyncio
+async def test_send_response_metrics_followup_uses_thread_metadata():
+    runner = _make_runner()
+    adapter = CaptureAdapter(platform=Platform.TELEGRAM)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="u1",
+        user_name="u1",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    await runner._send_response_metrics_followup(
+        adapter=adapter,
+        source=source,
+        metrics_summary="— 18s · 12.4K tok · gpt-5.4",
+    )
+
+    assert adapter.sent == [
+        {
+            "chat_id": "chat-1",
+            "content": "— 18s · 12.4K tok · gpt-5.4",
+            "reply_to": None,
+            "metadata": {"thread_id": "17585"},
+        }
+    ]

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -140,6 +140,10 @@ async def test_handle_message_persists_agent_token_counts(monkeypatch):
 
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
     monkeypatch.setattr(
+        gateway_run, "_load_gateway_config",
+        lambda: {"display": {"response_metrics": True}},
+    )
+    monkeypatch.setattr(
         "agent.model_metadata.get_model_context_length",
         lambda *_args, **_kwargs: 100000,
     )


### PR DESCRIPTION
## Summary
- add CLI status-bar metrics for time since the last executed user message and token delta since that message
- add compact per-response metrics for Slack, Telegram, and Discord replies
- cover both paths with targeted CLI and gateway tests

## What changed
- CLI:
  - track `last_user_message_at` and a per-turn token baseline in `HermesCLI`
  - extend the status-bar snapshot with elapsed-time and token-delta fields
  - render `Δt` / `Δtok` in wide layouts and degrade cleanly on narrower terminals
- Gateway:
  - format a compact per-response metrics summary (`— 18s · 12.4K tok · gpt-5.4`)
  - append it inline for normal replies
  - send it as a small follow-up message when streaming already delivered the final text
  - restrict this to Slack / Telegram / Discord

## Test Plan
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_cli_status_bar.py tests/gateway/test_response_metrics.py -q -o addopts=''`
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_run_progress_topics.py tests/gateway/test_voice_command.py -q -o addopts=''`

## Related
- Refines and extends #8541
- Related umbrella: #6642

Contributed back from https://github.com/xinbenlv/zn-hermes-agent, which is being used and tested by https://github.com/xinbenlv.
