### PR TITLE
fix(homeassistant): #8912 resolve XML tool calling loop by casting ne…

### DIFF
--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -274,6 +274,12 @@ def _handle_call_service(args: dict, **kw) -> str:
         return tool_error(f"Invalid entity_id format: {entity_id}")
 
     data = args.get("data")
+    if isinstance(data, str):
+        try:
+            data = json.loads(data) if data.strip() else None
+        except json.JSONDecodeError as e:
+            return tool_error(f"Invalid JSON string in 'data' parameter: {e}")
+
     try:
         result = _run_async(_async_call_service(domain, service, entity_id, data))
         return json.dumps({"result": result})
@@ -450,12 +456,12 @@ HA_CALL_SERVICE_SCHEMA = {
                 ),
             },
             "data": {
-                "type": "object",
+                "type": "string",
                 "description": (
-                    "Additional service data. Examples: "
-                    '{"brightness": 255, "color_name": "blue"} for lights, '
-                    '{"temperature": 22, "hvac_mode": "heat"} for climate, '
-                    '{"volume_level": 0.5} for media players.'
+                    "Additional service data provided as a valid JSON string. Examples: "
+                    '\'{"brightness": 255, "color_name": "blue"}\' for lights, '
+                    '\'{"temperature": 22, "hvac_mode": "heat"}\' for climate, '
+                    '\'{"volume_level": 0.5}\' for media players.'
                 ),
             },
         },


### PR DESCRIPTION
…sted object to JSON string

## What does this PR do?



Resolves #8912

### 🚨 Tool Calling Defect
A cognitive formatting loop was identified when the agent attempted to utilize the `ha_call_service` tool requiring nested data parameters (e.g., setting `hvac_mode`). Because the schema defined the `data` parameter as a JSON `"object"`, the LLM consistently failed to format the nested object correctly within the XML tags, defaulting to an empty payload (`{}`). This resulted in a persistent `400 Bad Request` from Home Assistant, triggering an infinite self-correction loop.

### 🛠️ Mitigation Strategy
This PR introduces a robust prompt-engineering workaround to decouple the nested JSON generation from the XML structure:
1. **Schema Simplification:** Re-typed the `data` parameter in `HA_CALL_SERVICE_SCHEMA` from `"object"` to `"string"`, instructing the model to output a serialized JSON string. This significantly lowers the cognitive load for the LLM when formatting XML.
2. **Runtime Deserialization:** Injected a `json.loads()` interceptor inside `_handle_call_service`. This safely parses the stringified payload back into a native Python dictionary immediately before dispatching the Home Assistant REST request. Added error handling to gracefully catch and return `JSONDecodeError` to the model.

### 📈 System Impact
* Neutralized the infinite 400 Bad Request retry loops.
* Restored full functionality for complex HA service calls requiring nested attributes.

