### PR TITLE
fix(agent): honor model.context_length override below 64K floor

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -135,10 +135,21 @@ class ContextCompressor(ContextEngine):
         # the percentage would suggest a lower value.  This prevents premature
         # compression on large-context models at 50% while keeping the % sane
         # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        #
+        # Exception: opt-in tiny models — when the model's *total* context is
+        # below the floor (only reachable via explicit ``model.context_length``
+        # in config.yaml; the run_agent reject-block otherwise blocks startup),
+        # applying the floor would put the threshold at or above total context
+        # and compression would never fire. In that regime, use the raw
+        # percentage as the threshold so compression still kicks in roughly
+        # half-full as intended.
+        if self.context_length >= MINIMUM_CONTEXT_LENGTH:
+            self.threshold_tokens = max(
+                int(self.context_length * threshold_percent),
+                MINIMUM_CONTEXT_LENGTH,
+            )
+        else:
+            self.threshold_tokens = int(self.context_length * threshold_percent)
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context

--- a/run_agent.py
+++ b/run_agent.py
@@ -1312,17 +1312,8 @@ class AIAgent:
         self.compression_enabled = compression_enabled
 
         # Reject models whose context window is below the minimum required
-        # for reliable tool-calling workflows (64K tokens).
-        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
-        _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
-            raise ValueError(
-                f"Model {self.model} has a context window of {_ctx:,} tokens, "
-                f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
-                f"by Hermes Agent.  Choose a model with at least "
-                f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
-                f"model.context_length in config.yaml to override."
-            )
+        # for reliable tool-calling workflows.
+        self._check_minimum_context_length()
 
         # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand)
         self._context_engine_tool_names: set = set()
@@ -1475,6 +1466,27 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
     
+    def _check_minimum_context_length(self) -> None:
+        """Reject models with context windows below MINIMUM_CONTEXT_LENGTH.
+
+        Bypassed when the user has explicitly set ``model.context_length`` in
+        config.yaml — that opt-in is treated as "user knows what they're doing
+        and accepts the risk", which the error message itself promises. Without
+        this bypass the override silently fails for any value below the floor,
+        which is precisely the case it's meant to enable.
+        """
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        ctx = getattr(self.context_compressor, "context_length", 0)
+        user_override = getattr(self, "_config_context_length", None)
+        if ctx and ctx < MINIMUM_CONTEXT_LENGTH and user_override is None:
+            raise ValueError(
+                f"Model {self.model} has a context window of {ctx:,} tokens, "
+                f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
+                f"by Hermes Agent.  Choose a model with at least "
+                f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
+                f"model.context_length in config.yaml to override."
+            )
+
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -621,6 +621,29 @@ class TestSummaryTargetRatio:
         # 50% of 200K = 100K, which is above the 64K floor
         assert c.threshold_tokens == 100_000
 
