### PR TITLE
fix(cli): require TTY for interactive chat mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -732,6 +732,10 @@ def cmd_chat(args):
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
 
+    # Interactive mode requires a TTY; single-query mode (-q/--image) does not.
+    if getattr(args, "query", None) is None and getattr(args, "image", None) is None:
+        _require_tty("chat")
+
     # Start update check in background (runs while other init happens)
     try:
         from hermes_cli.banner import prefetch_update_check

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -144,6 +144,43 @@ class TestNonInteractiveSetup:
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
 
+    def test_chat_interactive_mode_requires_tty(self, capsys):
+        """Interactive chat should fail fast with a clear TTY error in headless environments."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args()
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("sys.stdin") as mock_stdin,
+            patch("cli.main") as mock_cli_main,
+        ):
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(SystemExit) as exc:
+                cmd_chat(args)
+
+        assert exc.value.code == 1
+        mock_cli_main.assert_not_called()
+        err = capsys.readouterr().err
+        assert "requires an interactive terminal" in err
+        assert "hermes chat" in err
+
+    def test_chat_query_mode_allows_headless_execution(self):
+        """Single-query mode should remain available without an interactive TTY."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args(query="hello")
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("sys.stdin") as mock_stdin,
+            patch("cli.main") as mock_cli_main,
+        ):
+            mock_stdin.isatty.return_value = False
+            cmd_chat(args)
+
+        mock_cli_main.assert_called_once()
+
     def test_returning_user_terminal_menu_choice_dispatches_terminal_section(self, tmp_path):
         """Returning-user menu should map Terminal Backend to the terminal setup, not TTS."""
         from hermes_cli import setup as setup_mod


### PR DESCRIPTION
## Summary\n- fail fast in `cmd_chat` when interactive chat is requested without a TTY\n- keep single-query mode (`-q` / `--image`) working in headless environments\n- add regression tests for both interactive and single-query headless paths\n\n## Problem\n`prompt_toolkit` crashes in some headless/macOS uv-python cases with selector errors (e.g. `OSError: [Errno 22] Invalid argument`) when interactive chat starts without a usable TTY.\n\n## Change\nUse existing `_require_tty("chat")` guard only for interactive chat mode, after first-run setup handling, so users get a clear actionable error instead of a traceback.\n\n## Testing\n- `venv/bin/pytest -q tests/hermes_cli/test_setup_noninteractive.py`