### PR TITLE
Recover malformed embedded MiniMax tool calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential git nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/run_agent.py
+++ b/run_agent.py
@@ -3381,6 +3381,101 @@ class AIAgent:
 
         return None
 
+    def _recover_embedded_tool_calls(self, content: str) -> tuple[str, list | None]:
+        """Recover tool calls leaked into assistant text by buggy providers."""
+        text = content or ""
+        if "<tool_call" not in text and "<minimax:tool_call" not in text:
+            return text, None
+
+        block_re = re.compile(
+            r"<(?:\w+:)?tool_call>\s*(.*?)\s*</(?:\w+:)?tool_call>",
+            re.DOTALL | re.IGNORECASE,
+        )
+
+        recovered = []
+        cleaned_parts = []
+        last_end = 0
+
+        for match_index, match in enumerate(block_re.finditer(text)):
+            cleaned_parts.append(text[last_end:match.start()])
+            block = (match.group(1) or "").strip()
+            last_end = match.end()
+
+            block = re.sub(r"^(?:<(?:\w+:)?tool_call>\s*)+", "", block, flags=re.IGNORECASE)
+
+            parsed_name = None
+            parsed_args = None
+
+            if block.startswith("{"):
+                try:
+                    data = json.loads(block)
+                    if isinstance(data, dict):
+                        parsed_name = data.get("name")
+                        parsed_args = data.get("arguments")
+                except Exception:
+                    malformed_name = re.search(r'"name"\s*:\s*"([^"]+)"', block, flags=re.IGNORECASE)
+                    if malformed_name:
+                        parsed_name = malformed_name.group(1).strip() or None
+
+            invoke_match = re.search(
+                r"<invoke(?:\s+name=[\"']([^\"']+)[\"'])?\s*>",
+                block,
+                flags=re.IGNORECASE,
+            )
+            if parsed_name is None and invoke_match:
+                parsed_name = invoke_match.group(1) or None
+
+            params = {}
+            for param_match in re.finditer(
+                r"<parameter\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</parameter>",
+                block,
+                flags=re.DOTALL | re.IGNORECASE,
+            ):
+                key = (param_match.group(1) or "").strip()
+                value = re.sub(r"\s+", " ", (param_match.group(2) or "")).strip()
+                if key:
+                    params[key] = value
+
+            inline_param_match = re.search(
+                r'"parameter\s+name="\s*([^"]+)\s*">\s*([^<]+)',
+                block,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+            if inline_param_match:
+                key = (inline_param_match.group(1) or "").strip()
+                value = re.sub(r"\s+", " ", (inline_param_match.group(2) or "")).strip()
+                if key and key not in params:
+                    params[key] = value
+
+            if parsed_name is None and params.keys() == {"command"}:
+                parsed_name = "terminal"
+            if params:
+                parsed_args = params
+
+            if not isinstance(parsed_name, str) or not parsed_name.strip() or parsed_args is None:
+                cleaned_parts.append(match.group(0))
+                continue
+
+            arguments_json = parsed_args if isinstance(parsed_args, str) else json.dumps(parsed_args, ensure_ascii=False)
+            repaired_name = self._repair_tool_call(parsed_name.strip()) or parsed_name.strip()
+            recovered.append(
+                SimpleNamespace(
+                    id=self._deterministic_call_id(repaired_name, arguments_json, match_index),
+                    type="function",
+                    function=SimpleNamespace(name=repaired_name, arguments=arguments_json),
+                )
+            )
+
+        if not recovered:
+            return text, None
+
+        cleaned_parts.append(text[last_end:])
+        cleaned = "".join(cleaned_parts)
+        cleaned = re.sub(r"</(?:\w+:)?tool_call>\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"</tool>\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+        return cleaned, recovered
+
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
@@ -9425,6 +9520,14 @@ class AIAgent:
                         assistant_message.content = "\n".join(parts)
                     else:
                         assistant_message.content = str(raw)
+
+                recovered_content, recovered_tool_calls = self._recover_embedded_tool_calls(
+                    assistant_message.content or ""
+                )
+                assistant_message.content = recovered_content
+                if recovered_tool_calls and not getattr(assistant_message, "tool_calls", None):
+                    assistant_message.tool_calls = recovered_tool_calls
+                    finish_reason = "tool_calls"
 
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook

--- a/run_agent.py
+++ b/run_agent.py
@@ -3384,11 +3384,11 @@ class AIAgent:
     def _recover_embedded_tool_calls(self, content: str) -> tuple[str, list | None]:
         """Recover tool calls leaked into assistant text by buggy providers."""
         text = content or ""
-        if "<tool_call" not in text and "<minimax:tool_call" not in text:
+        if "tool_call" not in text:
             return text, None
 
         block_re = re.compile(
-            r"<(?:\w+:)?tool_call>\s*(.*?)\s*</(?:\w+:)?tool_call>",
+            r"<(?:\w+:)?tool_call(?:s)?>\s*(.*?)\s*</(?:\w+:)?tool_call(?:s)?>",
             re.DOTALL | re.IGNORECASE,
         )
 
@@ -3396,82 +3396,131 @@ class AIAgent:
         cleaned_parts = []
         last_end = 0
 
-        for match_index, match in enumerate(block_re.finditer(text)):
-            cleaned_parts.append(text[last_end:match.start()])
-            block = (match.group(1) or "").strip()
-            last_end = match.end()
+        def _normalize_value(value: str) -> str:
+            return re.sub(r"\s+", " ", value).strip()
 
-            block = re.sub(r"^(?:<(?:\w+:)?tool_call>\s*)+", "", block, flags=re.IGNORECASE)
-
-            parsed_name = None
-            parsed_args = None
-
-            if block.startswith("{"):
-                try:
-                    data = json.loads(block)
-                    if isinstance(data, dict):
-                        parsed_name = data.get("name")
-                        parsed_args = data.get("arguments")
-                except Exception:
-                    malformed_name = re.search(r'"name"\s*:\s*"([^"]+)"', block, flags=re.IGNORECASE)
-                    if malformed_name:
-                        parsed_name = malformed_name.group(1).strip() or None
-
-            invoke_match = re.search(
-                r"<invoke(?:\s+name=[\"']([^\"']+)[\"'])?\s*>",
-                block,
-                flags=re.IGNORECASE,
+        def _append_recovered(tool_name: str, tool_args, match_index: int) -> None:
+            arguments_json = tool_args if isinstance(tool_args, str) else json.dumps(tool_args, ensure_ascii=False)
+            repaired_name = self._repair_tool_call(tool_name.strip()) or tool_name.strip()
+            recovered.append(
+                SimpleNamespace(
+                    id=self._deterministic_call_id(repaired_name, arguments_json, match_index + len(recovered)),
+                    type="function",
+                    function=SimpleNamespace(name=repaired_name, arguments=arguments_json),
+                )
             )
-            if parsed_name is None and invoke_match:
-                parsed_name = invoke_match.group(1) or None
 
-            params = {}
-            for param_match in re.finditer(
-                r"<parameter\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</parameter>",
-                block,
-                flags=re.DOTALL | re.IGNORECASE,
-            ):
-                key = (param_match.group(1) or "").strip()
-                value = re.sub(r"\s+", " ", (param_match.group(2) or "")).strip()
-                if key:
-                    params[key] = value
-
-            inline_param_match = re.search(
+        def _extract_params(block: str) -> dict[str, str]:
+            params = {
+                key.strip(): _normalize_value(value)
+                for key, value in re.findall(
+                    r"<parameter\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</parameter>",
+                    block,
+                    flags=re.DOTALL | re.IGNORECASE,
+                )
+                if key.strip()
+            }
+            inline = re.search(
                 r'"parameter\s+name="\s*([^"]+)\s*">\s*([^<]+)',
                 block,
                 flags=re.DOTALL | re.IGNORECASE,
             )
-            if inline_param_match:
-                key = (inline_param_match.group(1) or "").strip()
-                value = re.sub(r"\s+", " ", (inline_param_match.group(2) or "")).strip()
+            if inline:
+                key = (inline.group(1) or "").strip()
+                value = _normalize_value(inline.group(2) or "")
                 if key and key not in params:
                     params[key] = value
+            return params
 
+        def _parse_json_payload(block: str):
+            if not block.startswith(("{", "[")):
+                return None
+            try:
+                data = json.loads(block)
+            except Exception:
+                if not block.startswith("{"):
+                    return None
+                malformed_name = re.search(r'"name"\s*:\s*"([^"]+)"', block, flags=re.IGNORECASE)
+                malformed_command = re.search(
+                    r'"command"\s*:\s*"(.+?)(?:</parameter>|<(?:/)?(?:invoke|tool|(?:\w+:)?tool_call)\b)',
+                    block,
+                    flags=re.DOTALL | re.IGNORECASE,
+                )
+                parsed_name = malformed_name.group(1).strip() if malformed_name else None
+                parsed_args = None
+                if malformed_command:
+                    command_value = _normalize_value(malformed_command.group(1))
+                    if command_value:
+                        parsed_args = {"command": command_value}
+                return [(parsed_name, parsed_args)] if parsed_name else None
+
+            if isinstance(data, dict):
+                return [(data.get("name"), data.get("arguments"))]
+            if isinstance(data, list):
+                return [
+                    (item.get("name"), item.get("arguments"))
+                    for item in data
+                    if isinstance(item, dict)
+                ] or None
+            return None
+
+        def _parse_single_block(block: str):
+            parsed_name = None
+            parsed_args = None
+            json_payload = _parse_json_payload(block)
+            if json_payload:
+                parsed_name, parsed_args = json_payload[0]
+
+            if parsed_name is None:
+                invoke_match = re.search(
+                    r"<invoke(?:\s+name=[\"']([^\"']+)[\"'])?\s*>",
+                    block,
+                    flags=re.IGNORECASE,
+                )
+                if invoke_match:
+                    parsed_name = invoke_match.group(1) or None
+
+            params = _extract_params(block)
             if parsed_name is None and params.keys() == {"command"}:
                 parsed_name = "terminal"
             if params:
                 parsed_args = params
 
             if not isinstance(parsed_name, str) or not parsed_name.strip() or parsed_args is None:
+                return None
+            return parsed_name.strip(), parsed_args
+
+        for match_index, match in enumerate(block_re.finditer(text)):
+            cleaned_parts.append(text[last_end:match.start()])
+            block = (match.group(1) or "").strip()
+            last_end = match.end()
+
+            block = re.sub(r"^(?:<(?:\w+:)?tool_call(?:s)?>\s*)+", "", block, flags=re.IGNORECASE)
+
+            json_payload = _parse_json_payload(block)
+            if json_payload and len(json_payload) > 1:
+                recovered_any = False
+                for parsed_name, parsed_args in json_payload:
+                    if isinstance(parsed_name, str) and parsed_name.strip() and parsed_args is not None:
+                        _append_recovered(parsed_name, parsed_args, match_index)
+                        recovered_any = True
+                if recovered_any:
+                    continue
+
+            parsed = _parse_single_block(block)
+            if parsed is None:
                 cleaned_parts.append(match.group(0))
                 continue
 
-            arguments_json = parsed_args if isinstance(parsed_args, str) else json.dumps(parsed_args, ensure_ascii=False)
-            repaired_name = self._repair_tool_call(parsed_name.strip()) or parsed_name.strip()
-            recovered.append(
-                SimpleNamespace(
-                    id=self._deterministic_call_id(repaired_name, arguments_json, match_index),
-                    type="function",
-                    function=SimpleNamespace(name=repaired_name, arguments=arguments_json),
-                )
-            )
+            parsed_name, parsed_args = parsed
+            _append_recovered(parsed_name, parsed_args, match_index)
 
         if not recovered:
             return text, None
 
         cleaned_parts.append(text[last_end:])
         cleaned = "".join(cleaned_parts)
-        cleaned = re.sub(r"</(?:\w+:)?tool_call>\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"</(?:\w+:)?tool_call(?:s)?>\s*", "", cleaned, flags=re.IGNORECASE)
         cleaned = re.sub(r"</tool>\s*", "", cleaned, flags=re.IGNORECASE)
         cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
         return cleaned, recovered

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -180,6 +180,74 @@ class TestProviderModelNormalization:
         assert agent.model == "anthropic/claude-sonnet-4.6"
 
 
+class TestEmbeddedToolCallRecovery:
+    def test_recovers_json_tool_call_block_from_assistant_text(self, agent):
+        content, tool_calls = agent._recover_embedded_tool_calls(
+            'Let me check.\n<tool_call>{"name":"terminal","arguments":{"command":"pwd"}}</tool_call>'
+        )
+
+        assert "Let me check." in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "terminal"
+        assert json.loads(tool_calls[0].function.arguments) == {"command": "pwd"}
+
+    def test_recovers_malformed_minimax_parameter_block(self, agent):
+        leaked = (
+            "<tool_call>\n"
+            "<tool_call>\n"
+            '<parameter name="command">head -5 /Users/nopenotagain/.hermes/skills/tool-use/SKILL.md</parameter>\n'
+            "</invoke>\n"
+            "</minimax:tool_call>"
+        )
+
+        content, tool_calls = agent._recover_embedded_tool_calls(leaked)
+
+        assert content == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "terminal"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "command": "head -5 /Users/nopenotagain/.hermes/skills/tool-use/SKILL.md"
+        }
+
+    def test_recovers_malformed_minimax_name_plus_parameter_block(self, agent):
+        leaked = (
+            "<tool_call>\n"
+            '{"name": "session_search">\n'
+            '<parameter name="limit">5</parameter>\n'
+            "</tool_call>\n"
+            "</minimax:tool_call>"
+        )
+
+        content, tool_calls = agent._recover_embedded_tool_calls(leaked)
+
+        assert content == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "session_search"
+        assert json.loads(tool_calls[0].function.arguments) == {"limit": "5"}
+
+    def test_recovers_inline_parameter_name_variant(self, agent):
+        leaked = (
+            "<tool_call>\n"
+            '{"name": "terminal", "parameter name="command">mkdir -p '
+            '"/Users/nopenotagain/Hermetius/0x1-proof-kernel-fast lane/0x1/models/lambda-RLM"</parameter>\n'
+            "</tool>\n"
+            "</minimax:tool_call>"
+        )
+
+        content, tool_calls = agent._recover_embedded_tool_calls(leaked)
+
+        assert content == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "terminal"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "command": 'mkdir -p "/Users/nopenotagain/Hermetius/0x1-proof-kernel-fast lane/0x1/models/lambda-RLM"'
+        }
+
+
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -247,6 +247,44 @@ class TestEmbeddedToolCallRecovery:
             "command": 'mkdir -p "/Users/nopenotagain/Hermetius/0x1-proof-kernel-fast lane/0x1/models/lambda-RLM"'
         }
 
+    def test_recovers_json_arguments_command_cut_off_by_parameter_close(self, agent):
+        leaked = (
+            "<tool_call>\n"
+            '{"name": "terminal", "arguments": {"command": "curl -L '
+            '\\"https://github.com/RamXX/zettelvault/archive/refs/heads/main.tar.gz\\" | '
+            'tar xz --strip-components=1 -C '
+            '\\"/Users/nopenotagain/Hermetius/0x1-proof-kernel-fastlane/0x1/right/absorb\\" '
+            '&& ls -la '
+            '\\"/Users/nopenotagain/Hermetius/0x1-proof-kernel-fastlane/0x1/right/absorb/zettelvault/\\" '
+            '2>/dev/null | head -20</parameter>\n'
+            "</invoke>\n"
+            "</minimax:tool_call>"
+        )
+
+        content, tool_calls = agent._recover_embedded_tool_calls(leaked)
+
+        assert content == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "terminal"
+        assert "zettelvault/archive/refs/heads/main.tar.gz" in json.loads(tool_calls[0].function.arguments)["command"]
+
+    def test_recovers_plural_tool_calls_wrapper_with_json_list(self, agent):
+        leaked = (
+            "Best Practices\n"
+            "<tool_calls>\n"
+            '[{"name": "session_search", "arguments": {"limit": 5}}]\n'
+            "</tool_calls>"
+        )
+
+        content, tool_calls = agent._recover_embedded_tool_calls(leaked)
+
+        assert "Best Practices" in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "session_search"
+        assert json.loads(tool_calls[0].function.arguments) == {"limit": 5}
+
 
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)


### PR DESCRIPTION
## Summary
- recover tool calls leaked into assistant text by buggy MiniMax responses
- support malformed name-plus-parameter and inline-parameter variants in addition to normal embedded `<tool_call>` JSON
- add focused regression coverage for the observed leak shapes

## Testing
- `python -m py_compile run_agent.py tests/run_agent/test_run_agent.py`
- `source .venv/bin/activate && python - <<'PY'`
```python
import sys, types, pytest
requests = types.ModuleType("requests")
requests.get = lambda *a, **k: None
requests.post = lambda *a, **k: None
requests.Session = object
requests.RequestException = Exception
sys.modules["requests"] = requests
raise SystemExit(pytest.main(["-o", "addopts=", "tests/run_agent/test_run_agent.py", "-k", "EmbeddedToolCallRecovery", "-q"]))
```
- `PY`