### PR TITLE
feat(skills): add computational-drug-discovery skill — AlphaFold, RCSB PDB, ZINC, pkCSM, QSAR

### DIFF
--- a/skills/science/computational-drug-discovery/SKILL.md
+++ b/skills/science/computational-drug-discovery/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: computational-drug-discovery
+description: >
+  Computer-Aided Drug Design (CADD) assistant covering structure-based and
+  ligand-based drug discovery workflows. Fetch protein structures from AlphaFold
+  and RCSB PDB, search compound libraries in ZINC and PubChem, predict ADMET
+  properties via pkCSM, run QSAR and similarity searches, and reason through
+  molecular docking, virtual screening, homology modelling, and pharmacophore
+  concepts. Use for computational chemistry, structural biology, in silico
+  screening, and target-based drug design questions.
+version: 1.0.0
+authors:
+  - bennytimz
+license: MIT
+metadata:
+  hermes:
+    tags: [science, chemistry, cadd, structural-biology, research]
+prerequisites:
+  commands: [curl, python3, jq]
+---
+
+# Computational Drug Discovery (CADD)
+
+You are an expert computational medicinal chemist fluent in both
+**structure-based (SB)** and **ligand-based (LB)** drug design approaches.
+
+**SB methods** — used when the 3D structure of the target protein is known
+(X-ray crystallography, cryo-EM, NMR, or AlphaFold prediction).
+
+**LB methods** — used when protein structure is NOT known but active ligands
+are available (QSAR, pharmacophore modelling, similarity searching).
+
+See references/CADD_METHODS.md for the full 8-method CADD framework.
+
+---
+
+## Core Workflows
+
+### 1 — Protein Structure Retrieval (AlphaFold)
+
+Fetch AI-predicted 3D protein structures for any UniProt ID. Free, no auth.
+
+```bash
+# Get AlphaFold structure metadata for a protein
+UNIPROT_ID="$1"
+curl -s "https://alphafold.ebi.ac.uk/api/prediction/${UNIPROT_ID}" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if not data:
+    print('No AlphaFold entry found for this UniProt ID.')
+    sys.exit()
+entry = data[0]
+print(f\"Protein     : {entry.get('uniprotDescription', 'N/A')}\")
+print(f\"Gene        : {entry.get('gene', 'N/A')}\")
+print(f\"Organism    : {entry.get('organismScientificName', 'N/A')}\")
+print(f\"UniProt ID  : {entry.get('uniprotAccession', 'N/A')}\")
+print(f\"pLDDT (avg) : {entry.get('confidenceAvgLocalScore', 'N/A')} (>90=very high, 70-90=high, 50-70=low, <50=very low)\")
+print(f\"Length      : {entry.get('uniprotSequenceLength', 'N/A')} aa\")
+print(f\"PDB file    : {entry.get('pdbUrl', 'N/A')}\")
+print(f\"View        : https://alphafold.ebi.ac.uk/entry/{entry.get('uniprotAccession', '')}\")
+"
+```
+
+```bash
+# Search UniProt for a gene name to get its UniProt ID
+GENE="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$GENE")
+curl -s "https://rest.uniprot.org/uniprotkb/search?query=${ENCODED}+AND+organism_id:9606+AND+reviewed:true&fields=accession,gene_names,protein_name,length&format=json&size=5" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+results = data.get('results', [])
+if not results:
+    print('No UniProt entries found.')
+    sys.exit()
+print('Top UniProt matches for human proteins:')
+for r in results:
+    acc   = r.get('primaryAccession', 'N/A')
+    genes = r.get('genes', [{}])[0].get('geneName', {}).get('value', 'N/A') if r.get('genes') else 'N/A'
+    name  = r.get('proteinDescription', {}).get('recommendedName', {}).get('fullName', {}).get('value', 'N/A')
+    length = r.get('sequence', {}).get('length', 'N/A')
+    print(f'  {acc}  |  {genes}  |  {name}  |  {length} aa')
+"
+```
+
+### 2 — Experimental Structure Search (RCSB PDB)
+
+```bash
+# Search RCSB PDB for experimental structures of a target
+TARGET="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$TARGET")
+curl -s "https://search.rcsb.org/rcsbsearch/v2/query?json=%7B%22query%22%3A%7B%22type%22%3A%22terminal%22%2C%22service%22%3A%22full_text%22%2C%22parameters%22%3A%7B%22value%22%3A%22${ENCODED}%22%7D%7D%2C%22return_type%22%3A%22entry%22%2C%22request_options%22%3A%7B%22paginate%22%3A%7B%22start%22%3A0%2C%22rows%22%3A5%7D%7D%7D" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+ids = [r['identifier'] for r in data.get('result_set', [])]
+if not ids:
+    print('No PDB structures found.')
+    sys.exit()
+print(f'PDB IDs found: {ids}')
+import urllib.request
+detail = json.loads(urllib.request.urlopen(f'https://data.rcsb.org/rest/v1/core/entry/{ids[0]}').read())
+struct = detail.get('struct', {})
+expt   = detail.get('exptl', [{}])[0]
+print(f'Top result: {ids[0]}')
+print(f'  Title     : {struct.get(\"title\", \"N/A\")}')
+print(f'  Method    : {expt.get(\"method\", \"N/A\")}')
+print(f'  Resolution: {detail.get(\"refine\", [{}])[0].get(\"ls_d_res_high\", \"N/A\")} Angstrom')
+print(f'  View      : https://www.rcsb.org/structure/{ids[0]}')
+print(f'  Download  : https://files.rcsb.org/download/{ids[0]}.pdb')
+"
+```
+
+### 3 — Virtual Screening Library (ZINC)
+
+```bash
+# Search ZINC for drug-like compounds
+QUERY="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$QUERY")
+curl -s "https://zinc.docking.org/substances/search/?q=${ENCODED}&count=10&format=json" \
+  | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    compounds = data if isinstance(data, list) else data.get('results', data.get('objects', []))
+    for c in compounds[:5]:
+        print(f\"  ZINC ID : {c.get('zinc_id', c.get('id', 'N/A'))}\")
+        print(f\"  Name    : {c.get('name', 'N/A')}\")
+        print(f\"  SMILES  : {c.get('smiles', 'N/A')}\")
+        print(f\"  MW      : {c.get('mwt', 'N/A')}\")
+        print()
+except Exception as e:
+    print(f'Error: {e}. Try https://zinc.docking.org/substances/search/?q=YOUR_QUERY')
+"
+```
+
+### 4 — ADMET Prediction (pkCSM)
+
+```bash
+# Predict ADMET properties for a SMILES string
+SMILES="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$SMILES")
+curl -s -X POST "http://biosig.lab.uq.edu.au/pkcsm/api/predict" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "smiles=${ENCODED}" \
+  | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print('=== pkCSM ADMET Predictions ===')
+    print('ABSORPTION')
+    print(f'  Caco-2 permeability : {data.get(\"Caco2_permeability\", \"N/A\")}')
+    print(f'  HIA                 : {data.get(\"HIA_Hou\", \"N/A\")}')
+    print(f'  Pgp substrate       : {data.get(\"Pgp_substrate\", \"N/A\")}')
+    print('DISTRIBUTION')
+    print(f'  BBB penetration     : {data.get(\"BBB_Martins\", \"N/A\")}')
+    print('METABOLISM')
+    for cyp in [\"CYP2D6_substrate\",\"CYP3A4_substrate\",\"CYP2C9_inhibitor\",\"CYP3A4_inhibitor\"]:
+        print(f'  {cyp:<28}: {data.get(cyp, \"N/A\")}')
+    print('TOXICITY')
+    print(f'  hERG inhibition     : {data.get(\"hERG_Karim\", \"N/A\")}')
+    print(f'  AMES mutagenicity   : {data.get(\"AMES\", \"N/A\")}')
+    print(f'  Hepatotoxicity      : {data.get(\"hepatotoxicity\", \"N/A\")}')
+except Exception as e:
+    print(f'API error: {e}. Try https://biosig.lab.uq.edu.au/pkcsm/ manually.')
+"
+```
+
+### 5 — Similarity Search (PubChem)
+
+```bash
+# Find compounds similar to a known active by PubChem CID
+CID="$1"
+THRESHOLD=90
+curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/fastsimilarity_2d/cid/${CID}/cids/JSON?Threshold=${THRESHOLD}&MaxRecords=10" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+cids = data.get('IdentifierList', {}).get('CID', [])
+print(f'Similar compounds (Tanimoto >= ${THRESHOLD}%): {len(cids)} found')
+print(f'CIDs: {cids[:10]}')
+"
+```
+
+### 6 — QSAR Data Extraction (ChEMBL)
+
+```bash
+# Get IC50 data for a ChEMBL target for QSAR model building
+TARGET_ID="$1"
+curl -s "https://www.ebi.ac.uk/chembl/api/data/activity?target_chembl_id=${TARGET_ID}&standard_type=IC50&pchembl_value__isnull=false&limit=20&format=json" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+acts = data.get('activities', [])
+print(f'IC50 data for QSAR ({len(acts)} records):')
+print(f'  {\"Molecule\":<18} {\"pIC50\":>6}  {\"IC50\":>10}  Assay')
+print('  ' + '-'*60)
+for a in acts:
+    print(f'  {a.get(\"molecule_chembl_id\",\"N/A\"):<18} {str(a.get(\"pchembl_value\",\"N/A\")):>6}  {str(a.get(\"standard_value\",\"N/A\")):>10}  {a.get(\"assay_chembl_id\",\"N/A\")}')
+"
+```
+
+---
+
+## Reasoning Framework
+Is the 3D protein structure known (X-ray/cryo-EM/NMR/AlphaFold)?
+YES → Structure-Based (SB): Docking, MD, Virtual Screening (SB), Homology Modelling
+NO  → Ligand-Based (LB): QSAR, Pharmacophore, Similarity Searching, Virtual Screening (LB)
+
+When reasoning about a CADD problem:
+1. Target known? → AlphaFold or PDB lookup first
+2. Binding site identified? → Check literature
+3. Known actives available? → Pull from ChEMBL
+4. Library to screen? → ZINC (purchasable), PubChem (broad)
+5. Computational resource? → Docking (regular PC), MD (GPU needed)
+
+See references/CADD_METHODS.md for full method notes including docking score
+interpretation, pLDDT thresholds, and QSAR descriptor guidance.
+
+---
+
+## Quick Reference
+
+| Method | API | Free | Auth |
+|--------|-----|------|------|
+| Protein structure (predicted) | AlphaFold | Yes | None |
+| Protein structure (experimental) | RCSB PDB | Yes | None |
+| Gene to UniProt ID | UniProt REST | Yes | None |
+| Compound library | ZINC | Yes | None |
+| ADMET prediction | pkCSM | Yes | None |
+| Similarity search | PubChem | Yes | None |
+| QSAR/SAR data | ChEMBL | Yes | None |
+
+Use alongside the drug-discovery skill for bioactivity and wet-lab workflows.

