### PR TITLE
fix(agent): gate summary provider hints to OpenRouter (#8591)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7435,18 +7435,24 @@ class AIAgent:
                 if self.max_tokens is not None:
                     summary_kwargs.update(self._max_tokens_param(self.max_tokens))
 
-                # Include provider routing preferences
-                provider_preferences = {}
-                if self.providers_allowed:
-                    provider_preferences["only"] = self.providers_allowed
-                if self.providers_ignored:
-                    provider_preferences["ignore"] = self.providers_ignored
-                if self.providers_order:
-                    provider_preferences["order"] = self.providers_order
-                if self.provider_sort:
-                    provider_preferences["sort"] = self.provider_sort
-                if provider_preferences:
-                    summary_extra_body["provider"] = provider_preferences
+                # Include provider routing preferences — OpenRouter-specific,
+                # must not be sent to other providers (#8591).
+                if self._is_openrouter_url():
+                    provider_preferences = {}
+                    if self.providers_allowed:
+                        provider_preferences["only"] = self.providers_allowed
+                    if self.providers_ignored:
+                        provider_preferences["ignore"] = self.providers_ignored
+                    if self.providers_order:
+                        provider_preferences["order"] = self.providers_order
+                    if self.provider_sort:
+                        provider_preferences["sort"] = self.provider_sort
+                    if self.provider_require_parameters:
+                        provider_preferences["require_parameters"] = True
+                    if self.provider_data_collection:
+                        provider_preferences["data_collection"] = self.provider_data_collection
+                    if provider_preferences:
+                        summary_extra_body["provider"] = provider_preferences
 
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1587,6 +1587,61 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_includes_provider_preferences_for_openrouter(self, agent):
+        """Provider routing prefs should be included for OpenRouter (#8591)."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.providers_allowed = ["Anthropic"]
+        agent.provider_sort = "price"
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        provider = kwargs["extra_body"]["provider"]
+        assert provider["only"] == ["Anthropic"]
+        assert provider["sort"] == "price"
+
+    def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
+        """Provider routing prefs must NOT be sent to non-OpenRouter providers (#8591)."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.base_url = "https://api.openai.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.providers_allowed = ["Anthropic"]
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "provider" not in kwargs.get("extra_body", {})
+
+    def test_summary_includes_require_parameters_for_openrouter(self, agent):
+        """require_parameters and data_collection should be forwarded to OpenRouter."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.providers_allowed = ["Anthropic"]
+        agent.provider_require_parameters = True
+        agent.provider_data_collection = "deny"
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        provider = kwargs["extra_body"]["provider"]
+        assert provider["require_parameters"] is True
+        assert provider["data_collection"] == "deny"
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.


### PR DESCRIPTION
## Summary

- Gate `provider_preferences` in `_handle_max_iterations()` behind `_is_openrouter_url()`, matching the existing guard in the main `_build_api_kwargs()` path
- Add missing `require_parameters` and `data_collection` fields that the summary path was silently dropping compared to the main API call path

## Root Cause

`_handle_max_iterations()` unconditionally injected `extra_body.provider` whenever provider routing preferences were configured. This field is OpenRouter-specific — non-OpenRouter providers reject the unknown payload with HTTP 400:

```
Invalid JSON payload received. Unknown name "provider": Cannot find field.
```

The main request path at line 6131 already has the correct guard:
```python
if provider_preferences and _is_openrouter:
    extra_body["provider"] = provider_preferences
```

The summary path was missing this check.

Additionally, the summary path was missing `require_parameters` and `data_collection` from the provider preferences dict, unlike the main path which includes all six fields.

Closes #8591.

## Validation

```bash
uv run --extra dev pytest tests/run_agent/test_run_agent.py -k "HandleMaxIterations or provider_preferences_injected" -v
```

All 7 tests pass (4 existing + 3 new):
- `test_summary_includes_provider_preferences_for_openrouter` — OpenRouter gets provider prefs
- `test_summary_omits_provider_preferences_for_non_openrouter` — non-OpenRouter does NOT get provider prefs
- `test_summary_includes_require_parameters_for_openrouter` — `require_parameters` and `data_collection` are forwarded

## Files Changed

| File | Change |
|------|--------|
| `run_agent.py` | Gate provider prefs behind `_is_openrouter_url()`, add missing fields |
| `tests/run_agent/test_run_agent.py` | 3 regression tests covering both OpenRouter and non-OpenRouter summary paths |