### PR TITLE
[codex] Fix Codex model normalization

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2198,35 +2198,26 @@ class HermesCLI:
         if resolved_provider != "openai-codex":
             return changed
 
-        # 1. Strip provider prefix ("openai/gpt-5.4" → "gpt-5.4")
-        if "/" in current_model:
-            slug = current_model.split("/", 1)[1]
-            if not self._model_is_default:
+        from hermes_cli.codex_models import normalize_codex_runtime_model
+
+        resolution = normalize_codex_runtime_model(
+            current_model,
+            access_token=self.api_key if self.api_key else None,
+            model_is_default=self._model_is_default,
+        )
+        if resolution.changed:
+            if resolution.replaced_incompatible and not self._model_is_default:
+                self.console.print(
+                    f"[yellow]⚠️  Model '{current_model}' is not supported by OpenAI Codex; "
+                    f"using '{resolution.model}' instead.[/]"
+                )
+            elif resolution.stripped_prefix and not self._model_is_default:
                 self.console.print(
                     f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; "
-                    f"using '{slug}' for OpenAI Codex.[/]"
+                    f"using '{resolution.model}' for OpenAI Codex.[/]"
                 )
-            self.model = slug
-            current_model = slug
+            self.model = resolution.model
             changed = True
-
-        # 2. Replace untouched default with a Codex model
-        if self._model_is_default:
-            fallback_model = "gpt-5.3-codex"
-            try:
-                from hermes_cli.codex_models import get_codex_model_ids
-
-                available = get_codex_model_ids(
-                    access_token=self.api_key if self.api_key else None,
-                )
-                if available:
-                    fallback_model = available[0]
-            except Exception:
-                pass
-
-            if current_model != fallback_model:
-                self.model = fallback_model
-                changed = True
 
         return changed
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -455,6 +455,37 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _normalize_gateway_runtime_model(model: str, runtime_kwargs: dict) -> str:
+    """Normalize provider/model pairs that would fail at request time."""
+    provider = str(runtime_kwargs.get("provider") or "").strip().lower()
+    if provider != "openai-codex":
+        return model
+
+    try:
+        from hermes_cli.codex_models import normalize_codex_runtime_model
+
+        resolution = normalize_codex_runtime_model(
+            model,
+            access_token=runtime_kwargs.get("api_key"),
+            model_is_default=not str(model or "").strip(),
+        )
+    except Exception:
+        return model
+
+    if resolution.changed:
+        if resolution.replaced_incompatible:
+            logger.warning(
+                "Gateway normalized incompatible Codex model %r to %r",
+                model, resolution.model,
+            )
+        else:
+            logger.info(
+                "Gateway normalized Codex model %r to %r",
+                model, resolution.model,
+            )
+    return resolution.model
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -883,6 +914,7 @@ class GatewayRunner:
                     (resolved_session_key or "")[:30], model, override_model,
                     override_runtime.get("provider"),
                 )
+                override_model = _normalize_gateway_runtime_model(override_model, override_runtime)
                 return override_model, override_runtime
             # Override exists but has no api_key — fall through to env-based
             # resolution and apply model/provider from the override on top.
@@ -919,6 +951,7 @@ class GatewayRunner:
             except Exception:
                 pass
 
+        model = _normalize_gateway_runtime_model(model, runtime_kwargs)
         return model, runtime_kwargs
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -1,9 +1,10 @@
-"""Codex model discovery from API, local cache, and config."""
+"""Codex model discovery and runtime model normalization."""
 
 from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
@@ -26,6 +27,24 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),
     ("gpt-5.3-codex-spark", ("gpt-5.3-codex", "gpt-5.2-codex")),
 ]
+
+_DEFAULT_CODEX_FALLBACK_MODEL = "gpt-5.3-codex"
+_LIKELY_OPENAI_CODEX_PREFIXES = (
+    "gpt-",
+    "codex",
+    "computer-use-",
+)
+
+
+@dataclass(frozen=True)
+class CodexModelResolution:
+    """Normalized model choice for the Codex backend."""
+
+    model: str
+    changed: bool
+    stripped_prefix: bool = False
+    replaced_incompatible: bool = False
+    used_fallback: bool = False
 
 
 def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