--- a/skills/science/computational-drug-discovery/references/CADD_METHODS.md
+++ b/skills/science/computational-drug-discovery/references/CADD_METHODS.md
@@ -1,0 +1,143 @@
+# CADD Methods Reference Guide
+
+Eight computational drug design methods organized by the SB/LB framework.
+
+## The SB vs LB Decision
+
+Structure-Based (SB): Requires 3D protein coordinates. Sources: X-ray (RCSB PDB), cryo-EM, NMR, AlphaFold. Advantage: precise — you see how the ligand fits the binding pocket.
+
+Ligand-Based (LB): No protein structure needed. Uses known active compounds to find new ones. Advantage: faster to start.
+
+## Method 1 — Molecular Docking
+
+Purpose: Predict how a ligand binds to a target — orientation, conformation, affinity.
+
+How it works:
+1. Obtain protein structure (PDB or AlphaFold)
+2. Define the binding site
+3. Generate ligand poses
+4. Score by estimated binding energy (more negative = better)
+5. Rank and select top poses
+
+Docking score interpretation:
+- More negative delta-G = more favorable binding
+- Typical drug scores: -7 to -12 kcal/mol
+- Validate with MD or experiment — scores alone are insufficient
+
+Computer requirement: Regular PC (AutoDock Vina runs on CPU)
+
+## Method 2 — Molecular Dynamics (MD)
+
+Purpose: Simulate time-dependent behavior of protein-ligand complex. Answers: is the docked pose stable over time?
+
+Key outputs:
+- RMSD: Root Mean Square Deviation. Low RMSD (<2 Angstrom) = stable complex
+- Binding free energy via MM-GBSA/MM-PBSA post-MD
+- Conformational sampling reveals induced fit effects
+
+Computer requirement: Strong PC or GPU cluster (GROMACS, AMBER — open source)
+
+Use MD to validate docking hits before synthesis. If RMSD spikes early, the pose was wrong.
+
+## Method 3 — Homology Modelling
+
+Purpose: Build a 3D model of a protein whose structure is experimentally unknown, using a related protein as template.
+
+When to use:
+- Target has no PDB entry
+- AlphaFold pLDDT < 70 for the binding region
+- Need structure for docking but none exists
+
+Quality thresholds:
+- Sequence identity > 30% = reliable model
+- 20-30% = twilight zone, use with caution
+- < 20% = very unreliable, prefer AlphaFold
+
+Free tools: SWISS-MODEL (web), Modeller, RoseTTAFold
+API: AlphaFold API is often faster and better
+
+## Method 4 — Virtual Screening
+
+Purpose: Screen large compound libraries (thousands to millions) computationally before lab testing.
+
+SB Virtual Screening (structure known):
+- Dock entire library against protein binding site
+- Score and rank — select top compounds for testing
+- Library sizes: 10,000 to 10,000,000+ compounds
+
+LB Virtual Screening (no structure):
+- Compare library to known actives by fingerprint similarity
+- Pharmacophore-based filtering
+- Faster than SB but less precise
+
+Free resources: ZINC (750M purchasable), PubChem, ChEMBL
+
+## Method 5 — QSAR
+
+Purpose: Mathematical models correlating molecular structure (descriptors) with biological activity.
+
+Principle: Similar structures = similar activities.
+
+Workflow:
+1. Collect actives + inactives with measured IC50 from ChEMBL
+2. Calculate molecular descriptors (MW, LogP, TPSA, fingerprints)
+3. Train ML model (random forest, SVM, neural net)
+4. Validate: R2 > 0.6 training, Q2 > 0.5 cross-validation
+5. Predict activity of new compounds
+
+Free tools: RDKit (descriptors), scikit-learn (ML)
+Data: ChEMBL (activity data), PubChem (properties)
+
+## Method 6 — Pharmacophore Modelling
+
+Purpose: Identify essential 3D chemical features (HBD, HBA, hydrophobic, charge) required for activity.
+
+Structure-based pharmacophore (protein known):
+- Features derived from protein-ligand interactions
+- More precise — grounded in actual binding geometry
+
+Ligand-based pharmacophore (no protein):
+- Align multiple active compounds in 3D
+- Find common features across all actives
+
+Pharmacophoric features: HBA, HBD, Hydrophobic, Positive ionizable, Negative ionizable, Aromatic
+
+## Method 7 — Similarity Searching
+
+Purpose: Find new actives by structural similarity to a known hit. Simplest and fastest LB method.
+
+Tanimoto coefficient: 0 (no similarity) to 1 (identical)
+Threshold: Tc > 0.85 (conservative), > 0.70 (broader search)
+
+Free tools: PubChem similarity API, ChEMBL similarity search
+
+## pLDDT Confidence Thresholds (AlphaFold)
+
+| pLDDT | Confidence | Use for docking? |
+|-------|-----------|-----------------|
+| > 90 | Very high | Yes — reliable backbone and sidechains |
+| 70-90 | High | Yes — backbone reliable |
+| 50-70 | Low | Caution — validate with MD |
+| < 50 | Very low | No — likely disordered region |
+
+Always check pLDDT at binding site residues specifically, not just the global average.
+
+## Full CADD Pipeline
+
+Target identification
+→ Protein structure retrieval (AlphaFold / RCSB PDB)
+→ Binding site identification (literature)
+→ Known actives from ChEMBL
+→ Virtual Screening (SB: docking) or (LB: pharmacophore/QSAR)
+→ ADMET filtering (pkCSM)
+→ Similarity search for analogs (PubChem)
+→ MD simulation to validate stability
+→ Synthesis and wet-lab testing
+
+## References
+
+- Jumper et al. (2021). Highly accurate protein structure prediction with AlphaFold. Nature 596, 583-589.
+- Berman et al. (2000). The Protein Data Bank. Nucleic Acids Res. 28, 235-242.
+- Irwin & Shoichet (2005). ZINC — a free database of commercially available compounds. J. Chem. Inf. Model. 45, 177-182.
+- Pires et al. (2015). pkCSM: predicting small-molecule pharmacokinetic and toxicity properties. J. Med. Chem. 58, 4066.
+- Lipinski et al. (1997). Experimental and computational approaches to estimate solubility and permeability. Adv. Drug Deliv. Rev. 23, 3-25.

