### PR TITLE
fix: include model in auxiliary client cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1807,7 +1807,7 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # Every auxiliary LLM consumer should use these instead of manually
 # constructing clients and calling .chat.completions.create().
 
-# Client cache: (provider, async_mode, base_url, api_key) -> (client, default_model)
+# Client cache: (provider, model_key, async_mode, base_url, api_key, api_mode, loop_id, runtime_key) -> (client, default_model, loop)
 _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 
@@ -1961,7 +1961,8 @@ def _get_cached_client(
             pass
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
-    cache_key = (provider, async_mode, base_url or "", api_key or "", api_mode or "", loop_id, runtime_key)
+    model_key = str(model or "").strip()
+    cache_key = (provider, model_key, async_mode, base_url or "", api_key or "", api_mode or "", loop_id, runtime_key)
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,12 +22,14 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _try_payment_fallback,
     _resolve_auto,
+    _get_cached_client,
+    _client_cache,
 )
 
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    """Strip provider env vars so each test starts clean."""
+    """Strip provider env vars and reset the auxiliary client cache so each test starts clean."""
     for key in (
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
@@ -40,6 +42,60 @@ def _clean_env(monkeypatch):
         "CONTEXT_COMPRESSION_PROVIDER", "CONTEXT_COMPRESSION_MODEL",
     ):
         monkeypatch.delenv(key, raising=False)
+    _client_cache.clear()
+    yield
+    _client_cache.clear()
+
+
+class TestCachedClientCacheKey:
+    def test_get_cached_client_separates_cache_by_model_for_custom_openai_endpoint(self):
+        created = []
+
+        def _fake_resolve(provider, model, async_mode, **kw):
+            client = MagicMock(name=f"client-{model}")
+            client.api_key = kw.get("explicit_api_key", "sk-test")
+            client.base_url = kw.get("explicit_base_url", "https://api.openai.com/v1")
+            created.append((model, client))
+            return client, model or "default-model"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_fake_resolve):
+            client_a1, effective_a1 = _get_cached_client(
+                "custom",
+                "gpt-4o-mini",
+                async_mode=False,
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+            )
+            client_b1, effective_b1 = _get_cached_client(
+                "custom",
+                "gpt-5.3-codex",
+                async_mode=False,
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+            )
+            client_a2, effective_a2 = _get_cached_client(
+                "custom",
+                "gpt-4o-mini",
+                async_mode=False,
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+            )
+            client_b2, effective_b2 = _get_cached_client(
+                "custom",
+                "gpt-5.3-codex",
+                async_mode=False,
+                base_url="https://api.openai.com/v1",
+                api_key="sk-test",
+            )
+
+        assert client_a1 is not client_b1
+        assert client_a1 is client_a2
+        assert client_b1 is client_b2
+        assert effective_a1 == "gpt-4o-mini"
+        assert effective_a2 == "gpt-4o-mini"
+        assert effective_b1 == "gpt-5.3-codex"
+        assert effective_b2 == "gpt-5.3-codex"
+        assert len(created) == 2
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

`_get_cached_client()` reuses a cached auxiliary client whenever the `(provider, async_mode, base_url, api_key, api_mode, loop_id)` tuple matches, regardless of the requested `model`. This means two callers that share the same endpoint but request different models can silently receive the same client instance.

The impact is most visible with custom OpenAI-compatible endpoints (e.g. a self-hosted proxy or a provider serving multiple models at the same base URL), and with codex/responses-style providers where the model string controls API behavior beyond just the payload.

## Root Cause

The `model` argument was accepted by `_get_cached_client()` but was not included in the cache key tuple.

## Fix

Add `model_key = str(model or "").strip()` and insert it into the cache key:

```python
# before
cache_key = (provider, async_mode, base_url or "", api_key or "", api_mode or "", loop_id, runtime_key)

# after
model_key = str(model or "").strip()
cache_key = (provider, model_key, async_mode, base_url or "", api_key or "", api_mode or "", loop_id, runtime_key)
```

## Test

Added `TestCachedClientCacheKey::test_get_cached_client_separates_cache_by_model_for_custom_openai_endpoint` in `tests/agent/test_auxiliary_client.py`.

The test verifies:
- same provider / base_url / api_key with two different models produces two distinct client instances
- repeated calls with the same model correctly reuse the cached client
- exactly two `resolve_provider_client` calls are made (no over-creation)

```
6 passed in 0.16s
```

Focused suite: `tests/agent/test_auxiliary_client.py::TestCachedClientCacheKey` + `tests/agent/test_crossloop_client_cache.py`