### PR TITLE
fix(copilot): resolve GHE token poisoning when GITHUB_TOKEN is set

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -127,6 +127,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
         api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        base_url_env_var="COPILOT_API_BASE_URL",
     ),
     "copilot-acp": ProviderConfig(
         id="copilot-acp",

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -117,14 +117,30 @@ def _gh_cli_candidates() -> list[str]:
 
 
 def _try_gh_cli_token() -> Optional[str]:
-    """Return a token from ``gh auth token`` when the GitHub CLI is available."""
+    """Return a token from ``gh auth token`` when the GitHub CLI is available.
+
+    When COPILOT_GH_HOST is set, passes ``--hostname`` so gh returns the
+    correct host's token.  Also strips GITHUB_TOKEN / GH_TOKEN from the
+    subprocess environment so ``gh`` reads from its own credential store
+    (hosts.yml) instead of just echoing the env var back.
+    """
+    hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+
+    # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
+    clean_env = {k: v for k, v in os.environ.items()
+                 if k not in ("GITHUB_TOKEN", "GH_TOKEN")}
+
     for gh_path in _gh_cli_candidates():
+        cmd = [gh_path, "auth", "token"]
+        if hostname:
+            cmd += ["--hostname", hostname]
         try:
             result = subprocess.run(
-                [gh_path, "auth", "token"],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=clean_env,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)


### PR DESCRIPTION
## Problem

When `GITHUB_TOKEN` is present in the environment (e.g. for `gh` CLI, GitHub Actions, or general repo access), Copilot authentication against **GitHub Enterprise (GHE)** instances breaks in two ways:

### 1. Wrong endpoint
The `copilot` ProviderConfig had no `base_url_env_var`, so `COPILOT_API_BASE_URL` was silently ignored — all inference requests were routed to the public `api.githubcopilot.com` endpoint regardless of user configuration.

### 2. Wrong token (env var poisoning)
`gh auth token` (the CLI fallback in the credential search chain) treats `GITHUB_TOKEN` in the environment as an override and **echoes it back** instead of reading from its own credential store (`hosts.yml`). This meant:

1. `COPILOT_GITHUB_TOKEN` — not set (user uses device-code auth) → skip
2. `GH_TOKEN` — not set → skip
3. `GITHUB_TOKEN` — present but is a `ghp_` classic PAT → correctly rejected by `validate_copilot_token()` → skip
4. `gh auth token` fallback → returns the **same** `GITHUB_TOKEN` value from env → rejected again → **auth fails entirely**

Even though the user has a perfectly valid `gho_` OAuth token in `gh`'s hosts.yml from device-code login, it never gets used.

## Fix

### `hermes_cli/auth.py`
- Add `base_url_env_var="COPILOT_API_BASE_URL"` to the `copilot` ProviderConfig so GHE users can override the inference endpoint.

### `hermes_cli/copilot_auth.py`
- **Strip `GITHUB_TOKEN` and `GH_TOKEN`** from the subprocess environment when calling `gh auth token`, so `gh` reads from its own credential store (`hosts.yml`) instead of just echoing the env var back.
- **Pass `--hostname`** from `COPILOT_GH_HOST` env var when set, so `gh` returns the GHE-specific OAuth token instead of the default host token.

## Impact
This fixes Copilot provider usage for anyone who:
- Uses a GitHub Enterprise instance with Copilot
- Has `GITHUB_TOKEN` set in their environment for other purposes (very common)
- Authenticates Copilot via `gh auth login` device-code flow rather than explicit env var tokens

## Testing
Verified the fix resolves correctly:
```
$ GITHUB_TOKEN=ghp_fake COPILOT_GH_HOST=ghe.example.com python3 -c '
from hermes_cli.copilot_auth import resolve_copilot_token
token, source = resolve_copilot_token()
print(f"Source: {source}, Prefix: {token[:4]}")
'
# Before: ValueError (no valid token found)
# After:  Source: gh auth token, Prefix: gho_  (correct GHE OAuth token)
```