### PR TITLE
fix(setup): skip auto-launch without interactive stdin

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2955,6 +2955,13 @@ def _offer_launch_chat():
         print_info("Could not relaunch Hermes automatically. Run 'hermes chat' manually.")
         return
 
+    if not is_interactive_stdin():
+        print_info(
+            "Setup finished without an interactive terminal. "
+            "Run 'hermes chat' manually in a terminal window."
+        )
+        return
+
     os.execvp(chat_argv[0], chat_argv)
 
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -388,6 +388,7 @@ def test_offer_launch_chat_execs_fresh_process(monkeypatch):
 
     monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: ["/usr/local/bin/hermes", "chat"])
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: True)
 
     exec_calls = []
 
@@ -401,6 +402,23 @@ def test_offer_launch_chat_execs_fresh_process(monkeypatch):
         setup_mod._offer_launch_chat()
 
     assert exec_calls == [("/usr/local/bin/hermes", ["/usr/local/bin/hermes", "chat"])]
+
+
+def test_offer_launch_chat_skips_auto_launch_without_interactive_stdin(monkeypatch, capsys):
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: ["/usr/local/bin/hermes", "chat"])
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: False)
+
+    exec_calls = []
+    monkeypatch.setattr(setup_mod.os, "execvp", lambda path, argv: exec_calls.append((path, argv)))
+
+    setup_mod._offer_launch_chat()
+
+    captured = capsys.readouterr()
+    assert exec_calls == []
+    assert "Run 'hermes chat' manually" in captured.out
 
 
 def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- guard the post-setup `hermes chat` handoff behind an interactive-stdin check
- keep the existing `execvp` fast path for interactive terminals
- add regression coverage for the new non-interactive fallback and preserve the existing interactive launch test

Fixes #8641.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-8641/hermes_cli/setup.py /Users/stephenyu/Documents/hermes-agent-wt-8641/tests/hermes_cli/test_setup.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-8641 --extra dev pytest -o addopts= /Users/stephenyu/Documents/hermes-agent-wt-8641/tests/hermes_cli/test_setup.py -k 'offer_launch_chat'`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
