### PR TITLE
feat(skills): add prd-hermes — autonomous PRD-driven development loop

### DIFF
--- a/skills/software-development/prd-hermes/DESIGN.md
+++ b/skills/software-development/prd-hermes/DESIGN.md
@@ -1,0 +1,261 @@
+# prd-hermes 设计文档
+
+## 背景
+
+2026年4月，pandacooming 在研究如何把 Ralph（一个 autonomous coding agent）的循环模式移植到 Hermes Agent 时，发现：
+
+1. Hermes 官方没有类似的 skill
+2. PR #5175（autoresearch）实现了类似功能，但使用了 cron 定时驱动，不符合用户偏好（"不要 cron timer"）
+3. 用户倾向于：主 agent 保持控制权，delegate_task 子 agent 执行，每次子 agent 完成后返回主 agent 再继续循环
+
+于是决定从头设计一个 Hermes 原生的 PRD 驱动自主开发循环。
+
+---
+
+## 核心问题
+
+**传统 AI coding agent 的问题：上下文会随着时间变脏。**
+
+- 错误累积、决策前后矛盾、忘记早期约定
+- 时间越长，问题越严重，最终要么 agent 迷失，要么结果质量下降
+
+**Ralph 的核心洞察：**
+
+> 与其试图保持 agent 上下文干净，不如每次都用全新的 agent，状态通过文件传递。
+
+---
+
+## 设计演变过程
+
+### 第一步：三个独立 skill
+
+最初参考 Ralph 的实现方式，拆成三个 skill：
+
+- `prd` — 生成 PRD 文档
+- `ralph` — 把 PRD markdown 转成 prd.json
+- `prd-loop` — 执行自主循环
+
+**问题：** 三个 skill 三套触发方式，用户需要理解它们之间的关系和调用顺序。用户体验割裂。
+
+### 第二步：合并为一个 skill
+
+把三个 skill 合并成 `prd-hermes`，一个 skill 包含完整的三阶段流程：
+
+```
+Feature idea
+    ↓ Phase 1: 生成 PRD
+    ↓ Phase 2: 转换格式
+    ↓ Phase 3: 循环执行
+```
+
+**原则：用户只需要说"帮我实现这个功能"，剩下的全部自动完成。**
+
+### 第三步：命名
+
+- `ralph-loop` — ❌ 听起来只有循环，名字来自外部工具
+- `prd-hermes` — ✅ `prd` 是核心概念，`hermes` 表示这是 Hermes 原生实现
+
+---
+
+## 核心设计决策
+
+### 决策 1：每个 acceptance criterion 完成后立即写 progress.txt
+
+**问题背景：**
+子 agent 的上下文会被 Hermes 自动压缩（~50% 时）。如果等到整个 story 完成才写进度，压缩发生时最多丢失整个 story。
+
+**解决方案：**
+
+```
+每个 criterion 完成后立即写 checkpoint，不等 story 结束。
+
+US-001 有 5 个 criteria：
+  Criterion 1 完成 → 写 progress.txt
+  Criterion 2 完成 → 写 progress.txt
+  Criterion 3 完成 → 写 progress.txt
+       ↓
+    上下文在这里被压缩
+       ↓
+  新子 agent 读 progress.txt
+       → 知道 Criterion 3 已完成
+       → 从 Criterion 4 继续
+       → 最多重做 Criterion 3（不严重）
+```
+
+**结论：** 不是"感知压缩再去救"，而是"每个 milestone 都保存进度"，让压缩变得无关紧要。
+
+---
+
+### 决策 2：子 agent 只有两种真正的停止原因
+
+经过梳理，子 agent 停止只有两种：
+
+```
+1. ✅ 任务完成
+   → 所有 criteria 完成 + commit → status: "complete"
+
+2. ⚠️ 上下文被压缩
+   → 发现被压缩了（忘了什么）→ status: "WIP"
+```
+
+（第三种：遇到无法恢复的错误 → status: "failed"）
+
+**设计原则：**
+- 不是"等满了再停"，而是"被压缩了立即停"
+- 子 agent 通过**自我检查**判断是否被压缩："我是否还记得这个 session 开始时的内容？"
+
+---
+
+### 决策 3：子 agent 返回时带结构化的 stop report
+
+子 agent 返回时携带一个明确的状态对象，而不是简单的文本摘要：
+
+```json
+{
+  "status": "complete" | "WIP" | "failed",
+  "story_id": "US-001",
+  "criterion_progress": "3/5",
+  "commit_sha": "abc123..." | null,
+  "learnings": ["pattern discovered"],
+  "next_action": "new_agent_continue_same_story" | "move_to_next_story"
+}
+```
+
+**为什么需要结构化？**
+因为主 agent 需要根据 status 做明确的决策：
+- `complete` → 下一个 story
+- `WIP` → 立即开新子 agent 继续同一个 story
+- `failed` → 标记失败，继续下一个 story
+
+如果只是文本摘要，主 agent 需要猜测意图，容易出错。
+
+---
+
+### 决策 4：主 agent 的决策表
+
+主 agent 是一个状态机，根据子 agent 返回的 status 决定下一步：
+
+```
+status: "complete"
+  → prd.json passes: true
+  → progress.txt 追加最终记录
+  → 回到 Phase 3a，选下一个 story
+
+status: "WIP"
+  → prd.json 保持 passes: false
+  → 立即 spawn 新子 agent 继续同一个 story
+  → progress.txt 已有 checkpoint，不需要额外操作
+
+status: "failed"
+  → prd.json notes: "FAILED: ..."
+  → progress.txt 追加失败记录
+  → 继续下一个 story
+```
+
+---
+
+### 决策 5：progress.txt 的双重用途
+
+同一个文件，服务于两个场景：
+
+| 场景 | progress.txt 内容 | 写入时机 |
+|------|------------------|----------|
+| WIP checkpoint | `Criterion N/M Complete` + completed/next/files | 每个 criterion 完成后立即 |
+| 最终记录 | `— COMPLETE` + commit SHA + learnings | story 全部完成后 |
+
+这使得 `progress.txt` 既是断点续传的依据，也是迭代学习的积累。
+
+---
+
+## prd-hermes vs Ralph（原始版本）
+
+| | Ralph 原版 | prd-hermes |
+|---|---|---|
+| 循环驱动 | bash 脚本 + cron | 主 agent 控制，delegate_task |
+| 状态文件 | prd.json + progress.txt | 相同 |
+| 进度保存 | 每个 story 完成后 | **每个 criterion 完成后** |
+| 压缩恢复 | 无专门机制 | 每个 criterion 是原子恢复单元 |
+| 子 agent 通信 | 依赖返回文本 | 结构化 stop report |
+| 适用场景 | Claude Code / Amp | Hermes delegate_task |
+
+**核心区别：** prd-hermes 通过更细粒度的 checkpoint（每个 criterion 一次）解决了子 agent 内部上下文压缩的问题，而原版 Ralph 只考虑了跨 story 的上下文污染。
+
+---
+
+## 状态文件
+
+### prd.json
+
+```json
+{
+  "project": "项目名",
+  "branchName": "prd-hermes/[feature-name]",
+  "description": "一句话描述",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "标题",
+      "description": "As a ... I want ... so that ...",
+      "acceptanceCriteria": ["criterion 1", "criterion 2", "Typecheck passes"],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}
+```
+
+### progress.txt
+
+**WIP checkpoint（每个 criterion 完成后）：**
+```
+## US-001 - Criterion 2/5 Complete
+- Completed: 实现 API endpoint 并测试通过
+- Next: 添加前端按钮组件
+- Files: src/api/likes.py, tests/test_likes.py
+```
+
+**最终记录（story 全部完成后）：**
+```
+## 2026-04-13 14:30 - US-001 — COMPLETE
+- All acceptance criteria met
+- Files changed: db/migrations/xxx.py, src/api/likes.py, tests/test_likes.py
+- Commit: abc123def
+- **Learnings:**
+  - 这个项目用 pytest 做单元测试，不是 unittest
+  - 数据库迁移用 alembic，不是 Django 自带的
+---
+```
+
+---
+
+## 三个核心原则
+
+### 原则 1：每个 story 干净上下文
+
+每次启动子 agent 都是全新 context，不继承上一轮的 agent 记忆。状态通过 `prd.json` + `progress.txt` 传递，不靠 memory。
+
+### 原则 2：进度立即写出，不到最后
+
+每个 acceptance criterion 完成后立即写入 progress.txt，永远不等到整个 story 结束。这样上下文压缩最多丢失一个 criterion，不是一个 story。
+
+### 原则 3：断点续传永远从最后一个 checkpoint
+
+新子 agent 启动时读 progress.txt，找到 `Criterion N/M Complete` 标记，从下一个 criterion 继续。不猜测，不重复。
+
+---
+
+## 局限性
+
+- **子 agent 自我检测压缩是尽力而为**：无法精确知道压缩何时发生，只能靠"是否忘记了一些事"这种模糊的自我感知。
+- **criterion 粒度需要合理**：如果单个 criterion 太大（超过 2-3 轮对话），仍然可能有风险。PRD 生成阶段应确保 criterion 足够小。
+- **依赖子 agent 正确返回**：如果子 agent 忘记了这个协议（比如被压缩后继续跑），进度可能丢失。指令的清晰度很重要。
+
+---
+
+## 未来可能的改进方向
+
+1. **acceptance criteria 数量限制**：Phase 1 生成 PRD 时规定每个 story 最多 5 个 criterion，超出的自动拆分
+2. **WIP commit 到 git**：当 criterion 数量较多时，可以把 WIP 也 commit 到 git，而不是只写在 progress.txt
+3. **主 agent 感知子 agent 存活状态**：不只是等子 agent 返回，而是主动检测子 agent 是否还在运行（这个目前 Hermes delegate_task 不支持）
+4. **learnings 跨 story 共享**：当前的 learnings 是 append-only 的，但没有结构化索引。新 story 可以优先参考相关的历史 learnings

