### PR TITLE
fix: restore Hermes ready notifications

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1619,6 +1619,7 @@ class HermesCLI:
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        self.osc9_ready_on_waiting = CLI_CONFIG["display"].get("osc9_ready_on_waiting", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
@@ -1825,6 +1826,7 @@ class HermesCLI:
         self._last_scrollback_tool: str = ""  # last tool name printed to scrollback (for "new" dedup)
         self._command_running = False
         self._command_status = ""
+        self._last_waiting_for_user_input = None
         self._attached_images: list[Path] = []
         self._image_counter = 0
         self.preloaded_skills: list[str] = []
@@ -1855,6 +1857,62 @@ class HermesCLI:
         if hasattr(self, "_app") and self._app and (now - self._last_invalidate) >= min_interval:
             self._last_invalidate = now
             self._app.invalidate()
+
+    def _emit_terminal_escape(self, seq: str) -> None:
+        if not seq:
+            return
+        try:
+            out = getattr(sys, "__stdout__", None) or sys.stdout
+            if out is None:
+                return
+            try:
+                if hasattr(out, "isatty") and not out.isatty():
+                    return
+            except Exception:
+                return
+
+            data = seq.encode("utf-8", errors="ignore")
+            try:
+                os.write(out.fileno(), data)
+                return
+            except Exception:
+                pass
+
+            out.write(seq)
+            out.flush()
+        except Exception:
+            logger.debug("terminal escape emit failed", exc_info=True)
+
+    def _emit_ready_osc9(self) -> None:
+        if not getattr(self, "osc9_ready_on_waiting", False):
+            return
+        self._emit_terminal_escape("\x1b]9;Hermes ready\x07")
+
+    def _is_waiting_for_user_input(self) -> bool:
+        if getattr(self, "_should_exit", False):
+            return False
+        return bool(
+            getattr(self, "_sudo_state", None)
+            or getattr(self, "_secret_state", None)
+            or getattr(self, "_approval_state", None)
+            or getattr(self, "_clarify_state", None)
+            or getattr(self, "_clarify_freetext", False)
+            or (
+                not getattr(self, "_agent_running", False)
+                and not getattr(self, "_command_running", False)
+                and not getattr(self, "_voice_processing", False)
+                and not getattr(self, "_voice_recording", False)
+            )
+        )
+
+    def _sync_ready_notification(self) -> None:
+        if not getattr(self, "osc9_ready_on_waiting", False):
+            return
+        waiting = self._is_waiting_for_user_input()
+        prev = getattr(self, "_last_waiting_for_user_input", None)
+        if waiting and prev is not True:
+            self._emit_ready_osc9()
+        self._last_waiting_for_user_input = waiting
 
     def _status_bar_context_style(self, percent_used: Optional[int]) -> str:
         if percent_used is None:
@@ -2647,6 +2705,7 @@ class HermesCLI:
         """Expose a temporary busy state in the TUI while a slash command runs."""
         self._command_running = True
         self._command_status = status
+        self._sync_ready_notification()
         self._invalidate(min_interval=0.0)
         try:
             print(f"⏳ {status}")
@@ -2654,6 +2713,7 @@ class HermesCLI:
         finally:
             self._command_running = False
             self._command_status = ""
+            self._sync_ready_notification()
             self._invalidate(min_interval=0.0)
 
     def _ensure_runtime_credentials(self) -> bool:
@@ -7249,6 +7309,7 @@ class HermesCLI:
         self._clarify_deadline = _time.monotonic() + timeout
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
+        self._sync_ready_notification()
 
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
@@ -7267,6 +7328,7 @@ class HermesCLI:
             try:
                 result = response_queue.get(timeout=1)
                 self._clarify_deadline = 0
+                self._sync_ready_notification()
                 return result
             except queue.Empty:
                 remaining = self._clarify_deadline - _time.monotonic()
@@ -7285,6 +7347,7 @@ class HermesCLI:
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
+        self._sync_ready_notification()
         self._invalidate()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
@@ -7310,6 +7373,7 @@ class HermesCLI:
             "response_queue": response_queue,
         }
         self._sudo_deadline = _time.monotonic() + timeout
+        self._sync_ready_notification()
 
         self._invalidate()
 
@@ -7318,6 +7382,7 @@ class HermesCLI:
                 result = response_queue.get(timeout=1)
                 self._sudo_state = None
                 self._sudo_deadline = 0
