### PR TITLE
fix(gateway): keep venv python symlink unresolved in systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -768,14 +768,22 @@ def _remap_path_for_user(path: str, target_home_dir: str) -> str:
 
       /root/.hermes/hermes-agent  -> /home/alice/.hermes/hermes-agent
       /opt/hermes                 -> /opt/hermes  (kept as-is)
+
+    Note: this function intentionally does NOT resolve symlinks. A venv's
+    ``bin/python`` is typically a symlink to the base interpreter (e.g. a
+    uv-managed CPython at ``~/.local/share/uv/python/.../python3.11``);
+    resolving that symlink swaps the unit's ``ExecStart`` to a bare Python
+    that has none of the venv's site-packages, so the service crashes on
+    the first ``import``. Keep the symlinked path so the venv activates
+    its own environment. Lexical expansion only via ``expanduser``.
     """
-    current_home = Path.home().resolve()
-    resolved = Path(path).resolve()
+    current_home = Path.home()
+    p = Path(path).expanduser()
     try:
-        relative = resolved.relative_to(current_home)
+        relative = p.relative_to(current_home)
         return str(Path(target_home_dir) / relative)
     except ValueError:
-        return str(resolved)
+        return str(p)
 
 
 def _hermes_home_for_target_user(target_home_dir: str) -> str:


### PR DESCRIPTION
## Summary

Salvage of #7735 by @akhater onto current main.

`_remap_path_for_user()` called `.resolve()` on the Python path when generating systemd units via `hermes gateway install --system`. On uv-managed venvs (where `venv/bin/python` symlinks into `~/.local/share/uv/python/...`), this swapped the unit's `ExecStart` to the bare base interpreter — no site-packages, crashes with `ModuleNotFoundError: yaml` on first import, loops on `Restart=on-failure`.

Fix: drop `.resolve()`, use `.expanduser()` for lexical `~` expansion only. The function's purpose is purely lexical home-prefix substitution, not symlink resolution.

Only affects the `--system` code path (cross-user install). User-level services are unaffected.

## Test plan
- 70/70 gateway service tests pass
- Existing `TestRemapPathForUser` + `TestSystemUnitPathRemapping` tests cover the core behavior