### PR TITLE
fix(weixin): rename send_document parameter to match base class

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1537,19 +1537,19 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,
         chat_id: str,
-        path: str,
+        file_path: str,
         caption: str = "",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         if not self._session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, path, caption)
+            message_id = await self._send_file(chat_id, file_path, caption)
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)


### PR DESCRIPTION
## Summary

`WeixinAdapter.send_document()` uses `path` as its parameter name, but `BasePlatformAdapter.send_document()` defines it as `file_path`. The base class calls the method with a keyword argument (`file_path=media_path`), causing:

```
WeixinAdapter.send_document() got an unexpected keyword argument 'file_path'
```

All file/document sending via WeChat fails silently (text responses still work).

## Changes

Rename `path` → `file_path` in `WeixinAdapter.send_document()` to match the base class signature.

Closes #8819