### PR TITLE
fix(update): sync uv-managed installs during hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4618,15 +4618,32 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
 
-    # Reinstall Python dependencies. Prefer .[all], but if one optional extra
-    # breaks on this machine, keep base deps and reinstall the remaining extras
-    # individually so update does not silently strip working capabilities.
+    # Reinstall Python dependencies. Prefer syncing from uv.lock when uv is
+    # available so the update phase leaves the environment in the exact state
+    # that a later `uv run hermes` expects. Fall back to the older editable
+    # reinstall path when the lockfile sync is unavailable or fails.
     print("→ Updating Python dependencies...")
-
     uv_bin = shutil.which("uv")
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-        _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        uv_env = {
+            **os.environ,
+            "VIRTUAL_ENV": str(PROJECT_ROOT / "venv"),
+            "UV_PROJECT_ENVIRONMENT": str(PROJECT_ROOT / "venv"),
+        }
+        lockfile = PROJECT_ROOT / "uv.lock"
+        if lockfile.exists():
+            try:
+                subprocess.run(
+                    [uv_bin, "sync", "--all-extras", "--locked"],
+                    cwd=PROJECT_ROOT,
+                    check=True,
+                    env=uv_env,
+                )
+            except subprocess.CalledProcessError:
+                print("⚠ uv lockfile sync failed, falling back to editable reinstall...")
+                _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
+        else:
+            _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.


### PR DESCRIPTION
## Summary
- make `hermes update` prefer `uv sync --all-extras --locked` when `uv.lock` exists and `uv` is available
- keep the previous editable reinstall path as a fallback when lockfile sync is unavailable or fails
- add a regression test proving the update flow finishes the uv-managed sync during the update phase

## Why
`uv run hermes` validates the project environment against `uv.lock` before launch. The previous `hermes update` flow refreshed code and then reinstalled with `uv pip install`, which could leave the environment out of sync with what a later `uv run hermes` expects.

That meant users could finish `hermes update` and still hit dependency resolution/network access on the next `uv run hermes` launch.

This patch moves the sync into the update phase itself when the repository has a lockfile, so the post-update environment already matches the lockfile state.

## Notes
- I investigated the tempting `[tool.uv].frozen = true` approach, but that setting is not valid in uv 0.11.4 and causes a parse error during settings discovery.
- So the fix here stays within Hermes: complete the `uv` sync during `hermes update` instead of relying on an invalid persistent `uv` setting.

## Test Plan
- `python3 -m py_compile hermes_cli/main.py`
- `uv run pytest -o addopts='' -q tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py`
- result: `28 passed`
- verified RED -> GREEN on the new regression test for the lockfile sync path

Closes #8744
