### PR TITLE
fix(weixin,api_server): proxy support, content normalization, HermesClaw docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ python -m pytest tests/ -q
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 💡 [Discussions](https://github.com/NousResearch/hermes-agent/discussions)
+- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
 
 ---
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -54,6 +54,66 @@ DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
+MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
+MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+
+
+def _normalize_chat_content(
+    content: Any, *, _max_depth: int = 10, _depth: int = 0,
+) -> str:
+    """Normalize OpenAI chat message content into a plain text string.
+
+    Some clients (Open WebUI, LobeChat, etc.) send content as an array of
+    typed parts instead of a plain string::
+
+        [{"type": "text", "text": "hello"}, {"type": "input_text", "text": "..."}]
+
+    This function flattens those into a single string so the agent pipeline
+    (which expects strings) doesn't choke.
+
+    Defensive limits prevent abuse: recursion depth, list size, and output
+    length are all bounded.
+    """
+    if _depth > _max_depth:
+        return ""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+
+    if isinstance(content, list):
+        parts: List[str] = []
+        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+        for item in items:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item[:MAX_NORMALIZED_TEXT_LENGTH])
+            elif isinstance(item, dict):
+                item_type = str(item.get("type") or "").strip().lower()
+                if item_type in {"text", "input_text", "output_text"}:
+                    text = item.get("text", "")
+                    if text:
+                        try:
+                            parts.append(str(text)[:MAX_NORMALIZED_TEXT_LENGTH])
+                        except Exception:
+                            pass
+                # Silently skip image_url / other non-text parts
+            elif isinstance(item, list):
+                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
+                if nested:
+                    parts.append(nested)
+            # Check accumulated size
+            if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
+                break
+        result = "\n".join(parts)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+
+    # Fallback for unexpected types (int, float, bool, etc.)
+    try:
+        result = str(content)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+    except Exception:
+        return ""
 
 
 def check_api_server_requirements() -> bool:
@@ -553,7 +613,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         for msg in messages:
             role = msg.get("role", "")
-            content = msg.get("content", "")
+            content = _normalize_chat_content(msg.get("content", ""))
             if role == "system":
                 # Accumulate system messages
                 if system_prompt is None:
@@ -926,18 +986,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
                     role = item.get("role", "user")
-                    content = item.get("content", "")
-                    # Handle content that may be a list of content parts
-                    if isinstance(content, list):
-                        text_parts = []
-                        for part in content:
-                            if isinstance(part, dict) and part.get("type") == "input_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, dict) and part.get("type") == "output_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, str):
-                                text_parts.append(part)
-                        content = "\n".join(text_parts)
+                    content = _normalize_chat_content(item.get("content", ""))
                     input_messages.append({"role": role, "content": content})
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -782,7 +782,7 @@ class MatrixAdapter(BasePlatformAdapter):
             # Try aiohttp first (always available), fall back to httpx
             try:
                 import aiohttp as _aiohttp
