### PR TITLE
fix(agent): improve prompt grounding for objectivity, recall, and codebase exploration

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -155,10 +155,24 @@ MEMORY_GUIDANCE = (
     "necessary later, save it as a skill with the skill tool."
 )
 
+OBJECTIVITY_GUIDANCE = (
+    "Prioritize technical accuracy and truthfulness over reflexive agreement. "
+    "When evidence points away from the user's assumption, say so clearly and respectfully. "
+    "Investigate uncertainty before endorsing a premise."
+)
+
+NO_TIME_ESTIMATES_GUIDANCE = (
+    "Do not give time estimates unless the user explicitly asks for them. "
+    "Describe the work, sequencing, and dependencies instead of guessing duration."
+)
+
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
-    "relevant cross-session context exists, use session_search to recall it before "
-    "asking them to repeat themselves."
+    "relevant cross-session context exists, use session_search before asking them "
+    "to repeat themselves. Triggers include references like 'as we discussed', "
+    "'continue', 'that bug', 'our approach', or 'what did we decide'. "
+    "Search with the specific topic or noun phrases, "
+    "not generic meta-conversation words."
 )
 
 SKILLS_GUIDANCE = (
@@ -273,6 +287,13 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "to prevent CLI tools from hanging on prompts.\n"
     "- **Keep going:** Work autonomously until the task is fully resolved. "
     "Don't stop with a plan — execute it.\n"
+)
+
+CONTEXT_EFFICIENCY_GUIDANCE = (
+    "When exploring a codebase, prefer targeted search before broad file reads. "
+    "Read complete small files, but for large files read only the context needed to act safely. "
+    "Parallelize independent searches and reads when possible. "
+    "Optimize for fewer corrective turns and safer edits, not just less reading."
 )
 
 # Model name substrings that should use the 'developer' role instead of

--- a/run_agent.py
+++ b/run_agent.py
@@ -81,6 +81,7 @@ from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    OBJECTIVITY_GUIDANCE, NO_TIME_ESTIMATES_GUIDANCE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -94,7 +95,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, CONTEXT_EFFICIENCY_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -3083,6 +3084,9 @@ class AIAgent:
             # Fallback to hardcoded identity
             prompt_parts = [DEFAULT_AGENT_IDENTITY]
 
+        prompt_parts.append(OBJECTIVITY_GUIDANCE)
+        prompt_parts.append(NO_TIME_ESTIMATES_GUIDANCE)
+
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
         if "memory" in self.valid_tool_names:
@@ -3093,6 +3097,12 @@ class AIAgent:
             tool_guidance.append(SKILLS_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
+
+        _context_efficiency_tools = {
+            "read_file", "search_files", "terminal", "execute_code"
+        }
+        if self.valid_tool_names & _context_efficiency_tools:
+            prompt_parts.append(CONTEXT_EFFICIENCY_GUIDANCE)
 
         nous_subscription_prompt = build_nous_subscription_prompt(self.valid_tool_names)
         if nous_subscription_prompt:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -26,6 +26,9 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    OBJECTIVITY_GUIDANCE,
+    NO_TIME_ESTIMATES_GUIDANCE,
+    CONTEXT_EFFICIENCY_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -45,9 +48,23 @@ class TestGuidanceConstants:
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
-    def test_session_search_guidance_is_simple_cross_session_recall(self):
+    def test_session_search_guidance_mentions_trigger_patterns(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
+        assert "that bug" in SESSION_SEARCH_GUIDANCE
+        assert "specific topic or noun phrases" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_objectivity_guidance_prioritizes_truth_over_agreement(self):
+        assert "truthfulness" in OBJECTIVITY_GUIDANCE
+        assert "respectfully" in OBJECTIVITY_GUIDANCE
+
+    def test_no_time_estimates_guidance_discourages_duration_guesses(self):
+        assert "Do not give time estimates" in NO_TIME_ESTIMATES_GUIDANCE
+        assert "dependencies" in NO_TIME_ESTIMATES_GUIDANCE
+
+    def test_context_efficiency_guidance_prefers_targeted_search(self):
+        assert "targeted search" in CONTEXT_EFFICIENCY_GUIDANCE
+        assert "Parallelize" in CONTEXT_EFFICIENCY_GUIDANCE
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -20,7 +20,13 @@ import pytest
 import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import (
+    DEFAULT_AGENT_IDENTITY,
+    OBJECTIVITY_GUIDANCE,
+    NO_TIME_ESTIMATES_GUIDANCE,
+    CONTEXT_EFFICIENCY_GUIDANCE,
+    SESSION_SEARCH_GUIDANCE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -647,6 +653,11 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert DEFAULT_AGENT_IDENTITY in prompt
 
+    def test_includes_global_objectivity_and_no_time_estimates_guidance(self, agent):
+        prompt = agent._build_system_prompt()
+        assert OBJECTIVITY_GUIDANCE in prompt
+        assert NO_TIME_ESTIMATES_GUIDANCE in prompt
+
     def test_includes_system_message(self, agent):
         prompt = agent._build_system_prompt(system_message="Custom instruction")
         assert "Custom instruction" in prompt
@@ -662,6 +673,50 @@ class TestBuildSystemPrompt:
 
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
+
+    def test_session_search_guidance_when_session_search_tool_loaded(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "session_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+
+        prompt = a._build_system_prompt()
+        assert SESSION_SEARCH_GUIDANCE in prompt
+
+    def test_context_efficiency_guidance_when_context_tools_loaded(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("search_files", "read_file"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+
+        prompt = a._build_system_prompt()
+        assert CONTEXT_EFFICIENCY_GUIDANCE in prompt
+
+    def test_context_efficiency_guidance_not_included_without_context_tools(self, agent):
+        prompt = agent._build_system_prompt()
+        assert CONTEXT_EFFICIENCY_GUIDANCE not in prompt
 
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()


### PR DESCRIPTION
## Summary

This PR tightens a small set of system-prompt instructions to improve response quality in places where the agent currently underperforms: agreeing too quickly with weak assumptions, guessing timelines, missing obvious cross-session recall opportunities, and exploring codebases less efficiently than it could.

## Why

A review of Hermes’s current prompt stack against stronger agent prompts showed a few lightweight but user-visible gaps:

- the agent can be too eager to agree instead of respectfully correcting bad assumptions
- it sometimes gives duration guesses when sequencing and dependencies would be more useful
- cross-session recall triggers are too vague, so it may ask the user to repeat context unnecessarily
- codebase exploration guidance is not explicit enough about targeted search before broad reading

These are small prompt-level issues, but they affect correctness, continuity, and execution quality.

## Expected benefit

This change is intended to improve:

- **accuracy** by preferring truthfulness over reflexive agreement
- **continuity** by improving recall behavior for prior-session references
- **execution quality** by discouraging speculative time estimates
- **repo exploration quality** by reinforcing search-first, selective-reading behavior

## Changes

- add global 
- add global 
- strengthen  with clearer continuity triggers and search phrasing
- add gated  when file, terminal, or code-execution tools are available
- add focused tests for the new guidance constants and prompt-assembly gates

## Scope

This PR is intentionally narrow and follows the contribution guideline to keep PRs focused on one logical change.

It does not change:
- external-content trust or prompt-injection guidance
- memory prompting behavior
- review-specific prompt shaping
- the overall prompt assembly architecture

## Validation

Passed:
- 
- targeted prompt-assembly tests in 

## Notes

A broader  run still surfaces an unrelated existing failure in , which appears outside the scope of this prompt-assembly change.