### PR TITLE
fix(model): forward context_length overrides to runtime metadata lookups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3061,9 +3061,14 @@ class GatewayRunner:
                 from agent.model_metadata import get_model_context_length
 
                 _msg_cwd = os.environ.get("MESSAGING_CWD", os.path.expanduser("~"))
+                _msg_config_context_length = self._resolve_config_context_length_for_model(
+                    self._model,
+                    base_url=self._base_url or "",
+                )
                 _msg_ctx_len = get_model_context_length(
                     self._model,
                     base_url=self._base_url or "",
+                    config_context_length=_msg_config_context_length,
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,
@@ -3845,20 +3850,17 @@ class GatewayRunner:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
     
-    def _format_session_info(self) -> str:
-        """Resolve current model config and return a formatted info block.
-
-        Surfaces model, provider, context length, and endpoint so gateway
-        users can immediately see if context detection went wrong (e.g.
-        local models falling to the 128K default).
-        """
-        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
-
-        model = _resolve_gateway_model()
-        config_context_length = None
-        provider = None
-        base_url = None
-        api_key = None
+    def _resolve_config_context_length_for_model(
+        self,
+        model: str,
+        *,
+        base_url: str = "",
+        provider: str = "",
+    ) -> int | None:
+        """Return the configured context-length override for a specific runtime."""
+        normalized_model = model or ""
+        normalized_base_url = (base_url or "").rstrip("/")
+        normalized_provider = (provider or "").strip().lower()
 
         try:
             cfg_path = _hermes_home / "config.yaml"
@@ -3869,11 +3871,69 @@ class GatewayRunner:
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
                     raw_ctx = model_cfg.get("context_length")
+                    configured_model = model_cfg.get("default") or ""
+                    configured_provider = (model_cfg.get("provider") or "").strip().lower()
+                    configured_base_url = (model_cfg.get("base_url") or "").rstrip("/")
                     if raw_ctx is not None:
                         try:
                             config_context_length = int(raw_ctx)
                         except (TypeError, ValueError):
-                            pass
+                            config_context_length = None
+                        else:
+                            model_matches = not configured_model or normalized_model == configured_model
+                            base_matches = not configured_base_url or not normalized_base_url or normalized_base_url == configured_base_url
+                            provider_matches = not configured_provider or not normalized_provider or normalized_provider == configured_provider
+                            if model_matches and base_matches and provider_matches:
+                                return config_context_length
+
+                custom_providers = data.get("custom_providers")
+                if isinstance(custom_providers, list) and normalized_base_url:
+                    for cp in custom_providers:
+                        if not isinstance(cp, dict):
+                            continue
+                        cp_url = (cp.get("base_url") or "").rstrip("/")
+                        if not cp_url or cp_url != normalized_base_url:
+                            continue
+                        cp_models = cp.get("models", {})
+                        if not isinstance(cp_models, dict):
+                            continue
+                        cp_model_cfg = cp_models.get(normalized_model, {})
+                        if not isinstance(cp_model_cfg, dict):
+                            continue
+                        cp_ctx = cp_model_cfg.get("context_length")
+                        if cp_ctx is None:
+                            return None
+                        try:
+                            return int(cp_ctx)
+                        except (TypeError, ValueError):
+                            return None
+        except Exception:
+            pass
+        return None
+
+    def _format_session_info(self) -> str:
+        """Resolve current model config and return a formatted info block.
+
+        Surfaces model, provider, context length, and endpoint so gateway
+        users can immediately see if context detection went wrong (e.g.
+        local models falling to the 128K default).
+        """
+        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+
+        model = _resolve_gateway_model()
+        provider = None
+        base_url = None
+        api_key = None
+        config_context_length = None
+
+        try:
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                import yaml as _info_yaml
+                with open(cfg_path, encoding="utf-8") as f:
+                    data = _info_yaml.safe_load(f) or {}
+                model_cfg = data.get("model", {})
+                if isinstance(model_cfg, dict):
                     provider = model_cfg.get("provider") or None
                     base_url = model_cfg.get("base_url") or None
         except Exception:
@@ -3887,6 +3947,12 @@ class GatewayRunner:
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        config_context_length = self._resolve_config_context_length_for_model(
+            model,
+            base_url=base_url or "",
+            provider=provider or "",
+        )
 
         context_length = get_model_context_length(
             model,
@@ -4520,11 +4586,17 @@ class GatewayRunner:
         else:
             try:
                 from agent.model_metadata import get_model_context_length
+                ctx_override = self._resolve_config_context_length_for_model(
+                    result.new_model,
+                    base_url=result.base_url or current_base_url,
+                    provider=result.target_provider,
+                )
                 ctx = get_model_context_length(
                     result.new_model,
                     base_url=result.base_url or current_base_url,
                     api_key=result.api_key or current_api_key,
                     provider=result.target_provider,
+                    config_context_length=ctx_override,
                 )
                 lines.append(f"Context: {ctx:,} tokens")
             except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1228,29 +1228,40 @@ class AIAgent:
             except (TypeError, ValueError):
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
+        # Store the configured default runtime so later context-length lookups
+        # can apply the override only to the matching model/path.
+        self._default_model = self.model
+        self._default_provider = self.provider
+        self._default_base_url = (self.base_url or "").rstrip("/")
         self._config_context_length = _config_context_length
+        self._custom_provider_context_lengths = {}
 
-        # Check custom_providers per-model context_length
-        if _config_context_length is None:
-            _custom_providers = _agent_cfg.get("custom_providers")
-            if isinstance(_custom_providers, list):
-                for _cp_entry in _custom_providers:
-                    if not isinstance(_cp_entry, dict):
+        # Index custom_providers per-model context_length overrides.
+        _custom_providers = _agent_cfg.get("custom_providers")
+        if isinstance(_custom_providers, list):
+            for _cp_entry in _custom_providers:
+                if not isinstance(_cp_entry, dict):
+                    continue
+                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+                if not _cp_url:
+                    continue
+                _cp_models = _cp_entry.get("models", {})
+                if not isinstance(_cp_models, dict):
+                    continue
+                for _cp_model_name, _cp_model_cfg in _cp_models.items():
+                    if not isinstance(_cp_model_cfg, dict):
                         continue
-                    _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                    if _cp_url and _cp_url == self.base_url.rstrip("/"):
-                        _cp_models = _cp_entry.get("models", {})
-                        if isinstance(_cp_models, dict):
-                            _cp_model_cfg = _cp_models.get(self.model, {})
-                            if isinstance(_cp_model_cfg, dict):
-                                _cp_ctx = _cp_model_cfg.get("context_length")
-                                if _cp_ctx is not None:
-                                    try:
-                                        _config_context_length = int(_cp_ctx)
-                                    except (TypeError, ValueError):
-                                        pass
-                        break
+                    _cp_ctx = _cp_model_cfg.get("context_length")
+                    if _cp_ctx is None:
+                        continue
+                    try:
+                        self._custom_provider_context_lengths[(_cp_url, _cp_model_name)] = int(_cp_ctx)
+                    except (TypeError, ValueError):
+                        continue
+        if _config_context_length is None:
+            _config_context_length = self._custom_provider_context_lengths.get(
+                (self.base_url.rstrip("/"), self.model)
+            )
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -1474,6 +1485,35 @@ class AIAgent:
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
+
+    def _resolve_config_context_length_for_model(
+        self,
+        model: str,
+        *,
+        base_url: str = "",
+        provider: str = "",
+    ) -> int | None:
+        """Return the configured context-length override for a specific runtime."""
+        normalized_model = model or ""
+        normalized_base_url = (base_url or "").rstrip("/")
+        normalized_provider = (provider or "").strip().lower()
+
+        default_model = getattr(self, "_default_model", None)
+        default_base_url = getattr(self, "_default_base_url", "") or ""
+        default_provider = (getattr(self, "_default_provider", "") or "").strip().lower()
+        default_override = getattr(self, "_config_context_length", None)
+
+        if default_override is not None:
+            model_matches = not default_model or normalized_model == default_model
+            base_matches = not default_base_url or not normalized_base_url or normalized_base_url == default_base_url
+            provider_matches = not default_provider or not normalized_provider or normalized_provider == default_provider
+            if model_matches and base_matches and provider_matches:
+                return default_override
+
+        custom_overrides = getattr(self, "_custom_provider_context_lengths", None) or {}
+        if normalized_base_url:
+            return custom_overrides.get((normalized_base_url, normalized_model))
+        return None
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -1551,12 +1591,17 @@ class AIAgent:
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
+            config_context_length = self._resolve_config_context_length_for_model(
+                self.model,
+                base_url=self.base_url,
+                provider=self.provider,
+            )
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=config_context_length,
             )
             self.context_compressor.update_model(
                 model=self.model,
@@ -1748,10 +1793,18 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            aux_provider = self.provider if aux_base_url.rstrip("/") == (self.base_url or "").rstrip("/") else ""
+            aux_config_context_length = self._resolve_config_context_length_for_model(
+                aux_model,
+                base_url=aux_base_url,
+                provider=aux_provider,
+            )
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
+                config_context_length=aux_config_context_length,
+                provider=aux_provider,
             )
 
             threshold = self.context_compressor.threshold_tokens
@@ -5516,9 +5569,15 @@ class AIAgent:
             # causing oversized sessions to overflow the fallback.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
+                fb_config_context_length = self._resolve_config_context_length_for_model(
+                    self.model,
+                    base_url=self.base_url,
+                    provider=self.provider,
+                )
                 fb_context_length = get_model_context_length(
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
+                    config_context_length=fb_config_context_length,
                 )
                 self.context_compressor.update_model(
                     model=self.model,

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -27,6 +27,58 @@ def _patch_info(tmp_path, config_yaml, model, runtime):
 
 class TestFormatSessionInfo:
 
+    def test_resolve_config_context_length_matches_default_runtime(self, runner, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "model:\n"
+            "  default: glm-5\n"
+            "  provider: custom\n"
+            "  base_url: http://custom-endpoint.test/v1\n"
+            "  context_length: 200000\n"
+        )
+        with patch("gateway.run._hermes_home", tmp_path):
+            resolved = runner._resolve_config_context_length_for_model(
+                "glm-5",
+                base_url="http://custom-endpoint.test/v1",
+                provider="custom",
+            )
+        assert resolved == 200000
+
+    def test_resolve_config_context_length_ignores_default_override_for_other_model(self, runner, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "model:\n"
+            "  default: glm-5\n"
+            "  provider: custom\n"
+            "  base_url: http://custom-endpoint.test/v1\n"
+            "  context_length: 200000\n"
+        )
+        with patch("gateway.run._hermes_home", tmp_path):
+            resolved = runner._resolve_config_context_length_for_model(
+                "other-model",
+                base_url="http://custom-endpoint.test/v1",
+                provider="custom",
+            )
+        assert resolved is None
+
+    def test_resolve_config_context_length_uses_custom_provider_model_entry(self, runner, tmp_path):
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "custom_providers:\n"
+            "  - name: local-glm\n"
+            "    base_url: http://custom-endpoint.test/v1\n"
+            "    models:\n"
+            "      glm-5:\n"
+            "        context_length: 200000\n"
+        )
+        with patch("gateway.run._hermes_home", tmp_path):
+            resolved = runner._resolve_config_context_length_for_model(
+                "glm-5",
+                base_url="http://custom-endpoint.test/v1",
+                provider="custom",
+            )
+        assert resolved == 200000
+
     def test_includes_model_name(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: anthropic/claude-opus-4.6\n  provider: openrouter\n",
                                   "anthropic/claude-opus-4.6",

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -43,6 +43,11 @@ def _make_agent(
     compressor.context_length = main_context
     compressor.threshold_tokens = int(main_context * threshold_percent)
     agent.context_compressor = compressor
+    agent._config_context_length = None
+    agent._default_model = agent.model
+    agent._default_provider = agent.provider
+    agent._default_base_url = agent.base_url
+    agent._custom_provider_context_lengths = {}
 
     return agent
 
@@ -128,6 +133,34 @@ def test_feasibility_check_passes_live_main_runtime():
             "api_mode": "codex_responses",
         },
     )
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_matching_context_override_to_aux_lookup(mock_get_client, mock_ctx_len):
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    agent.model = "glm-5"
+    agent.provider = "custom"
+    agent.base_url = "http://custom-endpoint.test/v1"
+    agent.api_key = ""
+    agent._default_model = "glm-5"
+    agent._default_provider = "custom"
+    agent._default_base_url = "http://custom-endpoint.test/v1"
+    agent._config_context_length = 200_000
+
+    mock_client = MagicMock()
+    mock_client.base_url = "http://custom-endpoint.test/v1"
+    mock_client.api_key = ""
+    mock_get_client.return_value = (mock_client, "glm-5")
+
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs["config_context_length"] == 200_000
+    assert call_kwargs["provider"] == "custom"
 
 
 @patch("agent.auxiliary_client.get_text_auxiliary_client")

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -21,6 +21,10 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
 
     # Store config_context_length for later use in switch_model
     agent._config_context_length = config_context_length
+    agent._default_model = "primary-model"
+    agent._default_provider = "openrouter"
+    agent._default_base_url = "https://openrouter.ai/api/v1"
+    agent._custom_provider_context_lengths = {}
 
     # Context compressor with primary model values
     compressor = ContextCompressor(
@@ -41,8 +45,8 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)
-def test_switch_model_preserves_config_context_length(mock_ctx_len):
-    """When switching models, config_context_length should be passed to get_model_context_length."""
+def test_switch_model_clears_default_context_override_for_different_model(mock_ctx_len):
+    """Top-level model.context_length should not bleed onto other models."""
     agent = _make_agent_with_compressor(config_context_length=32_768)
 
     assert agent.context_compressor.model == "primary-model"
@@ -51,10 +55,10 @@ def test_switch_model_preserves_config_context_length(mock_ctx_len):
     # Switch model
     agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 
-    # Verify get_model_context_length was called with config_context_length
+    # Verify get_model_context_length was called without the default-model override
     mock_ctx_len.assert_called_once()
     call_kwargs = mock_ctx_len.call_args.kwargs
-    assert call_kwargs.get("config_context_length") == 32_768
+    assert call_kwargs.get("config_context_length") is None
 
     # Verify compressor was updated
     assert agent.context_compressor.model == "new-model"
@@ -72,3 +76,30 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_resolve_config_context_length_matches_default_runtime():
+    agent = _make_agent_with_compressor(config_context_length=32_768)
+
+    resolved = agent._resolve_config_context_length_for_model(
+        "primary-model",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+    )
+
+    assert resolved == 32_768
+
+
+def test_resolve_config_context_length_prefers_custom_provider_entry():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._custom_provider_context_lengths = {
+        ("http://custom-endpoint.test/v1", "glm-5"): 200_000,
+    }
+
+    resolved = agent._resolve_config_context_length_for_model(
+        "glm-5",
+        base_url="http://custom-endpoint.test/v1",
+        provider="custom",
+    )
+
+    assert resolved == 200_000


### PR DESCRIPTION
## What does this PR do?

Fixes a real custom-provider bug where explicit `context_length` overrides were being dropped in some runtime metadata lookups.

`get_model_context_length()` already supports `config_context_length`, but several callers in `run_agent.py` and `gateway/run.py` were still calling it without forwarding the configured override. That meant users could have a valid config like:

```yaml
model:
  default: glm-5
  provider: custom
  base_url: http://host/v1
  context_length: 200000
```

and Hermes would still log the fallback `defaulting to 128,000` warning.

This patch fixes that by resolving the correct configured override for the active runtime before metadata lookups happen. It also avoids reintroducing the model-switch bug where a top-level default-model override could bleed into other switched/fallback models.

## Related Issue

Related to:
- #8499
- #8511
- #8590
- #8625

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added runtime-specific context-length override resolution in `run_agent.py`
- Indexed custom-provider per-model `context_length` overrides for exact `(base_url, model)` matching
- Threaded the resolved override into model-switch, compression-feasibility, and fallback compressor update paths
- Added matching resolution logic in `gateway/run.py`
- Threaded the resolved override into gateway metadata lookups used for context preprocessing, `/model` session info, and session-info display
- Added regression tests covering:
  - default-model override application only to the matching runtime
  - custom-provider per-model override resolution
  - compression feasibility passing the right override into auxiliary context lookup
  - gateway session-info resolution behavior

## How to Test

1. Reproduce the reported custom-provider case with a config like:
   ```yaml
   model:
     default: glm-5
     provider: custom
     base_url: http://your-custom-endpoint/v1
     context_length: 200000
   ```
   and verify Hermes no longer drops to the generic `128,000` fallback in the affected metadata paths.
2. Run the focused regression coverage:
   ```bash
   venv/bin/python -m pytest tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py tests/gateway/test_session_info.py -q -n0
   ```
3. Run the full suite serially:
   ```bash
   venv/bin/python -m pytest tests/ -v -n0
   ```
   Current `main` still has unrelated failures outside this change; this PR leaves the full-suite checkbox unchecked accordingly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression run:

```text
venv/bin/python -m pytest tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py tests/gateway/test_session_info.py -q -n0
29 passed in 2.35s
```

Full serial suite run:

```text
venv/bin/python -m pytest tests/ -v -n0
94 failed, 10918 passed, 33 skipped, 50 deselected in 842.60s
```

The full-suite failures are broad existing repo failures outside the paths touched by this PR.
