### PR TITLE
fix(gateway): treat empty/corrupt scoped lock files as stale

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -290,6 +290,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
     }
 
     existing = _read_json_file(lock_path)
+    if existing is None and lock_path.exists():
+        # Lock file exists but is empty or contains invalid JSON — treat as
+        # stale.  This happens when a previous process was killed between
+        # O_CREAT|O_EXCL and the subsequent json.dump() (e.g. DNS failure
+        # during rapid Slack reconnect retries).
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     if existing:
         try:
             existing_pid = int(existing["pid"])

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -209,6 +209,33 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
+        """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("")  # simulate crash between O_CREAT and json.dump
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "slack"
+
+    def test_acquire_scoped_lock_recovers_corrupt_lock_file(self, tmp_path, monkeypatch):
+        """Lock file with invalid JSON should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("{truncated")  # simulate partial write
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_release_scoped_lock_only_removes_current_owner(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
 


### PR DESCRIPTION
## Problem

When a gateway process is killed between `O_CREAT|O_EXCL` and the subsequent `json.dump()` (e.g. during DNS failures with rapid Slack reconnect retries), the scoped lock file is left empty (0 bytes) or with partial JSON.

On next startup:
1. `_read_json_file()` returns `None` for the empty/corrupt file
2. `existing` is falsy, so the code falls through to the `O_CREAT|O_EXCL` open
3. `FileExistsError` is raised because the file still exists on disk
4. `acquire_scoped_lock()` returns `(False, None)` — lock not acquired, no PID info

This makes the lock **permanently unacquirable** — `gateway restart` and `--replace` cannot recover because there is no PID to detect as stale. The only fix is manually deleting the lock file from `~/.local/state/hermes/gateway-locks/`.

## Root Cause

The lock creation in `acquire_scoped_lock()` is not atomic with respect to file content — the file is created empty via `os.open(O_CREAT|O_EXCL)`, then JSON is written in a separate step. A crash between these two operations leaves a zombie lock.

## Fix

After `_read_json_file()` returns `None`, check if the lock file still exists on disk. If so, treat it as stale and delete it before proceeding to the `O_CREAT` path.

## Tests

Added two test cases:
- `test_acquire_scoped_lock_recovers_empty_lock_file` — empty file (0 bytes)
- `test_acquire_scoped_lock_recovers_corrupt_lock_file` — invalid JSON content

All 14 tests in `test_status.py` pass.