### PR TITLE
fix(web): CronPage crash when rendering schedule object

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -222,12 +222,14 @@ export interface CronJob {
   id: string;
   name?: string;
   prompt: string;
-  schedule: string;
-  status: "enabled" | "paused" | "error";
+  schedule: { kind: string; expr: string; display: string };
+  schedule_display: string;
+  enabled: boolean;
+  state: string;
   deliver?: string;
   last_run_at?: string | null;
   next_run_at?: string | null;
-  error?: string | null;
+  last_error?: string | null;
 }
 
 export interface SkillInfo {

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -19,9 +19,13 @@ function formatTime(iso?: string | null): string {
 
 const STATUS_VARIANT: Record<string, "success" | "warning" | "destructive"> = {
   enabled: "success",
+  scheduled: "success",
   paused: "warning",
   error: "destructive",
+  exhausted: "destructive",
 };
+
+
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
@@ -75,7 +79,8 @@ export default function CronPage() {
 
   const handlePauseResume = async (job: CronJob) => {
     try {
-      if (job.status === "paused") {
+      const isPaused = job.state === "paused";
+      if (isPaused) {
         await api.resumeCronJob(job.id);
         showToast(`Resumed "${job.name || job.prompt.slice(0, 30)}"`, "success");
       } else {
@@ -212,8 +217,8 @@ export default function CronPage() {
                   <span className="font-medium text-sm truncate">
                     {job.name || job.prompt.slice(0, 60) + (job.prompt.length > 60 ? "..." : "")}
                   </span>
-                  <Badge variant={STATUS_VARIANT[job.status] ?? "secondary"}>
-                    {job.status}
+                  <Badge variant={STATUS_VARIANT[job.state] ?? "secondary"}>
+                    {job.state}
                   </Badge>
                   {job.deliver && job.deliver !== "local" && (
                     <Badge variant="outline">{job.deliver}</Badge>
@@ -225,12 +230,12 @@ export default function CronPage() {
                   </p>
                 )}
                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                  <span className="font-mono">{job.schedule}</span>
+                  <span className="font-mono">{job.schedule_display}</span>
                   <span>Last: {formatTime(job.last_run_at)}</span>
                   <span>Next: {formatTime(job.next_run_at)}</span>
                 </div>
-                {job.error && (
-                  <p className="text-xs text-destructive mt-1">{job.error}</p>
+                {job.last_error && (
+                  <p className="text-xs text-destructive mt-1">{job.last_error}</p>
                 )}
               </div>
 
@@ -239,11 +244,11 @@ export default function CronPage() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  title={job.status === "paused" ? "Resume" : "Pause"}
-                  aria-label={job.status === "paused" ? "Resume job" : "Pause job"}
+                  title={job.state === "paused" ? "Resume" : "Pause"}
+                  aria-label={job.state === "paused" ? "Resume job" : "Pause job"}
                   onClick={() => handlePauseResume(job)}
                 >
-                  {job.status === "paused" ? (
+                  {job.state === "paused" ? (
                     <Play className="h-4 w-4 text-success" />
                   ) : (
                     <Pause className="h-4 w-4 text-warning" />


### PR DESCRIPTION
## What does this PR do?

Fixes a crash on the Cron page in the web dashboard. The cron jobs API returns `schedule` as an object `{kind, expr, display}` but the frontend tried to render it directly as a React child, which crashes React with *Objects are not valid as a React child*.

The CronJob TypeScript interface also had stale field names (`status` instead of `state`, `error` instead of `last_error`) that didn't match the actual API response.

## Related Issue

N/A — discovered during manual testing of `hermes dashboard`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/api.ts`: Updated `CronJob` interface to match actual API response (`schedule` as object, `schedule_display`, `state`, `enabled`, `last_error`)
- `web/src/pages/CronPage.tsx`: Use `job.schedule_display` instead of `job.schedule`, `job.state` instead of `job.status`, `job.last_error` instead of `job.error`. Added `scheduled` and `exhausted` to status badge variant map.

## How to Test

1. Run `hermes dashboard --host 0.0.0.0`
2. Navigate to the Cron tab
3. Verify existing cron jobs render without crashing
4. Create a new cron job and verify it appears in the list
5. Verify pause/resume/trigger/delete buttons work

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Mac Mini)

### Documentation & Housekeeping

- [x] N/A — no docs, config, or schema changes needed