### PR TITLE
fix: preserve URL query params for Azure OpenAI and custom endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -46,6 +46,7 @@ import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse, parse_qs, urlunparse
 
 from openai import OpenAI
 
@@ -54,6 +55,17 @@ from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_url_query_params(url: str):
+    """Extract query params from URL, return (clean_url, default_query dict or None)."""
+    parsed = urlparse(url)
+    if parsed.query:
+        clean = urlunparse(parsed._replace(query=""))
+        params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+        return clean, params
+    return url, None
+
 
 # Module-level flag: only warn once per process about stale OPENAI_BASE_URL.
 _stale_base_url_warned = False
@@ -936,10 +948,12 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
         return None, None
     model = _read_main_model() or "gpt-4o-mini"
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
+    _clean_base, _dq = _extract_url_query_params(custom_base)
+    _extra = {"default_query": _dq} if _dq else {}
     if custom_mode == "codex_responses":
-        real_client = OpenAI(api_key=custom_key, base_url=custom_base)
+        real_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
-    return OpenAI(api_key=custom_key, base_url=custom_base), model
+    return OpenAI(api_key=custom_key, base_url=_clean_base, **_extra), model
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
@@ -1437,12 +1451,15 @@ def resolve_provider_client(
                 provider,
             )
             extra = {}
+            _clean_base, _dq = _extract_url_query_params(custom_base)
+            if _dq:
+                extra["default_query"] = _dq
             if "api.kimi.com" in custom_base.lower():
                 extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
             elif "api.githubcopilot.com" in custom_base.lower():
                 from hermes_cli.models import copilot_default_headers
                 extra["default_headers"] = copilot_default_headers()
-            client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
+            client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base)
             return (_to_async_client(client, final_model) if async_mode
                     else (client, final_model))
@@ -1472,8 +1489,10 @@ def resolve_provider_client(
                     model or _read_main_model() or "gpt-4o-mini",
                     provider,
                 )
-                client = OpenAI(api_key=custom_key, base_url=custom_base)
-                client = _wrap_if_needed(client, final_model, custom_base)
+                _clean_base2, _dq2 = _extract_url_query_params(custom_base)
+                _extra2 = {"default_query": _dq2} if _dq2 else {}
+                client = OpenAI(api_key=custom_key, base_url=_clean_base2, **_extra2)
+                client = _wrap_if_needed(client, final_model, _clean_base2)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s)",
                     provider, final_model)

--- a/run_agent.py
+++ b/run_agent.py
@@ -38,6 +38,7 @@ import threading
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse, parse_qs, urlunparse
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -854,7 +855,15 @@ class AIAgent:
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
-                client_kwargs = {"api_key": api_key, "base_url": base_url}
+                # Extract query params (e.g. Azure api-version) from base_url
+                # and pass via default_query to prevent loss during SDK URL joining
+                _parsed_url = urlparse(base_url)
+                if _parsed_url.query:
+                    _clean_url = urlunparse(_parsed_url._replace(query=""))
+                    _query_params = {k: v[0] for k, v in parse_qs(_parsed_url.query).items()}
+                    client_kwargs = {"api_key": api_key, "base_url": _clean_url, "default_query": _query_params}
+                else:
+                    client_kwargs = {"api_key": api_key, "base_url": base_url}
                 if self.provider == "copilot-acp":
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args


### PR DESCRIPTION
## Problem

Azure OpenAI endpoints require an `api-version` query parameter on every API request. When users configure this in `base_url` (e.g. `https://resource.openai.azure.com/openai?api-version=2025-04-01-preview`), the OpenAI Python SDK silently drops query parameters during URL construction, resulting in HTTP 404 errors.

This is the same class of issue as #4599 (Azure Anthropic), but affecting the **OpenAI SDK** path used by custom providers.

## Root Cause

The OpenAI SDK stores `base_url` as an `httpx.URL` and joins API paths (e.g. `/responses`, `/chat/completions`) onto it. During this join, any query parameters in the original URL are discarded — Azure never receives `api-version` and returns 404.

## Fix

Extract query parameters from `base_url` before passing it to the OpenAI SDK, and forward them via the SDK's `default_query` parameter. This ensures they are appended to every outgoing request.

**Files changed:**
- `run_agent.py` — main agent client creation
- `agent/auxiliary_client.py` — auxiliary client creation (added `_extract_url_query_params()` helper, applied to all custom endpoint paths)

## Backward Compatibility

- URLs **without** query params → `default_query` is `None`, original behavior unchanged
- URLs **with** query params → params extracted and forwarded correctly
- No hardcoded values — works for any provider requiring query parameters, not just Azure

## Example Configuration

```yaml
model:
  default: gpt-5.4  # Azure deployment name
  provider: custom
  base_url: https://your-resource.openai.azure.com/openai?api-version=2025-04-01-preview
  api_key: your-azure-key
  api_mode: codex_responses
```

## Test Plan

- [ ] Azure OpenAI endpoint with `api-version` in base_url returns successful responses
- [ ] Standard OpenAI / OpenRouter / other providers without query params work unchanged
- [ ] Custom endpoints with arbitrary query params preserve them in requests