### PR TITLE
fix(config): restore custom providers after v11→v12 migration

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1466,10 +1466,14 @@ def resolve_provider_client(
         custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = custom_entry.get("base_url", "").strip()
-            custom_key = custom_entry.get("api_key", "").strip() or "no-key-required"
+            custom_key = custom_entry.get("api_key", "").strip()
+            custom_key_env = custom_entry.get("key_env", "").strip()
+            if not custom_key and custom_key_env:
+                custom_key = os.getenv(custom_key_env, "").strip()
+            custom_key = custom_key or "no-key-required"
             if custom_base:
                 final_model = _normalize_resolved_model(
-                    model or _read_main_model() or "gpt-4o-mini",
+                    model or custom_entry.get("model") or _read_main_model() or "gpt-4o-mini",
                     provider,
                 )
                 client = OpenAI(api_key=custom_key, base_url=custom_base)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -287,8 +287,11 @@ def _iter_custom_providers(config: Optional[dict] = None):
         config = _load_config_safe()
     if config is None:
         return
-    custom_providers = config.get("custom_providers")
-    if not isinstance(custom_providers, list):
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        custom_providers = get_compatible_custom_providers(config)
+    except Exception:
         return
     for entry in custom_providers:
         if not isinstance(entry, dict):

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -36,25 +36,23 @@ _OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth"}
 
 
 def _get_custom_provider_names() -> list:
-    """Return list of (display_name, pool_key) tuples for custom_providers in config."""
+    """Return list of (display_name, pool_key, provider_key) tuples."""
     try:
-        from hermes_cli.config import load_config
+        from hermes_cli.config import get_compatible_custom_providers, load_config
 
         config = load_config()
     except Exception:
         return []
-    custom_providers = config.get("custom_providers")
-    if not isinstance(custom_providers, list):
-        return []
     result = []
-    for entry in custom_providers:
+    for entry in get_compatible_custom_providers(config):
         if not isinstance(entry, dict):
             continue
         name = entry.get("name")
         if not isinstance(name, str) or not name.strip():
             continue
         pool_key = f"{CUSTOM_POOL_PREFIX}{_normalize_custom_pool_name(name)}"
-        result.append((name.strip(), pool_key))
+        provider_key = str(entry.get("provider_key", "") or "").strip()
+        result.append((name.strip(), pool_key, provider_key))
     return result
 
 
@@ -66,8 +64,10 @@ def _resolve_custom_provider_input(raw: str) -> str | None:
     # Direct match on 'custom:name' format
     if normalized.startswith(CUSTOM_POOL_PREFIX):
         return normalized
-    for display_name, pool_key in _get_custom_provider_names():
+    for display_name, pool_key, provider_key in _get_custom_provider_names():
         if _normalize_custom_pool_name(display_name) == normalized:
+            return pool_key
+        if provider_key and provider_key.strip().lower() == normalized:
             return pool_key
     return None
 
@@ -405,7 +405,7 @@ def _pick_provider(prompt: str = "Provider") -> str:
     known = sorted(set(list(PROVIDER_REGISTRY.keys()) + ["openrouter"]))
     custom_names = _get_custom_provider_names()
     if custom_names:
-        custom_display = [name for name, _key in custom_names]
+        custom_display = [name for name, _key, _provider_key in custom_names]
         print(f"\nKnown providers: {', '.join(known)}")
         print(f"Custom endpoints: {', '.join(custom_display)}")
     else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1546,49 +1546,134 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     return missing
 
 
-def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
-    """Normalize ``providers`` config entries back into ``custom_providers`` form.
+def _normalize_custom_provider_entry(
+    entry: Any,
+    *,
+    provider_key: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Return a runtime-compatible custom provider entry or ``None``."""
+    if not isinstance(entry, dict):
+        return None
 
-    Runtime code still expects the legacy list shape in several places. This
-    helper keeps the field mapping in one place so config migrations and
-    runtime compatibility fallbacks stay aligned.
-    """
+    base_url = ""
+    for url_key in ("api", "url", "base_url"):
+        raw_url = entry.get(url_key)
+        if isinstance(raw_url, str) and raw_url.strip():
+            base_url = raw_url.strip()
+            break
+    if not base_url:
+        return None
+
+    name = ""
+    raw_name = entry.get("name")
+    if isinstance(raw_name, str) and raw_name.strip():
+        name = raw_name.strip()
+    elif provider_key.strip():
+        name = provider_key.strip()
+    if not name:
+        return None
+
+    normalized: Dict[str, Any] = {
+        "name": name,
+        "base_url": base_url,
+    }
+
+    provider_key = provider_key.strip()
+    if provider_key:
+        normalized["provider_key"] = provider_key
+
+    api_key = entry.get("api_key")
+    if isinstance(api_key, str) and api_key.strip():
+        normalized["api_key"] = api_key.strip()
+
+    key_env = entry.get("key_env")
+    if isinstance(key_env, str) and key_env.strip():
+        normalized["key_env"] = key_env.strip()
+
+    api_mode = entry.get("api_mode") or entry.get("transport")
+    if isinstance(api_mode, str) and api_mode.strip():
+        normalized["api_mode"] = api_mode.strip()
+
+    model_name = entry.get("model") or entry.get("default_model")
+    if isinstance(model_name, str) and model_name.strip():
+        normalized["model"] = model_name.strip()
+
+    models = entry.get("models")
+    if isinstance(models, dict) and models:
+        normalized["models"] = models
+
+    context_length = entry.get("context_length")
+    if isinstance(context_length, int) and context_length > 0:
+        normalized["context_length"] = context_length
+
+    rate_limit_delay = entry.get("rate_limit_delay")
+    if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
+        normalized["rate_limit_delay"] = rate_limit_delay
+
+    return normalized
+
+
+def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
+    """Normalize ``providers`` config entries into the legacy custom-provider shape."""
     if not isinstance(providers_dict, dict):
         return []
 
     custom_providers: List[Dict[str, Any]] = []
     for key, entry in providers_dict.items():
-        if not isinstance(entry, dict):
-            continue
-
-        base_url = str(entry.get("api", "") or "").strip()
-        if not base_url:
-            continue
-
-        name = str(entry.get("name", "") or "").strip() or str(key).strip()
-        if not name:
-            continue
-
-        custom_entry: Dict[str, Any] = {
-            "name": name,
-            "base_url": base_url,
-        }
-
-        api_key = str(entry.get("api_key", "") or "").strip()
-        if api_key:
-            custom_entry["api_key"] = api_key
-
-        api_mode = str(entry.get("transport", "") or "").strip()
-        if api_mode:
-            custom_entry["api_mode"] = api_mode
-
-        model_name = str(entry.get("default_model", "") or "").strip()
-        if model_name:
-            custom_entry["model"] = model_name
-
-        custom_providers.append(custom_entry)
+        normalized = _normalize_custom_provider_entry(entry, provider_key=str(key))
+        if normalized is not None:
+            custom_providers.append(normalized)
 
     return custom_providers
+
+
+def get_compatible_custom_providers(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Return a deduplicated custom-provider view across legacy and v12+ config.
+
+    ``custom_providers`` remains the on-disk legacy format, while ``providers``
+    is the newer keyed schema. Runtime and picker flows still need a single
+    list-shaped view, but we should not materialize that compatibility layer
+    back into config.yaml because it duplicates entries in UIs.
+    """
+    if config is None:
+        config = load_config()
+
+    compatible: List[Dict[str, Any]] = []
+    seen_provider_keys: set[str] = set()
+    seen_name_url_pairs: set[Tuple[str, str]] = set()
+
+    def _append_if_new(entry: Optional[Dict[str, Any]]) -> None:
+        if entry is None:
+            return
+        provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+        name = str(entry.get("name", "") or "").strip().lower()
+        base_url = str(entry.get("base_url", "") or "").strip().rstrip("/").lower()
+        pair = (name, base_url)
+
+        if provider_key and provider_key in seen_provider_keys:
+            return
+        if name and base_url and pair in seen_name_url_pairs:
+            return
+
+        compatible.append(entry)
+        if provider_key:
+            seen_provider_keys.add(provider_key)
+        if name and base_url:
+            seen_name_url_pairs.add(pair)
+
+    custom_providers = config.get("custom_providers")
+    if custom_providers is not None:
+        if not isinstance(custom_providers, list):
+            return []
+        for entry in custom_providers:
+            _append_if_new(_normalize_custom_provider_entry(entry))
+
+    for entry in providers_dict_to_custom_providers(config.get("providers")):
+        _append_if_new(entry)
+
+    return compatible
 
 
 def check_config_version() -> Tuple[int, int]:
@@ -1908,6 +1993,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
             if migrated_count > 0:
                 config["providers"] = providers_dict
+                config.pop("custom_providers", None)
                 save_config(config)
                 if not quiet:
                     print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
@@ -2018,19 +2104,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
             results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
 
-    # ── Version 16 → 17: restore custom_providers for runtime compatibility ──
+    # ── Version 16 → 17: runtime now reads providers: directly ──
     if current_ver < 17:
-        config = load_config()
-        if "custom_providers" not in config:
-            restored = providers_dict_to_custom_providers(config.get("providers"))
-            if restored:
-                config["custom_providers"] = restored
-                save_config(config)
-                results["config_added"].append("custom_providers (restored from providers)")
-                if not quiet:
-                    print(
-                        "  ✓ Restored custom_providers from providers for runtime compatibility"
-                    )
+        # Compatibility is now handled at runtime. Avoid writing a synthetic
+        # custom_providers list back to disk because picker flows enumerate both
+        # schemas separately and would show duplicate endpoints.
+        pass
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -702,7 +702,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 16,
+    "_config_version": 17,
 }
 
 # =============================================================================
