### PR TITLE
fix(docs): show full install identifier for namespaced skills on Skills Hub

### DIFF
--- a/website/scripts/extract-skills.py
+++ b/website/scripts/extract-skills.py
@@ -56,6 +56,12 @@ SOURCE_LABELS = {
     "lobehub": "LobeHub",
 }
 
+# CLI namespace prefix required by `hermes skills install <prefix>/<name>`.
+# Sources not listed here can be installed by bare name.
+SOURCE_INSTALL_PREFIX = {
+    "lobehub": "lobehub",
+}
+
 
 def extract_local_skills():
     skills = []
@@ -108,6 +114,7 @@ def extract_local_skills():
                 "category": category,
                 "categoryLabel": CATEGORY_LABELS.get(category, category.replace("-", " ").title()),
                 "source": source_label,
+                "installPrefix": "",
                 "tags": tags or [],
                 "platforms": fm.get("platforms", []),
                 "author": fm.get("author", ""),
@@ -136,9 +143,11 @@ def extract_cached_index_skills():
 
         stem = filename.replace(".json", "")
         source_label = "community"
+        install_prefix = ""
         for key, label in SOURCE_LABELS.items():
             if key in stem:
                 source_label = label
+                install_prefix = SOURCE_INSTALL_PREFIX.get(key, "")
                 break
 
         if isinstance(data, dict) and "agents" in data:
@@ -151,6 +160,7 @@ def extract_cached_index_skills():
                     "category": _guess_category(agent.get("meta", {}).get("tags", [])),
                     "categoryLabel": "",  # filled below
                     "source": source_label,
+                    "installPrefix": install_prefix,
                     "tags": agent.get("meta", {}).get("tags", []),
                     "platforms": [],
                     "author": agent.get("author", ""),
@@ -170,6 +180,7 @@ def extract_cached_index_skills():
                     "category": "uncategorized",
                     "categoryLabel": "",
                     "source": source_label,
+                    "installPrefix": install_prefix,
                     "tags": entry.get("tags", []),
                     "platforms": [],
                     "author": "",

--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -9,6 +9,7 @@ interface Skill {
   category: string;
   categoryLabel: string;
   source: string;
+  installPrefix: string;
   tags: string[];
   platforms: string[];
   author: string;
@@ -208,7 +209,7 @@ function SkillCard({
               </div>
             )}
             <div className={styles.installHint}>
-              <code>hermes skills install {skill.name}</code>
+              <code>hermes skills install {skill.installPrefix ? `${skill.installPrefix}/${skill.name}` : skill.name}</code>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

The Skills Hub docs page shows install commands with bare names for LobeHub skills, but the CLI requires the `lobehub/` prefix. This means the displayed command doesn't work:

```bash
# What the docs page shows (broken)
hermes skills install api-docs-writer

# What actually works
hermes skills install lobehub/api-docs-writer
```

## Fix

Add an `installPrefix` field to the skill data pipeline so the frontend doesn't need any hardcoded source-to-prefix mapping:

- **`website/scripts/extract-skills.py`**: New `SOURCE_INSTALL_PREFIX` dict maps index-cache source keys to their CLI namespace. Each skill gets an `installPrefix` field in the extracted JSON (`"lobehub"` for LobeHub skills, `""` for built-in/optional).
- **`website/src/pages/skills/index.tsx`**: `Skill` interface gains `installPrefix`. The install hint renders `<prefix>/<name>` when a prefix exists, bare `<name>` otherwise.

Adding a new namespaced source is just one line in `SOURCE_INSTALL_PREFIX`.

## Changes

| File | Change |
|------|--------|
| `website/scripts/extract-skills.py` | Add `SOURCE_INSTALL_PREFIX` dict, emit `installPrefix` on all skill entries |
| `website/src/pages/skills/index.tsx` | Add `installPrefix` to interface, use it in install command |

Ref #6866