### PR TITLE
fix(signal): process group sync messages from linked devices

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -365,7 +365,8 @@ class SignalAdapter(BasePlatformAdapter):
         envelope_data = envelope.get("envelope", envelope)
 
         # Handle syncMessage: extract "Note to Self" messages (sent to own account)
-        # while still filtering other sync events (read receipts, typing, etc.)
+        # and group messages sent from another device, while filtering other sync
+        # events (read receipts, typing, etc.)
         is_note_to_self = False
         if "syncMessage" in envelope_data:
             sync_msg = envelope_data.get("syncMessage")
@@ -380,6 +381,14 @@ class SignalAdapter(BasePlatformAdapter):
                             self._recent_sent_timestamps.discard(sent_ts)
                             return
                         # Genuine user Note to Self — promote to dataMessage
+                        is_note_to_self = True
+                        envelope_data = {**envelope_data, "dataMessage": sent_msg}
+                    elif sent_msg.get("groupInfo"):
+                        # Group message sent from another device — promote to dataMessage
+                        # and treat like Note to Self to bypass the self-loop filter below
+                        if sent_ts and sent_ts in self._recent_sent_timestamps:
+                            self._recent_sent_timestamps.discard(sent_ts)
+                            return
                         is_note_to_self = True
                         envelope_data = {**envelope_data, "dataMessage": sent_msg}
             if not is_note_to_self:


### PR DESCRIPTION
## Problem

When a user messages Hermes from a **Signal group** on a linked device (e.g., their phone), the gateway silently drops the message — no log output, no response.

**Root cause:** Signal delivers messages sent from a linked device as `syncMessage.sentMessage` envelopes, not as direct incoming envelopes. `_handle_envelope` only unwraps `syncMessage` for Note to Self (where `destinationNumber == own account`). Group messages don't match that check, so they hit the `if not is_note_to_self: return` guard and are silently dropped.

This affects any user who creates a Signal group (e.g., a dedicated "Hermes" channel) and messages it from their phone while `signal-cli` runs as a daemon.

## Fix

Add an `elif sent_msg.get("groupInfo"):` branch in the `syncMessage` handler, alongside the existing Note to Self branch. Promotes the sync'd group message to `dataMessage` so normal processing continues, with the same echo-dedup guard already used for Note to Self.

Sets `is_note_to_self = True` to also bypass the self-loop filter at line ~402 (`sender == account_normalized and not is_note_to_self`), since group sync messages also appear to originate from the account's own number.

## Testing

Verified locally with `signal-cli` 0.14.2 in daemon/HTTP mode:
1. Created a solo Signal group via the JSON-RPC API
2. Set it as `SIGNAL_HOME_CHANNEL`
3. Sent messages from phone → gateway now responds correctly

## Notes

- No new tests added (existing Signal adapter test suite doesn't cover SSE envelope parsing at this level)
- The fix is minimal and confined to the syncMessage handling block
- Nearest analogue in issues: #5819 (Matrix silent message drop — different platform/root cause, closed)