@@ -1546,6 +1546,51 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     return missing
 
 
+def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
+    """Normalize ``providers`` config entries back into ``custom_providers`` form.
+
+    Runtime code still expects the legacy list shape in several places. This
+    helper keeps the field mapping in one place so config migrations and
+    runtime compatibility fallbacks stay aligned.
+    """
+    if not isinstance(providers_dict, dict):
+        return []
+
+    custom_providers: List[Dict[str, Any]] = []
+    for key, entry in providers_dict.items():
+        if not isinstance(entry, dict):
+            continue
+
+        base_url = str(entry.get("api", "") or "").strip()
+        if not base_url:
+            continue
+
+        name = str(entry.get("name", "") or "").strip() or str(key).strip()
+        if not name:
+            continue
+
+        custom_entry: Dict[str, Any] = {
+            "name": name,
+            "base_url": base_url,
+        }
+
+        api_key = str(entry.get("api_key", "") or "").strip()
+        if api_key:
+            custom_entry["api_key"] = api_key
+
+        api_mode = str(entry.get("transport", "") or "").strip()
+        if api_mode:
+            custom_entry["api_mode"] = api_mode
+
+        model_name = str(entry.get("default_model", "") or "").strip()
+        if model_name:
+            custom_entry["model"] = model_name
+
+        custom_providers.append(custom_entry)
+
+    return custom_providers
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
@@ -1863,8 +1908,6 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
             if migrated_count > 0:
                 config["providers"] = providers_dict
