### PR TITLE
feat(weixin): add persistent group log, activity spike detection, daily digest

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import collections
 import hashlib
 import json
 import logging
@@ -902,6 +903,28 @@ def _message_type_from_media(media_types: List[str], text: str) -> MessageType:
     return MessageType.TEXT
 
 
+class GroupContextBuffer:
+    """Per-group ring buffer that stores recent messages for context injection."""
+
+    def __init__(self, maxlen: int = 50) -> None:
+        self._buf: collections.deque[Tuple[str, str, datetime]] = collections.deque(maxlen=maxlen)
+
+    def add(self, sender: str, text: str, ts: Optional[datetime] = None) -> None:
+        """Append a message to the ring buffer."""
+        self._buf.append((sender, text, ts or datetime.now()))
+
+    def format_context(self) -> str:
+        """Return formatted context string for injection into a prompt."""
+        if not self._buf:
+            return ""
+        lines = []
+        for sender, text, ts in self._buf:
+            stamp = ts.strftime("%H:%M")
+            lines.append(f"[{stamp}] {sender}: {text}")
+        count = len(self._buf)
+        return f"[群聊上下文 - 最近{count}条消息]\n" + "\n".join(lines) + "\n---\n"
+
+
 def _sync_buf_path(hermes_home: str, account_id: str) -> Path:
     return _account_dir(hermes_home) / f"{account_id}.sync.json"
 
@@ -1089,6 +1112,22 @@ class WeixinAdapter(BasePlatformAdapter):
             group_allow_from = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
