### PR TITLE
fix: use real user home instead of sandbox-overridden HOME

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -16,7 +16,7 @@ import logging
 import os
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -308,7 +308,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = _real_home() / ".claude" / ".credentials.json"
     if cred_path.exists():
         try:
             data = json.loads(cred_path.read_text(encoding="utf-8"))
@@ -330,7 +330,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
 def read_claude_managed_key() -> Optional[str]:
     """Read Claude's native managed key from ~/.claude.json for diagnostics only."""
-    claude_json = Path.home() / ".claude.json"
+    claude_json = get_real_home() / ".claude.json"
     if claude_json.exists():
         try:
             data = json.loads(claude_json.read_text(encoding="utf-8"))
@@ -456,7 +456,7 @@ def _write_claude_code_credentials(
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = get_real_home() / ".claude" / ".credentials.json"
     try:
         # Read existing file to preserve other fields
         existing = {}

--- a/cli.py
+++ b/cli.py
@@ -3810,7 +3810,8 @@ class HermesCLI:
         home = get_hermes_home()
         display = display_hermes_home()
 
-        profiles_parent = Path.home() / ".hermes" / "profiles"
+        from hermes_constants import get_real_home
+        profiles_parent = get_real_home() / ".hermes" / "profiles"
         try:
             rel = home.relative_to(profiles_parent)
             profile_name = str(rel).split("/")[0]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -348,6 +348,11 @@ DEFAULT_CONFIG = {
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         "timeout": 180,
+        # Per-profile HOME isolation: when running inside a profile, redirect
+        # subprocess HOME to {HERMES_HOME}/home/ so system tool configs (git,
+        # ssh, gh, npm) stay inside the profile.  Set to false to keep the
+        # real OS user home for all subprocesses.
+        "profile_home_isolation": True,
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -149,7 +149,8 @@ def _get_active_profile_path() -> Path:
 
 def _get_wrapper_dir() -> Path:
     """Return the directory for wrapper scripts."""
-    return Path.home() / ".local" / "bin"
+    from hermes_constants import get_real_home
+    return get_real_home() / ".local" / "bin"
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -8,13 +8,43 @@ import os
 from pathlib import Path
 
 
+# ── Real user home (captured at import time) ──────────────────────────────
+#
+# The terminal sandbox overrides ``HOME`` to ``{HERMES_HOME}/home/`` for
+# per-profile subprocess isolation.  ``Path.home()`` reads the overridden
+# value, so any code that needs the *real* OS user home must use this
+# module-level constant instead.
+#
+# Captured once at import time — before the sandbox can override it — so
+# downstream consumers always get the correct value even when ``HOME`` has
+# been repointed to a profile directory.
+
+_REAL_HOME: Path = Path(os.environ.get("HERMES_REAL_HOME", "")) or Path.home()
+
+
+def get_real_home() -> Path:
+    """Return the real OS user home directory.
+
+    Unlike ``Path.home()`` — which returns the sandbox-overridden ``HOME``
+    when running inside a profile — this always returns the actual user
+    home (e.g. ``/Users/alice``).
+
+    Use this when:
+    - Looking for external tool configs (``~/.claude.json``, ``~/.modal.toml``)
+    - Resolving the hermes root directory (``~/.hermes``)
+    - Creating wrapper scripts (``~/.local/bin``)
+    - Expanding user file paths (``~/Documents/file.txt``)
+    """
+    return _REAL_HOME
+
+
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: ~/.hermes).
 
     Reads HERMES_HOME env var, falls back to ~/.hermes.
     This is the single source of truth — all other copies should import this.
     """
-    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return Path(os.getenv("HERMES_HOME", get_real_home() / ".hermes"))
 
 
 def get_default_hermes_root() -> Path:
@@ -33,7 +63,7 @@ def get_default_hermes_root() -> Path:
 
     Import-safe — no dependencies beyond stdlib.
     """
-    native_home = Path.home() / ".hermes"
+    native_home = get_real_home() / ".hermes"
     env_home = os.environ.get("HERMES_HOME", "")
     if not env_home:
         return native_home

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -4,7 +4,10 @@ Import-safe module with no dependencies — can be imported from anywhere
 without risk of circular imports.
 """
 
+from __future__ import annotations
+
 import os
+import pwd
 from pathlib import Path
 
 
@@ -15,11 +18,17 @@ from pathlib import Path
 # value, so any code that needs the *real* OS user home must use this
 # module-level constant instead.
 #
-# Captured once at import time — before the sandbox can override it — so
-# downstream consumers always get the correct value even when ``HOME`` has
-# been repointed to a profile directory.
+# We use ``pwd.getpwuid()`` to bypass the ``HOME`` env var entirely and
+# get the actual user home from the system password database.  Falls back
+# to ``Path.home()`` on non-Unix platforms.
 
-_REAL_HOME: Path = Path(os.environ.get("HERMES_REAL_HOME", "")) or Path.home()
+def _get_real_home() -> Path:
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except (KeyError, ImportError, AttributeError):
+        return Path.home()
+
+_REAL_HOME: Path = _get_real_home()
 
 
 def get_real_home() -> Path:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -16,14 +16,15 @@ class TestGetDefaultHermesRoot:
     def test_no_hermes_home_returns_native(self, tmp_path, monkeypatch):
         """When HERMES_HOME is not set, returns ~/.hermes."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         assert get_default_hermes_root() == tmp_path / ".hermes"
 
     def test_hermes_home_is_native(self, tmp_path, monkeypatch):
         """When HERMES_HOME = ~/.hermes, returns ~/.hermes."""
         native = tmp_path / ".hermes"
         native.mkdir()
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(native))
         assert get_default_hermes_root() == native
 
