### PR TITLE
fix(cli): add 'custom' to --provider choices for hermes chat

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4522,7 +4522,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "xiaomi"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "xiaomi", "custom"],
         default=None,
         help="Inference provider (default: auto)"
     )


### PR DESCRIPTION
## Problem

`hermes chat --provider custom` fails with:

```
hermes chat: error: argument --provider: invalid choice: custom
```

The runtime already fully supports `"custom"` as a valid provider (resolved by `resolve_provider()` in `auth.py` L953-954), but the argparse `choices` list for `--provider` in the `chat` subparser was missing it.

This prevents:
- Explicitly selecting a custom endpoint via CLI flag
- Custom endpoints defined in `config.yaml` (`custom_providers` list) from being reachable via `--provider` flag
- Programmatic use of `hermes chat --provider custom --base-url <url>`

## Fix

Add `"custom"` to the `choices` list in `chat_parser.add_argument("--provider", ...)` in `hermes_cli/main.py`.

One-line change — no behavioral change to runtime resolution.

## Related

- #6945 — user-defined providers from providers: config cannot be resolved
- #6255 — fixes /model provider/model slug routing in CLI
- #6175 — fixes user_providers not forwarded in Telegram gateway