### PR TITLE
feat: Add StepFun provider support

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -70,6 +70,9 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "step-fun": "stepfun",
+    "stepplan": "stepfun-plan",
+    "step-plan": "stepfun-plan",
 }
 
 
@@ -104,6 +107,8 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "stepfun": "step-3.5-flash",
+    "stepfun-plan": "step-3.5-flash",
 }
 
 # Vision-specific model overrides for direct providers.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -37,6 +37,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "mimo", "xiaomi-mimo",
     "arcee-ai", "arceeai",
     "qwen-portal",
+    "stepfun", "stepfun-plan", "step-fun", "stepplan", "step-plan",
 })
 
 
@@ -126,6 +127,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,
+    # StepFun
+    "step-3.5": 262144,
     # MiniMax — official docs: 204,800 context for all models
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
     "minimax": 204800,
@@ -230,6 +233,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.x.ai": "xai",
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
+    "api.stepfun.com": "stepfun",
+    "api.stepfun.ai": "stepfun",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -163,6 +163,8 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "google": "google",
     "xai": "xai",
     "xiaomi": "xiaomi",
+    "stepfun": "stepfun",
+    "stepfun-plan": "stepfun",
     "nvidia": "nvidia",
     "groq": "groq",
     "mistral": "mistral",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -206,6 +206,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "stepfun": ProviderConfig(
+        id="stepfun",
+        name="StepFun",
+        auth_type="api_key",
+        inference_base_url="https://api.stepfun.com/v1",
+        api_key_env_vars=("STEPFUN_API_KEY",),
+        base_url_env_var="STEPFUN_BASE_URL",
+    ),
+    "stepfun-plan": ProviderConfig(
+        id="stepfun-plan",
+        name="StepFun Plan",
+        auth_type="api_key",
+        inference_base_url="https://api.stepfun.com/step_plan/v1",
+        api_key_env_vars=("STEPFUN_API_KEY",),
+        base_url_env_var="STEPFUN_PLAN_BASE_URL",
+    ),
     "deepseek": ProviderConfig(
         id="deepseek",
         name="DeepSeek",
@@ -919,6 +935,8 @@ def resolve_provider(
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
+        "step-fun": "stepfun", "step_fun": "stepfun",
+        "stepplan": "stepfun-plan", "step-plan": "stepfun-plan", "step_plan": "stepfun-plan",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         # Local server aliases — route through the generic custom provider

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1139,6 +1139,8 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
+    elif selected_provider == "stepfun":
+        _model_flow_stepfun(config, current_model)
     elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
@@ -2408,6 +2410,114 @@ def _model_flow_kimi(config, current_model=""):
         print(f"Default model set to: {selected} (via {endpoint_label})")
     else:
         print("No change.")
+
+
+def _model_flow_stepfun(config, current_model=""):
+    """StepFun model selection with endpoint mode and region routing.
+
+    Presents one provider entry that lets the user choose:
+    - Standard or Plan endpoint mode
+    - China (api.stepfun.com) or Global (api.stepfun.ai) region
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+
+    stepfun_urls = {
+        ("standard", "cn"): "https://api.stepfun.com/v1",
+        ("standard", "intl"): "https://api.stepfun.ai/v1",
+        ("plan", "cn"): "https://api.stepfun.com/step_plan/v1",
+        ("plan", "intl"): "https://api.stepfun.ai/step_plan/v1",
+    }
+
+    key_env = "STEPFUN_API_KEY"
+    existing_key = get_env_value(key_env) or os.getenv(key_env, "")
+    if not existing_key:
+        print("No StepFun API key configured.")
+        try:
+            import getpass
+            new_key = getpass.getpass(f"{key_env} (or Enter to cancel): ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if not new_key:
+            print("Cancelled.")
+            return
+        save_env_value(key_env, new_key)
+        existing_key = new_key
+        print("API key saved.")
+        print()
+    else:
+        print(f"  StepFun API key: {existing_key[:8]}... ✓")
+        print()
+
+    endpoint_choices = [
+        ("standard", "cn", "Standard — China       (api.stepfun.com/v1)"),
+        ("standard", "intl", "Standard — Global/Intl  (api.stepfun.ai/v1)"),
+        ("plan", "cn", "Plan — China            (api.stepfun.com/step_plan/v1)"),
+        ("plan", "intl", "Plan — Global/Intl      (api.stepfun.ai/step_plan/v1)"),
+    ]
+    print("  Select StepFun endpoint:")
+    for i, (_, _, label) in enumerate(endpoint_choices, 1):
+        print(f"    {i}. {label}")
+    print(f"    {len(endpoint_choices) + 1}. Cancel")
+    try:
+        raw = input("  Choice [1]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    idx = (int(raw) if raw.isdigit() else 1) - 1
+    if idx < 0 or idx >= len(endpoint_choices):
+        print("No change.")
+        return
+
+    mode, region, _ = endpoint_choices[idx]
+    is_plan = mode == "plan"
+    provider_id = "stepfun-plan" if is_plan else "stepfun"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    base_url_env = pconfig.base_url_env_var or ""
+
+    current_base = ""
+    if base_url_env:
+        current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
+    effective_base = current_base or stepfun_urls[(mode, region)]
+
+    mode_label = "Plan" if is_plan else "Standard"
+    region_label = "China" if region == "cn" else "Global"
+    endpoint_label = f"StepFun {mode_label} ({region_label})"
+    print(f"  Using {endpoint_label} → {effective_base}")
+    print()
+
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Enter model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model.pop("api_mode", None)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {endpoint_label})")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
@@ -4559,7 +4669,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "stepfun", "stepfun-plan", "kilocode", "xiaomi", "arcee"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -200,6 +200,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "mimo-v2-omni",
         "mimo-v2-flash",
     ],
+    "stepfun": [
+        "step-3.5-flash",
+    ],
+    "stepfun-plan": [
+        "step-3.5-flash",
+        "step-3.5-flash-2603",
+    ],
     "arcee": [
         "trinity-large-thinking",
         "trinity-large-preview",
@@ -524,6 +531,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("kimi-coding-cn", "Kimi / Moonshot (China)",  "Kimi / Moonshot China (Moonshot CN direct API)"),
     ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
     ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),
+    ProviderEntry("stepfun",        "StepFun",                  "StepFun (Step-3.5-Flash — standard & plan endpoints)"),
     ProviderEntry("alibaba",        "Alibaba Cloud (DashScope)","Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models — direct API)"),
@@ -536,6 +544,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
 # Derived dicts — used throughout the codebase
 _PROVIDER_LABELS = {p.slug: p.label for p in CANONICAL_PROVIDERS}
 _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named provider
+_PROVIDER_LABELS["stepfun-plan"] = "StepFun Plan"
 
 _PROVIDER_ALIASES = {
     "glm": "zai",
@@ -582,6 +591,11 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
+    "step-fun": "stepfun",
+    "step_fun": "stepfun",
+    "stepplan": "stepfun-plan",
+    "step-plan": "stepfun-plan",
+    "step_plan": "stepfun-plan",
     "grok": "xai",
     "x-ai": "xai",
     "x.ai": "xai",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -136,6 +136,14 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "stepfun": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="STEPFUN_BASE_URL",
+    ),
+    "stepfun-plan": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="STEPFUN_PLAN_BASE_URL",
+    ),
     "arcee": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://api.arcee.ai/api/v1",
@@ -236,6 +244,13 @@ ALIASES: Dict[str, str] = {
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
 
+    # stepfun
+    "step-fun": "stepfun",
+    "step_fun": "stepfun",
+    "stepplan": "stepfun-plan",
+    "step-plan": "stepfun-plan",
+    "step_plan": "stepfun-plan",
+
     # arcee
     "arcee-ai": "arcee",
     "arceeai": "arcee",
@@ -261,6 +276,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "xiaomi": "Xiaomi MiMo",
+    "stepfun-plan": "StepFun Plan",
     "local": "Local endpoint",
 }
 

--- a/tests/test_stepfun_provider.py
+++ b/tests/test_stepfun_provider.py
@@ -1,0 +1,170 @@
+"""Tests for StepFun / StepFun Plan provider wiring.
+
+Verifies that the stepfun and stepfun-plan providers are correctly
+registered across all layers: providers, auth, models, auxiliary client,
+model metadata, and alias resolution.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# providers.py
+# ---------------------------------------------------------------------------
+
+class TestProvidersOverlay:
+    """HERMES_OVERLAYS and ALIASES in hermes_cli/providers.py."""
+
+    def test_stepfun_overlay_registered(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "stepfun" in HERMES_OVERLAYS
+        assert HERMES_OVERLAYS["stepfun"].transport == "openai_chat"
+        assert HERMES_OVERLAYS["stepfun"].base_url_env_var == "STEPFUN_BASE_URL"
+
+    def test_stepfun_plan_overlay_registered(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "stepfun-plan" in HERMES_OVERLAYS
+        assert HERMES_OVERLAYS["stepfun-plan"].transport == "openai_chat"
+        assert HERMES_OVERLAYS["stepfun-plan"].base_url_env_var == "STEPFUN_PLAN_BASE_URL"
+
+    def test_aliases_resolve_to_stepfun(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("step-fun") == "stepfun"
+        assert normalize_provider("step_fun") == "stepfun"
+        assert normalize_provider("stepfun") == "stepfun"
+
+    def test_aliases_resolve_to_stepfun_plan(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("stepplan") == "stepfun-plan"
+        assert normalize_provider("step-plan") == "stepfun-plan"
+        assert normalize_provider("step_plan") == "stepfun-plan"
+
+    def test_get_provider_stepfun(self):
+        from hermes_cli.providers import get_provider
+        pdef = get_provider("stepfun")
+        assert pdef is not None
+        assert pdef.id == "stepfun"
+        assert pdef.transport == "openai_chat"
+        assert "STEPFUN_API_KEY" in pdef.api_key_env_vars
+
+    def test_get_provider_stepfun_plan(self):
+        from hermes_cli.providers import get_provider
+        pdef = get_provider("stepfun-plan")
+        assert pdef is not None
+        assert pdef.id == "stepfun-plan"
+        assert pdef.transport == "openai_chat"
+
+    def test_determine_api_mode(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("stepfun") == "chat_completions"
+        assert determine_api_mode("stepfun-plan") == "chat_completions"
+
+
+# ---------------------------------------------------------------------------
+# models.py
+# ---------------------------------------------------------------------------
+
+class TestModels:
+    """_PROVIDER_MODELS, _PROVIDER_LABELS, _PROVIDER_ALIASES in models.py."""
+
+    def test_stepfun_models_exist(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "stepfun" in _PROVIDER_MODELS
+        assert "step-3.5-flash" in _PROVIDER_MODELS["stepfun"]
+
+    def test_stepfun_plan_models_exist(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "stepfun-plan" in _PROVIDER_MODELS
+        assert "step-3.5-flash" in _PROVIDER_MODELS["stepfun-plan"]
+        assert "step-3.5-flash-2603" in _PROVIDER_MODELS["stepfun-plan"]
+
+    def test_provider_labels(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS.get("stepfun") == "StepFun"
+        assert _PROVIDER_LABELS.get("stepfun-plan") == "StepFun Plan"
+
+    def test_provider_aliases(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("step-fun") == "stepfun"
+        assert normalize_provider("stepplan") == "stepfun-plan"
+        assert normalize_provider("step-plan") == "stepfun-plan"
+
+    def test_provider_label_function(self):
+        from hermes_cli.models import provider_label
+        assert provider_label("stepfun") == "StepFun"
+        assert provider_label("stepfun-plan") == "StepFun Plan"
+
+
+# ---------------------------------------------------------------------------
+# model_metadata.py
+# ---------------------------------------------------------------------------
+
+class TestModelMetadata:
+    """Context lengths and URL inference in model_metadata.py."""
+
+    def test_context_length_step_3_5(self):
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+        # step-3.5 prefix should match 262144
+        assert any(
+            k.startswith("step-3.5") and v == 262144
+            for k, v in DEFAULT_CONTEXT_LENGTHS.items()
+        )
+
+    def test_url_to_provider_mapping(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("api.stepfun.com") == "stepfun"
+        assert _URL_TO_PROVIDER.get("api.stepfun.ai") == "stepfun"
+
+    def test_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "stepfun" in _PROVIDER_PREFIXES
+        assert "stepfun-plan" in _PROVIDER_PREFIXES
+        assert "step-fun" in _PROVIDER_PREFIXES
+        assert "step-plan" in _PROVIDER_PREFIXES
+
+
+# ---------------------------------------------------------------------------
+# models_dev.py
+# ---------------------------------------------------------------------------
+
+class TestModelsDev:
+    """PROVIDER_TO_MODELS_DEV mapping in models_dev.py."""
+
+    def test_stepfun_mapped(self):
+        from agent.models_dev import PROVIDER_TO_MODELS_DEV
+        assert PROVIDER_TO_MODELS_DEV.get("stepfun") == "stepfun"
+
+    def test_stepfun_plan_mapped(self):
+        from agent.models_dev import PROVIDER_TO_MODELS_DEV
+        # Both map to the same models.dev provider
+        assert PROVIDER_TO_MODELS_DEV.get("stepfun-plan") == "stepfun"
+
+
+# ---------------------------------------------------------------------------
+# auxiliary_client.py (requires openai SDK)
+# ---------------------------------------------------------------------------
+
+_has_openai = True
+try:
+    import openai  # noqa: F401
+except ImportError:
+    _has_openai = False
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai SDK not installed")
+class TestAuxiliaryClient:
+    """Aux model defaults in auxiliary_client.py."""
+
+    def test_stepfun_aux_model(self):
+        from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+        assert _API_KEY_PROVIDER_AUX_MODELS.get("stepfun") == "step-3.5-flash"
+
+    def test_stepfun_plan_aux_model(self):
+        from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+        assert _API_KEY_PROVIDER_AUX_MODELS.get("stepfun-plan") == "step-3.5-flash"
+
+    def test_aux_aliases(self):
+        from agent.auxiliary_client import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("step-fun") == "stepfun"
+        assert _PROVIDER_ALIASES.get("stepplan") == "stepfun-plan"
+        assert _PROVIDER_ALIASES.get("step-plan") == "stepfun-plan"

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -55,6 +55,7 @@ hermes setup       # Or configure everything at once
 | **Arcee AI** | Trinity models | Set `ARCEEAI_API_KEY` |
 | **MiniMax** | International MiniMax endpoint | Set `MINIMAX_API_KEY` |
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |
+| **StepFun** | Step-3.5-Flash — standard & plan endpoints (CN + intl) | Set `STEPFUN_API_KEY` |
 | **Alibaba Cloud** | Qwen models via DashScope | Set `DASHSCOPE_API_KEY` |
 | **Hugging Face** | 20+ open models via unified router (Qwen, DeepSeek, Kimi, etc.) | Set `HF_TOKEN` |
 | **Kilo Code** | KiloCode-hosted models | Set `KILOCODE_API_KEY` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -27,6 +27,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
+| **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`; aliases: `step-fun`; plan aliases: `stepfun-plan`, `stepplan`, `step-plan`) |
 | **Alibaba Cloud** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`, aliases: `dashscope`, `qwen`) |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
@@ -161,6 +162,15 @@ hermes chat --provider minimax --model MiniMax-M2.7
 hermes chat --provider minimax-cn --model MiniMax-M2.7
 # Requires: MINIMAX_CN_API_KEY in ~/.hermes/.env
 
+# StepFun (standard endpoint)
+hermes chat --provider stepfun --model step-3.5-flash
+# Requires: STEPFUN_API_KEY in ~/.hermes/.env
+
+# StepFun Plan (reasoning endpoint)
+hermes chat --provider stepfun-plan --model step-3.5-flash
+# Requires: STEPFUN_API_KEY in ~/.hermes/.env
+# International endpoint: set STEPFUN_PLAN_BASE_URL=https://api.stepfun.ai/step_plan/v1
+
 # Alibaba Cloud / DashScope (Qwen models)
 hermes chat --provider alibaba --model qwen3.5-plus
 # Requires: DASHSCOPE_API_KEY in ~/.hermes/.env
@@ -177,11 +187,11 @@ hermes chat --provider arcee --model trinity-large-thinking
 Or set the provider permanently in `config.yaml`:
 ```yaml
 model:
-  provider: "zai"       # or: kimi-coding, kimi-coding-cn, minimax, minimax-cn, alibaba, xiaomi, arcee
+  provider: "zai"       # or: kimi-coding, kimi-coding-cn, minimax, minimax-cn, stepfun, stepfun-plan, alibaba, xiaomi, arcee
   default: "glm-5"
 ```
 
-Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, or `XIAOMI_BASE_URL` environment variables.
+Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `STEPFUN_BASE_URL`, `STEPFUN_PLAN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, or `ARCEE_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -42,6 +42,9 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `KILOCODE_BASE_URL` | Override Kilo Code base URL (default: `https://api.kilo.ai/api/gateway`) |
 | `XIAOMI_API_KEY` | Xiaomi MiMo API key ([platform.xiaomimimo.com](https://platform.xiaomimimo.com)) |
 | `XIAOMI_BASE_URL` | Override Xiaomi MiMo base URL (default: `https://api.xiaomimimo.com/v1`) |
+| `STEPFUN_API_KEY` | StepFun API key ([platform.stepfun.com](https://platform.stepfun.com)) |
+| `STEPFUN_BASE_URL` | Override StepFun standard base URL (default: `https://api.stepfun.com/v1`, intl: `https://api.stepfun.ai/v1`) |
+| `STEPFUN_PLAN_BASE_URL` | Override StepFun Plan base URL (default: `https://api.stepfun.com/step_plan/v1`, intl: `https://api.stepfun.ai/step_plan/v1`) |
 | `HF_TOKEN` | Hugging Face token for Inference Providers ([huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)) |
 | `HF_BASE_URL` | Override Hugging Face base URL (default: `https://router.huggingface.co/v1`) |
 | `GOOGLE_API_KEY` | Google AI Studio API key ([aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)) |
@@ -70,7 +73,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `stepfun`, `stepfun-plan`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -601,7 +601,7 @@ Every model slot in Hermes — auxiliary tasks, compression, fallback — uses t
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers for auxiliary tasks: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `main`, `zai`, `kimi-coding`, `kimi-coding-cn`, `arcee`, `minimax`, any provider registered in the [provider registry](/docs/reference/environment-variables), or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+Available providers for auxiliary tasks: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `main`, `zai`, `kimi-coding`, `kimi-coding-cn`, `arcee`, `minimax`, `stepfun`, `stepfun-plan`, any provider registered in the [provider registry](/docs/reference/environment-variables), or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
 
 :::warning `"main"` is for auxiliary tasks only
 The `"main"` provider option means "use whatever provider my main agent uses" — it's only valid inside `auxiliary:`, `compression:`, and `fallback_model:` configs. It is **not** a valid value for your top-level `model.provider` setting. If you use a custom OpenAI-compatible endpoint, set `provider: custom` in your `model:` section. See [AI Providers](/docs/integrations/providers) for all main model provider options.


### PR DESCRIPTION
## What does this PR do?

Add native StepFun (阶跃星辰) model provider support to Hermes Agent, enabling quick access to StepFun's standard inference and Step Plan reasoning endpoints. This follows the established API-key provider integration pattern (similar to ZAI/GLM, MiniMax) and references the existing StepFun implementation in the openclaw project.

Two internal providers are registered (`stepfun` and `stepfun-plan`), but they are exposed as a **single "StepFun" menu entry** in `hermes model`. After selecting StepFun, the user chooses between 4 endpoint combinations (Standard/Plan × China/International) via a sub-menu — keeping the provider list clean while supporting both API surfaces and both regions.

**Endpoint matrix:**

| Mode | China (api.stepfun.com) | International (api.stepfun.ai) |
|------|------------------------|-------------------------------|
| Standard | `https://api.stepfun.com/v1` | `https://api.stepfun.ai/v1` |
| Plan | `https://api.stepfun.com/step_plan/v1` | `https://api.stepfun.ai/step_plan/v1` |




## Related Issue


Fixes #8853 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Core Provider Integration

- **`hermes_cli/providers.py`** — Added `stepfun` and `stepfun-plan` to `HERMES_OVERLAYS` (both `openai_chat` transport) and registered aliases (`step-fun`, `stepplan`, `step-plan`, etc.) in `ALIASES`
- **`hermes_cli/auth.py`** — Added `ProviderConfig` entries for both providers in `PROVIDER_REGISTRY` with shared `STEPFUN_API_KEY`, distinct `inference_base_url` (`/v1` vs `/step_plan/v1`), and separate base URL env vars (`STEPFUN_BASE_URL`, `STEPFUN_PLAN_BASE_URL`); added aliases to internal `_PROVIDER_ALIASES`
- **`hermes_cli/models.py`** — Added curated model lists to `_PROVIDER_MODELS` (`step-3.5-flash` for standard, plus `step-3.5-flash-2603` for plan), display labels to `_PROVIDER_LABELS`, aliases to `_PROVIDER_ALIASES`, and `stepfun` to `_PROVIDER_ORDER`
- **`hermes_cli/main.py`** — Added "StepFun" entry to `extended_providers` menu and `provider_labels` dict; added routing branch for `stepfun`; implemented `_model_flow_stepfun()` function with shared API key prompt → 4-choice sub-menu (Standard CN / Standard Intl / Plan CN / Plan Intl) → model picker → config save

### Agent Layer

- **`agent/models_dev.py`** — Added `stepfun` and `stepfun-plan` to `PROVIDER_TO_MODELS_DEV` mapping
- **`agent/model_metadata.py`** — Added `step-3.5` context length (262144) to `DEFAULT_CONTEXT_LENGTHS`; added `api.stepfun.com` and `api.stepfun.ai` to `_URL_TO_PROVIDER`; added provider names to `_PROVIDER_PREFIXES`
- **`agent/auxiliary_client.py`** — Added `step-3.5-flash` as auxiliary model for both providers in `_API_KEY_PROVIDER_AUX_MODELS`; added aliases to `_PROVIDER_ALIASES`

### Tests

- **`tests/test_stepfun_provider.py`** *(new)* — 20 tests covering all registration layers:
  - `TestProvidersOverlay` (7 tests): overlay entries, transport type, base URL env vars, aliases, `get_provider()`, `determine_api_mode()`
  - `TestModels` (5 tests): model catalog, display labels, aliases, `provider_label()` function
  - `TestModelMetadata` (3 tests): context length, URL→provider mapping, provider prefixes
  - `TestModelsDev` (2 tests): models.dev slug mapping for both providers
  - `TestAuxiliaryClient` (3 tests, skipped if `openai` SDK not installed): aux models, aliases

### Documentation

- **`website/docs/integrations/providers.md`** — Added StepFun to provider table, CLI examples, YAML config example, base URL override docs, Chinese AI models section reference, and fallback providers list
- **`website/docs/getting-started/quickstart.md`** — Added StepFun row to the provider overview table
- **`website/docs/user-guide/configuration.md`** — Added `stepfun` to auxiliary providers list; added `stepfun`, `stepfun-plan` to delegation providers list
- **`website/docs/reference/environment-variables.md`** — Added `STEPFUN_API_KEY`, `STEPFUN_BASE_URL`, `STEPFUN_PLAN_BASE_URL` entries; updated `HERMES_INFERENCE_PROVIDER` allowed values

## How to Test

1. Run `hermes model` → select "More providers..." → verify "StepFun" appears in the list
2. Select "StepFun" → enter a `STEPFUN_API_KEY` → choose one of the 4 endpoint combinations (Standard CN / Standard Intl / Plan CN / Plan Intl) → pick a model
3. Verify config is saved correctly: `cat ~/.hermes/config.yaml` should show `provider: stepfun` (or `stepfun-plan`) and the correct `base_url` for the chosen region
4. Verify alias resolution: `python -c "from hermes_cli.providers import normalize_provider; print(normalize_provider('stepplan'))"` → `stepfun-plan`
5. Verify `STEPFUN_BASE_URL=https://api.stepfun.ai/v1` overrides the default CN endpoint
6. Run `pytest tests/test_stepfun_provider.py -v` — 17 passed, 3 skipped (openai SDK not installed)
7. Run `pytest tests/ -k "provider or model" -q` — all API-key provider tests pass, no regressions

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

```
$ python -c "
from hermes_cli.providers import get_provider, normalize_provider
from hermes_cli.auth import PROVIDER_REGISTRY

p = get_provider('stepfun')
print(f'stepfun: {p.name}, transport={p.transport}, url={p.base_url}')

p2 = PROVIDER_REGISTRY['stepfun-plan']
print(f'stepfun-plan: {p2.name}, url={p2.inference_base_url}')

print(f'alias stepplan -> {normalize_provider(\"stepplan\")}')
print(f'alias step-fun -> {normalize_provider(\"step-fun\")}')
"

stepfun: StepFun, transport=openai_chat, url=https://api.stepfun.com/v1
stepfun-plan: StepFun Plan, url=https://api.stepfun.com/step_plan/v1
alias stepplan -> stepfun-plan
alias step-fun -> stepfun
```

```
$ pytest tests/test_stepfun_provider.py -v
tests/test_stepfun_provider.py::TestProvidersOverlay::test_stepfun_overlay_exists PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_stepfun_plan_overlay_exists PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_stepfun_transport PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_stepfun_base_url_env_vars PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_stepfun_aliases PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_get_provider_stepfun PASSED
tests/test_stepfun_provider.py::TestProvidersOverlay::test_determine_api_mode PASSED
tests/test_stepfun_provider.py::TestModels::test_stepfun_models PASSED
tests/test_stepfun_provider.py::TestModels::test_stepfun_plan_models PASSED
tests/test_stepfun_provider.py::TestModels::test_provider_labels PASSED
tests/test_stepfun_provider.py::TestModels::test_provider_aliases PASSED
tests/test_stepfun_provider.py::TestModels::test_provider_label_function PASSED
tests/test_stepfun_provider.py::TestModelMetadata::test_context_length PASSED
tests/test_stepfun_provider.py::TestModelMetadata::test_url_to_provider PASSED
tests/test_stepfun_provider.py::TestModelMetadata::test_provider_prefixes PASSED
tests/test_stepfun_provider.py::TestModelsDev::test_stepfun_models_dev PASSED
tests/test_stepfun_provider.py::TestModelsDev::test_stepfun_plan_models_dev PASSED
tests/test_stepfun_provider.py::TestAuxiliaryClient::test_aux_models SKIPPED
tests/test_stepfun_provider.py::TestAuxiliaryClient::test_aux_aliases SKIPPED
tests/test_stepfun_provider.py::TestAuxiliaryClient::test_aux_plan_model SKIPPED
17 passed, 3 skipped in 0.42s
```


<img width="1736" height="784" alt="image" src="https://github.com/user-attachments/assets/6c398380-96f3-43a8-be10-eaf04a441039" />
