### PR TITLE
fix(skills): discover symlinked skill directories

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -430,14 +430,47 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 
 
 def iter_skill_index_files(skills_dir: Path, filename: str):
-    """Walk skills_dir yielding sorted paths matching *filename*.
+    """Walk ``skills_dir`` yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub`` directories.
+    Symlinked directories are followed so nested skills discovered through
+    local or external skill roots are visible to all callers.  Traversal is
+    cycle-safe: each real directory is visited at most once, and the standard
+    excluded directories (``.git``, ``.github``, ``.hub``) are still pruned.
     """
     matches = []
-    for root, dirs, files in os.walk(skills_dir):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+    visited_real_dirs: Set[Path] = set()
+
+    for root, dirs, files in os.walk(skills_dir, followlinks=True):
+        root_path = Path(root)
+        try:
+            root_real = root_path.resolve()
+        except (OSError, RuntimeError):
+            dirs[:] = []
+            continue
+
+        if root_real in visited_real_dirs:
+            dirs[:] = []
+            continue
+        visited_real_dirs.add(root_real)
+
+        next_dirs = []
+        for dirname in dirs:
+            if dirname in EXCLUDED_SKILL_DIRS:
+                continue
+
+            child_path = root_path / dirname
+            try:
+                child_real = child_path.resolve()
+            except (OSError, RuntimeError):
+                continue
+
+            if child_real in visited_real_dirs:
+                continue
+            next_dirs.append(dirname)
+
+        dirs[:] = next_dirs
         if filename in files:
-            matches.append(Path(root) / filename)
+            matches.append(root_path / filename)
+
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):
         yield path

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,8 @@ import builtins
 import importlib
 import logging
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -30,6 +32,19 @@ from agent.prompt_builder import (
     WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
+
+
+def _can_symlink():
+    """Check if we can create symlinks (needs admin/dev-mode on Windows)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.mkdir()
+            lnk = Path(d) / "lnk"
+            lnk.symlink_to(src, target_is_directory=True)
+            return True
+    except OSError:
+        return False
 
 
 # =========================================================================
@@ -409,6 +424,34 @@ class TestBuildSkillsSystemPrompt:
 
         result = build_skills_system_prompt()
         assert "backend-skill" in result
