### PR TITLE
fix(tools): prevent credential pool from overriding delegation base_url

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -381,7 +381,20 @@ def _build_child_agent(
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+    # However, when delegation config explicitly set a different base_url,
+    # sharing the parent's pool would cause _swap_credential to overwrite
+    # the child's base_url with the parent's — routing subagents to the
+    # wrong endpoint.  Only share when the endpoints match.
+    _should_share_pool = (
+        override_base_url is None
+        or (
+            effective_base_url
+            and parent_agent.base_url
+            and effective_base_url.rstrip("/") == parent_agent.base_url.rstrip("/")
+        )
+    )
+    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent) if _should_share_pool else None
+
     if child_pool is not None:
         child._credential_pool = child_pool
 


### PR DESCRIPTION
## What does this PR do?

When both the parent agent and delegation config resolve to provider "custom" (e.g., parent on a local vLLM endpoint, subagents on a different local endpoint), `_resolve_child_credential_pool` shares the parent's credential pool with the child because the provider  matches.

During execution, `_run_single_child` calls `_swap_credential` on the leased pool entry, which overwrites `child.base_url` with the   pool's `base_url` — the parent's endpoint. The delegation `base_url` was correctly set during `AIAgent` construction, then silently     stomped.

Fixes subagents hitting the parent's endpoint instead of their configured delegation endpoint.

**tldr;**

Setting my main model endpoint to `http://192.168.1.10:8080` to use a model would cause the overriding of the subagent endpoints which were set at `http://192.168.1.123:8000`. It tried to use the correct model, but what it would do instead was try to hit `http://192.168.1.10:8080` looking for the model (which doesn't have it since these are 2 different server instances)

## Related Issue

No existing issue found.  lol there are A LOT of issues listed but I didn't find anything related.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

 ## Changes Made

   - `tools/delegate_tool.py`: Added a guard in `_build_child_agent()` to skip credential pool sharing when the delegation config          explicitly provides a different `override_base_url` from the parent's endpoint. Pool sharing is only meaningful when both agents target the same endpoint for credential rotation.

## How to Test

1. Configure `delegation.base_url` pointing to endpoint A (e.g., `http://192.168.1.123:8080/v1`) with a distinct model
2. Switch the main model to a different local/custom endpoint B (e.g., `http://192.168.1.10:8080/v1`)
3. Trigger a `delegate_task` — the subagent should hit endpoint A, not B
4. Verify subagent output shows the delegation model (not the parent model)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_delegate.py -q` and all 67 tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12, two separate local vLLM endpoints

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A**, no config keys or public API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is pure conditional logic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**, no schema changes

## Screenshots / Logs

N/A
