### PR TITLE
fix(docker): add .venv to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 
 # Dependencies
 node_modules
+.venv
 
 # CI/CD
 .github


### PR DESCRIPTION
## Summary

`COPY . /opt/hermes` in the Dockerfile copies the local `.venv` directory into the build context, causing `uv venv` to fail:

```
error: Failed to create virtual environment
Caused by: A virtual environment already exists at `/opt/hermes/.venv`. Use `--clear` to replace it
```

## Changes

Added `.venv` to `.dockerignore`.

Closes #8828