### PR TITLE
fix(gateway): validate file:// media paths to prevent path traversal

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -37,6 +37,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
 )
 from gateway.platforms.helpers import redact_phone
+from tools.path_security import validate_media_path
 
 logger = logging.getLogger(__name__)
 
@@ -662,6 +663,11 @@ class SignalAdapter(BasePlatformAdapter):
 
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
+
+        try:
+            validate_media_path(Path(file_path))
+        except PermissionError as e:
+            return SendResult(success=False, error=str(e))
 
         # Validate size
         file_size = Path(file_path).stat().st_size

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
+from tools.path_security import validate_media_path
 
 logger = logging.getLogger(__name__)
 
@@ -1068,6 +1069,8 @@ class WeComAdapter(BasePlatformAdapter):
 
         if not local_path.is_absolute():
             local_path = (Path.cwd() / local_path).resolve()
+
+        validate_media_path(local_path)
 
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -64,6 +64,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from hermes_constants import get_hermes_home
+from tools.path_security import validate_media_path
 from utils import atomic_json_write
 
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
@@ -1671,6 +1672,7 @@ class WeixinAdapter(BasePlatformAdapter):
             file_path = image_url.replace("file://", "")
             if not os.path.isabs(file_path):
                 file_path = os.path.abspath(file_path)
+            validate_media_path(Path(file_path))
             cleanup = False
         try:
             return await self.send_document(chat_id, file_path, caption=caption, metadata=metadata)

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -1,0 +1,54 @@
+"""Tests for tools.path_security — validate_media_path."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.path_security import validate_media_path
+
+
+class TestValidateMediaPath:
+    def test_allows_tmp_files(self, tmp_path: Path):
+        f = tmp_path / "image.png"
+        f.write_bytes(b"\x89PNG")
+        validate_media_path(f)
+
+    def test_blocks_etc_passwd(self):
+        with pytest.raises(PermissionError, match="sensitive system directory"):
+            validate_media_path(Path("/etc/passwd"))
+
+    def test_blocks_etc_hosts(self):
+        with pytest.raises(PermissionError, match="sensitive system directory"):
+            validate_media_path(Path("/etc/hosts"))
+
+    def test_blocks_proc_self_environ(self):
+        with pytest.raises(PermissionError, match="sensitive system directory"):
+            validate_media_path(Path("/proc/self/environ"))
+
+    def test_blocks_var_log(self):
+        with pytest.raises(PermissionError):
+            validate_media_path(Path("/var/log/syslog"))
+
+    def test_blocks_traversal(self):
+        with pytest.raises(PermissionError, match="traversal"):
+            validate_media_path(Path("/tmp/../etc/passwd"))
+
+    def test_blocks_home_ssh(self):
+        with pytest.raises(PermissionError, match="outside allowed directories"):
+            validate_media_path(Path.home() / ".ssh" / "id_rsa")
+
+    def test_blocks_arbitrary_home_file(self):
+        with pytest.raises(PermissionError, match="outside allowed directories"):
+            validate_media_path(Path.home() / "secret.txt")
+
+    def test_allows_extra_dirs(self, tmp_path: Path):
+        custom = tmp_path / "custom"
+        custom.mkdir()
+        f = custom / "photo.jpg"
+        f.write_bytes(b"\xff\xd8")
+        validate_media_path(f, extra_allowed=[custom])
+
+    def test_file_url_traversal_scenario(self):
+        with pytest.raises(PermissionError):
+            validate_media_path(Path("/etc/passwd"))

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -6,8 +6,12 @@ skills_hub, cronjob_tools, and credential_files.
 """
 
 import logging
+import os
+import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +45,57 @@ def has_traversal_component(path_str: str) -> bool:
     """
     parts = Path(path_str).parts
     return ".." in parts
+
+
+_SENSITIVE_PREFIXES = (
+    "/etc",
+    "/var",
+    "/sys",
+    "/proc",
+    "/dev",
+    "/private/etc",
+)
+
+
+def _default_allowed_media_dirs() -> List[Path]:
+    hermes = get_hermes_home()
+    return [
+        hermes / "cache",
+        hermes / "data",
+        hermes / "media",
+        Path(tempfile.gettempdir()),
+    ]
+
+
+def validate_media_path(
+    local_path: Path,
+    *,
+    extra_allowed: Optional[List[Path]] = None,
+) -> None:
+    """Raise ``PermissionError`` if *local_path* is outside allowed media directories."""
+    resolved = local_path.resolve()
+
+    if has_traversal_component(str(local_path)):
+        raise PermissionError(
+            f"Path traversal detected in media path: {local_path}"
+        )
+
+    resolved_str = str(resolved)
+    for prefix in _SENSITIVE_PREFIXES:
+        if resolved_str == prefix or resolved_str.startswith(prefix + os.sep):
+            raise PermissionError(
+                f"Media path points to sensitive system directory: {resolved}"
+            )
+
+    allowed = _default_allowed_media_dirs()
+    if extra_allowed:
+        allowed.extend(extra_allowed)
+
+    for allowed_dir in allowed:
+        if validate_within_dir(resolved, allowed_dir) is None:
+            return
+
+    raise PermissionError(
+        f"Media path '{local_path}' is outside allowed directories. "
+        "Only files in hermes cache/data/media or tmp directories can be sent as media."
+    )


### PR DESCRIPTION
## Summary

- Adds `validate_media_path()` to `tools/path_security.py` that restricts local file reads to hermes cache/data/media and system temp directories, blocking access to sensitive system paths (`/etc`, `/proc`, `/var`, `/dev`, etc.) and detecting `..` traversal components.
- Applies the validation in **wecom**, **signal**, and **weixin** platform adapters before any `file://` URL is read from disk.
- Adds 10 unit tests covering allowed paths, blocked sensitive directories, traversal detection, and custom allowlist support.

## Test plan

- [x] `pytest tests/tools/test_path_security.py` — 10/10 passed
- [x] `file:///etc/passwd` and similar sensitive paths are rejected with `PermissionError`
- [x] Files in `/tmp` and hermes data directories are still allowed
- [x] Path traversal via `..` components is detected and blocked

Closes #8733