### PR TITLE
fix(agent): recognize Tailscale CGNAT (100.64.0.0/10) as local for Ollama timeouts

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -4,6 +4,7 @@ Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
 
+import ipaddress
 import logging
 import os
 import re
@@ -43,6 +44,13 @@ _OLLAMA_TAG_PATTERN = re.compile(
     r"^(\d+\.?\d*b|latest|stable|q\d|fp?\d|instruct|chat|coder|vision|text)",
     re.IGNORECASE,
 )
+
+
+# Tailscale's CGNAT range (RFC 6598). `ipaddress.is_private` excludes this
+# block, so without an explicit check Ollama reached over Tailscale (e.g.
+# `http://100.77.243.5:11434`) wouldn't be treated as local and its stream
+# read / stale timeouts wouldn't get auto-bumped. Built once at import time.
+_TAILSCALE_CGNAT = ipaddress.IPv4Network("100.64.0.0/10")
 
 
 def _strip_provider_prefix(model: str) -> str:
@@ -253,7 +261,15 @@ def _is_known_provider_base_url(base_url: str) -> bool:
 
 
 def is_local_endpoint(base_url: str) -> bool:
-    """Return True if base_url points to a local machine (localhost / RFC-1918 / WSL)."""
+    """Return True if base_url points to a local machine.
+
+    Recognises loopback (``localhost``, ``127.0.0.0/8``, ``::1``),
+    container-internal DNS names (``host.docker.internal`` et al.),
+    RFC-1918 private ranges (``10/8``, ``172.16/12``, ``192.168/16``),
+    link-local, and Tailscale CGNAT (``100.64.0.0/10``). Tailscale CGNAT
+    is included so remote-but-trusted Ollama boxes reached over a
+    Tailscale mesh get the same timeout auto-bumps as localhost Ollama.
+    """
     normalized = _normalize_base_url(base_url)
     if not normalized:
         return False
@@ -268,14 +284,17 @@ def is_local_endpoint(base_url: str) -> bool:
     # Docker / Podman / Lima internal DNS names (e.g. host.docker.internal)
     if any(host.endswith(suffix) for suffix in _CONTAINER_LOCAL_SUFFIXES):
         return True
-    # RFC-1918 private ranges and link-local
-    import ipaddress
+    # RFC-1918 private ranges, link-local, and Tailscale CGNAT
     try:
         addr = ipaddress.ip_address(host)
-        return addr.is_private or addr.is_loopback or addr.is_link_local
+        if addr.is_private or addr.is_loopback or addr.is_link_local:
+            return True
+        if isinstance(addr, ipaddress.IPv4Address) and addr in _TAILSCALE_CGNAT:
+            return True
     except ValueError:
         pass
     # Bare IP that looks like a private range (e.g. 172.26.x.x for WSL)
+    # or Tailscale CGNAT (100.64.x.x–100.127.x.x).
     parts = host.split(".")
     if len(parts) == 4:
         try:
@@ -285,6 +304,8 @@ def is_local_endpoint(base_url: str) -> bool:
             if first == 172 and 16 <= second <= 31:
                 return True
             if first == 192 and second == 168:
+                return True
+            if first == 100 and 64 <= second <= 127:
                 return True
         except ValueError:
             pass

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -106,3 +106,25 @@ class TestIsLocalEndpoint:
     ])
     def test_remote_endpoints(self, url):
         assert is_local_endpoint(url) is False
+
+    @pytest.mark.parametrize("url", [
+        "http://100.64.0.0:11434",            # lower bound of CGNAT block
+        "http://100.64.0.1:11434/v1",         # lower bound +1
+        "http://100.77.243.5:11434",          # representative Tailscale host
+        "https://100.100.100.100:443",        # Tailscale MagicDNS anchor
+        "https://100.127.255.254:443",        # upper bound -1
+        "http://100.127.255.255:11434",       # upper bound of CGNAT block
+    ])
+    def test_tailscale_cgnat_is_local(self, url):
+        """Tailscale 100.64.0.0/10 should be treated as local for timeout bumps."""
+        assert is_local_endpoint(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "http://100.63.255.255:11434",        # just below CGNAT block
+        "http://100.128.0.1:11434",           # just above CGNAT block
+        "http://100.200.0.1:11434",           # well outside CGNAT
+        "http://99.64.0.1:11434",             # first octet wrong
+    ])
+    def test_near_but_not_cgnat_is_remote(self, url):
+        """Hosts adjacent to but outside 100.64.0.0/10 must not match."""
+        assert is_local_endpoint(url) is False


### PR DESCRIPTION
## What does this PR do?

`is_local_endpoint()` leans on `ipaddress.is_private`, which classifies RFC-1918 ranges and link-local as private but deliberately **excludes** the RFC 6598 CGNAT block (`100.64.0.0/10`) — the range Tailscale uses for its mesh IPs. As a result, Ollama reached over Tailscale (e.g. `http://100.77.243.5:11434`) is treated as remote and misses the automatic stream-read / stale-stream timeout bumps, so cold model load plus long prefill trips the 300 s watchdog before the first token.

This PR adds a module-level `_TAILSCALE_CGNAT = ipaddress.IPv4Network("100.64.0.0/10")` (built once, not per call) and extends `is_local_endpoint()` to match the block both via the parsed-`IPv4Address` path and the existing bare-string fallback (for symmetry with the existing 10/172/192 checks). Also hoists the previously function-local `import ipaddress` to module scope now that it's used by the constant.

All five existing call sites of `is_local_endpoint()` (`run_agent.py:1384` num_ctx detection, `run_agent.py:4896` stream-read timeout auto-bump, `run_agent.py:5299` stale timeout auto-bump, `model_metadata.py:977` `detect_local_server_type`, `model_metadata.py:1037` `get_model_context_length`) benefit automatically.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `agent/model_metadata.py` — add `_TAILSCALE_CGNAT` module constant; extend `is_local_endpoint()` parsed-IP and string-fallback branches to recognize CGNAT; hoist `import ipaddress` to module scope.
- `tests/agent/test_local_stream_timeout.py` — extend `TestIsLocalEndpoint` with a CGNAT positive set (lower bound `100.64.0.1`, representative host `100.77.243.5`, MagicDNS anchor, upper bound `100.127.255.254`) and a near-miss negative set (`100.63.255.255`, `100.128.0.1`, first-octet wrong).

## How to Test
1. `pytest tests/agent/test_local_stream_timeout.py -q` — all cases pass (39 total).
2. With Hermes pointed at a Tailscale Ollama endpoint, confirm `HERMES_STREAM_READ_TIMEOUT` auto-bumps to the local default and `hermes chat` no longer trips the 300 s watchdog during cold model load.

## Checklist
- [x] Conventional Commits
- [x] Tests added
- [x] PR contains only changes related to this fix
- [x] Tested on Linux (Ubuntu)