### PR TITLE
fix(security) : Security check & auto update github dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+version: 2
+updates:
+  # Root package.json (agent-browser, camoufox-browser)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Commit / PR title convention: chore(browser): bump <pkg> from X to Y
+    # Matches project Conventional Commits: chore = dependency / build updates
+    commit-message:
+      prefix: "chore(browser)"
+    groups:
+      root-npm:
+        patterns:
+          - "*"
+
+  # WhatsApp bridge (express, baileys, pino, qrcode-terminal)
+  - package-ecosystem: "npm"
+    directory: "/scripts/whatsapp-bridge"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Commit / PR title convention: chore(whatsapp): bump <pkg> from X to Y
+    commit-message:
+      prefix: "chore(whatsapp)"
+    groups:
+      whatsapp-bridge:
+        patterns:
+          - "*"
+
+  # Docusaurus website
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Commit / PR title convention: docs(deps): bump <pkg> from X to Y
+    commit-message:
+      prefix: "docs(deps)"
+    groups:
+      website-npm:
+        patterns:
+          - "*"
+
+  # Python packages (pyproject.toml / requirements.txt)
+  # Note: uv.lock is not natively supported; pip ecosystem covers declared deps in pyproject.toml.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Commit / PR title convention: chore(deps): bump <pkg> from X to Y
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+
+  # GitHub Actions workflow step versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Commit / PR title convention: chore(ci): bump <action> from X to Y
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -1,0 +1,131 @@
+name: Dependency checks
+
+# Runs automatically on any PR that touches dependency files (npm or Python).
+# Each job is path-filtered so only the affected ecosystem is tested.
+# Dependabot PRs that bump any package will trigger the matching job(s).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # npm — root
+      - 'package.json'
+      - 'package-lock.json'
+      # npm — WhatsApp bridge
+      - 'scripts/whatsapp-bridge/package.json'
+      - 'scripts/whatsapp-bridge/package-lock.json'
+      # Python — uv / pyproject
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'requirements.txt'
+      # workflow itself
+      - '.github/workflows/dependency-checks.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/whatsapp-bridge/package.json'
+      - 'scripts/whatsapp-bridge/package-lock.json'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'requirements.txt'
+
+concurrency:
+  group: dependency-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Root package.json — agent-browser / camoufox-browser
+  # ─────────────────────────────────────────────────────────────────────────────
+  root-npm:
+    name: Root npm audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      contains(github.event.head_commit.modified, 'package.json') ||
+      contains(github.event.head_commit.modified, 'package-lock.json') ||
+      github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Audit root npm dependencies
+        # Fails the job if moderate or higher vulnerabilities are found
+        run: npm audit --audit-level=moderate
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # WhatsApp bridge — express / baileys / pino / qrcode-terminal
+  # ─────────────────────────────────────────────────────────────────────────────
+  whatsapp-bridge:
+    name: WhatsApp bridge — audit + tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: scripts/whatsapp-bridge/package-lock.json
+
+      - name: Install WhatsApp bridge dependencies
+        run: npm ci
+        working-directory: scripts/whatsapp-bridge
+
+      - name: Audit WhatsApp bridge npm dependencies
+        # Fails the job if moderate or higher vulnerabilities remain after the bump
+        run: npm audit --audit-level=moderate
+        working-directory: scripts/whatsapp-bridge
+
+      - name: Run WhatsApp bridge unit tests
+        # Uses Node's built-in test runner — no extra dependencies needed
+        run: node --test allowlist.test.mjs
+        working-directory: scripts/whatsapp-bridge
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Python packages — pyproject.toml / uv.lock
+  # ─────────────────────────────────────────────────────────────────────────────
+  python-audit:
+    name: Python package audit (pip-audit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies (including pip-audit)
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run pip-audit
+        # --skip-editable: skip the hermes-agent package itself (no PyPI advisory for it)
+        # --json: structured output for clear failure messages
+        # Exit code is non-zero when any vulnerability is found → job fails automatically
+        run: |
+          source .venv/bin/activate
+          pip-audit --skip-editable
+        env:
+          # Prevent any accidental API calls from installed packages during audit
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -4,6 +4,7 @@ Doctor command for hermes CLI.
 Diagnoses issues with Hermes Agent setup.
 """
 
+import json
 import os
 import sys
 import subprocess
@@ -637,25 +638,121 @@ def run_doctor(args):
                     cwd=str(npm_dir),
                     capture_output=True, text=True, timeout=30,
                 )
-                import json as _json
-                audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
+                audit_data = json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
                 vuln_count = audit_data.get("metadata", {}).get("vulnerabilities", {})
                 critical = vuln_count.get("critical", 0)
                 high = vuln_count.get("high", 0)
                 moderate = vuln_count.get("moderate", 0)
-                total = critical + high + moderate
+                low = vuln_count.get("low", 0)
+                total = critical + high + moderate + low
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
-                    check_warn(
-                        f"{label} deps",
-                        f"({critical} critical, {high} high, {moderate} moderate — run: cd {npm_dir} && npm audit fix)"
-                    )
-                    issues.append(f"{label} has {total} npm vulnerability(ies)")
+                    severity_str = f"{critical} critical, {high} high, {moderate} moderate, {low} low"
+                    issue_msg = f"{label} has {critical + high} critical/high npm vulnerability(ies)"
+                    if should_fix:
+                        fix_result = subprocess.run(
+                            ["npm", "audit", "fix"],
+                            cwd=str(npm_dir),
+                            capture_output=True, text=True, timeout=60,
+                        )
+                        if fix_result.returncode == 0:
+                            fixed_count += 1
+                            check_ok(f"{label} deps", "(vulnerabilities fixed by npm audit fix)")
+                        else:
+                            check_warn(
+                                f"{label} deps",
+                                f"({severity_str} — npm audit fix failed, run manually: cd {npm_dir} && npm audit fix)"
+                            )
+                            manual_issues.append(f"{label}: npm audit fix failed — run: cd {npm_dir} && npm audit fix")
+                    else:
+                        check_warn(
+                            f"{label} deps",
+                            f"({severity_str} — run: cd {npm_dir} && npm audit fix)"
+                        )
+                        issues.append(issue_msg)
                 else:
-                    check_ok(f"{label} deps", f"({moderate} moderate vulnerability(ies))")
-            except Exception:
-                pass
+                    # moderate or low only
+                    mod_low_str = f"{moderate} moderate, {low} low"
+                    issue_msg = f"{label} has {moderate + low} moderate/low npm vulnerability(ies)"
+                    if should_fix:
+                        fix_result = subprocess.run(
+                            ["npm", "audit", "fix"],
+                            cwd=str(npm_dir),
+                            capture_output=True, text=True, timeout=60,
+                        )
+                        if fix_result.returncode == 0:
+                            fixed_count += 1
+                            check_ok(f"{label} deps", "(vulnerabilities fixed by npm audit fix)")
+                        else:
+                            check_warn(
+                                f"{label} deps",
+                                f"({mod_low_str} — npm audit fix failed, run manually: cd {npm_dir} && npm audit fix)"
+                            )
+                            manual_issues.append(f"{label}: npm audit fix failed — run: cd {npm_dir} && npm audit fix")
+                    else:
+                        check_warn(f"{label} deps", f"({mod_low_str} — run: cd {npm_dir} && npm audit fix)")
+                        issues.append(issue_msg)
+            except Exception as e:
+                check_warn(f"{label} deps", f"(npm audit failed: {e})")
+
+    # Python package security audit (pip-audit)
+    if shutil.which("pip-audit"):
+        try:
+            audit_result = subprocess.run(
+                ["pip-audit", "--json", "--skip-editable"],
+                capture_output=True, text=True, timeout=120,
+            )
+            audit_data = json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
+            deps = audit_data.get("dependencies", [])
+            vulnerable = [d for d in deps if d.get("vulns")]
+            vuln_count = sum(len(d["vulns"]) for d in vulnerable)
+            pkg_count = len(vulnerable)
+
+            if vuln_count == 0:
+                check_ok("Python packages", "(no known vulnerabilities)")
+            else:
+                severity_summary = f"{vuln_count} vulnerability(ies) across {pkg_count} package(s)"
+                issue_msg = f"Python packages have {severity_summary}"
+                if should_fix:
+                    fix_result = subprocess.run(
+                        ["pip-audit", "--fix", "--skip-editable"],
+                        capture_output=True, text=True, timeout=120,
+                    )
+                    if fix_result.returncode == 0:
+                        fixed_count += 1
+                        check_ok("Python packages", "(vulnerabilities fixed by pip-audit --fix)")
+                        # Sync uv.lock if uv is available so the lockfile stays current
+                        if shutil.which("uv"):
+                            uv_result = subprocess.run(
+                                ["uv", "lock"],
+                                cwd=str(PROJECT_ROOT),
+                                capture_output=True, text=True, timeout=120,
+                            )
+                            if uv_result.returncode == 0:
+                                check_ok("uv.lock", "(synced after pip-audit fix)")
+                            else:
+                                check_warn("uv.lock", "(sync failed — run: uv lock)")
+                                manual_issues.append("Run 'uv lock' to sync uv.lock after pip-audit fix")
+                    else:
+                        check_warn(
+                            "Python packages",
+                            f"({severity_summary} — pip-audit --fix failed, run manually: pip-audit --fix)"
+                        )
+                        manual_issues.append(f"Python packages: pip-audit --fix failed — run manually: pip-audit --fix")
+                else:
+                    pkgs_str = ", ".join(d["name"] for d in vulnerable[:5])
+                    if pkg_count > 5:
+                        pkgs_str += f" (+{pkg_count - 5} more)"
+                    check_warn(
+                        "Python packages",
+                        f"({severity_summary}: {pkgs_str} — run: pip-audit --fix)"
+                    )
+                    issues.append(issue_msg)
+        except Exception as e:
+            check_warn("Python packages", f"(pip-audit failed: {e})")
+    else:
+        check_info("Python packages: pip-audit not installed — run: pip install pip-audit")
 
     # =========================================================================
     # Check: API connectivity
@@ -842,7 +939,6 @@ def run_doctor(args):
         lock_file = hub_dir / "lock.json"
         if lock_file.exists():
             try:
-                import json
                 lock_data = json.loads(lock_file.read_text())
                 count = len(lock_data.get("installed", {}))
                 check_ok(f"Lock file OK ({count} hub-installed skill(s))")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "pip-audit>=2.7.0,<3"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,10 +1,13 @@
 """Tests for hermes_cli.doctor."""
 
+import io
+import json
 import os
 import sys
 import types
 from argparse import Namespace
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -292,3 +295,438 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
     assert "npm install -g agent-browser && agent-browser install" in out
+
+
+# =============================================================================
+# npm audit checks in hermes doctor
+# =============================================================================
+
+def _make_audit_json(critical=0, high=0, moderate=0, low=0):
+    """Build a minimal npm audit --json payload."""
+    return json.dumps({
+        "metadata": {
+            "vulnerabilities": {
+                "critical": critical,
+                "high": high,
+                "moderate": moderate,
+                "low": low,
+                "total": critical + high + moderate + low,
+            }
+        }
+    })
+
+
+def _make_completed_process(stdout="", returncode=0):
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.returncode = returncode
+    return proc
+
+
+class TestDoctorNpmAudit:
+    """Tests for the npm audit section of run_doctor."""
+
+    def _run_audit_section(self, monkeypatch, tmp_path, audit_json, fix=False, audit_fix_rc=0):
+        """
+        Run only the npm audit section of run_doctor by patching everything else
+        away and providing a fake project root with a node_modules directory.
+        """
+        # Create a fake project root with node_modules so the loop enters
+        project_root = tmp_path / "project"
+        node_modules = project_root / "node_modules"
+        node_modules.mkdir(parents=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+
+        # npm is available; pip-audit and node are absent so only npm section runs
+        real_which = doctor_mod.shutil.which
+        monkeypatch.setattr(
+            doctor_mod.shutil, "which",
+            lambda cmd: "/usr/bin/npm" if cmd == "npm" else (None if cmd in {"pip-audit", "node"} else real_which(cmd)),
+        )
+
+        audit_proc = _make_completed_process(stdout=audit_json, returncode=0 if json.loads(audit_json).get("metadata", {}).get("vulnerabilities", {}).get("total", 0) == 0 else 1)
+        fix_proc = _make_completed_process(stdout="", returncode=audit_fix_rc)
+
+        call_results = [audit_proc, fix_proc] if fix else [audit_proc]
+
+        subprocess_mock = MagicMock(side_effect=call_results)
+        monkeypatch.setattr(doctor_mod.subprocess, "run", subprocess_mock)
+
+        # Stub tool availability so doctor can complete the run
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=fix))
+        return buf.getvalue(), subprocess_mock
+
+    def test_no_vulnerabilities(self, monkeypatch, tmp_path):
+        """Zero vulns → clean checkmark with 'no known vulnerabilities'."""
+        out, _ = self._run_audit_section(monkeypatch, tmp_path, _make_audit_json())
+        assert "no known vulnerabilities" in out
+
+    def test_critical_high_warns_and_adds_issue(self, monkeypatch, tmp_path):
+        """Critical and high vulns → warning line and issue in summary."""
+        out, _ = self._run_audit_section(
+            monkeypatch, tmp_path, _make_audit_json(critical=1, high=2, moderate=1)
+        )
+        assert "⚠" in out or "warning" in out.lower() or "npm audit fix" in out
+        assert "npm audit fix" in out
+        assert "1 critical" in out or "critical/high" in out.lower() or "issue" in out.lower()
+
+    def test_moderate_only_warns(self, monkeypatch, tmp_path):
+        """Moderate-only vulns are now a warning (not a clean checkmark)."""
+        out, _ = self._run_audit_section(
+            monkeypatch, tmp_path, _make_audit_json(moderate=2)
+        )
+        # Must NOT show "✓" for this label without a follow-up fix
+        # Must include a warning and the npm audit fix hint
+        assert "npm audit fix" in out
+        assert "moderate" in out
+
+    def test_npm_not_on_path(self, monkeypatch, tmp_path):
+        """When npm is not available the audit section is skipped entirely."""
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: None)
+
+        subprocess_mock = MagicMock()
+        monkeypatch.setattr(doctor_mod.subprocess, "run", subprocess_mock)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        # npm audit should never have been called
+        audit_calls = [c for c in subprocess_mock.call_args_list if "npm" in str(c) and "audit" in str(c)]
+        assert audit_calls == []
+
+    def test_no_node_modules(self, monkeypatch, tmp_path):
+        """Directories without node_modules are skipped (no npm audit call)."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        # Deliberately no node_modules directory
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+
+        real_which = doctor_mod.shutil.which
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else real_which(cmd))
+
+        subprocess_mock = MagicMock()
+        monkeypatch.setattr(doctor_mod.subprocess, "run", subprocess_mock)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        audit_calls = [c for c in subprocess_mock.call_args_list if "npm" in str(c) and "audit" in str(c)]
+        assert audit_calls == []
+
+    def test_audit_exception_shows_warning(self, monkeypatch, tmp_path):
+        """If subprocess.run raises, a warning is shown instead of silently passing."""
+        project_root = tmp_path / "project"
+        (project_root / "node_modules").mkdir(parents=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+
+        real_which = doctor_mod.shutil.which
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else real_which(cmd))
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", MagicMock(side_effect=OSError("npm not found")))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        out = buf.getvalue()
+
+        assert "npm audit failed" in out
+
+    def test_fix_flag_runs_npm_audit_fix_on_success(self, monkeypatch, tmp_path):
+        """--fix with high vulns: npm audit fix is invoked and the issue is marked fixed."""
+        out, subprocess_mock = self._run_audit_section(
+            monkeypatch, tmp_path,
+            _make_audit_json(high=1, moderate=1),
+            fix=True,
+            audit_fix_rc=0,
+        )
+        fix_calls = [c for c in subprocess_mock.call_args_list if "audit" in str(c) and "fix" in str(c)]
+        assert fix_calls, "npm audit fix was not called when --fix is set and high vulns exist"
+        assert "fixed" in out.lower() or "no known vulnerabilities" in out
+
+    def test_fix_flag_reports_failure_when_audit_fix_fails(self, monkeypatch, tmp_path):
+        """--fix with npm audit fix failure → surfaced as a manual issue."""
+        out, subprocess_mock = self._run_audit_section(
+            monkeypatch, tmp_path,
+            _make_audit_json(high=1),
+            fix=True,
+            audit_fix_rc=1,
+        )
+        fix_calls = [c for c in subprocess_mock.call_args_list if "audit" in str(c) and "fix" in str(c)]
+        assert fix_calls, "npm audit fix was not called"
+        assert "failed" in out.lower() or "manually" in out.lower()
+
+
+# =============================================================================
+# Python (pip-audit) checks in hermes doctor
+# =============================================================================
+
+def _make_pip_audit_json(vulnerable_packages=None):
+    """
+    Build a minimal pip-audit --json payload.
+
+    vulnerable_packages: list of (name, version, vuln_ids) tuples.
+    """
+    if vulnerable_packages is None:
+        vulnerable_packages = []
+
+    deps = []
+    for name, version, vuln_ids in vulnerable_packages:
+        deps.append({
+            "name": name,
+            "version": version,
+            "vulns": [
+                {"id": vid, "fix_versions": [], "description": f"Test vuln {vid}", "aliases": []}
+                for vid in vuln_ids
+            ],
+        })
+    # Also include a clean package to confirm mixed results work
+    deps.append({"name": "safe-package", "version": "1.0.0", "vulns": []})
+    return json.dumps({"dependencies": deps})
+
+
+class TestDoctorPythonAudit:
+    """Tests for the pip-audit section of run_doctor."""
+
+    def _run_python_audit_section(
+        self,
+        monkeypatch,
+        tmp_path,
+        pip_audit_json,
+        fix=False,
+        audit_fix_rc=0,
+        uv_lock_rc=0,
+        pip_audit_available=True,
+    ):
+        """
+        Run run_doctor with pip-audit mocked out.
+        Returns (stdout_str, subprocess_mock).
+        """
+        project_root = tmp_path / "project"
+        project_root.mkdir(parents=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+
+        real_which = doctor_mod.shutil.which
+
+        def fake_which(cmd):
+            if cmd == "pip-audit":
+                return "/usr/bin/pip-audit" if pip_audit_available else None
+            if cmd in {"npm", "node"}:
+                return None  # skip npm audit section
+            if cmd == "uv":
+                return "/usr/bin/uv"
+            return real_which(cmd)
+
+        monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+        parsed = json.loads(pip_audit_json)
+        has_vulns = any(d.get("vulns") for d in parsed.get("dependencies", []))
+        audit_proc = _make_completed_process(stdout=pip_audit_json, returncode=1 if has_vulns else 0)
+        fix_proc = _make_completed_process(stdout="", returncode=audit_fix_rc)
+        uv_lock_proc = _make_completed_process(stdout="", returncode=uv_lock_rc)
+
+        # Build call_results: audit always first; fix + uv_lock only when --fix and vulns found
+        if fix and has_vulns:
+            call_results = [audit_proc, fix_proc, uv_lock_proc]
+        else:
+            call_results = [audit_proc]
+
+        subprocess_mock = MagicMock(side_effect=call_results)
+        monkeypatch.setattr(doctor_mod.subprocess, "run", subprocess_mock)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=fix))
+        return buf.getvalue(), subprocess_mock
+
+    def test_no_python_vulnerabilities(self, monkeypatch, tmp_path):
+        """Zero vulns → clean checkmark."""
+        out, _ = self._run_python_audit_section(
+            monkeypatch, tmp_path, _make_pip_audit_json()
+        )
+        assert "no known vulnerabilities" in out
+
+    def test_python_vulnerabilities_warn_and_add_issue(self, monkeypatch, tmp_path):
+        """Found vulns → warning + fix hint in output."""
+        out, _ = self._run_python_audit_section(
+            monkeypatch, tmp_path,
+            _make_pip_audit_json([("requests", "2.28.0", ["GHSA-1234", "GHSA-5678"])]),
+        )
+        assert "pip-audit --fix" in out
+        assert "requests" in out
+
+    def test_pip_audit_not_installed_shows_info(self, monkeypatch, tmp_path):
+        """When pip-audit is missing, print an info hint (not a hard error)."""
+        out, subprocess_mock = self._run_python_audit_section(
+            monkeypatch, tmp_path,
+            _make_pip_audit_json(),
+            pip_audit_available=False,
+        )
+        audit_calls = [c for c in subprocess_mock.call_args_list if "pip-audit" in str(c)]
+        assert audit_calls == [], "pip-audit should not be called when not on PATH"
+        assert "pip-audit" in out
+        assert "pip install pip-audit" in out
+
+    def test_pip_audit_exception_shows_warning(self, monkeypatch, tmp_path):
+        """If pip-audit raises, a warning is shown instead of silently passing."""
+        project_root = tmp_path / "project"
+        project_root.mkdir(parents=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path / ".hermes")
+        (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(tmp_path / ".hermes"))
+
+        real_which = doctor_mod.shutil.which
+        monkeypatch.setattr(
+            doctor_mod.shutil, "which",
+            lambda cmd: "/usr/bin/pip-audit" if cmd == "pip-audit" else (None if cmd in {"npm", "node"} else real_which(cmd)),
+        )
+        monkeypatch.setattr(doctor_mod.subprocess, "run", MagicMock(side_effect=OSError("pip-audit crashed")))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        assert "pip-audit failed" in buf.getvalue()
+
+    def test_fix_flag_runs_pip_audit_fix_and_uv_lock(self, monkeypatch, tmp_path):
+        """--fix with vulns: pip-audit --fix is called, then uv lock is run."""
+        out, subprocess_mock = self._run_python_audit_section(
+            monkeypatch, tmp_path,
+            _make_pip_audit_json([("cryptography", "3.0", ["CVE-2023-0001"])]),
+            fix=True,
+            audit_fix_rc=0,
+            uv_lock_rc=0,
+        )
+        calls_str = str(subprocess_mock.call_args_list)
+        assert "pip-audit" in calls_str and "--fix" in calls_str
+        assert "uv" in calls_str and "lock" in calls_str
+        assert "fixed" in out.lower() or "synced" in out.lower()
+
+    def test_fix_flag_reports_failure_when_pip_audit_fix_fails(self, monkeypatch, tmp_path):
+        """--fix with pip-audit --fix failure → surfaced as a manual issue."""
+        out, subprocess_mock = self._run_python_audit_section(
+            monkeypatch, tmp_path,
+            _make_pip_audit_json([("urllib3", "1.26.0", ["CVE-2023-0002"])]),
+            fix=True,
+            audit_fix_rc=1,
+        )
+        assert "failed" in out.lower() or "manually" in out.lower()
+
+    def test_fix_flag_warns_when_uv_lock_fails(self, monkeypatch, tmp_path):
+        """--fix: pip-audit --fix succeeds but uv lock fails → warning about manual uv lock."""
+        out, _ = self._run_python_audit_section(
+            monkeypatch, tmp_path,
+            _make_pip_audit_json([("pyyaml", "5.3", ["CVE-2020-1234"])]),
+            fix=True,
+            audit_fix_rc=0,
+            uv_lock_rc=1,
+        )
+        assert "uv lock" in out

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -50,10 +50,10 @@ Already up to date.  (or: Updating abc1234..def5678)
 `hermes update` handles the main update path, but a quick validation confirms everything landed cleanly:
 
 1. `git status --short` — if the tree is unexpectedly dirty, inspect before continuing
