### PR TITLE
feat(telegram): support inline keyboards on assistant replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1177,6 +1177,32 @@ class BasePlatformAdapter(ABC):
         
         return media, cleaned
 
+    def extract_inline_keyboard(
+        self, text: str,
+    ) -> Tuple[Optional[list], str]:
+        """Extract inline keyboard directives from response text.
+
+        Returns:
+            Tuple of (parsed keyboard data or None, cleaned text with tags removed).
+
+        The base implementation is a no-op — override in platform adapters
+        that support inline keyboards (e.g. Telegram).
+        """
+        return None, text
+
+    async def attach_inline_keyboard(
+        self,
+        chat_id: str,
+        message_id: str,
+        buttons: list,
+    ) -> "SendResult":
+        """Attach an inline keyboard to an existing message.
+
+        The base implementation is a no-op — override in platform adapters
+        that support inline keyboards (e.g. Telegram).
+        """
+        return SendResult(success=False, error="Not supported")
+
     @staticmethod
     def extract_local_files(content: str) -> Tuple[List[str], str]:
         """
@@ -1582,6 +1608,15 @@ class BasePlatformAdapter(ABC):
                 # Strip any remaining internal directives from message body (fixes #1561)
                 text_content = text_content.replace("[[audio_as_voice]]", "").strip()
                 text_content = re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
+
+                # Extract inline keyboard tags (e.g. [KEYBOARD: ...] blocks)
+                inline_keyboard = None
+                if text_content:
+                    try:
+                        inline_keyboard, text_content = self.extract_inline_keyboard(text_content)
+                    except Exception as kb_err:
+                        logger.warning("[%s] Failed to extract inline keyboard: %s", self.name, kb_err)
+
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
 
@@ -1637,6 +1672,23 @@ class BasePlatformAdapter(ABC):
                         metadata=_thread_metadata,
                     )
                     _record_delivery(result)
+
+                    # Attach inline keyboard to the last message chunk
+                    if inline_keyboard and result.success and result.message_id:
+                        target_id = result.message_id
+                        # For chunked messages, attach to the very last chunk
+                        if isinstance(getattr(result, "raw_response", None), dict):
+                            ids = result.raw_response.get("message_ids")
+                            if isinstance(ids, list) and ids:
+                                target_id = ids[-1]
+                        try:
+                            await self.attach_inline_keyboard(
+                                chat_id=event.source.chat_id,
+                                message_id=str(target_id),
+                                buttons=inline_keyboard,
+                            )
+                        except Exception as kb_err:
+                            logger.warning("[%s] Failed to attach inline keyboard: %s", self.name, kb_err)
 
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -1015,6 +1015,92 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=str(e))
 
+    # ------------------------------------------------------------------
+    # Inline keyboard support (extract from agent output → attach to msg)
+    # ------------------------------------------------------------------
+
+    def extract_inline_keyboard(
+        self, text: str,
+    ) -> Tuple[Optional[List[List[Tuple[str, str]]]], str]:
+        """Extract a ``[KEYBOARD: ...]`` block from agent output.
+
+        Syntax produced by the agent::
+
+            [KEYBOARD:
+            ✅ Confirm=ck:confirm | ❌ Cancel=ck:cancel
+            🔄 Later=ck:later
+            ]
+
+        Each line becomes one row; ``|`` separates buttons within a row.
+        Only ``ck:``-prefixed callback data is accepted (custom-keyboard
+        namespace).  Callbacks exceeding Telegram's 64-byte limit are
+        silently skipped.
+
+        Returns:
+            ``(buttons, cleaned_text)`` — *buttons* is ``None`` when no
+            valid keyboard block was found.
+        """
+        match = re.search(r'\[KEYBOARD:\s*\n(.*?)\]', text, re.DOTALL)
+        if not match:
+            return None, text
+
+        raw = match.group(1).strip()
+        cleaned = (text[:match.start()] + text[match.end():]).strip()
+
+        buttons: List[List[Tuple[str, str]]] = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            row: List[Tuple[str, str]] = []
+            for item in line.split("|"):
+                item = item.strip()
+                if "=" not in item:
+                    continue
+                label, callback = item.rsplit("=", 1)
+                label, callback = label.strip(), callback.strip()
+                if not label or not callback.startswith("ck:"):
+                    continue
+                if len(callback.encode("utf-8")) > 64:
+                    logger.warning(
+                        "[%s] Skipping keyboard callback over 64 bytes: %s",
+                        self.name, callback,
+                    )
+                    continue
+                row.append((label, callback))
+            if row:
+                buttons.append(row)
+
+        return (buttons or None), cleaned
+
+    async def attach_inline_keyboard(
+        self,
+        chat_id: str,
+        message_id: str,
+        buttons: List[List[Tuple[str, str]]],
+    ) -> SendResult:
+        """Attach an inline keyboard to an existing Telegram message."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            keyboard = InlineKeyboardMarkup([
+                [InlineKeyboardButton(label, callback_data=data)
+                 for label, data in row]
+                for row in buttons
+            ])
+            await self._bot.edit_message_reply_markup(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                reply_markup=keyboard,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.error(
+                "[%s] Failed to attach inline keyboard to msg %s: %s",
+                self.name, message_id, e, exc_info=True,
+            )
+            return SendResult(success=False, error=str(e))
+
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
@@ -1405,6 +1491,67 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    async def _handle_custom_keyboard_callback(
+        self, query: Any, data: str,
+    ) -> None:
+        """Re-inject a ``ck:`` callback as a virtual user message.
+
+        When the user taps an inline keyboard button whose callback_data
+        starts with ``ck:``, we acknowledge the tap, edit the message to
+        show which option was selected (removing the keyboard), and feed
+        the raw callback string back into the normal message handler so
+        the agent can act on it.
+        """
+        if not query or not query.message:
+            return
+
+        try:
+            await query.answer()
+        except Exception:
+            pass
+
+        # Find the label of the clicked button from the original keyboard
+        clicked_label = data
+        try:
+            markup = query.message.reply_markup
+            if markup and markup.inline_keyboard:
+                for row in markup.inline_keyboard:
+                    for btn in row:
+                        if btn.callback_data == data:
+                            clicked_label = btn.text
+                            break
+        except Exception:
+            pass
+
+        # Edit the message: keep original text, append selection, remove keyboard
+        try:
+            original_text = query.message.text or ""
+            user_display = getattr(query.from_user, "first_name", "User")
+            updated_text = f"{original_text}\n\n> {user_display} selected: {clicked_label}"
+            await query.edit_message_text(
+                text=updated_text,
+                reply_markup=None,
+            )
+        except Exception:
+            # Fallback: just remove the keyboard
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+        try:
+            event = self._build_message_event(query.message, MessageType.TEXT)
+            event.text = data
+            if event.source and getattr(query, "from_user", None):
+                event.source.user_id = str(query.from_user.id)
+                event.source.user_name = query.from_user.full_name
+            await self.handle_message(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] Failed to re-inject keyboard callback %r: %s",
+                self.name, data, exc, exc_info=True,
+            )
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -1419,6 +1566,11 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- Custom inline keyboard callbacks (ck:...) ---
+        if data.startswith("ck:"):
+            await self._handle_custom_keyboard_callback(query, data)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -233,6 +233,15 @@ class GatewayStreamConsumer:
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
+                    # Extract inline keyboard tags before the final delivery
+                    # so the raw [KEYBOARD:...] block is never shown to users.
+                    inline_keyboard = None
+                    if self._accumulated:
+                        try:
+                            inline_keyboard, self._accumulated = self.adapter.extract_inline_keyboard(self._accumulated)
+                        except Exception as kb_err:
+                            logger.warning("Stream: failed to extract keyboard tag: %s", kb_err)
+
                     # Final edit without cursor. If progressive editing failed
                     # mid-stream, send a single continuation/fallback message
                     # here instead of letting the base gateway path send the
