### PR TITLE
feat(api_server): make max concurrent runs configurable via env var

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1506,7 +1506,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # /v1/runs — structured event streaming
     # ------------------------------------------------------------------
 
-    _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
+    _MAX_CONCURRENT_RUNS = int(os.getenv("API_SERVER_MAX_CONCURRENT_RUNS", "30"))
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):


### PR DESCRIPTION
## Summary

The `/v1/runs` endpoint currently has a hardcoded limit of 10 concurrent runs (`_MAX_CONCURRENT_RUNS = 10`), which is insufficient for deployments managing 20+ devices/sessions simultaneously.

This PR makes the limit configurable via the `API_SERVER_MAX_CONCURRENT_RUNS` environment variable, following the same `os.getenv()` pattern used by other API server settings (`API_SERVER_HOST`, `API_SERVER_PORT`, `API_SERVER_KEY`, etc.).

- **Default**: 30 (increased from 10)
- **Configurable**: `API_SERVER_MAX_CONCURRENT_RUNS=50` in `.env` or environment

## Changes

- `gateway/platforms/api_server.py`: Replace hardcoded `_MAX_CONCURRENT_RUNS = 10` with `int(os.getenv("API_SERVER_MAX_CONCURRENT_RUNS", "30"))`

## Motivation

We use the Hermes API server to orchestrate mobile device automation across 20+ concurrent devices. The hardcoded limit of 10 forces users to modify source code for legitimate high-concurrency deployments.