### PR TITLE
Bugfix: ignore legacy compression model for auto providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -129,6 +129,7 @@ NOUS_EXTRA_BODY = {"tags": ["product=hermes-agent"]}
 
 # Set at resolve time — True if the auxiliary client points to Nous Portal
 auxiliary_is_nous: bool = False
+_legacy_compression_auto_model_warned: bool = False
 
 # Default auxiliary models per provider
 _OPENROUTER_MODEL = "google/gemini-3-flash-preview"
@@ -1277,6 +1278,47 @@ def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optio
         return model_name
 
 
+def _resolve_legacy_compression_config(
+    config: Dict[str, Any],
+    *,
+    warn_on_auto_model: bool = False,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Read legacy ``compression.*`` overrides safely.
+
+    The old compression section stores a provider/model pair separately from
+    ``auxiliary.compression``. A provider-specific model like
+    ``google/gemini-3-flash-preview`` is unsafe when the legacy provider is
+    left at ``auto`` because auto-detection may land on a non-OpenRouter
+    backend. In that case we ignore the legacy model and let the resolved
+    provider pick its own default model instead.
+    """
+    global _legacy_compression_auto_model_warned
+
+    comp = config.get("compression", {}) if isinstance(config, dict) else {}
+    if not isinstance(comp, dict):
+        return None, None, None
+
+    provider = str(comp.get("summary_provider") or "").strip() or None
+    model = str(comp.get("summary_model") or "").strip() or None
+    base_url = str(comp.get("summary_base_url") or "").strip() or None
+
+    if model and not base_url and (not provider or provider == "auto"):
+        if warn_on_auto_model and not _legacy_compression_auto_model_warned:
+            logger.warning(
+                "Ignoring legacy compression.summary_model=%r because "
+                "compression.summary_provider=%r uses auto-detection. "
+                "Compression summaries will use the resolved provider's "
+                "default model instead. To pin a specific model, set "
+                "auxiliary.compression.provider/model explicitly.",
+                model,
+                provider or "auto",
+            )
+            _legacy_compression_auto_model_warned = True
+        model = None
+
+    return provider, model, base_url
+
+
 def resolve_provider_client(
     provider: str,
     model: str = None,
@@ -2048,12 +2090,12 @@ def _resolve_task_provider_model(
         # The auxiliary.compression defaults to provider="auto", so treat
         # both None and "auto" as "not explicitly configured".
         if task == "compression" and (not cfg_provider or cfg_provider == "auto"):
-            comp = config.get("compression", {}) if isinstance(config, dict) else {}
-            if isinstance(comp, dict):
-                cfg_provider = comp.get("summary_provider", "").strip() or None
-                cfg_model = cfg_model or comp.get("summary_model", "").strip() or None
-                _sbu = comp.get("summary_base_url") or ""
-                cfg_base_url = cfg_base_url or _sbu.strip() or None
+            legacy_provider, legacy_model, legacy_base_url = _resolve_legacy_compression_config(
+                config, warn_on_auto_model=True
+            )
+            cfg_provider = legacy_provider
+            cfg_model = cfg_model or legacy_model
+            cfg_base_url = cfg_base_url or legacy_base_url
 
     # Env vars are backward-compat fallback only — config.yaml is primary.
     env_model = _get_auxiliary_env_override(task, "MODEL") if task else None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -310,10 +310,10 @@ compression:
   protect_last_n: 20
 
   # Model to use for generating summaries (fast/cheap recommended)
-  # This model compresses the middle turns into a concise summary.
-  # IMPORTANT: it receives the full middle section of the conversation, so it
-  # MUST support a context length at least as large as your main model's.
-  summary_model: "google/gemini-3-flash-preview"
+  # Leave empty to use the resolved compression provider's default model.
+  # Set this only when you also pin a compatible summary_provider or
+  # summary_base_url below.
+  summary_model: ""
   
   # Provider for the summary model (default: "auto")
   # Options: "auto", "openrouter", "nous", "main"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1212,7 +1212,15 @@ class AIAgent:
             _compression_cfg = {}
         compression_threshold = float(_compression_cfg.get("threshold", 0.50))
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
-        compression_summary_model = _compression_cfg.get("summary_model") or None
+        try:
+            from agent.auxiliary_client import _resolve_legacy_compression_config
+
+            _, compression_summary_model, _ = _resolve_legacy_compression_config(
+                _agent_cfg,
+                warn_on_auto_model=True,
+            )
+        except Exception:
+            compression_summary_model = _compression_cfg.get("summary_model") or None
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _try_payment_fallback,
     _resolve_auto,
+    _resolve_task_provider_model,
 )
 
 
@@ -970,6 +971,46 @@ class TestTaskSpecificOverrides:
         with patch("agent.auxiliary_client.OpenAI"):
             client, model = get_text_auxiliary_client("compression")
         assert model == "google/gemini-3-flash-preview"  # auto → OpenRouter
+
+    def test_legacy_compression_model_ignored_when_provider_is_auto(self, monkeypatch, tmp_path):
+        """Legacy compression.summary_model should not pin auto-detected providers."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """compression:
+  summary_provider: auto
+  summary_model: google/gemini-3-flash-preview
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("compression")
+
+        assert provider == "auto"
+        assert model is None
+        assert base_url is None
+        assert api_key is None
+        assert api_mode is None
+
+    def test_legacy_compression_model_preserved_for_pinned_provider(self, monkeypatch, tmp_path):
+        """Legacy compression.summary_model still works when provider is pinned."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """compression:
+  summary_provider: openrouter
+  summary_model: google/gemini-3-flash-preview
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("compression")
+
+        assert provider == "openrouter"
+        assert model == "google/gemini-3-flash-preview"
+        assert base_url is None
+        assert api_key is None
+        assert api_mode is None
 
     def test_resolve_auto_prefers_live_main_runtime_over_persisted_config(self, monkeypatch, tmp_path):
         """Session-only live model switches should override persisted config for auto routing."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -566,6 +566,32 @@ class TestInit:
                 f"session_id doesn't match expected format: {a.session_id}"
             )
 
+    def test_legacy_auto_compression_model_not_passed_to_context_compressor(self):
+        """Legacy compression.summary_model should not override auto compression backends."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "compression": {
+                        "summary_provider": "auto",
+                        "summary_model": "google/gemini-3-flash-preview",
+                    }
+                },
+            ),
+            patch("agent.context_compressor.get_model_context_length", return_value=200000),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.context_compressor.summary_model == ""
+
 
 class TestInterrupt:
     def test_interrupt_sets_flag(self, agent):


