### PR TITLE
fix(routing): add CJK keyword matching and preserve cheap_model api_mode

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -45,6 +45,37 @@ _COMPLEX_KEYWORDS = {
     "kubernetes",
 }
 
+# CJK Unicode character ranges (Chinese, Japanese kanji, Korean hangul).
+_CJK_CHAR_RE = re.compile(
+    r"[\u4e00-\u9fff"    # CJK Unified Ideographs
+    r"\u3400-\u4dbf"     # CJK Extension A
+    r"\uf900-\ufaff"     # CJK Compatibility Ideographs
+    r"\u3040-\u309f"     # Hiragana
+    r"\u30a0-\u30ff"     # Katakana
+    r"\uac00-\ud7af]"    # Hangul Syllables
+)
+
+# CJK task/action keywords that indicate the user needs the strong model.
+# These are matched as substrings in the original text — CJK languages
+# don't use spaces between words, so split()-based matching fails (#8516).
+_CJK_COMPLEX_KEYWORDS = {
+    # Task/action verbs (Chinese)
+    "帮忙", "帮我", "研究", "分析", "调查", "排查", "检查", "诊断",
+    "实现", "开发", "修复", "修改", "优化", "重构", "设计",
+    # Memory/knowledge
+    "记住", "记得", "记忆", "记录",
+    # Search/lookup
+    "查询", "搜索", "搜一下", "查一下",
+    # Tool-invoking
+    "设置", "配置", "安装", "部署", "定时", "提醒",
+    # Technical
+    "终端", "命令", "脚本", "代码", "接口",
+    # Japanese task keywords
+    "調べて", "分析して", "実装", "デバッグ", "検索",
+    # Korean task keywords
+    "분석", "검색", "구현", "디버그", "설치",
+}
+
 _URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
 
 
@@ -99,6 +130,14 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
     if words & _COMPLEX_KEYWORDS:
         return None
+
+    # CJK languages don't use spaces between words, so split() produces a
+    # single token for the entire message.  Use substring matching against
+    # known CJK task/action keywords instead (#8516).
+    if _CJK_CHAR_RE.search(text):
+        for kw in _CJK_COMPLEX_KEYWORDS:
+            if kw in text:
+                return None
 
     route = dict(cheap_model)
     route["provider"] = provider
@@ -172,24 +211,32 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             ),
         }
 
