### PR TITLE
feat(feishu): add Interactive Card sending support via send_message tool

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1346,10 +1346,53 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a Feishu message."""
+        """Send a Feishu message.
+
+        Supports sending Interactive Cards via metadata:
+            metadata={"interactive_card": {...card JSON...}}
+        When present, the card is sent as msg_type="interactive" and the
+        text *content* is sent as a separate follow-up message (if non-empty).
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # --- Interactive Card fast path ---
+        interactive_card = (metadata or {}).get("interactive_card")
+        if interactive_card is not None:
+            try:
+                card_payload = json.dumps(interactive_card, ensure_ascii=False)
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="interactive",
+                    payload=card_payload,
+                    reply_to=reply_to,
+                    metadata=None,
+                )
+                # Send text content as a follow-up message if present
+                text = (content or "").strip()
+                if text:
+                    formatted = self.format_message(text)
+                    chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                    last_response = response
+                    for chunk in chunks:
+                        msg_type, payload = self._build_outbound_payload(chunk)
+                        try:
+                            last_response = await self._feishu_send_with_retry(
+                                chat_id=chat_id,
+                                msg_type=msg_type,
+                                payload=payload,
+                                reply_to=None,
+                                metadata=None,
+                            )
+                        except Exception:
+                            pass  # best-effort follow-up
+                    return self._finalize_send_result(last_response, "send failed")
+                return self._finalize_send_result(response, "send failed")
+            except Exception as exc:
+                logger.error("[Feishu] Interactive card send error: %s", exc, exc_info=True)
+                return SendResult(success=False, error=str(exc))
+
+        # --- Standard text/post path ---
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -133,6 +133,7 @@ class TestSendMessageTool:
             "hello",
             thread_id=None,
             media_files=[],
+            interactive_card=None,
         )
         mirror_mock.assert_called_once_with("telegram", "-1002", "hello", source_label="cli", thread_id=None)
 
@@ -172,6 +173,7 @@ class TestSendMessageTool:
             "hello",
             thread_id="99999",
             media_files=[],
+            interactive_card=None,
         )
         mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="99999")
 
@@ -201,6 +203,7 @@ class TestSendMessageTool:
             "hello",
             thread_id="17585",
             media_files=[],
+            interactive_card=None,
         )
         mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="17585")
 
@@ -231,6 +234,7 @@ class TestSendMessageTool:
             "hello",
             thread_id="17585",
             media_files=[],
+            interactive_card=None,
         )
 
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
@@ -269,6 +273,7 @@ class TestSendMessageTool:
             "hello",
             thread_id="17585",
             media_files=[],
+            interactive_card=None,
         )
 
     def test_media_only_message_uses_placeholder_for_mirroring(self):
@@ -297,6 +302,7 @@ class TestSendMessageTool:
             "",
             thread_id=None,
             media_files=[("/tmp/example.ogg", False)],
+            interactive_card=None,
         )
         mirror_mock.assert_called_once_with(
             "telegram",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -73,6 +73,10 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send"
+            },
+            "interactive_card": {
+                "type": "object",
+                "description": "Optional Interactive Card JSON (Feishu/Lark only). When provided on a feishu target, sends the card via msg_type='interactive' instead of text/post. The card JSON follows the Feishu Open Message Card schema. Ignored on non-Feishu platforms."
             }
         },
         "required": []
@@ -139,6 +143,8 @@ def _handle_send(args):
     if is_interrupted():
         return tool_error("Interrupted")
 
+    interactive_card = args.get("interactive_card")
+
     try:
         from gateway.config import load_gateway_config, Platform
         config = load_gateway_config()
@@ -204,6 +210,7 @@ def _handle_send(args):
                 cleaned_message,
                 thread_id=thread_id,
                 media_files=media_files,
+                interactive_card=interactive_card,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -314,7 +321,7 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, interactive_card=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -421,7 +428,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id, interactive_card=interactive_card)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:
@@ -968,7 +975,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         return _error(f"BlueBubbles send failed: {e}")
 
 
-async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
+async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None, interactive_card=None):
     """Send via Feishu/Lark using the adapter's send pipeline."""
     try:
         from gateway.platforms.feishu import FeishuAdapter, FEISHU_AVAILABLE
@@ -985,10 +992,14 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+        metadata = {"thread_id": thread_id} if thread_id else {}
+        if interactive_card is not None:
+            metadata["interactive_card"] = interactive_card
+        if not metadata:
+            metadata = None
 
         last_result = None
-        if message.strip():
+        if message.strip() or interactive_card is not None:
             last_result = await adapter.send(chat_id, message, metadata=metadata)
             if not last_result.success:
                 return _error(f"Feishu send failed: {last_result.error}")


### PR DESCRIPTION
## Summary

Adds the ability to send Feishu/Lark Interactive Cards (msg_type=`interactive`) through the `send_message` tool, enabling agents to use buttons, forms, and other interactive UI elements in Feishu conversations.

## Changes

### `gateway/platforms/feishu.py`
- **`FeishuAdapter.send()`**: Added **Interactive Card fast path** — when `metadata` contains `"interactive_card"` key (dict/list), the card JSON is sent directly via `msg_type="interactive"`, bypassing the text/post `_build_outbound_payload()` logic. Text `content` is sent as a best-effort follow-up message if non-empty.

### `tools/send_message_tool.py`
- **Schema**: Added optional `interactive_card` parameter (type: object, Feishu/Lark only)
- **`_handle_send()`**: Extracts `interactive_card` from args, passes to `_send_to_platform()`
- **`_send_to_platform()`**: Added `interactive_card` kwarg, forwarded to `_send_feishu()`
- **`_send_feishu()`**: Injects `interactive_card` into metadata dict, triggers `adapter.send()` even when message text is empty (card-only mode)

### `tests/tools/test_send_message_tool.py`
- Updated mock assertions to include new `interactive_card=None` parameter

## Architecture

```
Agent calls send_message(interactive_card={...})
  → send_message_tool → _send_feishu(pconfig, chat_id, msg, interactive_card={...})
    → adapter.send(chat_id, msg, metadata={"interactive_card": {...}})
      → detects metadata["interactive_card"]
      → _feishu_send_with_retry(msg_type="interactive", payload=card_json)
```

**Bottom layers already supported this** — `_feishu_send_with_retry()` and `_send_raw_message()` accept any `msg_type` including `"interactive"`. Only the top-level `_build_outbound_payload()` was blocking it by only producing `text`/`post`.

**Card callbacks already work** — `_handle_card_action_event()` converts button clicks to `/card` synthetic commands that route back to the agent.

## Use Case

PDCA project management, interactive surveys, approval workflows — any scenario where the agent needs to collect structured input from Feishu users via buttons/forms instead of free-text.

## Tests

- 37/37 send_message_tool tests pass
- 142/142 feishu adapter tests pass (1 pre-existing failure unrelated to this PR — `register_p2_im_chat_member_bot_added_v1` SDK version issue)