### PR TITLE
fix(copilot-acp): keep ACP runtime on chat completions

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1248,6 +1248,8 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
+    if sync_client.__class__.__name__ == "CopilotACPClient":
+        return sync_client, model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -1488,7 +1490,11 @@ def resolve_provider_client(
 
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
     try:
-        from hermes_cli.auth import PROVIDER_REGISTRY, resolve_api_key_provider_credentials
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            resolve_api_key_provider_credentials,
+            resolve_external_process_provider_credentials,
+        )
     except ImportError:
         logger.debug("hermes_cli.auth not available for provider %s", provider)
         return None, None
@@ -1561,6 +1567,41 @@ def resolve_provider_client(
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
+
+    if pconfig.auth_type == "external_process":
+        creds = resolve_external_process_provider_credentials(provider)
+        final_model = _normalize_resolved_model(model or _read_main_model(), provider)
+        if provider == "copilot-acp":
+            api_key = str(creds.get("api_key", "")).strip()
+            base_url = str(creds.get("base_url", "")).strip()
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: copilot-acp requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            if not api_key or not base_url:
+                logger.warning(
+                    "resolve_provider_client: copilot-acp requested but external "
+                    "process credentials are incomplete"
+                )
+                return None, None
+            from agent.copilot_acp_client import CopilotACPClient
+
+            client = CopilotACPClient(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model) if async_mode
+                    else (client, final_model))
+        logger.warning("resolve_provider_client: external-process provider %s not "
+                       "directly supported", provider)
+        return None, None
 
     elif pconfig.auth_type in ("oauth_device_code", "oauth_external"):
         # OAuth providers — route through their specific try functions

--- a/run_agent.py
+++ b/run_agent.py
@@ -671,13 +671,19 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
+        # GPT-5.x models often require the Responses API path — they are
+        # rejected on /v1/chat/completions by both OpenAI and OpenRouter.
+        # Also auto-upgrade for direct OpenAI URLs (api.openai.com) since
         # newer tool-calling models prefer Responses there.
-        if self.api_mode == "chat_completions" and (
-            self._is_direct_openai_url()
-            or self._model_requires_responses_api(self.model)
+        if (
+            self.api_mode == "chat_completions"
+            and self.provider != "copilot-acp"
+            and not str(self.base_url or "").lower().startswith("acp://copilot")
+            and not str(self.base_url or "").lower().startswith("acp+tcp://")
+            and (
+                self._is_direct_openai_url()
+                or self._model_requires_responses_api(self.model)
+            )
         ):
             self.api_mode = "codex_responses"
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1059,6 +1059,46 @@ model:
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"
 
 
+def test_resolve_provider_client_supports_copilot_acp_external_process():
+    fake_client = MagicMock()
+
+    with patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4-mini"), \
+         patch("agent.auxiliary_client.CodexAuxiliaryClient", MagicMock()), \
+         patch("agent.copilot_acp_client.CopilotACPClient", return_value=fake_client) as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is fake_client
+    assert model == "gpt-5.4-mini"
+    assert mock_acp.call_args.kwargs["api_key"] == "copilot-acp"
+    assert mock_acp.call_args.kwargs["base_url"] == "acp://copilot"
+    assert mock_acp.call_args.kwargs["command"] == "/usr/bin/copilot"
+    assert mock_acp.call_args.kwargs["args"] == ["--acp", "--stdio"]
+
+
+def test_resolve_provider_client_copilot_acp_requires_explicit_or_configured_model():
+    with patch("agent.auxiliary_client._read_main_model", return_value=""), \
+         patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is None
+    assert model is None
+    mock_acp.assert_not_called()
+
+
 class TestAuxiliaryMaxTokensParam:
     def test_codex_fallback_uses_max_tokens(self, monkeypatch):
         """Codex adapter translates max_tokens internally, so we return max_tokens."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -243,6 +243,22 @@ def test_api_mode_respects_explicit_openrouter_provider_over_codex_url(monkeypat
     assert agent.provider == "openrouter"
 
 
+def test_copilot_acp_stays_on_chat_completions_for_gpt_5_models(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5.4-mini",
+        base_url="acp://copilot",
+        provider="copilot-acp",
+        api_key="copilot-acp",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "copilot-acp"
+    assert agent.api_mode == "chat_completions"
+
+
 def test_build_api_kwargs_codex(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = agent._build_api_kwargs(


### PR DESCRIPTION
## What does this PR do?

This fixes two real `copilot-acp` routing bugs that were getting conflated in user reports.

First, the main runtime could auto-upgrade `copilot-acp` GPT-5-family runs onto the Responses API path. That is wrong for the current ACP client: `CopilotACPClient` does not implement `.responses`, which is what produced errors like:

- `'CopilotACPClient' object has no attribute 'responses'`

Second, the auxiliary-client resolver did not support `auth_type == external_process`, which is how `copilot-acp` is configured. That led to warnings like:

- `resolve_provider_client: unhandled auth_type external_process for copilot-acp`

and caused aux resolution to fall away from the intended ACP provider.

This PR fixes both problems by:

- keeping ACP runtimes on chat-completions semantics instead of forcing them onto the generic Responses auto-upgrade path
- adding explicit `copilot-acp` support to `resolve_provider_client()` for `external_process` credentials
- requiring an explicit or configured model for ACP aux resolution instead of guessing a hard-coded fallback model

That means this is not just an aux-model workaround. It fixes the main runtime/client mismatch and the aux routing mismatch separately.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- In `run_agent.py`, excluded `copilot-acp` / `acp://copilot` / `acp+tcp://` runtimes from the generic `chat_completions -> codex_responses` auto-upgrade.
- In `agent/auxiliary_client.py`, added `external_process` resolution support for `copilot-acp` so auxiliary routing can build a `CopilotACPClient` instead of warning and falling through.
- In `agent/auxiliary_client.py`, made ACP aux resolution fail cleanly when there is no explicit/configured model instead of guessing one.
- Added ACP-specific regression coverage in:
  - `tests/run_agent/test_run_agent_codex_responses.py`
  - `tests/agent/test_auxiliary_client.py`

## How to Test

1. Configure Hermes to use `copilot-acp` with a GPT-5-family model.
2. Reproduce a turn that previously failed with `'CopilotACPClient' object has no attribute 'responses'` and confirm it stays on the chat-completions ACP path.
3. Exercise auxiliary resolution for `copilot-acp` and confirm it no longer logs `unhandled auth_type external_process for copilot-acp`.
4. Confirm ACP aux resolution uses the explicit/configured model and returns `None` instead of inventing a fallback model when no model is available.
5. Run:
   - `venv/bin/python -m pytest -n0 -q tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client tests/run_agent/test_run_agent_codex_responses.py::test_copilot_acp_stays_on_chat_completions_for_gpt_5_models tests/agent/test_auxiliary_client.py -k 'copilot or acp'`
   - `venv/bin/python -m pytest tests/ -v -n 3`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu on WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused ACP slice passes:

- `7 passed, 107 deselected in 2.94s`

Full suite rerun with capped xdist:

- `venv/bin/python -m pytest tests/ -v -n 3`
- `92 failed, 10917 passed, 33 skipped, 160 warnings in 338.35s (0:05:38)`

The full-suite failures appear to be pre-existing/unrelated; the ACP-specific tests above are green.