### PR TITLE
fix(gateway): disable stream deltas on platforms lacking message edit support

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7730,6 +7730,13 @@ class GatewayRunner:
                         # such platforms so streaming still delivers the final
                         # response, just without the typing indicator.
                         _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                        
+                        # Disable progressive stream deltas if the adapter cannot edit them,
+                        # otherwise it results in a small first chunk sent followed by
+                        # the remaining continuation sent as a second message.
+                        if not _adapter_supports_edit:
+                            _want_stream_deltas = False
+
                         _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                         _consumer_cfg = StreamConsumerConfig(
                             edit_interval=_scfg.edit_interval,


### PR DESCRIPTION
Fixes #8753

### Summary of Changes
Disabled progressive stream deltas entirely (`_want_stream_deltas = False`) if the connected adapter does not support `SUPPORTS_MESSAGE_EDITING` (e.g. WeChat, SMS, etc.).

### Context
When streaming to platforms that do not support editing previously sent messages, the gateway would still attempt to use streaming buffers. The `StreamConsumer` would send its first chunk of text successfully, realize it can't update that message with the rest of the stream, and send the remainder as a completely separate message. This results in every AI response being abruptly chopped into two messages.

This PR disables streaming updates at the source for these platforms, enforcing that the gateway waits for the final complete text block and sends it as one solid message.

### Testing
- [x] Tested with WeChat adapter (adapter with `SUPPORTS_MESSAGE_EDITING = False`). Received one unified response bubble instead of two.