### PR TITLE
fix(gateway): preserve venv python path when generating systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -770,7 +770,8 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
     current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    p = Path(path)
+    resolved = p.parent.resolve() / p.name  # resolve dirs, preserve file symlink
     try:
         relative = resolved.relative_to(current_home)
         return str(Path(target_home_dir) / relative)


### PR DESCRIPTION
## What does this PR do?

Fixes a systemd gateway regression where `ExecStart` could be rewritten to system Python (e.g. `/usr/bin/python3.11`) instead of the venv interpreter during `hermes gateway restart --system`.

Root cause: path remapping resolved symlinks, which collapsed `.../venv/bin/python` to the base interpreter path.  
Fix: preserve the original absolute path without symlink resolution when remapping.

## Related Issue

Related PR #7109

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated path remapping in `hermes_cli/gateway.py` (`_remap_path_for_user`) to avoid symlink dereference.
- Preserved venv interpreter path in generated systemd unit `ExecStart` for `--system` service flows.

## How to Test

1. Reproduce on current/main behavior:
   - Run `sudo hermes gateway restart --system`
   - Inspect unit and confirm `ExecStart` incorrectly points to system Python.
2. Apply this PR and rerun:
   - `sudo hermes gateway restart --system`
3. Verify fix:
   - `sudo systemctl cat hermes-gateway` (or profile-scoped unit)
   - Confirm `ExecStart` points to `.../venv/bin/python`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian (systemd)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

### hermes-gateway.service

Before
```
[Service]
Type=simple
User=hermes
Group=hermes
ExecStart=/usr/bin/python3.11 -m hermes_cli.main gateway run --replace
WorkingDirectory=/home/hermes/.hermes/hermes-agent
Environment="HOME=/home/hermes"
...
```

After:
```
[Service]
Type=simple
User=hermes
Group=hermes
ExecStart=/home/hermes/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace
WorkingDirectory=/home/hermes/.hermes/hermes-agent
Environment="HOME=/home/hermes"
...
```

### Debug Logs

Before:
```
[gateway-debug] generate_systemd_unit: system=True run_as_user=hermes service=hermes-gateway unit=/etc/systemd/system/hermes-gateway.service initial_python=/home/hermes/.hermes/hermes-agent/venv/bin/python
[gateway-debug] generate_systemd_unit: before remap python_path for run_as_user=hermes -> /home/hermes/.hermes/hermes-agent/venv/bin/python
[gateway-debug] generate_systemd_unit: remapped python_path for run_as_user=hermes -> /usr/bin/python3.11
```

After
```
[gateway-debug] generate_systemd_unit: system=True run_as_user=hermes service=hermes-gateway unit=/etc/systemd/system/hermes-gateway.service initial_python=/home/hermes/.hermes/hermes-agent/venv/bin/python
[gateway-debug] generate_systemd_unit: before remap python_path for run_as_user=hermes -> /home/hermes/.hermes/hermes-agent/venv/bin/python
[gateway-debug] generate_systemd_unit: remapped python_path for run_as_user=hermes -> /home/hermes/.hermes/hermes-agent/venv/bin/python
```