### PR TITLE
fix(doctor): avoid unicode crashes on GBK consoles

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -54,6 +54,7 @@ _PROVIDER_ENV_HINTS = (
     "XIAOMI_API_KEY",
 )
 
+_DOCTOR_UNICODE_SENTINEL = "—→─│┌┐└┘◆⚠✓✗🎉🩺"
 
 from hermes_constants import is_termux as _is_termux
 
@@ -79,6 +80,28 @@ def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps.append(f"{step}) npm install -g agent-browser")
     steps.append(f"{step + 1}) agent-browser install")
     return steps
+
+
+def _enable_stdout_fallback_for_doctor() -> None:
+    """Avoid UnicodeEncodeError on narrow Windows console encodings.
+
+    Some Windows terminals still default to GBK/CP936, which cannot encode
+    the doctor command's decorative Unicode glyphs. Switching stdout to
+    ``errors='replace'`` preserves the diagnostic output while avoiding a hard
+    crash in the middle of the command.
+    """
+    stream = getattr(sys, "stdout", None)
+    encoding = getattr(stream, "encoding", None)
+    if stream is None or not encoding or not hasattr(stream, "reconfigure"):
+        return
+
+    try:
+        _DOCTOR_UNICODE_SENTINEL.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        try:
+            stream.reconfigure(errors="replace")
+        except Exception:
+            pass
 
 
 def _has_provider_env_config(content: str) -> bool:
@@ -161,6 +184,7 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 
 def run_doctor(args):
     """Run diagnostic checks."""
+    _enable_stdout_fallback_for_doctor()
     should_fix = getattr(args, 'fix', False)
 
     # Doctor runs from the interactive CLI, so CLI-gated tool availability

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -31,6 +31,37 @@ class TestDoctorPlatformHints:
         assert doctor._system_package_install_cmd("ripgrep") == "sudo apt install ripgrep"
 
 
+class TestDoctorStdoutFallback:
+    class _FakeStdout:
+        def __init__(self, encoding: str | None, errors: str = "strict"):
+            self.encoding = encoding
+            self.errors = errors
+            self.calls = []
+
+        def reconfigure(self, **kwargs):
+            self.calls.append(kwargs)
+            if "errors" in kwargs:
+                self.errors = kwargs["errors"]
+
+    def test_enables_replace_mode_for_gbk_stdout(self, monkeypatch):
+        fake = self._FakeStdout("gbk")
+        monkeypatch.setattr(sys, "stdout", fake)
+
+        doctor._enable_stdout_fallback_for_doctor()
+
+        assert fake.calls == [{"errors": "replace"}]
+        assert fake.errors == "replace"
+
+    def test_leaves_utf8_stdout_unchanged(self, monkeypatch):
+        fake = self._FakeStdout("utf-8")
+        monkeypatch.setattr(sys, "stdout", fake)
+
+        doctor._enable_stdout_fallback_for_doctor()
+
+        assert fake.calls == []
+        assert fake.errors == "strict"
+
+
 class TestProviderEnvDetection:
     def test_detects_openai_api_key(self):
         content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"


### PR DESCRIPTION
## Summary
- detect stdout encodings that cannot represent the doctor command's Unicode glyphs
- switch doctor output to `errors='replace'` on those consoles so `hermes doctor` still completes instead of crashing with `UnicodeEncodeError`
- cover the regression with focused tests for GBK and UTF-8 stdout behavior

Fixes #7537.

## Testing
- `python3 -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-7537 --extra dev pytest -o addopts='' tests/hermes_cli/test_doctor.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
