### PR TITLE
fix(docker): install git for npm git deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential git nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## Summary
- install `git` in the Docker image before running project npm installs
- unblock Docker builds when npm needs git-backed dependencies

## Why
GitHub Actions Docker builds are currently failing with:
- `npm ERR! syscall spawn git`
- `npm ERR! path git`
- `npm ERR! enoent`

The failure occurs during the Dockerfile's root-level npm install step. The repo also installs `scripts/whatsapp-bridge`, whose lockfile contains git-backed dependencies (for example Baileys/libsignal), so the container needs `git` available.

## Validation
- inspected the failing Actions log for PR #8699 and confirmed the exact missing-`git` error
- verified the repo contains git-backed npm dependencies under `scripts/whatsapp-bridge/package-lock.json`
- confirmed the fix is the minimal unblocker for the observed Docker failure

## Notes
A longer-term hardening option would be replacing git/branch-based dependencies with published or fully commit-pinned tarball dependencies where possible, but that is out of scope for this unblocker.