### PR TITLE
fix: block /private/etc writes on macOS (symlink bypass)

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -238,6 +238,7 @@ def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
 
 def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "no-codex"))
     _write_auth_store(
         tmp_path,
         {
@@ -281,6 +282,7 @@ def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
 
 def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "no-codex"))
     _write_auth_store(
         tmp_path,
         {

--- a/tests/run_agent/test_dict_tool_call_args.py
+++ b/tests/run_agent/test_dict_tool_call_args.py
@@ -20,13 +20,14 @@ def _response_with_tool_call(arguments):
     return SimpleNamespace(choices=[choice], usage=None)
 
 
-class _FakeChatCompletions:
-    def __init__(self):
-        self.calls = 0
+_shared_call_count = 0
 
+
+class _FakeChatCompletions:
     def create(self, **kwargs):
-        self.calls += 1
-        if self.calls == 1:
+        global _shared_call_count
+        _shared_call_count += 1
+        if _shared_call_count == 1:
             return _response_with_tool_call({"path": "README.md"})
         return SimpleNamespace(
             choices=[
@@ -45,6 +46,9 @@ class _FakeClient:
 
 
 def test_tool_call_validation_accepts_dict_arguments(monkeypatch):
+    global _shared_call_count
+    _shared_call_count = 0
+
     from run_agent import AIAgent
 
     monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: _FakeClient())

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -298,8 +298,12 @@ class TestGatewayMode:
         """agent.log (catch-all) still receives gateway AND tool records."""
         hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
 
-        logging.getLogger("gateway.run").info("gateway msg")
-        logging.getLogger("tools.file_tools").info("file msg")
+        gw_logger = logging.getLogger("gateway.run")
+        tool_logger = logging.getLogger("tools.file_tools")
+        for lg in (gw_logger, tool_logger, logging.getLogger("tools")):
+            lg.setLevel(logging.NOTSET)
+        gw_logger.info("gateway msg")
+        tool_logger.info("file msg")
 
         for h in logging.getLogger().handlers:
             h.flush()

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -79,5 +79,33 @@ class TestSafeWriteRoot:
         assert _is_write_denied(os.path.expanduser("~/.ssh/id_rsa")) is True
 
 
+class TestCheckSensitivePathMacOSBypass:
+    """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""
+
+    def test_etc_hosts_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/etc/hosts") is not None
+
+    def test_private_etc_hosts_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/etc/hosts") is not None
+
+    def test_private_etc_ssh_config_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/etc/ssh/sshd_config") is not None
+
+    def test_private_var_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/db/something") is not None
+
+    def test_boot_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
+
+    def test_safe_path_allowed(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/tmp/safe_file.txt") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -71,6 +71,25 @@ class TestWriteDenyPrefixes:
         assert _is_write_denied("/etc/systemd/system/evil.service") is True
 
 
+class TestMacOSSymlinkBypass:
+    """Ensure /private/etc paths are denied (issue #8734)."""
+
+    def test_private_etc_sudoers(self):
+        assert _is_write_denied("/private/etc/sudoers") is True
+
+    def test_private_etc_passwd(self):
+        assert _is_write_denied("/private/etc/passwd") is True
+
+    def test_private_etc_shadow(self):
+        assert _is_write_denied("/private/etc/shadow") is True
+
+    def test_private_etc_sudoers_d(self):
+        assert _is_write_denied("/private/etc/sudoers.d/custom") is True
+
+    def test_private_etc_systemd(self):
+        assert _is_write_denied("/private/etc/systemd/system/evil.service") is True
+
+
 class TestWriteAllowed:
     def test_tmp_file(self):
         assert _is_write_denied("/tmp/safe_file.txt") is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -99,12 +99,14 @@ def _get_safe_write_root() -> Optional[str]:
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
     resolved = os.path.realpath(os.path.expanduser(str(path)))
+    normalized = os.path.normpath(os.path.expanduser(str(path)))
 
-    # 1) Static deny list
-    if resolved in WRITE_DENIED_PATHS:
+    # 1) Static deny list — check both resolved and normalized to catch
+    #    macOS symlinks like /etc -> /private/etc
+    if resolved in WRITE_DENIED_PATHS or normalized in WRITE_DENIED_PATHS:
         return True
     for prefix in WRITE_DENIED_PREFIXES:
-        if resolved.startswith(prefix):
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
             return True
 
     # 2) Optional safe-root sandbox

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -61,6 +61,9 @@ WRITE_DENIED_PATHS = {
         "/etc/sudoers",
         "/etc/passwd",
         "/etc/shadow",
+        "/private/etc/sudoers",
+        "/private/etc/passwd",
+        "/private/etc/shadow",
     ]
 }
 
@@ -72,6 +75,8 @@ WRITE_DENIED_PREFIXES = [
         os.path.join(_HOME, ".kube"),
         "/etc/sudoers.d",
         "/etc/systemd",
+        "/private/etc/sudoers.d",
+        "/private/etc/systemd",
         os.path.join(_HOME, ".docker"),
         os.path.join(_HOME, ".azure"),
         os.path.join(_HOME, ".config", "gh"),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -92,7 +92,10 @@ def _is_blocked_device(filepath: str) -> bool:
 
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
-_SENSITIVE_PATH_PREFIXES = ("/etc/", "/boot/", "/usr/lib/systemd/")
+_SENSITIVE_PATH_PREFIXES = (
+    "/etc/", "/boot/", "/usr/lib/systemd/",
+    "/private/etc/", "/private/var/",
+)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
@@ -102,17 +105,16 @@ def _check_sensitive_path(filepath: str) -> str | None:
         resolved = os.path.realpath(os.path.expanduser(filepath))
     except (OSError, ValueError):
         resolved = filepath
+    normalized = os.path.normpath(os.path.expanduser(filepath))
+    _err = (
+        f"Refusing to write to sensitive system path: {filepath}\n"
+        "Use the terminal tool with sudo if you need to modify system files."
+    )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix):
-            return (
-                f"Refusing to write to sensitive system path: {filepath}\n"
-                "Use the terminal tool with sudo if you need to modify system files."
-            )
-    if resolved in _SENSITIVE_EXACT_PATHS:
-        return (
-            f"Refusing to write to sensitive system path: {filepath}\n"
-            "Use the terminal tool with sudo if you need to modify system files."
-        )
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #8734 — on macOS, `/etc` is a symlink to `/private/etc`. `os.path.realpath()` resolves `/etc/hosts` → `/private/etc/hosts`, which doesn't match the `/etc/` prefix in the blocklist, allowing writes to system configuration files.

- **`_check_sensitive_path` (file_tools.py):** now checks both the `realpath`-resolved path and the `normpath`-normalized path against sensitive prefixes, and adds explicit `/private/etc/` and `/private/var/` prefixes
- **`_is_write_denied` (file_operations.py):** same dual-check approach for the static deny list and prefix deny list

## Test plan

- [x] Added `TestMacOSSymlinkBypass` in `test_write_deny.py` — verifies `/private/etc/sudoers`, `/private/etc/passwd`, `/private/etc/shadow`, `/private/etc/sudoers.d/*`, `/private/etc/systemd/*` are denied
- [x] Added `TestCheckSensitivePathMacOSBypass` in `test_file_write_safety.py` — verifies `/etc/hosts`, `/private/etc/hosts`, `/private/etc/ssh/sshd_config`, `/private/var/db/*` are blocked; safe paths remain allowed
- [x] All 40 tests pass locally on macOS