### PR TITLE
Add ActivityWatch integration wedge for Hermes reviews

### DIFF
--- a/optional-skills/productivity/activitywatch/SKILL.md
+++ b/optional-skills/productivity/activitywatch/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: activitywatch
+category: productivity
+description: Use local ActivityWatch data with Hermes for private self-observation, activity summaries, project heat signals, and context-aware review workflows. Covers querying the local ActivityWatch HTTP API, identifying useful bucket types, turning raw events into daily summaries, and feeding the results into Hermes reviews or cron jobs.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [activitywatch, self-tracking, productivity, observability, review, chronicle]
+    related_skills: [native-mcp, hermes-agent]
+prerequisites:
+  commands: [python3, curl]
+---
+
+# ActivityWatch
+
+Use a local ActivityWatch server as a private telemetry source for Hermes.
+
+This skill is for:
+- daily activity summaries
+- project heat analysis
+- understanding what apps, windows, editors, and browser tabs dominated a period
+- cross-checking perceived work against actual machine activity
+- feeding time-windowed signals into private Hermes reviews, not public output
+
+It is not for surveillance theater. The goal is useful self-observation and cleaner portfolio control.
+
+## What ActivityWatch gives you
+
+A local ActivityWatch instance typically exposes bucket data such as:
+- `aw-watcher-window_*` — active app/window titles over time
+- `aw-watcher-afk_*` — active vs AFK state
+- `aw-watcher-vscode_*` — editor/file activity when the VS Code watcher is installed
+- `aw-watcher-web-*` — current browser tab activity for supported browser integrations
+- `aw-watcher-input_*` — keyboard/mouse input intensity
+
+All of this is available over the local HTTP API, usually at:
+
+```bash
+http://127.0.0.1:5600/api/0/
+```
+
+## Quick checks
+
+### 1. Verify the server is up
+
+```bash
+curl -s http://127.0.0.1:5600/api/0/info
+```
+
+Expected output looks like JSON with hostname and version.
+
+### 2. List buckets
+
+```bash
+curl -s http://127.0.0.1:5600/api/0/buckets/
+```
+
+Or, for a cleaner list:
+
+```bash
+python3 - <<'PY'
+import urllib.request, json
+u = 'http://127.0.0.1:5600/api/0/buckets/'
+data = json.loads(urllib.request.urlopen(u, timeout=5).read().decode())
+for bucket_id, meta in data.items():
+    print(f"{bucket_id:45}  {meta.get('type')}")
+PY
+```
+
+## Most useful pattern: private summary, not raw dump
+
+Do not dump raw ActivityWatch event streams into canon.
+
+Preferred flow:
+1. Query only the buckets relevant to the question
+2. Summarize a bounded time window (today, yesterday, last 4h)
+3. Extract durable or operationally useful signals
+4. Write the summary into:
+   - a private review artifact
+   - `~/brain/reviews/...`
+   - or a private note for later curation
+
+## Example: summarize app/window activity for the last 24 hours
+
+Use Python instead of shell parsing so the output stays readable:
+
+```bash
+python3 - <<'PY'
+import urllib.request, json, datetime as dt
+from collections import Counter
+
+BASE = 'http://127.0.0.1:5600/api/0'
+now = dt.datetime.now(dt.timezone.utc)
+start = (now - dt.timedelta(hours=24)).isoformat()
+end = now.isoformat()
+
+buckets = json.loads(urllib.request.urlopen(f'{BASE}/buckets/', timeout=5).read().decode())
+window_buckets = [bid for bid, meta in buckets.items() if meta.get('type') == 'currentwindow']
+
+counter = Counter()
+for bid in window_buckets:
+    url = f'{BASE}/buckets/{bid}/events?start={start}&end={end}'
+    events = json.loads(urllib.request.urlopen(url, timeout=10).read().decode())
+    for ev in events:
+        app = (ev.get('data') or {}).get('app') or 'unknown'
+        title = (ev.get('data') or {}).get('title') or ''
+        counter[(app, title[:80])] += ev.get('duration', 0) or 0
+
+for (app, title), secs in counter.most_common(20):
+    print(f'{secs/3600:5.2f}h  {app:20}  {title}')
+PY
+```
+
+## Example: build a project heat hint
+
+A lightweight heuristic:
+- if active windows repeatedly include repo names, IDE titles, or terminals in a project directory,
+- and git activity also shows changes,
+- that project may deserve higher heat in Hermes' daily review.
+
+This means ActivityWatch should be treated as an additional signal layer, not the sole truth source.
+
+## Suggested Hermes use cases
+
+### 1. Daily heat scan enrichment
+Use ActivityWatch to validate:
+- which repos got real focused attention
+- whether the hottest repos by file changes match actual attention
+- whether a project is emotionally salient but not actually being worked on
+
+### 2. Weekly review reality check
+Ask:
+- what did Umut think he worked on?
+- what did the machine actually show?
+- where is there a mismatch between intention and time allocation?
+
+### 3. Context feed for "what was I doing?"
+When Umut asks:
+- "what was I working on yesterday?"
+- "what had my attention this week?"
+- "what did I keep context-switching between?"
+
+ActivityWatch is a strong source.
+
+## Good questions to ask with ActivityWatch
+
+- Which apps and windows dominated the last 24 hours?
+- Did actual attention align with the current Core projects?
+- Which repos had both git movement and real attention?
+- What looked hot in git, but not in actual usage?
+- Which browser tabs or docs kept recurring during a project push?
+
+## Bad uses
+
+- dumping raw event streams into the brain
+- pretending a window title alone proves meaningful work
+- using ActivityWatch as the only project truth source
+- using private telemetry for public outputs without a very explicit reason
+
+## Relationship to Hermes and OpenClaw
+
+### Hermes
+Hermes is a good fit for ActivityWatch when used as:
+- a private review input
+- a daily/weekly telemetry source
+- a context helper for portfolio control
+
+### OpenClaw
+OpenClaw can also consume ActivityWatch-like telemetry, but the cleanest first wedge is to integrate it with Hermes review workflows first, then evaluate whether the same logic should be ported or generalized.
+
+Do not build a two-headed integration monster first. Start with one local workflow that produces clearly useful output.
+
+## Practical recommendation
+
+First milestone:
+- add ActivityWatch-backed summaries to Hermes private review workflows
+
+Second milestone:
+- compare repo activity and ActivityWatch activity together
+
+Third milestone:
+- consider a reusable tool, MCP wrapper, or plugin surface if the workflow proves consistently useful
+
+## Output discipline
+
+When using ActivityWatch data, Hermes should return:
+1. bounded time window
+2. top observed signals
+3. interpretation with uncertainty
+4. suggested action or implication
+
+Never treat noisy telemetry as unquestionable truth.
+
+---
+
+This skill is intentionally focused on practical review workflows, not maximal telemetry ingestion.

