### PR TITLE
fix(gateway): resolve systemd reload kill path dynamically

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -804,6 +804,17 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
+def _resolved_systemd_reload_command() -> str:
+    """Return an absolute kill path for ExecReload, falling back conservatively.
+
+    systemd unit commands should use an absolute executable path when possible.
+    On hosts like NixOS, /bin/kill may not exist even though kill is installed,
+    so resolve the real binary first and preserve /bin/kill as a compatibility
+    fallback when discovery fails.
+    """
+    return shutil.which("kill") or "/bin/kill"
+
+
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -811,6 +822,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
     venv_bin = str(detected_venv / "bin") if detected_venv else str(PROJECT_ROOT / "venv" / "bin")
     node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
+    reload_command = _resolved_systemd_reload_command()
 
     path_entries = [venv_bin, node_bin]
     resolved_node = shutil.which("node")
@@ -862,7 +874,7 @@ RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_command} -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
 StandardError=journal
@@ -894,7 +906,7 @@ RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_command} -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
 StandardError=journal

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -84,14 +84,23 @@ class TestSystemdServiceRefresh:
 
 
 class TestGeneratedSystemdUnits:
-    def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
+    def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/custom/bin/kill" if cmd == "kill" else None)
+
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
-        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
+        assert "ExecReload=/custom/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
+
+    def test_user_unit_falls_back_to_bin_kill_when_kill_is_not_discoverable(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
@@ -100,12 +109,14 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
-    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
+    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/custom/bin/kill" if cmd == "kill" else None)
+
         unit = gateway_cli.generate_systemd_unit(system=True)
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
-        assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
+        assert "ExecReload=/custom/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit


### PR DESCRIPTION
## Summary
- resolve the systemd `ExecReload` command from the available `kill` binary instead of hardcoding `/bin/kill`
- preserve `/bin/kill` as the fallback when discovery fails
- add regression tests for resolved-path and fallback behavior

## Problem
On NixOS-like hosts, `/bin/kill` may not exist even though `kill` is installed and available elsewhere on PATH. That leaves generated gateway units stale or invalid even after an official `hermes gateway restart` refresh.

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q`
- `python -m pytest tests/hermes_cli/test_gateway.py -q`
