### PR TITLE
feat: add obsidian memory provider

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -24,7 +24,6 @@ from hermes_cli.auth import (
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
     _import_codex_cli_tokens,
-    _write_codex_cli_tokens,
     _load_auth_store,
     _load_provider_state,
     _resolve_kimi_base_url,
@@ -695,7 +694,7 @@ class CredentialPool:
                         self._persist()
                         self._sync_device_code_entry_to_auth_store(updated)
                         try:
-                            _write_codex_cli_tokens(
+                            auth_mod._write_codex_cli_tokens(
                                 updated.access_token,
                                 updated.refresh_token,
                                 last_refresh=updated.last_refresh,
@@ -731,7 +730,7 @@ class CredentialPool:
         # and VS Code don't hit "refresh_token_reused" on their next refresh.
         if self.provider == "openai-codex":
             try:
-                _write_codex_cli_tokens(
+                auth_mod._write_codex_cli_tokens(
                     updated.access_token,
                     updated.refresh_token,
                     last_refresh=updated.last_refresh,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -271,6 +271,17 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def on_tool_call_complete(self, tool_name: str, args: Dict[str, Any], result: str, **kwargs) -> None:
+        """Notify all providers that a tool call finished."""
+        for provider in self._providers:
+            try:
+                provider.on_tool_call_complete(tool_name, args, result, **kwargs)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' on_tool_call_complete failed: %s",
+                    provider.name, e,
+                )
+
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Notify all providers of session end."""
         for provider in self._providers:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -24,6 +24,7 @@ Lifecycle (called by MemoryManager, wired in run_agent.py):
 
 Optional hooks (override to opt in):
   on_turn_start(turn, message, **kwargs) — per-turn tick with runtime context
+  on_tool_call_complete(tool_name, args, result, **kwargs) — observe completed tool calls
   on_session_end(messages)               — end-of-session extraction
   on_pre_compress(messages) -> str       — extract before context compression
   on_memory_write(action, target, content) — mirror built-in memory writes
@@ -148,6 +149,15 @@ class MemoryProvider(ABC):
 
         kwargs may include: remaining_tokens, model, platform, tool_count.
         Providers use what they need; extras are ignored.
+        """
+
+    def on_tool_call_complete(self, tool_name: str, args: Dict[str, Any], result: str, **kwargs) -> None:
+        """Called after a tool call completes.
+
+        Use for checkpointing, audit logs, or provider-specific side channels.
+
+        kwargs may include: tool_call_id, duration, session_id, turn_number,
+        messages, and tool_index.
         """
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -155,6 +155,50 @@ MEMORY_GUIDANCE = (
     "necessary later, save it as a skill with the skill tool."
 )
 
+FOUR_LAYER_MEMORY_GUIDANCE = (
+    "# Memory layers\n"
+    "Hermes operates with four memory layers, from smallest/always-present to largest/on-demand:\n"
+    "1. Built-in memory (~2,200 chars): always injected compact facts and pointers.\n"
+    "2. AGENTS.md + SOUL.md: always injected operating rules, personality, and hard behavior constraints.\n"
+    "3. Obsidian vault: large read/write working memory that is NOT auto-injected; read it at session start, after compaction, and whenever more detail is needed. Write task starts, corrections, checkpoints every 3-5 tool calls, completions, and session-end flushes.\n"
+    "4. Session search: searchable archive of prior conversations; query it when the user references past work or cross-session context.\n"
+    "Use the smallest layer that solves the problem cleanly, and promote durable truths upward when they matter again."
+)
+
+
+def build_four_layer_memory_guidance(*, has_builtin_memory: bool = True, has_obsidian: bool = False, has_session_search: bool = False) -> str:
+    """Return runtime-accurate memory-layer guidance.
+
+    AGENTS/SOUL always exists. Built-in memory, Obsidian, and session-search
+    guidance should only be advertised when those capabilities are actually
+    available in the current runtime.
+    """
+    lines = [
+        "# Memory layers",
+        "Hermes operates with layered memory.",
+    ]
+    next_idx = 1
+    if has_builtin_memory:
+        lines.append(
+            f"{next_idx}. Built-in memory (~2,200 chars): always injected compact facts and pointers."
+        )
+        next_idx += 1
+    lines.append(
+        f"{next_idx}. AGENTS.md + SOUL.md: always injected operating rules, personality, and hard behavior constraints."
+    )
+    next_idx += 1
+    if has_obsidian:
+        lines.append(
+            f"{next_idx}. Obsidian vault: large read/write working memory that is NOT auto-injected; read it at session start, after compaction, and whenever more detail is needed. Write task starts, corrections, checkpoints every 3-5 tool calls, completions, and session-end flushes."
+        )
+        next_idx += 1
+    if has_session_search:
+        lines.append(
+            f"{next_idx}. Session search: searchable archive of prior conversations; query it when the user references past work or cross-session context."
+        )
+    lines.append("Use the smallest layer that solves the problem cleanly, and promote durable truths upward when they matter again.")
+    return "\n".join(lines)
+
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -606,10 +606,14 @@ DEFAULT_CONFIG = {
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
-        # Set to a provider name to activate: "openviking", "mem0",
+        # Set to a provider name to activate: "obsidian", "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Obsidian provider: checkpoint every 3-5 tool calls and cap how much
+        # note content is injected back into a prompt on refresh.
+        "obsidian_checkpoint_tool_calls": 4,
+        "obsidian_read_char_limit": 2500,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/default_soul.py
+++ b/hermes_cli/default_soul.py
@@ -1,11 +1,14 @@
 """Default SOUL.md template seeded into HERMES_HOME on first run."""
 
-DEFAULT_SOUL_MD = (
-    "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
-    "You are helpful, knowledgeable, and direct. You assist users with a wide "
-    "range of tasks including answering questions, writing and editing code, "
-    "analyzing information, creative work, and executing actions via your tools. "
-    "You communicate clearly, admit uncertainty when appropriate, and prioritize "
-    "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
-)
+DEFAULT_SOUL_MD = """You are Hermes Agent, an intelligent AI assistant created by Nous Research.
+You are helpful, knowledgeable, direct, and execution-oriented.
+
+Memory can operate across up to four layers:
+1. Built-in memory (~2,200 chars) — always injected; keep only compact durable facts and pointers.
+2. AGENTS.md + SOUL.md — always injected; this is the operating-rules and behavior layer.
+3. Obsidian vault — optional large on-demand memory when configured; read it at session start, after compaction, and when more detail is needed. Write task starts, checkpoints every 3-5 tool calls, completions, corrections, and session-end flushes.
+4. Session search — optional searchable archive of past conversations when the tool is available; use it when the user references prior work or cross-session context.
+
+When using the Obsidian layer, treat Agent-Shared/ as shared state, Agent-Hermes/ as Hermes-private state, and never write inside Agent-Aria/.
+Be targeted and efficient in your exploration and investigations.
+"""

--- a/plugins/memory/obsidian/__init__.py
+++ b/plugins/memory/obsidian/__init__.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _load_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+class ObsidianMemoryProvider(MemoryProvider):
+    name = "obsidian"
+
+    def __init__(self) -> None:
+        self._active = False
+        self._vault_path: Optional[Path] = None
+        self._session_id = ""
+        self._platform = ""
+        self._turn_count = 0
+        self._tool_calls_total = 0
+        self._tool_calls_since_checkpoint = 0
+        self._checkpoint_interval = 4
+        self._max_chars_per_note = 2500
+        self._prefetch_on_next_turn = True
+        self._session_started_logged = False
+        self._last_turn_message = ""
+        self._agent_home: Optional[Path] = None
+        self._shared_home: Optional[Path] = None
+        self._daily_home: Optional[Path] = None
+        self._private_home: Optional[Path] = None
+
+    def is_available(self) -> bool:
+        return self._resolve_vault_path() is not None
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id or ""
+        self._platform = str(kwargs.get("platform") or "")
+        cfg = _load_config()
+        mem_cfg = cfg.get("memory", {}) if isinstance(cfg.get("memory"), dict) else {}
+        self._checkpoint_interval = max(3, min(5, int(mem_cfg.get("obsidian_checkpoint_tool_calls", 4) or 4)))
+        self._max_chars_per_note = max(800, int(mem_cfg.get("obsidian_read_char_limit", 2500) or 2500))
+        self._vault_path = self._resolve_vault_path()
+        self._active = self._vault_path is not None
+        if not self._active:
+            return
+        self._shared_home = self._vault_path / "Agent-Shared"
+        self._private_home = self._vault_path / "Agent-Hermes"
+        self._daily_home = self._private_home / "daily"
+        self._agent_home = self._private_home
+        self._ensure_layout()
+
+    def system_prompt_block(self) -> str:
+        if not self._active or not self._vault_path:
+            return ""
+        today_rel = self._relative(self._today_note())
+        return "\n".join([
+            "# Obsidian vault memory layer",
+            f"Layer 3 lives in the shared Obsidian vault at {self._vault_path}.",
+            "Read these notes at session start and again after context compression or when you need more detail:",
+            f"- {self._relative(self._shared('user-profile.md'))}",
+            f"- {self._relative(self._shared('project-state.md'))}",
+            f"- {self._relative(self._private('working-context.md'))}",
+            f"- {today_rel}",
+            f"- {self._relative(self._shared('decisions-log.md'))} when decisions/history matter",
+            "Write to the vault on task start, every 3-5 tool calls, after corrections, on task completion, after compaction, and at session end.",
+            "Never write inside Agent-Aria/. Use Agent-Shared/ for shared state and Agent-Hermes/ for Hermes-private state.",
+        ])
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._active:
+            return ""
+        if not self._prefetch_on_next_turn and not self._query_needs_refresh(query):
+            return ""
+        self._prefetch_on_next_turn = False
+        parts = []
+        for title, path in [
+            ("Shared user profile", self._shared("user-profile.md")),
+            ("Shared project state", self._shared("project-state.md")),
+            ("Hermes working context", self._private("working-context.md")),
+            ("Today's daily log", self._today_note()),
+            ("Shared decisions", self._shared("decisions-log.md")),
+        ]:
+            text = self._safe_read(path)
+            if text:
+                parts.append(f"## {title} ({self._relative(path)})\n{text}")
+        if not parts:
+            return ""
+        return "# Obsidian vault context\n" + "\n\n".join(parts)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
+        if not self._active:
+            return
+        self._turn_count = max(turn_number, 0)
+        self._last_turn_message = (message or "").strip()
+        if not self._session_started_logged:
+            summary = self._shorten(self._last_turn_message or "Session started", 220)
+            self._append_daily("## Hermes session start", [
+                f"- session: `{self._session_id or 'unknown'}`",
+                f"- platform: {self._platform or 'unknown'}",
+                f"- first task: {summary}",
+            ])
+            self._append_working_context("session-start", [
+                f"Session {self._session_id or 'unknown'} started on {self._platform or 'unknown'}.",
+                f"Initial request: {summary}",
+            ])
+            self._session_started_logged = True
+
+    def on_tool_call_complete(self, tool_name: str, args: Dict[str, Any], result: str, **kwargs) -> None:
+        if not self._active:
+            return
+        self._tool_calls_total += 1
+        self._tool_calls_since_checkpoint += 1
+        if self._tool_calls_since_checkpoint < self._checkpoint_interval:
+            return
+        self._tool_calls_since_checkpoint = 0
+        preview = self._tool_preview(tool_name, args, result)
+        self._append_daily("## Hermes checkpoint", [
+            f"- turn: {self._turn_count}",
+            f"- tools total: {self._tool_calls_total}",
+            f"- latest tool: {preview}",
+        ])
+        self._append_working_context("checkpoint", [
+            f"Turn {self._turn_count}, tool {self._tool_calls_total}: {preview}",
+            f"Current request: {self._shorten(self._last_turn_message, 220)}",
+        ])
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if not self._active:
+            return ""
+        self._prefetch_on_next_turn = True
+        recent = self._conversation_summary(messages)
+        self._append_daily("## Hermes compaction", [
+            "- Context compression fired.",
+            f"- Snapshot: {recent}",
+        ])
+        self._append_working_context("compaction", [
+            "Context compression fired; re-read vault context next turn.",
+            recent,
+        ])
+        return ""
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._active:
+            return
+        recent = self._conversation_summary(messages)
+        self._append_daily("## Hermes session end", [
+            f"- session: `{self._session_id or 'unknown'}`",
+            f"- turns observed: {self._turn_count}",
+            f"- tool calls observed: {self._tool_calls_total}",
+            f"- summary: {recent}",
+        ])
+        self._append_working_context("session-end", [
+            f"Session {self._session_id or 'unknown'} ended.",
+            recent,
+        ])
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._active or action not in {"add", "replace"}:
+            return
+        cleaned = self._shorten((content or "").strip(), 240)
+        if not cleaned:
+            return
+        if target == "user":
+            self._append_shared_profile([f"- Explicit Hermes user memory ({action}): {cleaned}"])
+        else:
+            self._append_working_context("built-in-memory", [f"Hermes built-in memory {action}: {cleaned}"])
+
+    def shutdown(self) -> None:
+        return
+
+    def _resolve_vault_path(self) -> Optional[Path]:
+        env_path = os.getenv("OBSIDIAN_VAULT_PATH", "").strip()
+        if env_path:
+            p = Path(env_path).expanduser()
+            if p.exists():
+                return p
+        fallback = Path.home() / "Documents" / "Obsidian Vault"
+        if fallback.exists():
+            return fallback
+        config_path = Path.home() / "Library" / "Application Support" / "obsidian" / "obsidian.json"
+        if config_path.exists():
+            try:
+                data = json.loads(config_path.read_text())
+                vaults = data.get("vaults") or {}
+                for item in vaults.values():
+                    path = str((item or {}).get("path") or "").strip()
+                    if path:
+                        p = Path(path).expanduser()
+                        if p.exists():
+                            return p
+            except Exception:
+                logger.debug("Failed to parse Obsidian config", exc_info=True)
+        return None
+
+    def _ensure_layout(self) -> None:
+        for folder in [self._shared_home, self._private_home, self._daily_home]:
+            if folder:
+                folder.mkdir(parents=True, exist_ok=True)
+        self._ensure_file(self._shared("user-profile.md"), "# Shared user profile\n\n")
+        self._ensure_file(self._shared("project-state.md"), "# Shared project state\n\n")
+        self._ensure_file(self._shared("decisions-log.md"), "# Shared decisions log\n\n")
+        self._ensure_file(self._private("working-context.md"), "# Hermes working context\n\n## Activity log\n")
+        self._ensure_file(self._private("mistakes.md"), "# Hermes mistakes\n\n")
+        self._ensure_file(self._today_note(), f"# Hermes daily log - {self._today_str()}\n\n")
+
+    def _ensure_file(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_text(content)
+
+    def _shared(self, name: str) -> Path:
+        return (self._shared_home or Path(".")) / name
+
+    def _private(self, name: str) -> Path:
+        return (self._private_home or Path(".")) / name
+
+    def _today_note(self) -> Path:
+        return (self._daily_home or Path(".")) / f"{self._today_str()}.md"
+
+    def _today_str(self) -> str:
+        return datetime.now().strftime("%Y-%m-%d")
+
+    def _relative(self, path: Path) -> str:
+        try:
+            if self._vault_path:
+                return str(path.relative_to(self._vault_path))
+        except Exception:
+            pass
+        return str(path)
+
+    def _safe_read(self, path: Path) -> str:
+        try:
+            if not path.exists():
+                return ""
+            text = path.read_text().strip()
+            if len(text) > self._max_chars_per_note:
+                return text[: self._max_chars_per_note].rstrip() + "\n...[truncated]"
+            return text
+        except Exception:
+            logger.debug("Failed reading vault note %s", path, exc_info=True)
+            return ""
+
+    def _append_daily(self, heading: str, lines: List[str]) -> None:
+        self._append_block(self._today_note(), heading, lines)
+
+    def _append_working_context(self, label: str, lines: List[str]) -> None:
+        heading = f"## {datetime.now().strftime('%H:%M')} - {label}"
+        self._append_block(self._private("working-context.md"), heading, lines)
+
+    def _append_shared_profile(self, lines: List[str]) -> None:
+        self._append_block(self._shared("user-profile.md"), "## Hermes additions", lines)
+
+    def _append_block(self, path: Path, heading: str, lines: List[str]) -> None:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+            block = ["", heading, f"- logged: {timestamp}"]
+            block.extend(line if line.startswith("- ") else f"- {line}" for line in lines if line)
+            with path.open("a") as f:
+                f.write("\n".join(block) + "\n")
+        except Exception:
+            logger.debug("Failed writing vault note %s", path, exc_info=True)
+
+    def _shorten(self, text: str, limit: int) -> str:
+        clean = re.sub(r"\s+", " ", (text or "").strip())
+        if len(clean) <= limit:
+            return clean
+        return clean[: limit - 3].rstrip() + "..."
+
+    def _tool_preview(self, tool_name: str, args: Dict[str, Any], result: str) -> str:
+        arg_keys = ", ".join(sorted((args or {}).keys())[:6])
+        summary = self._shorten(result or "", 140)
+        return f"{tool_name}({arg_keys}) -> {summary}"
+
+    def _conversation_summary(self, messages: List[Dict[str, Any]]) -> str:
+        pairs = []
+        for msg in messages[-12:]:
+            role = msg.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            content = self._shorten(str(msg.get("content") or ""), 120)
+            if content:
+                pairs.append(f"{role}: {content}")
+        if not pairs:
+            return "No recent user/assistant messages captured."
+        return " | ".join(pairs[-4:])
+
+    def _query_needs_refresh(self, query: str) -> bool:
+        q = (query or "").lower()
+        return any(token in q for token in [
+            "obsidian", "vault", "memory", "profile", "project", "decision",
+            "context", "last time", "working on", "working context", "daily log",
+        ])
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(ObsidianMemoryProvider())

--- a/plugins/memory/obsidian/plugin.yaml
+++ b/plugins/memory/obsidian/plugin.yaml
@@ -1,0 +1,3 @@
+name: obsidian
+version: 1.0.0
+description: "Shared Obsidian-vault memory layer with session-start recall, working-context checkpoints, daily logs, and session flushes."

--- a/run_agent.py
+++ b/run_agent.py
@@ -94,7 +94,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, build_four_layer_memory_guidance
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -3132,6 +3132,17 @@ class AIAgent:
                 user_block = self._memory_store.format_for_system_prompt("user")
                 if user_block:
                     prompt_parts.append(user_block)
+
+        has_obsidian_layer = bool(self._memory_manager and self._memory_manager.get_provider("obsidian"))
+        has_session_search_layer = "session_search" in self.valid_tool_names
+        if self._memory_store or has_obsidian_layer or has_session_search_layer:
+            prompt_parts.append(
+                build_four_layer_memory_guidance(
+                    has_builtin_memory=bool(self._memory_store),
+                    has_obsidian=has_obsidian_layer,
+                    has_session_search=has_session_search_layer,
+                )
+            )
 
         # External memory provider system prompt block (additive to built-in)
         if self._memory_manager:
@@ -6970,6 +6981,22 @@ class AIAgent:
                 env=get_active_env(effective_task_id),
             )
 
+            if self._memory_manager:
+                try:
+                    self._memory_manager.on_tool_call_complete(
+                        name,
+                        args,
+                        function_result,
+                        tool_call_id=tc.id,
+                        duration=tool_duration,
+                        session_id=self.session_id,
+                        turn_number=self._user_turn_count,
+                        tool_index=i + 1,
+                        messages=list(messages),
+                    )
+                except Exception:
+                    pass
+
             subdir_hints = self._subdirectory_hints.check_tool_call(name, args)
             if subdir_hints:
                 function_result += subdir_hints
@@ -7291,6 +7318,22 @@ class AIAgent:
                 tool_use_id=tool_call.id,
                 env=get_active_env(effective_task_id),
             )
+
+            if self._memory_manager:
+                try:
+                    self._memory_manager.on_tool_call_complete(
+                        function_name,
+                        function_args,
+                        function_result,
+                        tool_call_id=tool_call.id,
+                        duration=tool_duration,
+                        session_id=self.session_id,
+                        turn_number=self._user_turn_count,
+                        tool_index=i,
+                        messages=list(messages),
+                    )
+                except Exception:
+                    pass
 
             # Discover subdirectory context files from tool arguments
             subdir_hints = self._subdirectory_hints.check_tool_call(function_name, function_args)
@@ -7647,6 +7690,20 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+
+        if self._memory_manager:
+            try:
+                self._memory_manager.on_turn_start(
+                    self._user_turn_count,
+                    original_user_message,
+                    session_id=self.session_id,
+                    model=self.model,
+                    platform=self.platform or "",
+                    is_first_turn=not bool(conversation_history),
+                    todo_count=len(self._todo_store.read()),
+                )
+            except Exception:
+                pass
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -24,6 +24,7 @@ class FakeMemoryProvider(MemoryProvider):
         self.prefetch_queries = []
         self.queued_prefetches = []
         self.turn_starts = []
+        self.tool_call_completions = []
         self.session_end_called = False
         self.pre_compress_called = False
         self.memory_writes = []
@@ -67,6 +68,9 @@ class FakeMemoryProvider(MemoryProvider):
     def on_turn_start(self, turn_number, message):
         self.turn_starts.append((turn_number, message))
 
+    def on_tool_call_complete(self, tool_name, args, result, **kwargs):
+        self.tool_call_completions.append((tool_name, args, result, kwargs))
+
     def on_session_end(self, messages):
         self.session_end_called = True
 
@@ -99,6 +103,7 @@ class TestMemoryProviderABC:
         p = FakeMemoryProvider()
         # These should not raise
         p.on_turn_start(1, "hello")
+        p.on_tool_call_complete("terminal", {"command": "pwd"}, "ok")
         p.on_session_end([])
         p.on_pre_compress([])
         p.on_memory_write("add", "memory", "test")
@@ -228,6 +233,57 @@ class TestMemoryManager:
         mgr.sync_all("user msg", "assistant msg")
         assert p1.synced_turns == [("user msg", "assistant msg")]
         assert p2.synced_turns == [("user msg", "assistant msg")]
+
+    def test_on_turn_start_calls_all_providers(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p2 = FakeMemoryProvider("external")
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        mgr.on_turn_start(3, "What do you know?")
+        assert p1.turn_starts == [(3, "What do you know?")]
+        assert p2.turn_starts == [(3, "What do you know?")]
+
+    def test_on_tool_call_complete_calls_all_providers(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p2 = FakeMemoryProvider("external")
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        mgr.on_tool_call_complete(
+            "terminal",
+            {"command": "pwd"},
+            "ok",
+            tool_call_id="call-1",
+            duration=0.25,
+            turn_number=2,
+        )
+
+        assert p1.tool_call_completions == [(
+            "terminal",
+            {"command": "pwd"},
+            "ok",
+            {"tool_call_id": "call-1", "duration": 0.25, "turn_number": 2},
+        )]
+        assert p2.tool_call_completions == [(
+            "terminal",
+            {"command": "pwd"},
+            "ok",
+            {"tool_call_id": "call-1", "duration": 0.25, "turn_number": 2},
+        )]
+
+    def test_on_session_end_calls_all_providers(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p2 = FakeMemoryProvider("external")
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        mgr.on_session_end([{"role": "user", "content": "bye"}])
+        assert p1.session_end_called
+
 
     def test_sync_failure_doesnt_block_others(self):
         """If one provider's sync fails, others still run."""
@@ -381,6 +437,7 @@ class TestPluginMemoryDiscovery:
         providers = discover_memory_providers()
         names = [name for name, _, _ in providers]
         assert "holographic" in names  # always available (no external deps)
+        assert "obsidian" in names
 
     def test_load_provider_by_name(self):
         """load_memory_provider returns a working provider instance."""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -25,6 +25,8 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
+    FOUR_LAYER_MEMORY_GUIDANCE,
+    build_four_layer_memory_guidance,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
@@ -44,6 +46,43 @@ class TestGuidanceConstants:
         assert "session_search" in MEMORY_GUIDANCE
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
+
+    def test_four_layer_memory_guidance_mentions_obsidian_and_session_search(self):
+        assert "four memory layers" in FOUR_LAYER_MEMORY_GUIDANCE
+        assert "Obsidian vault" in FOUR_LAYER_MEMORY_GUIDANCE
+        assert "session-end flushes" in FOUR_LAYER_MEMORY_GUIDANCE
+        assert "Session search" in FOUR_LAYER_MEMORY_GUIDANCE
+
+    def test_runtime_four_layer_guidance_hides_unavailable_layers(self):
+        guidance = build_four_layer_memory_guidance(
+            has_builtin_memory=True,
+            has_obsidian=False,
+            has_session_search=False,
+        )
+        assert "Built-in memory" in guidance
+        assert "AGENTS.md + SOUL.md" in guidance
+        assert "Obsidian vault" not in guidance
+        assert "Session search" not in guidance
+
+    def test_runtime_four_layer_guidance_mentions_only_available_optional_layers(self):
+        guidance = build_four_layer_memory_guidance(
+            has_builtin_memory=True,
+            has_obsidian=True,
+            has_session_search=False,
+        )
+        assert "Obsidian vault" in guidance
+        assert "Session search" not in guidance
+
+    def test_runtime_four_layer_guidance_hides_builtin_memory_when_disabled(self):
+        guidance = build_four_layer_memory_guidance(
+            has_builtin_memory=False,
+            has_obsidian=True,
+            has_session_search=True,
+        )
+        assert "Built-in memory" not in guidance
+        assert "AGENTS.md + SOUL.md" in guidance
+        assert "Obsidian vault" in guidance
+        assert "Session search" in guidance
 
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE

--- a/tests/hermes_cli/test_default_soul.py
+++ b/tests/hermes_cli/test_default_soul.py
@@ -1,0 +1,9 @@
+"""Tests for the default SOUL template."""
+
+from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+
+def test_default_soul_marks_optional_memory_layers_as_optional():
+    assert "up to four layers" in DEFAULT_SOUL_MD
+    assert "optional large on-demand memory when configured" in DEFAULT_SOUL_MD
+    assert "optional searchable archive of past conversations when the tool is available" in DEFAULT_SOUL_MD

--- a/tests/plugins/memory/test_obsidian_provider.py
+++ b/tests/plugins/memory/test_obsidian_provider.py
@@ -1,0 +1,146 @@
+"""Tests for the Obsidian memory provider plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.obsidian import ObsidianMemoryProvider
+
+
+@pytest.fixture()
+def vault(tmp_path: Path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "Agent-Shared").mkdir(parents=True)
+    (vault / "Agent-Hermes" / "daily").mkdir(parents=True)
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    monkeypatch.setattr(
+        "plugins.memory.obsidian._load_config",
+        lambda: {
+            "memory": {
+                "obsidian_checkpoint_tool_calls": 4,
+                "obsidian_read_char_limit": 2500,
+            }
+        },
+    )
+    return vault
+
+
+class TestObsidianProvider:
+    def test_is_available_when_vault_exists(self, vault):
+        provider = ObsidianMemoryProvider()
+        assert provider.is_available() is True
+
+    def test_initialize_creates_expected_layout(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+
+        assert (vault / "Agent-Shared" / "user-profile.md").exists()
+        assert (vault / "Agent-Shared" / "project-state.md").exists()
+        assert (vault / "Agent-Shared" / "decisions-log.md").exists()
+        assert (vault / "Agent-Hermes" / "working-context.md").exists()
+        assert (vault / "Agent-Hermes" / "mistakes.md").exists()
+        assert (vault / "Agent-Hermes" / "daily").exists()
+
+    def test_system_prompt_block_mentions_required_notes(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+
+        block = provider.system_prompt_block()
+        assert "Obsidian vault memory layer" in block
+        assert "Agent-Shared/user-profile.md" in block
+        assert "Agent-Hermes/working-context.md" in block
+        assert "Never write inside Agent-Aria/" in block
+
+    def test_prefetch_reads_shared_and_private_notes(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+        (vault / "Agent-Shared" / "user-profile.md").write_text("# Shared user profile\n\n- Danny prefers brevity\n")
+        (vault / "Agent-Shared" / "project-state.md").write_text("# Shared project state\n\n- Hermes work matters\n")
+        (vault / "Agent-Hermes" / "working-context.md").write_text("# Hermes working context\n\n- active task\n")
+        today = next((vault / "Agent-Hermes" / "daily").glob("*.md"))
+        today.write_text("# 2026-04-12\n\n- breadcrumb\n")
+
+        context = provider.prefetch("what were we working on?", session_id="sess-1")
+        assert "# Obsidian vault context" in context
+        assert "Danny prefers brevity" in context
+        assert "Hermes work matters" in context
+        assert "active task" in context
+        assert "breadcrumb" in context
+
+    def test_on_turn_start_logs_session_start_once(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+
+        provider.on_turn_start(1, "complete this task")
+        provider.on_turn_start(2, "follow up")
+
+        daily = next((vault / "Agent-Hermes" / "daily").glob("*.md")).read_text()
+        working = (vault / "Agent-Hermes" / "working-context.md").read_text()
+        assert daily.count("## Hermes session start") == 1
+        assert "first task: complete this task" in daily
+        assert "Initial request: complete this task" in working
+
+    def test_tool_call_checkpoint_writes_every_configured_interval(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+        provider.on_turn_start(1, "ship it")
+
+        for i in range(3):
+            provider.on_tool_call_complete("read_file", {"path": f"f{i}.md"}, "ok")
+
+        daily_path = next((vault / "Agent-Hermes" / "daily").glob("*.md"))
+        assert "## Hermes checkpoint" not in daily_path.read_text()
+
+        provider.on_tool_call_complete("read_file", {"path": "f4.md"}, "ok")
+        daily = daily_path.read_text()
+        working = (vault / "Agent-Hermes" / "working-context.md").read_text()
+        assert "## Hermes checkpoint" in daily
+        assert "tools total: 4" in daily
+        assert "read_file(path) -> ok" in daily
+        assert "Turn 1, tool 4: read_file(path) -> ok" in working
+
+    def test_on_pre_compress_marks_prefetch_for_next_turn(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+
+        provider.prefetch("first")
+        assert provider.prefetch("boring unrelated query") == ""
+
+        provider.on_pre_compress([
+            {"role": "user", "content": "compress me"},
+            {"role": "assistant", "content": "done"},
+        ])
+        refreshed = provider.prefetch("boring unrelated query")
+        assert "# Obsidian vault context" in refreshed
+
+    def test_on_session_end_writes_summary(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+        provider.on_turn_start(1, "wrap up")
+
+        provider.on_session_end([
+            {"role": "user", "content": "wrap up"},
+            {"role": "assistant", "content": "done"},
+        ])
+
+        daily = next((vault / "Agent-Hermes" / "daily").glob("*.md")).read_text()
+        working = (vault / "Agent-Hermes" / "working-context.md").read_text()
+        assert "## Hermes session end" in daily
+        assert "turns observed: 1" in daily
+        assert "tool calls observed: 0" in daily
+        assert "summary: user: wrap up | assistant: done" in daily
+        assert "Session sess-1 ended." in working
+
+    def test_on_memory_write_routes_user_entries_to_shared_profile(self, vault):
+        provider = ObsidianMemoryProvider()
+        provider.initialize("sess-1", platform="telegram")
+
+        provider.on_memory_write("add", "user", "Danny likes concise updates")
+        provider.on_memory_write("add", "memory", "Environment note")
+
+        profile = (vault / "Agent-Shared" / "user-profile.md").read_text()
+        working = (vault / "Agent-Hermes" / "working-context.md").read_text()
+        assert "Danny likes concise updates" in profile
+        assert "Environment note" in working


### PR DESCRIPTION
## Summary
- add a built-in Obsidian memory provider plugin for Layer 3 vault recall and checkpointing
- wire memory lifecycle hooks for turn start, completed tool calls, compaction refresh, and session-end flushes
- add prompt/config/default SOUL updates plus regression coverage for the new memory-layer behavior and the Codex token import fix

## Test Plan
- [x] `source venv/bin/activate && python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_default_soul.py tests/agent/test_memory_provider.py tests/agent/test_prompt_builder.py tests/plugins/memory/test_obsidian_provider.py -q -o 'addopts='`
- [x] import smoke test for `agent.credential_pool`, `agent.auxiliary_client`, `tools.browser_tool`, `run_agent`, and `plugins.memory.obsidian`
- [x] independent reviewer subagent passed on final diff

## Notes
- live `~/.hermes/config.yaml` is already set to `memory.provider: obsidian`
- package-lock.json was intentionally excluded as unrelated noise
