### PR TITLE
fix(cli): restore messaging toolset for gateway platforms

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
+    ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -8,6 +8,7 @@ from hermes_cli.tools_config import (
     _platform_toolset_summary,
     _save_platform_tools,
     _toolset_has_keys,
+    CONFIGURABLE_TOOLSETS,
     TOOL_CATEGORIES,
     _visible_providers,
     tools_command,
@@ -20,6 +21,15 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled
+
+
+def test_configurable_toolsets_include_messaging():
+    assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+def test_get_platform_tools_default_telegram_includes_messaging():
+    enabled = _get_platform_tools({}, "telegram")
+
+    assert "messaging" in enabled
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():


### PR DESCRIPTION
## Summary
- add the missing `messaging` entry back to `CONFIGURABLE_TOOLSETS`
- keep `send_message` visible when gateway platforms resolve composite toolsets like `hermes-telegram` / `hermes-matrix`
- add targeted regression tests for the registry entry and default Telegram platform resolution

## Root cause
`_get_platform_tools()` reverse-maps composite platform toolsets through `CONFIGURABLE_TOOLSETS`. The runtime `messaging` toolset already exists in `toolsets.py`, but because it was missing from the configurable registry, gateway platforms never re-enabled it and `send_message` was silently dropped from live platform sessions.

## Why this PR
I checked existing upstream work before sending this:
- issue: #8616
- related open PRs: #6007, #7333, #8626

This branch keeps the fix intentionally minimal and directly reproducible on current `origin/main`: one registry entry plus two focused regressions.

## Testing
- `python -m pytest tests/hermes_cli/test_tools_config.py -q`
- runtime verification via `_get_platform_tools(load_config(), "telegram")` + `get_tool_definitions(...)` confirms:
  - `messaging` present in resolved toolsets
  - `send_message` present in live schema

Fixes #8616.
