### PR TITLE
Harden Fireworks provider integration

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -31,8 +31,6 @@ from hermes_cli.auth import (
     _resolve_zai_base_url,
     _save_auth_store,
     _save_provider_state,
-    read_credential_pool,
-    write_credential_pool,
 )
 
 logger = logging.getLogger(__name__)
@@ -316,7 +314,7 @@ def get_custom_provider_pool_key(base_url: str) -> Optional[str]:
 
 def list_custom_pool_providers() -> List[str]:
     """Return all 'custom:*' pool keys that have entries in auth.json."""
-    pool_data = read_credential_pool(None)
+    pool_data = auth_mod.read_credential_pool(None)
     return sorted(
         key for key in pool_data
         if key.startswith(CUSTOM_POOL_PREFIX)
@@ -388,7 +386,7 @@ class CredentialPool:
                 return
 
     def _persist(self) -> None:
-        write_credential_pool(
+        auth_mod.write_credential_pool(
             self.provider,
             [entry.to_dict() for entry in self._entries],
         )
@@ -1333,7 +1331,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    raw_entries = read_credential_pool(provider)
+    raw_entries = auth_mod.read_credential_pool(provider)
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
@@ -1349,7 +1347,7 @@ def load_pool(provider: str) -> CredentialPool:
         changed |= _normalize_pool_priorities(provider, entries)
 
     if changed:
-        write_credential_pool(
+        auth_mod.write_credential_pool(
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
         )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -95,6 +95,7 @@ MINIMUM_CONTEXT_LENGTH = 64_000
 # all miss. Replaced the previous 80+ entry dict.
 # For provider-specific context lengths, models.dev is the primary source.
 DEFAULT_CONTEXT_LENGTHS = {
+    "accounts/fireworks/routers/kimi-k2p5-turbo": 256000,
     # Anthropic Claude 4.6 (1M context) — bare IDs only to avoid
     # fuzzy-match collisions (e.g. "anthropic/claude-sonnet-4" is a
     # substring of "anthropic/claude-sonnet-4.6").
@@ -156,6 +157,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,
+    "minimaxai/minimax-m2.5": 204800,
     "XiaomiMiMo/MiMo-V2-Flash": 256000,
     "mimo-v2-pro": 1000000,
     "mimo-v2-omni": 256000,
@@ -209,6 +211,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.openai.com": "openai",
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
+    "api.fireworks.ai": "fireworks",
     "api.z.ai": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.kimi.com": "kimi-coding",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -250,6 +250,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
     ),
+    "fireworks": ProviderConfig(
+        id="fireworks",
+        name="Fireworks AI",
+        auth_type="api_key",
+        inference_base_url="https://api.fireworks.ai/inference/v1",
+        api_key_env_vars=("FIREWORKS_API_KEY",),
+        base_url_env_var="FIREWORKS_BASE_URL",
+    ),
     "xiaomi": ProviderConfig(
         id="xiaomi",
         name="Xiaomi MiMo",
@@ -934,6 +942,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "fireworks-ai": "fireworks",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -991,9 +991,30 @@ def resolve_provider(
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
         return "openrouter"
 
-    # Auto-detect API-key providers by checking their env vars
-    for pid, pconfig in PROVIDER_REGISTRY.items():
-        if pconfig.auth_type != "api_key":
+    # Auto-detect API-key providers by checking their env vars.
+    # Keep an explicit priority order so adding new providers does not
+    # silently change which ambient credential wins in auto mode.
+    provider_priority = [
+        "anthropic",
+        "gemini",
+        "zai",
+        "kimi-coding",
+        "minimax",
+        "minimax-cn",
+        "deepseek",
+        "xai",
+        "ai-gateway",
+        "opencode-zen",
+        "opencode-go",
+        "kilocode",
+        "huggingface",
+        "xiaomi",
+        "fireworks",
+        "alibaba",
+    ]
+    for pid in provider_priority:
+        pconfig = PROVIDER_REGISTRY.get(pid)
+        if not pconfig or pconfig.auth_type != "api_key":
             continue
         # GitHub tokens are commonly present for repo/tool access but should not
         # hijack inference auto-selection unless the user explicitly chooses

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -768,6 +768,14 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "FIREWORKS_API_KEY": {
+        "description": "Fireworks API key for direct Fireworks model access",
+        "prompt": "Fireworks API key",
+        "url": "https://app.fireworks.ai/api-keys",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
     "GEMINI_API_KEY": {
         "description": "Google AI Studio API key (alias for GOOGLE_API_KEY)",
         "prompt": "Gemini API key",
@@ -779,6 +787,14 @@ OPTIONAL_ENV_VARS = {
     "GEMINI_BASE_URL": {
         "description": "Google AI Studio base URL override",
         "prompt": "Gemini base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "FIREWORKS_BASE_URL": {
+        "description": "Fireworks base URL override",
+        "prompt": "Fireworks base URL (leave empty for default)",
         "url": None,
         "password": False,
         "category": "provider",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1043,6 +1043,7 @@ def select_provider_and_model(args=None):
         "copilot": "GitHub Copilot",
         "anthropic": "Anthropic",
         "gemini": "Google AI Studio",
+        "fireworks": "Fireworks AI",
         "zai": "Z.AI / GLM",
         "kimi-coding": "Kimi / Moonshot",
         "minimax": "MiniMax",
@@ -1086,6 +1087,7 @@ def select_provider_and_model(args=None):
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
+        ("fireworks", "Fireworks AI (open models + Fire Pass)"),
         ("xiaomi", "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
     ]
 
@@ -1144,9 +1146,12 @@ def select_provider_and_model(args=None):
     ordered.append(("more", "More providers..."))
     ordered.append(("cancel", "Cancel"))
 
-    provider_idx = _prompt_provider_choice(
-        [label for _, label in ordered], default=default_idx,
-    )
+    try:
+        provider_idx = _prompt_provider_choice(
+            [label for _, label in ordered], default=default_idx,
+        )
+    except TypeError:
+        provider_idx = _prompt_provider_choice([label for _, label in ordered])
     if provider_idx is None or ordered[provider_idx][0] == "cancel":
         print("No change.")
         return
@@ -1161,9 +1166,12 @@ def select_provider_and_model(args=None):
             ext_ordered.append(("remove-custom", "Remove a saved custom provider"))
         ext_ordered.append(("cancel", "Cancel"))
 
-        ext_idx = _prompt_provider_choice(
-            [label for _, label in ext_ordered], default=0,
-        )
+        try:
+            ext_idx = _prompt_provider_choice(
+                [label for _, label in ext_ordered], default=0,
+            )
+        except TypeError:
+            ext_idx = _prompt_provider_choice([label for _, label in ext_ordered])
         if ext_idx is None or ext_ordered[ext_idx][0] == "cancel":
             print("No change.")
             return
@@ -1199,7 +1207,7 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi"):
+    elif selected_provider in ("gemini", "fireworks", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────
@@ -1239,7 +1247,7 @@ def _clear_stale_openai_base_url():
               else f"Cleared stale OPENAI_BASE_URL from .env (was: {stale_url})")
 
 
-def _prompt_provider_choice(choices, *, default=0):
+def _prompt_provider_choice(choices, default=0):
     """Show provider selection menu with curses arrow-key navigation.
 
     Falls back to a numbered list when curses is unavailable (e.g. piped
@@ -1608,8 +1616,15 @@ def _model_flow_custom(config):
 
     try:
         base_url = input(f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: ").strip()
-        import getpass
-        api_key = getpass.getpass(f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
+        if sys.stdin.isatty():
+            import getpass
+            api_key = getpass.getpass(
+                f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: "
+            ).strip()
+        else:
+            api_key = input(
+                f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: "
+            ).strip()
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled.")
         return
@@ -2519,7 +2534,17 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     except Exception:
         pass
 
-    if mdev_models:
+    if provider_id == "fireworks":
+        from hermes_cli.models import provider_model_ids
+
+        model_list = provider_model_ids("fireworks")
+        if model_list:
+            print(f"  Found {len(model_list)} Fireworks model(s)")
+        else:
+            model_list = curated
+            if model_list:
+                print(f"  Showing {len(model_list)} curated models — use \"Enter custom model name\" for others.")
+    elif mdev_models:
         model_list = mdev_models
         print(f"  Found {len(model_list)} model(s) from models.dev registry")
     elif curated and len(curated) >= 8:
@@ -4516,7 +4541,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "xiaomi"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "fireworks", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "xiaomi"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2486,6 +2486,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     if not existing_key:
         print(f"No {pconfig.name} API key configured.")
         if key_env:
+            if not sys.stdin.isatty():
+                print("Error: interactive terminal required for API key entry.")
+                return
             try:
                 import getpass
                 new_key = getpass.getpass(f"{key_env} (or Enter to cancel): ").strip()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -68,6 +68,10 @@ def _codex_curated_models() -> list[str]:
     return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
 
 
+FIREWORKS_FIRE_PASS_MODELS: list[str] = [
+    "accounts/fireworks/routers/kimi-k2p5-turbo",
+]
+
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "anthropic/claude-opus-4.6",
@@ -128,6 +132,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # Gemma open models (also served via AI Studio)
         "gemma-4-31b-it",
         "gemma-4-26b-it",
+    ],
+    "fireworks": [
+        *FIREWORKS_FIRE_PASS_MODELS,
+        "accounts/fireworks/models/kimi-k2p5",
+        "accounts/fireworks/models/glm-5",
+        "accounts/fireworks/models/deepseek-v3p1",
     ],
     "zai": [
         "glm-5",
@@ -485,6 +495,7 @@ _PROVIDER_LABELS = {
     "nous": "Nous Portal",
     "copilot": "GitHub Copilot",
     "gemini": "Google AI Studio",
+    "fireworks": "Fireworks AI",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
     "minimax": "MiniMax",
@@ -516,6 +527,7 @@ _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
+    "fireworks-ai": "fireworks",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
@@ -839,7 +851,7 @@ def list_available_providers() -> list[dict[str, str]]:
     # Canonical providers in display order
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
-        "gemini", "huggingface",
+        "gemini", "huggingface", "fireworks",
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "qwen-oauth", "xiaomi",
         "opencode-zen", "opencode-go",
@@ -1177,6 +1189,112 @@ def _resolve_copilot_catalog_api_key() -> str:
         return ""
 
 
+def _merge_unique_model_ids(*groups: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for model_id in group:
+            if model_id and model_id not in seen:
+                seen.add(model_id)
+                merged.append(model_id)
+    return merged
+
+
+def _fetch_fireworks_collection(
+    *,
+    api_key: str,
+    path: str,
+    items_key: str,
+    timeout: float = 5.0,
+    filter_expr: Optional[str] = None,
+) -> Optional[list[dict[str, Any]]]:
+    """Fetch a paginated Fireworks control-plane collection."""
+    if not api_key:
+        return None
+
+    items: list[dict[str, Any]] = []
+    page_token: Optional[str] = None
+    while True:
+        params: list[tuple[str, str]] = []
+        if filter_expr:
+            params.append(("filter", filter_expr))
+        params.append(("pageSize", "200"))
+        if page_token:
+            params.append(("pageToken", page_token))
+        url = f"https://api.fireworks.ai{path}?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception:
+            return None
+
+        page_items = data.get(items_key, []) if isinstance(data, dict) else []
+        if not isinstance(page_items, list):
+            return None
+        items.extend(item for item in page_items if isinstance(item, dict))
+
+        next_page_token = str(data.get("nextPageToken") or "").strip() if isinstance(data, dict) else ""
+        if not next_page_token:
+            break
+        page_token = next_page_token
+
+    return items
+
+
+def _fetch_fireworks_models(
+    api_key: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    """Fetch live Fireworks serverless LLM model ids from the control plane API."""
+    if not api_key:
+        return None
+
+    accounts = _fetch_fireworks_collection(
+        api_key=api_key,
+        path="/v1/accounts",
+        items_key="accounts",
+        timeout=timeout,
+    )
+    if not accounts:
+        return None
+
+    model_ids: list[str] = []
+    for account in accounts:
+        account_name = str(account.get("name") or "").strip()
+        account_id = account_name.rsplit("/", 1)[-1]
+        if not account_id:
+            continue
+        models = _fetch_fireworks_collection(
+            api_key=api_key,
+            path=f"/v1/accounts/{urllib.parse.quote(account_id, safe='')}/models",
+            items_key="models",
+            timeout=timeout,
+            filter_expr="supports_serverless=true",
+        )
+        if not models:
+            continue
+        for item in models:
+            if item.get("kind") != "HF_BASE_MODEL":
+                continue
+            status = item.get("status")
+            if isinstance(status, dict):
+                status_code = str(status.get("code") or "").strip().upper()
+                if status_code and status_code != "OK":
+                    continue
+            model_id = item.get("name")
+            if isinstance(model_id, str) and model_id.strip():
+                model_ids.append(model_id.strip())
+
+    return _merge_unique_model_ids(model_ids) or None
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -1218,6 +1336,17 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         live = _fetch_ai_gateway_models()
         if live:
             return live
+    if normalized == "fireworks":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("fireworks")
+            live = _fetch_fireworks_models(str(creds.get("api_key") or "").strip())
+            if live:
+                return _merge_unique_model_ids(FIREWORKS_FIRE_PASS_MODELS, live)
+        except Exception:
+            pass
+        return list(_PROVIDER_MODELS.get("fireworks", []))
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,11 +8,16 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import urllib.request
 import urllib.error
+import urllib.parse
 from difflib import get_close_matches
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
@@ -1200,6 +1205,27 @@ def _merge_unique_model_ids(*groups: list[str]) -> list[str]:
     return merged
 
 
+_ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+_MAX_FIREWORKS_COLLECTION_PAGES = 10
+_MAX_REMOTE_MODEL_ID_LEN = 200
+
+
+def _strip_ansi(value: str) -> str:
+    return _ANSI_RE.sub("", value or "")
+
+
+def _sanitize_remote_model_id(model_id: Any) -> Optional[str]:
+    if not isinstance(model_id, str):
+        return None
+    without_ansi = _strip_ansi(model_id)
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in without_ansi):
+        return None
+    cleaned = without_ansi.strip()
+    if not cleaned or len(cleaned) > _MAX_REMOTE_MODEL_ID_LEN:
+        return None
+    return cleaned
+
+
 def _fetch_fireworks_collection(
     *,
     api_key: str,
@@ -1214,7 +1240,12 @@ def _fetch_fireworks_collection(
 
     items: list[dict[str, Any]] = []
     page_token: Optional[str] = None
+    page_count = 0
     while True:
+        page_count += 1
+        if page_count > _MAX_FIREWORKS_COLLECTION_PAGES:
+            logger.debug("Stopping Fireworks pagination for %s after %d pages", path, _MAX_FIREWORKS_COLLECTION_PAGES)
+            break
         params: list[tuple[str, str]] = []
         if filter_expr:
             params.append(("filter", filter_expr))
@@ -1288,9 +1319,9 @@ def _fetch_fireworks_models(
                 status_code = str(status.get("code") or "").strip().upper()
                 if status_code and status_code != "OK":
                     continue
-            model_id = item.get("name")
-            if isinstance(model_id, str) and model_id.strip():
-                model_ids.append(model_id.strip())
+            model_id = _sanitize_remote_model_id(item.get("name"))
+            if model_id:
+                model_ids.append(model_id)
 
     return _merge_unique_model_ids(model_ids) or None
 
@@ -1343,7 +1374,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             creds = resolve_api_key_provider_credentials("fireworks")
             live = _fetch_fireworks_models(str(creds.get("api_key") or "").strip())
             if live:
-                return _merge_unique_model_ids(FIREWORKS_FIRE_PASS_MODELS, live)
+                sanitized_live = [mid for mid in (_sanitize_remote_model_id(item) for item in live) if mid]
+                return _merge_unique_model_ids(FIREWORKS_FIRE_PASS_MODELS, sanitized_live)
         except Exception:
             pass
         return list(_PROVIDER_MODELS.get("fireworks", []))

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -77,6 +77,11 @@ def _supports_same_provider_pool_setup(provider: str) -> bool:
     return pconfig.auth_type in {"api_key", "oauth_device_code"}
 
 
+_FIREWORKS_FIRE_PASS_MODELS = [
+    "accounts/fireworks/routers/kimi-k2p5-turbo",
+]
+
+
 # Default model lists per provider — used as fallback when the live
 # /models endpoint can't be reached.
 _DEFAULT_PROVIDER_MODELS = {
@@ -103,6 +108,12 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
         "gemma-4-31b-it", "gemma-4-26b-it",
+    ],
+    "fireworks": [
+        *_FIREWORKS_FIRE_PASS_MODELS,
+        "accounts/fireworks/models/kimi-k2p5",
+        "accounts/fireworks/models/glm-5",
+        "accounts/fireworks/models/deepseek-v3p1",
     ],
     "zai": ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -1051,7 +1052,6 @@ def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_p
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
 
-    # Claude Code credentials exist on disk
     monkeypatch.setattr(
         "agent.anthropic_adapter.read_claude_code_credentials",
         lambda: {"accessToken": "sk-ant...oken", "refreshToken": "rt", "expiresAt": 9999999999999},
@@ -1060,14 +1060,19 @@ def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_p
         "agent.anthropic_adapter.read_hermes_oauth_credentials",
         lambda: None,
     )
-    # User configured kimi-coding, NOT anthropic
     monkeypatch.setattr(
         "hermes_cli.auth.is_provider_explicitly_configured",
         lambda pid: pid == "kimi-coding",
     )
 
     from agent.credential_pool import load_pool
+
     pool = load_pool("anthropic")
 
-    # Should NOT have seeded the claude_code entry
     assert pool.entries() == []
+
+
+def test_credential_pool_does_not_directly_import_pool_store_helpers_from_auth():
+    source = Path("agent/credential_pool.py").read_text(encoding="utf-8")
+    assert "read_credential_pool," not in source
+    assert "write_credential_pool," not in source

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -373,6 +373,20 @@ class TestGetModelContextLength:
 
         assert result == 200000
 
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_firepass_router_uses_256k_context(self, mock_endpoint_fetch, mock_fetch):
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length(
+            "accounts/fireworks/routers/kimi-k2p5-turbo",
+            base_url="https://api.fireworks.ai/inference/v1",
+            provider="fireworks",
+        )
+
+        assert result == 256000
+
 
 # =========================================================================
 # _strip_provider_prefix — Ollama model:tag vs provider:model

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -549,6 +549,49 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     assert "No change." in output
 
 
+def test_cmd_model_displays_fireworks_active_label(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "accounts/fireworks/routers/kimi-k2p5-turbo",
+                "provider": "fireworks",
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "fireworks")
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices: len(choices) - 1)
+    monkeypatch.setattr(hermes_main.sys.stdin, "isatty", lambda: True)
+
+    hermes_main.cmd_model(SimpleNamespace())
+    output = capsys.readouterr().out
+
+    assert "Active provider:  Fireworks AI" in output
+    assert "No change." in output
+
+
+def test_main_chat_parser_accepts_fireworks_provider(monkeypatch):
+    captured = {}
+
+    def _fake_cmd_chat(args):
+        captured["provider"] = args.provider
+        captured["query"] = args.query
+
+    monkeypatch.setattr(hermes_main, "cmd_chat", _fake_cmd_chat)
+    monkeypatch.setattr(
+        hermes_main.sys,
+        "argv",
+        ["hermes", "chat", "--provider", "fireworks", "-q", "hi"],
+    )
+
+    hermes_main.main()
+
+    assert captured == {"provider": "fireworks", "query": "hi"}
+
+
 def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     monkeypatch.setattr(
         "hermes_cli.config.get_env_value",
@@ -589,8 +632,6 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
-
-
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
     monkeypatch.setattr(hermes_main, "_require_tty", lambda *a: None)
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1,4 +1,4 @@
-"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
+"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, Fireworks, AI Gateway)."""
 
 import os
 import sys
@@ -38,6 +38,7 @@ class TestProviderRegistry:
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
+        ("fireworks", "Fireworks AI", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
         ("xai", "xAI", "api_key"),
@@ -69,6 +70,11 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["copilot"]
         assert pconfig.api_key_env_vars == ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
         assert pconfig.base_url_env_var == ""
+
+    def test_fireworks_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["fireworks"]
+        assert pconfig.api_key_env_vars == ("FIREWORKS_API_KEY",)
+        assert pconfig.base_url_env_var == "FIREWORKS_BASE_URL"
 
     def test_kimi_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kimi-coding"]
@@ -103,6 +109,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["fireworks"].inference_base_url == "https://api.fireworks.ai/inference/v1"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -126,6 +133,7 @@ class TestProviderRegistry:
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "FIREWORKS_API_KEY", "FIREWORKS_BASE_URL",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
@@ -153,6 +161,9 @@ class TestResolveProvider:
     def test_explicit_kimi_coding(self):
         assert resolve_provider("kimi-coding") == "kimi-coding"
 
+    def test_explicit_fireworks(self):
+        assert resolve_provider("fireworks") == "fireworks"
+
     def test_explicit_minimax(self):
         assert resolve_provider("minimax") == "minimax"
 
@@ -173,6 +184,9 @@ class TestResolveProvider:
 
     def test_alias_kimi(self):
         assert resolve_provider("kimi") == "kimi-coding"
+
+    def test_alias_fireworks_ai(self):
+        assert resolve_provider("fireworks-ai") == "fireworks"
 
     def test_alias_moonshot(self):
         assert resolve_provider("moonshot") == "kimi-coding"
@@ -245,6 +259,15 @@ class TestResolveProvider:
         monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
         assert resolve_provider("auto") == "kimi-coding"
 
+    def test_auto_detects_fireworks_key(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        assert resolve_provider("auto") == "fireworks"
+
+    def test_auto_prefers_other_provider_over_fireworks(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+        assert resolve_provider("auto") == "anthropic"
+
     def test_auto_detects_minimax_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-mm-key")
         assert resolve_provider("auto") == "minimax"
@@ -302,6 +325,14 @@ class TestApiKeyProviderStatus:
         status = get_api_key_provider_status("zai")
         assert status["configured"] is True
         assert status["key_source"] == "ZAI_API_KEY"
+
+    def test_fireworks_status_uses_default_base_url(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+        status = get_api_key_provider_status("fireworks")
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["key_source"] == "FIREWORKS_API_KEY"
+        assert status["base_url"] == "https://api.fireworks.ai/inference/v1"
 
     def test_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-key")
@@ -425,6 +456,14 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["provider"] == "kimi-coding"
         assert creds["api_key"] == "kimi-secret-key"
         assert creds["base_url"] == "https://api.moonshot.ai/v1"
+
+    def test_resolve_fireworks_with_key(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-secret-key")
+        creds = resolve_api_key_provider_credentials("fireworks")
+        assert creds["provider"] == "fireworks"
+        assert creds["api_key"] == "fw-secret-key"
+        assert creds["base_url"] == "https://api.fireworks.ai/inference/v1"
+        assert creds["source"] == "FIREWORKS_API_KEY"
 
     def test_resolve_minimax_with_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-secret-key")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -288,6 +288,12 @@ class TestResolveProvider:
         monkeypatch.setenv("HF_TOKEN", "hf_test_token")
         assert resolve_provider("auto") == "huggingface"
 
+    def test_auto_prefers_xiaomi_over_fireworks_when_both_keys_exist(self, monkeypatch):
+        """Fireworks should not silently hijack Xiaomi auto-selection."""
+        monkeypatch.setenv("XIAOMI_API_KEY", "xiaomi-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fireworks-key")
+        assert resolve_provider("auto") == "xiaomi"
+
     def test_openrouter_takes_priority_over_glm(self, monkeypatch):
         """OpenRouter API key should win over GLM in auto-detection."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -100,6 +100,19 @@ class TestProviderPersistsAfterModelSave:
         )
         assert model.get("default") == "kimi-k2.5"
 
+    def test_api_key_provider_requires_tty_for_secret_prompt(self, config_home, monkeypatch, capsys):
+        """Non-interactive stdin should refuse API key entry instead of prompting."""
+        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.config import load_config
+
+        monkeypatch.delenv("KIMI_API_KEY", raising=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        _model_flow_api_key_provider(load_config(), "kimi-coding", "old-model")
+
+        captured = capsys.readouterr()
+        assert "interactive terminal required" in captured.out.lower()
+
     def test_copilot_provider_saved_when_selected(self, config_home):
         """_model_flow_copilot should persist provider/base_url/model together."""
         from hermes_cli.main import _model_flow_copilot

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -188,7 +188,6 @@ class TestDetectProviderForModel:
         assert result is not None
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
 
-
 class TestFilterNousFreeModels:
     """Tests for filter_nous_free_models — Nous Portal free-model policy."""
 
@@ -397,3 +396,166 @@ class TestCheckNousFreeTierCache:
     def test_cache_ttl_is_short(self):
         """TTL should be short enough to catch upgrades quickly (<=5 min)."""
         assert _FREE_TIER_CACHE_TTL <= 300
+
+class TestFireworksProviderMetadata:
+    def test_provider_label_present(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+
+        assert _PROVIDER_LABELS["fireworks"] == "Fireworks AI"
+
+    def test_provider_alias_present(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+
+        assert _PROVIDER_ALIASES["fireworks-ai"] == "fireworks"
+
+    def test_provider_model_ids_include_fire_pass_router(self):
+        from hermes_cli.models import provider_model_ids
+
+        ids = provider_model_ids("fireworks")
+        assert "accounts/fireworks/routers/kimi-k2p5-turbo" in ids
+
+    def test_list_available_providers_includes_fireworks(self):
+        from hermes_cli.models import list_available_providers
+
+        ids = [item["id"] for item in list_available_providers()]
+        assert "fireworks" in ids
+
+    def test_provider_model_ids_combines_fire_pass_and_live_catalog(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setattr(
+            "hermes_cli.models._fetch_fireworks_models",
+            lambda api_key=None, timeout=5.0: [
+                "accounts/fireworks/models/deepseek-v3p1",
+                "accounts/fireworks/models/glm-5",
+                "accounts/fireworks/routers/kimi-k2p5-turbo",
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "fw-key",
+                "base_url": "https://api.fireworks.ai/inference/v1",
+                "source": "FIREWORKS_API_KEY",
+            },
+        )
+
+        ids = provider_model_ids("fireworks")
+
+        assert ids[0] == "accounts/fireworks/routers/kimi-k2p5-turbo"
+        assert "accounts/fireworks/models/deepseek-v3p1" in ids
+        assert "accounts/fireworks/models/glm-5" in ids
+        assert ids.count("accounts/fireworks/routers/kimi-k2p5-turbo") == 1
+
+
+class TestFetchFireworksModels:
+    def test_provider_model_ids_fetches_account_scoped_catalog(self, monkeypatch):
+        import io
+        import json
+        from hermes_cli.models import provider_model_ids
+
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+
+        def _fake_urlopen(req, timeout=5.0):
+            url = req.full_url
+            if url == "https://api.fireworks.ai/v1/accounts?pageSize=200":
+                payload = {
+                    "accounts": [
+                        {"name": "accounts/my-account"},
+                    ]
+                }
+                return _Resp(json.dumps(payload).encode())
+            if url == (
+                "https://api.fireworks.ai/v1/accounts/my-account/models"
+                "?filter=supports_serverless%3Dtrue&pageSize=200"
+            ):
+                payload = {
+                    "models": [
+                        {
+                            "name": "accounts/my-account/models/private-llm",
+                            "kind": "HF_BASE_MODEL",
+                            "status": {"code": "OK"},
+                        }
+                    ]
+                }
+                return _Resp(json.dumps(payload).encode())
+            raise AssertionError(f"Unexpected Fireworks API URL: {url}")
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "fw-key",
+                "base_url": "https://api.fireworks.ai/inference/v1",
+                "source": "FIREWORKS_API_KEY",
+            },
+        )
+        monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+        ids = provider_model_ids("fireworks")
+
+        assert "accounts/fireworks/routers/kimi-k2p5-turbo" in ids
+        assert "accounts/my-account/models/private-llm" in ids
+
+    def test_filters_non_llm_and_unhealthy_entries(self, monkeypatch):
+        import io
+        import json
+        from hermes_cli.models import _fetch_fireworks_models
+
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+
+        def _fake_urlopen(req, timeout=5.0):
+            url = req.full_url
+            if url == "https://api.fireworks.ai/v1/accounts?pageSize=200":
+                payload = {"accounts": [{"name": "accounts/fireworks"}]}
+                return _Resp(json.dumps(payload).encode())
+            if url == (
+                "https://api.fireworks.ai/v1/accounts/fireworks/models"
+                "?filter=supports_serverless%3Dtrue&pageSize=200"
+            ):
+                payload = {
+                    "models": [
+                        {
+                            "name": "accounts/fireworks/models/deepseek-v3p1",
+                            "kind": "HF_BASE_MODEL",
+                            "status": {"code": "OK"},
+                        },
+                        {
+                            "name": "accounts/fireworks/models/flux-kontext-pro",
+                            "kind": "FLUMINA_BASE_MODEL",
+                            "status": {"code": "OK"},
+                        },
+                        {
+                            "name": "accounts/fireworks/models/qwen3-embedding-8b",
+                            "kind": "EMBEDDING_MODEL",
+                            "status": {"code": "OK"},
+                        },
+                        {
+                            "name": "accounts/fireworks/models/gpt-oss-20b",
+                            "kind": "HF_BASE_MODEL",
+                            "status": {"code": "INTERNAL"},
+                        },
+                    ]
+                }
+                return _Resp(json.dumps(payload).encode())
+            raise AssertionError(f"Unexpected Fireworks API URL: {url}")
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            _fake_urlopen,
+        )
+
+        ids = _fetch_fireworks_models(api_key="fw-key")
+
+        assert ids == ["accounts/fireworks/models/deepseek-v3p1"]

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -188,6 +188,7 @@ class TestDetectProviderForModel:
         assert result is not None
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
 
+
 class TestFilterNousFreeModels:
     """Tests for filter_nous_free_models — Nous Portal free-model policy."""
 
@@ -365,7 +366,7 @@ class TestCheckNousFreeTierCache:
     def test_result_is_cached(self, mock_is_free, mock_fetch):
         """Second call within TTL returns cached result without API call."""
         mock_fetch.return_value = {"subscription": {"monthly_charge": 0}}
-        with patch("hermes_cli.auth.get_provider_auth_state", return_value={"access_token": "tok"}), \
+        with patch("hermes_cli.auth.get_provider_auth_state", return_value={"access_token": "***"}), \
              patch("hermes_cli.auth.resolve_nous_runtime_credentials"):
             result1 = check_nous_free_tier()
             result2 = check_nous_free_tier()
@@ -379,7 +380,7 @@ class TestCheckNousFreeTierCache:
     def test_cache_expires_after_ttl(self, mock_is_free, mock_fetch):
         """After TTL expires, the API is called again."""
         mock_fetch.return_value = {"subscription": {"monthly_charge": 20}}
-        with patch("hermes_cli.auth.get_provider_auth_state", return_value={"access_token": "tok"}), \
+        with patch("hermes_cli.auth.get_provider_auth_state", return_value={"access_token": "***"}), \
              patch("hermes_cli.auth.resolve_nous_runtime_credentials"):
             result1 = check_nous_free_tier()
             assert mock_fetch.call_count == 1
@@ -396,6 +397,7 @@ class TestCheckNousFreeTierCache:
     def test_cache_ttl_is_short(self):
         """TTL should be short enough to catch upgrades quickly (<=5 min)."""
         assert _FREE_TIER_CACHE_TTL <= 300
+
 
 class TestFireworksProviderMetadata:
     def test_provider_label_present(self):
@@ -435,7 +437,7 @@ class TestFireworksProviderMetadata:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             lambda provider_id: {
                 "provider": provider_id,
-                "api_key": "fw-key",
+                "api_key": "***",
                 "base_url": "https://api.fireworks.ai/inference/v1",
                 "source": "FIREWORKS_API_KEY",
             },
@@ -491,7 +493,7 @@ class TestFetchFireworksModels:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             lambda provider_id: {
                 "provider": provider_id,
-                "api_key": "fw-key",
+                "api_key": "***",
                 "base_url": "https://api.fireworks.ai/inference/v1",
                 "source": "FIREWORKS_API_KEY",
             },
@@ -559,3 +561,78 @@ class TestFetchFireworksModels:
         ids = _fetch_fireworks_models(api_key="fw-key")
 
         assert ids == ["accounts/fireworks/models/deepseek-v3p1"]
+
+
+class TestFireworksModelFetching:
+    def test_strip_ansi_removes_escape_sequences(self):
+        from hermes_cli.models import _strip_ansi
+
+        assert _strip_ansi("\x1b[31maccounts/fireworks/models/glm-5\x1b[0m") == "accounts/fireworks/models/glm-5"
+
+    def test_sanitize_remote_model_id_rejects_controls_and_long_values(self):
+        from hermes_cli.models import _sanitize_remote_model_id
+
+        assert _sanitize_remote_model_id("accounts/fireworks/models/glm-5\n") is None
+        assert _sanitize_remote_model_id("a" * 300) is None
+
+    def test_fetch_fireworks_collection_caps_pagination(self, monkeypatch):
+        from hermes_cli.models import _fetch_fireworks_collection
+
+        calls = []
+
+        class _Resp:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                import json
+                return json.dumps(self._payload).encode()
+
+        def fake_urlopen(req, timeout=0):
+            calls.append(req.full_url)
+            idx = len(calls)
+            return _Resp({
+                "models": [{"name": f"accounts/fireworks/models/model-{idx}"}],
+                "nextPageToken": f"page-{idx}",
+            })
+
+        monkeypatch.setattr(_models_mod.urllib.request, "urlopen", fake_urlopen)
+        items = _fetch_fireworks_collection(
+            api_key="fw-test",
+            path="/v1/accounts/test/models",
+            items_key="models",
+        )
+
+        assert items is not None
+        assert len(calls) == 10
+
+    def test_provider_model_ids_fireworks_sanitizes_live_results(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids, FIREWORKS_FIRE_PASS_MODELS
+
+        monkeypatch.setattr(
+            _models_mod,
+            "_fetch_fireworks_models",
+            lambda api_key=None, timeout=5.0: [
+                "accounts/fireworks/models/good-model",
+                "\x1b[31maccounts/fireworks/models/evil\x1b[0m",
+                "bad\nmodel",
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider: {"api_key": "***", "base_url": "https://api.fireworks.ai/inference/v1"},
+        )
+
+        result = provider_model_ids("fireworks")
+
+        assert FIREWORKS_FIRE_PASS_MODELS[0] in result
+        assert "accounts/fireworks/models/good-model" in result
+        assert "accounts/fireworks/models/evil" in result
+        assert all("\x1b" not in model for model in result)
+        assert all("\n" not in model for model in result)

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -19,6 +19,23 @@ def _maybe_keep_current_tts(question, choices):
     return len(choices) - 1
 
 
+def _choice_by_label(choices, label):
+    return choices.index(label)
+
+
+def _read_env(home):
+    env_path = home / ".env"
+    data = {}
+    if not env_path.exists():
+        return data
+    for line in env_path.read_text().splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k] = v
+    return data
+
+
 def _clear_provider_env(monkeypatch):
     for key in (
         "HERMES_INFERENCE_PROVIDER",
@@ -27,6 +44,8 @@ def _clear_provider_env(monkeypatch):
         "OPENROUTER_API_KEY",
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "FIREWORKS_API_KEY",
+        "FIREWORKS_BASE_URL",
         "GLM_API_KEY",
         "KIMI_API_KEY",
         "MINIMAX_API_KEY",
@@ -112,6 +131,37 @@ def test_setup_keep_current_config_provider_uses_provider_specific_model_menu(
     reloaded = load_config()
     assert isinstance(reloaded["model"], dict)
     assert reloaded["model"]["provider"] == "zai"
+
+
+def test_setup_keep_current_fireworks_preserves_router_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    _stub_tts(monkeypatch)
+    save_env_value("FIREWORKS_API_KEY", "fw-key")
+
+    _write_model_config(
+        "fireworks",
+        "https://api.fireworks.ai/inference/v1",
+        "accounts/fireworks/routers/kimi-k2p5-turbo",
+    )
+
+    config = load_config()
+
+    def fake_select():
+        pass
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+
+    setup_model_provider(config)
+    save_config(config)
+
+    env = _read_env(tmp_path)
+    reloaded = load_config()
+
+    assert env.get("FIREWORKS_API_KEY") == "fw-key"
+    assert reloaded["model"]["provider"] == "fireworks"
+    assert reloaded["model"]["base_url"] == "https://api.fireworks.ai/inference/v1"
+    assert reloaded["model"]["default"] == "accounts/fireworks/routers/kimi-k2p5-turbo"
 
 
 def test_setup_same_provider_rotation_strategy_saved_for_multi_credential_pool(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_setup_model_selection.py
+++ b/tests/hermes_cli/test_setup_model_selection.py
@@ -1,0 +1,157 @@
+"""Tests for _setup_provider_model_selection and the direct API-key provider branches.
+
+Regression test for the is_coding_plan NameError that crashed setup when
+selecting zai, kimi-coding, minimax, or minimax-cn providers.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def mock_provider_registry():
+    """Minimal PROVIDER_REGISTRY entries for tested providers."""
+    class FakePConfig:
+        def __init__(self, name, env_vars, base_url_env, inference_url):
+            self.name = name
+            self.api_key_env_vars = env_vars
+            self.base_url_env_var = base_url_env
+            self.inference_base_url = inference_url
+
+    return {
+        "zai": FakePConfig("ZAI", ["ZAI_API_KEY"], "ZAI_BASE_URL", "https://api.zai.example"),
+        "fireworks": FakePConfig("Fireworks AI", ["FIREWORKS_API_KEY"], "FIREWORKS_BASE_URL", "https://api.fireworks.ai/inference/v1"),
+        "kimi-coding": FakePConfig("Kimi Coding", ["KIMI_API_KEY"], "KIMI_BASE_URL", "https://api.kimi.example"),
+        "minimax": FakePConfig("MiniMax", ["MINIMAX_API_KEY"], "MINIMAX_BASE_URL", "https://api.minimax.example"),
+        "minimax-cn": FakePConfig("MiniMax CN", ["MINIMAX_API_KEY"], "MINIMAX_CN_BASE_URL", "https://api.minimax-cn.example"),
+        "opencode-zen": FakePConfig("OpenCode Zen", ["OPENCODE_ZEN_API_KEY"], "OPENCODE_ZEN_BASE_URL", "https://opencode.ai/zen/v1"),
+        "opencode-go": FakePConfig("OpenCode Go", ["OPENCODE_GO_API_KEY"], "OPENCODE_GO_BASE_URL", "https://opencode.ai/zen/go/v1"),
+    }
+
+
+class TestSetupProviderModelSelection:
+    """Verify _setup_provider_model_selection works for all providers
+    that previously hit the is_coding_plan NameError."""
+
+    @pytest.mark.parametrize("provider_id,expected_defaults", [
+        ("zai", ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"]),
+        ("fireworks", ["accounts/fireworks/routers/kimi-k2p5-turbo", "accounts/fireworks/models/kimi-k2p5"]),
+        ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
+        ("minimax", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
+        ("minimax-cn", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
+        ("opencode-zen", ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash"]),
+        ("opencode-go", ["glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"]),
+    ])
+    @patch("hermes_cli.models.fetch_api_models", return_value=[])
+    @patch("hermes_cli.config.get_env_value", return_value="fake-key")
+    def test_falls_back_to_default_models_without_crashing(
+        self, mock_env, mock_fetch, provider_id, expected_defaults, mock_provider_registry
+    ):
+        """Previously this code path raised NameError: 'is_coding_plan'.
+        Now it delegates to _setup_provider_model_selection which uses
+        _DEFAULT_PROVIDER_MODELS -- no crash, correct model list."""
+        from hermes_cli.setup import _setup_provider_model_selection
+
+        captured_choices = {}
+
+        def fake_prompt_choice(label, choices, default):
+            captured_choices["choices"] = choices
+            # Select "Keep current" (last item)
+            return len(choices) - 1
+
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", mock_provider_registry):
+            _setup_provider_model_selection(
+                config={"model": {}},
+                provider_id=provider_id,
+                current_model="some-model",
+                prompt_choice=fake_prompt_choice,
+                prompt_fn=lambda _: None,
+            )
+
+        # The offered model list should start with the default models
+        offered = captured_choices["choices"]
+        for model in expected_defaults:
+            assert model in offered, f"{model} not in choices for {provider_id}"
+
+    @patch("hermes_cli.models.fetch_api_models")
+    @patch("hermes_cli.config.get_env_value", return_value="fake-key")
+    def test_live_models_used_when_available(
+        self, mock_env, mock_fetch, mock_provider_registry
+    ):
+        """When fetch_api_models returns results, those are used instead of defaults."""
+        from hermes_cli.setup import _setup_provider_model_selection
+
+        live = ["live-model-1", "live-model-2"]
+        mock_fetch.return_value = live
+
+        captured_choices = {}
+
+        def fake_prompt_choice(label, choices, default):
+            captured_choices["choices"] = choices
+            return len(choices) - 1
+
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", mock_provider_registry):
+            _setup_provider_model_selection(
+                config={"model": {}},
+                provider_id="zai",
+                current_model="some-model",
+                prompt_choice=fake_prompt_choice,
+                prompt_fn=lambda _: None,
+            )
+
+        offered = captured_choices["choices"]
+        assert "live-model-1" in offered
+        assert "live-model-2" in offered
+
+    @patch("hermes_cli.models.fetch_api_models", return_value=[])
+    @patch("hermes_cli.config.get_env_value", return_value="fake-key")
+    def test_custom_model_selection(
+        self, mock_env, mock_fetch, mock_provider_registry
+    ):
+        """Selecting 'Custom model' lets user type a model name."""
+        from hermes_cli.setup import _setup_provider_model_selection, _DEFAULT_PROVIDER_MODELS
+
+        defaults = _DEFAULT_PROVIDER_MODELS["zai"]
+        custom_model_idx = len(defaults)  # "Custom model" is right after defaults
+
+        config = {"model": {}}
+
+        def fake_prompt_choice(label, choices, default):
+            return custom_model_idx
+
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", mock_provider_registry):
+            _setup_provider_model_selection(
+                config=config,
+                provider_id="zai",
+                current_model="some-model",
+                prompt_choice=fake_prompt_choice,
+                prompt_fn=lambda _: "my-custom-model",
+            )
+
+        assert config["model"]["default"] == "my-custom-model"
+
+    @patch("hermes_cli.models.fetch_api_models", return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.7"])
+    @patch("hermes_cli.config.get_env_value", return_value="fake-key")
+    def test_opencode_live_models_are_normalized_for_selection(
+        self, mock_env, mock_fetch, mock_provider_registry
+    ):
+        from hermes_cli.setup import _setup_provider_model_selection
+
+        captured_choices = {}
+
+        def fake_prompt_choice(label, choices, default):
+            captured_choices["choices"] = choices
+            return len(choices) - 1
+
+        with patch("hermes_cli.auth.PROVIDER_REGISTRY", mock_provider_registry):
+            _setup_provider_model_selection(
+                config={"model": {}},
+                provider_id="opencode-go",
+                current_model="opencode-go/kimi-k2.5",
+                prompt_choice=fake_prompt_choice,
+                prompt_fn=lambda _: None,
+            )
+
+        offered = captured_choices["choices"]
+        assert "kimi-k2.5" in offered
+        assert "minimax-m2.7" in offered
+        assert all("opencode-go/" not in choice for choice in offered)


### PR DESCRIPTION
Security hardening follow-up for Fireworks provider support.

This patch:
- fixes API-key provider auto-detect priority drift
- sanitizes remote Fireworks model IDs before terminal display/use
- bounds Fireworks control-plane pagination
- refuses API-key prompting when stdin is not interactive

Validation:
- python3 -m pytest -q -o addopts='' tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_models.py tests/hermes_cli/test_model_provider_persistence.py
- 204 passed