--- a/optional-skills/productivity/activitywatch/SKILL.md
+++ b/optional-skills/productivity/activitywatch/SKILL.md
@@ -41,6 +41,26 @@ All of this is available over the local HTTP API, usually at:
 http://127.0.0.1:5600/api/0/
 ```
 
+## Helper script
+
+This skill now includes `scripts/activitywatch_summary.py` for repeatable local ActivityWatch queries.
+
+```bash
+# Server info
+python3 SKILL_DIR/scripts/activitywatch_summary.py info --pretty
+
+# List buckets
+python3 SKILL_DIR/scripts/activitywatch_summary.py buckets --pretty
+
+# Summarize top windows over the last 24h
+python3 SKILL_DIR/scripts/activitywatch_summary.py summary --hours 24 --pretty
+
+# Generate a lightweight project heat hint from window titles
+python3 SKILL_DIR/scripts/activitywatch_summary.py heat --hours 24 --pretty
+```
+
+`SKILL_DIR` is the directory containing this SKILL.md file.
+
 ## Quick checks
 
 ### 1. Verify the server is up
@@ -57,16 +77,10 @@ Expected output looks like JSON with hostname and version.
 curl -s http://127.0.0.1:5600/api/0/buckets/
 ```
 
-Or, for a cleaner list:
+Or use the helper:
 
 ```bash
-python3 - <<'PY'
-import urllib.request, json
-u = 'http://127.0.0.1:5600/api/0/buckets/'
-data = json.loads(urllib.request.urlopen(u, timeout=5).read().decode())
-for bucket_id, meta in data.items():
-    print(f"{bucket_id:45}  {meta.get('type')}")
-PY
+python3 SKILL_DIR/scripts/activitywatch_summary.py buckets --pretty
 ```
 
 ## Most useful pattern: private summary, not raw dump