-                # Remove the old list
-                del config["custom_providers"]
                 save_config(config)
                 if not quiet:
                     print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
@@ -1974,6 +2017,20 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 migrated = ", ".join(f"{p}={m}" for p, m in old_overrides.items())
                 print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
             results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
+
+    # ── Version 16 → 17: restore custom_providers for runtime compatibility ──
+    if current_ver < 17:
+        config = load_config()
+        if "custom_providers" not in config:
+            restored = providers_dict_to_custom_providers(config.get("providers"))
+            if restored:
+                config["custom_providers"] = restored
+                save_config(config)
+                results["config_added"].append("custom_providers (restored from providers)")
+                if not quiet:
+                    print(
+                        "  ✓ Restored custom_providers from providers for runtime compatibility"
+                    )
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -999,7 +999,7 @@ def select_provider_and_model(args=None):
     from hermes_cli.auth import (
         resolve_provider, AuthError, format_auth_error,
     )
-    from hermes_cli.config import load_config, get_env_value
+    from hermes_cli.config import get_compatible_custom_providers, load_config, get_env_value
 
     config = load_config()
     current_model = config.get("model")
@@ -1090,11 +1090,8 @@ def select_provider_and_model(args=None):
     ]
 
     def _named_custom_provider_map(cfg) -> dict[str, dict[str, str]]:
