### PR TITLE
fix(gateway): unblock pending approvals on /stop command (#8697)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2530,12 +2530,16 @@ class GatewayRunner:
             # /stop must hard-kill the session when an agent is running.
             # A soft interrupt (agent.interrupt()) doesn't help when the agent
             # is truly hung — the executor thread is blocked and never checks
-            # _interrupt_requested.  Force-clean _running_agents so the session
-            # is unlocked and subsequent messages are processed normally.
+            # _interrupt_requested. This also applies to gateway approval
+            # waits, where the agent thread is blocked on threading.Event.wait().
+            # Force-clean _running_agents so the session is unlocked and
+            # actively deny any blocked approvals so the executor thread can
+            # actually unwind.
             if _cmd_def_inner and _cmd_def_inner.name == "stop":
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Stop requested")
+                self._cancel_blocking_gateway_approvals(_quick_key)
                 # Force-clean: remove the session lock regardless of agent state
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -4100,6 +4104,22 @@ class GatewayRunner:
 
         return "\n".join(lines)
     
+    def _cancel_blocking_gateway_approvals(self, session_key: str) -> int:
+        """Resolve pending gateway approvals as denied so blocked threads exit."""
+        from tools.approval import resolve_gateway_approval
+
+        count = resolve_gateway_approval(session_key, "deny", resolve_all=True)
+        pending_approvals = getattr(self, "_pending_approvals", None)
+        if isinstance(pending_approvals, dict):
+            pending_approvals.pop(session_key, None)
+        if count:
+            logger.info(
+                "Cancelled %d pending gateway approval(s) for session %s during /stop",
+                count,
+                session_key[:20],
+            )
+        return count
+
     async def _handle_stop_command(self, event: MessageEvent) -> str:
         """Handle /stop command - interrupt a running agent.
 
@@ -4116,6 +4136,7 @@ class GatewayRunner:
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        cancelled_approvals = self._cancel_blocking_gateway_approvals(session_key)
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
@@ -4133,6 +4154,9 @@ class GatewayRunner:
                 del self._running_agents[session_key]
             self.session_store.suspend_session(session_key)
             return "⚡ Force-stopped. Your next message will start a fresh session."
+        if cancelled_approvals:
+            self.session_store.suspend_session(session_key)
+            return "⚡ Force-stopped. Pending approval was cancelled and the session will start fresh."
         else:
             return "No active task to stop."
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -310,6 +310,40 @@ class TestDenyCommand:
 
 
 # ------------------------------------------------------------------
+# /stop command
+# ------------------------------------------------------------------
+
+
+class TestStopCommand:
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_blocking_approval_without_running_agent(self):
+        """_handle_stop_command must also unblock a pending approval wait."""
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        runner.session_store.get_or_create_session.return_value = SimpleNamespace(
+            session_key=session_key
+        )
+
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_stop_command(_make_event("/stop"))
+
+        assert "force-stopped" in result.lower()
+        assert "approval" in result.lower()
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+        runner.session_store.suspend_session.assert_called_once_with(session_key)
+
+
+# ------------------------------------------------------------------
 # Bare "yes" must NOT trigger approval
 # ------------------------------------------------------------------
 

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -293,6 +293,40 @@ async def test_stop_hard_kills_running_agent():
 
 
 # ------------------------------------------------------------------
+# Test 6bb: /stop also cancels blocking gateway approvals
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_hard_kill_denies_blocking_gateway_approval():
+    """A hard /stop must unblock a pending gateway approval immediately."""
+    from tools import approval as approval_mod
+
+    runner = _make_runner()
+    session_key = build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    )
+
+    approval_mod._gateway_queues.clear()
+    approval_mod._gateway_notify_cbs.clear()
+
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+    entry = approval_mod._ApprovalEntry({"command": "rm -rf /tmp/test"})
+    approval_mod._gateway_queues[session_key] = [entry]
+
+    try:
+        result = await runner._handle_message(_make_event(text="/stop"))
+    finally:
+        approval_mod._gateway_queues.clear()
+        approval_mod._gateway_notify_cbs.clear()
+
+    assert result is not None
+    assert "force-stopped" in result.lower()
+    assert entry.event.is_set(), "/stop must unblock the approval wait"
+    assert entry.result == "deny"
+    assert session_key not in approval_mod._gateway_queues
+
+
+# ------------------------------------------------------------------
 # Test 6c: /stop clears pending messages to prevent stale replays
 # ------------------------------------------------------------------
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #8697

When a gateway session was blocked waiting for dangerous-command approval, `/stop` only interrupted the agent and cleared `_running_agents`. The executor thread could still remain blocked on `threading.Event.wait()` until the approval timeout expired.

This change makes `/stop` actively resolve any pending gateway approvals as denied, so blocked approval waits are released immediately and the session can unwind cleanly.

## What Changed

- Added a shared gateway helper to cancel blocking approval waits for a session
- Invoked that helper from the early `/stop` intercept path
- Invoked that helper from `_handle_stop_command()` as well
- Cleared stale `_pending_approvals` entries during stop cleanup
- Added regression tests for:
  - `/stop` while a running agent is blocked on gateway approval
  - `/stop` through `_handle_stop_command()` when approval is pending

## Why

The approval flow uses a blocking `threading.Event.wait()` in the executor thread. A normal `agent.interrupt()` does not wake that wait, so `/stop` could report success while the blocked thread remained stuck until timeout. Denying the pending approval explicitly is the safest way to unblock the wait and let the thread exit.

## Testing

- Added gateway regression tests covering both `/stop` entry points

