### PR TITLE
fix(gateway): wait for systemd restart to become active

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1014,6 +1014,42 @@ def _get_restart_drain_timeout() -> float:
     return parse_restart_drain_timeout(raw)
 
 
+def _wait_for_systemd_active(
+    system: bool = False,
+    *,
+    timeout: float = 60.0,
+    require_transition: bool = False,
+) -> bool:
+    """Wait for the gateway systemd unit to report ``active``.
+
+    When ``require_transition`` is true, the function waits until the unit has
+    first left the active state (for example ``inactive`` / ``activating``)
+    before accepting a later ``active`` result. This prevents graceful
+    self-restarts from returning immediately while the old process is still
+    draining under the original active unit.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout
+    saw_transition = not require_transition
+
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            _systemctl_cmd(system) + ["is-active", get_service_name()],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        status = result.stdout.strip()
+        if status != "active":
+            saw_transition = True
+        elif saw_transition:
+            return True
+        time.sleep(0.5)
+
+    return False
+
+
 def systemd_install(force: bool = False, system: bool = False, run_as_user: str | None = None):
     if system:
         _require_root_for_system_service("install")
@@ -1103,7 +1139,20 @@ def systemd_restart(system: bool = False):
 
     pid = get_running_pid()
     if pid is not None and _request_gateway_self_restart(pid):
-        print(f"✓ {_service_scope_label(system).capitalize()} service restart requested")
+        drain_timeout = _get_restart_drain_timeout()
+        _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+        restart_timeout = max(35.0, drain_timeout + 5.0)
+        if _wait_for_systemd_active(
+            system=system,
+            timeout=restart_timeout,
+            require_transition=True,
+        ):
+            print(f"✓ {_service_scope_label(system).capitalize()} service restarted")
+        else:
+            print(
+                f"⚠ {_service_scope_label(system).capitalize()} service restart requested, "
+                f"but it did not become active within {restart_timeout:.0f}s"
+            )
         return
     subprocess.run(_systemctl_cmd(system) + ["reload-or-restart", get_service_name()], check=True, timeout=90)
     print(f"✓ {_service_scope_label(system).capitalize()} service restarted")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -422,9 +422,12 @@ class TestGatewayServiceDetection:
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_self_requests_graceful_restart_without_reload_or_restart(self, monkeypatch, capsys):
         calls = []
+        statuses = iter(["inactive\n", "active\n"])
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 1.0)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: calls.append(("wait_exit", timeout, force_after)) or True)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 654,
@@ -434,16 +437,50 @@ class TestGatewaySystemServiceRouting:
             "_request_gateway_self_restart",
             lambda pid: calls.append(("self", pid)) or True,
         )
+
+        def fake_run(cmd, **kwargs):
+            calls.append(("run", cmd))
+            assert cmd == ["systemctl", "--user", "is-active", gateway_cli.get_service_name()]
+            return SimpleNamespace(returncode=0, stdout=next(statuses), stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.systemd_restart()
+
+        assert calls == [
+            ("refresh", False),
+            ("self", 654),
+            ("wait_exit", 1.0, None),
+            ("run", ["systemctl", "--user", "is-active", gateway_cli.get_service_name()]),
+            ("run", ["systemctl", "--user", "is-active", gateway_cli.get_service_name()]),
+        ]
+        assert "service restarted" in capsys.readouterr().out.lower()
+
+    def test_systemd_restart_warns_when_self_restart_never_returns_active(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: calls.append(("wait_exit", timeout, force_after)) or True)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: calls.append(("self", pid)) or True)
+        monkeypatch.setattr(gateway_cli, "_wait_for_systemd_active", lambda **kwargs: calls.append(("wait_active", kwargs)) or False)
         monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("systemctl should not run")),
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("systemctl reload-or-restart should not run")),
         )
 
         gateway_cli.systemd_restart()
 
-        assert calls == [("refresh", False), ("self", 654)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        assert calls == [
+            ("refresh", False),
+            ("self", 654),
+            ("wait_exit", 0.0, None),
+            ("wait_active", {"system": False, "timeout": 35.0, "require_transition": True}),
+        ]
+        assert "did not become active" in capsys.readouterr().out.lower()
 
     def test_gateway_install_passes_system_flags(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)


### PR DESCRIPTION
## Summary
- keep `systemd_restart()` from returning immediately after a graceful self-restart request by waiting for the old gateway process to exit
- poll `systemctl is-active` until the unit transitions away from the old active state and comes back active again, then report a completed restart instead of a fire-and-forget request
- cover both the success and timeout paths in `test_gateway_service.py` without falling back to `reload-or-restart`

Fixes #8260.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-8260/hermes_cli/gateway.py /Users/stephenyu/Documents/hermes-agent-wt-8260/tests/hermes_cli/test_gateway_service.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-8260 --extra dev pytest -o addopts='' /Users/stephenyu/Documents/hermes-agent-wt-8260/tests/hermes_cli/test_gateway_service.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
