### PR TITLE
docs: document native Windows install via PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Works on Linux, macOS, WSL2, and Android via Termux. The installer handles the p
 
 > **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
 >
-> **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
+> **Windows:** Native Windows is supported via the PowerShell installer:
+> ```powershell
+> irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+> ```
+> Alternatively, you can use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the Linux installation command above.
 
 After installation:
 


### PR DESCRIPTION
## What does this PR do?

Updates the README Windows install note to reflect the repo's actual support for native Windows installation via `scripts/install.ps1`.

The current README says native Windows is not supported and directs users to WSL2, but the repository already includes a PowerShell installer and the shell installer also points Windows users to that path. This PR makes the quick-start docs consistent with the current installation flow.

## Related Issue

Fixes #8806

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated the Windows note in `README.md`
- Replaced the incorrect "Native Windows is not supported" text
- Added the PowerShell install command:
  `irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex`
- Kept WSL2 as an alternative install path

## How to Test

1. Open `README.md`
2. Go to the Quick Install section
3. Confirm the Windows note now documents native Windows installation via PowerShell and still mentions WSL2 as an alternative
4. Confirm this matches the existing installer scripts in `scripts/install.ps1` and `scripts/install.sh`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
