### PR TITLE
fix: preserve dots in model names when base_url is not api.anthropic.com

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -288,7 +288,12 @@ def _prepend_vendor(model_name: str) -> str:
 # Main normalisation entry point
 # ---------------------------------------------------------------------------
 
-def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
+def normalize_model_for_provider(
+    model_input: str,
+    target_provider: str,
+    *,
+    base_url: str | None = None,
+) -> str:
     """Translate a model name into the format the target provider's API expects.
 
     This is the primary entry point for model name normalisation.  It
@@ -304,6 +309,11 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             ``"openrouter"``, ``"anthropic"``, ``"copilot"``,
             ``"deepseek"``, ``"custom"``.  Should already be normalised
             via ``hermes_cli.models.normalize_provider()``.
+        base_url: Optional base URL of the endpoint.  When the target
+            provider is ``"anthropic"`` but the URL does not point to
+            ``api.anthropic.com``, dot-to-hyphen normalisation is
+            skipped because the proxy likely needs the original dotted
+            model name.
 
     Returns:
         The model identifier string that the target provider's API
@@ -355,6 +365,10 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
+            return bare
+        # When base_url points to a non-native endpoint (custom proxy),
+        # preserve dots — only the official Anthropic API uses hyphens.
+        if base_url and "anthropic.com" not in base_url.lower():
             return bare
         return _dots_to_hyphens(bare)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -667,7 +667,10 @@ class AIAgent:
             )
 
             if self.provider not in _AGGREGATOR_PROVIDERS:
-                self.model = normalize_model_for_provider(self.model, self.provider)
+                self.model = normalize_model_for_provider(
+                    self.model, self.provider,
+                    base_url=getattr(self, "base_url", None),
+                )
         except Exception:
             pass
 
@@ -5816,14 +5819,22 @@ class AIAgent:
         return transformed
 
     def _anthropic_preserve_dots(self) -> bool:
-        """True when using an anthropic-compatible endpoint that preserves dots in model names.
-        Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go"}:
+        """True when the endpoint expects dots in model names (e.g. claude-opus-4.6).
+
+        Only the native Anthropic API and OpenCode Zen use hyphens
+        (claude-opus-4-6).  All other Anthropic-compatible endpoints
+        — custom proxies, Alibaba/DashScope, MiniMax, etc. — preserve
+        dots.  When provider is "anthropic" but base_url does not point
+        to api.anthropic.com, the user is routing through a proxy that
+        likely needs the original dotted name.
+        """
+        provider = (getattr(self, "provider", "") or "").lower()
+        if provider not in {"anthropic", "opencode-zen"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+        if base and "anthropic.com" not in base:
+            return True
+        return False
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -51,6 +51,30 @@ class TestAnthropicDotToHyphen:
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "anthropic")
         assert result == "claude-sonnet-4-6"
 
+    @pytest.mark.parametrize("model,expected", [
+        ("claude-opus-4.6-1m", "claude-opus-4.6-1m"),
+        ("claude-sonnet-4.6", "claude-sonnet-4.6"),
+    ])
+    def test_anthropic_preserves_dots_with_custom_base_url(self, model, expected):
+        """When base_url is not api.anthropic.com, dots must be preserved."""
+        result = normalize_model_for_provider(
+            model, "anthropic", base_url="http://localhost:8000"
+        )
+        assert result == expected
+
+    def test_anthropic_converts_dots_with_official_base_url(self):
+        """When base_url is api.anthropic.com, dots are still converted."""
+        result = normalize_model_for_provider(
+            "claude-opus-4.6", "anthropic",
+            base_url="https://api.anthropic.com",
+        )
+        assert result == "claude-opus-4-6"
+
+    def test_anthropic_converts_dots_when_no_base_url(self):
+        """When base_url is None (default), dots are converted as usual."""
+        result = normalize_model_for_provider("claude-opus-4.6", "anthropic")
+        assert result == "claude-opus-4-6"
+
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

