### PR TITLE
fix: support Gemma 4 <thought> reasoning tags in run_agent.py

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2018,6 +2018,7 @@ class AIAgent:
             inline_patterns = (
                 r"<think>(.*?)</think>",
                 r"<thinking>(.*?)</thinking>",
+                r"<thought>(.*?)</thought>",  # Gemma 4 thinking tag
                 r"<reasoning>(.*?)</reasoning>",
                 r"<REASONING_SCRATCHPAD>(.*?)</REASONING_SCRATCHPAD>",
             )


### PR DESCRIPTION
## What does this PR do?

This PR fixes Gemma 4 reasoning extraction in `run_agent.py` by adding support for inline `<thought>...</thought>` blocks in `_extract_reasoning()`.

Hermes already strips `<thought>` tags from visible output paths, but `_extract_reasoning()` was missing `<thought>` in its inline fallback patterns. As a result, Gemma 4 reasoning embedded in assistant content could be missed during reasoning extraction. This is a minimal, non-breaking fix that brings Gemma 4 inline reasoning handling in line with the existing tag-stripping logic.

## Related Issue

Fixes #6148

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `r"<thought>(.*?)</thought>"` to the `inline_patterns` tuple in `_extract_reasoning()` in `run_agent.py`
- Kept the change intentionally minimal and scoped to Gemma 4 reasoning-tag support
- No unrelated files or logic were modified

## How to Test

1. Run Hermes with a Google Gemma 4 model that emits inline `<thought>...</thought>` reasoning blocks
2. Verify that reasoning is captured through `_extract_reasoning()` and that the visible user-facing response does not expose raw `<thought>` reasoning content
3. Confirm that behavior for existing reasoning tags such as `<think>`, `<thinking>`, `<reasoning>`, and `<REASONING_SCRATCHPAD>` remains unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: GitHub web edit / local verification pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — this change is a small parsing fix in `run_agent.py` with a one-line code diff.