@@ -32,7 +33,7 @@ class TestGetDefaultHermesRoot:
         native = tmp_path / ".hermes"
         profile = native / "profiles" / "coder"
         profile.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_default_hermes_root() == native
 
@@ -40,7 +41,7 @@ class TestGetDefaultHermesRoot:
         """When HERMES_HOME points outside ~/.hermes (Docker), returns HERMES_HOME."""
         docker_home = tmp_path / "opt" / "data"
         docker_home.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(docker_home))
         assert get_default_hermes_root() == docker_home
 
@@ -48,7 +49,7 @@ class TestGetDefaultHermesRoot:
         """Any HERMES_HOME outside ~/.hermes is treated as the root."""
         custom = tmp_path / "my-hermes-data"
         custom.mkdir()
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(custom))
         assert get_default_hermes_root() == custom
 
@@ -58,7 +59,7 @@ class TestGetDefaultHermesRoot:
         docker_root = tmp_path / "opt" / "data"
         profile = docker_root / "profiles" / "coder"
         profile.mkdir(parents=True)
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("hermes_constants._REAL_HOME", tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_default_hermes_root() == docker_root
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1022,10 +1022,20 @@ def execute_code(
 
         # Per-profile HOME isolation: redirect system tool configs into
         # {HERMES_HOME}/home/ when that directory exists.
+        # Controlled by config: terminal.profile_home_isolation (default: true).
         from hermes_constants import get_subprocess_home
         _profile_home = get_subprocess_home()
         if _profile_home:
-            child_env["HOME"] = _profile_home
+            _isolate = True
+            try:
+                from hermes_cli.config import get_config
+                _isolate = get_config().get("terminal", {}).get(
+                    "profile_home_isolation", True
+                )
+            except Exception:
+                pass
+            if _isolate:
+                child_env["HOME"] = _profile_home
 
         proc = subprocess.Popen(
             [sys.executable, "script.py"],

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1023,19 +1023,21 @@ def execute_code(
         # Per-profile HOME isolation: redirect system tool configs into
         # {HERMES_HOME}/home/ when that directory exists.
         # Controlled by config: terminal.profile_home_isolation (default: true).
-        from hermes_constants import get_subprocess_home
+        from hermes_constants import get_subprocess_home, get_real_home
         _profile_home = get_subprocess_home()
         if _profile_home:
             _isolate = True
             try:
-                from hermes_cli.config import get_config
-                _isolate = get_config().get("terminal", {}).get(
+                from hermes_cli.config import load_config
+                _isolate = load_config().get("terminal", {}).get(
                     "profile_home_isolation", True
                 )
             except Exception:
                 pass
             if _isolate:
                 child_env["HOME"] = _profile_home
+            else:
+                child_env["HOME"] = str(get_real_home())
 
         proc = subprocess.Popen(
             [sys.executable, "script.py"],

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -23,8 +23,10 @@ import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import get_real_home
 from toolsets import TOOLSETS
 
 
@@ -139,7 +141,10 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
         if not candidate:
             continue
         try:
-            text = os.path.abspath(os.path.expanduser(str(candidate)))
+            text = str(candidate)
+            if text.startswith("~"):
+                text = str(get_real_home()) + text[1:]
+            text = os.path.abspath(text)
         except Exception:
             continue
         if os.path.isabs(text) and os.path.isdir(text):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -130,9 +130,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     # Per-profile HOME isolation for background processes (same as _make_run_env).
+    # Controlled by config: terminal.profile_home_isolation (default: true).
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
-    if _profile_home:
+    if _profile_home and _should_isolate_profile_home():
         sanitized["HOME"] = _profile_home
 
     return sanitized
@@ -176,6 +177,26 @@ def _find_bash() -> str:
 _find_shell = _find_bash
 
 
+# Cached config value — read once to avoid repeated YAML parsing.
+_profile_home_isolation: bool | None = None
+
+
+def _should_isolate_profile_home() -> bool:
+    """Return True if profile HOME isolation is enabled in config."""
+    global _profile_home_isolation
+    if _profile_home_isolation is not None:
+        return _profile_home_isolation
+    try:
+        from hermes_cli.config import get_config
+        cfg = get_config()
+        _profile_home_isolation = cfg.get("terminal", {}).get(
+            "profile_home_isolation", True
+        )
+    except Exception:
+        _profile_home_isolation = True  # safe default
+    return _profile_home_isolation
+
+
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
@@ -205,9 +226,10 @@ def _make_run_env(env: dict) -> dict:
     # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
     # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
     # subprocess sees the override — the Python process keeps the real HOME.
+    # Controlled by config: terminal.profile_home_isolation (default: true).
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
-    if _profile_home:
+    if _profile_home and _should_isolate_profile_home():
         run_env["HOME"] = _profile_home
 
     return run_env

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -131,10 +131,13 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     # Per-profile HOME isolation for background processes (same as _make_run_env).
     # Controlled by config: terminal.profile_home_isolation (default: true).
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_subprocess_home, get_real_home
     _profile_home = get_subprocess_home()
-    if _profile_home and _should_isolate_profile_home():
+    _isolate = _should_isolate_profile_home()
+    if _profile_home and _isolate:
         sanitized["HOME"] = _profile_home
+    elif _profile_home and not _isolate:
+        sanitized["HOME"] = str(get_real_home())
 
     return sanitized
 
@@ -187,12 +190,16 @@ def _should_isolate_profile_home() -> bool:
     if _profile_home_isolation is not None:
         return _profile_home_isolation
     try:
-        from hermes_cli.config import get_config
-        cfg = get_config()
+        from hermes_cli.config import load_config
+        cfg = load_config()
         _profile_home_isolation = cfg.get("terminal", {}).get(
             "profile_home_isolation", True
         )
-    except Exception:
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning(
+            "profile_home_isolation config read failed: %s, defaulting to True", e
+        )
         _profile_home_isolation = True  # safe default
     return _profile_home_isolation
 
@@ -227,10 +234,15 @@ def _make_run_env(env: dict) -> dict:
     # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
     # subprocess sees the override — the Python process keeps the real HOME.
     # Controlled by config: terminal.profile_home_isolation (default: true).
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_subprocess_home, get_real_home
     _profile_home = get_subprocess_home()
-    if _profile_home and _should_isolate_profile_home():
+    _isolate = _should_isolate_profile_home()
+    if _profile_home and _isolate:
         run_env["HOME"] = _profile_home
+    elif _profile_home and not _isolate:
+        # Explicitly restore real HOME when isolation is disabled, in case
+        # the parent process already has the profile HOME set.
+        run_env["HOME"] = str(get_real_home())
 
     return run_env
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,11 +7,20 @@ import logging
 import os
 import threading
 from pathlib import Path
+from hermes_constants import get_real_home
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import ShellFileOperations
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+
+def _expanduser(path: str) -> str:
+    """Expand ``~`` to the real user home, not the sandbox-overridden HOME."""
+    home = str(get_real_home())
+    if path == "~" or path.startswith("~/"):
+        return home + path[1:]
+    return os.path.expanduser(path)
 
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
@@ -79,7 +88,7 @@ def _is_blocked_device(filepath: str) -> bool:
     through (e.g. /dev/stdin → /proc/self/fd/0 → /dev/pts/0), defeating
     the check.
     """
-    normalized = os.path.expanduser(filepath)
+    normalized = _expanduser(filepath)
     if normalized in _BLOCKED_DEVICE_PATHS:
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
@@ -99,7 +108,7 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = os.path.realpath(os.path.expanduser(filepath))
+        resolved = os.path.realpath(_expanduser(filepath))
     except (OSError, ValueError):
         resolved = filepath
     for prefix in _SENSITIVE_PATH_PREFIXES:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
+from hermes_constants import get_real_home
 from utils import env_var_enabled
 
 _DEFAULT_BROWSER_PROVIDER = "local"
@@ -41,7 +42,7 @@ def has_direct_modal_credentials() -> bool:
     """Return True when direct Modal credentials/config are available."""
     return bool(
         (os.getenv("MODAL_TOKEN_ID") and os.getenv("MODAL_TOKEN_SECRET"))
-        or (Path.home() / ".modal.toml").exists()
+        or (get_real_home() / ".modal.toml").exists()
     )
 
 


### PR DESCRIPTION
## Summary

Captures the real OS user home at module import time (before the sandbox can override `HOME`) and uses it for all `Path.home()` and `os.path.expanduser()` calls that need the actual user home.

## Problem

The terminal sandbox overrides `HOME` to `{HERMES_HOME}/home/` for profile isolation. This silently breaks:
- `gh` CLI auth (looks in wrong place for keychain tokens)
- Claude adapter credential discovery
- User file paths (`~/Documents/file.txt`)
- Profile root detection
- Wrapper script creation

## Changes

| File | Change |
|------|--------|
| `hermes_constants.py` | Add `_REAL_HOME` constant and `get_real_home()` helper |
| `hermes_constants.py` | `get_hermes_home()` and `get_default_hermes_root()` use `get_real_home()` |
| `cli.py` | Profile parent detection uses `get_real_home()` |
| `hermes_cli/profiles.py` | `_get_wrapper_dir()` uses `get_real_home()` |
| `agent/anthropic_adapter.py` | All 3 Claude config paths use `get_real_home()` |
| `tools/tool_backend_helpers.py` | modal.toml check uses `get_real_home()` |
| `tools/file_tools.py` | Add `_expanduser()` helper that expands `~` to real home |
| `tools/delegate_tool.py` | CWD resolution uses `get_real_home()` |
| `tests/test_hermes_constants.py` | Update monkeypatching for `_REAL_HOME` |

Closes #8669
