### PR TITLE
perf: stabilize system prompt timestamp across compression cycles

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3171,9 +3171,18 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
+        # Use session_start (set once at __init__) for a stable timestamp.
+        # Before this fix, _hermes_now() was called here, which meant the
+        # "Conversation started" time changed after every compression cycle —
+        # invalidating the system prompt prefix cache on local LLM backends.
         from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
+        _start = getattr(self, "session_start", None) or _hermes_now()
+        timestamp_line = f"Conversation started: {_start.strftime('%A, %B %d, %Y %I:%M %p')}"
+        # Track compression history so the model knows context was compacted
+        _cc = getattr(getattr(self, "context_compressor", None), "compression_count", 0) or 0
+        if _cc > 0:
+            _now = _hermes_now()
+            timestamp_line += f"\nLast context compaction: {_now.strftime('%A, %B %d, %Y %I:%M %p')} (#{_cc})"
         if self.pass_session_id and self.session_id:
             timestamp_line += f"\nSession ID: {self.session_id}"
         if self.model:


### PR DESCRIPTION
## Summary

Stabilizes the "Conversation started" timestamp in the system prompt across compression cycles, preventing prefix cache invalidation on local LLM backends.

### Before
```python
now = _hermes_now()  # current time — changes after every compression!
timestamp_line = f"Conversation started: {now.strftime(...)}"
```

### After
```python
_start = getattr(self, "session_start", None) or _hermes_now()  # set once at __init__
timestamp_line = f"Conversation started: {_start.strftime(...)}"
# Only after compression:
timestamp_line += f"\nLast context compaction: {_now.strftime(...)} (#{count})"
```

### Evidence

MITM proxy analysis showed the timestamp was the ONLY difference between system prompts. On LM Studio with phi-3.5-mini (~17K token prompt): **3.6x latency penalty per cache miss** (2.2s vs 8.0s).

After fix, validated via MITM: "Conversation started" stays stable. Post-compression adds exactly one line, preserving the prefix before it for partial cache matching.

## Test plan

- [x] MITM proxy validation: "Conversation started" stable across compression
- [x] Post-compression prompt adds "Last context compaction: {date} (#{count})"
- [x] Defensive: handles missing session_start and context_compressor gracefully
- [ ] CI tests pass

Closes #8687. Relates to #3353, #4319.
