### PR TITLE
feat(skills): add explicit text aliases for skill activation

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -19,6 +19,84 @@ _PLAN_SLUG_RE = re.compile(r"[^a-z0-9]+")
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_TEXT_SKILL_ACTIVATORS = {"skill", "скилл", "скил"}
+
+
+def _normalize_text_skill_alias(value: str) -> str:
+    """Normalize a text alias for explicit skill activation matching."""
+    return " ".join(
+        str(value or "")
+        .strip()
+        .lower()
+        .replace("ё", "е")
+        .replace("_", "-")
+        .split()
+    )
+
+
+def _extract_frontmatter_aliases(frontmatter: dict[str, Any], skill_name: str) -> list[str]:
+    """Return deduplicated explicit text aliases from top-level frontmatter.
+
+    The canonical skill name is always included so text activation works even
+    when ``aliases`` is omitted.
+    """
+    aliases: list[str] = [str(skill_name or "").strip()]
+    raw_aliases = frontmatter.get("aliases")
+    if isinstance(raw_aliases, str):
+        aliases.append(raw_aliases)
+    elif isinstance(raw_aliases, list):
+        aliases.extend(str(item) for item in raw_aliases if isinstance(item, str))
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for alias in aliases:
+        cleaned = str(alias or "").strip()
+        normalized = _normalize_text_skill_alias(cleaned)
+        if not cleaned or not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(cleaned)
+    return result
+
+
+def parse_text_skill_invocation(message: str) -> dict[str, str] | None:
+    """Parse explicit voice/text-friendly skill activation.
+
+    Supports messages that begin with a dedicated activator, e.g.
+    ``skill weather Moscow`` or ``скилл погода Москва``.
+    """
+    raw = str(message or "").strip()
+    if not raw:
+        return None
+    parts = raw.split(maxsplit=2)
+    if not parts:
+        return None
+    activator = _normalize_text_skill_alias(parts[0])
+    if activator not in _TEXT_SKILL_ACTIVATORS:
+        return None
+    alias = parts[1].strip() if len(parts) > 1 else ""
+    instruction = parts[2].strip() if len(parts) > 2 else ""
+    return {
+        "activator": parts[0],
+        "alias": alias,
+        "alias_normalized": _normalize_text_skill_alias(alias),
+        "user_instruction": instruction,
+    }
+
+
+def resolve_text_skill_invocation(message: str) -> tuple[str, str] | None:
+    """Resolve an explicit text skill invocation to ``(/cmd-key, args)``."""
+    parsed = parse_text_skill_invocation(message)
+    if not parsed:
+        return None
+    alias = parsed.get("alias_normalized") or ""
+    if not alias:
+        return None
+    for cmd_key, info in get_skill_commands().items():
+        aliases = info.get("aliases_normalized") or []
+        if alias in aliases:
+            return cmd_key, parsed.get("user_instruction", "")
+    return None
 
 
 def build_plan_path(
@@ -240,6 +318,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                             if line and not line.startswith('#'):
                                 description = line[:80]
                                 break
+                    aliases = _extract_frontmatter_aliases(frontmatter, name)
                     seen_names.add(name)
                     # Normalize to hyphen-separated slug, stripping
                     # non-alnum chars (e.g. +, /) to avoid invalid
@@ -252,6 +331,10 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
+                        "aliases": aliases,
+                        "aliases_normalized": [
+                            _normalize_text_skill_alias(alias) for alias in aliases
+                        ],
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
                     }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2918,6 +2918,51 @@ class GatewayRunner:
                         )
             except Exception as e:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
+
+        if not command:
+            try:
+                from agent.skill_commands import (
+                    build_skill_invocation_message,
+                    get_skill_commands,
+                    parse_text_skill_invocation,
+                    resolve_text_skill_invocation,
+                )
+
+                parsed_skill = parse_text_skill_invocation(event.text)
+                if parsed_skill is not None:
+                    alias = parsed_skill.get("alias", "")
+                    if not alias:
+                        return (
+                            "Skill activation needs a skill name after the prefix. "
+                            "Example: `skill weather Moscow` or `скилл погода Москва`."
+                        )
+
+                    resolved = resolve_text_skill_invocation(event.text)
+                    if resolved is None:
+                        return (
+                            f"Unknown skill alias `{alias}`. "
+                            f"Try /commands or /skills to see available skills."
+                        )
+
+                    cmd_key, user_instruction = resolved
+                    skill_cmds = get_skill_commands()
+                    _skill_name = skill_cmds.get(cmd_key, {}).get("name", "")
+                    _plat = source.platform.value if source.platform else None
+                    if _plat and _skill_name:
+                        from agent.skill_utils import get_disabled_skill_names as _get_plat_disabled
+                        if _skill_name in _get_plat_disabled(platform=_plat):
+                            return (
+                                f"The **{_skill_name}** skill is disabled for {_plat}.\n"
+                                f"Enable it with: `hermes skills config`"
+                            )
+
+                    msg = build_skill_invocation_message(
+                        cmd_key, user_instruction, task_id=_quick_key
+                    )
+                    if msg:
+                        event.text = msg
+            except Exception as e:
+                logger.debug("Text skill activation check failed (non-fatal): %s", e)
         
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -10,7 +10,9 @@ from agent.skill_commands import (
     build_plan_path,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    parse_text_skill_invocation,
     resolve_skill_command_key,
+    resolve_text_skill_invocation,
     scan_skill_commands,
 )
 