--- a/skills/software-development/prd-hermes/SKILL.md
+++ b/skills/software-development/prd-hermes/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: prd-hermes
+description: "Hermes-native autonomous PRD-driven development. Generate a PRD, convert to prd.json, then iteratively implement each user story via delegate_task until all pass. Each acceptance criterion is checkpointed immediately to progress.txt — context compression mid-story is harmless."
+category: software-development
+---
+
+# prd-hermes — Autonomous PRD-Driven Development
+
+Turn a feature idea into a fully-implemented feature by autonomously iterating through user stories using `delegate_task`.
+
+## The Complete Workflow
+
+```
+Feature idea
+    ↓ Phase 1: Generate PRD
+    ↓ Phase 2: Convert to prd.json
+    ↓ Phase 3: Loop (delegate_task per story)
+         ├─ Story 1 → implement → passes: true
+         ├─ Story 2 → implement → passes: true
+         └─ ... → All done → Final report
+```
+
+## State Files
+
+| File | Purpose |
+|------|---------|
+| `tasks/prd-[feature].md` | Generated PRD with user stories |
+| `prd.json` | Structured story list (branch, priorities, acceptance criteria) |
+| `progress.txt` | Append-only iteration log — learnings accumulate across stories |
+
+---
+
+## Phase 1: Generate PRD
+
+**When to start:** User describes a feature they want to build and asks to implement it, or says "run Ralph", "start the loop", etc.
+
+### Step 1a: Ask Clarifying Questions
+
+Before writing anything, ask 3-5 clarifying questions:
+
+- **Scope** — What is in scope vs out of scope?
+- **Users** — Who are the end users?
+- **Success criteria** — How do we know it's done?
+- **Edge cases** — What should happen when things go wrong?
+- **Dependencies** — External services, APIs, or libraries needed?
+- **Tech stack** — Any constraints on language, framework, or architecture?
+
+### Step 1b: Generate PRD
+
+After receiving answers, write the PRD to `tasks/prd-[feature-name].md`:
+
+```markdown
+# PRD: [Feature Name]
+
+## Overview
+[One paragraph summary of the feature and why it matters]
+
+## User Stories
+
+### US-001: [Title]
+**As a** [user type]  
+**I want** [feature]  
+**So that** [benefit]
+
+**Acceptance Criteria:**
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+**Priority:** 1
+
+---
+
+### US-002: ...
+```
+
+**Tips:**
+- Keep acceptance criteria **verifiable** — not "works well" but "clicking X shows Y"
+- Each story should be implementable in 1-4 hours
+- If a story is too large, split it
+- Priority: 1 = highest (do first)
+
+---
+
+## Phase 2: Convert to prd.json
+
+### Step 2: Parse and Write prd.json
+
+Read the PRD from `tasks/prd-[feature].md` and write `prd.json`:
+
+```json
+{
+  "project": "[Project Name]",
+  "branchName": "ralph/[feature-name]",
+  "description": "[One-line description]",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "[Title]",
+      "description": "As a [user], I want [feature] so that [benefit]",
+      "acceptanceCriteria": ["Criterion 1", "Criterion 2", "Typecheck passes", "Tests pass"],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}
+```
+
+Branch name convention: `ralph/[feature-name]` (kebab-case).
+
+Show the user the resulting `prd.json` and ask for confirmation before starting the loop.
+
+---
+
+## Phase 3: Autonomous Loop
+
+### Step 3a: Read prd.json
+
+Find the story with the **lowest `priority`** number where `passes: false`.
+
+If **all stories have `passes: true`**, skip to Step 3f (Final Report).
+
+### Step 3b: Spawn Child Agent
+
+Call `delegate_task` with:
+
+- **goal**: Implement story `[ID]: [title]` from `prd.json`
+- **context**: 
+  - Story description and all acceptanceCriteria (list every criterion explicitly)
+  - Project description from `prd.json`
+  - Branch name from `prd.json`
+  - Reference `progress.txt` for any WIP or learnings from prior attempts
+
+**Child agent instructions:**
+
+1. Checkout or create branch `ralph/[feature-name]`
+2. If `progress.txt` has a WIP entry for this story, read it first — resume from where it left off
+3. Work through the acceptance criteria **one by one**
+4. **After completing each criterion**, immediately append a checkpoint to `progress.txt`:
+   ```
+   ## [Story ID] - Criterion [N/M] Complete
+   - Completed: [what this criterion required]
+   - Next: [the next criterion's goal]
+   - Files: [files modified]
+   ```
+5. Run quality checks (typecheck, lint, tests) after each criterion
+6. After **all criteria pass**, commit: `feat: [ID] - [title]`
+
+**Checkpoint rule — the most important part:**
+
+> Do NOT wait until the entire story is done to write progress. Write after **every single criterion**, no matter how small. Each criterion checkpoint is the atomic unit of progress.
+
+**When to return to the main agent — three triggers:**
+
+```
+Trigger 1 — Story complete:
+  All criteria done + committed
+  → Return: { status: "complete", criterion_progress: "M/M", commit_sha: "..." }
+
+Trigger 2 — Context compression detected:
+  You notice you have "forgotten" something from earlier in this session
+  (e.g., you can no longer recall the original acceptance criteria, a decision
+  made earlier, or what files were just modified)
+  → Return: { status: "WIP", criterion_progress: "N/M", last_checkpoint: "Criterion N/M Complete" }
+
+Trigger 3 — Unrecoverable error:
+  An error prevents continuing (compile failure, dependency missing, etc.)
+  → Return: { status: "failed", criterion_progress: "N/M", error: "..." }
+```
+
+**What to return — structured stop report:**
+
+```
+{
+  "status": "complete" | "WIP" | "failed",
+  "story_id": "US-001",
+  "criterion_progress": "3/5",
+  "commit_sha": "abc123..." | null,
+  "learnings": ["pattern discovered", "gotcha encountered"],
+  "next_action": "new_agent_continue_same_story" | "move_to_next_story"
+}
+```
+
+### Step 3c: Update State — Decision Table
+
+The main agent decides what to do based on the child's `status`:
+
+```
+status: "complete"
+  → prd.json: set passes: true for this story_id
+  → progress.txt: append final COMPLETE record (see format below)
+  → Loop back to Step 3a to pick next story
+
+status: "WIP"
+  → prd.json: keep passes: false (not done yet)
+  → progress.txt: already has the last checkpoint — no extra action needed
+  → Immediately spawn a new child agent for the SAME story
+    (new agent will read progress.txt, find last checkpoint, resume from next criterion)
+
+status: "failed"
+  → prd.json: set notes: "FAILED: [error summary]"
+  → progress.txt: append failure record
+  → Continue to next story
+```
+
+**Final progress.txt record (for "complete" status):**
+```
+## [Date/Time] - [Story ID] — COMPLETE
+- All acceptance criteria met
+- Files changed: [list]
+- Commit: [SHA]
+- **Learnings:**
+  - [Pattern or gotcha discovered]
+---
+```
+
+### Step 3d: Loop
+
+Go back to Step 3a. Continue until all stories have `passes: true`.
+
+### Step 3e: Final Report
+
+When loop completes (all stories have `passes: true` or `notes: "FAILED:..."`), output:
+- Total stories completed vs failed
+- Commit SHAs for each story
+- Key learnings from `progress.txt`
+
+### Context Compression — How It Works
+
+The child agent's context IS compressed at 50% by Hermes automatically. The key insight:
+
+- The child agent **detects compression by self-checking**: "Do I still remember everything from the start of this session?"
+- If the answer is NO → the agent was compressed → returns `status: "WIP"` immediately
+- Progress is NEVER lost because every criterion was already written to `progress.txt` before the checkpoint
+- The new child agent picks up from the last checkpoint, not from scratch
+
+### Error Handling
+
+- `status: "failed"` → mark story in `prd.json` with `notes: "FAILED: [error]"`, log to `progress.txt`, continue to next story
+- The loop does NOT stop on failure — it logs and proceeds
+
+---
+
+## prd.json Example
+
+```json
+{
+  "project": "Blog Like Button",
+  "branchName": "ralph/like-button",
+  "description": "Add a like button to blog posts with counter",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add like count to database",
+      "description": "As a developer, I need to store like counts so posts can track popularity",
+      "acceptanceCriteria": [
+        "Add likes column to posts table",
+        "Generate and run migration",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Implement like button UI",
+      "description": "As a reader, I want to click a like button so I can show appreciation",
+      "acceptanceCriteria": [
+        "Like button appears on each post",
+        "Clicking increments the counter",
+        "Typecheck passes",
+        "Unit tests pass"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}
+```
+
+## Key Ralph Principles
+
+**1. Clean context per story.**
+Each iteration gets a **fresh subagent** with clean context. State is passed through files (`prd.json`, `progress.txt`). The main agent orchestrates — it never gets polluted by implementation details.
+
+**2. Progress is written immediately, not at the end.**
+Each acceptance criterion is checkpointed to `progress.txt` the moment it completes — not when the whole story is done. This means context compression is harmless: at most one criterion is lost and re-done, never the entire story.
+
+**3. Resumption is always from the last checkpoint.**
+When a new subagent picks up a story (after compression or failure), it reads `progress.txt`, finds the last `Criterion N/M Complete` entry, and resumes from the next one. No guessing, no duplication.

