### PR TITLE
fix: catch OSError 'Invalid argument' in stdin selector guard

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9650,7 +9650,7 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393).
             # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err) or "Invalid argument" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Summary

- The existing handler for broken stdin (#6393) catches `"is not registered"` and `"Bad file descriptor"` messages, but on **macOS with uv-managed CPython 3.11 (aarch64)** the kqueue selector raises `OSError: [Errno 22] Invalid argument` instead when fd 0 is in a bad state at exit.
- This variant slips through the guard and produces an unhandled traceback on `hermes chat` exit.
- Added `"Invalid argument"` to the condition so this OS error variant is also caught gracefully.

## Reproduction

- macOS (Apple Silicon)
- Python 3.11.14 installed via `uv` (`~/.local/share/uv/python/cpython-3.11.14-macos-aarch64-none`)
- Run `hermes chat`, then exit — crashes with:

```
OSError: [Errno 22] Invalid argument
```

at `selector_events.py` → `_add_reader` → `selectors.py` → `register` → kqueue `control()`.

## Test plan

- [x] Verified the fix catches the error and prints the friendly message instead of a traceback
- [ ] Existing tests should continue to pass (no behavioral change for normal stdin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)