### PR TITLE
fix(skills): invalidate LRU cache when skill files are deleted

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -439,8 +440,17 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
-    """Load the disk snapshot if it exists and its manifest still matches."""
+def _load_skills_snapshot(
+    skills_dir: Path,
+    manifest: dict[str, list[int]] | None = None,
+) -> Optional[dict]:
+    """Load the disk snapshot if it exists and its manifest still matches.
+
+    Args:
+        skills_dir: The local skills directory.
+        manifest: Pre-computed manifest to avoid redundant filesystem walks.
+            When *None*, builds the manifest from scratch.
+    """
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
         return None
@@ -452,7 +462,9 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    if manifest is None:
+        manifest = _build_skills_manifest(skills_dir)
+    if snapshot.get("manifest") != manifest:
         return None
     return snapshot
 
@@ -587,18 +599,26 @@ def build_skills_system_prompt(
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
+    # The manifest fingerprint ensures file additions/deletions/edits
+    # automatically invalidate the cache (fixes phantom skill entries
+    # when files are deleted outside the skill manager).
     from gateway.session_context import get_session_env
     _platform_hint = (
         os.environ.get("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
+    manifest = _build_skills_manifest(skills_dir)
+    manifest_fingerprint = hashlib.md5(
+        json.dumps(manifest, sort_keys=True).encode()
+    ).hexdigest()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        manifest_fingerprint,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -609,7 +629,7 @@ def build_skills_system_prompt(
     disabled = get_disabled_skill_names()
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, manifest=manifest)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -678,7 +698,7 @@ def build_skills_system_prompt(
 
         _write_skills_snapshot(
             skills_dir,
-            _build_skills_manifest(skills_dir),
+            manifest,
             skill_entries,
             category_descriptions,
         )

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -354,6 +354,45 @@ class TestBuildSkillsSystemPrompt:
         assert "web-search" in result
         assert "old-tool" not in result
 
+    def test_deleted_skill_not_in_subsequent_calls(self, monkeypatch, tmp_path):
+        """Skills deleted after the first call must not appear in subsequent calls.
+
+        Regression test for phantom skill entries (#8845): when files were
+        deleted outside the skill manager, the in-process LRU cache would
+        keep serving stale entries because the cache key did not include a
+        filesystem fingerprint.
+        """
+        import shutil
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+
+        # Create two skills
+        keeper = skills_dir / "keeper"
+        keeper.mkdir()
+        (keeper / "SKILL.md").write_text(
+            "---\nname: keeper\ndescription: Stays around\n---\n"
+        )
+
+        phantom = skills_dir / "phantom"
+        phantom.mkdir()
+        (phantom / "SKILL.md").write_text(
+            "---\nname: phantom\ndescription: Will be deleted\n---\n"
+        )
+
+        # First call populates caches
+        result1 = build_skills_system_prompt()
+        assert "keeper" in result1
+        assert "phantom" in result1
+
+        # Delete the phantom skill (simulates manual pruning)
+        shutil.rmtree(phantom)
+
+        # Second call must NOT return the phantom skill
+        result2 = build_skills_system_prompt()
+        assert "keeper" in result2
+        assert "phantom" not in result2
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)


### PR DESCRIPTION
## Problem

The skill availability list injected into the system prompt can include phantom entries — skills whose `SKILL.md` files no longer exist on disk. When the agent tries to load one of these phantom skills, it gets a file-not-found error.

This happens because the in-process LRU cache key for `build_skills_system_prompt()` did not include any filesystem state. Once a skill appeared in the cache, it stayed there for the process lifetime regardless of file deletions.

The most common trigger is manual pruning after `hermes claw migrate` — skills are deleted from `$HERMES_HOME/skills/openclaw-imports/` but the cached prompt still lists them.

## Root Cause

The LRU cache key was based on:
- skills directory path
- external directories
- available tools/toolsets
- platform hint

...but **not** the actual filesystem state. When files were deleted outside the skill manager (which calls `clear_skills_system_prompt_cache()`), the cache was never invalidated.

## Fix

Include a lightweight MD5 fingerprint of the skills-directory manifest (file paths + mtime + size) in the cache key. This ensures any file addition, deletion, or modification automatically invalidates the cache.

Also reuses the pre-computed manifest across the cache key, snapshot validation, and snapshot write path — eliminating 1-2 redundant filesystem walks per call when the cache misses.

## Testing

Added regression test `test_deleted_skill_not_in_subsequent_calls` that:
1. Creates two skills and calls `build_skills_system_prompt()` (populates cache)
2. Deletes one skill from disk
3. Calls `build_skills_system_prompt()` again
4. Asserts the deleted skill does **not** appear in the result

Closes #8845