### PR TITLE
fix: omit authorization from request debug dumps

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2691,12 +2691,6 @@ class AIAgent:
             body.pop("timeout", None)
             body = {k: v for k, v in body.items() if v is not None}
 
-            api_key = None
-            try:
-                api_key = getattr(self.client, "api_key", None)
-            except Exception as e:
-                logger.debug("Could not extract API key for debug dump: %s", e)
-
             dump_payload: Dict[str, Any] = {
                 "timestamp": datetime.now().isoformat(),
                 "session_id": self.session_id,
@@ -2705,7 +2699,6 @@ class AIAgent:
                     "method": "POST",
                     "url": f"{self.base_url.rstrip('/')}{'/responses' if self.api_mode == 'codex_responses' else '/chat/completions'}",
                     "headers": {
-                        "Authorization": f"Bearer {self._mask_api_key_for_logs(api_key)}",
                         "Content-Type": "application/json",
                     },
                     "body": body,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -442,6 +442,32 @@ class TestMaskApiKey:
         assert "..." in result
 
 
+class TestApiRequestDebugDump:
+    def test_request_dump_omits_authorization_header(self, agent, tmp_path):
+        secret = "sk-proj-secret-abcdefghijklmnopqrstuvwxyz"
+        agent.logs_dir = tmp_path
+        agent.session_id = "debug-dump-test"
+        agent.base_url = "https://api.example.test/v1"
+        agent.api_mode = "chat_completions"
+        agent.client.api_key = secret
+
+        dump_path = agent._dump_api_request_debug(
+            {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+            reason="unit-test",
+        )
+
+        assert dump_path is not None
+        payload = json.loads(dump_path.read_text(encoding="utf-8"))
+        headers = payload["request"]["headers"]
+        assert headers == {"Content-Type": "application/json"}
+
+        serialized = json.dumps(payload)
+        assert "Authorization" not in serialized
+        assert secret not in serialized
+        assert secret[:8] not in serialized
+        assert secret[-4:] not in serialized
+
+
 # ===================================================================
 # Group 2: State / Structure Methods
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?

Removes the `Authorization` header from request debug dump files written by `_dump_api_request_debug()`.

The dump is meant to help diagnose provider request failures, but it does not need to persist credential material. Omitting the header entirely avoids exposing even partially masked API keys in `request_dump_*.json` files while preserving the request URL, content type, body, and error context needed for debugging.

## Related Issue

Fixes #8518

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed API key extraction from `_dump_api_request_debug()` in `run_agent.py`.
- Removed `Authorization` from the persisted debug dump header payload.
- Added a regression test that writes a dump and verifies no full or partial API key material appears in the serialized JSON.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/run_agent/test_run_agent.py::TestApiRequestDebugDump tests/run_agent/test_run_agent.py::TestMaskApiKey -q -o addopts=''
   ```
2. Confirm the dump contains only `Content-Type` under request headers.
3. Confirm the serialized dump does not contain `Authorization` or API key fragments.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8 x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
4 passed, 1 warning in 1.47s
```
