### PR TITLE
feat(gateway/dingtalk): env-based config and richer msgtype handling

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -303,6 +303,9 @@ class GatewayConfig:
             # BlueBubbles uses extra dict for local server config
             elif platform == Platform.BLUEBUBBLES and config.extra.get("server_url") and config.extra.get("password"):
                 connected.append(platform)
+            # DingTalk uses extra dict for app credentials
+            elif platform == Platform.DINGTALK and config.extra.get("client_id"):
+                connected.append(platform)
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
@@ -1084,6 +1087,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
+            )
+
+    # DingTalk
+    dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
+    dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
+    if dingtalk_client_id and dingtalk_client_secret:
+        if Platform.DINGTALK not in config.platforms:
+            config.platforms[Platform.DINGTALK] = PlatformConfig()
+        config.platforms[Platform.DINGTALK].enabled = True
+        config.platforms[Platform.DINGTALK].extra.update({
+            "client_id": dingtalk_client_id,
+            "client_secret": dingtalk_client_secret,
+        })
+        dingtalk_allowed_users = os.getenv("DINGTALK_ALLOWED_USERS", "")
+        if dingtalk_allowed_users:
+            config.platforms[Platform.DINGTALK].extra["allowed_users"] = [
+                u.strip() for u in dingtalk_allowed_users.split(",") if u.strip()
+            ]
+        dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
+        if dingtalk_home:
+            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+                platform=Platform.DINGTALK,
+                chat_id=dingtalk_home,
+                name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
             )
 
     # BlueBubbles (iMessage)

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -57,6 +57,14 @@ RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
 
+# DingTalk Stream only delivers these three msgtypes to chatbot callbacks.
+# The SDK exposes them as raw string literals, so we pin our own constants
+# to keep dispatch sites from growing divergent typos.
+_MSGTYPE_TEXT = "text"
+_MSGTYPE_PICTURE = "picture"
+_MSGTYPE_RICH_TEXT = "richText"
+_PICTURE_PLACEHOLDER = "[图片]"
+
 
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured."""
@@ -181,10 +189,19 @@ class DingTalkAdapter(BasePlatformAdapter):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
 
-        text = self._extract_text(message)
+        msgtype = getattr(message, "message_type", None) or ""
+        text = self._extract_text(message, msgtype)
+
+        # Empty plain-text is usually a stripped at-mention or keep-alive — drop it.
+        # Every other msgtype still dispatches with a placeholder so the agent
+        # knows something non-text arrived.
         if not text:
-            logger.debug("[%s] Empty message, skipping", self.name)
-            return
+            if msgtype in ("", _MSGTYPE_TEXT):
+                logger.debug("[%s] Empty text message, skipping", self.name)
+                return
+            text = f"[未能解析的 {msgtype} 类型消息]"
+
+        event_type = MessageType.PHOTO if msgtype == _MSGTYPE_PICTURE else MessageType.TEXT
 
         # Chat context
         conversation_id = getattr(message, "conversation_id", "") or ""
@@ -226,7 +243,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=event_type,
             source=source,
             message_id=msg_id,
             raw_message=message,
@@ -238,22 +255,61 @@ class DingTalkAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     @staticmethod
-    def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
-        if isinstance(text, dict):
-            content = text.get("content", "").strip()
-        else:
-            content = str(text).strip()
+    def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:
+        """Render a DingTalk chatbot message as human-readable text.
 
