### PR TITLE
fix(discord): soften multi-chunk continuation markers

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -45,6 +45,8 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 from gateway.config import Platform, PlatformConfig
 import re
 
+_RAW_CHUNK_SUFFIX_RE = re.compile(r"\s+\((\d+)/(\d+)\)$")
+
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -762,6 +764,63 @@ class DiscordAdapter(BasePlatformAdapter):
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
 
+    @staticmethod
+    def _strip_chunk_suffix(text: str) -> str:
+        return _RAW_CHUNK_SUFFIX_RE.sub("", text)
+
+    @classmethod
+    def _format_chunk_for_discord(cls, text: str, index: int, total: int) -> str:
+        clean = cls._strip_chunk_suffix(text)
+        if total <= 1 or index <= 1:
+            return clean
+        return f"↪ Continued {index}/{total}\n{clean}"
+
+    @classmethod
+    def _continuation_prefix_budget(cls, total: int) -> int:
+        if total <= 1:
+            return 0
+        return len(f"↪ Continued {total}/{total}\n")
+
+    def _truncate_message_for_discord(self, formatted: str) -> list[str]:
+        chunk_limit = self.MAX_MESSAGE_LENGTH
+        while True:
+            chunks = self.truncate_message(formatted, chunk_limit)
+            total = len(chunks)
+            adjusted_limit = max(
+                1,
+                self.MAX_MESSAGE_LENGTH - self._continuation_prefix_budget(total),
+            )
+            if total <= 1 or adjusted_limit >= chunk_limit:
+                return chunks
+            chunk_limit = adjusted_limit
+
+    def _format_chunks_for_discord(
+        self,
+        chunks: list[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> list[str]:
+        if not chunks:
+            return chunks
+        if len(chunks) > 1:
+            total = len(chunks)
+            return [
+                self._format_chunk_for_discord(chunk, idx, total)
+                for idx, chunk in enumerate(chunks, start=1)
+            ]
+
+        indicator = None
+        if isinstance(metadata, dict):
+            indicator = metadata.get("_discord_chunk_position")
+        if isinstance(indicator, dict):
+            try:
+                idx = int(indicator.get("index", 1))
+                total = int(indicator.get("total", 1))
+            except Exception:
+                return chunks
+            return [self._format_chunk_for_discord(chunks[0], idx, total)]
+
+        return chunks
+
     async def send(
         self,
         chat_id: str,
@@ -800,7 +859,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = self._truncate_message_for_discord(formatted)
+            chunks = self._format_chunks_for_discord(chunks, metadata)
 
             message_ids = []
             reference = None

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -188,8 +188,18 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
-                        for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
+                        total_chunks = len(chunks)
+                        for idx, chunk in enumerate(chunks, start=1):
+                            chunk_meta = dict(self.metadata) if self.metadata else {}
+                            chunk_meta["_discord_chunk_position"] = {
+                                "index": idx,
+                                "total": total_chunks,
+                            }
+                            await self._send_new_chunk(
+                                chunk,
+                                self._message_id,
+                                metadata=chunk_meta,
+                            )
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
@@ -308,7 +318,12 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
-    async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
+    async def _send_new_chunk(
+        self,
+        text: str,
+        reply_to_id: Optional[str],
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
         Returns the message_id so callers can thread subsequent chunks.
@@ -317,7 +332,7 @@ class GatewayStreamConsumer:
         if not text.strip():
             return reply_to_id
         try:
-            meta = dict(self.metadata) if self.metadata else {}
+            meta = dict(metadata) if metadata else (dict(self.metadata) if self.metadata else {})
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -78,3 +78,89 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     assert channel.send.await_count == 2
     assert send_calls[0]["reference"] is ref_msg
     assert send_calls[1]["reference"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_formats_continuation_chunks_without_trailing_parenthesized_suffix():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=1234)
+    sent_chunks = []
+
+    async def fake_send(*, content, reference=None):
+        sent_chunks.append({"content": content, "reference": reference})
+        return sent_msg
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter.truncate_message = lambda content, max_len: ["First chunk (1/2)", "Second chunk (2/2)"]
+
+    result = await adapter.send("555", "Long answer")
+
+    assert result.success is True
+    assert sent_chunks == [
+        {"content": "First chunk", "reference": None},
+        {"content": "↪ Continued 2/2\nSecond chunk", "reference": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_formats_prechunked_stream_continuation_metadata():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=5678)
+    sent_chunks = []
+
+    async def fake_send(*, content, reference=None):
+        sent_chunks.append({"content": content, "reference": reference})
+        return sent_msg
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "555",
+        "Pre-chunked second chunk (2/2)",
+        metadata={"_discord_chunk_position": {"index": 2, "total": 2}},
+    )
+
+    assert result.success is True
+    assert sent_chunks == [
+        {"content": "↪ Continued 2/2\nPre-chunked second chunk", "reference": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_keeps_continuation_chunks_within_discord_limit():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=9012)
+    sent_chunks = []
+
+    async def fake_send(*, content, reference=None):
+        if len(content) > adapter.MAX_MESSAGE_LENGTH:
+            raise RuntimeError(
+                "400 Bad Request (error code: 50035): Invalid Form Body\n"
+                "In content: Must be 2000 or fewer in length."
+            )
+        sent_chunks.append({"content": content, "reference": reference})
+        return sent_msg
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "a" * 5000)
+
+    assert result.success is True
+    assert len(sent_chunks) >= 3
+    assert all(len(chunk["content"]) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert sent_chunks[1]["content"].startswith("↪ Continued 2/")

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -506,6 +506,30 @@ class TestSegmentBreakOnToolBoundary:
         assert sent_texts[0].startswith(prefix)
         assert sum(len(t) for t in sent_texts[1:]) == len(tail)
 
+    @pytest.mark.asyncio
+    async def test_initial_split_passes_chunk_position_metadata(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 610
+        adapter.truncate_message = MagicMock(return_value=["First chunk (1/2)", "Second chunk (2/2)"])
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("x" * 620)
+        consumer.finish()
+        await consumer.run()
+
+        assert adapter.send.call_count == 2
+        first_meta = adapter.send.call_args_list[0].kwargs["metadata"]
+        second_meta = adapter.send.call_args_list[1].kwargs["metadata"]
+        assert first_meta["_discord_chunk_position"] == {"index": 1, "total": 2}
+        assert second_meta["_discord_chunk_position"] == {"index": 2, "total": 2}
+
 
 class TestInterimCommentaryMessages:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace raw trailing chunk suffixes like `(2/2)` with a softer Discord continuation prefix
- preserve the first chunk without any continuation marker
- propagate chunk position metadata from the streaming split path so pre-chunked Discord sends render consistently

## Why
The previous Discord multi-chunk UX appended `(N/N)` at the end of split messages, which made the last line of long answers feel noisy. This change moves the continuation cue to the front of follow-up chunks so the flow reads more naturally in Discord.

## What changed
- `gateway/platforms/discord.py`
  - strip raw trailing chunk suffixes before send
  - format continuation chunks as `↪ Continued N/total`
  - reserve headroom for the longer continuation prefix so split sends still stay under Discord's 2000-character limit
  - apply the same formatting when chunk position arrives via metadata
- `gateway/stream_consumer.py`
  - attach `_discord_chunk_position` metadata when the initial streaming split produces multiple chunks
  - allow `_send_new_chunk()` to receive per-chunk metadata
- tests
  - add coverage for continuation formatting in the direct send path
  - add coverage for pre-chunked streaming metadata
  - add coverage for initial split metadata propagation
  - ensure the longer continuation prefix still stays under Discord's 2000-character limit

## Notes
- this is a manual port of local commit `2889950c`
- clean cherry-pick to `origin/main` was not possible because the same 4 files had drifted upstream, so this PR ports only the minimal logic needed on top of current `main`
- the upstream variant uses the neutral English prefix `↪ Continued N/total` to stay consistent with the repository's existing English-facing UI text

## Testing
```bash
python -m py_compile gateway/platforms/discord.py gateway/stream_consumer.py tests/gateway/test_discord_send.py tests/gateway/test_stream_consumer.py
python -m pytest tests/gateway/test_discord_send.py tests/gateway/test_stream_consumer.py tests/gateway/test_platform_base.py -q
```

Result:
- `92 passed in 1.00s`
