### PR TITLE
fix(skills): remove [:4000] frontmatter truncation in skills_tool.py and skills_sync.py

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -112,7 +112,7 @@ def _write_manifest(entries: Dict[str, str]):
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
     """Read the name field from SKILL.md YAML frontmatter, falling back to *fallback*."""
     try:
-        content = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+        content = skill_md.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return fallback
     in_frontmatter = False

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -542,7 +542,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             skill_dir = skill_md.parent
 
             try:
-                content = skill_md.read_text(encoding="utf-8")[:4000]
+                content = skill_md.read_text(encoding="utf-8")
                 frontmatter, body = _parse_frontmatter(content)
 
                 if not skill_matches_platform(frontmatter):
@@ -671,9 +671,10 @@ def skills_categories(verbose: bool = False, task_id: str = None) -> str:
 
                 try:
                     frontmatter, _ = _parse_frontmatter(
-                        skill_md.read_text(encoding="utf-8")[:4000]
+                        skill_md.read_text(encoding="utf-8")
                     )
-                except Exception:
+                except Exception as e:
+                    logger.warning("Failed to parse frontmatter for %s: %s", skill_md, e)
                     frontmatter = {}
 
                 if not skill_matches_platform(frontmatter):


### PR DESCRIPTION
Fixes #7390.

The actual truncation was [:4000] across two files, not [:2000] in agent/prompt_builder.py (which already reads the full file and has logger.warning on failure).

**Changes:**
- tools/skills_tool.py:545 (_list_skills) — removed [:4000] slice before frontmatter parse
- tools/skills_tool.py:674 (category scan) — removed [:4000]; upgraded silent except to logger.warning
- tools/skills_sync.py:115 (_read_skill_name) — removed [:4000] slice

Any skill whose frontmatter closing --- fell past character 4000 would silently lose all metadata — no description, no tags, no platform filters — while appearing to load normally. The bug description in #7390 was accurate; only the file paths and threshold value were off.