-        custom_providers_cfg = cfg.get("custom_providers") or []
         custom_provider_map = {}
-        if not isinstance(custom_providers_cfg, list):
-            return custom_provider_map
-        for entry in custom_providers_cfg:
+        for entry in get_compatible_custom_providers(cfg):
             if not isinstance(entry, dict):
                 continue
             name = (entry.get("name") or "").strip()
@@ -1102,17 +1099,26 @@ def select_provider_and_model(args=None):
             if not name or not base_url:
                 continue
             key = "custom:" + name.lower().replace(" ", "-")
+            provider_key = (entry.get("provider_key") or "").strip()
+            if provider_key:
+                try:
+                    resolve_provider(provider_key)
+                except AuthError:
+                    key = provider_key
             custom_provider_map[key] = {
                 "name": name,
                 "base_url": base_url,
                 "api_key": entry.get("api_key", ""),
+                "key_env": entry.get("key_env", ""),
                 "model": entry.get("model", ""),
                 "api_mode": entry.get("api_mode", ""),
+                "provider_key": provider_key,
             }
         return custom_provider_map
 
     # Add user-defined custom providers from config.yaml
     _custom_provider_map = _named_custom_provider_map(config)  # key → {name, base_url, api_key}
+    _has_saved_custom_list = isinstance(config.get("custom_providers"), list) and bool(config.get("custom_providers"))
     for key, provider_info in _custom_provider_map.items():
         name = provider_info["name"]
         base_url = provider_info["base_url"]
@@ -1157,7 +1163,7 @@ def select_provider_and_model(args=None):
     if selected_provider == "more":
         ext_ordered = list(extended_providers)
         ext_ordered.append(("custom", "Custom endpoint (enter URL manually)"))
-        if _custom_provider_map:
+        if _has_saved_custom_list:
             ext_ordered.append(("remove-custom", "Remove a saved custom provider"))
         ext_ordered.append(("cancel", "Cancel"))
 
@@ -1184,7 +1190,7 @@ def select_provider_and_model(args=None):
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
         _model_flow_custom(config)