--- a/skills/science/computational-drug-discovery/scripts/alphafold_lookup.py
+++ b/skills/science/computational-drug-discovery/scripts/alphafold_lookup.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+alphafold_lookup.py — Batch AlphaFold structure lookup via UniProt IDs or gene names.
+Usage:
+    python3 alphafold_lookup.py P00533 P69905 P04637
+    python3 alphafold_lookup.py --gene EGFR BRAF TP53
+No external dependencies.
+"""
+import sys, json, time, argparse
+import urllib.request, urllib.parse, urllib.error
+
+ALPHAFOLD_API = "https://alphafold.ebi.ac.uk/api/prediction"
+UNIPROT_API   = "https://rest.uniprot.org/uniprotkb/search"
+
+def fetch(url):
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404: return None
+        print(f"HTTP {e.code} for {url}", file=sys.stderr); return None
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr); return None
+
+def gene_to_uniprot(gene):
+    enc = urllib.parse.quote(f"{gene} AND organism_id:9606 AND reviewed:true")
+    data = fetch(f"{UNIPROT_API}?query={enc}&fields=accession&format=json&size=1")
+    if not data or not data.get("results"): return None
+    return data["results"][0].get("primaryAccession")
+
+def confidence_label(score):
+    try:
+        s = float(score)
+        if s >= 90: return "Very high (reliable for docking)"
+        if s >= 70: return "High (backbone reliable)"
+        if s >= 50: return "Low (use with caution)"
+        return "Very low (likely disordered - avoid docking)"
+    except: return "N/A"
+
+def print_entry(identifier, entry, resolved=""):
+    label = identifier + (f" -> {resolved}" if resolved else "")
+    if entry is None:
+        print(f"Not found: {label}"); return
+    score = entry.get("confidenceAvgLocalScore", "N/A")
+    print(f"\n{'='*60}")
+    print(f"  Protein   : {entry.get('uniprotDescription', 'N/A')}")
+    print(f"  Gene      : {entry.get('gene', 'N/A')}")
+    print(f"  Organism  : {entry.get('organismScientificName', 'N/A')}")
+    print(f"  UniProt   : {entry.get('uniprotAccession', 'N/A')}")
+    print(f"  Length    : {entry.get('uniprotSequenceLength', 'N/A')} aa")
+    print(f"  pLDDT avg : {score} — {confidence_label(score)}")
+    print(f"  PDB file  : {entry.get('pdbUrl', 'N/A')}")
+    print(f"  View      : https://alphafold.ebi.ac.uk/entry/{entry.get('uniprotAccession', '')}")
+    print(f"{'='*60}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Batch AlphaFold lookup")
+    parser.add_argument("identifiers", nargs="+")
+    parser.add_argument("--gene", action="store_true", help="Resolve gene names to UniProt IDs")
+    args = parser.parse_args()
+    print(f"\nAlphaFold lookup — {len(args.identifiers)} queries\n")
+    for ident in args.identifiers:
+        uniprot_id = ident
+        resolved = ""
+        if args.gene:
+            resolved = gene_to_uniprot(ident)
+            if not resolved:
+                print(f"Gene not found in UniProt (human): {ident}"); continue
+            uniprot_id = resolved
+        entry_data = fetch(f"{ALPHAFOLD_API}/{uniprot_id}")
+        entry = entry_data[0] if isinstance(entry_data, list) and entry_data else None
+        print_entry(ident, entry, resolved if args.gene else "")
+        time.sleep(0.3)
+    print()
+
+if __name__ == "__main__": main()


### PR DESCRIPTION
Companion to #8695 (drug-discovery skill). Adds a CADD skill covering structure-based and ligand-based drug design workflows: AlphaFold protein structure retrieval (with pLDDT confidence interpretation), RCSB PDB experimental structure search, ZINC virtual screening library, pkCSM ADMET prediction, PubChem fingerprint similarity searching, and ChEMBL QSAR data extraction. Includes a full 8-method CADD reference (molecular docking, MD simulation, homology modelling, virtual screening, QSAR, pharmacophore modelling, similarity searching) and a batch alphafold_lookup.py helper script. All APIs free, no authentication required, stdlib Python only.