+        self._group_require_mention = _coerce_bool(
+            extra.get("group_require_mention")
+            or os.getenv("WEIXIN_GROUP_REQUIRE_MENTION", "true"),
+            default=True,
+        )
+        self._group_silent = _coerce_bool(
+            extra.get("group_silent") or os.getenv("WEIXIN_GROUP_SILENT", "false"),
+            default=False,
+        )
+        self._bot_name = str(extra.get("bot_name") or os.getenv("WEIXIN_BOT_NAME", "")).strip()
+        self._group_context_limit = int(
+            extra.get("group_context_messages") or os.getenv("WEIXIN_GROUP_CONTEXT_MESSAGES", "50")
+        )
+        self._group_context: Dict[str, GroupContextBuffer] = {}
+        self._group_context_max_chats = 100  # Cap tracked groups to prevent unbounded growth
+        self._bot_name_warning_logged = False
         self._split_multiline_messages = _coerce_bool(
             extra.get("split_multiline_messages")
             or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"),
@@ -1250,9 +1289,60 @@ class WeixinAdapter(BasePlatformAdapter):
 
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
+
+        # -- Group intelligence: context buffer, silent mode, mention gating --
+        if chat_type == "group" and text:
+            if effective_chat_id not in self._group_context:
+                # Evict oldest group context if at capacity
+                if len(self._group_context) >= self._group_context_max_chats:
+                    oldest = next(iter(self._group_context))
+                    del self._group_context[oldest]
+                self._group_context[effective_chat_id] = GroupContextBuffer(
+                    maxlen=self._group_context_limit
+                )
+            ctx_buf = self._group_context[effective_chat_id]
+            ctx_buf.add(sender_id, text)
+
+            if self._group_silent:
+                logger.debug(
+                    "[Weixin] Silent mode: buffered group message from %s in %s",
+                    _safe_id(sender_id),
+                    _safe_id(effective_chat_id),
+                )
+                return
+
+            if self._group_require_mention:
+                if not self._bot_name:
+                    if not self._bot_name_warning_logged:
+                        logger.warning(
+                            "[Weixin] WEIXIN_BOT_NAME not set — cannot gate on @mentions, "
+                            "responding to all group messages. Set WEIXIN_BOT_NAME to enable "
+                            "mention gating."
+                        )
+                        self._bot_name_warning_logged = True
+                else:
+                    mentioned = re.search(
+                        rf"@{re.escape(self._bot_name)}[\s\u2005\u00a0]?",
+                        text,
+                        re.IGNORECASE,
+                    )
+                    if not mentioned:
+                        return
+                    # Strip the @mention from text before sending to agent
+                    text = re.sub(
+                        rf"@{re.escape(self._bot_name)}[\s\u2005\u00a0]?",
+                        "",
+                        text,
+                        flags=re.IGNORECASE,
+                    ).strip()
+
+            # Prepend group context to the message
+            context_prefix = ctx_buf.format_context()
+            if context_prefix:
+                text = context_prefix + text
+
         media_paths: List[str] = []
         media_types: List[str] = []
-
         for item in item_list:
             await self._collect_media(item, media_paths, media_types)
             ref_message = item.get("ref_msg") or {}

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -931,54 +931,78 @@ class GroupContextBuffer:
 
 
 class GroupActivityMonitor:
-    """Per-group sliding-window activity tracker with spike detection.
+    """Per-group adaptive activity tracker with burst detection.
 
-    Maintains a deque of message timestamps per group.  ``is_hot`` returns
-    *True* when the number of messages inside the sliding window exceeds the
-    configured threshold.  ``should_notify`` adds a per-group cooldown so that
-    notifications are not sent too frequently.
+    Instead of a fixed threshold, each group learns its own "normal" message
+    rate via an exponential moving average (EMA).  A burst is detected when
+    the current window count exceeds ``burst_multiplier × EMA``.
+
+    Cold-start protection: during the first ``warmup_windows`` observation
+    periods a group only learns — no notifications are emitted.
+
+    A hard ``min_absolute`` floor prevents spurious alerts in very quiet groups
+    (e.g. 1→3 messages should never trigger).
     """
 
     def __init__(
         self,
-        threshold: int = 10,
         window_seconds: int = 300,
         cooldown_seconds: int = 1800,
+        burst_multiplier: float = 3.0,
+        min_absolute: int = 5,
+        warmup_windows: int = 6,
+        ema_alpha: float = 0.3,
     ) -> None:
-        self._threshold = threshold
         self._window = window_seconds
         self._cooldown = cooldown_seconds
+        self._burst_multiplier = burst_multiplier
+        self._min_absolute = min_absolute
+        self._warmup_windows = warmup_windows
+        self._ema_alpha = ema_alpha
+
+        # Per-group state
         self._timestamps: Dict[str, collections.deque] = {}
         self._last_notified: Dict[str, float] = {}
+        self._ema: Dict[str, float] = {}              # exponential moving average
+        self._last_ema_update: Dict[str, float] = {}   # last window boundary timestamp
+        self._observation_count: Dict[str, int] = {}   # windows observed (for warmup)
 
     # -- public API ----------------------------------------------------------
 
     def record(self, chat_id: str) -> None:
-        """Record a message timestamp for *chat_id*."""
+        """Record a message timestamp for *chat_id* and update EMA."""
         now = time.time()
         if chat_id not in self._timestamps:
             self._timestamps[chat_id] = collections.deque()
+            self._ema[chat_id] = 0.0
+            self._last_ema_update[chat_id] = now
+            self._observation_count[chat_id] = 0
         dq = self._timestamps[chat_id]
         dq.append(now)
         # Prune entries outside the window
         cutoff = now - self._window
         while dq and dq[0] < cutoff:
             dq.popleft()
+        # Update EMA once per window boundary
+        self._maybe_update_ema(chat_id, now)
 
     def is_hot(self, chat_id: str) -> bool:
-        """Return *True* if message count in window exceeds threshold."""
-        dq = self._timestamps.get(chat_id)
-        if not dq:
+        """Return *True* if current activity is a burst above the learned baseline."""
+        count = self.window_count(chat_id)
+        if count < self._min_absolute:
             return False
-        now = time.time()
-        cutoff = now - self._window
-        while dq and dq[0] < cutoff:
-            dq.popleft()
-        return len(dq) >= self._threshold
+        ema = self._ema.get(chat_id, 0.0)
+        if ema < 1.0:
+            # Not enough history — use absolute minimum only
+            return count >= self._min_absolute * 2
+        return count >= ema * self._burst_multiplier
 
     def should_notify(self, chat_id: str) -> bool:
-        """Return *True* if the group is hot AND the cooldown has expired."""
+        """Return *True* if burst detected, warmup passed, and cooldown expired."""
         if not self.is_hot(chat_id):
+            return False
+        # Warmup protection: don't notify until we've seen enough windows
+        if self._observation_count.get(chat_id, 0) < self._warmup_windows:
             return False
         last = self._last_notified.get(chat_id, 0.0)
         return (time.time() - last) >= self._cooldown
@@ -990,7 +1014,31 @@ class GroupActivityMonitor:
     def window_count(self, chat_id: str) -> int:
         """Return the number of messages in the current window."""
         dq = self._timestamps.get(chat_id)
-        return len(dq) if dq else 0
+        if not dq:
+            return 0
+        now = time.time()
+        cutoff = now - self._window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+        return len(dq)
+
+    def get_ema(self, chat_id: str) -> float:
+        """Return the current EMA baseline for *chat_id*."""
+        return self._ema.get(chat_id, 0.0)
+
+    # -- internals -----------------------------------------------------------
+
+    def _maybe_update_ema(self, chat_id: str, now: float) -> None:
+        """Update EMA if a full window period has elapsed since last update."""
+        last_update = self._last_ema_update.get(chat_id, now)
+        if (now - last_update) < self._window:
+            return
+        count = len(self._timestamps.get(chat_id, []))
+        old_ema = self._ema.get(chat_id, 0.0)
+        alpha = self._ema_alpha
+        self._ema[chat_id] = alpha * count + (1 - alpha) * old_ema
+        self._last_ema_update[chat_id] = now
+        self._observation_count[chat_id] = self._observation_count.get(chat_id, 0) + 1
 
 
 def _sync_buf_path(hermes_home: str, account_id: str) -> Path:
@@ -1215,7 +1263,7 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._group_activity_threshold = int(
             extra.get("group_activity_threshold")
-            or os.getenv("WEIXIN_GROUP_ACTIVITY_THRESHOLD", "10")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_THRESHOLD", "5")
         )
         self._group_activity_window = int(
             extra.get("group_activity_window")
@@ -1225,10 +1273,20 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("group_activity_cooldown")
             or os.getenv("WEIXIN_GROUP_ACTIVITY_COOLDOWN", "1800")
         )
+        self._group_activity_burst_multiplier = float(
+            extra.get("group_activity_burst_multiplier")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_BURST_MULTIPLIER", "3.0")
+        )
+        self._group_activity_warmup = int(
+            extra.get("group_activity_warmup")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_WARMUP", "6")
+        )
         self._activity_monitor = GroupActivityMonitor(
-            threshold=self._group_activity_threshold,
             window_seconds=self._group_activity_window,
             cooldown_seconds=self._group_activity_cooldown,
+            burst_multiplier=self._group_activity_burst_multiplier,
+            min_absolute=self._group_activity_threshold,
+            warmup_windows=self._group_activity_warmup,
         )
         self._home_contact = str(
             extra.get("home_contact") or os.getenv("WEIXIN_HOME_CONTACT", "")
@@ -1549,6 +1607,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.debug("[Weixin] Activity spike in %s but no WEIXIN_HOME_CONTACT set", _safe_id(chat_id))
             return
         count = self._activity_monitor.window_count(chat_id)
+        ema = self._activity_monitor.get_ema(chat_id)
         window = self._group_activity_window
         recent = ctx_buf.recent(5)
         preview_lines: List[str] = []
@@ -1558,7 +1617,7 @@ class WeixinAdapter(BasePlatformAdapter):
         preview = "\n".join(preview_lines) if preview_lines else "  (无预览)"
         body = (
             f"🔥 群 {_safe_id(chat_id)} 活跃度飙升！"
-            f"最近{window}秒内{count}条消息\n\n"
+            f"最近{window}秒内{count}条消息（基线: {ema:.1f}）\n\n"
             f"最近消息预览：\n{preview}"
         )
         logger.info("[Weixin] Activity spike notification for group %s (%d msgs in %ds)", _safe_id(chat_id), count, window)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -913,6 +913,11 @@ class GroupContextBuffer:
         """Append a message to the ring buffer."""
         self._buf.append((sender, text, ts or datetime.now()))
 
+    def recent(self, n: int = 5) -> List[Tuple[str, str, datetime]]:
+        """Return the *n* most recent entries (oldest-first)."""
+        items = list(self._buf)
+        return items[-n:] if len(items) > n else items
+
     def format_context(self) -> str:
         """Return formatted context string for injection into a prompt."""
         if not self._buf:
@@ -923,6 +928,69 @@ class GroupContextBuffer:
             lines.append(f"[{stamp}] {sender}: {text}")
         count = len(self._buf)
         return f"[群聊上下文 - 最近{count}条消息]\n" + "\n".join(lines) + "\n---\n"
+
+
+class GroupActivityMonitor:
+    """Per-group sliding-window activity tracker with spike detection.
+
+    Maintains a deque of message timestamps per group.  ``is_hot`` returns
+    *True* when the number of messages inside the sliding window exceeds the
+    configured threshold.  ``should_notify`` adds a per-group cooldown so that
+    notifications are not sent too frequently.
+    """
+
+    def __init__(
+        self,
+        threshold: int = 10,
+        window_seconds: int = 300,
+        cooldown_seconds: int = 1800,
+    ) -> None:
+        self._threshold = threshold
+        self._window = window_seconds
+        self._cooldown = cooldown_seconds
+        self._timestamps: Dict[str, collections.deque] = {}
+        self._last_notified: Dict[str, float] = {}
+
+    # -- public API ----------------------------------------------------------
+
+    def record(self, chat_id: str) -> None:
+        """Record a message timestamp for *chat_id*."""
+        now = time.time()
+        if chat_id not in self._timestamps:
+            self._timestamps[chat_id] = collections.deque()
+        dq = self._timestamps[chat_id]
+        dq.append(now)
+        # Prune entries outside the window
+        cutoff = now - self._window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+
+    def is_hot(self, chat_id: str) -> bool:
+        """Return *True* if message count in window exceeds threshold."""
+        dq = self._timestamps.get(chat_id)
+        if not dq:
+            return False
+        now = time.time()
+        cutoff = now - self._window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+        return len(dq) >= self._threshold
+
+    def should_notify(self, chat_id: str) -> bool:
+        """Return *True* if the group is hot AND the cooldown has expired."""
+        if not self.is_hot(chat_id):
+            return False
+        last = self._last_notified.get(chat_id, 0.0)
+        return (time.time() - last) >= self._cooldown
+
+    def mark_notified(self, chat_id: str) -> None:
+        """Record that a notification was just sent for *chat_id*."""
+        self._last_notified[chat_id] = time.time()
+
+    def window_count(self, chat_id: str) -> int:
+        """Return the number of messages in the current window."""
+        dq = self._timestamps.get(chat_id)
+        return len(dq) if dq else 0
 
 
 def _sync_buf_path(hermes_home: str, account_id: str) -> Path:
@@ -1128,6 +1196,44 @@ class WeixinAdapter(BasePlatformAdapter):
         self._group_context: Dict[str, GroupContextBuffer] = {}
         self._group_context_max_chats = 100  # Cap tracked groups to prevent unbounded growth
         self._bot_name_warning_logged = False
+
+        # -- Persistent group message log --
+        self._group_log = _coerce_bool(
+            extra.get("group_log") or os.getenv("WEIXIN_GROUP_LOG", "false"),
+            default=False,
+        )
+        self._group_log_dir = Path(
+            extra.get("group_log_dir") or os.getenv("WEIXIN_GROUP_LOG_DIR", "")
+            or str(Path(hermes_home) / "weixin" / "group-logs")
+        )
+
+        # -- Activity spike detection --
+        self._group_activity_enabled = _coerce_bool(
+            extra.get("group_activity_enabled")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_ENABLED", "false"),
+            default=False,
+        )
+        self._group_activity_threshold = int(
+            extra.get("group_activity_threshold")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_THRESHOLD", "10")
+        )
+        self._group_activity_window = int(
+            extra.get("group_activity_window")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_WINDOW", "300")
+        )
+        self._group_activity_cooldown = int(
+            extra.get("group_activity_cooldown")
+            or os.getenv("WEIXIN_GROUP_ACTIVITY_COOLDOWN", "1800")
+        )
+        self._activity_monitor = GroupActivityMonitor(
+            threshold=self._group_activity_threshold,
+            window_seconds=self._group_activity_window,
+            cooldown_seconds=self._group_activity_cooldown,
+        )
+        self._home_contact = str(
+            extra.get("home_contact") or os.getenv("WEIXIN_HOME_CONTACT", "")
+        ).strip()
+
         self._split_multiline_messages = _coerce_bool(
             extra.get("split_multiline_messages")
             or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"),
@@ -1303,6 +1409,26 @@ class WeixinAdapter(BasePlatformAdapter):
             ctx_buf = self._group_context[effective_chat_id]
             ctx_buf.add(sender_id, text)
 
+            # -- Persistent group message log --
+            if self._group_log:
+                self._append_group_log(
+                    chat_id=effective_chat_id,
+                    sender=sender_id,
+                    text=text,
+                    msg_id=message_id,
+                )
+
+            # -- Activity spike detection --
+            if self._group_activity_enabled:
+                self._activity_monitor.record(effective_chat_id)
+                if self._activity_monitor.should_notify(effective_chat_id):
+                    self._activity_monitor.mark_notified(effective_chat_id)
+                    asyncio.create_task(
+                        self._send_activity_spike_notification(
+                            effective_chat_id, ctx_buf,
+                        )
+                    )
+
             if self._group_silent:
                 logger.debug(
                     "[Weixin] Silent mode: buffered group message from %s in %s",
@@ -1378,6 +1504,118 @@ class WeixinAdapter(BasePlatformAdapter):
         if self._dm_policy == "allowlist":
             return sender_id in self._allow_from
         return True
+
+    # -- Group log helpers ---------------------------------------------------
+
+    def _append_group_log(
+        self,
+        *,
+        chat_id: str,
+        sender: str,
+        text: str,
+        msg_id: str,
+    ) -> None:
+        """Append a single group message to a date-partitioned JSONL log file."""
+        try:
+            now = datetime.now()
+            date_dir = self._group_log_dir / now.strftime("%Y-%m-%d")
+            date_dir.mkdir(parents=True, exist_ok=True)
+            log_path = date_dir / f"{chat_id}.jsonl"
+            entry = json.dumps(
+                {
+                    "ts": now.isoformat(),
+                    "sender": sender,
+                    "text": text,
+                    "msg_id": msg_id,
+                },
+                ensure_ascii=False,
+            )
+            with open(log_path, "a", encoding="utf-8") as fh:
+                fh.write(entry + "\n")
+        except Exception as exc:
+            logger.warning(
+                "[Weixin] Failed to write group log for %s: %s",
+                _safe_id(chat_id),
+                exc,
+            )
+
+    async def _send_activity_spike_notification(
+        self,
+        chat_id: str,
+        ctx_buf: GroupContextBuffer,
+    ) -> None:
+        """Send an activity spike notification to the home contact (fire-and-forget)."""
+        if not self._home_contact:
+            logger.debug("[Weixin] Activity spike in %s but no WEIXIN_HOME_CONTACT set", _safe_id(chat_id))
+            return
+        count = self._activity_monitor.window_count(chat_id)
+        window = self._group_activity_window
+        recent = ctx_buf.recent(5)
+        preview_lines: List[str] = []
+        for sender, text, ts in recent:
+            stamp = ts.strftime("%H:%M")
+            preview_lines.append(f"  [{stamp}] {_safe_id(sender)}: {text[:80]}")
+        preview = "\n".join(preview_lines) if preview_lines else "  (无预览)"
+        body = (
+            f"🔥 群 {_safe_id(chat_id)} 活跃度飙升！"
+            f"最近{window}秒内{count}条消息\n\n"
+            f"最近消息预览：\n{preview}"
+        )
+        logger.info("[Weixin] Activity spike notification for group %s (%d msgs in %ds)", _safe_id(chat_id), count, window)
+        try:
+            await self.send(self._home_contact, body)
+        except Exception as exc:
+            logger.warning("[Weixin] Failed to send activity spike notification: %s", exc)
+
+    def get_group_log_dir(self) -> Path:
+        """Return the configured group log directory path."""
+        return self._group_log_dir
+
+    @staticmethod
+    def generate_daily_digest(
+        log_dir: Path,
+        date: str,
+        chat_ids: Optional[List[str]] = None,
+    ) -> Dict[str, List[dict]]:
+        """Read JSONL log files for *date* and return ``{chat_id: [messages]}``.
+
+        Parameters
+        ----------
+        log_dir:
+            Root group-logs directory (contains date sub-directories).
+        date:
+            Date string in ``YYYY-MM-DD`` format.
+        chat_ids:
+            Optional list of chat IDs to include.  ``None`` means all.
+
+        Returns
+        -------
+        Dict mapping chat ID to a list of message dicts read from the JSONL
+        files.  Returns an empty dict when no data is found.
+        """
+        date_dir = log_dir / date
+        result: Dict[str, List[dict]] = {}
+        if not date_dir.is_dir():
+            return result
+        for log_file in sorted(date_dir.glob("*.jsonl")):
+            cid = log_file.stem
+            if chat_ids is not None and cid not in chat_ids:
+                continue
+            messages: List[dict] = []
+            try:
+                with open(log_file, "r", encoding="utf-8") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if line:
+                            try:
+                                messages.append(json.loads(line))
+                            except json.JSONDecodeError:
+                                continue
+            except Exception:
+                continue
+            if messages:
+                result[cid] = messages
+        return result
 
     async def _collect_media(self, item: Dict[str, Any], media_paths: List[str], media_types: List[str]) -> None:
         item_type = item.get("type")


### PR DESCRIPTION
## Summary

Builds on PR #8890 (mention gating, silent mode, context buffer) to add **persistent logging**, **activity spike detection**, and **daily digest** support for Weixin group chats.

### 1. Persistent Group Message Log (`WEIXIN_GROUP_LOG`)

Append every group message to date-partitioned JSONL files for audit and digest generation.

- Storage: `~/.hermes/weixin/group-logs/{YYYY-MM-DD}/{chat_id}.jsonl`
- Each line: `{"ts": "ISO8601", "sender": "user_id", "text": "...", "msg_id": "..."}`
- Runs **before** silent/mention checks — logs ALL messages that pass group policy
- Date-based directories make cleanup/rotation trivial (`rm -rf group-logs/2026-04-01/`)
- Custom path via `WEIXIN_GROUP_LOG_DIR`
- Graceful error handling — log write failures never crash the adapter

### 2. Activity Spike Detection (`WEIXIN_GROUP_ACTIVITY_ENABLED`)

Detect when a group gets unusually active and notify the user in real-time.

**New class: `GroupActivityMonitor`**
- Per-group sliding window using `collections.deque` of timestamps
- Configurable threshold, window size, and cooldown period
- Methods: `record()`, `is_hot()`, `should_notify()`, `mark_notified()`, `window_count()`

**Spike notification flow:**
1. Each group message is recorded in the sliding window
2. If message count exceeds threshold within the window → spike detected
3. If cooldown has expired → fire-and-forget notification to `WEIXIN_HOME_CONTACT`
4. Notification includes message count and 5-message preview:
   ```
   🔥 群 abc123@chatroom 活跃度飙升！最近300秒内15条消息

   最近消息预览：
     [14:21] user_a: BTC突然拉了一波
     [14:22] user_b: 什么情况？
     [14:22] user_c: 好像是ETF消息
     [14:23] user_a: 涨了3%了
     [14:23] user_d: 冲冲冲
   ```

### 3. Daily Digest Helper

Utility for cron-based daily summaries.

- `WeixinAdapter.generate_daily_digest(log_dir, date, chat_ids)` — static method
  - Reads JSONL files for a given date
  - Returns `{chat_id: [messages]}` dict
  - Optional `chat_ids` filter (None = all groups)
- `get_group_log_dir()` — convenience accessor for external callers

**Example cron usage:**
```python
from gateway.platforms.weixin import WeixinAdapter
from pathlib import Path

data = WeixinAdapter.generate_daily_digest(
    Path("~/.hermes/weixin/group-logs").expanduser(),
    "2026-04-13",
)
for chat_id, messages in data.items():
    print(f"Group {chat_id}: {len(messages)} messages")
```

### 4. Enhanced GroupContextBuffer

Added `recent(n)` method to retrieve the last N entries (used by spike notifications).

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `WEIXIN_GROUP_LOG` | `false` | Enable persistent JSONL logging of group messages |
| `WEIXIN_GROUP_LOG_DIR` | `~/.hermes/weixin/group-logs` | Custom log directory path |
| `WEIXIN_GROUP_ACTIVITY_ENABLED` | `false` | Enable activity spike detection |
| `WEIXIN_GROUP_ACTIVITY_THRESHOLD` | `10` | Messages in window to trigger spike |
| `WEIXIN_GROUP_ACTIVITY_WINDOW` | `300` | Sliding window size in seconds |
| `WEIXIN_GROUP_ACTIVITY_COOLDOWN` | `1800` | Cooldown between notifications per group |
| `WEIXIN_HOME_CONTACT` | (empty) | User ID to receive spike notifications |

All settings also work via `config.yaml` under `platforms.weixin.extra.*`.

## Processing Order (complete)

```
Group message arrives
  → Group policy check (disabled/allowlist) — existing
  → Buffer into GroupContextBuffer — PR #8890
  → Persistent log (if enabled) — NEW
  → Activity spike detection (if enabled) — NEW
  → Silent mode check — PR #8890
  → Mention gating (@bot check) — PR #8890
  → Context injection — PR #8890
  → handle_message() → agent responds
```

## Design Decisions
- **JSONL format** — one JSON object per line, easy to parse/grep/stream
- **Date partitioning** — each day in its own directory for simple log rotation
- **Fire-and-forget notifications** — spike alerts are sent via `asyncio.create_task`, never blocking message processing
- **Sliding window with pruning** — old timestamps are pruned on every `record()` and `is_hot()` call
- **Static digest method** — no adapter instance needed, can be called from cron scripts
- **All features off by default** — zero behavior change unless explicitly enabled

## Depends On
- PR #8890 (mention gating, silent mode, context buffer)

## Testing
- Syntax verified with `ast.parse()`
- All changes additive — existing behavior unchanged when new features are disabled