### PR TITLE
fix(compression): honor auxiliary context_length override

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2112,6 +2112,30 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
+def get_auxiliary_task_context_length(task: str) -> Optional[int]:
+    """Read an optional context_length override from auxiliary.{task}.context_length."""
+    if not task:
+        return None
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return None
+    aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+    task_config = aux.get(task, {}) if isinstance(aux, dict) else {}
+    if not isinstance(task_config, dict):
+        return None
+    raw = task_config.get("context_length")
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -366,6 +366,12 @@ compression:
 #   web_extract:
 #     provider: "auto"
 #     model: ""
+#
+#   # Context compression summaries
+#   compression:
+#     provider: "auto"
+#     model: ""
+#     context_length: null   # Optional override when the compression endpoint cannot report model metadata
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -470,6 +470,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "context_length": None,  # optional manual override when endpoint metadata is unavailable
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
         },
         "session_search": {

--- a/run_agent.py
+++ b/run_agent.py
@@ -1725,7 +1725,10 @@ class AIAgent:
         if not self.compression_enabled:
             return
         try:
-            from agent.auxiliary_client import get_text_auxiliary_client
+            from agent.auxiliary_client import (
+                get_auxiliary_task_context_length,
+                get_text_auxiliary_client,
+            )
             from agent.model_metadata import get_model_context_length
 
             client, aux_model = get_text_auxiliary_client(
@@ -1748,10 +1751,12 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            aux_config_context_length = get_auxiliary_task_context_length("compression")
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
+                config_context_length=aux_config_context_length,
             )
 
             threshold = self.context_compressor.threshold_tokens

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -130,6 +130,33 @@ def test_feasibility_check_passes_live_main_runtime():
     )
 
 
+@patch("agent.auxiliary_client.get_auxiliary_task_context_length", return_value=65_536)
+@patch("agent.model_metadata.get_model_context_length", return_value=65_536)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_respects_auxiliary_context_override(
+    mock_get_client,
+    mock_ctx_len,
+    mock_get_aux_context_length,
+):
+    """Compression feasibility should honor auxiliary.compression.context_length."""
+    agent = _make_agent(main_context=100_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "http://localhost:11434/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "custom/compression-model")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_get_aux_context_length.assert_called_once_with("compression")
+    mock_ctx_len.assert_called_once_with(
+        "custom/compression-model",
+        base_url="http://localhost:11434/v1",
+        api_key="sk-aux",
+        config_context_length=65_536,
+    )
+
+
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_warns_when_no_auxiliary_provider(mock_get_client):
     """Warning emitted when no auxiliary provider is configured."""


### PR DESCRIPTION
## Summary
- respect `auxiliary.compression.context_length` when checking whether the compression model can fit the configured threshold
- add a shared helper for reading per-task auxiliary context length overrides
- document the optional compression auxiliary `context_length` key in `cli-config.yaml.example` and cover the behavior with a regression test

Fixes #8499.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-8499/agent/auxiliary_client.py /Users/stephenyu/Documents/hermes-agent-wt-8499/run_agent.py /Users/stephenyu/Documents/hermes-agent-wt-8499/hermes_cli/config.py /Users/stephenyu/Documents/hermes-agent-wt-8499/tests/run_agent/test_compression_feasibility.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-8499 --extra dev pytest -o addopts= /Users/stephenyu/Documents/hermes-agent-wt-8499/tests/run_agent/test_compression_feasibility.py`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
