### PR TITLE
fix: preserve dots for OpenCode Zen non-Claude models

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -8,8 +8,9 @@ Different LLM providers expect model identifiers in different formats:
   hyphens: ``claude-sonnet-4-6``.
 - **Copilot** expects bare names *with* dots preserved:
   ``claude-sonnet-4.6``.
-- **OpenCode Zen** follows the same dot-to-hyphen convention as
-  Anthropic: ``claude-sonnet-4-6``.
+- **OpenCode Zen** preserves dots for GPT/GLM/Gemini/Kimi/MiniMax-style
+  model IDs, but Claude still uses hyphenated native names like
+  ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
 - **DeepSeek** only accepts two model identifiers:
   ``deepseek-chat`` and ``deepseek-reasoner``.
@@ -65,9 +66,9 @@ _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
 })
 
 # Providers that want bare names with dots replaced by hyphens.
+# OpenCode Zen is mixed-mode and handled explicitly in normalize_model_for_provider().
 _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
     "anthropic",
-    "opencode-zen",
 })
 
 # Providers that want bare names with dots preserved.
@@ -351,7 +352,16 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)
 
-    # --- Anthropic / OpenCode: strip matching provider prefix, dots -> hyphens ---
+    # --- OpenCode Zen: Claude stays hyphenated; other native slugs keep dots ---
+    if provider == "opencode-zen":
+        bare = _strip_matching_provider_prefix(name, provider)
+        if "/" in bare:
+            return bare
+        if bare.lower().startswith("claude-"):
+            return _dots_to_hyphens(bare)
+        return bare
+
+    # --- Anthropic: strip matching provider prefix, dots -> hyphens ---
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -54,20 +54,23 @@ class TestAnthropicDotToHyphen:
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 
-class TestOpenCodeZenDotToHyphen:
-    """OpenCode Zen follows Anthropic convention (dots→hyphens)."""
+class TestOpenCodeZenModelNormalization:
+    """OpenCode Zen preserves dots for most models, but Claude stays hyphenated."""
 
     @pytest.mark.parametrize("model,expected", [
         ("claude-sonnet-4.6", "claude-sonnet-4-6"),
-        ("glm-4.5", "glm-4-5"),
+        ("opencode-zen/claude-opus-4.5", "claude-opus-4-5"),
+        ("glm-4.5", "glm-4.5"),
+        ("glm-5.1", "glm-5.1"),
+        ("gpt-5.4", "gpt-5.4"),
     ])
-    def test_zen_converts_dots(self, model, expected):
+    def test_zen_normalizes_models(self, model, expected):
         result = normalize_model_for_provider(model, "opencode-zen")
         assert result == expected
 
-    def test_zen_strips_vendor_prefix(self):
-        result = normalize_model_for_provider("opencode-zen/claude-sonnet-4.6", "opencode-zen")
-        assert result == "claude-sonnet-4-6"
+    def test_zen_strips_vendor_prefix_for_glm_with_dots(self):
+        result = normalize_model_for_provider("opencode-zen/glm-5.1", "opencode-zen")
+        assert result == "glm-5.1"
 
 
 # ── Copilot dot preservation (regression) ──────────────────────────────


### PR DESCRIPTION
## Summary
- preserve dotted GPT/GLM-style model ids for OpenCode Zen normalization
- keep Claude ids hyphenated on OpenCode Zen
- add regression coverage for `glm-5.1`, `gpt-5.4`, and vendor-prefixed OpenCode Zen slugs

## Why
OpenCode Zen accepts model ids like `glm-5.1` and `gpt-5.4`, but Hermes was normalizing `opencode-zen` through the generic dot-to-hyphen path, which turned those into `glm-5-1` / `gpt-5-4`. That breaks valid OpenCode Zen model ids while Claude still needs hyphenated native slugs.

This narrows the normalization behavior:
- Claude on OpenCode Zen -> dots become hyphens
- GPT / GLM / Gemini / Kimi / MiniMax-style ids on OpenCode Zen -> dots are preserved

## Test Plan
- `python -m pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_model_validation.py -q`

## Platforms tested
- macOS
