### PR TITLE
fix: improve third-party Anthropic-compatible endpoint support

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -39,10 +39,18 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
 
     Direct api.openai.com endpoints need the Responses API for GPT-5.x
     tool calls with reasoning (chat/completions returns 400).
+
+    Third-party Anthropic-compatible endpoints (e.g. Ant Group's antchat,
+    DashScope, MiniMax) use a URL convention ending in ``/anthropic``.
+    Auto-detect these so the Anthropic Messages API adapter is used instead
+    of chat completions — consistent with ``determine_api_mode()`` in
+    ``providers.py``.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
     if "api.openai.com" in normalized and "openrouter" not in normalized:
         return "codex_responses"
+    if normalized.endswith("/anthropic") or "api.anthropic.com" in normalized:
+        return "anthropic_messages"
     return None
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5853,14 +5853,23 @@ class AIAgent:
         return transformed
 
     def _anthropic_preserve_dots(self) -> bool:
-        """True when using an anthropic-compatible endpoint that preserves dots in model names.
-        Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go"}:
-            return True
-        base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/go" in base
+        """True when model name dots should NOT be converted to hyphens.
+
+        The dot-to-hyphen conversion exists for native Anthropic endpoints,
+        where OpenRouter uses dots (claude-opus-4.6) but Anthropic's API
+        uses hyphens (claude-opus-4-6).
+
+        All third-party Anthropic-compatible endpoints use their own model
+        naming conventions which often include dots (e.g. GLM-5.1,
+        qwen3.5-plus, MiniMax-M2.7), so dots must be preserved.  Rather
+        than maintaining a hard-coded allowlist of known providers, we
+        simply check whether the endpoint is the native Anthropic API."""
+        base = (getattr(self, "base_url", "") or "").lower().rstrip("/")
+        # No base_url or direct Anthropic API → convert dots to hyphens
+        if not base or "api.anthropic.com" in base:
+            return False
+        # All third-party endpoints → preserve dots
+        return True
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""


### PR DESCRIPTION
## Summary

When using a custom Anthropic-compatible endpoint (e.g. `antchat.alipay.com/api/anthropic` with model `GLM-5.1`), two bugs prevent it from working:

1. **`_detect_api_mode_for_url()` misses `/anthropic` suffix detection** — `determine_api_mode()` in `providers.py` already detects URLs ending with `/anthropic` and returns `anthropic_messages`, but the parallel function `_detect_api_mode_for_url()` in `runtime_provider.py` does not. When a `custom` provider is configured with such a URL, the runtime resolver falls through to `_detect_api_mode_for_url()`, which returns `None`, defaulting to `chat_completions`. This causes requests to hit `/chat/completions` → HTTP 404.

2. **`_anthropic_preserve_dots()` uses a hard-coded provider allowlist** — Only Alibaba, MiniMax, and OpenCode Go endpoints were recognized. Any other third-party endpoint (e.g. Ant Group's antchat proxy serving GLM models) had its model name mangled: `GLM-5.1` → `GLM-5-1`, causing the API to return 500 errors (interpreted as empty responses by Hermes).

## Changes

- **`hermes_cli/runtime_provider.py`**: Add `/anthropic` suffix and `api.anthropic.com` detection to `_detect_api_mode_for_url()`, making it consistent with `determine_api_mode()` in `providers.py`.
- **`run_agent.py`**: Replace the hard-coded provider allowlist in `_anthropic_preserve_dots()` with a general rule: only apply dot-to-hyphen conversion for the native Anthropic API (`api.anthropic.com`); preserve dots for all third-party endpoints. The dot-to-hyphen conversion is an Anthropic-specific naming convention (OpenRouter `claude-opus-4.6` → Anthropic `claude-opus-4-6`) and should not be applied to third-party models.

## Reproduction

```yaml
# config.yaml
model:
  default: GLM-5.1
  provider: custom
  base_url: https://example.com/api/anthropic
custom_providers:
  - name: MyProvider
    base_url: https://example.com/api/anthropic
    model: GLM-5.1
```

**Before fix:** HTTP 404 (`/api/anthropic/chat/completions`) or empty responses (model name `GLM-5-1` not found).

**After fix:** Correctly uses Anthropic Messages API at `/api/anthropic/v1/messages` with original model name `GLM-5.1`.

## Test plan

- [ ] Verify native Anthropic endpoints (`api.anthropic.com`) still convert dots to hyphens (e.g. `claude-opus-4.6` → `claude-opus-4-6`)
- [ ] Verify third-party `/anthropic` endpoints auto-detect `anthropic_messages` mode
- [ ] Verify third-party endpoints preserve dots in model names (e.g. `GLM-5.1`, `qwen3.5-plus`)
- [ ] Verify existing Alibaba/MiniMax endpoints continue to work correctly