### PR TITLE
fix(cli): sanitize surrogate characters in handle_paste

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8693,6 +8693,9 @@ class HermesCLI:
             if _should_auto_attach_clipboard_image_on_paste(pasted_text) and self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:
+                # Sanitize surrogate characters (e.g. from Word/Google Docs paste) before writing
+                from run_agent import _sanitize_surrogates
+                pasted_text = _sanitize_surrogates(pasted_text)
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
                 if line_count >= 5 and not buf.text.strip().startswith('/'):


### PR DESCRIPTION
## What does this PR do?

Sanitizes lone surrogate characters (U+D800-U+DFFF) in the `handle_paste` function before writing pasted text to disk. Word and Google Docs commonly embed these surrogate characters in rich text, which are invalid in UTF-8 and cause Python to raise `UnicodeEncodeError: 'utf-8' codec can't encode characters in position X: surrogates not allowed`. The fix reuses the existing `_sanitize_surrogates()` helper from `run_agent.py`.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `cli.py`: Added surrogate sanitization in `handle_paste` before `write_text` (3 lines)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Copy any text from Word or Google Docs containing special/rich-text characters
2. Paste into Hermes CLI (e.g. via Ctrl+V or bracketed paste mode)
3. Confirm no crash and text is saved correctly to `~/.hermes/pastes/`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`, `feat(cli):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation \& Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Exception 'utf-8' codec can't encode characters in position 1613-1614: surrogates not allowed
Press ENTER to continue...
```