### PR TITLE
feat(tts): add speed support for Edge TTS, OpenAI TTS, and MiniMax global fallback

### DIFF
--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -1,0 +1,145 @@
+"""Tests for TTS speed configuration across providers."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("OPENAI_API_KEY", "MINIMAX_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Edge TTS speed
+# ---------------------------------------------------------------------------
+
+class TestEdgeTtsSpeed:
+    def _run(self, tts_config, tmp_path):
+        mock_comm = MagicMock()
+        mock_comm.save = AsyncMock()
+        mock_edge = MagicMock()
+        mock_edge.Communicate = MagicMock(return_value=mock_comm)
+
+        with patch("tools.tts_tool._import_edge_tts", return_value=mock_edge):
+            from tools.tts_tool import _generate_edge_tts
+            asyncio.run(_generate_edge_tts("Hello", str(tmp_path / "out.mp3"), tts_config))
+        return mock_edge.Communicate
+
+    def test_default_no_rate_kwarg(self, tmp_path):
+        """No speed config => no rate kwarg passed to Communicate."""
+        comm_cls = self._run({}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert "rate" not in kwargs
+
+    def test_global_speed_applied(self, tmp_path):
+        """Global tts.speed used as fallback."""
+        comm_cls = self._run({"speed": 1.5}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert kwargs["rate"] == "+50%"
+
+    def test_provider_speed_overrides_global(self, tmp_path):
+        """tts.edge.speed takes precedence over tts.speed."""
+        comm_cls = self._run({"speed": 1.5, "edge": {"speed": 2.0}}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert kwargs["rate"] == "+100%"
+
+    def test_speed_below_one(self, tmp_path):
+        """Speed < 1.0 produces a negative rate string."""
+        comm_cls = self._run({"speed": 0.5}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert kwargs["rate"] == "-50%"
+
+    def test_speed_exactly_one_no_rate(self, tmp_path):
+        """Explicit speed=1.0 should not pass rate kwarg."""
+        comm_cls = self._run({"speed": 1.0}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert "rate" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# OpenAI TTS speed
+# ---------------------------------------------------------------------------
+
+class TestOpenaiTtsSpeed:
+    def _run(self, tts_config, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool._resolve_openai_audio_client_config",
+                   return_value=("test-key", None)):
+            from tools.tts_tool import _generate_openai_tts
+            _generate_openai_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+        return mock_client.audio.speech.create
+
+    def test_default_no_speed_kwarg(self, tmp_path, monkeypatch):
+        """No speed config => no speed kwarg in create call."""
+        create = self._run({}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert "speed" not in kwargs
+
+    def test_global_speed_applied(self, tmp_path, monkeypatch):
+        """Global tts.speed used as fallback."""
+        create = self._run({"speed": 1.5}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["speed"] == 1.5
+
+    def test_provider_speed_overrides_global(self, tmp_path, monkeypatch):
+        """tts.openai.speed takes precedence over tts.speed."""
+        create = self._run({"speed": 1.5, "openai": {"speed": 2.0}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["speed"] == 2.0
+
+    def test_speed_clamped_low(self, tmp_path, monkeypatch):
+        """Speed below 0.25 is clamped to 0.25."""
+        create = self._run({"speed": 0.1}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["speed"] == 0.25
+
+    def test_speed_clamped_high(self, tmp_path, monkeypatch):
+        """Speed above 4.0 is clamped to 4.0."""
+        create = self._run({"speed": 10.0}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["speed"] == 4.0
+
+
+# ---------------------------------------------------------------------------
+# MiniMax TTS speed (global fallback wired)
+# ---------------------------------------------------------------------------
+
+class TestMinimaxTtsSpeed:
+    def _run(self, tts_config, tmp_path, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {"audio": "deadbeef"},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+            "extra_info": {"audio_size": 8},
+        }
+
+        # requests is imported locally inside _generate_minimax_tts
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.tts_tool import _generate_minimax_tts
+            _generate_minimax_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+        return mock_post
+
+    def test_global_speed_fallback(self, tmp_path, monkeypatch):
+        """Global tts.speed used when minimax.speed not set."""
+        mock_post = self._run({"speed": 1.5}, tmp_path, monkeypatch)
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voice_setting"]["speed"] == 1.5
+
+    def test_provider_speed_overrides_global(self, tmp_path, monkeypatch):
+        """tts.minimax.speed takes precedence over tts.speed."""
+        mock_post = self._run(
+            {"speed": 1.5, "minimax": {"speed": 2.0}}, tmp_path, monkeypatch
+        )
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voice_setting"]["speed"] == 2.0

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -188,8 +188,14 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     _edge_tts = _import_edge_tts()
     edge_config = tts_config.get("edge", {})
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
+    speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
 
-    communicate = _edge_tts.Communicate(text, voice)
+    kwargs = {"voice": voice}
+    if speed != 1.0:
+        pct = round((speed - 1.0) * 100)
+        kwargs["rate"] = f"{pct:+d}%"
+
+    communicate = _edge_tts.Communicate(text, **kwargs)
     await communicate.save(output_path)
     return output_path
 
@@ -261,6 +267,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
     base_url = oai_config.get("base_url", base_url)
+    speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -271,13 +278,16 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     OpenAIClient = _import_openai_client()
     client = OpenAIClient(api_key=api_key, base_url=base_url)
     try:
-        response = client.audio.speech.create(
+        create_kwargs = dict(
             model=model,
             voice=voice,
             input=text,
             response_format=response_format,
             extra_headers={"x-idempotency-key": str(uuid.uuid4())},
         )
+        if speed != 1.0:
+            create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)
         return output_path
@@ -314,7 +324,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     mm_config = tts_config.get("minimax", {})
     model = mm_config.get("model", DEFAULT_MINIMAX_MODEL)
     voice_id = mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
-    speed = mm_config.get("speed", 1)
+    speed = mm_config.get("speed", tts_config.get("speed", 1))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
     base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)


### PR DESCRIPTION
## Summary
Salvage of PR #7378 by @0xbyt4 — cherry-picked onto current main with fixes.

Adds a `speed` config parameter for TTS providers. Users set `tts.speed: 1.5` in config.yaml for a global default, or override per-provider with `tts.edge.speed`, `tts.openai.speed`, etc.

## Changes from original PR
1. **Fixed config precedence** — provider-specific speed now correctly overrides global (original had it backwards)
2. **Wired MiniMax into global fallback** — MiniMax previously only read `tts.minimax.speed`; now falls back to `tts.speed` like Edge and OpenAI
3. **Added 12 regression tests** covering precedence, defaults, Edge SSML rate conversion, and OpenAI clamping

## Config example
```yaml
tts:
  provider: edge
  speed: 1.5           # global default
  edge:
    speed: 2.0         # overrides global for Edge only
```

## Provider details
- **Edge TTS**: converts speed float to SSML prosody rate (`+50%`, `-25%`, etc.)
- **OpenAI TTS**: passes `speed` param clamped to 0.25–4.0
- **MiniMax**: passes speed in `voice_setting` payload

## Test plan
```
tests/tools/test_tts_speed.py — 12 passed
tests/tools/test_tts_mistral.py — 17 passed (no regression)
```

Closes #7378 — credit to @0xbyt4 for the original implementation.