### PR TITLE
fix(agent): propagate api_mode to vision provider resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -75,13 +75,13 @@ _PROVIDER_ALIASES = {
 }
 
 
-def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False) -> str:
+def _normalize_aux_provider(provider: Optional[str]) -> str:
     normalized = (provider or "auto").strip().lower()
     if normalized.startswith("custom:"):
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
             return "custom"
-        normalized = suffix if not for_vision else "custom"
+        normalized = suffix
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":
@@ -1631,7 +1631,7 @@ _VISION_AUTO_PROVIDER_ORDER = (
 
 
 def _normalize_vision_provider(provider: Optional[str]) -> str:
-    return _normalize_aux_provider(provider, for_vision=True)
+    return _normalize_aux_provider(provider)
 
 
 def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -1714,6 +1714,7 @@ def resolve_vision_provider_client(
             async_mode=async_mode,
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
         )
         if client is None:
             return "custom", None, None
@@ -1738,7 +1739,8 @@ def resolve_vision_provider_client(
                 # Use provider-specific vision model if available, otherwise main model.
                 vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
                 rpc_client, rpc_model = resolve_provider_client(
-                    main_provider, vision_model)
+                    main_provider, vision_model,
+                    api_mode=resolved_api_mode)
                 if rpc_client is not None:
                     logger.info(
                         "Vision auto-detect: using active provider %s (%s)",
@@ -1762,7 +1764,8 @@ def resolve_vision_provider_client(
         sync_client, default_model = _resolve_strict_vision_backend(requested)
         return _finalize(requested, sync_client, default_model)
 
-    client, final_model = _get_cached_client(requested, resolved_model, async_mode)
+    client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+                                             api_mode=resolved_api_mode)
     if client is None:
         return requested, None, None
     return requested, client, final_model

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -69,6 +69,10 @@ class TestNormalizeVisionProvider:
         assert _normalize_vision_provider("beans") == "beans"
         assert _normalize_vision_provider("deepseek") == "deepseek"
 
+    def test_custom_colon_named_provider_preserved(self):
+        from agent.auxiliary_client import _normalize_vision_provider
+        assert _normalize_vision_provider("custom:beans") == "beans"
+
     def test_codex_alias_still_works(self):
         from agent.auxiliary_client import _normalize_vision_provider
         assert _normalize_vision_provider("codex") == "openai-codex"
@@ -240,3 +244,22 @@ class TestResolveVisionProviderClientModelNormalization:
         assert provider == "zai"
         assert client is not None
         assert model == "glm-5.1"
+
+
+class TestVisionPathApiMode:
+    """Vision path should propagate api_mode to _get_cached_client."""
+
+    def test_explicit_provider_passes_api_mode(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "auxiliary": {"vision": {"api_mode": "chat_completions"}},
+        })
+        with patch("agent.auxiliary_client._get_cached_client") as mock_gcc:
+            mock_gcc.return_value = (MagicMock(), "test-model")
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client(provider="deepseek")
+
+        mock_gcc.assert_called_once()
+        _, kwargs = mock_gcc.call_args
+        assert kwargs.get("api_mode") == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

`resolve_vision_provider_client()` in `agent/auxiliary_client.py` resolves `api_mode` from config via `_resolve_task_provider_model("vision", ...)` but **never passes it downstream** to `resolve_provider_client()` or `_get_cached_client()`. This causes `vision_analyze` and `browser_vision` to crash when the provider uses a non-default API mode (e.g., `api_mode: anthropic_messages` for a custom corporate Anthropic proxy).

Additionally, `_normalize_aux_provider()` had a `for_vision` branch that incorrectly stripped named custom provider identity (e.g., `custom:corp-anthropic` → `custom`) for vision tasks only.

## Related Issue

Fixes #8857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Two independent bugs combine:

1. **`api_mode` not propagated**: The variable `resolved_api_mode` is computed at line 1696 but never passed to any of the three downstream call sites. Compare with the non-vision path in `call_llm()` which correctly passes `api_mode=resolved_api_mode`. Fixed by adding `api_mode=resolved_api_mode` to all three downstream calls.

2. **Named custom provider lost for vision**: `_normalize_aux_provider(for_vision=True)` returned `"custom"` instead of the named suffix, losing provider identity needed for config lookup. Fixed by removing the `for_vision` special case — named custom providers are now preserved for all tasks.

3. **Dead code cleanup**: Removed the now-unused `for_vision` parameter from `_normalize_aux_provider()`.

4. **Tests**: Added 2 targeted tests — named custom provider preservation + api_mode forwarding verification.

## How to Test

1. Configure a custom provider with `api_mode: anthropic_messages`:
   ```yaml
   model:
     default: claude-opus-4-6
     provider: custom:corp-anthropic
   custom_providers:
     - name: corp-anthropic
       base_url: https://my-proxy.example.com/anthropic
       api_mode: anthropic_messages
   ```
2. Send an image to the agent — `vision_analyze` should work without crashing
3. Run the test suite: `pytest tests/agent/test_auxiliary_named_custom_providers.py -v` — all 19 tests pass
4. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e` — passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A