### PR TITLE
fix(paths): preserve real home under sandbox HOME overrides

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -16,7 +16,7 @@ import logging
 import os
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -308,7 +308,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = get_real_home() / ".claude" / ".credentials.json"
     if cred_path.exists():
         try:
             data = json.loads(cred_path.read_text(encoding="utf-8"))
@@ -330,7 +330,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
 def read_claude_managed_key() -> Optional[str]:
     """Read Claude's native managed key from ~/.claude.json for diagnostics only."""
-    claude_json = Path.home() / ".claude.json"
+    claude_json = get_real_home() / ".claude.json"
     if claude_json.exists():
         try:
             data = json.loads(claude_json.read_text(encoding="utf-8"))
@@ -456,7 +456,7 @@ def _write_claude_code_credentials(
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = get_real_home() / ".claude" / ".credentials.json"
     try:
         # Read existing file to preserve other fields
         existing = {}

--- a/cli.py
+++ b/cli.py
@@ -70,7 +70,7 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import expand_real_user_path, get_hermes_home, display_hermes_home, get_real_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
 _hermes_home = get_hermes_home()
@@ -93,7 +93,7 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
     """
     if not file_path:
         return []
-    path = Path(file_path).expanduser()
+    path = expand_real_user_path(file_path)
     if not path.is_absolute():
         path = _hermes_home / path
     if not path.exists():
@@ -1155,7 +1155,7 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     if not token:
         return None
 
-    expanded = os.path.expandvars(os.path.expanduser(token))
+    expanded = os.path.expandvars(str(expand_real_user_path(token)))
     path = Path(expanded)
     if not path.is_absolute():
         base_dir = Path(os.getenv("TERMINAL_CWD", os.getcwd()))
@@ -3788,7 +3788,7 @@ class HermesCLI:
         home = get_hermes_home()
         display = display_hermes_home()
 
-        profiles_parent = Path.home() / ".hermes" / "profiles"
+        profiles_parent = get_real_home() / ".hermes" / "profiles"
         try:
             rel = home.relative_to(profiles_parent)
             profile_name = str(rel).split("/")[0]

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 from typing import Any, Optional
 
 _GATEWAY_KIND = "hermes-gateway"
@@ -45,7 +45,7 @@ def _get_lock_dir() -> Path:
     override = os.getenv("HERMES_GATEWAY_LOCK_DIR")
     if override:
         return Path(override)
-    state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    state_home = Path(os.getenv("XDG_STATE_HOME", get_real_home() / ".local" / "state"))
     return state_home / "hermes" / _LOCKS_DIRNAME
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -149,7 +149,8 @@ def _get_active_profile_path() -> Path:
 
 def _get_wrapper_dir() -> Path:
     """Return the directory for wrapper scripts."""
-    return Path.home() / ".local" / "bin"
+    from hermes_constants import get_real_home
+    return get_real_home() / ".local" / "bin"
 
 
 # ---------------------------------------------------------------------------
@@ -610,7 +611,8 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
 
         if _platform.system() == "Linux":
             svc_name = get_service_name()
-            svc_file = Path.home() / ".config" / "systemd" / "user" / f"{svc_name}.service"
+            from hermes_constants import get_real_home
+            svc_file = get_real_home() / ".config" / "systemd" / "user" / f"{svc_name}.service"
             if svc_file.exists():
                 subprocess.run(
                     ["systemctl", "--user", "disable", svc_name],

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -8,13 +8,40 @@ import os
 from pathlib import Path
 
 
+def get_real_home() -> Path:
+    """Return the caller's real OS home directory.
+
+    Hermes may give subprocesses a profile-local ``HOME`` under
+    ``{HERMES_HOME}/home`` for tool/config isolation. Code that needs the
+    user's actual machine home should use this helper instead of ``Path.home()``.
+
+    Child processes receive ``HERMES_REAL_HOME`` from the parent before any
+    per-profile ``HOME`` override is applied, so sandboxed Python code can
+    still resolve the original home directory.
+    """
+    override = os.getenv("HERMES_REAL_HOME", "").strip()
+    if override:
+        return Path(override)
+    return Path.home()
+
+
+def expand_real_user_path(path: str | os.PathLike[str]) -> Path:
+    """Expand ``~`` against :func:`get_real_home` instead of ``HOME``."""
+    text = os.fspath(path)
+    if text == "~":
+        return get_real_home()
+    if text.startswith(("~/", "~\\")):
+        return get_real_home() / text[2:].lstrip("/\\")
+    return Path(os.path.expanduser(text))
+
+
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: ~/.hermes).
 
     Reads HERMES_HOME env var, falls back to ~/.hermes.
     This is the single source of truth — all other copies should import this.
     """
-    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return Path(os.getenv("HERMES_HOME", get_real_home() / ".hermes"))
 
 
 def get_default_hermes_root() -> Path:
@@ -33,7 +60,7 @@ def get_default_hermes_root() -> Path:
 
     Import-safe — no dependencies beyond stdlib.
     """
-    native_home = Path.home() / ".hermes"
+    native_home = get_real_home() / ".hermes"
     env_home = os.environ.get("HERMES_HOME", "")
     if not env_home:
         return native_home
@@ -106,7 +133,7 @@ def display_hermes_home() -> str:
     """
     home = get_hermes_home()
     try:
-        return "~/" + str(home.relative_to(Path.home()))
+        return "~/" + str(home.relative_to(get_real_home()))
     except ValueError:
         return str(home)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -162,6 +162,26 @@ class TestReadClaudeCodeCredentials:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert read_claude_code_credentials() is None
 
+    def test_uses_real_home_override_when_profile_home_differs(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        cred_file = machine_home / ".claude" / ".credentials.json"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat01-token",
+                "refreshToken": "sk-ant-oat01-refresh",
+            }
+        }))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: profile_home)
+
+        creds = read_claude_code_credentials()
+        assert creds is not None
+        assert creds["accessToken"] == "sk-ant-oat01-token"
+
 
 class TestIsClaudeCodeTokenValid:
     def test_valid_token(self):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,12 +2,24 @@
 
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 from gateway import status
 
 
 class TestGatewayPidState:
