### PR TITLE
fix(gateway): handle stale lock files in acquire_scoped_lock (Fixes bug that kills slack - it cannot reconnect even after gateway restart)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -290,6 +290,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
     }
 
     existing = _read_json_file(lock_path)
+    if existing is None and lock_path.exists():
+        # Lock file exists but is empty or contains invalid JSON — treat as
+        # stale.  This happens when a previous process was killed between
+        # O_CREAT|O_EXCL and the subsequent json.dump() (e.g. DNS failure
+        # during rapid Slack reconnect retries).
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     if existing:
         try:
             existing_pid = int(existing["pid"])

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -209,6 +209,33 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
+        """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("")  # simulate crash between O_CREAT and json.dump
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "slack"
+
+    def test_acquire_scoped_lock_recovers_corrupt_lock_file(self, tmp_path, monkeypatch):
+        """Lock file with invalid JSON should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("{truncated")  # simulate partial write
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_release_scoped_lock_only_removes_current_owner(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
 


### PR DESCRIPTION
## What does this PR do?
Fixes bug that kills slack - it cannot reconnect even after gateway restart.
`acquire_scoped_lock()` could get stuck when a lock file **exists on disk but is empty or not valid JSON** (e.g. process killed after creating the file but before `json.dump()`, or a partial write). `_read_json_file()` returns `None` in that case, but the path was still treated as “present,” so the caller never acquired a new lock.

This change **removes that stale file** when it exists but parses to nothing, then continues with normal acquisition—same idea as handling a dead owner, but for corrupt/empty files.

## Related Issue

Fixes # _(add the issue number, or remove if none)_

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/status.py` — In `acquire_scoped_lock`, if the lock path exists but `_read_json_file` returns `None`, **unlink** the file (ignore `OSError`) so empty/corrupt locks do not block forever.
- `tests/gateway/test_status.py` — Tests for **empty** lock file and **invalid JSON** (truncated) both recovering and successfully acquiring.

## How to Test

1. `source venv/bin/activate && python -m pytest tests/gateway/test_status.py::TestScopedLocks::test_acquire_scoped_lock_recovers_empty_lock_file tests/gateway/test_status.py::TestScopedLocks::test_acquire_scoped_lock_recovers_corrupt_lock_file -q`
2. Optionally run `python -m pytest tests/gateway/test_status.py -q` for the whole scoped-lock suite.

## Checklist

_(Leave for you to tick after you verify locally.)_

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A**
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

## For New Skills

_Delete this section._

## Screenshots / Logs

_N/A (backend lock-file behavior)._

---

**Note:** Your branch name is `fix/empty-scoped-lock-file`; compared to `main`, the diff is only the two files above (no extra commits in the PR if you open it from this branch).