### PR TITLE
fix: budget-exhausted conversations now get a summary instead of empty response

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10156,17 +10156,11 @@ class AIAgent:
         if final_response is None and (
             api_call_count >= self.max_iterations
             or self.iteration_budget.remaining <= 0
-        ) and not self._budget_exhausted_injected:
-            # Budget exhausted but we haven't tried asking the model to
-            # summarise yet.  Inject a user message and give it one grace
-            # API call to produce a text response.
-            self._budget_exhausted_injected = True
-            self._budget_grace_call = True
-            _grace_msg = (
-                "Your tool budget ran out. Please give me the information "
-                "or actions you've completed so far."
-            )
-            messages.append({"role": "user", "content": _grace_msg})
+        ):
+            # Budget exhausted — ask the model for a summary via one extra
+            # API call with tools stripped.  _handle_max_iterations injects a
+            # user message and makes a single toolless request.
+            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{self.max_iterations})"
             self._emit_status(
                 f"⚠️ Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
                 "— asking model to summarise"
@@ -10176,14 +10170,6 @@ class AIAgent:
                     f"\n⚠️  Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
                     "— requesting summary..."
                 )
-
-        if final_response is None and (
-            api_call_count >= self.max_iterations
-            or self.iteration_budget.remaining <= 0
-        ) and not self._budget_grace_call:
-            _turn_exit_reason = f"max_iterations_reached({api_call_count}/{self.max_iterations})"
-            if self.iteration_budget.remaining <= 0 and not self.quiet_mode:
-                print(f"\n⚠️  Iteration budget exhausted ({self.iteration_budget.used}/{self.iteration_budget.max_total} iterations used)")
             final_response = self._handle_max_iterations(messages, api_call_count)
         
         # Determine if conversation completed successfully


### PR DESCRIPTION
When the agent hits max iterations or budget exhaustion, users see an empty/no response. This is a long-standing bug affecting both CLI and gateway.

**Root cause:** The post-loop grace call mechanism at line 10156 was dead code. It:
1. Injected a user message asking for a summary
2. Set `_budget_grace_call = True`
3. But could never re-enter the while loop (already exited)
4. And the flag *blocked* the fallback `_handle_max_iterations` from running (condition: `not self._budget_grace_call`)
5. Result: `final_response = None` → empty response to user

**Fix:** Remove the broken grace block. Let `_handle_max_iterations` handle budget exhaustion directly — it already injects a summary request and makes one extra toolless API call.

**Change:** 5 insertions, 19 deletions. Net simpler.