+    def test_lock_dir_uses_real_home_override(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        monkeypatch.setattr(status.Path, "home", lambda: profile_home)
+
+        assert status._get_lock_dir() == machine_home / ".local" / "state" / "hermes" / "gateway-locks"
+
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -32,6 +32,7 @@ from hermes_cli.profiles import (
     generate_zsh_completion,
     _get_profiles_root,
     _get_default_hermes_home,
+    _get_wrapper_dir,
 )
 
 
@@ -106,6 +107,19 @@ class TestGetProfileDir:
         tmp_path = profile_env
         result = get_profile_dir("coder")
         assert result == tmp_path / ".hermes" / "profiles" / "coder"
+
+
+class TestWrapperDir:
+    def test_uses_real_home_override(self, profile_env, monkeypatch):
+        tmp_path = profile_env
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        monkeypatch.setattr(Path, "home", lambda: profile_home)
+
+        assert _get_wrapper_dir() == machine_home / ".local" / "bin"
 
 
 # ===================================================================

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -7,7 +7,19 @@ from unittest.mock import patch
 import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import display_hermes_home, get_default_hermes_root, get_real_home, is_container
+
+
+class TestGetRealHome:
+    def test_prefers_explicit_real_home_override(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "profile-home"
+        machine_home = tmp_path / "machine-home"
+        profile_home.mkdir()
+        machine_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: profile_home)
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+
+        assert get_real_home() == machine_home
 
 
 class TestGetDefaultHermesRoot:
@@ -18,6 +30,17 @@ class TestGetDefaultHermesRoot:
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert get_default_hermes_root() == tmp_path / ".hermes"
+
+    def test_real_home_override_beats_profile_home(self, tmp_path, monkeypatch):
+        """When HOME points at a profile sandbox, use HERMES_REAL_HOME instead."""
+        profile_home = tmp_path / "profile-home"
+        machine_home = tmp_path / "machine-home"
+        profile_home.mkdir()
+        machine_home.mkdir()
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: profile_home)
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        assert get_default_hermes_root() == machine_home / ".hermes"
 
     def test_hermes_home_is_native(self, tmp_path, monkeypatch):
         """When HERMES_HOME = ~/.hermes, returns ~/.hermes."""
@@ -61,7 +84,6 @@ class TestGetDefaultHermesRoot:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_default_hermes_root() == docker_root
-
 
 class TestIsContainer:
     """Tests for is_container() — Docker/Podman detection."""
@@ -111,3 +133,18 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestDisplayHermesHome:
+    def test_uses_real_home_for_tilde_display(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        hermes_home = machine_home / ".hermes" / "profiles" / "coder"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: profile_home)
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert display_hermes_home() == "~/.hermes/profiles/coder"

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -85,6 +85,7 @@ class TestMakeRunEnvHomeInjection:
         hermes_home.mkdir()
         (hermes_home / "home").mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", "/home/real-user")
         monkeypatch.setenv("HOME", "/root")
         monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
