### PR TITLE
feat: support provider "none" to disable auxiliary routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -77,6 +77,8 @@ _PROVIDER_ALIASES = {
 
 def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False) -> str:
     normalized = (provider or "auto").strip().lower()
+    if normalized == "none":
+        return "none"
     if normalized.startswith("custom:"):
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
@@ -1298,6 +1300,7 @@ def resolve_provider_client(
         provider: Provider identifier.  One of:
             "openrouter", "nous", "openai-codex" (or "codex"),
             "zai", "kimi-coding", "minimax", "minimax-cn",
+            "none" (disable auxiliary routing for this call),
             "custom" (OPENAI_BASE_URL + OPENAI_API_KEY),
             "auto" (full auto-detection chain).
         model: Model slug override.  If None, uses the provider's default
@@ -1319,6 +1322,9 @@ def resolve_provider_client(
     """
     # Normalise aliases
     provider = _normalize_aux_provider(provider)
+    if provider == "none":
+        logger.debug("resolve_provider_client: auxiliary routing disabled")
+        return None, None
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:
         """Decide if a plain OpenAI client should be wrapped for Responses API.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -428,12 +428,13 @@ DEFAULT_CONFIG = {
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
+    # "none" for provider = disable auxiliary routing for that task.
     # Empty model = use provider's default auxiliary model.
     # All tasks fall back to openrouter:google/gemini-3-flash-preview if
     # the configured provider is unavailable.
     "auxiliary": {
         "vision": {
-            "provider": "auto",    # auto | openrouter | nous | codex | custom
+            "provider": "auto",    # auto | none | openrouter | nous | codex | custom
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)


### PR DESCRIPTION
## Summary

Add `"none"` as a recognized auxiliary provider value that cleanly short-circuits `resolve_provider_client()` with `(None, None)`, allowing users to disable individual auxiliary tasks (vision, compression, etc.) via `config.yaml` without side effects.

## Changes

- **`agent/auxiliary_client.py`**: Handle `"none"` in `_normalize_aux_provider()` (early return) and `resolve_provider_client()` (short-circuit before any auth resolution).
- **`hermes_cli/config.py`**: Document `"none"` as a valid provider option in the auxiliary config defaults and inline comment.

## Testing

All 47 fallback-related tests pass (`test_fallback_model.py`, `test_provider_fallback.py`, `TestFallbackSetsOAuthFlag`, `TestFallbackAnthropicProvider`, `test_compressor_fallback_update.py`).