-                async with _aiohttp.ClientSession() as http:
+                async with _aiohttp.ClientSession(trust_env=True) as http:
                     async with http.get(image_url, timeout=_aiohttp.ClientTimeout(total=30)) as resp:
                         resp.raise_for_status()
                         data = await resp.read()

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -266,7 +266,7 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession(trust_env=True)
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -935,7 +935,7 @@ async def qr_login(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError("aiohttp is required for Weixin QR login")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         try:
             qr_resp = await _api_get(
                 session,
@@ -1134,7 +1134,7 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._session = aiohttp.ClientSession()
+        self._session = aiohttp.ClientSession(trust_env=True)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -1784,7 +1784,7 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         adapter = WeixinAdapter(
             PlatformConfig(
                 enabled=True,

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -1,0 +1,87 @@
+"""Tests for _normalize_chat_content in the API server adapter."""
+
+from gateway.platforms.api_server import _normalize_chat_content
+
+
+class TestNormalizeChatContent:
+    """Content normalization converts array-based content parts to plain text."""
+
+    def test_none_returns_empty_string(self):
+        assert _normalize_chat_content(None) == ""
+
+    def test_plain_string_returned_as_is(self):
+        assert _normalize_chat_content("hello world") == "hello world"
+
+    def test_empty_string_returned_as_is(self):
+        assert _normalize_chat_content("") == ""
+
+    def test_text_content_part(self):
+        content = [{"type": "text", "text": "hello"}]
+        assert _normalize_chat_content(content) == "hello"
+
+    def test_input_text_content_part(self):
+        content = [{"type": "input_text", "text": "user input"}]
+        assert _normalize_chat_content(content) == "user input"
+
+    def test_output_text_content_part(self):
+        content = [{"type": "output_text", "text": "assistant output"}]
+        assert _normalize_chat_content(content) == "assistant output"
+
+    def test_multiple_text_parts_joined_with_newline(self):
+        content = [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ]
+        assert _normalize_chat_content(content) == "first\nsecond"
+
+    def test_mixed_string_and_dict_parts(self):
+        content = ["plain string", {"type": "text", "text": "dict part"}]
+        assert _normalize_chat_content(content) == "plain string\ndict part"
+
+    def test_image_url_parts_silently_skipped(self):
+        content = [
+            {"type": "text", "text": "check this:"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+        ]
+        assert _normalize_chat_content(content) == "check this:"
+
+    def test_integer_content_converted(self):
+        assert _normalize_chat_content(42) == "42"
+
+    def test_boolean_content_converted(self):
+        assert _normalize_chat_content(True) == "True"
+
+    def test_deeply_nested_list_respects_depth_limit(self):
+        """Nesting beyond max_depth returns empty string."""
+        content = [[[[[[[[[[[["deep"]]]]]]]]]]]]
+        result = _normalize_chat_content(content)
+        # The deep nesting should be truncated, not crash
+        assert isinstance(result, str)
+
+    def test_large_list_capped(self):
+        """Lists beyond MAX_CONTENT_LIST_SIZE are truncated."""
+        content = [{"type": "text", "text": f"item{i}"} for i in range(2000)]
+        result = _normalize_chat_content(content)
+        # Should not contain all 2000 items
+        assert result.count("item") <= 1000
+
+    def test_oversized_string_truncated(self):
+        """Strings beyond 64KB are truncated."""
+        huge = "x" * 100_000
+        result = _normalize_chat_content(huge)
+        assert len(result) == 65_536
+
+    def test_empty_text_parts_filtered(self):
+        content = [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "actual"},
+            {"type": "text", "text": ""},
+        ]
+        assert _normalize_chat_content(content) == "actual"
+
+    def test_dict_without_type_skipped(self):
+        content = [{"foo": "bar"}, {"type": "text", "text": "real"}]
+        assert _normalize_chat_content(content) == "real"
+
+    def test_empty_list_returns_empty(self):
+        assert _normalize_chat_content([]) == ""


### PR DESCRIPTION
## Summary

Three changes salvaged from community PRs, each independent and clean.

### 1. Proxy support for aiohttp sessions (cherry-pick from #8280)
Adds `trust_env=True` to all `aiohttp.ClientSession()` calls in weixin.py, wecom.py, and matrix.py. This makes aiohttp respect `HTTP_PROXY`/`HTTPS_PROXY` env vars — critical for Chinese users behind proxies (Clash fake-IP mode) who can't connect to WeChat/WeCom APIs at all without it. No-op for non-proxy users.

**Author:** Sicheng Li (@MaybeRichard)

### 2. HermesClaw community docs (cherry-pick from #7375)
One-line README addition linking HermesClaw (community WeChat bridge) in the Community section.

**Author:** AaronWong1999 (@AaronWong1999)

### 3. Normalize array-based content parts in API server (salvaged from #7980)
Some OpenAI-compatible clients send content as typed arrays (`[{type: 'text', text: 'hello'}]`) instead of strings. The Chat Completions endpoint had no normalization, causing silent failures. Adds `_normalize_chat_content()` with defensive limits (recursion depth, list size, 64KB output cap) and applies it to both Chat Completions and Responses API endpoints. The Responses path had inline normalization that only handled `input_text`/`output_text` — the shared function also handles the standard `text` type.

**Only the content normalization from #7980 was taken.** The SSE changes (reverted #6972 tool progress fix, removed keepalive pings) and Weixin changes (conflicted with #8665, removed retry logic, removed blank-message guards) were regressions and are excluded.

**Author:** ikelvingo (@ikelvingo) — co-authored

## Files changed
- `gateway/platforms/weixin.py` — trust_env=True (3 locations)
- `gateway/platforms/wecom.py` — trust_env=True (1 location)
- `gateway/platforms/matrix.py` — trust_env=True (1 location)
- `gateway/platforms/api_server.py` — _normalize_chat_content function + applied in 2 endpoints
- `tests/gateway/test_api_server_normalize.py` — 17 new tests
- `README.md` — 1 line added

## Test plan
```
python -m pytest tests/gateway/test_api_server_normalize.py -v  # 17 passed
python -m pytest tests/gateway/test_api_server*.py -v            # 188 passed
python -m pytest tests/gateway/test_weixin.py -v                 # 34 passed
```

## PRs to close after merge
- #8280 (cherry-picked with authorship preserved)
- #7375 (cherry-picked with authorship preserved)
- #7980 (content normalization salvaged; SSE + Weixin changes excluded as regressions)