### PR TITLE
fix(openviking): create OpenViking session in initialize() before use

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -291,7 +291,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
         self._api_key = os.environ.get("OPENVIKING_API_KEY", "")
-        self._session_id = session_id
+        self._hermes_session_id = session_id  # Hermes's session (separate namespace)
+        self._session_id = ""                   # OpenViking's session (created below)
         self._turn_count = 0
 
         try:
@@ -299,8 +300,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if not self._client.health():
                 logger.warning("OpenViking server at %s is not reachable", self._endpoint)
                 self._client = None
+                return
+            # OpenViking generates its own session IDs — create one here
+            # so subsequent /sessions/{id}/... calls work correctly.
+            resp = self._client.post("/api/v1/sessions", {"query": f"hermes:{session_id}"})
+            self._session_id = resp.get("result", {}).get("session_id", "")
+            if not self._session_id:
+                logger.warning("OpenViking /sessions returned no session_id")
+                self._client = None
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
+            self._client = None
+        except Exception as e:
+            logger.warning("OpenViking session creation failed: %s", e)
             self._client = None
 
         # Register as the last active provider for atexit safety net


### PR DESCRIPTION
## Bug Fix

**Issue:** #8705

OpenViking generates its own session IDs server-side. The `initialize()` method was storing Hermes's session_id and using it directly in API calls, causing all writes (`viking_remember`, `sync_turn`, `on_memory_write`) to fail with:

```
500 Internal Server Error
Failed to append to file viking://session/default/{hermes_session_id}/messages.jsonl: not found
```

## Fix

In `initialize()`, after creating the client and confirming health, call `POST /api/v1/sessions` to create an OpenViking session and store the returned `session_id`. All subsequent `/sessions/{id}/...` calls then use the real OpenViking session.

## Testing

Confirmed via direct API calls:
1. Create session with `POST /api/v1/sessions` → returns UUID session_id
2. Write with that ID → 200 OK
3. Write with Hermes session_id (fake) → 500 not found