+
+    @pytest.mark.skipif(not _can_symlink(), reason="Symlinks need elevated privileges")
+    def test_nested_symlinked_skill_is_included(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        target_skill = tmp_path / "linked-skill-source"
+        target_skill.mkdir()
+        (target_skill / "SKILL.md").write_text(
+            "---\nname: nested-real\ndescription: Nested symlinked skill.\n---\n\n# Nested Real\n"
+        )
+
+        nested_link = skills_root / "mlops" / "nested-real"
+        nested_link.parent.mkdir(parents=True)
+        nested_link.symlink_to(target_skill, target_is_directory=True)
+
+        result = build_skills_system_prompt()
+        assert "nested-real" in result
+        assert "mlops" in result
+        assert "Nested symlinked skill" in result
+
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache()
+        snapshot_result = build_skills_system_prompt()
+        assert "nested-real" in snapshot_result
+        assert "Nested symlinked skill" in snapshot_result
 
 
 class TestBuildNousSubscriptionPrompt:
@@ -1032,6 +1075,3 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-
-

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -2,11 +2,13 @@
 
 import json
 import os
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from agent.skill_utils import iter_skill_index_files
 import tools.skills_tool as skills_tool_module
 from tools.skills_tool import (
     _get_required_environment_variables,
@@ -44,6 +46,19 @@ description: Description for {name}.
 """
     (skill_dir / "SKILL.md").write_text(content)
     return skill_dir
+
+
+def _can_symlink():
+    """Check if we can create symlinks (needs admin/dev-mode on Windows)."""
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.mkdir()
+            lnk = Path(d) / "lnk"
+            lnk.symlink_to(src, target_is_directory=True)
+            return True
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +284,53 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
+    @pytest.mark.skipif(not _can_symlink(), reason="Symlinks need elevated privileges")
+    def test_finds_nested_symlinked_skill_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        target_skill = tmp_path / "linked-skill-source"
+        target_skill.mkdir()
+        (target_skill / "SKILL.md").write_text(
+            "---\nname: nested-real\ndescription: Nested symlinked skill.\n---\n\n# Nested Real\n"
+        )
+
+        nested_link = skills_root / "mlops" / "nested-real"
+        nested_link.parent.mkdir(parents=True)
+        nested_link.symlink_to(target_skill, target_is_directory=True)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            skills = _find_all_skills()
+
+        assert [s["name"] for s in skills] == ["nested-real"]
+        assert skills[0]["category"] == "mlops"
+        assert skills[0]["description"] == "Nested symlinked skill."
+
+    @pytest.mark.skipif(not _can_symlink(), reason="Symlinks need elevated privileges")
+    def test_cycle_protection_in_iterator(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        normal_skill = skills_root / "real-skill"
+        normal_skill.mkdir()
+        (normal_skill / "SKILL.md").write_text(
+            "---\nname: real-skill\ndescription: Real skill.\n---\n\n# Real Skill\n"
+        )
+
+        loop_skill = skills_root / "loop-skill"
+        loop_skill.mkdir()
+        (loop_skill / "SKILL.md").write_text(
+            "---\nname: loop-skill\ndescription: Loop skill.\n---\n\n# Loop Skill\n"
+        )
+        (loop_skill / "back").symlink_to(skills_root, target_is_directory=True)
+
+        paths = list(iter_skill_index_files(skills_root, "SKILL.md"))
+        assert [str(path.relative_to(skills_root)) for path in paths] == [
+            "loop-skill/SKILL.md",
+            "real-skill/SKILL.md",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -301,6 +363,30 @@ class TestSkillsList:
         result = json.loads(raw)
         assert result["count"] == 1
         assert result["skills"][0]["name"] == "skill-a"
+
+    @pytest.mark.skipif(not _can_symlink(), reason="Symlinks need elevated privileges")
+    def test_lists_nested_symlinked_skill_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+
+        target_skill = tmp_path / "linked-skill-source"
+        target_skill.mkdir()
+        (target_skill / "SKILL.md").write_text(
+            "---\nname: nested-real\ndescription: Nested symlinked skill.\n---\n\n# Nested Real\n"
+        )
+
+        nested_link = skills_root / "mlops" / "nested-real"
+        nested_link.parent.mkdir(parents=True)
+        nested_link.symlink_to(target_skill, target_is_directory=True)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            raw = skills_list()
+
+        result = json.loads(raw)
+        assert result["count"] == 1
+        assert result["skills"][0]["name"] == "nested-real"
+        assert result["skills"][0]["category"] == "mlops"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -520,7 +520,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs
+    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
     skills = []
     seen_names: set = set()
@@ -535,10 +535,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
-        for skill_md in scan_dir.rglob("SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
-                continue
-
+        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
             skill_dir = skill_md.parent
 
             try:
@@ -664,11 +661,9 @@ def skills_categories(verbose: bool = False, task_id: str = None) -> str:
 
         category_dirs = {}
         category_counts: Dict[str, int] = {}
+        from agent.skill_utils import iter_skill_index_files
         for scan_dir in all_dirs:
-            for skill_md in scan_dir.rglob("SKILL.md"):
-                if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
-                    continue
-
+            for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
                 try:
                     frontmatter, _ = _parse_frontmatter(
                         skill_md.read_text(encoding="utf-8")[:4000]
@@ -789,7 +784,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         JSON string with skill content or error message
     """
     try:
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
         # Build list of all skill directories to search
         all_dirs = []
@@ -824,7 +819,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         # Search by directory name across all dirs
         if not skill_md:
             for search_dir in all_dirs:
-                for found_skill_md in search_dir.rglob("SKILL.md"):
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md


### PR DESCRIPTION
## What does this PR do?

Fixes recursive skill discovery for skill directories that are symlinked under `~/.hermes/skills/<category>/<name>` or configured external skill roots.

Direct path loading already worked for some top-level symlinks, but recursive discovery used `Path.rglob()` / `os.walk()` without following directory links. That made `skills_list`, bare-name `skill_view`, and the skills system prompt disagree about whether the same skill existed. This change centralizes recursive skill-file discovery on a symlink-aware, cycle-safe iterator.

## Related Issue

Fixes #8293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/skill_utils.py` so `iter_skill_index_files()` follows symlinked directories while visiting each real directory only once.
- Switched `tools/skills_tool.py` recursive `SKILL.md` scans to the shared iterator for `_find_all_skills()`, `skills_categories()`, and bare-name `skill_view()` fallback.
- Added regression tests for nested symlinked skills in `skills_list`, `skill_view`, and `build_skills_system_prompt()`.
- Added cycle-protection coverage for recursive symlink loops.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/tools/test_skills_tool.py tests/agent/test_prompt_builder.py -q -o addopts=''
   ```
2. Confirm nested symlinked skill directories appear in `skills_list()`.
3. Confirm `skill_view("<name>")` can load a symlinked skill by bare directory name.
4. Confirm the prompt-builder skills index includes the same symlinked skill.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8 x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
192 passed, 1 warning in 1.42s
```
