### PR TITLE
dfeat(compression): per-model summarization model routing

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -79,6 +79,29 @@ class ContextCompressor(ContextEngine):
         self._context_probe_persistable = False
         self._previous_summary = None
 
+    def _resolve_summary_model(self, main_model: str) -> str:
+        """Resolve the summarization model for a given main model.
+
+        Checks ``self.summary_models`` for a per-model override first
+        (longest-prefix match), then falls back to the global
+        ``self._global_summary_model`` (from ``compression.summary_model``).
+        """
+        if not self.summary_models or not main_model:
+            return self._global_summary_model or ""
+        # Exact match first
+        if main_model in self.summary_models:
+            return self.summary_models[main_model]
+        # Longest-prefix match (e.g. "gpt-5.4" matches "gpt-5.4-0620")
+        best_match = ""
+        best_key = ""
+        for key, val in self.summary_models.items():
+            if main_model.startswith(key) and len(key) > len(best_key):
+                best_key = key
+                best_match = val
+        if best_match:
+            return best_match
+        return self._global_summary_model or ""
+
     def update_model(
         self,
         model: str,
@@ -99,6 +122,8 @@ class ContextCompressor(ContextEngine):
             int(context_length * self.threshold_percent),
             MINIMUM_CONTEXT_LENGTH,
         )
