### PR TITLE
fix(gateway): avoid stuck streaming cursor on no-edit platforms

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -556,9 +556,16 @@ class GatewayStreamConsumer:
                     return False
             else:
                 # First message — send new
+                send_text = text
+                if self.cfg.cursor and send_text.endswith(self.cfg.cursor):
+                    # Keep the first streamed send cursor-free until we know the
+                    # platform returned an editable message id. Platforms that
+                    # cannot edit would otherwise leave a permanent trailing
+                    # cursor block visible to the user.
+                    send_text = send_text[:-len(self.cfg.cursor)]
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
-                    content=text,
+                    content=send_text,
                     metadata=self.metadata,
                 )
                 if result.success:
@@ -567,7 +574,7 @@ class GatewayStreamConsumer:
                     else:
                         self._edit_supported = False
                     self._already_sent = True
-                    self._last_sent_text = text
+                    self._last_sent_text = send_text
                     if not result.message_id:
                         self._fallback_prefix = self._visible_prefix()
                         self._fallback_final_send = True

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -381,7 +381,7 @@ class TestSegmentBreakOnToolBoundary:
         await task
 
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
-        assert sent_texts == ["Hello ▉", "Next segment"]
+        assert sent_texts == ["Hello", "Next segment"]
 
     @pytest.mark.asyncio
     async def test_no_message_id_enters_fallback_mode(self):
@@ -436,6 +436,7 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer.already_sent
         # Only one send call (the initial message)
         assert adapter.send.call_count == 1
+        assert adapter.send.call_args[1]["content"] == "Short response."
 
     @pytest.mark.asyncio
     async def test_no_message_id_segment_breaks_do_not_resend(self):
@@ -580,6 +581,24 @@ class TestInterimCommentaryMessages:
         await task
 
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
-        assert sent_texts == ["Hello ▉", "world"]
+        assert sent_texts == ["Hello", "world"]
         assert consumer.already_sent is True
         assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_first_stream_send_omits_cursor_until_editability_is_known(self):
+        """The initial streamed send should stay cursor-free until the platform
+        proves it returned an editable message id."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉"),
+        )
+
+        await consumer._send_or_edit("Hello ▉")
+
+        assert adapter.send.call_args[1]["content"] == "Hello"


### PR DESCRIPTION
## Summary
- strip the streaming cursor from the very first outbound chunk until the platform proves that the message can be edited later
- preserve the existing incremental edit flow for adapters that do return a stable `message_id`
- update the stream-consumer regression tests to cover no-edit and segment-break paths without leaving a stuck trailing cursor

Fixes #8326.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-8326/gateway/stream_consumer.py /Users/stephenyu/Documents/hermes-agent-wt-8326/tests/gateway/test_stream_consumer.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-8326 --extra dev pytest -o addopts='' /Users/stephenyu/Documents/hermes-agent-wt-8326/tests/gateway/test_stream_consumer.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