When `provider: anthropic` is used with a custom `base_url` (not `api.anthropic.com`), model name dots are incorrectly converted to hyphens. For example, `claude-opus-4.6-1m` becomes `claude-opus-4-6-1m`, which breaks custom proxies that need the original dotted format.

- Skip dot→hyphen conversion in `normalize_model_for_provider()` when `base_url` is not `api.anthropic.com`
- Invert `_anthropic_preserve_dots()` logic: only convert dots for native Anthropic API endpoints
- Regression tests for all scenarios

## Bug Description

Two layers of code unconditionally convert dots to hyphens when `provider=anthropic`, regardless of whether the endpoint is the official Anthropic API or a custom proxy:

| Layer | Location | What it does |
|---|---|---|
| 1 | `hermes_cli/model_normalize.py:355-359` | `_dots_to_hyphens()` runs on agent init when provider ∈ `_DOT_TO_HYPHEN_PROVIDERS` |
| 2 | `agent/anthropic_adapter.py:759-762` | `normalize_model_name()` runs on every API request unless `preserve_dots=True` |

The `preserve_dots` flag is controlled by `_anthropic_preserve_dots()` in `run_agent.py`, which previously only whitelisted specific providers (alibaba, minimax, opencode-go) and URL substrings. Any other custom endpoint was not recognized.

### Impact

Users who configure `provider: anthropic` with a custom `base_url` (e.g. a local proxy, gateway, or load balancer) have their model names silently mangled. The proxy receives `claude-opus-4-6-1m` instead of `claude-opus-4.6-1m`, which may cause model-not-found errors or misrouting.

Setting `provider: custom` avoids Layer 1 but not Layer 2 (when `api_mode: anthropic_messages` is used), and also requires explicitly setting `api_mode` since `custom` defaults to `chat_completions`.

## Steps to Reproduce

```yaml
# ~/.hermes/config.yaml
model:
  provider: "anthropic"
  model: "claude-opus-4.6-1m"
  base_url: "http://localhost:8000"  # custom proxy
```

1. Start hermes with this config
2. Send any message
3. **Expected**: API request contains `model: "claude-opus-4.6-1m"`
4. **Actual**: API request contains `model: "claude-opus-4-6-1m"`

## Fix

### Layer 1: `normalize_model_for_provider()` (`hermes_cli/model_normalize.py`)

Added optional `base_url` keyword parameter. When `base_url` is provided and does not contain `anthropic.com`, the dot→hyphen conversion is skipped for `_DOT_TO_HYPHEN_PROVIDERS`.

```python
def normalize_model_for_provider(
    model_input: str,
    target_provider: str,
    *,
    base_url: str | None = None,  # NEW
) -> str:
```

The caller in `run_agent.py:670` now passes `base_url`:

```python
self.model = normalize_model_for_provider(
    self.model, self.provider,
    base_url=getattr(self, "base_url", None),
)
```

### Layer 2: `_anthropic_preserve_dots()` (`run_agent.py`)

Inverted the logic from a whitelist of known dot-preserving providers to a much simpler rule:

- If provider is NOT `anthropic` or `opencode-zen` → preserve dots (covers all custom/third-party providers)
- If provider IS `anthropic`/`opencode-zen` but `base_url` does not contain `anthropic.com` → preserve dots (custom proxy)
- Otherwise → convert dots (native Anthropic API)

This is a superset of the previous behavior — alibaba, minimax, opencode-go, and dashscope URLs are all covered by the first rule.

## Test Plan

- [x] 4 new tests in `test_model_normalize.py`:
  - `test_anthropic_preserves_dots_with_custom_base_url` — dots preserved for `localhost:8000`
  - `test_anthropic_converts_dots_with_official_base_url` — dots still converted for `api.anthropic.com`
  - `test_anthropic_converts_dots_when_no_base_url` — backward compatibility (no base_url = convert)
- [x] All 32 existing + new tests pass with zero regressions

```
======================== 32 passed, 1 warning in 0.13s =========================
```

## Related Issues

- #5211 — OpenCode Go model names with dots must not be mangled (same category of dot-preservation bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)