@@ -143,6 +145,59 @@ class TestScanSkillCommands:
             result = scan_skill_commands()
         assert "/sonarr-v3v4-api" in result
         assert any("/" in k[1:] for k in result) is False  # no unescaped /
+
+
+class TestTextSkillAliases:
+    def test_scan_registers_top_level_aliases(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "weather",
+                frontmatter_extra="""aliases:
+  - погода
+  - forecast
+""",
+            )
+            result = scan_skill_commands()
+
+        assert result["/weather"]["aliases"] == ["weather", "погода", "forecast"]
+        assert "погода" in result["/weather"]["aliases_normalized"]
+
+    def test_parse_text_skill_invocation_english(self):
+        parsed = parse_text_skill_invocation("skill weather Moscow")
+        assert parsed is not None
+        assert parsed["alias"] == "weather"
+        assert parsed["user_instruction"] == "Moscow"
+
+    def test_parse_text_skill_invocation_russian(self):
+        parsed = parse_text_skill_invocation("скилл погода Москва")
+        assert parsed is not None
+        assert parsed["alias"] == "погода"
+        assert parsed["user_instruction"] == "Москва"
+
+    def test_parse_text_skill_invocation_requires_prefix(self):
+        assert parse_text_skill_invocation("weather Moscow") is None
+
+    def test_resolve_text_skill_invocation_matches_alias(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "weather",
+                frontmatter_extra="""aliases:
+  - погода
+""",
+            )
+            scan_skill_commands()
+            assert resolve_text_skill_invocation("скилл погода Москва") == (
+                "/weather",
+                "Москва",
+            )
+
+    def test_resolve_text_skill_invocation_returns_none_for_unknown_alias(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "weather")
+            scan_skill_commands()
+            assert resolve_text_skill_invocation("skill forecast Tokyo") is None
 
 
 class TestResolveSkillCommandKey:

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -164,3 +164,68 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
     # Whatever /reload_mcp returns, it must not be the unknown-command guard.
     if result is not None:
         assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+async def test_text_skill_alias_invokes_skill_pipeline(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": []})
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {
+            "/weather": {
+                "name": "weather",
+                "aliases": ["weather", "погода"],
+                "aliases_normalized": ["weather", "погода"],
+                "skill_dir": "/tmp/weather",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.build_skill_invocation_message",
+        lambda cmd_key, user_instruction, task_id=None: f"SKILL:{cmd_key}:{user_instruction}",
+    )
+
+    result = await runner._handle_message(_make_event("скилл погода Москва"))
+
+    assert result == "ok"
+    runner._run_agent.assert_called_once()
+    assert runner._run_agent.call_args.kwargs["message"] == "SKILL:/weather:Москва"
+
+
+@pytest.mark.asyncio
+async def test_text_skill_alias_unknown_returns_guidance(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("unknown text skill alias leaked through to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {
+            "/weather": {
+                "name": "weather",
+                "aliases": ["weather"],
+                "aliases_normalized": ["weather"],
+                "skill_dir": "/tmp/weather",
+            }
+        },
+    )
+
+    result = await runner._handle_message(_make_event("skill forecast Tokyo"))
+
+    assert result is not None
+    assert "Unknown skill alias" in result
+    assert "forecast" in result
+    runner._run_agent.assert_not_called()


### PR DESCRIPTION
## Summary
- add top-level `aliases` support for skills in `SKILL.md`
- support explicit text/voice-friendly activation via `skill ...`, `скилл ...`, and `скил ...`
- route explicit text activations through the existing skill invocation pipeline
- add tests for alias parsing, resolution, and gateway routing

## Test Plan
- source /root/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/agent/test_skill_commands.py tests/gateway/test_unknown_command.py -q
- manual smoke check: `resolve_text_skill_invocation("скилл погода Москва")`

## Notes
- PR branch has now been refreshed onto current upstream `main` and force-pushed to keep the diff focused and CI-compatible.
- Local-only `~/.hermes/skills/coding/SKILL.md` aliases used for live gateway testing are intentionally not included in this PR.
