### PR TITLE
fix(tools): narrow RuntimeError catch in session summarization to allow retries

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -359,7 +359,7 @@ class TestSessionSearch:
         from unittest.mock import AsyncMock, patch as _patch
         with _patch("tools.session_search_tool.async_call_llm",
                      new_callable=AsyncMock,
-                     side_effect=RuntimeError("no provider")):
+                     side_effect=RuntimeError("No LLM provider configured for task=session_search provider=auto. Run: hermes setup")):
             result = json.loads(session_search(
                 query="test", db=mock_db, current_session_id=current_sid,
             ))
@@ -483,3 +483,111 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+
+# =========================================================================
+# _summarize_session — RuntimeError handling (#8045)
+# =========================================================================
+
+class TestSummarizeSessionRuntimeError:
+    """Verify that _summarize_session distinguishes provider-missing errors
+    (immediate return None) from transient RuntimeErrors (retry)."""
+
+    @pytest.mark.asyncio
+    async def test_provider_missing_error_returns_none_immediately(self):
+        """RuntimeError with 'No LLM provider' should return None without retrying."""
+        from unittest.mock import patch as _patch
+        from tools.session_search_tool import _summarize_session
+
+        call_count = 0
+        async def _fail_no_provider(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("No LLM provider configured for task=session_search provider=auto. Run: hermes setup")
+
+        with _patch("tools.session_search_tool.async_call_llm", side_effect=_fail_no_provider):
+            result = await _summarize_session("test convo", "query", {"source": "telegram"})
+
+        assert result is None
+        assert call_count == 1  # Should NOT retry
+
+    @pytest.mark.asyncio
+    async def test_transient_runtime_error_retries(self):
+        """RuntimeError from invalid LLM response should trigger retries."""
+        from unittest.mock import patch as _patch
+        from tools.session_search_tool import _summarize_session
+
+        call_count = 0
+        async def _fail_invalid_response(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Auxiliary session_search: LLM returned None response")
+
+        with _patch("tools.session_search_tool.async_call_llm", side_effect=_fail_invalid_response):
+            result = await _summarize_session("test convo", "query", {"source": "telegram"})
+
+        assert result is None
+        assert call_count == 3  # Should retry 3 times
+
+    @pytest.mark.asyncio
+    async def test_transient_runtime_error_succeeds_on_retry(self):
+        """A transient RuntimeError on first attempt should succeed on retry."""
+        from unittest.mock import patch as _patch
+        from types import SimpleNamespace
+        from tools.session_search_tool import _summarize_session
+
+        call_count = 0
+        async def _fail_then_succeed(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Auxiliary session_search: LLM returned invalid response (type=str)")
+            # Return a valid response on second attempt
+            msg = SimpleNamespace(content="Summary of conversation", reasoning_content=None)
+            choice = SimpleNamespace(message=msg)
+            return SimpleNamespace(choices=[choice])
+
+        with _patch("tools.session_search_tool.async_call_llm", side_effect=_fail_then_succeed):
+            result = await _summarize_session("test convo", "query", {"source": "telegram"})
+
+        assert result == "Summary of conversation"
+        assert call_count == 2  # First failed, second succeeded
+
+    @pytest.mark.asyncio
+    async def test_api_key_missing_error_returns_none_immediately(self):
+        """RuntimeError about missing API key should return None without retrying."""
+        from unittest.mock import patch as _patch
+        from tools.session_search_tool import _summarize_session
+
+        call_count = 0
+        async def _fail_no_key(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError(
+                "Provider 'google' is set in config.yaml but no API key "
+                "was found. Set the GOOGLE_API_KEY environment variable."
+            )
+
+        with _patch("tools.session_search_tool.async_call_llm", side_effect=_fail_no_key):
+            result = await _summarize_session("test convo", "query", {"source": "telegram"})
+
+        assert result is None
+        assert call_count == 1  # Should NOT retry
+
+    @pytest.mark.asyncio
+    async def test_unknown_runtime_error_does_not_retry(self):
+        """Unrecognized RuntimeError should fail fast, not retry."""
+        from unittest.mock import patch as _patch
+        from tools.session_search_tool import _summarize_session
+
+        call_count = 0
+        async def _fail_unknown(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Something completely unexpected happened")
+
+        with _patch("tools.session_search_tool.async_call_llm", side_effect=_fail_unknown):
+            result = await _summarize_session("test convo", "query", {"source": "telegram"})
+
+        assert result is None
+        assert call_count == 1  # Unknown errors should NOT retry

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -241,8 +241,21 @@ async def _summarize_session(
                 await asyncio.sleep(1 * (attempt + 1))
                 continue
             return content
-        except RuntimeError:
-            logging.warning("No auxiliary model available for session summarization")
+        except RuntimeError as e:
+            err_msg = str(e).lower()
+            # Known transient errors from _validate_llm_response() —
+            # the LLM returned a malformed or empty payload that may
+            # succeed on a subsequent attempt.
+            _transient = ("llm returned none response" in err_msg
+                          or "llm returned invalid response" in err_msg)
+            if _transient and attempt < max_retries - 1:
+                logging.warning("Session summarization RuntimeError (attempt %d/%d): %s", attempt + 1, max_retries, e)
+                await asyncio.sleep(1 * (attempt + 1))
+                continue
+            # Non-transient (e.g. no provider, missing API key) or
+            # final attempt — give up immediately.
+            logging.warning("Session summarization failed: %s", e,
+                            exc_info=(attempt >= max_retries - 1))
             return None
         except Exception as e:
             if attempt < max_retries - 1:


### PR DESCRIPTION
## What does this PR do?

`_summarize_session()` in `tools/session_search_tool.py` had a blanket `except RuntimeError: return None` that treated **every** `RuntimeError` as non-recoverable, immediately giving up without retrying. This caused `session_search` to fall back to `"[Raw preview — summarization unavailable]"` even when a retry would have succeeded.

After PR #7647 added `_validate_llm_response()` to `auxiliary_client.py`, two new **transient** `RuntimeError`s started being raised (`"LLM returned None response"` and `"LLM returned invalid response"`) when the LLM returns a malformed payload. These are recoverable on retry, but the old blanket catch swallowed them silently.

This PR inverts the logic: only retry on **known transient** errors from `_validate_llm_response()`; treat all other `RuntimeError`s (no provider configured, missing API key, etc.) as non-recoverable and fail fast.

## Related Issue

Fixes #8045

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/session_search_tool.py`**: Replace blanket `except RuntimeError: return None` with whitelist-based retry logic:
  - `"llm returned none response"` / `"llm returned invalid response"` → transient, retry with backoff
  - All other `RuntimeError`s (no provider, missing API key, unknown) → fail fast, return `None`
  - Attach `exc_info` traceback only on final attempt to avoid log noise

- **`tests/tools/test_session_search.py`**:
  - Fix existing mock to use realistic error message (`"No LLM provider configured..."` instead of `"no provider"`)
  - Add 5 new test cases covering all branches:
    - `test_provider_missing_error_returns_none_immediately` — no provider → 1 call, no retry
    - `test_transient_runtime_error_retries` — invalid response → 3 retries
    - `test_transient_runtime_error_succeeds_on_retry` — fail once, succeed on retry
    - `test_api_key_missing_error_returns_none_immediately` — missing API key → 1 call, no retry
    - `test_unknown_runtime_error_does_not_retry` — unknown error → fail fast (safe default)

## How to Test

1. `pytest tests/tools/test_session_search.py -v` — all 30 tests pass
2. `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e` — full suite passes
3. Manual: trigger a session_search with a flaky auxiliary provider — transient LLM response errors should now be retried instead of immediately falling back to raw preview

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A