### PR TITLE
fix(run_agent): use public default_headers attr when preserving routed client headers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -886,8 +886,8 @@ class AIAgent:
                         "base_url": str(_routed_client.base_url),
                     }
                     # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    if hasattr(_routed_client, 'default_headers') and _routed_client.default_headers:
+                        client_kwargs["default_headers"] = dict(_routed_client.default_headers)
                 else:
                     # When the user explicitly chose a non-OpenRouter provider
                     # but no credentials were found, fail fast with a clear


### PR DESCRIPTION
## Problem

In `run_agent.py`, when falling back to the centralized provider router (`resolve_provider_client`), the code attempts to preserve the `default_headers` that the router may have set on the returned OpenAI client. However, it checks for the **private** attribute `._default_headers` instead of the **public** `.default_headers` attribute exposed by the OpenAI Python SDK.

Because `hasattr(_routed_client, '_default_headers')` is always `False` on current versions of the `openai` package, the routed client's headers are silently dropped. This causes API requests to Kimi (and potentially other providers that rely on `default_headers`) to fail with an HTTP **403** because the required `User-Agent: KimiCLI/1.30.0` header is missing.

Closes #8779

## Change

```diff
- if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-     client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+ if hasattr(_routed_client, 'default_headers') and _routed_client.default_headers:
+     client_kwargs["default_headers"] = dict(_routed_client.default_headers)
```

The codebase already correctly uses `getattr(fb_client, "default_headers", None)` elsewhere (line 5514), so this just brings the provider-router fallback branch in line with the rest of the file.

## Verification

- Confirmed that `openai.OpenAI` instances expose `default_headers` as a public attribute in `openai>=1.0`
- With this change, Kimi Coding requests correctly include `User-Agent: KimiCLI/1.30.0` and no longer return 403