### PR DESCRIPTION
## Summary
- ignore legacy `compression.summary_model` when `compression.summary_provider` is still `auto`
- stop passing that legacy model override into `ContextCompressor`, so auto-routed compression summaries use a provider-compatible default model
- update the example config and add regression coverage for both the config bridge and agent init path

## Root Cause
The legacy compression section allowed a provider-specific model like `google/gemini-3-flash-preview` to remain configured while the provider stayed on `auto`. That value could be threaded into compression summary calls even when the resolved backend was not OpenRouter-compatible.

## Validation
- `pytest -n 0 tests/agent/test_auxiliary_client.py::TestTaskSpecificOverrides::test_task_without_override_uses_auto tests/agent/test_auxiliary_client.py::TestTaskSpecificOverrides::test_legacy_compression_model_ignored_when_provider_is_auto tests/agent/test_auxiliary_client.py::TestTaskSpecificOverrides::test_legacy_compression_model_preserved_for_pinned_provider tests/agent/test_auxiliary_client.py::TestTaskSpecificOverrides::test_explicit_compression_pin_still_wins_over_live_main_runtime tests/agent/test_auxiliary_client.py::TestTaskSpecificOverrides::test_compression_summary_base_url_from_config tests/run_agent/test_run_agent.py::TestInit::test_legacy_auto_compression_model_not_passed_to_context_compressor`
- `pytest -n 0 tests/agent/test_context_compressor.py`
- `pytest -n 0 tests/run_agent/test_413_compression.py`

Closes #8923