+    # Prefer cheap_model config values for api_mode, command, and args
+    # over the runtime-resolved values.  resolve_runtime_provider reads
+    # api_mode from the PRIMARY model config, not the cheap_model config,
+    # so it can return the wrong value for the routed model (#8515).
+    effective_api_mode = route.get("api_mode") or runtime.get("api_mode")
+    effective_command = route.get("command") or runtime.get("command")
+    effective_args = list(route.get("args") or runtime.get("args") or [])
+
     return {
         "model": route.get("model"),
         "runtime": {
             "api_key": runtime.get("api_key"),
             "base_url": runtime.get("base_url"),
             "provider": runtime.get("provider"),
-            "api_mode": runtime.get("api_mode"),
-            "command": runtime.get("command"),
-            "args": list(runtime.get("args") or []),
+            "api_mode": effective_api_mode,
+            "command": effective_command,
+            "args": effective_args,
             "credential_pool": runtime.get("credential_pool"),
         },
-        "label": f"smart route → {route.get('model')} ({runtime.get('provider')})",
+        "label": f"smart route \u2192 {route.get('model')} ({runtime.get('provider')})",
         "signature": (
             route.get("model"),
             runtime.get("provider"),
             runtime.get("base_url"),
-            runtime.get("api_mode"),
-            runtime.get("command"),
-            tuple(runtime.get("args") or ()),
+            effective_api_mode,
+            effective_command,
+            tuple(effective_args),
         ),
     }

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -59,3 +59,173 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+# -- CJK keyword matching tests (#8516) ---------------------------------------
+
+
+def test_chinese_simple_greeting_routes_to_cheap():
+    """Simple Chinese greetings without task keywords should use cheap model."""
+    result = choose_cheap_model_route("你好", _BASE_CONFIG)
+    assert result is not None, "Simple greeting '你好' should route to cheap model"
+    assert result["routing_reason"] == "simple_turn"
+
+
+def test_chinese_goodnight_routes_to_cheap():
+    """Simple Chinese well-wishes should use cheap model."""
+    result = choose_cheap_model_route("晚安", _BASE_CONFIG)
+    assert result is not None, "Simple '晚安' should route to cheap model"
+
+
+def test_chinese_task_keyword_routes_to_primary():
+    """Chinese messages with task keywords should route to primary model."""
+    assert choose_cheap_model_route("帮我查一下附近的奶茶店", _BASE_CONFIG) is None
+
+
+def test_chinese_memory_keyword_routes_to_primary():
+    """Chinese messages asking to remember should route to primary model."""
+    assert choose_cheap_model_route("记住我喜欢喝红茶玛奇朵", _BASE_CONFIG) is None
+
+
+def test_chinese_search_keyword_routes_to_primary():
+    """Chinese search requests should route to primary model."""
+    assert choose_cheap_model_route("搜索最新的AI论文", _BASE_CONFIG) is None
+
+
+def test_chinese_setup_keyword_routes_to_primary():
+    """Chinese setup/config requests should route to primary model."""
+    assert choose_cheap_model_route("帮我设置一个提醒", _BASE_CONFIG) is None
+
+
+def test_chinese_code_keyword_routes_to_primary():
+    """Chinese technical requests should route to primary model."""
+    assert choose_cheap_model_route("帮我修改这段代码", _BASE_CONFIG) is None
+
+
+def test_japanese_simple_routes_to_cheap():
+    """Simple Japanese greetings should route to cheap model."""
+    result = choose_cheap_model_route("こんにちは", _BASE_CONFIG)
+    assert result is not None, "Simple Japanese greeting should route to cheap"
+
+
+def test_japanese_task_keyword_routes_to_primary():
+    """Japanese task requests should route to primary model."""
+    assert choose_cheap_model_route("このバグをデバッグして", _BASE_CONFIG) is None
+
+
+def test_korean_simple_routes_to_cheap():
+    """Simple Korean greetings should route to cheap model."""
+    result = choose_cheap_model_route("안녕하세요", _BASE_CONFIG)
+    assert result is not None, "Simple Korean greeting should route to cheap"
+
+
+def test_korean_task_keyword_routes_to_primary():
+    """Korean task requests should route to primary model."""
+    assert choose_cheap_model_route("이 패키지를 설치해주세요", _BASE_CONFIG) is None
+
+
+def test_english_routing_unchanged_by_cjk_addition():
+    """English routing should not be affected by CJK keyword additions."""
+    # Simple English still routes to cheap
+    result = choose_cheap_model_route("hello there", _BASE_CONFIG)
+    assert result is not None
+
+    # Complex English still routes to primary
+    assert choose_cheap_model_route("debug this error", _BASE_CONFIG) is None
+
+
+def test_mixed_cjk_english_with_task_keyword():
+    """Mixed CJK+English messages with CJK task keywords route to primary."""
+    assert choose_cheap_model_route("帮我 debug this", _BASE_CONFIG) is None
+
+
+# -- api_mode propagation tests (#8515) ----------------------------------------
+
+
+def test_resolve_turn_route_preserves_cheap_model_api_mode(monkeypatch):
+    """cheap_model api_mode should take precedence over runtime-resolved value."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-cheap",
+            "base_url": "http://localhost:8000",
+            "provider": "custom",
+            "api_mode": "chat_completions",  # runtime returns wrong api_mode
+        },
+    )
+
+    cfg = {
+        "enabled": True,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://localhost:8000",
+            "api_mode": "anthropic_messages",  # user explicitly configured this
+        },
+    }
+    result = resolve_turn_route(
+        "hello",
+        cfg,
+        {"model": "claude-sonnet-4", "provider": "openrouter"},
+    )
+    assert result["model"] == "local-model"
+    assert result["runtime"]["api_mode"] == "anthropic_messages"
+    assert result["signature"][3] == "anthropic_messages"
+
+
+def test_resolve_turn_route_falls_back_to_runtime_api_mode(monkeypatch):
+    """When cheap_model has no api_mode, use the runtime-resolved value."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-or",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    result = resolve_turn_route(
+        "hello",
+        _BASE_CONFIG,
+        {"model": "claude-sonnet-4", "provider": "openrouter"},
+    )
+    assert result["runtime"]["api_mode"] == "chat_completions"
+
+
+def test_resolve_turn_route_preserves_cheap_model_command_and_args(monkeypatch):
+    """cheap_model command and args should take precedence over runtime."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": None,
+            "base_url": None,
+            "provider": "custom",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+
+    cfg = {
+        "enabled": True,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "local-model",
+            "command": "/usr/local/bin/llama-server",
+            "args": ["--model", "qwen-9b"],
+        },
+    }
+    result = resolve_turn_route(
+        "hi",
+        cfg,
+        {"model": "claude-sonnet-4", "provider": "openrouter"},
+    )
+    assert result["runtime"]["command"] == "/usr/local/bin/llama-server"
+    assert result["runtime"]["args"] == ["--model", "qwen-9b"]


### PR DESCRIPTION
## Summary

Two related bugs in `agent/smart_model_routing.py` that affect users of smart model routing with CJK languages or custom providers:

1. **CJK messages always routed to cheap model (#8516):** `text.split()` produces a single token for Chinese/Japanese/Korean text since these languages have no word-separating spaces. The existing `_COMPLEX_KEYWORDS` set intersection never matches, so all CJK messages are classified as "simple" regardless of content.

2. **`cheap_model` api_mode silently dropped (#8515):** `resolve_runtime_provider` reads `api_mode` from the primary model config, not the `cheap_model` config. When the cheap model uses a different API format (e.g., `anthropic_messages` for a local inference server), the request silently uses the wrong format and fails.

## Changes

### CJK keyword matching (`choose_cheap_model_route`)

- Add `_CJK_CHAR_RE` regex to detect CJK characters (Chinese, Japanese kanji/kana, Korean hangul)
- Add `_CJK_COMPLEX_KEYWORDS` set with task/action keywords across Chinese, Japanese, and Korean
- When CJK characters are detected, scan for keyword substrings instead of relying on whitespace-split word matching
- Simple greetings (你好, こんにちは, 안녕하세요) still route to the cheap model
- Task requests (帮我查一下, デバッグして, 설치해주세요) correctly route to the primary model

### api_mode propagation (`resolve_turn_route`)

- Prefer `route.get("api_mode")` (from `cheap_model` config) over `runtime.get("api_mode")` (from primary model config)
- Same treatment for `command` and `args` fields
- Falls back to runtime-resolved values when `cheap_model` config doesn't specify them

## Routing results (after fix)

| Message | Expected | Before | After |
|---------|----------|--------|-------|
| 你好 (hello) | cheap | cheap | cheap |
| 晚安 (good night) | cheap | cheap | cheap |
| 帮我查一下附近的奶茶店 (help find nearby shops) | **primary** | cheap | **primary** |
| 记住我喜欢喝红茶 (remember I like tea) | **primary** | cheap | **primary** |
| このバグをデバッグして (debug this bug) | **primary** | cheap | **primary** |
| 이 패키지를 설치해주세요 (install this package) | **primary** | cheap | **primary** |
| hello there | cheap | cheap | cheap |
| debug this error | primary | primary | primary |

## How to test

```bash
pytest tests/agent/test_smart_model_routing.py -v
```

16 new tests covering:
- Chinese simple greetings -> cheap model (2 tests)
- Chinese task/memory/search/setup/code keywords -> primary model (5 tests)
- Japanese simple -> cheap, task -> primary (2 tests)
- Korean simple -> cheap, task -> primary (2 tests)
- English routing unchanged (1 test)
- Mixed CJK+English (1 test)
- api_mode preserved from cheap_model config (1 test)
- api_mode falls back to runtime when not configured (1 test)
- command and args preserved from cheap_model config (1 test)

## Design decisions

- **No new dependencies:** Uses stdlib `re` with Unicode character ranges instead of adding jieba or other segmentation libraries. Substring matching against curated keywords is sufficient for the "conservative by design" routing philosophy.
- **Substring matching, not character-class density:** Unlike approaches that route ALL CJK to primary, this preserves cheap-model routing for simple CJK greetings. Smart routing should save costs for CJK users too.
- **Route config takes precedence:** For `api_mode`/`command`/`args`, the explicit `cheap_model` config is the user's intent. The runtime-resolved values are a fallback, not the authority.

## Related Issues

Fixes #8516
Fixes #8515

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — no config keys added, no new dependencies