### PR TITLE
feat: enforce Guard verdicts in ACP tool flows

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +40,7 @@ TOOL_KIND_MAP: Dict[str, ToolKind] = {
     "browser_scroll": "execute",
     "browser_press": "execute",
     "browser_back": "execute",
+    "browser_close": "execute",
     "browser_get_images": "read",
     # Agent internals
     "delegate_task": "execute",
@@ -181,9 +183,26 @@ def build_tool_complete(
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""
     kind = get_tool_kind(tool_name)
+    status = "completed"
 
-    # Truncate very large results for the UI
     display_result = result or ""
+    if result:
+        try:
+            payload = json.loads(result)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("blocked") is True:
+            status = "failed"
+            reason = str(payload.get("error", "")).strip() or "Guard blocked this tool call."
+            recommendation = str(payload.get("guard_recommendation", "")).strip()
+            source = str(payload.get("guard_source", "")).strip()
+            lines = [reason]
+            if recommendation:
+                lines.append(f"Recommendation: {recommendation}")
+            if source:
+                lines.append(f"Source: {source}")
+            display_result = "\n".join(lines)
+
     if len(display_result) > 5000:
         display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
 
@@ -191,7 +210,7 @@ def build_tool_complete(
     return acp.update_tool_call(
         tool_call_id,
         kind=kind,
-        status="completed",
+        status=status,
         content=content,
         raw_output=result,
     )

--- a/model_tools.py
+++ b/model_tools.py
@@ -27,6 +27,7 @@ import threading
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import registry
+from tools.guard_runtime_policy import evaluate_guard_tool_call
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ _LEGACY_TOOLSET_MAP = {
     "browser_tools": [
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",
-        "browser_press", "browser_get_images",
+        "browser_press", "browser_close", "browser_get_images",
         "browser_vision", "browser_console"
     ],
     "cronjob_tools": ["cronjob"],
@@ -496,6 +497,17 @@ def handle_function_call(
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
+
+        guard_block = evaluate_guard_tool_call(function_name, function_args)
+        if guard_block is not None:
+            return json.dumps(
+                {
+                    "error": guard_block.reason,
+                    "blocked": True,
+                    "guard_recommendation": guard_block.recommendation,
+                    "guard_source": guard_block.source,
+                }
+            )
 
         try:
             from hermes_cli.plugins import invoke_hook

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -7,9 +7,7 @@ Exercises the full flow through the ACP server layer:
     session_update events arrive at the mock client
 """
 
-import asyncio
-from collections import deque
-from types import SimpleNamespace
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,6 +27,7 @@ from acp.schema import (
 
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
+from model_tools import handle_function_call
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +229,147 @@ class TestMcpRegistrationE2E:
         assert start_ids == completion_ids, (
             f"IDs must match: starts={start_ids}, completions={completion_ids}"
         )
+
+    @pytest.mark.asyncio
+    async def test_prompt_guard_block_emits_failed_tool_completion(self, acp_agent, mock_manager):
+        """Guard-stopped MCP calls should surface as failed ACP tool updates."""
+        resp = await acp_agent.new_session(cwd="/tmp")
+        session_id = resp.session_id
+        state = mock_manager.get_session(session_id)
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        mock_conn.request_permission = AsyncMock()
+        acp_agent._conn = mock_conn
+
+        class _FakeResponse:
+            def __init__(self, payload, status_code=200):
+                self._payload = payload
+                self.status_code = status_code
+
+            def json(self):
+                return self._payload
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise RuntimeError("request failed")
+
+        class _FakeClient:
+            def __init__(self, routes, recorded_posts):
+                self._routes = routes
+                self._recorded_posts = recorded_posts
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, headers=None):
+                payload = self._routes.get(("GET", url), {})
+                return _FakeResponse(payload)
+
+            def post(self, url, headers=None, json=None):
+                self._recorded_posts.append({"url": url, "headers": headers, "json": json})
+                payload = self._routes.get(("POST", url), {})
+                return _FakeResponse(payload)
+
+        routes = {
+            ("POST", "https://guard.example/api/v1/consumer/verdict/pre-execution"): {
+                "decision": "block",
+                "rationale": "Guard blocked the MCP server before execution.",
+                "scope": "artifact",
+            },
+            ("POST", "https://guard.example/api/v1/consumer/signals/pain"): {"items": []},
+        }
+        recorded_posts = []
+
+        def mock_run_conversation(user_message, conversation_history=None, task_id=None):
+            agent = state.agent
+            if agent.tool_progress_callback:
+                agent.tool_progress_callback(
+                    "tool.started",
+                    "mcp_github_create_issue",
+                    "mcp github create issue",
+                    {"title": "blocked"},
+                )
+
+            tool_result = handle_function_call("mcp_github_create_issue", {"title": "blocked"})
+            parsed_result = json.loads(tool_result)
+            assert parsed_result["blocked"] is True
+
+            if agent.step_callback:
+                agent.step_callback(
+                    1,
+                    [
+                        {
+                            "name": "mcp_github_create_issue",
+                            "result": tool_result,
+                        }
+                    ],
+                )
+
+            return {
+                "final_response": "Guard stopped the tool call before execution.",
+                "messages": [
+                    {"role": "user", "content": user_message},
+                    {"role": "assistant", "content": "Guard stopped the tool call before execution."},
+                ],
+            }
+
+        state.agent.run_conversation = mock_run_conversation
+
+        with (
+            patch(
+                "tools.guard_runtime_policy.load_config",
+                lambda: {
+                    "guard": {
+                        "enabled": True,
+                        "base_url": "https://guard.example/api/v1/consumer",
+                        "timeout_seconds": 5,
+                        "fail_open": False,
+                        "cache_ttl_seconds": 1,
+                        "token_env_var": "HERMES_GUARD_TOKEN",
+                        "enforce_mcp_tools": True,
+                        "pain_signals_enabled": True,
+                    }
+                },
+            ),
+            patch(
+                "tools.guard_runtime_policy._load_mcp_config",
+                lambda: {
+                    "github": {
+                        "url": "https://mcp.github.example/mcp",
+                    }
+                },
+            ),
+            patch(
+                "tools.guard_runtime_policy.httpx.Client",
+                lambda timeout: _FakeClient(routes, recorded_posts),
+            ),
+            patch("tools.guard_runtime_policy.time.time", lambda: 1_700_000_000.0),
+            patch("tools.guard_runtime_policy._CACHE", {}),
+            patch.dict("os.environ", {"HERMES_GUARD_TOKEN": "guard-token"}, clear=False),
+        ):
+            prompt = [TextContentBlock(type="text", text="create the blocked issue")]
+            response = await acp_agent.prompt(prompt=prompt, session_id=session_id)
+
+        assert isinstance(response, PromptResponse)
+        updates = []
+        for call in mock_conn.session_update.call_args_list:
+            update_arg = call[1].get("update") or call[0][1]
+            updates.append(update_arg)
+
+        completions = [u for u in updates if getattr(u, "session_update", None) == "tool_call_update"]
+        assert len(completions) == 1
+        completion = completions[0]
+        assert isinstance(completion, ToolCallProgress)
+        assert completion.status == "failed"
+        assert completion.raw_output is not None
+        assert '"blocked": true' in completion.raw_output
+        assert "Guard blocked the MCP server before execution." in completion.content[0].content.text
+        assert recorded_posts[0]["url"].endswith("/verdict/pre-execution")
+        assert recorded_posts[1]["url"].endswith("/receipts/submit")
 
 
 class TestMcpSanitizationE2E:

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,7 +1,5 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
-import pytest
-
 from acp_adapter.tools import (
     TOOL_KIND_MAP,
     build_tool_complete,
@@ -214,6 +212,20 @@ class TestBuildToolComplete:
         display_text = result.content[0].content.text
         assert len(display_text) < 6000
         assert "truncated" in display_text
+
+    def test_build_tool_complete_marks_guard_blocks_failed(self):
+        """Guard-blocked tool results should surface as failed ACP events."""
+        result = build_tool_complete(
+            "tc-7",
+            "mcp_github_create_issue",
+            '{"error":"Guard blocked this MCP server.","blocked":true,"guard_recommendation":"block","guard_source":"preexecution-artifact"}',
+        )
+        assert isinstance(result, ToolCallProgress)
+        assert result.status == "failed"
+        display_text = result.content[0].content.text
+        assert "Guard blocked this MCP server." in display_text
+        assert "Recommendation: block" in display_text
+        assert "Source: preexecution-artifact" in display_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -3,8 +3,6 @@
 import json
 from unittest.mock import call, patch
 
-import pytest
-
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
@@ -42,6 +40,7 @@ class TestHandleFunctionCall:
 
     def test_tool_hooks_receive_session_and_tool_call_ids(self):
         with (
+            patch("model_tools.evaluate_guard_tool_call", return_value=None, create=True),
             patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
             patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
         ):
@@ -73,6 +72,32 @@ class TestHandleFunctionCall:
                 tool_call_id="call-1",
             ),
         ]
+
+    def test_guard_block_prevents_dispatch(self):
+        with (
+            patch(
+                "model_tools.evaluate_guard_tool_call",
+                return_value=type(
+                    "GuardBlock",
+                    (),
+                    {
+                        "reason": "Guard blocked this MCP server.",
+                        "recommendation": "block",
+                        "source": "watchlist",
+                    },
+                )(),
+                create=True,
+            ),
+            patch("model_tools.registry.dispatch") as mock_dispatch,
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
+        ):
+            result = json.loads(handle_function_call("mcp_github_create_issue", {"title": "x"}))
+
+        assert result["blocked"] is True
+        assert result["guard_recommendation"] == "block"
+        assert result["guard_source"] == "watchlist"
+        mock_dispatch.assert_not_called()
+        mock_invoke_hook.assert_not_called()
 
 
 # =========================================================================

--- a/tests/tools/test_guard_runtime_policy.py
+++ b/tests/tools/test_guard_runtime_policy.py
@@ -1,0 +1,254 @@
+"""Tests for Guard-backed Hermes MCP runtime policy checks."""
+
+from __future__ import annotations
+
+import httpx
+
+from tools.guard_runtime_policy import evaluate_guard_tool_call
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "request failed",
+                request=httpx.Request("GET", "https://hol.org"),
+                response=httpx.Response(self.status_code),
+            )
+
+
+class _FakeClient:
+    def __init__(self, routes, recorded_posts):
+        self._routes = routes
+        self._recorded_posts = recorded_posts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        key = ("GET", url)
+        payload = self._routes.get(key)
+        if isinstance(payload, Exception):
+            raise payload
+        if payload is None:
+            return _FakeResponse({})
+        return _FakeResponse(payload)
+
+    def post(self, url, headers=None, json=None):
+        self._recorded_posts.append({"url": url, "headers": headers, "json": json})
+        payload = self._routes.get(("POST", url), {})
+        if isinstance(payload, Exception):
+            raise payload
+        return _FakeResponse(payload)
+
+
+def _patch_guard(monkeypatch, routes, *, token="guard-token", fail_open=True):
+    recorded_posts = []
+
+    monkeypatch.setattr(
+        "tools.guard_runtime_policy.load_config",
+        lambda: {
+            "guard": {
+                "enabled": True,
+                "base_url": "https://guard.example/api/v1/consumer",
+                "timeout_seconds": 5,
+                "fail_open": fail_open,
+                "cache_ttl_seconds": 1,
+                "token_env_var": "HERMES_GUARD_TOKEN",
+                "enforce_mcp_tools": True,
+                "pain_signals_enabled": True,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "tools.guard_runtime_policy._load_mcp_config",
+        lambda: {
+            "github": {
+                "url": "https://mcp.github.example/mcp",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "tools.guard_runtime_policy.httpx.Client",
+        lambda timeout: _FakeClient(routes, recorded_posts),
+    )
+    monkeypatch.setattr("tools.guard_runtime_policy.time.time", lambda: 1_700_000_000.0)
+    monkeypatch.setattr("tools.guard_runtime_policy._CACHE", {})
+    if token:
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", token)
+    else:
+        monkeypatch.delenv("HERMES_GUARD_TOKEN", raising=False)
+    return recorded_posts
+
+
+def test_ignores_non_mcp_tool(monkeypatch):
+    _patch_guard(monkeypatch, {})
+    assert evaluate_guard_tool_call("web_search", {"q": "x"}) is None
+
+
+def test_blocks_watchlisted_mcp_tool_and_emits_pain_signal(monkeypatch):
+    routes = {
+        ("GET", "https://guard.example/api/v1/consumer/exceptions"): {"items": []},
+        ("GET", "https://guard.example/api/v1/consumer/team/policy-pack"): {
+            "blockedArtifacts": [],
+            "blockedDomains": [],
+            "blockedPublishers": [],
+        },
+        ("GET", "https://guard.example/api/v1/consumer/watchlist"): {
+            "items": [
+                {
+                    "artifactId": "mcp:hermes:github",
+                    "artifactName": "github",
+                    "artifactSlug": "github",
+                    "reason": "Known data exfiltration behavior.",
+                }
+            ]
+        },
+        ("POST", "https://guard.example/api/v1/consumer/signals/pain"): {"items": []},
+    }
+    recorded_posts = _patch_guard(monkeypatch, routes)
+
+    result = evaluate_guard_tool_call("mcp_github_create_issue", {"title": "x"})
+
+    assert result is not None
+    assert result.source == "watchlist"
+    assert "Known data exfiltration behavior." in result.reason
+    assert len(recorded_posts) == 3
+    assert recorded_posts[0]["url"].endswith("/verdict/pre-execution")
+    assert recorded_posts[1]["url"].endswith("/receipts/submit")
+    assert recorded_posts[2]["json"]["items"][0]["artifactId"] == "mcp:hermes:github"
+
+
+def test_active_exception_allows_mcp_tool(monkeypatch):
+    routes = {
+        ("GET", "https://guard.example/api/v1/consumer/exceptions"): {
+            "items": [
+                {
+                    "scope": "artifact",
+                    "artifactId": "mcp:hermes:github",
+                    "expiresAt": "2099-01-01T00:00:00Z",
+                }
+            ]
+        },
+    }
+    _patch_guard(monkeypatch, routes)
+
+    result = evaluate_guard_tool_call("mcp_github_create_issue", {"title": "x"})
+
+    assert result is None
+
+
+def test_preexecution_verdict_blocks_before_fallback_lookups(monkeypatch):
+    routes = {
+        ("POST", "https://guard.example/api/v1/consumer/verdict/pre-execution"): {
+            "decision": "block",
+            "rationale": "Team policy blocks github before execution.",
+            "scope": "artifact",
+        },
+        ("POST", "https://guard.example/api/v1/consumer/signals/pain"): {"items": []},
+    }
+    recorded_posts = _patch_guard(monkeypatch, routes)
+
+    result = evaluate_guard_tool_call("mcp_github_create_issue", {"title": "x"})
+
+    assert result is not None
+    assert result.source == "preexecution-artifact"
+    assert result.recommendation == "block"
+    assert len(recorded_posts) == 3
+    assert recorded_posts[0]["url"].endswith("/verdict/pre-execution")
+    assert recorded_posts[0]["json"]["artifactId"] == "mcp:hermes:github"
+    assert recorded_posts[1]["url"].endswith("/receipts/submit")
+
+
+def test_verdict_investigate_blocks_when_no_exception(monkeypatch):
+    routes = {
+        ("POST", "https://guard.example/api/v1/consumer/verdict/pre-execution"): httpx.ConnectError(
+            "offline"
+        ),
+        ("GET", "https://guard.example/api/v1/consumer/exceptions"): {"items": []},
+        ("GET", "https://guard.example/api/v1/consumer/team/policy-pack"): {
+            "blockedArtifacts": [],
+            "blockedDomains": [],
+            "blockedPublishers": [],
+        },
+        ("GET", "https://guard.example/api/v1/consumer/watchlist"): {"items": []},
+        (
+            "GET",
+            "https://guard.example/api/v1/consumer/verdict/resolve?ecosystem=hermes&name=github",
+        ): {
+            "items": [
+                {
+                    "artifactName": "GitHub Remote MCP",
+                    "recommendation": "investigate",
+                }
+            ]
+        },
+        ("POST", "https://guard.example/api/v1/consumer/signals/pain"): {"items": []},
+    }
+    recorded_posts = _patch_guard(monkeypatch, routes)
+
+    result = evaluate_guard_tool_call("mcp_github_create_issue", {"title": "x"})
+
+    assert result is not None
+    assert result.source == "verdict"
+    assert result.recommendation == "investigate"
+    assert "GitHub Remote MCP" in result.reason
+    assert len(recorded_posts) == 3
+    assert recorded_posts[0]["url"].endswith("/verdict/pre-execution")
+    assert recorded_posts[1]["url"].endswith("/receipts/submit")
+
+
+def test_fail_open_allows_on_lookup_error(monkeypatch):
+    routes = {
+        ("GET", "https://guard.example/api/v1/consumer/exceptions"): httpx.ConnectError(
+            "offline"
+        ),
+    }
+    _patch_guard(monkeypatch, routes, fail_open=True)
+
+    result = evaluate_guard_tool_call("mcp_github_create_issue", {"title": "x"})
+
+    assert result is None
+
+
+def test_declared_guard_artifact_supports_non_mcp_tools(monkeypatch):
+    routes = {
+        ("POST", "https://guard.example/api/v1/consumer/verdict/pre-execution"): {
+            "decision": "block",
+            "rationale": "Guard blocks the outbound skill before execution.",
+            "scope": "artifact",
+        },
+        ("POST", "https://guard.example/api/v1/consumer/signals/pain"): {"items": []},
+    }
+    recorded_posts = _patch_guard(monkeypatch, routes)
+
+    result = evaluate_guard_tool_call(
+        "run_skill",
+        {
+            "guard_artifact": {
+                "guard_artifact_id": "skill:hermes:secret-probe",
+                "guard_artifact_name": "Secret Probe",
+                "guard_artifact_slug": "secret-probe",
+                "guard_artifact_type": "skill",
+                "guard_publisher": "odd-labs",
+                "guard_domain": "evil.example",
+                "guard_launch_summary": "python secret_probe.py --upload",
+            }
+        },
+    )
+
+    assert result is not None
+    assert result.source == "preexecution-artifact"
+    assert recorded_posts[0]["json"]["artifactId"] == "skill:hermes:secret-probe"
+    assert recorded_posts[0]["json"]["artifactType"] == "skill"
+    assert recorded_posts[1]["url"].endswith("/receipts/submit")

--- a/tools/guard_runtime_policy.py
+++ b/tools/guard_runtime_policy.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""
+Guard-backed runtime policy checks for Hermes MCP tool calls.
+
+This module gives Hermes a lightweight Guard client for MCP tool execution.
+It resolves the MCP server behind a tool name, consults Guard verdict,
+watchlist, exception, and team-policy surfaces, and can emit pain signals
+when Guard blocks a tool call before execution.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+from urllib.parse import urlencode, urlparse
+
+import httpx
+
+from hermes_cli.config import load_config
+from tools.mcp_tool import _load_mcp_config
+
+logger = logging.getLogger(__name__)
+
+_CACHE: Dict[str, tuple[float, object]] = {}
+
+
+@dataclass(frozen=True)
+class GuardRuntimeSettings:
+    enabled: bool
+    base_url: str
+    timeout_seconds: float
+    fail_open: bool
+    cache_ttl_seconds: int
+    token_env_var: str
+    enforce_mcp_tools: bool
+    pain_signals_enabled: bool
+
+
+@dataclass(frozen=True)
+class GuardArtifactContext:
+    artifact_id: str
+    artifact_name: str
+    artifact_slug: str
+    artifact_type: str
+    harness: str
+    tool_name: str
+    server_name: str
+    publisher: Optional[str]
+    domain: Optional[str]
+    launch_summary: str
+
+
+@dataclass(frozen=True)
+class GuardRuntimeBlock:
+    reason: str
+    recommendation: str
+    source: str
+
+
+def evaluate_guard_tool_call(function_name: str, function_args: dict | None) -> Optional[GuardRuntimeBlock]:
+    """Return a Guard block decision for the tool call, or ``None`` to allow."""
+    settings = _load_guard_runtime_settings()
+    if not settings.enabled or not settings.enforce_mcp_tools:
+        return None
+
+    artifact = _resolve_guard_artifact(function_name, function_args)
+    if artifact is None:
+        return None
+
+    try:
+        return _evaluate_mcp_artifact(settings, artifact)
+    except Exception as error:
+        if settings.fail_open:
+            logger.warning("Guard runtime policy check failed open: %s", error)
+            return None
+        return GuardRuntimeBlock(
+            reason=f"Guard policy lookup failed: {error}",
+            recommendation="block",
+            source="guard-runtime",
+        )
+
+
+def _load_guard_runtime_settings() -> GuardRuntimeSettings:
+    config = load_config()
+    raw = config.get("guard")
+    if not isinstance(raw, dict):
+        raw = {}
+
+    base_url = str(raw.get("base_url", "https://hol.org/api/v1/consumer")).rstrip("/")
+    timeout_raw = raw.get("timeout_seconds", 5)
+    cache_raw = raw.get("cache_ttl_seconds", 60)
+
+    try:
+        timeout_seconds = float(timeout_raw)
+    except (TypeError, ValueError):
+        timeout_seconds = 5.0
+
+    try:
+        cache_ttl_seconds = int(cache_raw)
+    except (TypeError, ValueError):
+        cache_ttl_seconds = 60
+
+    return GuardRuntimeSettings(
+        enabled=bool(raw.get("enabled", True)),
+        base_url=base_url,
+        timeout_seconds=max(timeout_seconds, 1.0),
+        fail_open=bool(raw.get("fail_open", True)),
+        cache_ttl_seconds=max(cache_ttl_seconds, 1),
+        token_env_var=str(raw.get("token_env_var", "HERMES_GUARD_TOKEN")),
+        enforce_mcp_tools=bool(raw.get("enforce_mcp_tools", True)),
+        pain_signals_enabled=bool(raw.get("pain_signals_enabled", True)),
+    )
+
+
+def _normalize_mcp_name(value: str) -> str:
+    return value.replace("-", "_").replace(".", "_")
+
+
+def _resolve_guard_artifact(
+    function_name: str,
+    function_args: dict | None,
+) -> Optional[GuardArtifactContext]:
+    artifact = _resolve_mcp_artifact(function_name)
+    if artifact is not None:
+        return artifact
+    return _resolve_declared_guard_artifact(function_name, function_args)
+
+
+def _resolve_mcp_artifact(function_name: str) -> Optional[GuardArtifactContext]:
+    if not function_name.startswith("mcp_"):
+        return None
+
+    servers = _load_mcp_config()
+    if not isinstance(servers, dict) or not servers:
+        return None
+
+    for server_name, server_config in servers.items():
+        normalized = _normalize_mcp_name(server_name)
+        prefix = f"mcp_{normalized}_"
+        if not function_name.startswith(prefix):
+            continue
+
+        artifact_id = f"mcp:hermes:{server_name}"
+        artifact_slug = server_name.lower()
+        url = str(server_config.get("url", "")).strip()
+        domain = urlparse(url).netloc or None
+        command = str(server_config.get("command", "")).strip()
+        args = server_config.get("args")
+        launch_summary = url if url else " ".join(
+            [part for part in [command, *args] if isinstance(part, str) and part]
+        ).strip()
+        if not launch_summary:
+            launch_summary = server_name
+
+        publisher = domain or command or None
+
+        return GuardArtifactContext(
+            artifact_id=artifact_id,
+            artifact_name=server_name,
+            artifact_slug=artifact_slug,
+            artifact_type="mcp-server",
+            harness="hermes",
+            tool_name=function_name,
+            server_name=server_name,
+            publisher=publisher,
+            domain=domain,
+            launch_summary=launch_summary,
+        )
+
+    return None
+
+
+def _resolve_declared_guard_artifact(
+    function_name: str,
+    function_args: dict | None,
+) -> Optional[GuardArtifactContext]:
+    if not isinstance(function_args, dict):
+        return None
+
+    raw_artifact = function_args.get("guard_artifact")
+    metadata = raw_artifact if isinstance(raw_artifact, dict) else function_args
+
+    artifact_name = str(
+        metadata.get("guard_artifact_name")
+        or metadata.get("artifact_name")
+        or metadata.get("name")
+        or ""
+    ).strip()
+    if not artifact_name:
+        return None
+
+    artifact_id = str(
+        metadata.get("guard_artifact_id")
+        or metadata.get("artifact_id")
+        or f"tool:hermes:{function_name}"
+    ).strip()
+    artifact_slug = str(
+        metadata.get("guard_artifact_slug")
+        or metadata.get("artifact_slug")
+        or artifact_name.lower().replace(" ", "-")
+    ).strip()
+    artifact_type = str(
+        metadata.get("guard_artifact_type")
+        or metadata.get("artifact_type")
+        or "plugin"
+    ).strip() or "plugin"
+    harness = str(metadata.get("guard_harness") or "hermes").strip() or "hermes"
+    publisher = str(
+        metadata.get("guard_publisher")
+        or metadata.get("publisher")
+        or ""
+    ).strip() or None
+    domain = str(
+        metadata.get("guard_domain")
+        or metadata.get("domain")
+        or ""
+    ).strip() or None
+    launch_summary = str(
+        metadata.get("guard_launch_summary")
+        or metadata.get("launch_summary")
+        or function_name
+    ).strip() or function_name
+
+    return GuardArtifactContext(
+        artifact_id=artifact_id,
+        artifact_name=artifact_name,
+        artifact_slug=artifact_slug,
+        artifact_type=artifact_type,
+        harness=harness,
+        tool_name=function_name,
+        server_name=artifact_name,
+        publisher=publisher,
+        domain=domain,
+        launch_summary=launch_summary,
+    )
+
+
+def _evaluate_mcp_artifact(
+    settings: GuardRuntimeSettings,
+    artifact: GuardArtifactContext,
+) -> Optional[GuardRuntimeBlock]:
+    with httpx.Client(timeout=settings.timeout_seconds) as client:
+        preexecution_verdict = _match_preexecution_verdict(
+            settings,
+            client,
+            artifact,
+        )
+        if preexecution_verdict is not _PREEXECUTION_FALLBACK:
+            if preexecution_verdict is None:
+                return None
+            _emit_receipt(settings, client, artifact, preexecution_verdict)
+            _emit_pain_signal(settings, client, artifact, preexecution_verdict)
+            return preexecution_verdict
+
+        exception_block = _match_exception(settings, client, artifact)
+        if exception_block == "allow":
+            return None
+
+        team_policy_block = _match_team_policy(settings, client, artifact)
+        if team_policy_block is not None:
+            _emit_receipt(settings, client, artifact, team_policy_block)
+            _emit_pain_signal(settings, client, artifact, team_policy_block)
+            return team_policy_block
+
+        watchlist_block = _match_watchlist(settings, client, artifact)
+        if watchlist_block is not None:
+            _emit_receipt(settings, client, artifact, watchlist_block)
+            _emit_pain_signal(settings, client, artifact, watchlist_block)
+            return watchlist_block
+
+        verdict_block = _match_verdict(settings, client, artifact)
+        if verdict_block is not None:
+            _emit_receipt(settings, client, artifact, verdict_block)
+            _emit_pain_signal(settings, client, artifact, verdict_block)
+            return verdict_block
+
+    return None
+
+
+_PREEXECUTION_FALLBACK = object()
+
+
+def _authorized_headers(settings: GuardRuntimeSettings) -> Dict[str, str]:
+    token = os.getenv(settings.token_env_var, "").strip()
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cache_key(settings: GuardRuntimeSettings, suffix: str) -> str:
+    return f"{settings.base_url}|{settings.token_env_var}|{suffix}"
+
+
+def _get_cached(settings: GuardRuntimeSettings, suffix: str) -> object | None:
+    cache_key = _cache_key(settings, suffix)
+    cached = _CACHE.get(cache_key)
+    if cached is None:
+        return None
+    expires_at, payload = cached
+    if expires_at < time.time():
+        _CACHE.pop(cache_key, None)
+        return None
+    return payload
+
+
+def _set_cached(settings: GuardRuntimeSettings, suffix: str, payload: object) -> object:
+    _CACHE[_cache_key(settings, suffix)] = (
+        time.time() + settings.cache_ttl_seconds,
+        payload,
+    )
+    return payload
+
+
+def _fetch_json(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    path: str,
+    *,
+    require_auth: bool = False,
+) -> object | None:
+    cached = _get_cached(settings, path)
+    if cached is not None:
+        return cached
+
+    headers = _authorized_headers(settings)
+    if require_auth and not headers:
+        return None
+
+    response = client.get(f"{settings.base_url}{path}", headers=headers or None)
+    response.raise_for_status()
+    return _set_cached(settings, path, response.json())
+
+
+def _post_json(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    path: str,
+    payload: dict,
+    *,
+    require_auth: bool = False,
+) -> object | None:
+    headers = _authorized_headers(settings)
+    if require_auth and not headers:
+        return None
+
+    response = client.post(
+        f"{settings.base_url}{path}",
+        headers=headers or None,
+        json=payload,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _matches_artifact(record: dict, artifact: GuardArtifactContext) -> bool:
+    haystacks = [
+        str(record.get("artifactId", "")).strip().lower(),
+        str(record.get("artifactSlug", "")).strip().lower(),
+        str(record.get("artifactName", "")).strip().lower(),
+    ]
+    needles = [
+        artifact.artifact_id.lower(),
+        artifact.artifact_slug.lower(),
+        artifact.server_name.lower(),
+    ]
+    for needle in needles:
+        if not needle:
+            continue
+        if any(needle == haystack or needle in haystack for haystack in haystacks if haystack):
+            return True
+    return False
+
+
+def _match_exception(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+) -> Optional[str]:
+    payload = _fetch_json(settings, client, "/exceptions", require_auth=True)
+    if not isinstance(payload, dict):
+        return None
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return None
+
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        expires_at = str(item.get("expiresAt", ""))
+        if expires_at and expires_at <= now:
+            continue
+        scope = str(item.get("scope", ""))
+        if scope == "global":
+            return "allow"
+        if scope == "harness" and str(item.get("harness", "")) == artifact.harness:
+            return "allow"
+        if scope == "artifact" and str(item.get("artifactId", "")) == artifact.artifact_id:
+            return "allow"
+    return None
+
+
+def _match_preexecution_verdict(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+) -> object:
+    headers = _authorized_headers(settings)
+    if not headers:
+        return _PREEXECUTION_FALLBACK
+
+    payload = {
+        "harness": artifact.harness,
+        "artifactName": artifact.artifact_name,
+        "artifactType": artifact.artifact_type,
+        "artifactId": artifact.artifact_id,
+        "artifactSlug": artifact.artifact_slug,
+        "publisher": artifact.publisher,
+        "domain": artifact.domain,
+        "launchSummary": artifact.launch_summary,
+    }
+
+    cache_suffix = f"/verdict/pre-execution:{artifact.artifact_id}"
+    cached = _get_cached(settings, cache_suffix)
+    if isinstance(cached, dict):
+        return _block_from_preexecution_payload(cached)
+
+    try:
+        response = _post_json(
+            settings,
+            client,
+            "/verdict/pre-execution",
+            payload,
+            require_auth=True,
+        )
+    except Exception as error:
+        logger.warning("Guard pre-execution verdict lookup failed: %s", error)
+        return _PREEXECUTION_FALLBACK
+
+    if not isinstance(response, dict):
+        return _PREEXECUTION_FALLBACK
+
+    if str(response.get("decision", "")).strip().lower() == "allow":
+        _emit_receipt(
+            settings,
+            client,
+            artifact,
+            GuardRuntimeBlock(
+                reason=str(response.get("rationale", "")).strip()
+                or "Guard allowed tool execution.",
+                recommendation="monitor",
+                source=f"preexecution-{str(response.get('scope', 'guard')).strip() or 'guard'}",
+            ),
+        )
+
+    _set_cached(settings, cache_suffix, response)
+    return _block_from_preexecution_payload(response)
+
+
+def _block_from_preexecution_payload(
+    payload: dict,
+) -> object:
+    decision = str(payload.get("decision", "")).strip().lower()
+    rationale = str(payload.get("rationale", "")).strip()
+    scope = str(payload.get("scope", "guard")).strip() or "guard"
+
+    if decision == "allow":
+        return None
+
+    if decision in {"block", "review"}:
+        recommendation = "block" if decision == "block" else "review"
+        return GuardRuntimeBlock(
+            reason=rationale or f"Guard requires {decision} before tool execution.",
+            recommendation=recommendation,
+            source=f"preexecution-{scope}",
+        )
+
+    return _PREEXECUTION_FALLBACK
+
+
+def _match_team_policy(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+) -> Optional[GuardRuntimeBlock]:
+    payload = _fetch_json(settings, client, "/team/policy-pack", require_auth=True)
+    if not isinstance(payload, dict):
+        return None
+
+    blocked_artifacts = payload.get("blockedArtifacts")
+    if isinstance(blocked_artifacts, list):
+        if artifact.artifact_id in {str(item) for item in blocked_artifacts}:
+            return GuardRuntimeBlock(
+                reason=f"Guard team policy blocks the MCP server '{artifact.server_name}'.",
+                recommendation="block",
+                source="team-policy",
+            )
+
+    blocked_domains = payload.get("blockedDomains")
+    if artifact.domain and isinstance(blocked_domains, list):
+        normalized_domain = artifact.domain.lower()
+        if normalized_domain in {str(item).lower() for item in blocked_domains}:
+            return GuardRuntimeBlock(
+                reason=f"Guard team policy blocks the domain '{artifact.domain}' used by '{artifact.server_name}'.",
+                recommendation="block",
+                source="team-policy",
+            )
+
+    blocked_publishers = payload.get("blockedPublishers")
+    if artifact.publisher and isinstance(blocked_publishers, list):
+        normalized_publisher = artifact.publisher.lower()
+        if normalized_publisher in {str(item).lower() for item in blocked_publishers}:
+            return GuardRuntimeBlock(
+                reason=f"Guard team policy blocks the publisher '{artifact.publisher}'.",
+                recommendation="block",
+                source="team-policy",
+            )
+
+    return None
+
+
+def _match_watchlist(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+) -> Optional[GuardRuntimeBlock]:
+    payload = _fetch_json(settings, client, "/watchlist", require_auth=True)
+    if not isinstance(payload, dict):
+        return None
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return None
+
+    for item in items:
+        if isinstance(item, dict) and _matches_artifact(item, artifact):
+            reason = str(item.get("reason", "")).strip()
+            detail = reason or f"Guard watchlist matched '{artifact.server_name}'."
+            return GuardRuntimeBlock(
+                reason=detail,
+                recommendation="block",
+                source="watchlist",
+            )
+    return None
+
+
+def _match_verdict(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+) -> Optional[GuardRuntimeBlock]:
+    query = urlencode({"ecosystem": "hermes", "name": artifact.server_name})
+    payload = _fetch_json(settings, client, f"/verdict/resolve?{query}")
+    if not isinstance(payload, dict):
+        return None
+
+    items = payload.get("items")
+    if not isinstance(items, list) or not items:
+        return None
+
+    first = items[0]
+    if not isinstance(first, dict):
+        return None
+
+    recommendation = str(first.get("recommendation", "")).strip().lower()
+    artifact_name = str(first.get("artifactName", artifact.server_name)).strip()
+    if recommendation == "block":
+        return GuardRuntimeBlock(
+            reason=f"Guard marked '{artifact_name}' as blocked before tool execution.",
+            recommendation="block",
+            source="verdict",
+        )
+    if recommendation == "investigate":
+        return GuardRuntimeBlock(
+            reason=f"Guard requires review for '{artifact_name}' before tool execution.",
+            recommendation="investigate",
+            source="verdict",
+        )
+    return None
+
+
+def _emit_pain_signal(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+    block: GuardRuntimeBlock,
+) -> None:
+    if not settings.pain_signals_enabled:
+        return
+
+    headers = _authorized_headers(settings)
+    if not headers:
+        return
+
+    payload = {
+        "items": [
+            {
+                "signalId": f"{artifact.artifact_id}:blocked-tool-call",
+                "signalName": "blocked-tool-call",
+                "artifactId": artifact.artifact_id,
+                "artifactName": artifact.artifact_name,
+                "artifactType": artifact.artifact_type,
+                "harness": artifact.harness,
+                "latestSummary": f"{block.reason} Tool: {artifact.tool_name}. Launch: {artifact.launch_summary}.",
+                "occurredAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "count": 1,
+                "source": "scanner",
+                "publisher": artifact.publisher,
+            }
+        ]
+    }
+
+    try:
+        client.post(
+            f"{settings.base_url}/signals/pain",
+            headers=headers,
+            json=payload,
+        ).raise_for_status()
+    except Exception as error:
+        if settings.fail_open:
+            logger.warning("Failed to emit Guard pain signal: %s", error)
+            return
+        raise
+
+
+def _emit_receipt(
+    settings: GuardRuntimeSettings,
+    client: httpx.Client,
+    artifact: GuardArtifactContext,
+    block: GuardRuntimeBlock,
+) -> None:
+    headers = _authorized_headers(settings)
+    if not headers:
+        return
+
+    captured_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    artifact_hash = hashlib.sha256(
+        f"{artifact.artifact_id}|{artifact.launch_summary}".encode("utf-8")
+    ).hexdigest()
+    policy_decision = "allow"
+    if block.recommendation == "block":
+        policy_decision = "block"
+    elif block.recommendation == "review":
+        policy_decision = "review"
+
+    payload = {
+        "receipts": [
+            {
+                "receiptId": f"{artifact.artifact_id}:{policy_decision}:{captured_at}",
+                "capturedAt": captured_at,
+                "harness": artifact.harness,
+                "deviceId": "hermes-runtime",
+                "deviceName": "Hermes Runtime",
+                "artifactId": artifact.artifact_id,
+                "artifactName": artifact.artifact_name,
+                "artifactType": artifact.artifact_type,
+                "artifactSlug": artifact.artifact_slug,
+                "artifactHash": artifact_hash,
+                "policyDecision": policy_decision,
+                "recommendation": block.recommendation,
+                "changedSinceLastApproval": policy_decision != "allow",
+                "publisher": artifact.publisher,
+                "capabilities": [artifact.tool_name],
+                "summary": block.reason,
+            }
+        ]
+    }
+
+    try:
+        client.post(
+            f"{settings.base_url}/receipts/submit",
+            headers=headers,
+            json=payload,
+        ).raise_for_status()
+    except Exception as error:
+        if settings.fail_open:
+            logger.warning("Failed to submit Guard receipt: %s", error)
+            return
+        raise


### PR DESCRIPTION
## Summary
- surface Guard verdict blocks as failed ACP tool completions
- gate ACP/MCP tool dispatch through Guard runtime policy before execution
- add ACP and Guard runtime regression coverage for blocked tool flows

## Verification
- uv run --with pytest --with pytest-xdist --with pytest-asyncio pytest -q tests/acp/test_tools.py tests/acp/test_mcp_e2e.py tests/tools/test_guard_runtime_policy.py tests/test_model_tools.py
- uv run --with ruff ruff check acp_adapter/tools.py tests/acp/test_tools.py tests/acp/test_mcp_e2e.py tests/tools/test_guard_runtime_policy.py tests/test_model_tools.py model_tools.py tools/guard_runtime_policy.py
- uv run python3 -m compileall model_tools.py tools/guard_runtime_policy.py tests/acp/test_tools.py tests/acp/test_mcp_e2e.py tests/tools/test_guard_runtime_policy.py tests/test_model_tools.py