### PR TITLE
fix: preserve installed systemd context on gateway restart --system

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -766,16 +766,24 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
     If *path* lives under ``Path.home()`` the corresponding prefix is swapped
     to *target_home_dir*; otherwise the path is returned unchanged.
 
+    Important: this preserves the original lexical path instead of resolving
+    symlinks first. A virtualenv Python commonly lives at ``venv/bin/python``
+    but is itself a symlink to a shared base interpreter (for example uv's
+    managed CPython under ``~/.local/share/uv/python/...``). Resolving the
+    symlink before remapping would bake the shared interpreter into the unit
+    file and bypass the virtualenv, which is exactly the broken ExecStart we
+    must avoid.
+
       /root/.hermes/hermes-agent  -> /home/alice/.hermes/hermes-agent
       /opt/hermes                 -> /opt/hermes  (kept as-is)
     """
-    current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    current_home = Path(os.path.abspath(os.path.expanduser(str(Path.home()))))
+    normalized = Path(os.path.abspath(os.path.expanduser(path)))
     try:
-        relative = resolved.relative_to(current_home)
+        relative = normalized.relative_to(current_home)
         return str(Path(target_home_dir) / relative)
     except ValueError:
-        return str(resolved)
+        return str(normalized)
 
 
 def _hermes_home_for_target_user(target_home_dir: str) -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -812,13 +812,69 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
-def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
-    python_path = get_python_path()
-    working_dir = str(PROJECT_ROOT)
-    detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
-    venv_bin = str(detected_venv / "bin") if detected_venv else str(PROJECT_ROOT / "venv" / "bin")
-    node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
+def _read_systemd_environment_from_unit(unit_path: Path) -> dict[str, str]:
+    if not unit_path.exists():
+        return {}
+
+    env: dict[str, str] = {}
+    for line in unit_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("Environment="):
+            continue
+        payload = line.split("=", 1)[1].strip()
+        if len(payload) >= 2 and payload[0] == payload[-1] == '"':
+            payload = payload[1:-1]
+        if "=" not in payload:
+            continue
+        key, value = payload.split("=", 1)
+        env[key] = value
+    return env
+
+
+def _read_systemd_property_from_unit(unit_path: Path, prefix: str) -> str | None:
+    if not unit_path.exists():
+        return None
+
+    for line in unit_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            value = line.split("=", 1)[1].strip()
+            return value or None
+    return None
+
+
+def _systemd_generation_context_from_unit(unit_path: Path) -> dict[str, str | None]:
+    env = _read_systemd_environment_from_unit(unit_path)
+    working_dir = _read_systemd_property_from_unit(unit_path, "WorkingDirectory=")
+    venv_dir = env.get("VIRTUAL_ENV")
+    python_path = None
+
+    if venv_dir:
+        python_path = str(Path(venv_dir) / ("Scripts/python.exe" if is_windows() else "bin/python"))
+    elif working_dir:
+        python_path = str(Path(working_dir) / "venv" / ("Scripts/python.exe" if is_windows() else "bin/python"))
+
+    return {
+        "python_path": python_path,
+        "working_dir": working_dir,
+        "venv_dir": venv_dir,
+        "hermes_home": env.get("HERMES_HOME"),
+    }
+
+
+def generate_systemd_unit(
+    system: bool = False,
+    run_as_user: str | None = None,
+    *,
+    python_path_override: str | None = None,
+    working_dir_override: str | None = None,
+    venv_dir_override: str | None = None,
+    hermes_home_override: str | None = None,
+) -> str:
+    python_path = python_path_override or get_python_path()
+    working_dir = working_dir_override or str(PROJECT_ROOT)
+    detected_venv = Path(venv_dir_override) if venv_dir_override else _detect_venv_dir()
+    venv_dir = str(detected_venv) if detected_venv else str(Path(working_dir) / "venv")
+    venv_bin = str(Path(venv_dir) / "bin")
+    node_bin = str(Path(working_dir) / "node_modules" / ".bin")
 
     path_entries = [venv_bin, node_bin]
     resolved_node = shutil.which("node")
@@ -832,7 +888,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
-        hermes_home = _hermes_home_for_target_user(home_dir)
+        hermes_home = hermes_home_override or _hermes_home_for_target_user(home_dir)
         profile_arg = _profile_arg(hermes_home)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
@@ -879,7 +935,7 @@ StandardError=journal
 WantedBy=multi-user.target
 """
 
