### PR TITLE
fix(gateway): process sessions.json updates without waiting for state.db writes

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -331,6 +331,7 @@ class EventBridge:
         when nothing has changed — makes 200ms polling essentially free.
         """
         # Check if sessions.json has changed (mtime check is ~1μs)
+        sessions_changed = False
         sessions_file = _get_sessions_dir() / "sessions.json"
         try:
             sj_mtime = sessions_file.stat().st_mtime if sessions_file.exists() else 0.0
@@ -338,6 +339,7 @@ class EventBridge:
             sj_mtime = 0.0
 
         if sj_mtime != self._sessions_json_mtime:
+            sessions_changed = True
             self._sessions_json_mtime = sj_mtime
             self._cached_sessions_index = _load_sessions_index()
 
@@ -353,7 +355,8 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+        if not db_changed and not sessions_changed:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1041,6 +1041,70 @@ class TestEventBridgePollE2E:
         assert db.call_count == first_calls, \
             "Second poll should skip DB queries when files unchanged"
 
+    def test_poll_detects_sessions_index_change_without_db_write(self, tmp_path, monkeypatch):
+        """A sessions.json change must be processed even when state.db mtime is unchanged."""
+        import mcp_serve
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        db_path = tmp_path / "state.db"
+        session_a = "20260329_150000_idx_a"
+        session_b = "20260329_150000_idx_b"
+        sessions_file = sessions_dir / "sessions.json"
+
+        sessions_data = {
+            "agent:main:telegram:dm:index-a": {
+                "session_key": "agent:main:telegram:dm:index-a",
+                "session_id": session_a,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": "index-a"},
+            }
+        }
+        sessions_file.write_text(json.dumps(sessions_data))
+
+        _create_test_db(db_path, session_a, [
+            {"role": "user", "content": "From A", "timestamp": "2026-03-29T15:00:01"},
+        ])
+        _create_test_db(db_path, session_b, [
+            {"role": "assistant", "content": "From B", "timestamp": "2026-03-29T15:00:02"},
+        ])
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        bridge._poll_once(db)
+        first = bridge.poll_events(after_cursor=0)
+        assert [event["content"] for event in first["events"]] == ["From A"]
+
+        sessions_data["agent:main:telegram:dm:index-b"] = {
+            "session_key": "agent:main:telegram:dm:index-b",
+            "session_id": session_b,
+            "platform": "telegram",
+            "updated_at": "2026-03-29T15:00:06",
+            "origin": {"platform": "telegram", "chat_id": "index-b"},
+        }
+        sessions_file.write_text(json.dumps(sessions_data))
+        new_mtime = sessions_file.stat().st_mtime + 1
+        os.utime(sessions_file, (new_mtime, new_mtime))
+
+        bridge._poll_once(db)
+        second = bridge.poll_events(after_cursor=first["next_cursor"])
+        assert [event["content"] for event in second["events"]] == ["From B"]
+
     def test_poll_detects_new_message_after_db_write(self, tmp_path, monkeypatch):
         """Write a new message to the DB after first poll, verify it's detected."""
         import mcp_serve


### PR DESCRIPTION
## What changed

Fixed a bug in `mcp_serve.py` inside `EventBridge._poll_once()`.

Previously, the early-return optimization could skip processing when `sessions.json` changed but `state.db` did not. In that case, newly indexed sessions could remain invisible to MCP clients until a later SQLite write happened. The root cause was that the poll loop updated the cached `sessions.json` mtime before evaluating whether anything had changed, which made the unchanged-path check too strict.

This change tracks `sessions.json` changes independently from `state.db` changes. The bridge now re-processes events when either file changes, instead of requiring a database write to make a sessions index update visible.

## Why

`EventBridge` uses mtime-based polling to avoid unnecessary work, but the old logic could incorrectly treat a fresh `sessions.json` update as a no-op. That delayed event visibility for newly added or updated session index entries.

The fix preserves the optimization while making the poll behavior correct.

## Tests

Added a regression test in `tests/test_mcp_serve.py`:

- `test_poll_detects_sessions_index_change_without_db_write`

This test verifies that when `sessions.json` gains a new session entry and `state.db` stays unchanged, `EventBridge._poll_once()` still ingests the new session's messages.

Also re-ran the MCP serve test coverage in the current workspace Python environment:

- `41 passed`
- `39 skipped`

## How to test

Run the targeted regression test:

```bash
pytest tests/test_mcp_serve.py::TestEventBridgePollE2E::test_poll_detects_sessions_index_change_without_db_write -v

Or run the full MCP serve test file:

pytest tests/test_mcp_serve.py


## Notes
No profile-safety regressions: existing get_hermes_home() usage remains intact.
The fix is cross-platform and relies on existing pathlib/mtime behavior without introducing OS-specific branching.