### PR TITLE
fix(tts): add speed validation for Edge TTS and float cast for MiniMax

### DIFF
--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -143,3 +143,45 @@ class TestMinimaxTtsSpeed:
         )
         payload = mock_post.call_args[1]["json"]
         assert payload["voice_setting"]["speed"] == 2.0
+
+    def test_default_speed_is_one(self, tmp_path, monkeypatch):
+        """No speed config => speed defaults to 1.0."""
+        mock_post = self._run({}, tmp_path, monkeypatch)
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voice_setting"]["speed"] == 1.0
+
+    def test_string_speed_cast_to_float(self, tmp_path, monkeypatch):
+        """String speed from YAML is cast to float."""
+        mock_post = self._run({"speed": "1.5"}, tmp_path, monkeypatch)
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voice_setting"]["speed"] == 1.5
+        assert isinstance(payload["voice_setting"]["speed"], float)
+
+
+# ---------------------------------------------------------------------------
+# Edge TTS speed clamping
+# ---------------------------------------------------------------------------
+
+class TestEdgeTtsSpeedClamping:
+    def _run(self, tts_config, tmp_path):
+        mock_comm = MagicMock()
+        mock_comm.save = AsyncMock()
+        mock_edge = MagicMock()
+        mock_edge.Communicate = MagicMock(return_value=mock_comm)
+
+        with patch("tools.tts_tool._import_edge_tts", return_value=mock_edge):
+            from tools.tts_tool import _generate_edge_tts
+            asyncio.run(_generate_edge_tts("Hello", str(tmp_path / "out.mp3"), tts_config))
+        return mock_edge.Communicate
+
+    def test_speed_clamped_low(self, tmp_path):
+        """Speed below 0.1 is clamped to 0.1."""
+        comm_cls = self._run({"speed": 0.0}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert kwargs["rate"] == "-90%"
+
+    def test_speed_clamped_high(self, tmp_path):
+        """Speed above 3.0 is clamped to 3.0."""
+        comm_cls = self._run({"speed": 5.0}, tmp_path)
+        kwargs = comm_cls.call_args[1]
+        assert kwargs["rate"] == "+200%"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -189,6 +189,7 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     edge_config = tts_config.get("edge", {})
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
+    speed = max(0.1, min(3.0, speed))  # Edge TTS practical range
 
     kwargs = {"voice": voice}
     if speed != 1.0:
@@ -324,7 +325,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     mm_config = tts_config.get("minimax", {})
     model = mm_config.get("model", DEFAULT_MINIMAX_MODEL)
     voice_id = mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
-    speed = mm_config.get("speed", tts_config.get("speed", 1))
+    speed = float(mm_config.get("speed", tts_config.get("speed", 1.0)))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
     base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)


### PR DESCRIPTION
## Summary

- Edge TTS speed is now clamped to [0.1, 3.0] to prevent invalid rate strings (e.g., speed=0 producing `-100%`)
- - MiniMax TTS speed is explicitly cast to `float()` to handle YAML string parsing edge cases
- - Added 4 new test cases: Edge TTS clamping (low/high), MiniMax default speed, MiniMax string-to-float conversion
## What does this PR do?

Fixes two robustness issues in the TTS speed configuration:

1. **Edge TTS**: No validation on the `speed` parameter meant values like `0.0` or negative numbers could produce invalid rate strings (e.g., `rate: "-100%"`), causing Edge TTS to fail. Now clamped to `[0.1, 3.0]`.
2. **MiniMax TTS**: The `speed` value was not cast to `float()`, unlike Edge and OpenAI providers. If YAML parsed `"1.5"` as a string, it would pass a string to the MiniMax API instead of a number. Now explicitly cast.
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] - [x] Tests added
## Test Plan

- [x] All 16 TTS speed tests pass (was 12, added 4)
- [ ] - [x] All 33 TTS-related tests pass (test_tts_speed + test_tts_mistral)
- [ ] - [ ] CI pipeline runs on PR creation