-    hermes_home = str(get_hermes_home().resolve())
+    hermes_home = hermes_home_override or str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(common_bin_paths)
@@ -941,7 +997,18 @@ def systemd_unit_is_current(system: bool = False) -> bool:
 
     installed = unit_path.read_text(encoding="utf-8")
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    expected = generate_systemd_unit(system=system, run_as_user=expected_user)
+    if system:
+        context = _systemd_generation_context_from_unit(unit_path)
+        expected = generate_systemd_unit(
+            system=True,
+            run_as_user=expected_user,
+            python_path_override=context.get("python_path"),
+            working_dir_override=context.get("working_dir"),
+            venv_dir_override=context.get("venv_dir"),
+            hermes_home_override=context.get("hermes_home"),
+        )
+    else:
+        expected = generate_systemd_unit(system=False, run_as_user=expected_user)
     return _normalize_service_definition(installed) == _normalize_service_definition(expected)
 
 
@@ -953,7 +1020,21 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
         return False
 
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    unit_path.write_text(generate_systemd_unit(system=system, run_as_user=expected_user), encoding="utf-8")
+    if system:
+        context = _systemd_generation_context_from_unit(unit_path)
+        unit_path.write_text(
+            generate_systemd_unit(
+                system=True,
+                run_as_user=expected_user,
+                python_path_override=context.get("python_path"),
+                working_dir_override=context.get("working_dir"),
+                venv_dir_override=context.get("venv_dir"),
+                hermes_home_override=context.get("hermes_home"),
+            ),
+            encoding="utf-8",
+        )
+    else:
+        unit_path.write_text(generate_systemd_unit(system=False, run_as_user=expected_user), encoding="utf-8")
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     print(f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install")
     return True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -631,8 +631,45 @@ class TestDetectVenvDir:
         assert result is None
 
 
+class TestRemapPathForUser:
+    def test_preserves_lexical_virtualenv_path_instead_of_resolving_symlink(self, tmp_path, monkeypatch):
+        current_home = tmp_path / "current"
+        target_home = tmp_path / "target"
+        current_home.mkdir()
+        target_home.mkdir()
+
+        real_python = current_home / ".local" / "share" / "uv" / "python" / "cpython-3.11" / "bin"
+        real_python.mkdir(parents=True)
+        (real_python / "python3.11").write_text("", encoding="utf-8")
+
+        venv_bin = current_home / ".hermes" / "hermes-agent" / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").symlink_to(real_python / "python3.11")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: current_home))
+
+        remapped = gateway_cli._remap_path_for_user(str(venv_bin / "python"), str(target_home))
+
+        assert remapped == str(target_home / ".hermes" / "hermes-agent" / "venv" / "bin" / "python")
+        assert ".local/share/uv/python" not in remapped
+
+
 class TestSystemUnitHermesHome:
     """HERMES_HOME in system units must reference the target user, not root."""
+
+    def test_system_unit_keeps_virtualenv_execstart_path_when_running_as_root(self, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/root/.hermes/hermes-agent/venv/bin/python")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: Path("/root/.hermes/hermes-agent/venv"))
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity", lambda run_as_user=None: ("root", "root", "/root")
+        )
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="root")
+
+        assert "ExecStart=/root/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace" in unit
+        assert "/root/.local/share/uv/python" not in unit
 
     def test_system_unit_uses_target_user_home_not_calling_user(self, monkeypatch):
         # Simulate sudo: Path.home() returns /root, target user is alice

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -13,6 +13,100 @@ from gateway.restart import (
 
 
 class TestSystemdServiceRefresh:
+    def test_systemd_unit_is_current_uses_installed_system_context(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/root/.hermes/hermes-agent/venv/bin/python")
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", Path("/root/.hermes/hermes-agent"))
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: Path("/root/.hermes/hermes-agent/venv"))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 60)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit_path.write_text(
+            gateway_cli.generate_systemd_unit(
+                system=True,
+                run_as_user="alice",
+                python_path_override="/home/alice/.hermes/hermes-agent/venv/bin/python",
+                working_dir_override="/home/alice/.hermes/hermes-agent",
+                venv_dir_override="/home/alice/.hermes/hermes-agent/venv",
+                hermes_home_override="/home/alice/.hermes",
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+
+        assert gateway_cli.systemd_unit_is_current(system=True) is True
+
+    def test_refresh_systemd_unit_repairs_broken_execstart_using_installed_venv(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(
+            """[Unit]
+Description=Hermes Agent Gateway - Messaging Platform Integration
+
+[Service]
+Type=simple
+User=alice
+Group=alice
+ExecStart=/home/alice/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/bin/python3.11 -m hermes_cli.main gateway run --replace
+WorkingDirectory=/home/alice/.hermes/hermes-agent
+Environment=\"HOME=/home/alice\"
+Environment=\"USER=alice\"
+Environment=\"LOGNAME=alice\"
+Environment=\"PATH=/home/alice/.hermes/hermes-agent/venv/bin:/home/alice/.hermes/hermes-agent/node_modules/.bin:/usr/bin\"
+Environment=\"VIRTUAL_ENV=/home/alice/.hermes/hermes-agent/venv\"
+Environment=\"HERMES_HOME=/home/alice/.hermes\"
+Restart=on-failure
+RestartSec=30
+RestartForceExitStatus=75
+KillMode=mixed
+KillSignal=SIGTERM
+ExecReload=/bin/kill -USR1 $MAINPID
+TimeoutStopSec=60
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+""",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/root/.hermes/hermes-agent/venv/bin/python")
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", Path("/root/.hermes/hermes-agent"))
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: Path("/root/.hermes/hermes-agent/venv"))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: [])
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 60)
+
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        refreshed = gateway_cli.refresh_systemd_unit_if_needed(system=True)
+
+        assert refreshed is True
+        unit_text = unit_path.read_text(encoding="utf-8")
+        assert "ExecStart=/home/alice/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace" in unit_text
+        assert "/root/.hermes/hermes-agent" not in unit_text
+        assert ".local/share/uv/python" not in unit_text
+        assert calls == [["systemctl", "daemon-reload"]]
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")


### PR DESCRIPTION
## Bug Description

`gateway restart --system` could decide that an installed systemd unit was stale using the current CLI process environment instead of the installed unit's own context, and then rewrite the unit with the wrong runtime paths.

In practice this meant a valid service installed for another user could be "refreshed" into a broken unit, including a bad `ExecStart` such as a resolved uv shared interpreter path.

## Root Cause

The system-service freshness check and refresh path regenerated expected unit content from the current process environment (`WorkingDirectory`, `VIRTUAL_ENV`, `HERMES_HOME`, python path), rather than from the installed unit file being checked/refreshed.

That made `gateway restart --system` compare against the wrong context and rewrite the unit with incorrect paths.

## Fix

- parse the installed systemd unit's `WorkingDirectory` and `Environment=` values
- derive generation context from the installed unit when checking or refreshing system services
- allow systemd unit generation to accept explicit overrides for python path, working directory, venv dir, and Hermes home
- keep the old non-system call pattern intact to avoid breaking existing tests/mocks
- add regressions for both stale-check correctness and repairing a broken `ExecStart`

## How to Verify

1. Install or simulate a system unit whose `WorkingDirectory`/`VIRTUAL_ENV` point to a non-current environment.
2. Run `gateway restart --system` from a different environment/user context.
3. Confirm the unit is not rewritten when already correct, and that a broken `ExecStart` is repaired using the installed unit's venv path.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [ ] Manual verification of the fix

Commands run:

```bash
./venv/bin/python -m pytest -q tests/hermes_cli/test_gateway_service.py
```

## Risk Assessment

Low — changes are scoped to systemd unit comparison/refresh for system services, and non-system behavior keeps the previous call path for compatibility.