-        # Fall back to rich text if present
-        if not content:
-            rich_text = getattr(message, "rich_text", None)
-            if rich_text and isinstance(rich_text, list):
-                parts = [item["text"] for item in rich_text
-                         if isinstance(item, dict) and item.get("text")]
-                content = " ".join(parts).strip()
-        return content
+        Picture downloads would require the ``robot/messageFiles/download``
+        OpenAPI scope which this adapter deliberately does not call —
+        picture segments are replaced with a ``[图片]`` placeholder so the
+        agent at least sees that something visual arrived.
+        """
+        if msgtype is None:
+            msgtype = getattr(message, "message_type", None) or ""
+
+        if msgtype == _MSGTYPE_TEXT:
+            return DingTalkAdapter._read_plain_text(message)
+        if msgtype == _MSGTYPE_RICH_TEXT:
+            return DingTalkAdapter._render_rich_text(message)
+        if msgtype == _MSGTYPE_PICTURE:
+            return _PICTURE_PLACEHOLDER
+        if msgtype:
+            return f"[未支持的消息类型: {msgtype}]"
+        return DingTalkAdapter._read_plain_text(message)
+
+    @staticmethod
+    def _read_plain_text(message: "ChatbotMessage") -> str:
+        text_attr = getattr(message, "text", None)
+        if text_attr is None:
+            return ""
+        if hasattr(text_attr, "content"):
+            return (text_attr.content or "").strip()
+        if isinstance(text_attr, dict):
+            return (text_attr.get("content") or "").strip()
+        return str(text_attr).strip()
+
+    @staticmethod
+    def _render_rich_text(message: "ChatbotMessage") -> str:
+        rich = getattr(message, "rich_text_content", None)
+        items = getattr(rich, "rich_text_list", None) if rich is not None else None
+        if not isinstance(items, list):
+            return ""
+
+        out = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text_val = item.get("text")
+            if text_val:
+                out.append(str(text_val))
+                continue
+            if item.get("downloadCode") or item.get("type") == "picture":
+                out.append(_PICTURE_PLACEHOLDER)
+                continue
+            if item.get("type") == "at":
+                who = item.get("name") or item.get("userId")
+                if who:
+                    out.append(f"@{who}")
+        return " ".join(out).strip()
 
     # -- Outbound messaging -------------------------------------------------
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -83,30 +83,56 @@ class TestExtractText:
     def test_extracts_dict_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = {"content": "  hello world  "}
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == "hello world"
 
     def test_extracts_string_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = "plain text"
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == "plain text"
-
-    def test_falls_back_to_rich_text(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
-        assert DingTalkAdapter._extract_text(msg) == "part1 part2"
 
     def test_returns_empty_for_no_content(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = ""
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == ""
+
+    def test_picture_msgtype_returns_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "picture"
+        assert DingTalkAdapter._extract_text(msg) == "[图片]"
+
+    def test_rich_text_renders_segments_and_at_mentions(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "richText"
+        rich = MagicMock()
+        rich.rich_text_list = [
+            {"text": "hi"},
+            {"type": "at", "name": "Yoji"},
+            {"downloadCode": "abc"},
+            {"text": "there"},
+        ]
+        msg.rich_text_content = rich
+        assert DingTalkAdapter._extract_text(msg) == "hi @Yoji [图片] there"
+
+    def test_unsupported_msgtype_returns_labelled_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "audio"
+        assert DingTalkAdapter._extract_text(msg) == "[未支持的消息类型: audio]"
+
+    def test_explicit_msgtype_arg_wins_over_attribute(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "text"
+        msg.text = "ignored"
+        assert DingTalkAdapter._extract_text(msg, msgtype="picture") == "[图片]"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Aligns the DingTalk adapter with the env-var bootstrap pattern other platforms (Telegram/Discord/WhatsApp/BlueBubbles) use, and extends inbound handling beyond the `text` msgtype.

### Environment variables (`gateway/config.py`)
- `DINGTALK_CLIENT_ID` / `DINGTALK_CLIENT_SECRET` enable the platform
- `DINGTALK_ALLOWED_USERS` (comma-separated staff ids) populates the allow-list under `extra.allowed_users`
- `DINGTALK_HOME_CHANNEL` / `DINGTALK_HOME_CHANNEL_NAME` set the home conversation
- `get_connected_platforms` now recognizes DingTalk via `extra.client_id`

### Message-type dispatch (`gateway/platforms/dingtalk.py`)
DingTalk Stream delivers exactly three chatbot msgtypes: `text`, `picture`, `richText`. Previously anything other than `text` was silently dropped.
- `picture` → `MessageType.PHOTO` with `[图片]` placeholder (the download API requires an OpenAPI scope this adapter doesn't call)
- `richText` → render each segment: plain text, `@user` mentions, inline pictures as `[图片]`
- unknown types → labelled placeholder `[未支持的消息类型: <type>]` rather than silent drop
- `_extract_text` now takes an explicit `msgtype` to keep callers honest; falls back to `message.message_type` when omitted

## Test plan

- [x] 24 tests pass including new dispatch coverage for picture / richText / unsupported / explicit-msgtype paths.
- [ ] Verified locally: sending a picture to the bot no longer silently drops; richText messages render with mentions and image placeholders.

Depends conceptually on #8954 (SDK 0.24 compat) for the `TextContent` reading path in `_read_plain_text`, but the static methods are backwards-compatible with older SDKs via `hasattr`/`isinstance` fallbacks.