-2. `hermes doctor` — checks config, dependencies, and service health
+2. `hermes doctor` — checks config, dependencies, npm security, and service health
 3. `hermes --version` — confirm the version bumped as expected
 4. If you use the gateway: `hermes gateway status`
-5. If `doctor` reports npm audit issues: run `npm audit fix` in the flagged directory
+5. If `doctor` reports npm or Python package vulnerabilities: run `hermes doctor --fix` to auto-remediate both (`npm audit fix` for Node.js, `pip-audit --fix` + `uv lock` for Python), or fix manually using the commands shown in the issue summary
 
 :::warning Dirty working tree after update
 If `git status --short` shows unexpected changes after `hermes update`, stop and inspect them before continuing. This usually means local modifications were reapplied on top of the updated code, or a dependency step refreshed lockfiles.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -274,9 +274,68 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 hermes doctor [--fix]
 ```
 
+Runs a comprehensive health check across config files, API credentials, external tools, Node.js dependencies, and running services.
+
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+
+### What it checks
+
+| Section | Details |
+|---------|---------|
+| **Python & packages** | Python version, required pip packages |
+| **Config files** | `.env` presence, `config.yaml` validity, stale keys, schema validation |
+| **Auth providers** | API key presence for configured LLM providers |
+| **External tools** | `git`, `rg`, `docker`, `ssh`, `daytona`, Node.js, `agent-browser` |
+| **npm security** | Runs `npm audit` in browser tools and WhatsApp bridge directories; reports critical, high, and moderate vulnerabilities |
+| **API connectivity** | Live reachability check for configured providers |
+| **Tool availability** | Which toolsets are active vs. missing prerequisites |
+| **Skills Hub** | Skill index reachability |
+| **Memory provider** | Active provider health (built-in, Honcho, Mem0) |
+| **Profiles** | Orphan aliases, missing configs |
+
+### npm security checks
+
+`hermes doctor` runs `npm audit` in two directories when `node_modules` is present:
+
+- **Browser tools** (`/` — `agent-browser`, `camoufox-browser`)
+- **WhatsApp bridge** (`scripts/whatsapp-bridge/`)
+
+Severity thresholds:
+
+| Severity | Reported as |
+|----------|-------------|
+| Critical or High | `⚠` warning + listed in issues summary |
+| Moderate or Low | `⚠` warning + listed in issues summary |
+| None | `✓` clean |
+
+With `--fix`, Hermes automatically runs `npm audit fix` in each affected directory. If `npm audit fix` cannot resolve the issue automatically, it is surfaced as a manual action item.
+
+```bash
+hermes doctor          # report npm vulnerabilities
+hermes doctor --fix    # attempt npm audit fix automatically
+```
+
+### Python package security checks
+
+`hermes doctor` also runs `pip-audit` against the active Python environment to detect known CVEs in installed packages.
+
+`pip-audit` is included in the `dev` extra (`pip install "hermes-agent[dev]"`). If it is not installed, the check prints an install hint and is skipped.
+
+| Outcome | Reported as |
+|---------|-------------|
+| No vulnerabilities found | `✓` clean |
+| One or more vulnerabilities | `⚠` warning with package names and count |
+| `pip-audit` not installed | Info hint: `pip install pip-audit` |
+| `pip-audit` crashes | `⚠` warning with the error |
+
+With `--fix`, Hermes runs `pip-audit --fix` to auto-upgrade vulnerable packages, then calls `uv lock` to keep `uv.lock` in sync with the new versions. If `uv lock` fails (e.g. a constraint conflict), a manual action item is added to the summary.
+
+```bash
+hermes doctor          # report Python package vulnerabilities
+hermes doctor --fix    # auto-fix via pip-audit --fix + re-sync uv.lock
+```
 
 ## `hermes dump`
 


### PR DESCRIPTION
Fixes : #8578 and #8576

## What does this PR do?

The repository had no automated mechanism to detect or track vulnerable dependencies,
and `hermes doctor` silently skipped npm audit errors and misreported moderate-severity
npm vulnerabilities as clean. This PR closes both gaps:

1. **Proactive**: Added `.github/dependabot.yml` so GitHub Dependabot automatically
   opens PRs every Monday for outdated or vulnerable packages across all five dependency
   ecosystems (root npm, WhatsApp bridge npm, website npm, Python pip, GitHub Actions).
   Each Dependabot PR title follows the project's Conventional Commits convention via
   per-ecosystem `commit-message.prefix` config (e.g. `chore(whatsapp):`, `chore(ci):`).

2. **Reactive**: Added `.github/workflows/dependency-checks.yml`, a path-filtered CI
   workflow that runs `npm audit`, `node --test`, and `pip-audit` automatically on any
   PR (including Dependabot PRs) that touches dependency files — blocking merges if
   vulnerabilities are introduced.

3. **Visibility**: Improved `hermes doctor` to surface npm and Python package
   vulnerabilities correctly at all severity levels, and extended `hermes doctor --fix`
   to auto-remediate both npm (`npm audit fix`) and Python (`pip-audit --fix` + `uv lock`)
   vulnerabilities in a single command.

This approach was chosen over a manual patch-and-forget workflow because it creates a
self-sustaining loop: Dependabot finds vulnerabilities → CI validates the fix → `hermes
doctor` surfaces any remaining issues locally.


## Related Issue

Fixes #


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

### New files
- `.github/dependabot.yml` — weekly Dependabot config for npm (×3), pip, and
  GitHub Actions ecosystems with Conventional Commit prefixes per ecosystem
- `.github/workflows/dependency-checks.yml` — path-filtered CI workflow with three
  jobs: `root-npm` (npm audit), `whatsapp-bridge` (npm audit + `allowlist.test.mjs`),
  `python-audit` (pip-audit via uv); replaces `npm-checks.yml`

### `hermes_cli/doctor.py`
- Moved `import json` to module level, removing two stale inline imports that caused
  `UnboundLocalError` for all `json.loads` calls earlier in `run_doctor`
- Fixed npm audit `except Exception: pass` → `check_warn` so failures are visible
- Changed moderate/low npm vulnerabilities from `check_ok` to `check_warn` so all
  severity levels are surfaced as actionable warnings
- Added `--fix` auto-remediation for npm: runs `npm audit fix`, increments
  `fixed_count` on success, adds to `manual_issues` on failure
- Added Python package security audit section using `pip-audit --json --skip-editable`
  with full severity reporting and package name listing
- Added `--fix` auto-remediation for Python: runs `pip-audit --fix` then `uv lock`
  to keep `uv.lock` in sync; each step's failure is surfaced individually

### `pyproject.toml`
- Added `pip-audit>=2.7.0,<3` to the `dev` extra so pip-audit is available in all
  development and CI environments

### `tests/hermes_cli/test_doctor.py`
- Added `TestDoctorNpmAudit` (8 cases): no vulns, critical/high warn, moderate warn,
  npm not on PATH, missing node_modules, subprocess exception, --fix success, --fix
  failure
- Added `TestDoctorPythonAudit` (7 cases): no vulns, vulns warn, pip-audit not
  installed info hint, exception handling, --fix with uv lock sync, --fix pip-audit
  failure, --fix uv lock failure
- Fixed `TestDoctorNpmAudit` helper to suppress pip-audit from PATH so the two test
  suites do not interfere with each other

### `website/docs/reference/cli-commands.md`
- Expanded `hermes doctor` section with a full check table, npm audit severity
  threshold table, and new Python package audit subsection documenting `--fix`
  behaviour for both ecosystems

### `website/docs/getting-started/updating.md`
- Updated post-update checklist step 5 to reference `hermes doctor --fix` for both
  npm and Python vulnerability remediation


## How to Test

1. **Validate Dependabot config syntax**
   ```bash
   pip install check-jsonschema
   check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
   # Expected: ok -- validation done
   ```

2. **Run the full doctor test suite**
   ```bash
   pytest tests/hermes_cli/test_doctor.py -v --override-ini="addopts="
   # Expected: 32 passed
   ```

3. **Verify npm audit CI commands match what the workflow runs**
   ```bash
   cd scripts/whatsapp-bridge && npm ci
   npm audit --audit-level=moderate   # exits 1 = existing vulns present (expected)
   node --test allowlist.test.mjs     # Expected: 4 passed
   ```

4. **Verify pip-audit runs cleanly against the project environment (not system Python)**
   ```bash
   uv venv /tmp/test-venv --python 3.11
   uv pip install -e ".[all,dev]" --python /tmp/test-venv/bin/python
   /tmp/test-venv/bin/pip-audit --skip-editable
   # Expected: 1 known vulnerability (pynacl 1.5.0 — Dependabot will patch this)
   ```

5. **Verify `hermes doctor` reports npm and Python vulnerabilities**
   ```bash
   hermes doctor
   # Expected: ⚠ warnings for npm dirs with node_modules and Python packages with CVEs
   ```

6. **After merging, verify Dependabot activates**
   ```
   GitHub repo → Insights → Dependency graph → Dependabot → "Check for updates"
   # Expected: PRs opened with titles like:
   #   chore(whatsapp): bump express from 4.21.0 to 5.1.0
   #   chore(deps): bump pynacl from 1.5.0 to 1.6.2
   ```


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (32/32 in `test_doctor.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 25.2.0 (Darwin), Python 3.11.5, Node.js 25.2.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated `website/docs/reference/cli-commands.md` and `website/docs/getting-started/updating.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `subprocess.run` and `shutil.which` are cross-platform; `npm` and `pip-audit` checks gracefully skip when not on PATH
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A


## Screenshots / Logs

**`hermes doctor` with npm vulnerabilities (before fix flag):**
```
◆ External Tools
  ✓ Node.js
  ⚠ WhatsApp bridge deps (1 moderate, 2 high — run: cd scripts/whatsapp-bridge && npm audit fix)
  ⚠ Python packages (1 vulnerability across 1 package: pynacl — run: pip-audit --fix)
```

**`hermes doctor --fix` output:**
```
◆ External Tools
  ✓ Node.js
  ✓ WhatsApp bridge deps (vulnerabilities fixed by npm audit fix)
  ✓ Python packages (vulnerabilities fixed by pip-audit --fix)
  ✓ uv.lock (synced after pip-audit fix)
```

**Dependabot PR title format (after merge):**
```
chore(whatsapp): bump express from 4.21.0 to 5.1.0 in /scripts/whatsapp-bridge
chore(deps): bump pynacl from 1.5.0 to 1.6.2
chore(ci): bump actions/checkout from 4 to 5
```