### PR TITLE
Fix UnicodeEncodeError in ASCII locales

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -48,6 +48,23 @@ def _load_config_safe() -> Optional[dict]:
         return None
 
 
+def _sanitize_ascii_token(value: Any, *, field: str, provider: str, entry_id: str) -> str:
+    """Return a token-safe ASCII string, stripping unexpected non-ASCII chars."""
+    token = "".join(str(value or "").split())
+    if not token:
+        return ""
+    if token.isascii():
+        return token
+    sanitized = "".join(ch for ch in token if ord(ch) < 128)
+    logger.warning(
+        "Credential pool entry %s (%s) has non-ASCII %s; sanitizing token value.",
+        entry_id,
+        provider,
+        field,
+    )
+    return sanitized
+
+
 # --- Status and type constants ---
 
 STATUS_OK = "ok"
@@ -136,6 +153,27 @@ class PooledCredential:
         data.setdefault("priority", 0)
         data.setdefault("source", SOURCE_MANUAL)
         data.setdefault("access_token", "")
+        entry_id = str(data.get("id") or payload.get("id") or "unknown")
+        data["access_token"] = _sanitize_ascii_token(
+            data.get("access_token"),
+            field="access_token",
+            provider=provider,
+            entry_id=entry_id,
+        )
+        if "refresh_token" in data:
+            data["refresh_token"] = _sanitize_ascii_token(
+                data.get("refresh_token"),
+                field="refresh_token",
+                provider=provider,
+                entry_id=entry_id,
+            ) or None
+        if "agent_key" in data:
+            data["agent_key"] = _sanitize_ascii_token(
+                data.get("agent_key"),
+                field="agent_key",
+                provider=provider,
+                entry_id=entry_id,
+            ) or None
         return cls(provider=provider, **data)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -460,6 +460,40 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
     return found
 
 
+def _sanitize_tools_non_ascii(tools: list) -> bool:
+    """Strip non-ASCII characters from tool payloads in-place."""
+    return _sanitize_structure_non_ascii(tools)
+
+
+def _sanitize_structure_non_ascii(payload: Any) -> bool:
+    """Strip non-ASCII characters from nested dict/list payloads in-place."""
+    found = False
+
+    def _walk(node):
+        nonlocal found
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, str):
+                    sanitized = _strip_non_ascii(value)
+                    if sanitized != value:
+                        node[key] = sanitized
+                        found = True
+                elif isinstance(value, (dict, list)):
+                    _walk(value)
+        elif isinstance(node, list):
+            for idx, value in enumerate(node):
+                if isinstance(value, str):
+                    sanitized = _strip_non_ascii(value)
+                    if sanitized != value:
+                        node[idx] = sanitized
+                        found = True
+                elif isinstance(value, (dict, list)):
+                    _walk(value)
+
+    _walk(payload)
+    return found
+
+
 
 
 
@@ -737,6 +771,7 @@ class AIAgent:
         self.service_tier = service_tier
         self.request_overrides = dict(request_overrides or {})
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
+        self._force_ascii_payload = False
         
         # Anthropic prompt caching: auto-enabled for Claude models via OpenRouter.
         # Reduces input costs by ~75% on multi-turn conversations by caching the
@@ -8094,6 +8129,8 @@ class AIAgent:
                 try:
                     self._reset_stream_delivery_tracking()
                     api_kwargs = self._build_api_kwargs(api_messages)
+                    if self._force_ascii_payload:
+                        _sanitize_structure_non_ascii(api_kwargs)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
 
@@ -8710,13 +8747,51 @@ class AIAgent:
                             )
                             continue
                         if _is_ascii_codec:
+                            self._force_ascii_payload = True
                             # ASCII codec: the system encoding can't handle
                             # non-ASCII characters at all. Sanitize all
