### PR TITLE
docs: restore Orchestra Research attribution in research-paper-writing skill

### DIFF
--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -820,6 +820,24 @@ Every successful ML paper centers on what Neel Nanda calls "the narrative": a sh
 
 **If you cannot state your contribution in one sentence, you don't yet have a paper.**
 
+### The Sources Behind This Guidance
+
+This skill synthesizes writing philosophy from researchers who have published extensively at top venues. The writing philosophy layer was originally compiled by [Orchestra Research](https://github.com/orchestra-research) as the `ml-paper-writing` skill.
+
+| Source | Key Contribution | Link |
+|--------|-----------------|------|
+| **Neel Nanda** (Google DeepMind) | The Narrative Principle, What/Why/So What framework | [How to Write ML Papers](https://www.alignmentforum.org/posts/eJGptPbbFPZGLpjsp/highly-opinionated-advice-on-how-to-write-ml-papers) |
+| **Sebastian Farquhar** (DeepMind) | 5-sentence abstract formula | [How to Write ML Papers](https://sebastianfarquhar.com/on-research/2024/11/04/how_to_write_ml_papers/) |
+| **Gopen & Swan** | 7 principles of reader expectations | [Science of Scientific Writing](https://cseweb.ucsd.edu/~swanson/papers/science-of-writing.pdf) |
+| **Zachary Lipton** | Word choice, eliminating hedging | [Heuristics for Scientific Writing](https://www.approximatelycorrect.com/2018/01/29/heuristics-technical-scientific-writing-machine-learning-perspective/) |
+| **Jacob Steinhardt** (UC Berkeley) | Precision, consistent terminology | [Writing Tips](https://bounded-regret.ghost.io/) |
+| **Ethan Perez** (Anthropic) | Micro-level clarity tips | [Easy Paper Writing Tips](https://ethanperez.net/easy-paper-writing-tips/) |
+| **Andrej Karpathy** | Single contribution focus | Various lectures |
+
+**For deeper dives into any of these, see:**
+- [references/writing-guide.md](references/writing-guide.md) — Full explanations with examples
+- [references/sources.md](references/sources.md) — Complete bibliography
+
 ### Time Allocation
 
 Spend approximately **equal time** on each of:

--- a/skills/research/research-paper-writing/references/sources.md
+++ b/skills/research/research-paper-writing/references/sources.md
@@ -4,6 +4,12 @@ This document lists all authoritative sources used to build this skill, organize
 
 ---
 
+## Origin & Attribution
+
+The writing philosophy, citation verification workflow, and conference reference materials in this skill were originally compiled by **[Orchestra Research](https://github.com/orchestra-research)** as the `ml-paper-writing` skill (January 2026), drawing on Neel Nanda's blog post and other researcher guides listed below. The skill was integrated into hermes-agent by teknium (January 2026), then expanded into the current `research-paper-writing` pipeline by SHL0MS (April 2026, PR #4654), which added experiment design, execution monitoring, iterative refinement, and submission phases while preserving the original writing philosophy and reference files.
+
+---
+
 ## Writing Philosophy & Guides
 
 ### Primary Sources (Must-Read)


### PR DESCRIPTION
## Summary

PR #4654 replaced `ml-paper-writing` with `research-paper-writing`, preserving the writing philosophy and reference files byte-identical but dropping the dedicated attribution section from the SKILL.md body.

**Chain of custody:** Nanda's blog post → Orchestra Research compiled `ml-paper-writing` skill → teknium added to hermes-agent → SHL0MS expanded into `research-paper-writing`

## Changes

**SKILL.md** — Re-adds the `### The Sources Behind This Guidance` section after the Narrative Principle, matching the original `ml-paper-writing` skill's attribution table:
- Full researcher table (Nanda, Farquhar, Gopen & Swan, Lipton, Steinhardt, Perez, Karpathy) with affiliations, key contributions, and links
- Credits Orchestra Research as original compiler of the writing philosophy layer
- Pointers to `references/writing-guide.md` and `references/sources.md`

**references/sources.md** — Adds `## Origin & Attribution` section documenting the full provenance chain: Orchestra Research → teknium integration → SHL0MS expansion (PR #4654)

## What's NOT changed
- The `author: Orchestra Research` frontmatter was already preserved — no change needed
- All existing content untouched — this is purely additive