### PR TITLE
fix(whatsapp): send read receipts for inbound messages

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -27,6 +27,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { sendReadReceipt } from './read_receipts.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -356,6 +357,8 @@ async function startSocket() {
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
       }
+
+      await sendReadReceipt(sock, msg);
     }
   });
 }

--- a/scripts/whatsapp-bridge/read_receipts.js
+++ b/scripts/whatsapp-bridge/read_receipts.js
@@ -1,0 +1,14 @@
+export async function sendReadReceipt(sock, msg, log = console) {
+  const key = msg?.key;
+  if (!sock?.readMessages || !key?.id || !key?.remoteJid || key.fromMe) {
+    return false;
+  }
+
+  try {
+    await sock.readMessages([key]);
+    return true;
+  } catch (err) {
+    log.error?.('[bridge] Failed to send read receipt:', err?.message || err);
+    return false;
+  }
+}

--- a/scripts/whatsapp-bridge/read_receipts.test.mjs
+++ b/scripts/whatsapp-bridge/read_receipts.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sendReadReceipt } from './read_receipts.js';
+
+test('sendReadReceipt forwards inbound message keys to Baileys', async () => {
+  const calls = [];
+  const sock = {
+    async readMessages(keys) {
+      calls.push(keys);
+    },
+  };
+  const msg = {
+    key: {
+      id: 'abc123',
+      fromMe: false,
+      remoteJid: '19175395595@s.whatsapp.net',
+    },
+  };
+
+  const sent = await sendReadReceipt(sock, msg);
+  assert.equal(sent, true);
+  assert.deepEqual(calls, [[msg.key]]);
+});
+
+test('sendReadReceipt skips fromMe messages', async () => {
+  const sock = {
+    async readMessages() {
+      throw new Error('should not be called');
+    },
+  };
+  const msg = {
+    key: {
+      id: 'abc123',
+      fromMe: true,
+      remoteJid: '19175395595@s.whatsapp.net',
+    },
+  };
+
+  const sent = await sendReadReceipt(sock, msg);
+  assert.equal(sent, false);
+});
+
+test('sendReadReceipt swallows bridge ack errors', async () => {
+  const errors = [];
+  const sock = {
+    async readMessages() {
+      throw new Error('network down');
+    },
+  };
+  const msg = {
+    key: {
+      id: 'abc123',
+      fromMe: false,
+      remoteJid: '19175395595@s.whatsapp.net',
+    },
+  };
+
+  const sent = await sendReadReceipt(sock, msg, {
+    error: (...args) => errors.push(args.join(' ')),
+  });
+  assert.equal(sent, false);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /Failed to send read receipt/);
+});


### PR DESCRIPTION
## Summary
- add a small bridge helper that sends Baileys read receipts for inbound WhatsApp messages Hermes accepts for processing
- invoke the helper after accepted inbound messages are queued so senders see blue-tick read confirmations
- add focused Node tests for success, skip, and error-swallowing paths

## Root Cause
The native WhatsApp bridge received inbound messages and forwarded them into Hermes, but it never called Baileys' read receipt flow for those messages. As a result, Hermes could respond while WhatsApp still showed the message as unread.

Closes #6055.

## Testing
- `node --check scripts/whatsapp-bridge/bridge.js`
- `node --check scripts/whatsapp-bridge/read_receipts.js`
- `node --test scripts/whatsapp-bridge/read_receipts.test.mjs scripts/whatsapp-bridge/allowlist.test.mjs`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped bug fix.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
