### PR TITLE
fix(copilot-acp): keep ACP runtime off responses path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1248,6 +1248,8 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
+    if sync_client.__class__.__name__ == "CopilotACPClient":
+        return sync_client, model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -1488,7 +1490,11 @@ def resolve_provider_client(
 
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
     try:
-        from hermes_cli.auth import PROVIDER_REGISTRY, resolve_api_key_provider_credentials
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            resolve_api_key_provider_credentials,
+            resolve_external_process_provider_credentials,
+        )
     except ImportError:
         logger.debug("hermes_cli.auth not available for provider %s", provider)
         return None, None
@@ -1561,6 +1567,35 @@ def resolve_provider_client(
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
+
+    if pconfig.auth_type == "external_process":
+        creds = resolve_external_process_provider_credentials(provider)
+        final_model = _normalize_resolved_model(model or _read_main_model(), provider)
+        if provider == "copilot-acp":
+            # Do not invent a fallback model here. For ACP runtimes we either
+            # have an explicit model (task/runtime override) or a configured
+            # main model. Guessing a hard-coded model silently changes user
+            # intent and can hide configuration problems.
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: copilot-acp requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            from agent.copilot_acp_client import CopilotACPClient
+
+            client = CopilotACPClient(
+                api_key=str(creds.get("api_key", "")).strip() or "copilot-acp",
+                base_url=str(creds.get("base_url", "")).strip() or "acp://copilot",
+                command=str(creds.get("command", "")).strip() or None,
+                args=list(creds.get("args") or []),
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model) if async_mode
+                    else (client, final_model))
+        logger.warning("resolve_provider_client: external-process provider %s not "
+                       "directly supported", provider)
+        return None, None
 
     elif pconfig.auth_type in ("oauth_device_code", "oauth_external"):
         # OAuth providers — route through their specific try functions

--- a/run_agent.py
+++ b/run_agent.py
@@ -671,13 +671,25 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
+        # GPT-5.x models often require the Responses API path — they are
+        # rejected on /v1/chat/completions by both OpenAI and OpenRouter.
+        # Also auto-upgrade for direct OpenAI URLs (api.openai.com) since
         # newer tool-calling models prefer Responses there.
-        if self.api_mode == "chat_completions" and (
-            self._is_direct_openai_url()
-            or self._model_requires_responses_api(self.model)
+        #
+        # copilot-acp is intentionally excluded here: CopilotACPClient is an
+        # ACP transport client with chat-completions semantics and does not
+        # expose a `.responses` interface. Routing ACP turns through the
+        # generic Responses upgrade path causes runtime failures instead of
+        # being a harmless model selection optimization.
+        if (
+            self.api_mode == "chat_completions"
+            and self.provider != "copilot-acp"
+            and not str(self.base_url or "").lower().startswith("acp://copilot")
+            and not str(self.base_url or "").lower().startswith("acp+tcp://")
+            and (
+                self._is_direct_openai_url()
+                or self._model_requires_responses_api(self.model)
+            )
         ):
             self.api_mode = "codex_responses"
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1059,6 +1059,46 @@ model:
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"
 
 
+def test_resolve_provider_client_supports_copilot_acp_external_process():
+    fake_client = MagicMock()
+
+    with patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4-mini"), \
+         patch("agent.auxiliary_client.CodexAuxiliaryClient", MagicMock()), \
+         patch("agent.copilot_acp_client.CopilotACPClient", return_value=fake_client) as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is fake_client
+    assert model == "gpt-5.4-mini"
+    assert mock_acp.call_args.kwargs["api_key"] == "copilot-acp"
+    assert mock_acp.call_args.kwargs["base_url"] == "acp://copilot"
+    assert mock_acp.call_args.kwargs["command"] == "/usr/bin/copilot"
+    assert mock_acp.call_args.kwargs["args"] == ["--acp", "--stdio"]
+
+
+def test_resolve_provider_client_copilot_acp_requires_explicit_or_configured_model():
+    with patch("agent.auxiliary_client._read_main_model", return_value=""), \
+         patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is None
+    assert model is None
+    mock_acp.assert_not_called()
+
+
 class TestAuxiliaryMaxTokensParam:
     def test_codex_fallback_uses_max_tokens(self, monkeypatch):
         """Codex adapter translates max_tokens internally, so we return max_tokens."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -243,6 +243,22 @@ def test_api_mode_respects_explicit_openrouter_provider_over_codex_url(monkeypat
     assert agent.provider == "openrouter"
 
 
+def test_copilot_acp_stays_on_chat_completions_for_gpt_5_models(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5.4-mini",
+        base_url="acp://copilot",
+        provider="copilot-acp",
+        api_key="copilot-acp",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "copilot-acp"
+    assert agent.api_mode == "chat_completions"
+
+
 def test_build_api_kwargs_codex(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = agent._build_api_kwargs(


### PR DESCRIPTION
## What does this PR do?

Fixes a real `copilot-acp` transport mismatch in the main agent runtime.

`AIAgent` has generic logic that auto-upgrades some GPT-5-family runtimes to the Responses API path. That is correct for normal OpenAI-compatible clients, but wrong for `copilot-acp`: `CopilotACPClient` is an ACP transport client with chat-completions semantics and does not expose a `.responses` interface.

That mismatch produced failures like:

- `'CopilotACPClient' object has no attribute 'responses'`
- `resolve_provider_client: unhandled auth_type external_process for copilot-acp`

This PR does two things:

1. Keeps the main `copilot-acp` runtime off the generic Responses auto-upgrade path.
2. Adds explicit auxiliary-client support for `copilot-acp` external-process credentials instead of warning and silently falling away to another provider.

It does **not** rely on changing the auxiliary model to a completions-compatible workaround, and it does **not** guess a hard-coded fallback model when none is configured.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Prevent `AIAgent` from auto-upgrading `copilot-acp` / `acp://copilot` runtimes to `codex_responses` in [run_agent.py].
- Add `external_process` provider handling for `copilot-acp` in [agent/auxiliary_client.py].
- Preserve `CopilotACPClient` as-is in async auxiliary resolution instead of trying to wrap it like an OpenAI client.
- Require an explicit/configured model for `copilot-acp` auxiliary resolution instead of guessing a hard-coded fallback model.
- Add regression coverage for:
  - keeping `copilot-acp` GPT-5 models on chat-completions
  - resolving a `copilot-acp` auxiliary client from external-process credentials
  - refusing to invent a `copilot-acp` model when none is configured

## How to Test

1. Configure Hermes to use `copilot-acp` with a GPT-5 model such as `gpt-5.4-mini`.
2. Run a turn that previously failed with `'CopilotACPClient' object has no attribute 'responses'` and confirm Hermes stays on the ACP runtime instead of trying to use a Responses-style client path.
3. Run the focused regression tests:
   - `venv/bin/python -m pytest -n0 -q tests/run_agent/test_run_agent_codex_responses.py::test_copilot_acp_stays_on_chat_completions_for_gpt_5_models tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client`
   - `venv/bin/python -m pytest -n0 -q tests/agent/test_auxiliary_client.py -k 'copilot or acp'`
4. Full suite was also run with a capped xdist fanout:
   - `venv/bin/python -m pytest tests/ -v -n 3`
   - current repo baseline remains red (`93 failed, 10915 passed, 33 skipped`), but the ACP-specific tests above pass and the touched failures investigated were unrelated to this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant failures this fixes:

- `ERROR ... 'CopilotACPClient' object has no attribute 'responses' | provider=copilot-acp model=gpt-5.4-mini`
- `WARNING agent.auxiliary_client: resolve_provider_client: unhandled auth_type external_process for copilot-acp`