--- a/optional-skills/productivity/activitywatch/scripts/activitywatch_summary.py
+++ b/optional-skills/productivity/activitywatch/scripts/activitywatch_summary.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""ActivityWatch summary helper for Hermes optional skill.
+
+Uses the local ActivityWatch HTTP API to:
+- inspect server info
+- list buckets
+- summarize app/window activity for a bounded time window
+- generate a lightweight project heat hint based on window titles and project roots
+
+Stdlib only. Output is JSON by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE_URL = "http://127.0.0.1:5600/api/0"
+DEFAULT_ROOTS = [str(Path.home() / "Projects"), "/Volumes/Work/Storage/Projects"]
+
+
+class AWError(RuntimeError):
+    pass
+
+
+def _get_json(url: str, timeout: int = 10) -> Any:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        raise AWError(f"Failed to fetch ActivityWatch URL {url}: {exc}") from exc
+
+
+def _api(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def get_info(base_url: str) -> dict[str, Any]:
+    data = _get_json(_api(base_url, "info"), timeout=5)
+    if not isinstance(data, dict):
+        raise AWError("Unexpected /info payload")
+    return data
+
+
+def get_buckets(base_url: str) -> dict[str, Any]:
+    data = _get_json(_api(base_url, "buckets/"), timeout=10)
+    if not isinstance(data, dict):
+        raise AWError("Unexpected /buckets payload")
+    return data
+
+
+def _parse_time_range(hours: int | None, start: str | None, end: str | None) -> tuple[str, str]:
+    now = dt.datetime.now(dt.timezone.utc)
+    if start:
+        start_dt = dt.datetime.fromisoformat(start)
+        if start_dt.tzinfo is None:
+            start_dt = start_dt.replace(tzinfo=dt.timezone.utc)
+    else:
+        span = dt.timedelta(hours=hours or 24)
+        start_dt = now - span
+    if end:
+        end_dt = dt.datetime.fromisoformat(end)
+        if end_dt.tzinfo is None:
+            end_dt = end_dt.replace(tzinfo=dt.timezone.utc)
+    else:
+        end_dt = now
+    return start_dt.isoformat(), end_dt.isoformat()
+
+
+def _bucket_ids_by_type(buckets: dict[str, Any], bucket_type: str) -> list[str]:
+    ids = []
+    for bucket_id, meta in buckets.items():
+        if isinstance(meta, dict) and meta.get("type") == bucket_type:
+            ids.append(bucket_id)
+    return ids
+
+
+def _fetch_bucket_events(base_url: str, bucket_id: str, start: str, end: str) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode({"start": start, "end": end})
+    data = _get_json(_api(base_url, f"buckets/{bucket_id}/events?{query}"), timeout=20)
+    if not isinstance(data, list):
+        raise AWError(f"Unexpected events payload for bucket {bucket_id}")
+    return [ev for ev in data if isinstance(ev, dict)]
+
+
+def summarize_windows(base_url: str, start: str, end: str) -> dict[str, Any]:
+    buckets = get_buckets(base_url)
+    window_buckets = _bucket_ids_by_type(buckets, "currentwindow")
+    totals: Counter[tuple[str, str]] = Counter()
+    bucket_counts: dict[str, int] = {}
+    for bucket_id in window_buckets:
+        events = _fetch_bucket_events(base_url, bucket_id, start, end)
+        bucket_counts[bucket_id] = len(events)
+        for ev in events:
+            data = ev.get("data") or {}
+            app = str(data.get("app") or "unknown")
+            title = str(data.get("title") or "")[:160]
+            duration = float(ev.get("duration") or 0)
+            if duration <= 0:
+                continue
+            totals[(app, title)] += duration
+    top = [
+        {
+            "app": app,
+            "title": title,
+            "seconds": round(secs, 2),
+            "hours": round(secs / 3600, 3),
+        }
+        for (app, title), secs in totals.most_common(25)
+    ]
+    return {
+        "start": start,
+        "end": end,
+        "window_bucket_count": len(window_buckets),
+        "bucket_event_counts": bucket_counts,
+        "top_windows": top,
+    }
+
+
+def _project_catalog(project_roots: list[str]) -> dict[str, dict[str, str]]:
+    catalog: dict[str, dict[str, str]] = {}
+    for root in project_roots:
+        root_path = Path(root).expanduser()
+        if not root_path.exists():
+            continue
+        for domain in root_path.iterdir():
+            if not domain.is_dir() or domain.name.startswith('.'):
+                continue
+            for proj in domain.iterdir():
+                if not proj.is_dir() or proj.name.startswith('.'):
+                    continue
+                key = proj.name.lower().replace('_', '-').replace(' ', '-')
+                catalog[key] = {
+                    "project": proj.name,
+                    "domain": domain.name,
+                    "path": str(proj),
+                }
+    return catalog
+
+
+def _tokenize_title(title: str) -> set[str]:
+    pieces = re.split(r"[^a-zA-Z0-9]+", title.lower())
+    return {p for p in pieces if len(p) >= 3}
+
+
+def project_heat(base_url: str, start: str, end: str, project_roots: list[str]) -> dict[str, Any]:
+    summary = summarize_windows(base_url, start, end)
+    catalog = _project_catalog(project_roots)
+    scores: defaultdict[str, float] = defaultdict(float)
+    evidence: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for item in summary["top_windows"]:
+        title = item["title"]
+        tokens = _tokenize_title(title)
+        for key, meta in catalog.items():
+            key_tokens = _tokenize_title(key)
+            if key in title.lower() or (key_tokens and key_tokens.issubset(tokens)):
+                scores[key] += float(item["seconds"])
+                evidence[key].append({
+                    "app": item["app"],
+                    "title": title,
+                    "hours": item["hours"],
+                })
+
+    ranked = []
+    for key, secs in sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:20]:
+        meta = catalog[key]
+        ranked.append({
+            "project": meta["project"],
+            "domain": meta["domain"],
+            "path": meta["path"],
+            "seconds": round(secs, 2),
+            "hours": round(secs / 3600, 3),
+            "evidence": evidence[key][:5],
+        })
+
+    return {
+        "start": start,
+        "end": end,
+        "project_roots": project_roots,
+        "matched_projects": ranked,
+        "note": "Heuristic only. Window titles are noisy; use alongside repo truth, not instead of it.",
+    }
+
+
+def list_buckets(base_url: str) -> dict[str, Any]:
+    buckets = get_buckets(base_url)
+    rows = []
+    for bucket_id, meta in buckets.items():
+        if not isinstance(meta, dict):
+            continue
+        rows.append({
+            "id": bucket_id,
+            "type": meta.get("type"),
+            "client": meta.get("client"),
+            "hostname": meta.get("hostname"),
+            "last_updated": meta.get("last_updated"),
+        })
+    rows.sort(key=lambda r: (str(r.get("type") or ""), str(r.get("id") or "")))
+    return {"buckets": rows}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="ActivityWatch helper for Hermes")
+    parser.add_argument("command", choices=["info", "buckets", "summary", "heat"])
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--hours", type=int, default=24, help="Lookback window in hours when start is not provided")
+    parser.add_argument("--start", help="ISO start timestamp")
+    parser.add_argument("--end", help="ISO end timestamp")
+    parser.add_argument(
+        "--project-root",
+        action="append",
+        default=[],
+        help="Project root to use for heat matching (repeatable). Defaults to ~/Projects and /Volumes/Work/Storage/Projects",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    base_url = args.base_url
+    pretty = args.pretty
+
+    if args.command == "info":
+        result = get_info(base_url)
+    elif args.command == "buckets":
+        result = list_buckets(base_url)
+    else:
+        start, end = _parse_time_range(args.hours, args.start, args.end)
+        if args.command == "summary":
+            result = summarize_windows(base_url, start, end)
+        else:
+            project_roots = args.project_root or DEFAULT_ROOTS
+            result = project_heat(base_url, start, end, project_roots)
+
+    if pretty:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AWError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        raise SystemExit(1)

--- a/website/docs/guides/use-activitywatch-with-hermes.md
+++ b/website/docs/guides/use-activitywatch-with-hermes.md
@@ -1,0 +1,197 @@
+---
+sidebar_position: 12
+title: "Use ActivityWatch with Hermes"
+description: "Use a local ActivityWatch server as a private telemetry source for Hermes reviews, project heat scans, and self-observation workflows."
+---
+
+# Use ActivityWatch with Hermes
+
+ActivityWatch is a local, self-hosted activity tracker that records app, window, editor, browser, and AFK signals. Hermes can use that data as a **private telemetry source** to improve reviews and project awareness.
+
+This guide shows how to:
+- verify a local ActivityWatch server
+- inspect available buckets
+- summarize recent activity
+- use it safely in Hermes review workflows
+
+## Why use ActivityWatch with Hermes?
+
+Hermes already reads:
+- repo state (`git status`, modified files, docs)
+- your private brain
+- portfolio and review artifacts
+
+ActivityWatch adds a different kind of signal:
+- what actually had your attention
+- which apps and windows dominated your time
+- where perceived work and real work differ
+- whether a project is "hot" in practice or only hot in your head
+
+This is most useful for:
+- daily project heat scans
+- weekly portfolio reviews
+- cleanup and context-switch analysis
+- answering "what was I actually doing?"
+
+## Prerequisites
+
+- Hermes Agent installed and working
+- ActivityWatch running locally
+- `python3` and `curl` available
+
+Default local endpoint:
+
+```bash
+http://127.0.0.1:5600/api/0/
+```
+
+## Step 1: verify the server
+
+```bash
+curl -s http://127.0.0.1:5600/api/0/info
+```
+
+Expected output is JSON with version and hostname.
+
+If you get no response, make sure ActivityWatch is running.
+
+## Step 2: inspect bucket types
+
+List available buckets:
+
+```bash
+curl -s http://127.0.0.1:5600/api/0/buckets/
+```
+
+For a cleaner view:
+
+```bash
+python3 - <<'PY'
+import urllib.request, json
+u = 'http://127.0.0.1:5600/api/0/buckets/'
+data = json.loads(urllib.request.urlopen(u, timeout=5).read().decode())
+for bucket_id, meta in data.items():
+    print(f"{bucket_id:45}  {meta.get('type')}")
+PY
+```
+
+Common bucket types include:
+- `currentwindow`
+- `afkstatus`
+- `app.editor.activity`
+- `web.tab.current`
+- `os.hid.input`
+
+## Step 3: summarize recent activity
+
+Do **not** ingest raw event streams into canon by default.
+Summarize a bounded time window first.
+
+Example: top app/window signals over the last 24 hours.
+
+```bash
+python3 - <<'PY'
+import urllib.request, json, datetime as dt
+from collections import Counter
+
+BASE = 'http://127.0.0.1:5600/api/0'
+now = dt.datetime.now(dt.timezone.utc)
+start = (now - dt.timedelta(hours=24)).isoformat()
+end = now.isoformat()
+
+buckets = json.loads(urllib.request.urlopen(f'{BASE}/buckets/', timeout=5).read().decode())
+window_buckets = [bid for bid, meta in buckets.items() if meta.get('type') == 'currentwindow']
+
+counter = Counter()
+for bid in window_buckets:
+    url = f'{BASE}/buckets/{bid}/events?start={start}&end={end}'
+    events = json.loads(urllib.request.urlopen(url, timeout=10).read().decode())
+    for ev in events:
+        data = ev.get('data') or {}
+        app = data.get('app') or 'unknown'
+        title = (data.get('title') or '')[:80]
+        counter[(app, title)] += ev.get('duration', 0) or 0
+
+for (app, title), secs in counter.most_common(20):
+    print(f'{secs/3600:5.2f}h  {app:20}  {title}')
+PY
+```
+
+## Step 4: use it in Hermes reviews
+
+The best first wedge is **private review enrichment**, not public posting and not giant lifelog ingestion.
+
+Examples:
+
+### Daily heat scan
+Ask Hermes to compare:
+- repo activity
+- project board priorities
+- ActivityWatch attention signals
+
+This can reveal:
+- which project actually got attention
+- what felt important but didn't get real time
+- what generated git noise without real focus
+
+### Weekly portfolio review
+Ask Hermes:
+
+```text
+Use repo signals plus ActivityWatch data from the last 7 days.
+Tell me whether my attention matched my Core Now projects,
+where I context-switched too much, and what probably deserves cleanup or demotion.
+```
+
+### Context reconstruction
+Ask Hermes:
+
+```text
+Use ActivityWatch and repo signals to reconstruct what I was probably working on yesterday.
+Prefer concrete app/window/repo evidence over generic guesses.
+```
+
+## Safe usage rules
+
+Treat ActivityWatch as:
+- a **signal source**
+- a **private telemetry layer**
+- a **review input**
+
+Do **not** treat it as:
+- unquestionable truth
+- a substitute for repo truth
+- default public content input
+
+## Recommended rollout path
+
+Start simple:
+1. Use ActivityWatch manually in review prompts
+2. Add it to private heat/weekly workflows if it proves useful
+3. Only then consider a reusable tool, skill, plugin, or MCP wrapper
+
+That keeps the integration honest and avoids building a telemetry monster before proving the workflow.
+
+## Optional skill
+
+Hermes also ships an optional skill for this workflow style:
+
+```bash
+hermes skills install official/productivity/activitywatch
+```
+
+That skill focuses on:
+- local HTTP API usage
+- bucket inspection
+- bounded summaries
+- integrating ActivityWatch into Hermes' review workflows
+
+## Relationship to OpenClaw
+
+If you also use OpenClaw, the cleanest approach is:
+- prove a Hermes review workflow first
+- keep the logic small and local
+- port or generalize only after the output is clearly useful
+
+Do not try to unify everything at once.
+A proven single-wedge workflow beats a grand integration that never stabilizes.

--- a/website/docs/guides/use-activitywatch-with-hermes.md
+++ b/website/docs/guides/use-activitywatch-with-hermes.md
@@ -87,34 +87,16 @@ Common bucket types include:
 Do **not** ingest raw event streams into canon by default.
 Summarize a bounded time window first.
 
-Example: top app/window signals over the last 24 hours.
+Use the helper script shipped with the optional skill:
 
 ```bash
-python3 - <<'PY'
-import urllib.request, json, datetime as dt
-from collections import Counter
+python3 ~/.hermes/hermes-agent/optional-skills/productivity/activitywatch/scripts/activitywatch_summary.py summary --hours 24 --pretty
+```
 
-BASE = 'http://127.0.0.1:5600/api/0'
-now = dt.datetime.now(dt.timezone.utc)
-start = (now - dt.timedelta(hours=24)).isoformat()
-end = now.isoformat()
+For a lightweight project-heat hint based on window titles:
 
-buckets = json.loads(urllib.request.urlopen(f'{BASE}/buckets/', timeout=5).read().decode())
-window_buckets = [bid for bid, meta in buckets.items() if meta.get('type') == 'currentwindow']
-
-counter = Counter()
-for bid in window_buckets:
-    url = f'{BASE}/buckets/{bid}/events?start={start}&end={end}'
-    events = json.loads(urllib.request.urlopen(url, timeout=10).read().decode())
-    for ev in events:
-        data = ev.get('data') or {}
-        app = data.get('app') or 'unknown'
-        title = (data.get('title') or '')[:80]
-        counter[(app, title)] += ev.get('duration', 0) or 0
-
-for (app, title), secs in counter.most_common(20):
-    print(f'{secs/3600:5.2f}h  {app:20}  {title}')
-PY
+```bash
+python3 ~/.hermes/hermes-agent/optional-skills/productivity/activitywatch/scripts/activitywatch_summary.py heat --hours 24 --pretty
 ```
 
 ## Step 4: use it in Hermes reviews

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -116,6 +116,7 @@ The largest optional category — covers the full ML pipeline from data curation
 
 | Skill | Description |
 |-------|-------------|
+| **activitywatch** | Use local ActivityWatch data with Hermes for private self-observation, activity summaries, project heat signals, and context-aware review workflows. Covers querying the local ActivityWatch HTTP API, inspecting bucket types, and turning raw events into bounded summaries. |
 | **canvas** | Canvas LMS integration — fetch enrolled courses and assignments using API token authentication. |
 | **memento-flashcards** | Spaced repetition flashcard system for learning and knowledge retention. |
 | **siyuan** | SiYuan Note API for searching, reading, creating, and managing blocks and documents in a self-hosted knowledge base. |


### PR DESCRIPTION
## Summary
- add an optional `activitywatch` skill focused on private Hermes review workflows
- add a reusable stdlib helper script for querying the local ActivityWatch HTTP API
- document how to use ActivityWatch for bounded summaries and project heat hints
- add the skill to the optional skills catalog

## Why
This is a first practical wedge for using ActivityWatch with Hermes as a private telemetry source for:
- daily project heat scans
- weekly portfolio reviews
- attention vs repo-activity comparisons
- context reconstruction

The scope is intentionally conservative: it proves the workflow before introducing a heavier core integration.

## Verification
- verified the local ActivityWatch info endpoint
- verified bucket listing
- verified summary helper output over a bounded 24h window
- verified project heat hint output against local project roots

## Notes
- this PR adds a docs + optional-skill wedge, not a core built-in tool yet
- if the workflow proves useful, a later iteration can wire the helper more directly into Hermes review automation