### PR TITLE
fix(auxiliary): add missing copilot/github provider aliases

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -72,6 +72,9 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "github": "copilot",
+    "github-copilot": "copilot",
+    "github-models": "copilot",
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `"github"`, `"github-copilot"`, and `"github-models"` to the `_PROVIDER_ALIASES` map in `agent/auxiliary_client.py`
- These aliases already exist in `hermes_cli/auth.py` but were missing from the auxiliary client's normalization, causing repeated `unknown provider 'github-copilot'` warnings

## Root cause

`models_dev.py` maps `"copilot"` → `"github-copilot"` (the models.dev canonical ID). When this ID flows back into `auxiliary_client.resolve_provider_client()`, the alias table didn't have the reverse mapping, so `PROVIDER_REGISTRY.get("github-copilot")` returned `None`.

## Test plan

- [x] Verify `_normalize_aux_provider("github-copilot")` returns `"copilot"`
- [x] Verify `_normalize_aux_provider("github")` returns `"copilot"`
- [x] Verify `_normalize_aux_provider("github-models")` returns `"copilot"`
- [x] No `unknown provider 'github-copilot'` warnings in gateway logs after restart