@@ -246,6 +255,20 @@ class GatewayStreamConsumer:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
+
+                    # Attach inline keyboard to the final streamed message
+                    if (inline_keyboard
+                            and self._message_id
+                            and self._message_id != "__no_edit__"):
+                        try:
+                            await self.adapter.attach_inline_keyboard(
+                                chat_id=self.chat_id,
+                                message_id=str(self._message_id),
+                                buttons=inline_keyboard,
+                            )
+                        except Exception as kb_err:
+                            logger.warning("Stream: failed to attach keyboard: %s", kb_err)
+
                     return
 
                 if commentary_text is not None:
@@ -287,6 +310,8 @@ class GatewayStreamConsumer:
     # Matches the simple cleanup regex used by the non-streaming path in
     # gateway/platforms/base.py for post-processing.
     _MEDIA_RE = re.compile(r'''[`"']?MEDIA:\s*\S+[`"']?''')
+    # Pattern to strip complete [KEYBOARD: ...] blocks from streaming display.
+    _KEYBOARD_RE = re.compile(r'\[KEYBOARD:\s*\n.*?\]', re.DOTALL)
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
@@ -299,10 +324,17 @@ class GatewayStreamConsumer:
         stream finishes — we just need to hide the raw directives from the
         user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
+        if ("MEDIA:" not in text
+                and "[[audio_as_voice]]" not in text
+                and "[KEYBOARD:" not in text):
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
+        # Strip complete [KEYBOARD:...] blocks; if the closing ']' hasn't
+        # arrived yet, hide everything from the opening tag onward.
+        cleaned = GatewayStreamConsumer._KEYBOARD_RE.sub("", cleaned)
+        if "[KEYBOARD:" in cleaned:
+            cleaned = cleaned.split("[KEYBOARD:", 1)[0]
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content


### PR DESCRIPTION
## What does this PR do?

Adds inline keyboard support for Telegram assistant replies. Agents can output `[KEYBOARD: ...]` tags to attach interactive buttons to their messages. When a user taps a button, the message is edited to show the selection, the keyboard is removed, and the callback is re-injected as a virtual user message for the agent to act on.

Follows the same extract-then-attach pattern as `MEDIA:` tags — base class provides no-op methods, Telegram overrides with real implementations.

## Related Issue

Related to #503

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — Add `extract_inline_keyboard()` and `attach_inline_keyboard()` no-op methods; call them in `_deliver_response` for non-streaming path
- `gateway/platforms/telegram.py` — Override both methods with Telegram implementations; add `_handle_custom_keyboard_callback()` and `ck:` routing in `_handle_callback_query`
- `gateway/stream_consumer.py` — Strip `[KEYBOARD:]` blocks during streaming display; extract and attach keyboard on stream completion

## How to Test

1. Configure a Telegram bot and instruct the agent (via system prompt) to use `[KEYBOARD: ...]` syntax
2. Send a message that triggers the agent to respond with a keyboard:
   ```
   [KEYBOARD:
   ✅ Confirm=ck:confirm | ❌ Cancel=ck:cancel
   🔄 Later=ck:later
   ]
   ```
3. Verify inline buttons appear below the assistant message
4. Tap a button — message should be edited to show selection, keyboard removed, callback re-injected
5. Verify normal messages (without `[KEYBOARD:]`) are unaffected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

_Tested manually on Telegram: inline keyboard renders correctly, button tap edits message and re-injects callback._