-    elif selected_provider.startswith("custom:"):
+    elif selected_provider.startswith("custom:") or selected_provider in _custom_provider_map:
         provider_info = _named_custom_provider_map(load_config()).get(selected_provider)
         if provider_info is None:
             print(
@@ -1869,7 +1875,9 @@ def _model_flow_named_custom(config, provider_info):
     name = provider_info["name"]
     base_url = provider_info["base_url"]
     api_key = provider_info.get("api_key", "")
+    key_env = provider_info.get("key_env", "")
     saved_model = provider_info.get("model", "")
+    provider_key = (provider_info.get("provider_key") or "").strip()
 
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
@@ -1952,10 +1960,15 @@ def _model_flow_named_custom(config, provider_info):
     if not isinstance(model, dict):
         model = {"default": model} if model else {}
         cfg["model"] = model
-    model["provider"] = "custom"
-    model["base_url"] = base_url
-    if api_key:
-        model["api_key"] = api_key
+    if provider_key:
+        model["provider"] = provider_key
+        model.pop("base_url", None)
+        model.pop("api_key", None)
+    else:
+        model["provider"] = "custom"
+        model["base_url"] = base_url
+        if api_key:
+            model["api_key"] = api_key
     # Apply api_mode from custom_providers entry, or clear stale value
     custom_api_mode = provider_info.get("api_mode", "")
     if custom_api_mode:
@@ -1965,8 +1978,22 @@ def _model_flow_named_custom(config, provider_info):
     save_config(cfg)
     deactivate_provider()
 
-    # Save model name to the custom_providers entry for next time
-    _save_custom_provider(base_url, api_key, model_name)
+    # Persist the selected model back to whichever schema owns this endpoint.
+    if provider_key:
+        cfg = load_config()
+        providers_cfg = cfg.get("providers")
+        if isinstance(providers_cfg, dict):
+            provider_entry = providers_cfg.get(provider_key)
+            if isinstance(provider_entry, dict):
+                provider_entry["default_model"] = model_name
+                if api_key and not str(provider_entry.get("api_key", "") or "").strip():
+                    provider_entry["api_key"] = api_key
+                if key_env and not str(provider_entry.get("key_env", "") or "").strip():
+                    provider_entry["key_env"] = key_env
+                cfg["providers"] = providers_cfg
+                save_config(cfg)
+    else:
+        _save_custom_provider(base_url, api_key, model_name)
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -26,7 +26,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import load_config, providers_dict_to_custom_providers
+from hermes_cli.config import get_compatible_custom_providers, load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -276,17 +276,17 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
 
     config = load_config()
     custom_providers = config.get("custom_providers")
-    if not isinstance(custom_providers, list):
-        if isinstance(custom_providers, dict):
-            logger.warning(
-                "custom_providers in config.yaml is a dict, not a list. "
-                "Each entry must be prefixed with '-' in YAML. "
-                "Run 'hermes doctor' for details."
-            )
-            return None
-        custom_providers = providers_dict_to_custom_providers(config.get("providers"))
-        if not custom_providers:
-            return None
+    if isinstance(custom_providers, dict):
+        logger.warning(
+            "custom_providers in config.yaml is a dict, not a list. "
+            "Each entry must be prefixed with '-' in YAML. "
+            "Run 'hermes doctor' for details."
+        )
+        return None
+
+    custom_providers = get_compatible_custom_providers(config)
+    if not custom_providers:
+        return None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -297,13 +297,21 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             continue
         name_norm = _normalize_custom_provider_name(name)
         menu_key = f"custom:{name_norm}"
-        if requested_norm not in {name_norm, menu_key}:
+        provider_key = str(entry.get("provider_key", "") or "").strip()
+        provider_key_norm = _normalize_custom_provider_name(provider_key) if provider_key else ""
+        provider_menu_key = f"custom:{provider_key_norm}" if provider_key_norm else ""
+        if requested_norm not in {name_norm, menu_key, provider_key_norm, provider_menu_key}:
             continue
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
+        key_env = str(entry.get("key_env", "") or "").strip()
+        if key_env:
+            result["key_env"] = key_env
+        if provider_key:
+            result["provider_key"] = provider_key
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
@@ -345,6 +353,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
+        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -26,7 +26,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import load_config
+from hermes_cli.config import load_config, providers_dict_to_custom_providers
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -283,7 +283,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 "Each entry must be prefixed with '-' in YAML. "
                 "Run 'hermes doctor' for details."
             )
-        return None
+            return None
+        custom_providers = providers_dict_to_custom_providers(config.get("providers"))
+        if not custom_providers:
+            return None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -175,6 +175,31 @@ class TestResolveProviderClientNamedCustom:
         assert model == "my-model"
         assert "direct.local" in str(client.base_url)
 
