### PR TITLE
fix(skills): use cross platform path matching for excluded directories on Windows

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -315,6 +315,24 @@ def _check_gateway_running(profile_dir: Path) -> bool:
             ProcessLookupError, PermissionError, OSError):
         return False
 
+# Directories to exclude when counting SKILL.md files in a profile.
+# Uses Path.parts comparison (not string matching) for cross-platform safety —
+# str(Path) uses backslashes on Windows, so "/.git/" would never match.
+_SKILL_EXCLUDED_DIRS = frozenset({".git", ".hub"})
+
+
+def _profile_in_excluded_dir(path: Path, root: Path) -> bool:
+    """Return True if *path* has an excluded directory component relative to *root*.
+
+    Uses ``Path.parts`` instead of string matching so the check works on
+    both Unix (``/``) and Windows (``\\``) path separators.
+    """
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        rel_parts = path.parts
+    return bool(_SKILL_EXCLUDED_DIRS.intersection(rel_parts))
+
 
 def _count_skills(profile_dir: Path) -> int:
     """Count installed skills in a profile."""
@@ -323,7 +341,7 @@ def _count_skills(profile_dir: Path) -> int:
         return 0
     count = 0
     for md in skills_dir.rglob("SKILL.md"):
-        if "/.hub/" not in str(md) and "/.git/" not in str(md):
+        if not _profile_in_excluded_dir(md, skills_dir):
             count += 1
     return count
 

--- a/tests/hermes_cli/test_profiles_count_skills.py
+++ b/tests/hermes_cli/test_profiles_count_skills.py
@@ -1,0 +1,66 @@
+"""Regression tests for _count_skills directory filtering in profiles.py.
+
+Ensures .git and .hub directories are excluded from skill counts regardless
+of the OS path separator (fixes Windows where str(Path) uses backslashes).
+"""
+
+from pathlib import Path
+
+from hermes_cli.profiles import _count_skills
+
+
+class TestCountSkillsFiltering:
+    """Verify that _count_skills excludes .git and .hub directories."""
+
+    def test_excludes_git_directory_skills(self, tmp_path):
+        """SKILL.md inside .git must not be counted."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / ".git" / "hooks").mkdir(parents=True)
+        (skills_dir / ".git" / "hooks" / "SKILL.md").write_text("# Fake")
+        # _count_skills expects the profile dir, it adds /skills internally
+        assert _count_skills(tmp_path) == 0
+
+    def test_excludes_hub_directory_skills(self, tmp_path):
+        """SKILL.md inside .hub must not be counted."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / ".hub" / "cache").mkdir(parents=True)
+        (skills_dir / ".hub" / "cache" / "SKILL.md").write_text("# Fake")
+        assert _count_skills(tmp_path) == 0
+
+    def test_counts_legitimate_skills(self, tmp_path):
+        """Normal skills must be counted correctly."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "my-skill").mkdir(parents=True)
+        (skills_dir / "my-skill" / "SKILL.md").write_text("# Real Skill")
+        assert _count_skills(tmp_path) == 1
+
+    def test_counts_nested_legitimate_skills(self, tmp_path):
+        """Skills in category subdirectories must be counted."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "category" / "skill-a").mkdir(parents=True)
+        (skills_dir / "category" / "skill-a" / "SKILL.md").write_text("# A")
+        (skills_dir / "category" / "skill-b").mkdir(parents=True)
+        (skills_dir / "category" / "skill-b" / "SKILL.md").write_text("# B")
+        assert _count_skills(tmp_path) == 2
+
+    def test_mixed_excluded_and_legitimate(self, tmp_path):
+        """Excluded dirs filtered, legitimate skills kept."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / ".git" / "hooks").mkdir(parents=True)
+        (skills_dir / ".git" / "hooks" / "SKILL.md").write_text("# Fake git")
+        (skills_dir / ".hub" / "data").mkdir(parents=True)
+        (skills_dir / ".hub" / "data" / "SKILL.md").write_text("# Fake hub")
+        (skills_dir / "real-skill").mkdir(parents=True)
+        (skills_dir / "real-skill" / "SKILL.md").write_text("# Real")
+        assert _count_skills(tmp_path) == 1
+
+    def test_no_skills_dir(self, tmp_path):
+        """Profile without a skills directory returns 0."""
+        assert _count_skills(tmp_path) == 0
+
+    def test_git_in_name_not_excluded(self, tmp_path):
+        """Skills with 'git' in their name must NOT be excluded."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "git-workflow").mkdir(parents=True)
+        (skills_dir / "git-workflow" / "SKILL.md").write_text("# Git Workflow")
+        assert _count_skills(tmp_path) == 1

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -123,10 +123,47 @@ class TestDiscoverBundledSkills:
         assert "not-a-skill" not in skill_names
 
     def test_ignores_git_directories(self, tmp_path):
+        """SKILL.md inside .git must be ignored regardless of OS path separator."""
         (tmp_path / ".git" / "hooks").mkdir(parents=True)
         (tmp_path / ".git" / "hooks" / "SKILL.md").write_text("# Fake")
         skills = _discover_bundled_skills(tmp_path)
         assert len(skills) == 0