+                self._sync_ready_notification()
                 self._restore_modal_input_snapshot()
                 self._invalidate()
                 if result:
@@ -7333,6 +7398,7 @@ class HermesCLI:
 
         self._sudo_state = None
         self._sudo_deadline = 0
+        self._sync_ready_notification()
         self._restore_modal_input_snapshot()
         self._invalidate()
         _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
@@ -7367,6 +7433,7 @@ class HermesCLI:
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+            self._sync_ready_notification()
 
             self._invalidate()
 
@@ -7376,6 +7443,7 @@ class HermesCLI:
                     result = response_queue.get(timeout=1)
                     self._approval_state = None
                     self._approval_deadline = 0
+                    self._sync_ready_notification()
                     self._invalidate()
                     return result
                 except queue.Empty:
@@ -7389,6 +7457,7 @@ class HermesCLI:
 
             self._approval_state = None
             self._approval_deadline = 0
+            self._sync_ready_notification()
             self._invalidate()
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
@@ -7422,6 +7491,7 @@ class HermesCLI:
 
         state["response_queue"].put(chosen)
         self._approval_state = None
+        self._sync_ready_notification()
         self._invalidate()
 
     def _get_approval_display_fragments(self):
@@ -7539,6 +7609,7 @@ class HermesCLI:
         self._secret_state["response_queue"].put(value)
         self._secret_state = None
         self._secret_deadline = 0
+        self._sync_ready_notification()
         self._invalidate()
 
     def _cancel_secret_capture(self) -> None:
@@ -8315,6 +8386,7 @@ class HermesCLI:
         # Secure secret capture state for skill setup
         self._secret_state = None       # dict with var_name, prompt, metadata, response_queue
         self._secret_deadline = 0
+        self._last_waiting_for_user_input = None
 
         # Clipboard image attachments (paste images into the CLI)
         self._attached_images: list[Path] = []
@@ -8373,6 +8445,7 @@ class HermesCLI:
                 text = event.app.current_buffer.text
                 self._sudo_state["response_queue"].put(text)
                 self._sudo_state = None
+                self._sync_ready_notification()
                 event.app.invalidate()
                 return
 
@@ -8403,6 +8476,7 @@ class HermesCLI:
                     self._clarify_state["response_queue"].put(text)
                     self._clarify_state = None
                     self._clarify_freetext = False
+                    self._sync_ready_notification()
                     event.app.current_buffer.reset()
                     event.app.invalidate()
                 return
@@ -8415,6 +8489,7 @@ class HermesCLI:
                 if selected < len(choices):
                     state["response_queue"].put(choices[selected])
                     self._clarify_state = None
+                    self._sync_ready_notification()
                     event.app.invalidate()
                 else:
                     # "Other" selected → switch to freetext
@@ -8612,6 +8687,7 @@ class HermesCLI:
             if self._sudo_state:
                 self._sudo_state["response_queue"].put("")
                 self._sudo_state = None
+                self._sync_ready_notification()
                 event.app.invalidate()
                 return
 
@@ -8626,6 +8702,7 @@ class HermesCLI:
             if self._approval_state:
                 self._approval_state["response_queue"].put("deny")
                 self._approval_state = None
+                self._sync_ready_notification()
                 event.app.invalidate()
                 return
 
@@ -8643,6 +8720,7 @@ class HermesCLI:
                 )
                 self._clarify_state = None
                 self._clarify_freetext = False
+                self._sync_ready_notification()
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
@@ -9461,6 +9539,7 @@ class HermesCLI:
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback
+        self._sync_ready_notification()
 
         # ── Fix ghost status-bar lines on terminal resize ──────────────
         # When the terminal shrinks (e.g. un-maximize), the emulator reflows
@@ -9641,12 +9720,14 @@ class HermesCLI:
 
                     # Regular chat - run agent
                     self._agent_running = True
+                    self._sync_ready_notification()
                     app.invalidate()  # Refresh status line
 
                     try:
                         self.chat(user_input, images=submit_images or None)
                     finally:
                         self._agent_running = False
+                        self._sync_ready_notification()
                         self._spinner_text = ""
                         self._tool_start_time = 0.0
                         self._pending_tool_info.clear()

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -15,6 +15,16 @@ from hermes_cli.config import save_env_value_secure
 from hermes_constants import display_hermes_home
 
 