+    def test_named_custom_provider_from_providers_dict_uses_key_env(self, tmp_path, monkeypatch):
+        _write_config(tmp_path, {
+            "model": {"default": "main-model"},
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "http://proxy.local/v1",
+                    "default_model": "acme-large",
+                    "key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            },
+        })
+        monkeypatch.setenv("MYCORP_API_KEY", "env-secret")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("mycorp-proxy")
+
+        assert client is not None
+        assert model == "acme-large"
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["api_key"] == "env-secret"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://proxy.local/v1"
+
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "test"},

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -107,6 +107,25 @@ class TestResolveProviderClientMainAlias:
         assert client is not None
         assert "beans.local" in str(client.base_url)
 
+    def test_main_resolves_to_named_provider_from_providers_dict(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "my-model", "provider": "openai-direct"},
+            "providers": {
+                "openai-direct": {
+                    "api": "http://direct.local/v1",
+                    "api_key": "k",
+                    "name": "OpenAI Direct",
+                    "transport": "codex_responses",
+                    "default_model": "gpt-5-mini",
+                }
+            },
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, model = resolve_provider_client("main", "override-model")
+        assert client is not None
+        assert model == "override-model"
+        assert "direct.local" in str(client.base_url)
+
 
 class TestResolveProviderClientNamedCustom:
     """resolve_provider_client should resolve named custom providers directly."""
@@ -136,6 +155,25 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # Should use _read_main_model() fallback
         assert model == "main-model"
