### PR TITLE
fix(file_tools): block sensitive paths before and after symlink resol…

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -14,6 +14,7 @@ from tools.file_tools import (
     WRITE_FILE_SCHEMA,
     PATCH_SCHEMA,
     SEARCH_FILES_SCHEMA,
+    _check_sensitive_path,
 )
 
 
@@ -74,6 +75,13 @@ class TestReadFileHandler:
 
 
 class TestWriteFileHandler:
+    def test_sensitive_path_check_blocks_literal_and_resolved_paths(self):
+        with patch("tools.file_tools.os.path.realpath", return_value="/private/etc/hosts"):
+            error = _check_sensitive_path("/etc/hosts")
+
+        assert error is not None
+        assert "sensitive system path" in error.lower()
+
     @patch("tools.file_tools._get_file_ops")
     def test_writes_content(self, mock_get):
         mock_ops = MagicMock()
@@ -309,6 +317,5 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
-
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -98,21 +98,25 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
+    expanded = os.path.expanduser(filepath)
     try:
-        resolved = os.path.realpath(os.path.expanduser(filepath))
+        resolved = os.path.realpath(expanded)
     except (OSError, ValueError):
-        resolved = filepath
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix):
+        resolved = expanded
+
+    candidates = (expanded, resolved)
+    for candidate in candidates:
+        for prefix in _SENSITIVE_PATH_PREFIXES:
+            if candidate.startswith(prefix):
+                return (
+                    f"Refusing to write to sensitive system path: {filepath}\n"
+                    "Use the terminal tool with sudo if you need to modify system files."
+                )
+        if candidate in _SENSITIVE_EXACT_PATHS:
             return (
                 f"Refusing to write to sensitive system path: {filepath}\n"
                 "Use the terminal tool with sudo if you need to modify system files."
             )
-    if resolved in _SENSITIVE_EXACT_PATHS:
-        return (
-            f"Refusing to write to sensitive system path: {filepath}\n"
-            "Use the terminal tool with sudo if you need to modify system files."
-        )
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS path-safety bypass in `tools/file_tools.py`.

`_check_sensitive_path()` previously only checked the resolved path after `realpath()`. On macOS, paths like `/etc/hosts` resolve to `/private/etc/hosts`, which bypassed the `/etc/` prefix check. This change validates both the expanded original path and the resolved path, so sensitive paths are blocked before and after symlink resolution.

## Related Issue

Fixes #8734

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/file_tools.py` so `_check_sensitive_path()` checks both the expanded input path and the resolved real path
- Added a regression test in `tests/tools/test_file_tools.py` covering the macOS `/etc -> /private/etc` resolution case

## How to Test

1. Run `python -m pytest tests/tools/test_file_tools.py -q`
2. Confirm the suite passes
3. Verify the new regression test blocks `/etc/hosts` even when `realpath()` returns `/private/etc/hosts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/tools/test_file_tools.py -q
25 passed, 10 warnings in 1.85s