@@ -92,6 +93,7 @@ class TestMakeRunEnvHomeInjection:
         result = _make_run_env({})
 
         assert result["HOME"] == str(hermes_home / "home")
+        assert result["HERMES_REAL_HOME"] == "/home/real-user"
 
     def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -129,12 +131,14 @@ class TestSanitizeSubprocessEnvHomeInjection:
         hermes_home.mkdir()
         (hermes_home / "home").mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", "/home/real-user")
 
         base_env = {"HOME": "/root", "PATH": "/usr/bin", "USER": "root"}
         from tools.environments.local import _sanitize_subprocess_env
         result = _sanitize_subprocess_env(base_env)
 
         assert result["HOME"] == str(hermes_home / "home")
+        assert result["HERMES_REAL_HOME"] == "/home/real-user"
 
     def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -72,6 +72,28 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    @patch("tools.file_tools.has_binary_extension", return_value=False)
+    @patch("tools.file_tools._get_file_ops")
+    def test_tilde_uses_real_home_override(self, mock_get, _mock_binary, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        target = machine_home / "notes.txt"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        target.write_text("hello")
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "hello"
+        result_obj.to_dict.return_value = {"content": "hello", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        read_file_tool("~/notes.txt")
+        mock_ops.read_file.assert_called_once_with(str(target), 1, 500)
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")
@@ -309,6 +331,5 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
-
 
 

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -154,6 +154,18 @@ class TestHasDirectModalCredentials:
         with patch.object(Path, "home", return_value=tmp_path):
             assert has_direct_modal_credentials() is True
 
+    def test_config_file_uses_real_home_override(self, monkeypatch, tmp_path):
+        machine_home = tmp_path / "machine-home"
+        profile_home = tmp_path / "profile-home"
+        machine_home.mkdir()
+        profile_home.mkdir()
+        (machine_home / ".modal.toml").touch()
+        monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+        monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+        monkeypatch.setenv("HERMES_REAL_HOME", str(machine_home))
+        with patch.object(Path, "home", return_value=profile_home):
+            assert has_direct_modal_credentials() is True
+
     def test_env_vars_take_priority_over_file(self, monkeypatch, tmp_path):
         monkeypatch.setenv("MODAL_TOKEN_ID", "id-123")
         monkeypatch.setenv("MODAL_TOKEN_SECRET", "sec-456")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1022,7 +1022,8 @@ def execute_code(
 
         # Per-profile HOME isolation: redirect system tool configs into
         # {HERMES_HOME}/home/ when that directory exists.
-        from hermes_constants import get_subprocess_home
+        from hermes_constants import get_real_home, get_subprocess_home
+        child_env.setdefault("HERMES_REAL_HOME", str(get_real_home()))
         _profile_home = get_subprocess_home()
         if _profile_home:
             child_env["HOME"] = _profile_home

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -25,6 +25,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import expand_real_user_path
 from toolsets import TOOLSETS
 
 
@@ -139,7 +140,7 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         if not candidate:
             continue
         try:
-            text = os.path.abspath(os.path.expanduser(str(candidate)))
+            text = os.path.abspath(str(expand_real_user_path(str(candidate))))
         except Exception:
             continue
         if os.path.isabs(text) and os.path.isdir(text):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -130,7 +130,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     # Per-profile HOME isolation for background processes (same as _make_run_env).
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_real_home, get_subprocess_home
+    sanitized.setdefault("HERMES_REAL_HOME", str(get_real_home()))
     _profile_home = get_subprocess_home()
     if _profile_home:
         sanitized["HOME"] = _profile_home
@@ -205,7 +206,8 @@ def _make_run_env(env: dict) -> dict:
     # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
     # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
     # subprocess sees the override — the Python process keeps the real HOME.
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_real_home, get_subprocess_home
+    run_env.setdefault("HERMES_REAL_HOME", str(get_real_home()))
     _profile_home = get_subprocess_home()
     if _profile_home:
         run_env["HOME"] = _profile_home

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 from pathlib import Path
+from hermes_constants import expand_real_user_path
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import ShellFileOperations
 from agent.redact import redact_sensitive_text
@@ -79,7 +80,7 @@ def _is_blocked_device(filepath: str) -> bool:
     through (e.g. /dev/stdin → /proc/self/fd/0 → /dev/pts/0), defeating
     the check.
     """
-    normalized = os.path.expanduser(filepath)
+    normalized = str(expand_real_user_path(filepath))
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
@@ -99,7 +100,7 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = os.path.realpath(os.path.expanduser(filepath))
+        resolved = os.path.realpath(str(expand_real_user_path(filepath)))
     except (OSError, ValueError):
         resolved = filepath
     for prefix in _SENSITIVE_PATH_PREFIXES:
@@ -291,7 +292,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = Path(path).expanduser().resolve()
+        _expanded_path = str(expand_real_user_path(path))
+        _resolved = Path(_expanded_path).resolve()
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -356,7 +358,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(_expanded_path, offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -527,7 +529,7 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     refreshes the stored timestamp to match the file's new state.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(expand_real_user_path(filepath).resolve())
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
@@ -545,7 +547,7 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     or was never read.  Does not block — the write still proceeds.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(expand_real_user_path(filepath).resolve())
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
@@ -576,7 +578,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     try:
         stale_warning = _check_file_staleness(path, task_id)
         file_ops = _get_file_ops(task_id)
-        result = file_ops.write_file(path, content)
+        expanded_path = str(expand_real_user_path(path))
+        result = file_ops.write_file(expanded_path, content)
         result_dict = result.to_dict()
         if stale_warning:
             result_dict["_warning"] = stale_warning
@@ -623,7 +626,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 return tool_error("path required")
             if old_string is None or new_string is None:
                 return tool_error("old_string and new_string required")
-            result = file_ops.patch_replace(path, old_string, new_string, replace_all)
+            expanded_path = str(expand_real_user_path(path))
+            result = file_ops.patch_replace(expanded_path, old_string, new_string, replace_all)
         elif mode == "patch":
             if not patch:
                 return tool_error("patch content required")
@@ -690,8 +694,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             }, ensure_ascii=False)
 
         file_ops = _get_file_ops(task_id)
+        expanded_path = str(expand_real_user_path(path))
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=expanded_path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         if hasattr(result, 'matches'):

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Any, Dict
 
+from hermes_constants import get_real_home
 from utils import env_var_enabled
 
 _DEFAULT_BROWSER_PROVIDER = "local"
@@ -41,7 +41,7 @@ def has_direct_modal_credentials() -> bool:
     """Return True when direct Modal credentials/config are available."""
     return bool(
         (os.getenv("MODAL_TOKEN_ID") and os.getenv("MODAL_TOKEN_SECRET"))
-        or (Path.home() / ".modal.toml").exists()
+        or (get_real_home() / ".modal.toml").exists()
     )
 
 


### PR DESCRIPTION
## Summary
- add `get_real_home()` and `expand_real_user_path()` so Hermes can distinguish the machine home from profile-local subprocess `HOME` sandboxes
- pass `HERMES_REAL_HOME` into local/background/code-execution subprocess environments and switch the affected path-resolution call sites to use the real home helper
- update file tools to expand `~/...` before handing paths to the shell, and cover the regression with focused tests across constants, subprocess envs, Claude credentials, Modal config, gateway status, profiles, and file tools

## Root Cause
Hermes used `Path.home()` and sandbox-local `HOME` values interchangeably, which broke path resolution whenever a profile or subprocess intentionally overrode `HOME`. That caused features that should use the real machine home directory to drift into the sandbox home instead.

Fixes #8669.

## Testing
- `python3 -m py_compile hermes_constants.py tools/environments/local.py tools/code_execution_tool.py hermes_cli/profiles.py agent/anthropic_adapter.py tools/tool_backend_helpers.py gateway/status.py tools/file_tools.py tools/delegate_tool.py cli.py tests/test_hermes_constants.py tests/test_subprocess_home_isolation.py tests/agent/test_anthropic_adapter.py tests/tools/test_tool_backend_helpers.py tests/hermes_cli/test_profiles.py tests/gateway/test_status.py tests/tools/test_file_tools.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-8669 --extra dev pytest -o addopts='' tests/test_hermes_constants.py tests/test_subprocess_home_isolation.py tests/agent/test_anthropic_adapter.py tests/tools/test_tool_backend_helpers.py tests/hermes_cli/test_profiles.py tests/gateway/test_status.py tests/tools/test_file_tools.py -q` -> `321 passed`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Rebased onto the latest `main`, resolved the only test-file conflict by preserving both branches' coverage, and reran the full targeted verification commands listed above.
- I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
