### PR TITLE
fix(feishu): preserve topic thread context for forum replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2171,13 +2171,15 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id)
+        source_chat_type = self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type)
+        thread_id = self._resolve_inbound_thread_id(message=message, source_chat_type=source_chat_type)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=source_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
-            thread_id=getattr(message, "thread_id", None) or None,
+            thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
         )
         normalized = MessageEvent(
@@ -2193,6 +2195,25 @@ class FeishuAdapter(BasePlatformAdapter):
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
+
+    @staticmethod
+    def _resolve_inbound_thread_id(*, message: Any, source_chat_type: str) -> Optional[str]:
+        """Infer Feishu thread context for forum/topic messages.
+
+        Feishu does not reliably populate ``thread_id`` on every message inside an
+        existing topic. In forum chats, ``upper_message_id`` is the best available
+        topic anchor; fall back to ``parent_id`` only when nothing better exists.
+        """
+        explicit_thread_id = str(getattr(message, "thread_id", "") or "").strip()
+        if explicit_thread_id:
+            return explicit_thread_id
+        if source_chat_type != "forum":
+            return None
+        upper_message_id = str(getattr(message, "upper_message_id", "") or "").strip()
+        if upper_message_id:
+            return upper_message_id
+        parent_id = str(getattr(message, "parent_id", "") or "").strip()
+        return parent_id or None
 
     async def _dispatch_inbound_event(self, event: MessageEvent) -> None:
         """Apply Feishu-specific burst protection before entering the base adapter."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1881,6 +1881,116 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_forum_message_uses_upper_message_id_as_thread_context(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_forum", "name": "Feishu Topic", "type": "forum"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_forum",
+            thread_id=None,
+            parent_id="om_parent",
+            upper_message_id="om_topic_root",
+            message_type="text",
+            content='{"text":"inside topic"}',
+            message_id="om_topic_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="group",
+                message_id="om_topic_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.chat_type, "forum")
+        self.assertEqual(event.source.thread_id, "om_topic_root")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_forum_message_falls_back_to_parent_id_for_thread_context(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_forum", "name": "Feishu Topic", "type": "forum"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_forum",
+            thread_id=None,
+            parent_id="om_topic_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"inside topic"}',
+            message_id="om_topic_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="group",
+                message_id="om_topic_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "om_topic_parent")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_group_reply_does_not_promote_parent_to_thread_context(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id=None,
+            parent_id="om_parent",
+            upper_message_id="om_upper",
+            message_type="text",
+            content='{"text":"reply in group"}',
+            message_id="om_group_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                chat_type="group",
+                message_id="om_group_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.chat_type, "group")
+        self.assertIsNone(event.source.thread_id)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- preserve Feishu forum/topic thread context when inbound messages omit `thread_id`
- derive thread context from `upper_message_id` first, then `parent_id`, but only for forum chats
- add regression tests to lock in forum thread inference and prove regular group replies are not misclassified as threads

## Problem
Part of #7734 reports that messages sent inside an existing Feishu topic can still trigger Hermes replies that start a new topic instead of staying inside the current one.

The adapter only propagated `message.thread_id` into `source.thread_id`. In Feishu forum chats, that field is not reliably present on every inbound message, so the downstream gateway lost the thread context and sent follow-up replies without `reply_in_thread=True`.

## Fix
- add `_resolve_inbound_thread_id()` in `gateway/platforms/feishu.py`
- keep explicit `thread_id` when Feishu provides it
- for `forum` chats only, fall back to `upper_message_id`, then `parent_id`
- leave regular `group` messages unchanged so ordinary replies do not become synthetic threads

## Scope
This PR addresses the topic-threading half of #7734. The interactive authorization-card button error discussed in that issue appears to depend on Feishu callback permissions / account capabilities and is intentionally out of scope here.

## Testing
- `python3 -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py`
- `uv run --extra dev pytest -o addopts='' tests/gateway/test_feishu.py -k 'thread_context or replies_in_thread_when_thread_metadata_present or fetches_reply_to_text'`

## Notes
- `uv run --extra dev pytest -o addopts='' tests/gateway/test_feishu.py -q` still hits one pre-existing mock-builder failure on current `main` (`test_build_event_handler_registers_reaction_and_card_processors`) unrelated to this change.

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