+
+    def test_ignores_github_directories(self, tmp_path):
+        """SKILL.md inside .github must also be ignored."""
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        (tmp_path / ".github" / "workflows" / "SKILL.md").write_text("# Fake")
+        skills = _discover_bundled_skills(tmp_path)
+        assert len(skills) == 0
+
+    def test_ignores_hub_directories(self, tmp_path):
+        """SKILL.md inside .hub must also be ignored."""
+        (tmp_path / ".hub" / "cache").mkdir(parents=True)
+        (tmp_path / ".hub" / "cache" / "SKILL.md").write_text("# Fake")
+        skills = _discover_bundled_skills(tmp_path)
+        assert len(skills) == 0
+
+    def test_git_filter_does_not_affect_legitimate_skills(self, tmp_path):
+        """Skills with 'git' in their name should NOT be filtered out."""
+        (tmp_path / "git-workflow").mkdir()
+        (tmp_path / "git-workflow" / "SKILL.md").write_text("# Git Workflow")
+        skills = _discover_bundled_skills(tmp_path)
+        assert len(skills) == 1
+        assert skills[0][0] == "git-workflow"
+
+    def test_mixed_excluded_and_legitimate(self, tmp_path):
+        """Excluded dirs filtered, legitimate skills kept, in one scan."""
+        (tmp_path / ".git" / "hooks").mkdir(parents=True)
+        (tmp_path / ".git" / "hooks" / "SKILL.md").write_text("# Fake git")
+        (tmp_path / ".github" / "actions").mkdir(parents=True)
+        (tmp_path / ".github" / "actions" / "SKILL.md").write_text("# Fake github")
+        (tmp_path / ".hub" / "data").mkdir(parents=True)
+        (tmp_path / ".hub" / "data" / "SKILL.md").write_text("# Fake hub")
+        (tmp_path / "real-skill").mkdir()
+        (tmp_path / "real-skill" / "SKILL.md").write_text("# Real Skill")
+        skills = _discover_bundled_skills(tmp_path)
+        assert len(skills) == 1
+        assert skills[0][0] == "real-skill"
 
     def test_nonexistent_dir_returns_empty(self, tmp_path):
         skills = _discover_bundled_skills(tmp_path / "nonexistent")
@@ -169,7 +206,7 @@ class TestComputeRelativeDest:
         bundled = Path("/repo/skills")
         skill_dir = Path("/repo/skills/mlops/axolotl")
         dest = _compute_relative_dest(skill_dir, bundled)
-        assert str(dest).endswith("mlops/axolotl")
+        assert dest.parts[-2:] == ("mlops", "axolotl")
 
     def test_flat_skill(self):
         bundled = Path("/repo/skills")

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -31,6 +31,24 @@ from typing import Dict, List, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Directories to exclude when scanning for SKILL.md files.
+# Uses Path.parts comparison (not string matching) for cross-platform safety —
+# str(Path) uses backslashes on Windows, so "/.git/" would never match.
+_EXCLUDED_DIRS = frozenset({".git", ".github", ".hub"})
+
+
+def _in_excluded_dir(path: Path, root: Path) -> bool:
+    """Return True if *path* has an excluded directory component relative to *root*.
+
+    Uses ``Path.parts`` instead of string matching so the check works on
+    both Unix (``/``) and Windows (``\\``) path separators.
+    """
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        rel_parts = path.parts
+    return bool(_EXCLUDED_DIRS.intersection(rel_parts))
+
 
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
@@ -140,8 +158,7 @@ def _discover_bundled_skills(bundled_dir: Path) -> List[Tuple[str, Path]]:
         return skills
 
     for skill_md in bundled_dir.rglob("SKILL.md"):
-        path_str = str(skill_md)
-        if "/.git/" in path_str or "/.github/" in path_str or "/.hub/" in path_str:
+        if _in_excluded_dir(skill_md, bundled_dir):
             continue
         skill_dir = skill_md.parent
         skill_name = _read_skill_name(skill_md, skill_dir.name)


### PR DESCRIPTION
## What it does
Replaces string-based forward-slash path matching with `Path.parts` intersection checks when filtering out bundled skills and profiles. Also fixes an existing broken string-suffix assertion in `tests/tools/test_skills_sync.py` that naturally failed on Windows.

## Why it's needed
Previously, `_discover_bundled_skills()` in `tools/skills_sync.py` and `_count_skills()` in `hermes_cli/profiles.py` filtered out `SKILL.md` files located in `.git/`, `.github/`, and `.hub/` directories using a hardcoded `if "/.git/" in path_str` substring check. 

Because `str(Path)` yields backslashes on Windows (e.g., `C:\repo\.git\hooks\SKILL.md`), this filter would silently fail. This resulted in git internals and hub files being illegally synced to user skill directories and incorrectly inflating active profile skill counts strictly on Windows.

We now use `Path.parts` to make the directory exclusion checks OS-agnostic, resolving the cross-platform discrepancy in adherence to `CONTRIBUTING.md`.

## How to Test
1. Run the targeted new test cases proving Unix & Windows directory isolation natively:
   `pytest tests/tools/test_skills_sync.py`
   `pytest tests/hermes_cli/test_profiles_count_skills.py`
2. **Manual Regression (Windows):** Load a default hermes-agent profile on a fresh Windows terminal, verify via `hermes profile list` that the skill count correctly omits the `.git` directory and does not copy unintended resources to `~/.hermes/skills/`.

## Platforms Tested
- [x] Windows
- [ ] macOS
- [ ] Linux