+
+    def test_named_custom_provider_from_providers_dict(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "main-model"},
+            "providers": {
+                "openai-direct": {
+                    "api": "http://direct.local/v1",
+                    "api_key": "k",
+                    "name": "OpenAI Direct",
+                    "transport": "codex_responses",
+                    "default_model": "gpt-5-mini",
+                }
+            },
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, model = resolve_provider_client("openai-direct", "my-model")
+        assert client is not None
+        assert model == "my-model"
+        assert "direct.local" in str(client.base_url)
 
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -10,6 +10,7 @@ from hermes_cli.config import (
     DEFAULT_CONFIG,
     get_hermes_home,
     ensure_hermes_home,
+    get_compatible_custom_providers,
     load_config,
     load_env,
     migrate_config,
@@ -427,7 +428,7 @@ class TestAnthropicTokenMigration:
 class TestCustomProviderCompatibilityMigration:
     """Custom provider migrations must preserve the runtime-compatible shape."""
 
-    def test_v11_upgrade_keeps_custom_providers_alongside_providers(self, tmp_path):
+    def test_v11_upgrade_moves_custom_providers_into_providers(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump(
@@ -466,20 +467,12 @@ class TestCustomProviderCompatibilityMigration:
             "name": "OpenAI Direct",
             "transport": "codex_responses",
         }
-        assert raw["custom_providers"] == [
-            {
-                "name": "OpenAI Direct",
-                "base_url": "https://api.openai.com/v1",
-                "api_key": "direct-key",
-                "api_mode": "codex_responses",
-                "model": "gpt-5-mini",
-            }
-        ]
+        assert "custom_providers" not in raw
         assert raw["fallback_providers"] == [
             {"provider": "openai-direct", "model": "gpt-5-mini"}
         ]
 
-    def test_v16_upgrade_restores_custom_providers_from_providers_dict(self, tmp_path):
+    def test_v16_upgrade_keeps_runtime_compatibility_in_memory_only(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump(
@@ -507,17 +500,39 @@ class TestCustomProviderCompatibilityMigration:
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
         assert raw["_config_version"] == 17
-        assert raw["custom_providers"] == [
-            {
-                "name": "OpenAI Direct",
-                "base_url": "https://api.openai.com/v1",
-                "api_key": "direct-key",
-                "api_mode": "codex_responses",
-                "model": "gpt-5-mini",
-            }
-        ]
+        assert "custom_providers" not in raw
         assert raw["fallback_providers"] == [
             {"provider": "openai-direct", "model": "gpt-5-mini"}
+        ]
+
+    def test_compatible_custom_providers_prefers_api_then_url_then_base_url(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "my-provider": {
+                            "name": "My Provider",
+                            "api": "https://api.example.com/v1",
+                            "url": "https://url.example.com/v1",
+                            "base_url": "https://base.example.com/v1",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == [
+            {
+                "name": "My Provider",
+                "base_url": "https://api.example.com/v1",
+                "provider_key": "my-provider",
+            }
         ]
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -424,6 +424,103 @@ class TestAnthropicTokenMigration:
             assert load_env().get("ANTHROPIC_TOKEN") == "current-token"
 
 
+class TestCustomProviderCompatibilityMigration:
+    """Custom provider migrations must preserve the runtime-compatible shape."""
+
+    def test_v11_upgrade_keeps_custom_providers_alongside_providers(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 11,
+                    "model": {
+                        "default": "openai/gpt-5.4",
+                        "provider": "openrouter",
+                    },
+                    "custom_providers": [
+                        {
+                            "name": "OpenAI Direct",
+                            "base_url": "https://api.openai.com/v1",
+                            "api_key": "direct-key",
+                            "api_mode": "codex_responses",
+                            "model": "gpt-5-mini",
+                        }
+                    ],
+                    "fallback_providers": [
+                        {"provider": "openai-direct", "model": "gpt-5-mini"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 17
+        assert raw["providers"]["openai-direct"] == {
+            "api": "https://api.openai.com/v1",
+            "api_key": "direct-key",
+            "default_model": "gpt-5-mini",
+            "name": "OpenAI Direct",
+            "transport": "codex_responses",
+        }
+        assert raw["custom_providers"] == [
+            {
+                "name": "OpenAI Direct",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "direct-key",
+                "api_mode": "codex_responses",
+                "model": "gpt-5-mini",
+            }
+        ]
+        assert raw["fallback_providers"] == [
+            {"provider": "openai-direct", "model": "gpt-5-mini"}
+        ]
+
+    def test_v16_upgrade_restores_custom_providers_from_providers_dict(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 16,
+                    "providers": {
+                        "openai-direct": {
+                            "api": "https://api.openai.com/v1",
+                            "api_key": "direct-key",
+                            "default_model": "gpt-5-mini",
+                            "name": "OpenAI Direct",
+                            "transport": "codex_responses",
+                        }
+                    },
+                    "fallback_providers": [
+                        {"provider": "openai-direct", "model": "gpt-5-mini"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 17
+        assert raw["custom_providers"] == [
+            {
+                "name": "OpenAI Direct",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "direct-key",
+                "api_mode": "codex_responses",
+                "model": "gpt-5-mini",
+            }
+        ]
+        assert raw["fallback_providers"] == [
+            {"provider": "openai-direct", "model": "gpt-5-mini"}
+        ]
+
+
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""
 
@@ -441,6 +538,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 16
+        assert raw["_config_version"] == 17
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -580,11 +580,11 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
         "load_config",
         lambda: {
             "providers": {
-                "openai-direct": {
+                "openai-direct-primary": {
                     "api": "https://api.openai.com/v1",
                     "api_key": "dir-key",
                     "default_model": "gpt-5-mini",
-                    "name": "OpenAI Direct",
+                    "name": "OpenAI Direct (Primary)",
                     "transport": "codex_responses",
                 }
             }
@@ -600,15 +600,54 @@ def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch
         ),
     )
 
-    resolved = rp.resolve_runtime_provider(requested="openai-direct")
+    resolved = rp.resolve_runtime_provider(requested="openai-direct-primary")
 
     assert resolved["provider"] == "custom"
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.openai.com/v1"
     assert resolved["api_key"] == "dir-key"
-    assert resolved["requested_provider"] == "openai-direct"
-    assert resolved["source"] == "custom_provider:OpenAI Direct"
+    assert resolved["requested_provider"] == "openai-direct-primary"
+    assert resolved["source"] == "custom_provider:OpenAI Direct (Primary)"
     assert resolved["model"] == "gpt-5-mini"
+
+
+def test_named_custom_provider_uses_providers_key_env_when_list_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MYCORP_API_KEY", "env-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-secret"
+    assert resolved["requested_provider"] == "mycorp-proxy"
+    assert resolved["source"] == "custom_provider:MyCorp Proxy"
+    assert resolved["model"] == "acme-large"
 
 
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -119,6 +119,11 @@ def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
 
 
 def test_resolve_runtime_provider_codex(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
     monkeypatch.setattr(
         rp,
@@ -567,6 +572,45 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["source"] == "custom_provider:Local"
 
 
+def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "openai-direct": {
+                    "api": "https://api.openai.com/v1",
+                    "api_key": "dir-key",
+                    "default_model": "gpt-5-mini",
+                    "name": "OpenAI Direct",
+                    "transport": "codex_responses",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-direct")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "dir-key"
+    assert resolved["requested_provider"] == "openai-direct"
+    assert resolved["source"] == "custom_provider:OpenAI Direct"
+    assert resolved["model"] == "gpt-5-mini"
+
+
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -611,6 +655,39 @@ def test_named_custom_provider_does_not_shadow_builtin_provider(monkeypatch):
                     "api_key": "shadow-key",
                 }
             ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_nous_runtime_credentials",
+        lambda **kwargs: {
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-key",
+            "source": "portal",
+            "expires_at": None,
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous")
+
+    assert resolved["provider"] == "nous"
+    assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
+    assert resolved["api_key"] == "nous-key"
+    assert resolved["requested_provider"] == "nous"
+
+
+def test_named_custom_provider_from_providers_dict_does_not_shadow_builtin(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "nous": {
+                    "api": "http://localhost:1234/v1",
+                    "api_key": "shadow-key",
+                    "name": "nous",
+                }
+            }
         },
     )
     monkeypatch.setattr(

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 15
+        assert DEFAULT_CONFIG["_config_version"] == 17


### PR DESCRIPTION
## What does this PR do?

The v11 -> v12 config migration rewrites `custom_providers` into `providers`, but runtime resolution still reads `custom_providers`. After migration, named custom providers and fallback providers can stop resolving at runtime.

This PR restores compatibility in two places:
- the migration keeps or rebuilds `custom_providers` so already-migrated configs keep working
- runtime resolution falls back to `providers` when `custom_providers` is missing

This keeps the fix small and compatibility-focused. It does not try to fully cut runtime over to a new config model.

## Related Issue

Fixes #8776

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `providers_dict_to_custom_providers()` in `hermes_cli/config.py` to keep the field mapping in one place
- updated the v11 -> v12 migration to stop deleting `custom_providers`
- added a v16 -> v17 compatibility migration that rebuilds `custom_providers` from `providers` when needed
- updated `hermes_cli/runtime_provider.py` so named custom provider lookup falls back to `providers`
- added regression tests for config migration, runtime provider resolution, and auxiliary client fallback paths
- updated the browser config version assertion to match the current schema version

## How to Test

1. `source venv/bin/activate`
2. `python -m pytest tests/hermes_cli/test_config.py -q`
3. `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
4. `python -m pytest tests/agent/test_auxiliary_named_custom_providers.py -q`
5. Optional: `python -m pytest tests/ -q`

Example migrated config that now resolves correctly again:

```yaml
model:
  default: openai/gpt-5.4
  provider: openrouter
providers:
  openai-direct:
    api: https://api.openai.com/v1
    api_key: dir-key
    default_model: gpt-5-mini
    name: OpenAI Direct
    transport: codex_responses
fallback_providers:
- provider: openai-direct
  model: gpt-5-mini
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression tests passed locally.

I also ran `python -m pytest tests/ -q` locally. The current tree still has unrelated failures outside this diff, including missing `acp` imports and existing failures in gateway, voice, reasoning, and auxiliary-client tests.