@@ -50,6 +69,76 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
             seen.add(synthetic_model)
 
     return ordered
+
+
+def _looks_like_openai_codex_model(
+    model_id: str,
+    *,
+    available_models: Optional[List[str]] = None,
+) -> bool:
+    """Best-effort check for models that plausibly belong on Codex.
+
+    We intentionally preserve explicit OpenAI-family slugs even when they
+    are newer than our local catalog, but reject obviously cross-provider
+    slugs like Claude/Gemini/Qwen when routed to the Codex backend.
+    """
+    normalized = model_id.strip().lower()
+    if not normalized:
+        return False
+    if available_models and normalized in {item.strip().lower() for item in available_models if item}:
+        return True
+    if any(normalized.startswith(prefix) for prefix in _LIKELY_OPENAI_CODEX_PREFIXES):
+        return True
+    if len(normalized) >= 2 and normalized[0] == "o" and normalized[1].isdigit():
+        return True
+    return False
+
+
+def normalize_codex_runtime_model(
+    model_id: str,
+    *,
+    access_token: Optional[str] = None,
+    model_is_default: bool = False,
+) -> CodexModelResolution:
+    """Normalize a runtime model before sending it to the Codex backend."""
+    original = (model_id or "").strip()
+    candidate = original
+    stripped_prefix = False
+
+    if "/" in candidate:
+        candidate = candidate.split("/", 1)[1].strip()
+        stripped_prefix = True
+
+    fallback_model = _DEFAULT_CODEX_FALLBACK_MODEL
+    try:
+        available_models = get_codex_model_ids(access_token=access_token)
+    except Exception:
+        available_models = []
+    if available_models:
+        fallback_model = available_models[0]
+
+    if not candidate or model_is_default:
+        return CodexModelResolution(
+            model=fallback_model,
+            changed=(candidate != fallback_model) or stripped_prefix,
+            stripped_prefix=stripped_prefix,
+            used_fallback=True,
+        )
+
+    if _looks_like_openai_codex_model(candidate, available_models=available_models):
+        return CodexModelResolution(
+            model=candidate,
+            changed=stripped_prefix,
+            stripped_prefix=stripped_prefix,
+        )
+
+    return CodexModelResolution(
+        model=fallback_model,
+        changed=(candidate != fallback_model) or stripped_prefix,
+        stripped_prefix=stripped_prefix,
+        replaced_incompatible=True,
+        used_fallback=True,
+    )
 
 
 def _fetch_models_from_api(access_token: str) -> List[str]:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -136,13 +136,7 @@ def _make_cli(model="anthropic/claude-opus-4.6", **kwargs):
 
 
 class TestNormalizeModelForProvider:
-    """_normalize_model_for_provider() trusts user-selected models.
-
-    Only two things happen:
-    1. Provider prefixes are stripped (API needs bare slugs)
-    2. The *untouched default* model is swapped for a Codex model
-    Everything else passes through — the API is the judge.
-    """
+    """_normalize_model_for_provider() protects Codex from cross-provider slugs."""
 
     def test_non_codex_provider_is_noop(self):
         cli = _make_cli(model="gpt-5.4")
@@ -169,13 +163,16 @@ class TestNormalizeModelForProvider:
         assert changed is False
         assert cli.model == "gpt-5.4"
 
-    def test_any_bare_model_trusted(self):
-        """Even a non-OpenAI bare model passes through — user explicitly set it."""
+    def test_incompatible_bare_model_falls_back_to_codex(self):
+        """Cross-provider bare slugs must not be sent to the Codex backend."""
         cli = _make_cli(model="claude-opus-4-6")
-        changed = cli._normalize_model_for_provider("openai-codex")
-        # User explicitly chose this model — we trust them, API will error if wrong
-        assert changed is False
-        assert cli.model == "claude-opus-4-6"
+        with patch(
+            "hermes_cli.codex_models.get_codex_model_ids",
+            return_value=["gpt-5.4-mini", "gpt-5.3-codex"],
+        ):
+            changed = cli._normalize_model_for_provider("openai-codex")
+        assert changed is True
+        assert cli.model == "gpt-5.4-mini"
 
     def test_provider_prefix_stripped(self):
         """openai/gpt-5.4 → gpt-5.4 (strip prefix, keep model)."""