+        # Re-resolve summary model for the new main model
+        self.summary_model = self._resolve_summary_model(model)
 
     def __init__(
         self,
@@ -109,6 +134,7 @@ class ContextCompressor(ContextEngine):
         summary_target_ratio: float = 0.20,
         quiet_mode: bool = False,
         summary_model_override: str = None,
+        summary_models: dict = None,
         base_url: str = "",
         api_key: str = "",
         config_context_length: int | None = None,
@@ -125,6 +151,10 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+
+        # Per-model summary routing: maps main model name (or prefix) to the
+        # summarization model to use.  Empty dict = no per-model overrides.
+        self.summary_models: dict = summary_models or {}
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -152,18 +182,21 @@ class ContextCompressor(ContextEngine):
             logger.info(
                 "Context compressor initialized: model=%s context_length=%d "
                 "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
-                "provider=%s base_url=%s",
+                "provider=%s base_url=%s summary_models=%s",
                 model, self.context_length, self.threshold_tokens,
                 threshold_percent * 100, self.summary_target_ratio * 100,
                 self.tail_token_budget,
                 provider or "none", base_url or "none",
+                self.summary_models or "{}",
             )
         self._context_probed = False  # True after a step-down from context error
 
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
 
-        self.summary_model = summary_model_override or ""
+        # Resolve summary model: per-model override > global override
+        self._global_summary_model = summary_model_override or ""
+        self.summary_model = self._resolve_summary_model(model)
 
         # Stores the previous compaction summary for iterative updates
         self._previous_summary: Optional[str] = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -1213,6 +1213,9 @@ class AIAgent:
         compression_threshold = float(_compression_cfg.get("threshold", 0.50))
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_summary_model = _compression_cfg.get("summary_model") or None
+        _compression_summary_models = _compression_cfg.get("summary_models")
+        if not isinstance(_compression_summary_models, dict):
+            _compression_summary_models = {}
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
 
@@ -1230,6 +1233,7 @@ class AIAgent:
 
         # Store for reuse in switch_model (so config override persists across model switches)
         self._config_context_length = _config_context_length
+        self._compression_summary_models = _compression_summary_models
 
         # Check custom_providers per-model context_length
         if _config_context_length is None:
@@ -1302,6 +1306,7 @@ class AIAgent:
                 protect_last_n=compression_protect_last,
                 summary_target_ratio=compression_target_ratio,
                 summary_model_override=compression_summary_model,
+                summary_models=_compression_summary_models,
                 quiet_mode=self.quiet_mode,
                 base_url=self.base_url,
                 api_key=getattr(self, "api_key", ""),

--- a/tests/agent/test_per_model_summary.py
+++ b/tests/agent/test_per_model_summary.py
@@ -1,0 +1,203 @@
+"""Tests for per-model summarization model routing.
+
+Covers the ``summary_models`` config option that maps main models to their
+preferred summarization model, with longest-prefix matching and fallback
+to the global ``summary_model``.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _make(**kwargs):
+    """Create a ContextCompressor with mocked get_model_context_length."""
+    defaults = {
+        "model": "test/model",
+        "quiet_mode": True,
+    }
+    defaults.update(kwargs)
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100000
+    ):
+        return ContextCompressor(**defaults)
+
+
+class TestResolveSummaryModelExactMatch:
+    def test_exact_match_wins(self):
+        c = _make(
+            summary_model_override="global/summary-model",
+            summary_models={"test/model": "test/summary-model"},
+        )
+        assert c.summary_model == "test/summary-model"
+
+    def test_exact_match_case_sensitive(self):
+        c = _make(
+            summary_model_override="global/summary",
+            summary_models={"Test/Model": "other/summary"},
+        )
+        # "test/model" != "Test/Model"
+        assert c.summary_model == "global/summary"
+
+
+class TestResolveSummaryModelPrefixMatch:
+    def test_prefix_match(self):
+        c = _make(
+            model="gpt-5.4-0620",
+            summary_model_override="global/summary",
+            summary_models={"gpt-5.4": "gpt-5.3-codex-spark"},
+        )
+        assert c.summary_model == "gpt-5.3-codex-spark"
+
+    def test_longest_prefix_wins(self):
+        c = _make(
+            model="gpt-5.4-0620-preview",
+            summary_model_override="global/summary",
+            summary_models={
+                "gpt-5": "gpt-5-base-summary",
+                "gpt-5.4": "gpt-5.4-summary",
+                "gpt-5.4-0620": "gpt-5.4-0620-summary",
+            },
+        )
+        assert c.summary_model == "gpt-5.4-0620-summary"
+
+    def test_prefix_no_partial_word_match(self):
+        """Prefix matching is literal — 'gpt-5' matches 'gpt-5.4'."""
+        c = _make(
+            model="gpt-5.4",
+            summary_model_override="global/summary",
+            summary_models={"gpt-5": "gpt-5-summary"},
+        )
+        assert c.summary_model == "gpt-5-summary"
+
+
+class TestResolveSummaryModelFallback:
+    def test_no_match_uses_global(self):
+        c = _make(
+            model="claude-sonnet-4",
+            summary_model_override="global/summary",
+            summary_models={"gpt-5.4": "gpt-5.3-codex-spark"},
+        )
+        assert c.summary_model == "global/summary"
+
+    def test_no_global_no_match(self):
+        c = _make(
+            model="claude-sonnet-4",
+            summary_models={"gpt-5.4": "gpt-5.3-codex-spark"},
+        )
+        assert c.summary_model == ""
+
+    def test_empty_dict_uses_global(self):
+        c = _make(
+            model="test/model",
+            summary_model_override="global/summary",
+            summary_models={},
+        )
+        assert c.summary_model == "global/summary"
+
+    def test_none_dict_uses_global(self):
+        c = _make(
+            model="test/model",
+            summary_model_override="global/summary",
+            summary_models=None,
+        )
+        assert c.summary_model == "global/summary"
+
+    def test_no_global_no_dict(self):
+        c = _make(model="test/model")
+        assert c.summary_model == ""
+
+
+class TestUpdateModelResolvesSummary:
+    def test_update_model_re_resolves(self):
+        c = _make(
+            model="glm-5.1",
+            summary_model_override="global/summary",
+            summary_models={
+                "glm": "glm/cheap-summary",
+                "gpt-5.4": "gpt-5.3-codex-spark",
+            },
+        )
+        assert c.summary_model == "glm/cheap-summary"
+
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=200000
+        ):
+            c.update_model(
+                model="gpt-5.4",
+                context_length=200000,
+                base_url="",
+                api_key="",
+                provider="openai-codex",
+            )
+        assert c.summary_model == "gpt-5.3-codex-spark"
+
+    def test_update_model_falls_back_to_global(self):
+        c = _make(
+            model="glm-5.1",
+            summary_model_override="global/summary",
+            summary_models={"gpt-5.4": "gpt-5.3-codex-spark"},
+        )
+
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=200000
+        ):
+            c.update_model(
+                model="claude-sonnet-4",
+                context_length=200000,
+            )
+        assert c.summary_model == "global/summary"
+
+    def test_update_model_preserves_summary_models_dict(self):
+        """The summary_models dict should survive model switches."""
+        sm = {"gpt-5.4": "gpt-5.3-codex-spark", "glm": "glm/summary"}
+        c = _make(
+            model="gpt-5.4",
+            summary_model_override="global/summary",
+            summary_models=sm,
+        )
+        assert c.summary_model == "gpt-5.3-codex-spark"
+
+        # Switch to a model with no per-model override
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=200000
+        ):
+            c.update_model(model="unknown-model", context_length=200000)
+        assert c.summary_model == "global/summary"
+
+        # Switch back — should still work
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=200000
+        ):
+            c.update_model(model="gpt-5.4", context_length=200000)
+        assert c.summary_model == "gpt-5.3-codex-spark"
+
+
+class TestBackwardCompatibility:
+    """Existing configs without summary_models should work identically."""
+
+    def test_no_summary_models_uses_override(self):
+        c = _make(
+            model="test/model",
+            summary_model_override="google/gemini-3-flash-preview",
+        )
+        assert c.summary_model == "google/gemini-3-flash-preview"
+
+    def test_no_summary_models_no_override(self):
+        c = _make(model="test/model")
+        assert c.summary_model == ""
+
+    def test_existing_fixture_pattern(self):
+        """The default test fixture pattern should still work."""
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=100000
+        ):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+        assert c.summary_model == ""


### PR DESCRIPTION
Add compression.summary_models config option that maps main model names to their preferred summarization model. Supports exact match and longest-prefix matching (e.g. 'gpt-5.4' matches 'gpt-5.4-0620').

When no per-model match is found, falls back to the existing global compression.summary_model setting. Fully backward compatible -- configs without summary_models work identically.

Example config:
  compression:
    summary_model: google/gemini-3-flash-preview  # default
    summary_models:                                # per-model overrides
      gpt-5.4: gpt-5.3-codex-spark
      glm: glm-4.7-flash

The summary model is re-resolved on model switch via /model command or fallback activation, so each model always uses its configured summarizer.

Changes:
- context_compressor.py: add summary_models param, _resolve_summary_model() method with prefix matching, re-resolve in update_model()
- run_agent.py: read summary_models from config, pass to compressor, store for switch_model reuse
- test_per_model_summary.py: 16 tests covering exact/prefix/fallback/ update/backward-compat scenarios

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

