### PR TITLE
fix(cli): prefer native MiniMax over OpenRouter for /model minimax

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -365,7 +365,20 @@ def _resolve_alias_fallback(
     Falls back to ``("openrouter", "nous")`` only when no authenticated
     providers are supplied (backwards compat for non-interactive callers).
     """
-    providers = authenticated_providers or ("openrouter", "nous")
+    from hermes_cli.providers import is_aggregator
+
+    if not authenticated_providers:
+        providers: list[str] = ["openrouter", "nous"]
+    else:
+        # Prefer direct API providers over aggregators (OpenRouter, Nous).
+        # Otherwise ``/model minimax`` matches ``minimax/minimax-*`` on
+        # OpenRouter first whenever OPENROUTER_API_KEY is set, even if
+        # MINIMAX_API_KEY is also set — users expect native MiniMax.
+        providers = sorted(
+            list(authenticated_providers),
+            key=lambda s: (is_aggregator(s), s),
+        )
+
     for provider in providers:
         result = resolve_alias(raw_input, provider)
         if result is not None:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1031,6 +1031,40 @@ def detect_provider_for_model(
         # give a clear error rather than silently using the wrong provider
         return (direct_match, name)
 
+    # --- Step 1b: vendor/model slugs that exist on OpenRouter AND as native API ---
+    # Typing `minimax/MiniMax-M2.7` (or OR's `minimax/minimax-m2.7`) was matching
+    # Step 2 and switching to OpenRouter even when MINIMAX_API_KEY is set — same
+    # string is a valid direct MiniMax model id. Prefer native API when creds exist.
+    if "/" in name:
+        prefix, remainder = name.split("/", 1)
+        prefix_key = _PROVIDER_ALIASES.get(prefix.strip().lower(), prefix.strip().lower())
+        remainder = remainder.strip()
+        if (
+            prefix_key
+            and remainder
+            and prefix_key in _PROVIDER_MODELS
+            and prefix_key not in _AGGREGATORS
+        ):
+            for mid in _PROVIDER_MODELS[prefix_key]:
+                if mid.lower() == remainder.lower():
+                    has_native_creds = False
+                    try:
+                        from hermes_cli.auth import PROVIDER_REGISTRY
+
+                        pconfig = PROVIDER_REGISTRY.get(prefix_key)
+                        if pconfig and pconfig.auth_type == "api_key":
+                            import os
+
+                            for env_var in pconfig.api_key_env_vars:
+                                if os.getenv(env_var, "").strip():
+                                    has_native_creds = True
+                                    break
+                    except Exception:
+                        pass
+                    if has_native_creds:
+                        return (prefix_key, mid)
+                    break
+
     # --- Step 2: check OpenRouter catalog ---
     # First try exact match (handles provider/model format)
     or_slug = _find_openrouter_slug(name)


### PR DESCRIPTION
## Summary

When using `/model minimax`, Hermes was routing through OpenRouter even when the user had a native MiniMax API key configured. This caused unnecessary OpenRouter charges.

## Changes

- `hermes_cli/model_switch.py`: Sort alias fallback providers so direct API keys win over aggregators
- `hermes_cli/models.py`: Add Step 1b to detect vendor/model slugs and prefer native API credentials before OpenRouter fallback

## Behavior

- `/model minimax` → Uses native MiniMax API (if configured) before falling back to OpenRouter
- `/model minimax/MiniMax-M2.7` → Prefers native MiniMax if credentials exist, falls back to OpenRouter if not

This ensures users with native provider credentials aren't accidentally charged through aggregators.
