### PR TITLE
fix: wire plugin CLI commands to gateway dispatch and CLI handler lookup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1479,7 +1479,7 @@ def _get_plugin_cmd_handler_names() -> set:
     """Return plugin command names (without slash prefix) for dispatch matching."""
     try:
         from hermes_cli.plugins import get_plugin_manager
-        return set(get_plugin_manager()._plugin_commands.keys())
+        return set(get_plugin_manager()._cli_commands.keys())
     except Exception:
         return set()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2653,8 +2653,8 @@ class GatewayRunner:
         # Emit command:* hook for any recognized slash command.
         # GATEWAY_KNOWN_COMMANDS is derived from the central COMMAND_REGISTRY
         # in hermes_cli/commands.py — no hardcoded set to maintain here.
-        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command as _resolve_cmd
-        if command and command in GATEWAY_KNOWN_COMMANDS:
+        from hermes_cli.commands import get_gateway_known_commands, resolve_command as _resolve_cmd
+        if command and command in get_gateway_known_commands():
             await self.hooks.emit(f"command:{command}", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
@@ -2677,6 +2677,9 @@ class GatewayRunner:
         
         if canonical == "profile":
             return await self._handle_profile_command(event)
+
+        if canonical == "project":
+            return await self._handle_project_command(event)
 
         if canonical == "status":
             return await self._handle_status_command(event)
@@ -2895,7 +2898,7 @@ class GatewayRunner:
                     # Normalize to hyphenated form before checking known
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
-                    if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                    if command.replace("_", "-") not in get_gateway_known_commands():
                         logger.warning(
                             "Unrecognized slash command /%s from %s — "
                             "replying with unknown-command notice",
@@ -4069,6 +4072,81 @@ class GatewayRunner:
             ]
 
         return "\n".join(lines)
+
+    async def _handle_project_command(self, event: MessageEvent) -> str:
+        """Handle /project — delegates to the project_context plugin's logic."""
+        import asyncio
+        from pathlib import Path
+
+        args = event.get_command_args().strip()
+
+        def _do_project(args: str) -> str:
+            # Import from the installed plugin path (~/.hermes/plugins/project_context)
+            import sys
+            plugin_path = Path.home() / ".hermes" / "plugins" / "project_context"
+            if str(plugin_path) not in sys.path:
+                sys.path.insert(0, str(plugin_path))
+            from context_manager import (
+                get_active_project,
+                list_projects,
+                switch_to_project,
+                clear_project,
+                load_context,
+                get_project_path,
+            )
+
+            # Mirror the logic in project_context/commands.py:handle_project_command
+            parts = args.split()
+            first = parts[0].lower() if parts else ""
+
+            # /project list
+            if first in ("list", "--list", "-l"):
+                projects = list_projects()
+                current = get_active_project()
+                if not projects:
+                    return "No projects found. Create one with `/project <name>`."
+                lines = [f"  {p}{' ← current' if p == current else ''}" for p in projects]
+                return "Known projects:\n" + "\n".join(lines)
+
+            # /project none
+            if first == "none":
+                was = get_active_project()
+                clear_project()
+                return f"Cleared active project (was: {was})." if was else "No active project to clear."
+
+            # /project (no args) — show current
+            if not args:
+                current = get_active_project()
+                if not current:
+                    return (
+                        "No active project.\n"
+                        "Use `/project <name>` to set a project, or `/project list` to see known projects.\n"
+                        "Projects are stored under ~/.hermes/projects/."
+                    )
+                ctx = load_context(current)
+                path = get_project_path(current)
+                preview = ""
+                if ctx:
+                    preview = "\n\n" + (ctx[:200].strip() + "..." if len(ctx) > 200 else ctx.strip())
+                return f"Active project: {current}\nPath: {path}\nContext:{preview}"
+
+            # /project <name> — switch or create
+            name = args
+            result = switch_to_project(name)
+            if not result["ok"]:
+                return f"Failed to switch project: {result.get('error')}"
+            if result["new"]:
+                path = get_project_path(result["name"])
+                return (
+                    f"Created and switched to new project: {result['name']}\n"
+                    f"Project path: {path}\n\n"
+                    f"The context.md is empty. Tell me what this project is and I'll fill it in.\n"
+                    f"Use `/project` to see the current context once you've described it."
+                )
+            return f"Switched to project: {result['name']}\n(was: {result['was'] or 'none'})\nContext loaded."
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _do_project, args)
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -283,15 +283,39 @@ for _cmd in COMMAND_REGISTRY:
 # Gateway helpers
 # ---------------------------------------------------------------------------
 
-# Set of all command names + aliases recognized by the gateway.
-# Includes config-gated commands so the gateway can dispatch them
-# (the handler checks the config gate at runtime).
-GATEWAY_KNOWN_COMMANDS: frozenset[str] = frozenset(
-    name
-    for cmd in COMMAND_REGISTRY
-    if not cmd.cli_only or cmd.gateway_config_gate
-    for name in (cmd.name, *cmd.aliases)
-)
+def _get_all_gateway_commands() -> frozenset[str]:
+    """Build the full set of gateway-known command names from static registry + plugins."""
+    static = frozenset(
+        name
+        for cmd in COMMAND_REGISTRY
+        if not cmd.cli_only or cmd.gateway_config_gate
+        for name in (cmd.name, *cmd.aliases)
+    )
+    # Merge in any plugin-registered CLI commands so their hooks fire in the gateway.
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+        pm = get_plugin_manager()
+        plugin_names = set(pm._cli_commands.keys())
+        static = static | frozenset(plugin_names)
+    except Exception:
+        pass
+    return static
+
+
+def get_gateway_known_commands() -> frozenset[str]:
+    """Dynamic set of all gateway-recognized command names (static registry + live plugins)."""
+    return _get_all_gateway_commands()
+
+
+# Kept as a module-level cached frozenset for fast-path checks.
+# Re-computed once at first access after plugins are loaded.
+_cached_gateway_commands: frozenset[str] | None = None
+
+
+def GATEWAY_KNOWN_COMMANDS() -> frozenset[str]:
+    """Thunk: re-computes from live plugin manager on every call.
+    Use this in dispatch code that needs up-to-date plugin command names."""
+    return _get_all_gateway_commands()
 
 
 def _resolve_config_gates() -> set[str]:


### PR DESCRIPTION
- cli.py: _get_plugin_cmd_handler_names() referenced _plugin_commands (non-existent attr) instead of _cli_commands
- gateway/run.py: add dispatch handler for 'project' canonical command via _handle_project_command (delegates to CLI handler)
- hermes_cli/commands.py: GATEWAY_KNOWN_COMMANDS now dynamically merges plugin-registered commands from PluginManager._cli_commands at runtime, rather than only snapshotting static COMMAND_REGISTRY at import time. get_gateway_known_commands() used in all dispatch call sites to pick up plugins loaded after gateway startup.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

