### PR TITLE
fix: honor named custom anthropic runtime in AIAgent init

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+from urllib.parse import parse_qs
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -109,6 +110,24 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     if ":" in deliver:
         platform_name, rest = deliver.split(":", 1)
         platform_key = platform_name.lower()
+        target_options = {}
+
+        if "?" in rest:
+            rest, query = rest.split("?", 1)
+            query_params = parse_qs(query, keep_blank_values=False)
+            thread_name = (query_params.get("thread_name") or [None])[0]
+            if thread_name:
+                target_options["thread_name"] = thread_name
+            auto_archive = (query_params.get("thread_auto_archive") or [None])[0]
+            if auto_archive:
+                try:
+                    target_options["thread_auto_archive"] = int(auto_archive)
+                except ValueError:
+                    logger.warning(
+                        "Job '%s': invalid thread_auto_archive=%r in deliver target; ignoring",
+                        job.get("id", "?"),
+                        auto_archive,
+                    )
 
         from tools.send_message_tool import _parse_target_ref
 
@@ -135,6 +154,7 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
+            **target_options,
         }
 
     platform_name = deliver
@@ -156,6 +176,103 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
         "chat_id": chat_id,
         "thread_id": None,
     }
+
+
+def _render_thread_name(template: str) -> str:
+    """Render a Discord cron thread name from a strftime template."""
+    rendered = _hermes_now().strftime(template).strip()
+    return rendered[:100] if rendered else "Hermes"
+
+
+def _ensure_discord_delivery_thread(job: dict, target: dict, pconfig, runtime_adapter=None, loop=None) -> str | None:
+    """Create a Discord thread for cron delivery when requested by the target."""
+    thread_name_template = (target.get("thread_name") or "").strip()
+    if not thread_name_template or target.get("thread_id"):
+        return target.get("thread_id")
+
+    thread_name = _render_thread_name(thread_name_template)
+    auto_archive_duration = target.get("thread_auto_archive") or 1440
+
+    if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                runtime_adapter.create_thread(
+                    target["chat_id"],
+                    thread_name,
+                    auto_archive_duration=auto_archive_duration,
+                ),
+                loop,
+            )
+            result = future.result(timeout=60)
+            if result and getattr(result, "success", False):
+                raw = getattr(result, "raw_response", {}) or {}
+                thread_id = raw.get("thread_id") or getattr(result, "message_id", None)
+                if thread_id:
+                    return str(thread_id)
+            logger.warning(
+                "Job '%s': live Discord thread creation failed for %s (%s)",
+                job["id"],
+                target["chat_id"],
+                getattr(result, "error", "unknown error") if result else "empty result",
+            )
+        except Exception as e:
+            logger.warning(
+                "Job '%s': live Discord thread creation failed for %s (%s)",
+                job["id"],
+                target["chat_id"],
+                e,
+            )
+
+    try:
+        from tools.send_message_tool import _create_discord_thread
+
+        result = asyncio.run(
+            _create_discord_thread(
+                pconfig.token,
+                target["chat_id"],
+                thread_name,
+                auto_archive_duration=auto_archive_duration,
+            )
+        )
+        if result and result.get("success") and result.get("thread_id"):
+            return str(result["thread_id"])
+        logger.warning(
+            "Job '%s': standalone Discord thread creation failed for %s (%s)",
+            job["id"],
+            target["chat_id"],
+            result.get("error", "unknown error") if isinstance(result, dict) else result,
+        )
+    except RuntimeError:
+        from tools.send_message_tool import _create_discord_thread
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                asyncio.run,
+                _create_discord_thread(
+                    pconfig.token,
+                    target["chat_id"],
+                    thread_name,
+                    auto_archive_duration=auto_archive_duration,
+                ),
+            )
+            result = future.result(timeout=60)
+            if result and result.get("success") and result.get("thread_id"):
+                return str(result["thread_id"])
+            logger.warning(
+                "Job '%s': standalone Discord thread creation failed for %s (%s)",
+                job["id"],
+                target["chat_id"],
+                result.get("error", "unknown error") if isinstance(result, dict) else result,
+            )
+    except Exception as e:
+        logger.warning(
+            "Job '%s': standalone Discord thread creation failed for %s (%s)",
+            job["id"],
+            target["chat_id"],
+            e,
+        )
+
+    return None
 
 
 # Media extension sets — keep in sync with gateway/platforms/base.py:_process_message_background