--- a/skills/software-development/prd-hermes/references/prd.json.example
+++ b/skills/software-development/prd-hermes/references/prd.json.example
@@ -1,0 +1,47 @@
+{
+  "project": "Blog Like Button",
+  "branchName": "ralph/like-button",
+  "description": "Add a like button to blog posts with counter",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add like count to database",
+      "description": "As a developer, I need to store like counts so posts can track popularity",
+      "acceptanceCriteria": [
+        "Add likes column to posts table",
+        "Generate and run migration",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Implement like button UI",
+      "description": "As a reader, I want to click a like button so I can show appreciation for content",
+      "acceptanceCriteria": [
+        "Like button appears on each post",
+        "Clicking increments the counter",
+        "Typecheck passes",
+        "Unit tests pass"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Display like count on post listing",
+      "description": "As a reader, I want to see like counts on the listing page so I can identify popular posts",
+      "acceptanceCriteria": [
+        "Like count shown next to each post",
+        "Count updates after liking",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new prd-hermes skill for Hermes-native autonomous development driven by a PRD.

## What It Does

1. **Phase 1**: Generate PRD — ask clarifying questions, write structured PRD with user stories and acceptance criteria
2. **Phase 2**: Convert to prd.json — transform PRD markdown into structured JSON  
3. **Phase 3**: Autonomous loop — iteratively implement each story via delegate_task, checkpointing after each acceptance criterion

## Key Design Decisions

**Checkpoint-per-Criterion**: Each acceptance criterion is written to progress.txt the moment it completes — not when the entire story is done. Context compression (Hermes at ~50%) is harmless: at most one criterion is lost and re-done.

**Structured Stop Reports**: Child agents return status (complete/WIP/failed) so the main agent makes exact decisions.

**Context Compression Recovery**: Child agents self-check "Do I still remember everything?" If no, they return status: WIP. New agent reads progress.txt and resumes from last checkpoint.

## Files

- SKILL.md — Full execution protocol
- DESIGN.md — Design rationale and decision history
- references/prd.json.example — Example format

## Motivation

Addresses the core problem: context gets dirty over time. Fresh subagents per story with clean context + state through files. Also addresses Issue #356 (acceptance criteria as atomic progress unit).

## Test Plan

- [ ] Skill loads and appears in /skills under software-development
- [ ] Phase 1 generates PRD from feature idea
- [ ] Phase 2 converts PRD to valid prd.json
- [ ] Phase 3 implements stories one-by-one with checkpointing
- [ ] Compression recovery: resuming agent reads progress.txt
- [ ] Final report with commit SHAs and learnings