### PR TITLE
fix(prompt): tolerate inaccessible context parent paths

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -79,10 +79,20 @@ def _find_git_root(start: Path) -> Optional[Path]:
     Returns the directory containing ``.git``, or ``None`` if we hit the
     filesystem root without finding one.
     """
-    current = start.resolve()
+    try:
+        current = start.resolve()
+    except OSError as e:
+        logger.debug("Could not resolve %s: %s", start, e)
+        return None
+
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
+        git_dir = parent / ".git"
+        try:
+            if git_dir.exists():
+                return parent
+        except OSError as e:
+            logger.debug("Could not check %s for .git: %s", git_dir, e)
+            continue
     return None
 
 
@@ -97,13 +107,21 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     ``None`` if nothing is found.
     """
     stop_at = _find_git_root(cwd)
-    current = cwd.resolve()
+    try:
+        current = cwd.resolve()
+    except OSError as e:
+        logger.debug("Could not resolve %s: %s", cwd, e)
+        return None
 
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError as e:
+                logger.debug("Could not check %s: %s", candidate, e)
+                continue
         # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:
             break

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -709,6 +709,37 @@ class TestFindHermesMd:
         (repo / ".git").mkdir()
         assert _find_hermes_md(repo) is None
 
+    def test_returns_none_when_resolve_raises(self, tmp_path):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with patch.object(Path, "resolve", side_effect=OSError("permission denied")):
+            assert _find_hermes_md(tmp_path) is None
+
+    def test_skips_inaccessible_candidates(self, tmp_path):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / ".hermes.md").write_text("root rules")
+        sub = repo / "src" / "nested"
+        sub.mkdir(parents=True)
+        blocked_candidates = {
+            repo / "src" / ".hermes.md",
+            repo / "src" / "HERMES.md",
+        }
+        original_is_file = Path.is_file
+
+        def patched_is_file(self):
+            if self in blocked_candidates:
+                raise PermissionError("permission denied")
+            return original_is_file(self)
+
+        with patch.object(Path, "is_file", patched_is_file):
+            assert _find_hermes_md(sub) == repo / ".hermes.md"
+
 
 class TestFindGitRoot:
     def test_finds_git_dir(self, tmp_path):
@@ -734,6 +765,33 @@ class TestFindGitRoot:
         # If result is not None, it must actually contain .git
         if result is not None:
             assert (result / ".git").exists()
+
+    def test_returns_none_when_resolve_raises(self, tmp_path):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with patch.object(Path, "resolve", side_effect=OSError("permission denied")):
+            assert _find_git_root(tmp_path) is None
+
+    def test_skips_inaccessible_git_checks(self, tmp_path):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        sub = repo / "src" / "nested"
+        sub.mkdir(parents=True)
+        blocked_git = repo / "src" / ".git"
+        original_exists = Path.exists
+
+        def patched_exists(self):
+            if self == blocked_git:
+                raise PermissionError("permission denied")
+            return original_exists(self)
+
+        with patch.object(Path, "exists", patched_exists):
+            assert _find_git_root(sub) == repo
 
 
 class TestStripYamlFrontmatter:
@@ -1032,6 +1090,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes prompt context discovery crashes when filesystem permission barriers are encountered while walking parent directories for `.git`, `.hermes.md`, or `HERMES.md`.

The prompt builder treats these files as optional context. If a parent path cannot be resolved or inspected, Hermes should skip that lookup instead of failing startup or prompt construction. This change keeps the normal discovery behavior unchanged while making inaccessible paths non-fatal.

## Related Issue

Fixes #8751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added guarded `resolve()`, `.exists()`, and `.is_file()` checks in `agent/prompt_builder.py`.
- Logged inaccessible context-path checks at debug level and continued discovery where possible.
- Added regression coverage for resolve failures and inaccessible candidate checks in `tests/agent/test_prompt_builder.py`.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/agent/test_prompt_builder.py -q -o addopts=''
   ```
2. Confirm all prompt-builder tests pass.
3. Confirm inaccessible parent context checks return `None` or continue to the next candidate instead of raising.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8 x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
115 passed, 1 warning in 0.42s
```
