### PR TITLE
fix(telegram): pass proxy URL explicitly to HTTPXRequest when proxy env vars are set

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -572,10 +572,19 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 if proxy_configured:
                     logger.info("[%s] Proxy configured; skipping Telegram fallback-IP transport", self.name)
-                elif disable_fallback:
-                    logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                    proxy_url = (
+                        os.getenv("HTTPS_PROXY") or os.getenv("https_proxy") or
+                        os.getenv("HTTP_PROXY") or os.getenv("http_proxy") or
+                        os.getenv("ALL_PROXY") or os.getenv("all_proxy")
+                    )
+                    logger.info("[%s] Using explicit proxy for HTTPXRequest: %s", self.name, proxy_url)
+                    request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                    get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                else:
+                    if disable_fallback:
+                        logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
+                    request = HTTPXRequest(**request_kwargs)
+                    get_updates_request = HTTPXRequest(**request_kwargs)
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()


### PR DESCRIPTION
## Problem

When `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` env vars are set, the gateway correctly detects `proxy_configured=True` and skips the fallback-IP transport — but then creates `HTTPXRequest(**request_kwargs)` **without** an explicit `proxy=` argument, relying solely on httpx's `trust_env` mechanism.

In practice, `trust_env` alone is unreliable when the proxy is an **HTTP CONNECT proxy** (e.g. Clash / ClashMac in fake-ip mode, common for users in China): the TLS handshake inside the CONNECT tunnel fails intermittently via httpcore's anyio backend, even though the same proxy works fine from `curl` or `requests`/`urllib3`. The result is a flood of `httpx.ConnectError` / `httpx.ConnectTimeout` errors and failed message delivery.

## Fix

When `proxy_configured` is `True`, read the proxy URL from the environment and pass it **explicitly** via `HTTPXRequest(..., proxy=proxy_url)`. This matches the explicit approach already used in the aiohttp-based adapters (weixin/wecom/matrix, see #8680) and is more robust than `trust_env` for users behind HTTP CONNECT proxies.

```python
# before
request = HTTPXRequest(**request_kwargs)
get_updates_request = HTTPXRequest(**request_kwargs)

# after
proxy_url = (
    os.getenv("HTTPS_PROXY") or os.getenv("https_proxy") or
    os.getenv("HTTP_PROXY") or os.getenv("http_proxy") or
    os.getenv("ALL_PROXY") or os.getenv("all_proxy")
)
request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
```

## Test

Verified on macOS with ClashMac proxy (`http://127.0.0.1:7890`) in fake-ip mode. Before the fix: repeated `ConnectError` / `TimedOut` on polling and sends. After the fix: stable connection, messages delivered reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)