### PR TITLE
fix(installer): show heartbeat for quiet npm steps

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,6 +117,26 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+run_with_heartbeat() {
+    local label="$1"
+    shift
+    local interval="${HERMES_INSTALL_HEARTBEAT_SECONDS:-15}"
+    local elapsed=0
+
+    "$@" &
+    local cmd_pid=$!
+
+    while kill -0 "$cmd_pid" 2>/dev/null; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+        if [ "$interval" -gt 0 ] && [ $((elapsed % interval)) -eq 0 ]; then
+            log_info "$label still running... (${elapsed}s elapsed)"
+        fi
+    done
+
+    wait "$cmd_pid"
+}
+
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
@@ -1075,8 +1095,9 @@ install_node_deps() {
 
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
+        log_info "This step can be quiet for a while while npm downloads browser packages."
         cd "$INSTALL_DIR"
-        npm install --silent 2>/dev/null || {
+        run_with_heartbeat "Installing Node.js dependencies (browser tools)" npm install --silent || {
             log_warn "npm install failed (browser tools may not work)"
         }
         log_success "Node.js dependencies installed"
@@ -1144,7 +1165,8 @@ install_node_deps() {
     if [ -f "$INSTALL_DIR/scripts/whatsapp-bridge/package.json" ]; then
         log_info "Installing WhatsApp bridge dependencies..."
         cd "$INSTALL_DIR/scripts/whatsapp-bridge"
-        npm install --silent 2>/dev/null || {
+        log_info "This step can also be quiet while npm resolves WhatsApp bridge packages."
+        run_with_heartbeat "Installing WhatsApp bridge dependencies" npm install --silent || {
             log_warn "WhatsApp bridge npm install failed (WhatsApp may not work)"
         }
         log_success "WhatsApp bridge dependencies installed"


### PR DESCRIPTION
## Summary

- add a tiny `run_with_heartbeat()` helper to the bash installer
- surface a clear note before quiet npm steps so users know browser/WhatsApp package setup may take a while
- emit periodic `still running` progress lines during silent npm installs so the installer no longer looks frozen

## Problem

Issue #8145 reports the Linux installer appearing to hang at:

```text
→ Installing Node.js dependencies (browser tools)...
```

In practice, the bash installer runs `npm install --silent`, which can spend a noticeable amount of time downloading browser-related packages while producing no visible output. On a fresh install this looks indistinguishable from a hang.

## Fix

Keep the install behavior the same, but make the quiet steps observable:

- `scripts/install.sh` now prints an explicit note that the step may stay quiet while npm downloads packages
- `npm install --silent` for browser tools is wrapped in a heartbeat helper that prints `still running...` every 15 seconds
- the same heartbeat is reused for the WhatsApp bridge npm install, which has the same silent-step UX problem

This is intentionally scoped as an installer UX fix, not a dependency-resolution change.

## Test plan

- `bash -n scripts/install.sh`
- manual helper smoke test:
  - `eval "$(sed -n '104,138p' scripts/install.sh)"`
  - `HERMES_INSTALL_HEARTBEAT_SECONDS=1 run_with_heartbeat 'Demo install step' bash -lc 'sleep 2'`
- local repro sanity check:
  - `npm install --silent` completes locally, but without heartbeat emits almost no intermediate output, matching the confusing UX described in #8145

Fixes #8145

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
