### PR TITLE
fix(gateway): include external_dirs skills in Telegram/Discord slash command registration

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -600,13 +600,21 @@ def _collect_gateway_skill_entries(
     try:
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
+        from agent.skill_utils import get_external_skills_dirs
         _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve())
+        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
+        # Build set of allowed directory prefixes: local skills + external dirs.
+        # Ensure each prefix ends with "/" to avoid false positives when one
+        # directory name is a prefix of another (e.g. "/my-skills" vs "/my-skills-extra").
+        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
+        _allowed_prefixes.extend(str(d).rstrip("/") + "/" for d in get_external_skills_dirs())
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
-            if not skill_path.startswith(_skills_dir):
+            if not skill_path:
+                continue
+            if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
                 continue
             if skill_path.startswith(_hub_dir):
                 continue

--- a/tests/hermes_cli/test_gateway_external_skills.py
+++ b/tests/hermes_cli/test_gateway_external_skills.py
@@ -1,0 +1,319 @@
+"""Tests that _collect_gateway_skill_entries includes external skills."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    """Create a minimal HERMES_HOME with skills directory."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    return home
+
+
+@pytest.fixture
+def external_skills_dir(tmp_path):
+    """Create a temp dir with a sample external skill."""
+    ext_dir = tmp_path / "external-skills"
+    skill_dir = ext_dir / "morning-briefing"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: morning-briefing\n"
+        "description: Daily morning briefing\n---\n\n"
+        "# Morning Briefing\n\nBrief the user on the day ahead.\n"
+    )
+    return ext_dir
+
+
+@pytest.fixture
+def local_skill(hermes_home):
+    """Create a local skill under HERMES_HOME/skills."""
+    skill_dir = hermes_home / "skills" / "local-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: local-skill\n"
+        "description: A local skill\n---\n\n"
+        "# Local Skill\n\nDo local things.\n"
+    )
+    return skill_dir
+
+
+class TestCollectGatewaySkillEntriesExternal:
+    """Verify that external skills from skills.external_dirs appear in gateway
+    slash command registration (Fixes #8110)."""
+
+    def test_external_skill_included_in_gateway_entries(
+        self, hermes_home, external_skills_dir, local_skill
+    ):
+        """External skills should be included alongside local skills."""
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
+        )
+        local_skills = hermes_home / "skills"
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            # Clear cached skill commands to force a fresh scan
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, hidden = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "morning-briefing" in names, (
+            "External skill 'morning-briefing' should be registered as a "
+            "gateway slash command"
+        )
+        assert "local-skill" in names, (
+            "Local skill should still be registered"
+        )
+
+    def test_external_skill_excluded_without_fix(
+        self, hermes_home, external_skills_dir
+    ):
+        """Without external_dirs config, only local skills appear."""
+        # No config.yaml → no external dirs
+        local_skills = hermes_home / "skills"
+        local_dir = local_skills / "only-local"
+        local_dir.mkdir(parents=True)
+        (local_dir / "SKILL.md").write_text(
+            "---\nname: only-local\n"
+            "description: Only local\n---\n\nLocal.\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, hidden = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "only-local" in names
+
+    def test_hub_skills_still_excluded(self, hermes_home):
+        """Hub-installed skills should remain excluded even from local dir."""
+        local_skills = hermes_home / "skills"
+        hub_dir = local_skills / ".hub" / "hub-skill"
+        hub_dir.mkdir(parents=True)
+        (hub_dir / "SKILL.md").write_text(
+            "---\nname: hub-skill\n"
+            "description: A hub skill\n---\n\nHub.\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, hidden = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "hub-skill" not in names, (
+            "Hub skills should remain excluded from gateway registration"
+        )
+
+    def test_path_prefix_boundary_not_confused(self, hermes_home, tmp_path):
+        """A dir whose name is a prefix of another should not cause false matches.
+
+        e.g. external_dir '/tmp/my-skills' must NOT match a skill under
+        '/tmp/my-skills-extra/'.
+        """
+        # "my-skills" is the configured external dir
+        real_ext = tmp_path / "my-skills"
+        skill_dir = real_ext / "real-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: real-skill\n"
+            "description: Real skill\n---\n\nReal.\n"
+        )
+
+        # "my-skills-extra" is NOT configured — a skill here should NOT appear
+        imposter_ext = tmp_path / "my-skills-extra"
+        imposter_dir = imposter_ext / "imposter-skill"
+        imposter_dir.mkdir(parents=True)
+        (imposter_dir / "SKILL.md").write_text(
+            "---\nname: imposter-skill\n"
+            "description: Imposter\n---\n\nImposter.\n"
+        )
+
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {real_ext}\n"
+        )
+        local_skills = hermes_home / "skills"
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, _ = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "real-skill" in names
+        assert "imposter-skill" not in names, (
+            "Skill from a dir whose name only shares a prefix should be excluded"
+        )
+
+    def test_multiple_external_dirs_all_included(self, hermes_home, tmp_path):
+        """Skills from multiple configured external dirs should all appear."""
+        ext_a = tmp_path / "ext-a"
+        (ext_a / "skill-a").mkdir(parents=True)
+        (ext_a / "skill-a" / "SKILL.md").write_text(
+            "---\nname: skill-a\ndescription: Skill A\n---\n\nA.\n"
+        )
+
+        ext_b = tmp_path / "ext-b"
+        (ext_b / "skill-b").mkdir(parents=True)
+        (ext_b / "skill-b" / "SKILL.md").write_text(
+            "---\nname: skill-b\ndescription: Skill B\n---\n\nB.\n"
+        )
+
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext_a}\n    - {ext_b}\n"
+        )
+        local_skills = hermes_home / "skills"
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, _ = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "skill-a" in names
+        assert "skill-b" in names
+
+    def test_empty_skill_md_path_skipped(self, hermes_home):
+        """A skill entry with an empty skill_md_path should be silently skipped."""
+        local_skills = hermes_home / "skills"
+        # Create one valid local skill so scan produces something
+        valid_dir = local_skills / "valid-skill"
+        valid_dir.mkdir(parents=True)
+        (valid_dir / "SKILL.md").write_text(
+            "---\nname: valid-skill\n"
+            "description: Valid\n---\n\nValid.\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            # Inject a bogus entry with empty skill_md_path after scan
+            from agent.skill_commands import get_skill_commands
+            cmds = get_skill_commands()
+            cmds["/ghost-skill"] = {
+                "name": "ghost-skill",
+                "description": "Has no path",
+                "skill_md_path": "",
+                "skill_dir": "",
+            }
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, _ = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "ghost-skill" not in names, (
+            "Skill with empty skill_md_path should be skipped"
+        )
+        assert "valid-skill" in names
+
+    def test_hub_sibling_dir_not_excluded(self, hermes_home):
+        """A directory named '.hub-extra' should NOT be excluded by the hub filter.
+
+        Only skills under the actual '.hub/' directory should be excluded.
+        """
+        local_skills = hermes_home / "skills"
+
+        # This skill is under ".hub-extra", not ".hub" — it should pass
+        sibling_dir = local_skills / ".hub-extra" / "sibling-skill"
+        sibling_dir.mkdir(parents=True)
+        (sibling_dir / "SKILL.md").write_text(
+            "---\nname: sibling-skill\n"
+            "description: Not a hub skill\n---\n\nSibling.\n"
+        )
+
+        # This skill is under the real ".hub" — it should be excluded
+        hub_dir = local_skills / ".hub" / "real-hub-skill"
+        hub_dir.mkdir(parents=True)
+        (hub_dir / "SKILL.md").write_text(
+            "---\nname: real-hub-skill\n"
+            "description: A real hub skill\n---\n\nHub.\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent import skill_commands as _sc_mod
+            _sc_mod._skill_commands.clear()
+
+            from hermes_cli.commands import _collect_gateway_skill_entries
+            entries, _ = _collect_gateway_skill_entries(
+                platform="telegram",
+                max_slots=100,
+                reserved_names=set(),
+                desc_limit=40,
+            )
+
+        names = [name for name, _desc, _key in entries]
+        assert "sibling-skill" in names, (
+            "Skill under '.hub-extra/' should NOT be excluded by hub filter"
+        )
+        assert "real-hub-skill" not in names, (
+            "Skill under '.hub/' should still be excluded"
+        )


### PR DESCRIPTION
## What does this PR do?

Skills configured via `skills.external_dirs` in `config.yaml` were visible in CLI (`hermes skills list`) and usable by the agent, but silently excluded from Telegram and Discord slash command menus. Users who organized skills in external directories could not invoke them via `/slash-commands` on gateway platforms.

The root cause is in `_collect_gateway_skill_entries()` (`hermes_cli/commands.py`): it filtered skills by checking `skill_path.startswith(_skills_dir)` where `_skills_dir` is only `~/.hermes/skills/`. External skills have paths outside this prefix (e.g. `~/my-skills/morning-briefing/SKILL.md`), so they were dropped by the `continue` statement. Meanwhile, `scan_skill_commands()` correctly scans both local and external directories — the inconsistency was only in the gateway registration path.

This PR widens the allowed-prefix set to include all configured external directories alongside the local skills dir. It also:
- Enforces trailing `/` on all directory prefixes to prevent false-positive matches when one directory name is a prefix of another (e.g. `/my-skills` vs `/my-skills-extra`)
- Skips entries with empty `skill_md_path` to avoid accidental matches

## Related Issue

Fixes #8110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands.py`: Import `get_external_skills_dirs`, build `_allowed_prefixes` from `SKILLS_DIR` + external dirs (all slash-terminated), replace single `startswith(_skills_dir)` with `any(startswith(prefix) for prefix in _allowed_prefixes)`, add empty-path guard, slash-terminate `_hub_dir` for consistency
- `tests/hermes_cli/test_gateway_external_skills.py` (new): 7 test cases covering external skill inclusion, local-only behavior, hub exclusion, path-prefix boundary safety, multiple external dirs, empty skill_md_path handling, and hub-sibling directory boundary

## How to Test

1. `pytest tests/hermes_cli/test_gateway_external_skills.py -v` — all 7 tests pass
2. `pytest tests/ -q` — full suite passes (pre-existing env-dependent failures are unrelated)
3. Manual verification:
   - Configure `skills.external_dirs` in `~/.hermes/config.yaml` pointing to a directory with a valid `SKILL.md`
   - Confirm `hermes skills list` shows the external skill
   - Start a Telegram gateway — the external skill should now appear in the slash command menu (`getMyCommands`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A