@@ -184,13 +181,16 @@ class TestNormalizeModelForProvider:
         assert changed is True
         assert cli.model == "gpt-5.4"
 
-    def test_any_provider_prefix_stripped(self):
-        """anthropic/claude-opus-4.6 → claude-opus-4.6 (strip prefix only).
-        User explicitly chose this — let the API decide if it works."""
+    def test_incompatible_provider_prefix_falls_back(self):
+        """anthropic/claude-opus-4.6 should be replaced with a Codex model."""
         cli = _make_cli(model="anthropic/claude-opus-4.6")
-        changed = cli._normalize_model_for_provider("openai-codex")
+        with patch(
+            "hermes_cli.codex_models.get_codex_model_ids",
+            return_value=["gpt-5.4", "gpt-5.3-codex"],
+        ):
+            changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
-        assert cli.model == "claude-opus-4.6"
+        assert cli.model == "gpt-5.4"
 
     def test_opencode_go_prefix_stripped(self):
         cli = _make_cli(model="opencode-go/kimi-k2.5")

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -76,6 +76,29 @@ class TestGatewayEmptyModelFallback:
 
         assert model == "gpt-5.4", "Explicit model should not be overridden"
 
+    def test_incompatible_codex_model_is_normalized(self):
+        """Gateway should not send Claude slugs to the Codex backend."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+
+        with patch("gateway.run._resolve_gateway_model", return_value="anthropic/claude-opus-4.6"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "openai-codex",
+                 "api_key": "test-key",
+                 "base_url": "https://chatgpt.com/backend-api/codex",
+                 "api_mode": "codex_responses",
+             }), \
+             patch(
+                 "hermes_cli.codex_models.get_codex_model_ids",
+                 return_value=["gpt-5.4-mini", "gpt-5.3-codex"],
+             ):
+            model, kwargs = runner._resolve_session_agent_runtime()
+
+        assert model == "gpt-5.4-mini"
+        assert kwargs["provider"] == "openai-codex"
+
     def test_empty_model_no_provider_stays_empty(self):
         """When both model and provider are empty, model stays empty."""
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## Summary
- centralize Codex runtime model normalization in a shared helper
- replace incompatible cross-provider slugs with an available Codex model before request dispatch
- apply the same normalization in the gateway session/runtime path so Telegram and other gateway sessions cannot reuse a stale Claude default with Codex credentials
- add regression coverage for both the CLI and gateway pathways

## Root Cause
Hermes could resolve the active provider to `openai-codex` while still carrying forward a model string that belonged to a different provider, most notably the default `anthropic/claude-opus-4.6`.

The failure happened in two places:
- CLI path: `HermesCLI._normalize_model_for_provider()` only swapped models when the configured model was treated as the untouched default. If a non-empty config or explicit session model survived provider resolution, Hermes could still send a Claude slug to the ChatGPT/Codex backend.
- Gateway path: `GatewayRunner._resolve_session_agent_runtime()` paired config or session-override model values with Codex runtime credentials without re-normalizing the model, so gateway sessions could keep issuing the same incompatible model/backend combination.

That mismatch produced non-retryable 400 responses from the Codex backend because ChatGPT-backed Codex does not accept Anthropic model identifiers like `anthropic/claude-opus-4.6`.

## What Changed
- added `normalize_codex_runtime_model()` in `hermes_cli/codex_models.py` as the shared source of truth for Codex runtime model selection
- preserved explicit OpenAI/Codex-looking models, including prefix stripping when needed
- fell back to the first available Codex model when the incoming model was empty, defaulted, or clearly incompatible with the Codex backend
- normalized gateway session override and resolved runtime models before agent construction

## Validation
- `uv run --extra dev pytest /Users/dev/ai-gen-tooling/hermes-agent/tests/test_empty_model_fallback.py /Users/dev/ai-gen-tooling/hermes-agent/tests/cli/test_cli_provider_resolution.py -k codex -n0`
