### PR TITLE
fix(gateway): dispatch quick command aliases before built-in handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2458,6 +2458,26 @@ class GatewayRunner:
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
                 return f"✓ Sent `{label}` to the update process."
 
+        if isinstance(self.config, dict):
+            quick_commands = self.config.get("quick_commands", {}) or {}
+        else:
+            quick_commands = getattr(self.config, "quick_commands", {}) or {}
+        if not isinstance(quick_commands, dict):
+            quick_commands = {}
+
+        # Rewrite alias quick commands before built-in command checks so they
+        # behave exactly like the target command, including busy-session
+        # bypasses such as /model or /new.
+        _initial_command = event.get_command()
+        if _initial_command and _initial_command in quick_commands:
+            _qcmd = quick_commands[_initial_command]
+            if _qcmd.get("type") == "alias":
+                target = _qcmd.get("target", "").strip()
+                if target:
+                    target = target if target.startswith("/") else f"/{target}"
+                    user_args = event.get_command_args().strip()
+                    event.text = f"{target} {user_args}".strip()
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.
@@ -2783,12 +2803,6 @@ class GatewayRunner:
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
@@ -2813,10 +2827,9 @@ class GatewayRunner:
                     target = qcmd.get("target", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
-                        target_command = target.lstrip("/")
                         user_args = event.get_command_args().strip()
                         event.text = f"{target} {user_args}".strip()
-                        command = target_command
+                        command = event.get_command()
                         # Fall through to normal command dispatch below
                     else:
                         return f"Quick command '/{command}' has no target defined."

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -4,6 +4,11 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from rich.text import Text
 import pytest
 
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from tests.gateway.restart_test_helpers import make_restart_runner
+
 
 # ── CLI tests ──────────────────────────────────────────────────────────────
 
@@ -127,6 +132,20 @@ class TestGatewayQuickCommands:
         event.source.chat_id = "123"
         return event
 
+    def _make_real_event(self, text):
+        return MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="dm",
+                user_id="test_user",
+                user_name="Test User",
+            ),
+            message_id="m1",
+        )
+
     @pytest.mark.asyncio
     async def test_exec_command_returns_output(self):
         from gateway.run import GatewayRunner
@@ -186,3 +205,41 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_alias_command_rewrites_before_builtin_dispatch(self):
+        runner, _adapter = make_restart_runner()
+        runner.config.quick_commands = {
+            "cy": {"type": "alias", "target": "model codex"}
+        }
+        runner._handle_model_command = AsyncMock(
+            side_effect=lambda event: f"model:{event.get_command_args().strip()}"
+        )
+
+        result = await runner._handle_message(self._make_real_event("/cy"))
+
+        assert result == "model:codex"
+        runner._handle_model_command.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_alias_command_matches_builtin_busy_session_behavior(self):
+        runner, _adapter = make_restart_runner()
+        runner.config.quick_commands = {
+            "cy": {"type": "alias", "target": "model codex"}
+        }
+        session_key = runner._session_key_for_source(
+            SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="123",
+                chat_type="dm",
+                user_id="test_user",
+                user_name="Test User",
+            )
+        )
+        runner._running_agents[session_key] = MagicMock()
+        runner._running_agents_ts[session_key] = 0
+
+        result = await runner._handle_message(self._make_real_event("/cy"))
+
+        assert result is not None
+        assert "wait or /stop first" in result


### PR DESCRIPTION
## Summary
This PR fixes a critical dispatch bug in the Gateway (gateway/run.py) where quick_commands of type alias would silently fail or result in "Unknown command" errors.

Fixes #8653

##  Why
The previous implementation had two major architectural "leaks":

Ordering Paradox: Alias rewriting happened after the built-in command dispatch chain. By the time /cy was rewritten to /model codex, the system had already finished checking for /model, /clear, etc.

Parsing Failure: The system treated the entire target string (e.g., model codex) as a single command name instead of splitting it into command + args.

## Changes
Early Resolution: Moved quick_commands alias resolution to the start of _handle_message(), ensuring rewritten commands are available for the entire dispatch lifecycle.

Proper Re-parsing: After a rewrite, we now call event.get_command() to correctly re-extract the command and its arguments. This ensures /model codex is handled as model with codex as an argument.

Session Guard Synergy: Aliased commands now correctly respect busy-session guards and platform-specific constraints.

Regression Suite: Added new tests in tests/cli/test_quick_commands.py to lock down this behavior.

## Verification & Tests
Verified that /cy (aliased to /model codex) successfully switches models and triggers the appropriate "Agent is busy" response when a session is active.

##  Automated Checks:
Bash
# Targeted regression tests
python -m pytest tests/cli/test_quick_commands.py -q
python -m pytest tests/gateway/test_command_bypass_active_session.py -q
Result: ✅ All tests passed.