+def _sync_ready_notification(cli) -> None:
+    sync = getattr(cli, "_sync_ready_notification", None)
+    if not callable(sync):
+        return
+    try:
+        sync()
+    except Exception:
+        pass
+
+
 def clarify_callback(cli, question, choices):
     """Prompt for clarifying question through the TUI.
 
@@ -35,6 +45,7 @@ def clarify_callback(cli, question, choices):
     }
     cli._clarify_deadline = _time.monotonic() + timeout
     cli._clarify_freetext = is_open_ended
+    _sync_ready_notification(cli)
 
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
@@ -43,6 +54,7 @@ def clarify_callback(cli, question, choices):
         try:
             result = response_queue.get(timeout=1)
             cli._clarify_deadline = 0
+            _sync_ready_notification(cli)
             return result
         except queue.Empty:
             remaining = cli._clarify_deadline - _time.monotonic()
@@ -54,6 +66,7 @@ def clarify_callback(cli, question, choices):
     cli._clarify_state = None
     cli._clarify_freetext = False
     cli._clarify_deadline = 0
+    _sync_ready_notification(cli)
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
     cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
@@ -109,6 +122,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
         "response_queue": response_queue,
     }
     cli._secret_deadline = _time.monotonic() + timeout
+    _sync_ready_notification(cli)
     # Avoid storing stale draft input as the secret when Enter is pressed.
     if hasattr(cli, "_clear_secret_input_buffer"):
         try:
@@ -129,6 +143,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
             value = response_queue.get(timeout=1)
             cli._secret_state = None
             cli._secret_deadline = 0
+            _sync_ready_notification(cli)
             if hasattr(cli, "_app") and cli._app:
                 cli._app.invalidate()
 
@@ -160,6 +175,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
 
     cli._secret_state = None
     cli._secret_deadline = 0
+    _sync_ready_notification(cli)
     if hasattr(cli, "_clear_secret_input_buffer"):
         try:
             cli._clear_secret_input_buffer()
@@ -215,6 +231,7 @@ def approval_callback(cli, command: str, description: str) -> str:
             "response_queue": response_queue,
         }
         cli._approval_deadline = _time.monotonic() + timeout
+        _sync_ready_notification(cli)
 
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()
@@ -224,6 +241,7 @@ def approval_callback(cli, command: str, description: str) -> str:
                 result = response_queue.get(timeout=1)
                 cli._approval_state = None
                 cli._approval_deadline = 0
+                _sync_ready_notification(cli)
                 if hasattr(cli, "_app") and cli._app:
                     cli._app.invalidate()
                 return result
@@ -236,6 +254,7 @@ def approval_callback(cli, command: str, description: str) -> str:
 
         cli._approval_state = None
         cli._approval_deadline = 0
+        _sync_ready_notification(cli)
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()
         cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -495,6 +495,7 @@ DEFAULT_CONFIG = {
         "resume_display": "full",
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
+        "osc9_ready_on_waiting": False,
         "show_reasoning": False,
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
@@ -2779,6 +2780,7 @@ def show_config():
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  OSC 9 ready:  {'on' if display.get('osc9_ready_on_waiting', False) else 'off'}")
 
     # Terminal
     print()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,6 +1055,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3909,6 +3910,7 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -3927,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/tests/cli/test_cli_ready_notifications.py
+++ b/tests/cli/test_cli_ready_notifications.py
@@ -1,0 +1,145 @@
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import cli as cli_module
+from cli import HermesCLI
+from hermes_cli.callbacks import prompt_for_secret
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+class _FakeBuffer:
+    def __init__(self):
+        self.reset_called = False
+
+    def reset(self):
+        self.reset_called = True
+
+
+class _FakeApp:
+    def __init__(self):
+        self.invalidated = False
+        self.current_buffer = _FakeBuffer()
+
+    def invalidate(self):
+        self.invalidated = True
+
+
+def _make_cli_stub(with_app=True):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.osc9_ready_on_waiting = True
+    cli._agent_running = False
+    cli._command_running = False
+    cli._sudo_state = None
+    cli._secret_state = None
+    cli._approval_state = None
+    cli._approval_deadline = 0
+    cli._approval_lock = threading.Lock()
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._voice_processing = False
+    cli._voice_recording = False
+    cli._should_exit = False
+    cli._last_waiting_for_user_input = None
+    cli._last_invalidate = 0.0
+    cli._secret_deadline = 0
+    cli._modal_input_snapshot = None
+    cli._invalidate = MagicMock()
+    cli._app = _FakeApp() if with_app else None
+    return cli
+
+
+def test_display_config_defaults_osc9_ready_disabled():
+    assert DEFAULT_CONFIG["display"]["osc9_ready_on_waiting"] is False
+
+
+def test_emit_terminal_escape_uses_real_tty_stdout_and_os_write():
+    cli = _make_cli_stub()
+    fake_stdout = MagicMock()
+    fake_stdout.isatty.return_value = True
+    fake_stdout.fileno.return_value = 123
+
+    with patch.object(cli_module.sys, "__stdout__", fake_stdout), patch.object(cli_module.os, "write") as mock_write:
+        HermesCLI._emit_terminal_escape(cli, "\x1b]9;Hermes ready\x07")
+
+    mock_write.assert_called_once_with(123, b"\x1b]9;Hermes ready\x07")
+
+
+def test_sync_ready_notification_emits_once_per_busy_to_waiting_transition():
+    cli = _make_cli_stub(with_app=False)
+    cli._emit_ready_osc9 = MagicMock()
+
+    HermesCLI._sync_ready_notification(cli)
+    HermesCLI._sync_ready_notification(cli)
+
+    cli._emit_ready_osc9.assert_called_once()
+
+    cli._agent_running = True
+    HermesCLI._sync_ready_notification(cli)
+    cli._agent_running = False
+    HermesCLI._sync_ready_notification(cli)
+
+    assert cli._emit_ready_osc9.call_count == 2
+
+
+def test_busy_command_syncs_ready_notification_on_entry_and_exit():
+    cli = _make_cli_stub(with_app=False)
+    cli._sync_ready_notification = MagicMock()
+
+    with HermesCLI._busy_command(cli, "Testing notifications"):
+        pass
+
+    assert cli._sync_ready_notification.call_count == 2
+
+
+def test_submit_secret_response_syncs_ready_notification():
+    cli = _make_cli_stub()
+    cli._sync_ready_notification = MagicMock()
+    cli._secret_state = {
+        "response_queue": queue.Queue(),
+        "var_name": "TENOR_API_KEY",
+        "prompt": "Tenor API key",
+        "metadata": {},
+    }
+    cli._secret_deadline = 123
+
+    HermesCLI._submit_secret_response(cli, "super-secret-value")
+
+    assert cli._secret_state is None
+    assert cli._secret_deadline == 0
+    cli._sync_ready_notification.assert_called_once_with()
+
+
+def test_prompt_for_secret_syncs_ready_notification_on_open_and_timeout():
+    cli = _make_cli_stub(with_app=True)
+    cli._sync_ready_notification = MagicMock()
+
+    with patch("hermes_cli.callbacks.queue.Queue.get", side_effect=queue.Empty), patch(
+        "hermes_cli.callbacks._time.monotonic",
+        side_effect=[0, 121],
+    ):
+        result = prompt_for_secret(cli, "TENOR_API_KEY", "Tenor API key")
+
+    assert result["success"] is True
+    assert result["reason"] == "timeout"
+    assert cli._sync_ready_notification.call_count == 2
+
+
+def test_handle_approval_selection_syncs_ready_notification():
+    cli = _make_cli_stub()
+    cli._sync_ready_notification = MagicMock()
+    response_queue = queue.Queue()
+    cli._approval_state = {
+        "command": "rm -rf /tmp/demo",
+        "description": "delete temp files",
+        "choices": ["once", "session", "always", "deny"],
+        "selected": 0,
+        "response_queue": response_queue,
+    }
+
+    cli._handle_approval_selection()
+
+    assert cli._approval_state is None
+    assert response_queue.get_nowait() == "once"
+    cli._sync_ready_notification.assert_called_once_with()


### PR DESCRIPTION
## Summary
- restore `display.osc9_ready_on_waiting` config wiring and CLI ready-notification helpers
- emit OSC 9 via raw terminal writes on busy -> waiting transitions in CLI and callback prompt flows
- add regression tests for config defaults, busy/idle transitions, secret capture, approval handling, and startup idle state

## Test Plan
- source venv/bin/activate && pytest tests/cli/test_cli_ready_notifications.py -q
- source venv/bin/activate && pytest tests/cli/test_cli_ready_notifications.py tests/cli/test_cli_secret_capture.py tests/cli/test_cli_approval_ui.py tests/cli/test_cli_init.py -q