### PR TITLE
fix: relaunch chat with a fresh tty after setup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9654,7 +9654,11 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393).
             # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            if (
+                "is not registered" in str(_stdin_err)
+                or "Bad file descriptor" in str(_stdin_err)
+                or "Invalid argument" in str(_stdin_err)
+            ):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -15,6 +15,7 @@ import importlib.util
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import copy
 from pathlib import Path
@@ -2956,6 +2957,36 @@ def _resolve_hermes_chat_argv() -> Optional[list[str]]:
     return None
 
 
+def _launch_chat_process(chat_argv: list[str]) -> bool:
+    """Launch ``hermes chat`` with a fresh TTY-backed stdin when possible.
+
+    The setup wizard is often run from the curl installer, which invokes the
+    wizard with ``stdin`` redirected from ``/dev/tty``. Re-execing directly from
+    that process can leave prompt_toolkit with a broken fd 0 on macOS + uv-
+    managed Python. Spawning a child process with a newly opened ``/dev/tty``
+    avoids inheriting the problematic stdin state.
+    """
+    try:
+        if os.name != "nt":
+            tty_fd = os.open("/dev/tty", os.O_RDWR)
+            try:
+                subprocess.run(
+                    chat_argv,
+                    check=False,
+                    stdin=tty_fd,
+                    stdout=tty_fd,
+                    stderr=tty_fd,
+                )
+            finally:
+                os.close(tty_fd)
+        else:
+            subprocess.run(chat_argv, check=False)
+        return True
+    except OSError as exc:
+        logger.debug("Could not launch Hermes chat automatically: %s", exc)
+        return False
+
+
 def _offer_launch_chat():
     """Prompt the user to jump straight into chat after setup."""
     print()
@@ -2967,7 +2998,8 @@ def _offer_launch_chat():
         print_info("Could not relaunch Hermes automatically. Run 'hermes chat' manually.")
         return
 
-    os.execvp(chat_argv[0], chat_argv)
+    if not _launch_chat_process(chat_argv):
+        print_info("Could not relaunch Hermes automatically. Run 'hermes chat' manually.")
 
 
 def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -468,18 +468,30 @@ def test_offer_launch_chat_execs_fresh_process(monkeypatch):
     monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: ["/usr/local/bin/hermes", "chat"])
 
-    exec_calls = []
+    launch_calls = []
 
-    def fake_execvp(path, argv):
-        exec_calls.append((path, argv))
-        raise SystemExit(0)
+    def fake_launch(argv):
+        launch_calls.append(argv)
+        return True
 
-    monkeypatch.setattr(setup_mod.os, "execvp", fake_execvp)
+    monkeypatch.setattr(setup_mod, "_launch_chat_process", fake_launch)
 
-    with pytest.raises(SystemExit):
-        setup_mod._offer_launch_chat()
+    setup_mod._offer_launch_chat()
 
-    assert exec_calls == [("/usr/local/bin/hermes", ["/usr/local/bin/hermes", "chat"])]
+    assert launch_calls == [["/usr/local/bin/hermes", "chat"]]
+
+
+def test_offer_launch_chat_manual_fallback_when_launch_fails(monkeypatch, capsys):
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: ["/usr/local/bin/hermes", "chat"])
+    monkeypatch.setattr(setup_mod, "_launch_chat_process", lambda _argv: False)
+
+    setup_mod._offer_launch_chat()
+
+    captured = capsys.readouterr()
+    assert "Run 'hermes chat' manually" in captured.out
 
 
 def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- relaunch `hermes chat` after setup using a fresh `/dev/tty`-backed subprocess instead of `os.execvp`
- avoid inheriting broken stdin state from installer/setup flows such as `curl ... | bash`
- treat `Invalid argument` like other broken-stdin prompt_toolkit startup failures
- update setup tests to cover the new launch path

## Problem
When Hermes is installed via the curl installer on macOS, the setup wizard can successfully run interactively by reading from `/dev/tty`, but choosing `Launch hermes chat now?` may immediately crash with:
- `KeyError: '0 is not registered'`
- `OSError: [Errno 22] Invalid argument`

This happens because the setup process re-execs into `hermes chat`, and the new prompt_toolkit app inherits a broken stdin/fd 0 state from the installer/setup chain.

## Fix
Instead of replacing the current process with `os.execvp`, launch chat in a new subprocess wired directly to a freshly opened `/dev/tty`. This gives prompt_toolkit a clean TTY-backed stdin/stdout/stderr and avoids the broken inherited fd state.

As a small follow-up hardening step, the CLI stdin fallback now also treats `Invalid argument` as a broken-stdin startup error and prints the same friendly guidance instead of a raw traceback.

## Testing
- `venv/bin/python -m pytest tests/hermes_cli/test_setup.py -q`
- manually verified `printf "/exit\n" | hermes chat` exits cleanly after the setup-launch change
