### PR TITLE
fix(matrix): trust m.mentions.user_ids as authoritative mention signal

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1135,7 +1135,10 @@ class MatrixAdapter(BasePlatformAdapter):
             thread_id = relates_to.get("event_id")
 
         formatted_body = source_content.get("formatted_body")
-        is_mentioned = self._is_bot_mentioned(body, formatted_body)
+        # m.mentions.user_ids (MSC3952 / Matrix v1.7) — authoritative mention signal.
+        mentions_block = source_content.get("m.mentions") or {}
+        mention_user_ids = mentions_block.get("user_ids") if isinstance(mentions_block, dict) else None
+        is_mentioned = self._is_bot_mentioned(body, formatted_body, mention_user_ids)
 
         # Require-mention gating.
         if not is_dm:
@@ -1822,8 +1825,24 @@ class MatrixAdapter(BasePlatformAdapter):
     # Mention detection helpers
     # ------------------------------------------------------------------
 
-    def _is_bot_mentioned(self, body: str, formatted_body: Optional[str] = None) -> bool:
-        """Return True if the bot is mentioned in the message."""
+    def _is_bot_mentioned(
+        self,
+        body: str,
+        formatted_body: Optional[str] = None,
+        mention_user_ids: Optional[list] = None,
+    ) -> bool:
+        """Return True if the bot is mentioned in the message.
+
+        Per MSC3952, ``m.mentions.user_ids`` is the authoritative mention
+        signal in the Matrix spec.  When the sender's client populates that
+        field with the bot's user-id, we trust it — even when the visible
+        body text does not contain an explicit ``@bot`` string (some clients
+        only render mention "pills" in ``formatted_body`` or use display
+        names).
+        """
+        # m.mentions.user_ids — authoritative per MSC3952 / Matrix v1.7.
+        if mention_user_ids and self._user_id and self._user_id in mention_user_ids:
+            return True
         if not body and not formatted_body:
             return False
         if self._user_id and self._user_id in body:

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -48,6 +48,7 @@ def _make_event(
     room_id="!room1:example.org",
     formatted_body=None,
     thread_id=None,
+    mention_user_ids=None,
 ):
     """Create a fake room message event.
 
@@ -59,6 +60,9 @@ def _make_event(
     if formatted_body:
         content["formatted_body"] = formatted_body
         content["format"] = "org.matrix.custom.html"
+
+    if mention_user_ids is not None:
+        content["m.mentions"] = {"user_ids": mention_user_ids}
 
     relates_to = {}
     if thread_id:
@@ -107,6 +111,44 @@ class TestIsBotMentioned:
     def test_partial_localpart_no_match(self):
         # "hermesbot" should not match word-boundary check for "hermes"
         assert not self.adapter._is_bot_mentioned("hermesbot is here")
+
+    # m.mentions.user_ids — MSC3952 / Matrix v1.7 authoritative mentions
+    # Ported from openclaw/openclaw#64796
+
+    def test_m_mentions_user_ids_authoritative(self):
+        """m.mentions.user_ids alone is sufficient — no body text needed."""
+        assert self.adapter._is_bot_mentioned(
+            "please reply",  # no @hermes anywhere in body
+            mention_user_ids=["@hermes:example.org"],
+        )
+
+    def test_m_mentions_user_ids_with_body_mention(self):
+        """Both m.mentions and body mention — should still be True."""
+        assert self.adapter._is_bot_mentioned(
+            "hey @hermes:example.org help",
+            mention_user_ids=["@hermes:example.org"],
+        )
+
+    def test_m_mentions_user_ids_other_user_only(self):
+        """m.mentions with a different user — bot is NOT mentioned."""
+        assert not self.adapter._is_bot_mentioned(
+            "hello",
+            mention_user_ids=["@alice:example.org"],
+        )
+
+    def test_m_mentions_user_ids_empty_list(self):
+        """Empty user_ids list — falls through to text detection."""
+        assert not self.adapter._is_bot_mentioned(
+            "hello everyone",
+            mention_user_ids=[],
+        )
+
+    def test_m_mentions_user_ids_none(self):
+        """None mention_user_ids — falls through to text detection."""
+        assert not self.adapter._is_bot_mentioned(
+            "hello everyone",
+            mention_user_ids=None,
+        )
 
 
 class TestStripMention:
@@ -174,6 +216,44 @@ async def test_require_mention_html_pill(monkeypatch):
 
     await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_m_mentions_user_ids(monkeypatch):
+    """m.mentions.user_ids is authoritative per MSC3952 — no body mention needed.
+
+    Ported from openclaw/openclaw#64796.
+    """
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    # Body has NO mention, but m.mentions.user_ids includes the bot.
+    event = _make_event(
+        "please reply",
+        mention_user_ids=["@hermes:example.org"],
+    )
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_m_mentions_other_user_ignored(monkeypatch):
+    """m.mentions.user_ids mentioning another user should NOT activate the bot."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    event = _make_event(
+        "hey alice check this",
+        mention_user_ids=["@alice:example.org"],
+    )
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Port of [openclaw/openclaw#64796](https://github.com/openclaw/openclaw/pull/64796): Per MSC3952 / Matrix v1.7, `m.mentions.user_ids` is the **authoritative** mention signal in the Matrix spec.

### Problem

Non-Hermes Matrix clients (Element, matrix-bot-sdk bots, etc.) commonly send messages with proper `m.mentions.user_ids` metadata but **without** duplicating the `@bot` text in the message body. For example:

```json
{
  "body": "please reply",
  "m.mentions": { "user_ids": ["@hermes:matrix.org"] }
}
```

Before this change, `_is_bot_mentioned()` relied entirely on text-based detection (body string matching + HTML pill detection). These messages were **silently dropped** when `MATRIX_REQUIRE_MENTION=true` — effectively breaking mention-gating for any Matrix room receiving messages from non-Hermes clients.

### Solution

- Add `mention_user_ids` parameter to `_is_bot_mentioned()`
- If the bot's user_id appears in `m.mentions.user_ids`, that alone is sufficient to register a mention
- Extract `m.mentions.user_ids` from event content in `_resolve_message_context()` and pass it through
- Text-based fallback remains for backwards compatibility with older clients

### Architectural Differences from OpenClaw

OpenClaw's fix removed the body-text requirement from a conjunction. Our implementation adds `m.mentions.user_ids` as a **new first-check** in the detection chain, preserving the existing text-based checks unchanged as fallback.

### Tests

- 5 new unit tests for `_is_bot_mentioned()` with `mention_user_ids`
- 2 new integration tests through `_on_room_message()` verifying the full flow
- All 43 matrix mention tests pass

### Test plan

```bash
python3 -m pytest tests/gateway/test_matrix_mention.py -o 'addopts=' -q
```