+    def test_threshold_floor_skipped_for_opt_in_tiny_models(self):
+        """When the user has opted into a sub-64K model via config override,
+        the 64K floor must be skipped — otherwise the threshold would equal
+        or exceed total context and compression would never fire.
+
+        Concrete example: hermes-brain:qwen3-14b-ctx32k at 32_768 tokens
+        should compress at ~16_384 tokens (50% of 32_768), not 32_768.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=32_768):
+            c = ContextCompressor(
+                model="hermes-brain:qwen3-14b-ctx32k",
+                quiet_mode=True,
+                config_context_length=32_768,
+            )
+        assert c.context_length == 32_768
+        # Raw percentage applies, no 64K floor.
+        assert c.threshold_tokens == 16_384, (
+            f"Expected threshold 16384 (50% of 32768), got {c.threshold_tokens}. "
+            "The MINIMUM_CONTEXT_LENGTH floor must not apply when the model's "
+            "total context is itself below the floor — otherwise compression "
+            "never fires on opt-in tiny models."
+        )
+
     def test_default_protect_last_n_is_20(self):
         """Default protect_last_n should be 20."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -1,9 +1,13 @@
 """Tests that switch_model preserves config_context_length."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
 
 
 def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
@@ -72,3 +76,56 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+# ---------------------------------------------------------------------------
+# _check_minimum_context_length — minimum-floor reject and config override
+# ---------------------------------------------------------------------------
+
+def _make_agent_for_min_check(*, ctx_length: int, config_override) -> AIAgent:
+    """Build an AIAgent stub that exposes only what _check_minimum_context_length reads."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "fake-local-model"
+    agent.context_compressor = SimpleNamespace(context_length=ctx_length)
+    agent._config_context_length = config_override
+    return agent
+
+
+def test_check_minimum_context_length_rejects_low_context_without_override():
+    """A model below MINIMUM_CONTEXT_LENGTH with no config override raises."""
+    low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+    agent = _make_agent_for_min_check(ctx_length=low_ctx, config_override=None)
+    with pytest.raises(ValueError, match=r"below the minimum"):
+        agent._check_minimum_context_length()
+
+
+def test_check_minimum_context_length_accepts_low_context_with_override():
+    """When the user explicitly sets model.context_length, the floor is bypassed.
+
+    The error message itself promises 'set model.context_length in config.yaml
+    to override' — without this bypass the override silently fails for any
+    value below the floor (the exact case it exists to handle, e.g.
+    hermes-brain:qwen3-14b-ctx32k at 32768 tokens).
+    """
+    low_ctx = 32_768
+    agent = _make_agent_for_min_check(ctx_length=low_ctx, config_override=low_ctx)
+    # Must not raise.
+    agent._check_minimum_context_length()
+
+
+def test_check_minimum_context_length_accepts_above_floor_without_override():
+    """Models at or above the minimum pass without an override."""
+    agent = _make_agent_for_min_check(
+        ctx_length=MINIMUM_CONTEXT_LENGTH, config_override=None
+    )
+    agent._check_minimum_context_length()
+
+
+def test_check_minimum_context_length_accepts_zero_context_length():
+    """A zero/missing context_length (compressor not yet initialized) is a no-op.
+
+    The check guards on ``ctx and ctx < MINIMUM_CONTEXT_LENGTH`` — a 0 short-
+    circuits because the value is meaningless, not because it's "fine".
+    """
+    agent = _make_agent_for_min_check(ctx_length=0, config_override=None)
+    agent._check_minimum_context_length()


### PR DESCRIPTION
## What does this PR do?

Two call sites hard-coded `MINIMUM_CONTEXT_LENGTH` (64K) as an immovable floor, silently defeating the `model.context_length` config override that their **own error message** tells users to reach for:

> "Choose a model with at least 64K context, or set `model.context_length` in config.yaml to override."

1. `AIAgent.__init__` rejected any compressor whose context was below the floor, **regardless** of whether the user had set an override. The override is the only way to run a sub-64K model, so the reject was unreachable for its intended case.
2. `ContextCompressor.__init__` floored `threshold_tokens` at 64K even when total context was below 64K. On an opt-in 32K model this pushed the compression threshold to 32K — equal to total context — so compression would literally never fire.

Motivating case: `hermes-brain:qwen3-14b-ctx32k`, a Modelfile wrapping `qwen3:14b` with `num_ctx 32768` for a ~15K-token baseline system prompt plus real conversation history. Without both fixes, startup fails at (1) and — once (1) is bypassed — compression never fires at (2).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `run_agent.py` — extract the inline 64K reject block from `AIAgent.__init__` into `_check_minimum_context_length()`, which skips when `self._config_context_length is not None` (the user opt-in the error message promises).
- `agent/context_compressor.py` — when `self.context_length < MINIMUM_CONTEXT_LENGTH`, use the raw percentage as `threshold_tokens` instead of clamping to the 64K floor. Above the floor, behavior is unchanged.
- `tests/run_agent/test_switch_model_context.py` — 4 new `_check_minimum_context_length_*` cases (rejects without override, accepts with override, accepts above floor, no-ops on 0).
- `tests/agent/test_context_compressor.py` — `test_threshold_floor_skipped_for_opt_in_tiny_models` proves an opt-in 32K model with `threshold_percent=0.50` gets `threshold_tokens=16384` (not 32768).

## How to Test
1. `pytest tests/agent/test_context_compressor.py tests/run_agent/test_switch_model_context.py -q` — passes (47 cases total).
2. With a sub-64K local model declared in `config.yaml` via `model.context_length: 32768`, `hermes chat -q "hi"` no longer raises `"is below the minimum 64,000 required"`.
3. Watch the same session: compression fires when the conversation crosses ~50% of total context, not at 100%.

## Checklist
- [x] Conventional Commits
- [x] Tests added
- [x] PR contains only changes related to this fix
- [x] Tested on Linux (Ubuntu)