-                            # non-ASCII content from messages and retry.
-                            if _sanitize_messages_non_ascii(messages):
+                            # non-ASCII content from messages/tool schemas and retry.
+                            _messages_sanitized = _sanitize_messages_non_ascii(messages)
+                            _prefill_sanitized = False
+                            if isinstance(getattr(self, "prefill_messages", None), list):
+                                _prefill_sanitized = _sanitize_messages_non_ascii(self.prefill_messages)
+
+                            _tools_sanitized = False
+                            if isinstance(getattr(self, "tools", None), list):
+                                _tools_sanitized = _sanitize_tools_non_ascii(self.tools)
+
+                            _system_sanitized = False
+                            if isinstance(active_system_prompt, str):
+                                _sanitized_system = _strip_non_ascii(active_system_prompt)
+                                if _sanitized_system != active_system_prompt:
+                                    active_system_prompt = _sanitized_system
+                                    self._cached_system_prompt = _sanitized_system
+                                    _system_sanitized = True
+                            if isinstance(getattr(self, "ephemeral_system_prompt", None), str):
+                                _sanitized_ephemeral = _strip_non_ascii(self.ephemeral_system_prompt)
+                                if _sanitized_ephemeral != self.ephemeral_system_prompt:
+                                    self.ephemeral_system_prompt = _sanitized_ephemeral
+                                    _system_sanitized = True
+
+                            _headers_sanitized = False
+                            _default_headers = (
+                                self._client_kwargs.get("default_headers")
+                                if isinstance(getattr(self, "_client_kwargs", None), dict)
+                                else None
+                            )
+                            if isinstance(_default_headers, dict):
+                                _headers_sanitized = _sanitize_structure_non_ascii(_default_headers)
+
+                            if (
+                                _messages_sanitized
+                                or _prefill_sanitized
+                                or _tools_sanitized
+                                or _system_sanitized
+                                or _headers_sanitized
+                            ):
                                 self._unicode_sanitization_passes += 1
                                 self._vprint(
-                                    f"{self.log_prefix}⚠️  System encoding is ASCII — stripped non-ASCII characters from messages. Retrying...",
+                                    f"{self.log_prefix}⚠️  System encoding is ASCII — stripped non-ASCII characters from request payload. Retrying...",
                                     force=True,
                                 )
                                 continue

--- a/tests/agent/test_credential_pool_ascii_token_sanitization.py
+++ b/tests/agent/test_credential_pool_ascii_token_sanitization.py
@@ -1,0 +1,49 @@
+from agent.credential_pool import PooledCredential
+
+
+def test_from_dict_strips_non_ascii_from_access_token():
+    entry = PooledCredential.from_dict(
+        "copilot",
+        {
+            "id": "abc123",
+            "label": "test",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "tok123│tail",
+        },
+    )
+    assert entry.access_token == "tok123tail"
+
+
+def test_from_dict_strips_non_ascii_from_refresh_and_agent_key():
+    entry = PooledCredential.from_dict(
+        "nous",
+        {
+            "id": "abc123",
+            "label": "test",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "access",
+            "refresh_token": "refresh│token",
+            "agent_key": "agent│key",
+        },
+    )
+    assert entry.refresh_token == "refreshtoken"
+    assert entry.agent_key == "agentkey"
+
+
+def test_from_dict_removes_internal_whitespace_from_tokens():
+    entry = PooledCredential.from_dict(
+        "copilot",
+        {
+            "id": "abc123",
+            "label": "test",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "tok en\twith\nspaces",
+        },
+    )
+    assert entry.access_token == "tokenwithspaces"

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -9,6 +9,8 @@ import pytest
 from run_agent import (
     _strip_non_ascii,
     _sanitize_messages_non_ascii,
+    _sanitize_structure_non_ascii,
+    _sanitize_tools_non_ascii,
     _sanitize_messages_surrogates,
 )
 
@@ -138,3 +140,66 @@ class TestSurrogateVsAsciiSanitization:
         """When no surrogates present, _sanitize_messages_surrogates returns False."""
         messages = [{"role": "user", "content": "hello ⚕ world"}]
         assert _sanitize_messages_surrogates(messages) is False
+
+
+class TestSanitizeToolsNonAscii:
+    """Tests for _sanitize_tools_non_ascii."""
+
+    def test_sanitizes_tool_description_and_parameter_descriptions(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Print structured output │ with emoji 🤖",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "File path │ with unicode",
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+
+        assert _sanitize_tools_non_ascii(tools) is True
+        assert tools[0]["function"]["description"] == "Print structured output  with emoji "
+        assert tools[0]["function"]["parameters"]["properties"]["path"]["description"] == "File path  with unicode"
+
+    def test_no_change_for_ascii_only_tools(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read file content",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "File path",
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+
+        assert _sanitize_tools_non_ascii(tools) is False
+
+
+class TestSanitizeStructureNonAscii:
+    def test_sanitizes_nested_dict_structure(self):
+        payload = {
+            "default_headers": {
+                "X-Title": "Hermes │ Agent",
+                "User-Agent": "Hermes/1.0 🤖",
+            }
+        }
+        assert _sanitize_structure_non_ascii(payload) is True
+        assert payload["default_headers"]["X-Title"] == "Hermes  Agent"
+        assert payload["default_headers"]["User-Agent"] == "Hermes/1.0 "


### PR DESCRIPTION
## Summary
- fix ASCII-locale UnicodeEncodeError retries by sanitizing request payloads when encoding errors are detected
- sanitize credential-pool token fields loaded from auth store to remove non-ASCII/whitespace corruption that can break HTTP headers
- add regression tests for payload/tool sanitization and credential token sanitization paths

## Test Plan
- [x] ./venv/bin/python -m pytest -q tests/run_agent/test_unicode_ascii_codec.py tests/agent/test_credential_pool_ascii_token_sanitization.py
- [ ] ./venv/bin/python -m pytest -q (known pre-existing failures in current repository baseline)