### PR TITLE
fix(models): list named custom provider models

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -753,7 +753,11 @@ def list_authenticated_providers(
         get_provider_info as _mdev_pinfo,
     )
     from hermes_cli.auth import PROVIDER_REGISTRY
-    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
+    from hermes_cli.models import (
+        OPENROUTER_MODELS,
+        _PROVIDER_MODELS,
+        _custom_provider_model_ids,
+    )
 
     results: List[dict] = []
     seen_slugs: set = set()
@@ -920,6 +924,7 @@ def list_authenticated_providers(
             models_list = []
             if default_model:
                 models_list.append(default_model)
+            top = models_list[:max_models]
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config
@@ -928,7 +933,7 @@ def list_authenticated_providers(
                 "name": display_name,
                 "is_current": ep_name == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": top,
                 "total_models": len(models_list) if models_list else 0,
                 "source": "user-config",
                 "api_url": api_url,
@@ -954,17 +959,19 @@ def list_authenticated_providers(
             if slug in seen_slugs:
                 continue
 
-            models_list = []
-            default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
+            models_list = _custom_provider_model_ids(
+                slug,
+                custom_providers=custom_providers,
+                include_probe=max_models > 0,
+            )
+            top = models_list[:max_models]
 
             results.append({
                 "slug": slug,
                 "name": display_name,
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
+                "models": top,
                 "total_models": len(models_list),
                 "source": "user-config",
                 "api_url": api_url,
@@ -975,5 +982,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
-

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,6 +8,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.request
 import urllib.error
@@ -1177,6 +1178,135 @@ def _resolve_copilot_catalog_api_key() -> str:
         return ""
 
 
+def _custom_provider_model_ids(
+    provider_name: str,
+    *,
+    custom_providers: Optional[list[dict[str, Any]]] = None,
+    include_probe: bool = True,
+    probe_timeout: float = 2.0,
+) -> list[str]:
+    """Return model IDs for a named custom provider from config.yaml.
+
+    Resolution order:
+      1. ``custom_providers[].models`` mapping/list
+      2. short ``/models`` probe
+      3. saved ``custom_providers[].model`` fallback
+
+    Results are de-duplicated in discovery order.
+    """
+    requested = normalize_provider(provider_name)
+    if not requested.startswith("custom:"):
+        return []
+
+    requested_key = requested.split("custom:", 1)[1].strip().lower()
+    if not requested_key:
+        return []
+
+    if custom_providers is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+            custom_providers = config.get("custom_providers")
+        except Exception:
+            custom_providers = None
+
+    if not isinstance(custom_providers, list):
+        return []
+
+    from hermes_cli.providers import custom_provider_slug
+
+    entry: Optional[dict[str, Any]] = None
+    for candidate in custom_providers:
+        if not isinstance(candidate, dict):
+            continue
+
+        display_name = str(candidate.get("name") or "").strip()
+        api_url = str(
+            candidate.get("base_url", "")
+            or candidate.get("url", "")
+            or candidate.get("api", "")
+            or ""
+        ).strip()
+        if not display_name or not api_url:
+            continue
+
+        slug = custom_provider_slug(display_name)
+        if requested_key in {display_name.lower(), slug.split("custom:", 1)[1]}:
+            entry = candidate
+            break
+
+    if entry is None:
+        return []
+
+    def _coerce_models(raw_models: Any) -> list[str]:
+        if isinstance(raw_models, dict):
+            raw_items = list(raw_models.keys())
+        elif isinstance(raw_models, list):
+            raw_items = raw_models
+        else:
+            return []
+
+        result: list[str] = []
+        for item in raw_items:
+            if isinstance(item, str):
+                model_id = item.strip()
+            elif isinstance(item, dict):
+                model_id = str(item.get("id") or item.get("model") or "").strip()
+            else:
+                model_id = str(item).strip()
+            if model_id:
+                result.append(model_id)
+        return result
+
+    ordered_models: list[str] = []
+    seen: set[str] = set()
+
+    def _append_all(model_ids: list[str]) -> None:
+        for model_id in model_ids:
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            ordered_models.append(model_id)
+
+    mapped_models = _coerce_models(entry.get("models"))
+    if mapped_models:
+        _append_all(mapped_models)
+        return ordered_models
+
+    if include_probe:
+        api_url = str(
+            entry.get("base_url", "")
+            or entry.get("url", "")
+            or entry.get("api", "")
+            or ""
+        ).strip()
+        if api_url:
+            api_key = str(entry.get("api_key") or "").strip() or None
+            try:
+                probe = probe_api_models(api_key, api_url, timeout=probe_timeout)
+                live_models = probe.get("models") or []
+                if isinstance(live_models, list):
+                    _append_all([
+                        str(model_id).strip()
+                        for model_id in live_models
+                        if str(model_id).strip()
+                    ])
+            except Exception as exc:
+                logging.getLogger(__name__).debug(
+                    "Failed to probe custom provider %s: %s", requested, exc
+                )
+
+    if ordered_models:
+        return ordered_models
+
+    fallback_model = str(entry.get("model") or "").strip()
+    if fallback_model:
+        _append_all([fallback_model])
+
+    return ordered_models
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -1190,6 +1320,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         from hermes_cli.codex_models import get_codex_model_ids
 
         return get_codex_model_ids()
+    if normalized.startswith("custom:"):
+        return _custom_provider_model_ids(normalized)
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -22,6 +22,7 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     """No-args /model menus should include saved custom_providers entries."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", lambda *a, **k: {"models": []})
 
     providers = list_authenticated_providers(
         current_provider="openai-codex",
@@ -41,6 +42,114 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
         and p["name"] == "Local (127.0.0.1:4141)"
         and p["models"] == ["rotator-openrouter-coding"]
         and p["api_url"] == "http://127.0.0.1:4141/v1"
+        for p in providers
+    )
+
+
+def test_list_authenticated_providers_prefers_custom_models_mapping(monkeypatch):
+    """Named custom providers should trust explicit mapped models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("explicit custom_providers[].models should skip probing")
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", _boom)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Router",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "api_key": "custom-key",
+                "model": "fallback-model",
+                "models": {
+                    "model-alpha": {},
+                    "model-beta": {},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    assert any(
+        p["slug"] == "custom:local-router"
+        and p["models"] == ["model-alpha", "model-beta"]
+        and p["total_models"] == 2
+        for p in providers
+    )
+
+
+def test_list_authenticated_providers_uses_probe_when_mapping_missing(monkeypatch):
+    """Named custom providers should probe /models when no explicit model map exists."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    probe_calls = []
+
+    def fake_probe(api_key, base_url, timeout=2.0):
+        probe_calls.append((api_key, base_url, timeout))
+        return {"models": ["model-alpha", "model-beta", "model-alpha"]}
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", fake_probe)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Router",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "api_key": "custom-key",
+                "model": "fallback-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert probe_calls == [("custom-key", "http://127.0.0.1:4141/v1", 2.0)]
+    assert any(
+        p["slug"] == "custom:local-router"
+        and p["models"] == ["model-alpha", "model-beta"]
+        and p["total_models"] == 2
+        for p in providers
+    )
+
+
+def test_list_authenticated_providers_skips_probe_when_max_models_zero(monkeypatch):
+    """Slug-only listing should not probe named custom endpoints."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("probe_api_models should not be called when max_models=0")
+
+    monkeypatch.setattr("hermes_cli.models.probe_api_models", _boom)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Router",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "api_key": "custom-key",
+                "model": "fallback-model",
+                "models": {
+                    "model-alpha": {},
+                    "model-beta": {},
+                },
+            }
+        ],
+        max_models=0,
+    )
+
+    assert any(
+        p["slug"] == "custom:local-router"
+        and p["models"] == []
+        and p["total_models"] == 2
         for p in providers
     )
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, menu_labels, model_ids, detect_provider_for_model,
+    provider_model_ids,
     filter_nous_free_models, _NOUS_ALLOWED_FREE_MODELS,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
@@ -187,6 +188,74 @@ class TestDetectProviderForModel:
             result = detect_provider_for_model("claude-opus-4-6", "openai-codex")
         assert result is not None
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
+
+
+class TestProviderModelIds:
+    def test_named_custom_provider_uses_configured_models_mapping(self, monkeypatch):
+        """Named custom providers should prefer explicit configured models."""
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "custom_providers": [{
+                "name": "Local Router",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "api_key": "custom-key",
+                "model": "fallback-model",
+                "models": {
+                    "model-alpha": {},
+                    "model-beta": {},
+                },
+            }],
+        })
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("explicit custom_providers[].models should skip probing")
+
+        monkeypatch.setattr("hermes_cli.models.probe_api_models", _boom)
+
+        ids = provider_model_ids("custom:local-router")
+
+        assert ids == ["model-alpha", "model-beta"]
+
+    def test_named_custom_provider_uses_probe_when_mapping_missing(self, monkeypatch):
+        """Named custom providers should probe /models before falling back to saved model."""
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "custom_providers": [{
+                "name": "Local Router",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "api_key": "custom-key",
+                "model": "fallback-model",
+            }],
+        })
+
+        probe_calls = []
+
+        def fake_probe(api_key, base_url, timeout=2.0):
+            probe_calls.append((api_key, base_url, timeout))
+            return {"models": ["model-alpha", "model-beta", "model-alpha"]}
+
+        monkeypatch.setattr("hermes_cli.models.probe_api_models", fake_probe)
+
+        ids = provider_model_ids("custom:local-router")
+
+        assert probe_calls == [("custom-key", "http://127.0.0.1:4141/v1", 2.0)]
+        assert ids == ["model-alpha", "model-beta"]
+
+    def test_named_custom_provider_uses_saved_model_when_probe_fails(self, monkeypatch):
+        """When probe fails, the saved model fallback should still appear."""
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "custom_providers": [{
+                "name": "Backup Router",
+                "base_url": "http://127.0.0.1:4142/v1",
+                "model": "fallback-model",
+            }],
+        })
+        def _raise_probe(*args, **kwargs):
+            raise OSError("offline")
+
+        monkeypatch.setattr("hermes_cli.models.probe_api_models", _raise_probe)
+
+        ids = provider_model_ids("custom:backup-router")
+
+        assert ids == ["fallback-model"]
 
 
 class TestFilterNousFreeModels:


### PR DESCRIPTION
## What does this PR do?

Fixes named `custom_providers` model discovery for the shared `/model` picker and `provider_model_ids("custom:<slug>")` path.

Named custom providers now use their explicit `models` mapping when configured. If no mapping is present, Hermes performs a short `/models` probe and de-duplicates live results. If probing fails or returns no models, Hermes falls back to the saved `model` value. Slug-only provider listing also skips endpoint probing when `max_models=0`.

## Related Issue

Fixes #8758

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added named custom-provider model discovery in `hermes_cli/models.py`.
- Wired `provider_model_ids("custom:<slug>")` to resolve `custom_providers` entries from config.
- Updated `list_authenticated_providers()` in `hermes_cli/model_switch.py` to use the same discovery helper.
- Kept `max_models=0` listing from probing custom endpoints.
- Added regression tests for explicit model mappings, probe fallback, de-duplication, saved-model fallback, and probe skipping.

## How to Test

1. Run:
   ```bash
   python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_models.py -o addopts='' -q
   ```
2. Configure a named custom provider with `models:` and confirm `/model` lists those model IDs.
3. Remove `models:` and confirm `/model` falls back to `/models`, then to the saved `model` when probing fails.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8 x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
55 passed, 1 warning in 0.53s
```