@@ -281,6 +398,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> None:
     # Prefer the live adapter when the gateway is running — this supports E2EE
     # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
     runtime_adapter = (adapters or {}).get(platform)
+    if platform == Platform.DISCORD and target.get("thread_name") and not thread_id:
+        thread_id = _ensure_discord_delivery_thread(
+            job,
+            target,
+            pconfig,
+            runtime_adapter=runtime_adapter,
+            loop=loop,
+        )
     if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
         send_metadata = {"thread_id": thread_id} if thread_id else None
         try:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -759,13 +759,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            # Get the channel
-            channel = self._client.get_channel(int(chat_id))
+            channel = await self._resolve_target_channel(chat_id, metadata=metadata)
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             # Format and split message if needed
             formatted = self.format_message(content)
@@ -818,6 +815,83 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def _resolve_target_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Any]:
+        """Resolve a Discord channel, honoring metadata.thread_id when present."""
+        if not self._client:
+            return None
+
+        target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+        channel = self._client.get_channel(int(target_id))
+        if not channel:
+            channel = await self._client.fetch_channel(int(target_id))
+        return channel
+
+    async def create_thread(
+        self,
+        chat_id: str,
+        name: str,
+        *,
+        auto_archive_duration: int = 1440,
+        message: str = "",
+    ) -> SendResult:
+        """Create a Discord thread from a channel ID for cron/background deliveries."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        name = (name or "").strip()
+        if not name:
+            return SendResult(success=False, error="Thread name is required")
+        if auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
+            allowed = ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES))
+            return SendResult(success=False, error=f"auto_archive_duration must be one of: {allowed}")
+
+        try:
+            channel = await self._resolve_target_channel(chat_id)
+            if channel is None:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+            if isinstance(channel, discord.DMChannel):
+                return SendResult(success=False, error="Discord threads can only be created inside server text channels, not DMs.")
+
+            parent_channel = self._thread_parent_channel(channel)
+            if parent_channel is None:
+                return SendResult(success=False, error="Could not determine a parent text channel for the new thread.")
+
+            starter_message = (message or "").strip()
+            reason = "Hermes cron delivery"
+
+            try:
+                thread = await parent_channel.create_thread(
+                    name=name,
+                    auto_archive_duration=auto_archive_duration,
+                    reason=reason,
+                )
+                if starter_message:
+                    await thread.send(starter_message)
+            except Exception:
+                seed_content = starter_message or f"🧵 Thread created by Hermes: **{name}**"
+                seed_msg = await parent_channel.send(seed_content)
+                thread = await seed_msg.create_thread(
+                    name=name,
+                    auto_archive_duration=auto_archive_duration,
+                    reason=reason,
+                )
+
+            return SendResult(
+                success=True,
+                message_id=str(thread.id),
+                raw_response={
+                    "thread_id": str(thread.id),
+                    "thread_name": getattr(thread, "name", None) or name,
+                },
+            )
+        except Exception as e:
+            logger.error("[%s] Failed to create Discord thread: %s", self.name, e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     async def edit_message(
         self,
         chat_id: str,
@@ -847,16 +921,16 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
+        channel = await self._resolve_target_channel(chat_id, metadata=metadata)
         if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
-        if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+            target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+            return SendResult(success=False, error=f"Channel {target_id} not found")
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -895,11 +969,10 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
+            channel = await self._resolve_target_channel(chat_id, metadata=metadata)
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
@@ -1267,7 +1340,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -1293,11 +1366,10 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
+            channel = await self._resolve_target_channel(chat_id, metadata=metadata)
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
@@ -1353,7 +1425,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -1371,7 +1443,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/run_agent.py
+++ b/run_agent.py
@@ -767,27 +767,34 @@ class AIAgent:
         self._anthropic_client = None
         self._is_anthropic_oauth = False
 
-        if self.api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
-            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
-            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
-            # Falling back would send Anthropic credentials to third-party endpoints (Fixes #1739, #minimax-401).
-            _is_native_anthropic = self.provider == "anthropic"
-            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+        def _init_anthropic_client(effective_key: str, effective_base_url: str):
+            from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token as _is_oat
+
+            self.api_mode = "anthropic_messages"
             self.api_key = effective_key
+            self.base_url = effective_base_url or ""
             self._anthropic_api_key = effective_key
-            self._anthropic_base_url = base_url
-            from agent.anthropic_adapter import _is_oauth_token as _is_oat
+            self._anthropic_base_url = effective_base_url
             self._is_anthropic_oauth = _is_oat(effective_key)
-            self._anthropic_client = build_anthropic_client(effective_key, base_url)
-            # No OpenAI client needed for Anthropic mode
+            self._anthropic_client = build_anthropic_client(effective_key, effective_base_url)
             self.client = None
             self._client_kwargs = {}
             if not self.quiet_mode:
                 print(f"🤖 AI Agent initialized with model: {self.model} (Anthropic native)")
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
+
+        if self.api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import resolve_anthropic_token
+
+            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
+            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.
+            _is_native_anthropic = self.provider == "anthropic"
+            effective_key = (api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or "")
+            _init_anthropic_client(effective_key, base_url)
         else:
+            client_kwargs = None
+
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
@@ -811,76 +818,104 @@ class AIAgent:
                         "User-Agent": "KimiCLI/1.3",
                     }
             else:
-                # No explicit creds — use the centralized provider router
-                from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
-                    self.provider or "auto", model=self.model, raw_codex=True)
-                if _routed_client is not None:
-                    client_kwargs = {
-                        "api_key": _routed_client.api_key,
-                        "base_url": str(_routed_client.base_url),
-                    }
-                    # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
-                else:
-                    # When the user explicitly chose a non-OpenRouter provider
-                    # but no credentials were found, fail fast with a clear
-                    # message instead of silently routing through OpenRouter.
-                    _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
-                        raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
-                            f"variable, or switch to a different provider with `hermes model`."
-                        )
-                    # Final fallback: try raw OpenRouter key
-                    client_kwargs = {
-                        "api_key": os.getenv("OPENROUTER_API_KEY", ""),
-                        "base_url": OPENROUTER_BASE_URL,
-                        "default_headers": {
-                            "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                            "X-OpenRouter-Title": "Hermes Agent",
-                            "X-OpenRouter-Categories": "productivity,cli-agent",
-                        },
-                    }
-            
-            self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+                runtime = None
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    runtime = resolve_runtime_provider(requested=self.provider or "auto")
+                except Exception:
+                    runtime = None
 
-            # Enable fine-grained tool streaming for Claude on OpenRouter.
-            # Without this, Anthropic buffers the entire tool call and goes
-            # silent for minutes while thinking — OpenRouter's upstream proxy
-            # times out during the silence.  The beta header makes Anthropic
-            # stream tool call arguments token-by-token, keeping the
-            # connection alive.
-            _effective_base = str(client_kwargs.get("base_url", "")).lower()
-            if "openrouter" in _effective_base and "claude" in (self.model or "").lower():
-                headers = client_kwargs.get("default_headers") or {}
-                existing_beta = headers.get("x-anthropic-beta", "")
-                _FINE_GRAINED = "fine-grained-tool-streaming-2025-05-14"
-                if _FINE_GRAINED not in existing_beta:
-                    if existing_beta:
-                        headers["x-anthropic-beta"] = f"{existing_beta},{_FINE_GRAINED}"
-                    else:
-                        headers["x-anthropic-beta"] = _FINE_GRAINED
-                    client_kwargs["default_headers"] = headers
+                if isinstance(runtime, dict):
+                    runtime_mode = runtime.get("api_mode") or "chat_completions"
+                    runtime_base = str(runtime.get("base_url") or "")
+                    runtime_key = runtime.get("api_key") or ""
+                    runtime_pool = runtime.get("credential_pool")
+                    if runtime_pool is not None:
+                        self._credential_pool = runtime_pool
+                    runtime_model = runtime.get("model")
+                    if runtime_model and not self.model:
+                        self.model = runtime_model
 
-            self.api_key = client_kwargs.get("api_key", "")
-            try:
-                self.client = self._create_openai_client(client_kwargs, reason="agent_init", shared=True)
-                if not self.quiet_mode:
-                    print(f"🤖 AI Agent initialized with model: {self.model}")
-                    if base_url:
-                        print(f"🔗 Using custom base URL: {base_url}")
-                    # Always show API key info (masked) for debugging auth issues
-                    key_used = client_kwargs.get("api_key", "none")
-                    if key_used and key_used != "dummy-key" and len(key_used) > 12:
-                        print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                    if runtime_mode == "anthropic_messages":
+                        _init_anthropic_client(runtime_key, runtime_base)
                     else:
-                        print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
-            except Exception as e:
-                raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
-        
+                        client_kwargs = {
+                            "api_key": runtime_key,
+                            "base_url": runtime_base,
+                        }
+
+                if client_kwargs is None and self.api_mode != "anthropic_messages":
+                    # No explicit creds — use the centralized provider router
+                    from agent.auxiliary_client import resolve_provider_client
+                    _routed_client, _ = resolve_provider_client(
+                        self.provider or "auto", model=self.model, raw_codex=True)
+                    if _routed_client is not None:
+                        client_kwargs = {
+                            "api_key": _routed_client.api_key,
+                            "base_url": str(_routed_client.base_url),
+                        }
+                        # Preserve any default_headers the router set
+                        if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
+                            client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    else:
+                        # When the user explicitly chose a non-OpenRouter provider
+                        # but no credentials were found, fail fast with a clear
+                        # message instead of silently routing through OpenRouter.
+                        _explicit = (self.provider or "").strip().lower()
+                        if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                            raise RuntimeError(
+                                f"Provider '{_explicit}' is set in config.yaml but no API key "
+                                f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                                f"variable, or switch to a different provider with `hermes model`."
+                            )
+                        # Final fallback: try raw OpenRouter key
+                        client_kwargs = {
+                            "api_key": os.getenv("OPENROUTER_API_KEY", ""),
+                            "base_url": OPENROUTER_BASE_URL,
+                            "default_headers": {
+                                "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+                                "X-OpenRouter-Title": "Hermes Agent",
+                                "X-OpenRouter-Categories": "productivity,cli-agent",
+                            },
+                        }
+
+            if self.api_mode != "anthropic_messages":
+                self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+
+                # Enable fine-grained tool streaming for Claude on OpenRouter.
+                # Without this, Anthropic buffers the entire tool call and goes
+                # silent for minutes while thinking — OpenRouter's upstream proxy
+                # times out during the silence.  The beta header makes Anthropic
+                # stream tool call arguments token-by-token, keeping the
+                # connection alive.
+                _effective_base = str(client_kwargs.get("base_url", "")).lower()
+                if "openrouter" in _effective_base and "claude" in (self.model or "").lower():
+                    headers = client_kwargs.get("default_headers") or {}
+                    existing_beta = headers.get("x-anthropic-beta", "")
+                    _FINE_GRAINED = "fine-grained-tool-streaming-2025-05-14"
+                    if _FINE_GRAINED not in existing_beta:
+                        if existing_beta:
+                            headers["x-anthropic-beta"] = f"{existing_beta},{_FINE_GRAINED}"
+                        else:
+                            headers["x-anthropic-beta"] = _FINE_GRAINED
+                        client_kwargs["default_headers"] = headers
+
+                self.api_key = client_kwargs.get("api_key", "")
+                self.base_url = client_kwargs.get("base_url", self.base_url)
+                try:
+                    self.client = self._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+                    if not self.quiet_mode:
+                        print(f"🤖 AI Agent initialized with model: {self.model}")
+                        if self.base_url:
+                            print(f"🔗 Using custom base URL: {self.base_url}")
+                        # Always show API key info (masked) for debugging auth issues
+                        key_used = client_kwargs.get("api_key", "none")
+                        if key_used and key_used != "dummy-key" and len(key_used) > 12:
+                            print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                        else:
+                            print(f"⚠️  Warning: API key appears invalid or missing (got: '{key_used[:20] if key_used else 'none'}...')")
+                except Exception as e:
+                    raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
         # Provider fallback chain — ordered list of backup providers tried
         # when the primary is exhausted (rate-limit, overload, connection
         # failure).  Supports both legacy single-dict ``fallback_model`` and

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -84,6 +84,18 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_discord_target_parses_thread_creation_query(self):
+        job = {
+            "deliver": "discord:1491307591471726594?thread_name=GitHub趋势-%Y-%m-%d&thread_auto_archive=4320",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "discord",
+            "chat_id": "1491307591471726594",
+            "thread_id": None,
+            "thread_name": "GitHub趋势-%Y-%m-%d",
+            "thread_auto_archive": 4320,
+        }
+
     def test_human_friendly_label_resolved_via_channel_directory(self):
         """deliver: 'whatsapp:Alice (dm)' resolves to the real JID."""
         job = {"deliver": "whatsapp:Alice (dm)"}
@@ -506,6 +518,84 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
+
+    def test_discord_delivery_creates_thread_via_live_adapter(self):
+        """Discord cron deliveries can create a fresh thread before sending."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.create_thread.return_value = MagicMock(
+            success=True,
+            message_id="222",
+            raw_response={"thread_id": "222", "thread_name": "GitHub趋势-2026-04-13"},
+        )
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        run_results = iter([
+            adapter.create_thread.return_value,
+            adapter.send.return_value,
+        ])
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(next(run_results))
+            coro.close()
+            return future
+
+        job = {
+            "id": "discord-thread-job",
+            "deliver": "discord:1491307591471726594?thread_name=GitHub趋势-%Y-%m-%d",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "Top 10 repos",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        adapter.create_thread.assert_called_once()
+        adapter.send.assert_called_once_with(
+            "1491307591471726594",
+            "Top 10 repos",
+            metadata={"thread_id": "222"},
+        )
+
+    def test_discord_delivery_creates_thread_via_standalone_helper(self):
+        """Without a live adapter, cron should still create a Discord thread before sending."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.token = "fake-token"
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        job = {
+            "id": "discord-thread-standalone",
+            "deliver": "discord:1491307591471726594?thread_name=GitHub趋势-%Y-%m-%d",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._create_discord_thread", new=AsyncMock(return_value={"success": True, "thread_id": "333"})), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            _deliver_result(job, "Top 10 repos")
+
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs["thread_id"] == "333"
 
 
 class TestRunJobSessionPersistence:

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -219,6 +219,36 @@ class TestDiscordSendImageFile:
         assert result.message_id == "99"
         mock_channel.send.assert_awaited_once()
 
+    def test_send_respects_thread_id_metadata(self, adapter):
+        """Discord text sends should route into the target thread when metadata.thread_id is set."""
+        parent_channel = MagicMock()
+        thread_channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 77
+        thread_channel.send = AsyncMock(return_value=sent_msg)
+
+        def get_channel(channel_id):
+            if channel_id == 123:
+                return parent_channel
+            if channel_id == 456:
+                return thread_channel
+            return None
+
+        adapter._client.get_channel = MagicMock(side_effect=get_channel)
+        adapter._client.fetch_channel = AsyncMock(return_value=None)
+
+        result = _run(
+            adapter.send(
+                chat_id="123",
+                content="hello thread",
+                metadata={"thread_id": "456"},
+            )
+        )
+
+        assert result.success
+        thread_channel.send.assert_awaited_once()
+        parent_channel.send.assert_not_called()
+
     def test_send_document_uploads_file_attachment(self, adapter, tmp_path):
         """send_document should upload a native Discord attachment."""
         pdf = tmp_path / "sample.pdf"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -373,7 +373,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.DISCORD:
-            result = await _send_discord(pconfig.token, chat_id, chunk)
+            result = await _send_discord(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.SLACK:
             result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
@@ -535,7 +535,70 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_discord(token, chat_id, message):
+async def _create_discord_thread(token, chat_id, name, auto_archive_duration=1440):
+    """Create a Discord thread via REST, with a seed-message fallback."""
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            direct_url = f"https://discord.com/api/v10/channels/{chat_id}/threads"
+            direct_payload = {
+                "name": name,
+                "auto_archive_duration": auto_archive_duration,
+                "type": 11,
+            }
+            async with session.post(direct_url, headers=headers, json=direct_payload) as resp:
+                if resp.status in (200, 201):
+                    data = await resp.json()
+                    return {
+                        "success": True,
+                        "platform": "discord",
+                        "chat_id": chat_id,
+                        "thread_id": data.get("id"),
+                        "thread_name": data.get("name") or name,
+                    }
+                direct_error = await resp.text()
+
+            seed_url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+            seed_payload = {"content": f"🧵 Thread created by Hermes: **{name}**"}
+            async with session.post(seed_url, headers=headers, json=seed_payload) as seed_resp:
+                if seed_resp.status not in (200, 201):
+                    seed_error = await seed_resp.text()
+                    return _error(
+                        "Discord thread creation failed. "
+                        f"Direct error: {direct_error}. Seed error ({seed_resp.status}): {seed_error}"
+                    )
+                seed_data = await seed_resp.json()
+
+            from_message_url = f"https://discord.com/api/v10/channels/{chat_id}/messages/{seed_data['id']}/threads"
+            from_message_payload = {
+                "name": name,
+                "auto_archive_duration": auto_archive_duration,
+            }
+            async with session.post(from_message_url, headers=headers, json=from_message_payload) as thread_resp:
+                if thread_resp.status not in (200, 201):
+                    thread_error = await thread_resp.text()
+                    return _error(
+                        "Discord thread creation failed. "
+                        f"Direct error: {direct_error}. Fallback error ({thread_resp.status}): {thread_error}"
+                    )
+                data = await thread_resp.json()
+                return {
+                    "success": True,
+                    "platform": "discord",
+                    "chat_id": chat_id,
+                    "thread_id": data.get("id"),
+                    "thread_name": data.get("name") or name,
+                }
+    except Exception as e:
+        return _error(f"Discord thread creation failed: {e}")
+
+
+async def _send_discord(token, chat_id, message, thread_id=None):
     """Send a single message via Discord REST API (no websocket client needed).
 
     Chunking is handled by _send_to_platform() before this is called.
@@ -545,7 +608,8 @@ async def _send_discord(token, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
-        url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+        target_id = thread_id or chat_id
+        url = f"https://discord.com/api/v10/channels/{target_id}/messages"
         headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             async with session.post(url, headers=headers, json={"content": message}) as resp:
@@ -553,7 +617,7 @@ async def _send_discord(token, chat_id, message):
                     body = await resp.text()
                     return _error(f"Discord API error ({resp.status}): {body}")
                 data = await resp.json()
-        return {"success": True, "platform": "discord", "chat_id": chat_id, "message_id": data.get("id")}
+        return {"success": True, "platform": "discord", "chat_id": chat_id, "thread_id": thread_id, "message_id": data.get("id")}
     except Exception as e:
         return _error(f"Discord send failed: {e}")
 


### PR DESCRIPTION
Summary:
- resolve explicit named custom providers through runtime provider resolution before client init
- initialize Anthropic-compatible custom endpoints with the Anthropic client instead of falling back to chat completions
- persist resolved base_url onto the agent state for downstream feature detection

Verification:
- local targeted runtime-provider test: `tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_anthropic_api_mode`
- local real smoke test: `AIAgent(model="qwen3-coder-next", provider="alibaba-coding-plan")` returned exact `OK` against `https://coding.dashscope.aliyuncs.com/apps/anthropic`

Notes:
- local full `tests/run_agent/test_run_agent.py` is noisy under this machine's DashScope env because generic auto-provider paths pick up local provider config; this change was kept scoped to explicit named providers.