### PR TITLE
fix(config): restore custom provider resolution and nested config han…

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2157,7 +2157,7 @@ def _expand_env_vars(obj):
     if isinstance(obj, str):
         return re.sub(
             r"\${([^}]+)}",
-            lambda m: os.environ.get(m.group(1), m.group(0)),
+            lambda m: get_env_value(m.group(1)) or m.group(0),
             obj,
         )
     if isinstance(obj, dict):
@@ -2256,7 +2256,26 @@ def load_config() -> Dict[str, Any]:
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
     
-    return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+    config = _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+
+    # Auto-correct common user typo (api_base -> base_url)
+    if isinstance(config.get("model"), dict) and "api_base" in config["model"]:
+        config["model"]["base_url"] = config["model"].pop("api_base")
+
+    # Apply runtime environment overrides
+    env_provider = get_env_value("HERMES_INFERENCE_PROVIDER")
+    env_base_url = get_env_value("OPENAI_BASE_URL")
+    if env_provider or env_base_url:
+        model_cfg = config.get("model")
+        if not isinstance(model_cfg, dict):
+            model_cfg = {"default": model_cfg} if model_cfg else {}
+        if env_provider:
+            model_cfg["provider"] = env_provider
+        if env_base_url:
+            model_cfg["base_url"] = env_base_url
+        config["model"] = model_cfg
+
+    return config
 
 
 _SECURITY_COMMENT = """
@@ -2894,7 +2913,7 @@ def set_config_value(key: str, value: str):
         'TINKER_API_KEY',
     ]
     
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
+    if key.upper() in api_keys or ('.' not in key and key.upper().endswith(('_API_KEY', '_TOKEN'))) or ('.' not in key and key.upper().startswith('TERMINAL_SSH')):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
@@ -2975,6 +2994,29 @@ def config_command(args):
     
     elif subcmd == "edit":
         edit_config()
+
+    elif subcmd == "get":
+        key = getattr(args, 'key', None)
+        if not key:
+            print("Usage: hermes config get <key>")
+            sys.exit(1)
+        config = load_config()
+        current = config
+        for part in key.split('.'):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                current = None
+                break
+        if current is not None:
+            if isinstance(current, bool):
+                print(str(current).lower())
+            elif isinstance(current, (dict, list)):
+                print(yaml.dump(current, default_flow_style=False).strip())
+            else:
+                print(current)
+        else:
+            print()
     
     elif subcmd == "set":
         key = getattr(args, 'key', None)


### PR DESCRIPTION
…dling (#8919)

## What does this PR do?  Fixes #8919



Custom providers (e.g. LiteLLM on localhost) were ignored and Hermes defaulted to OpenAI endpoints, causing 401 errors.

bug
- CLI intercepting nested `*_API_KEY` keys (e.g. `model.api_key`)
- `api_base` vs `base_url` schema mismatch
- Missing runtime hydration of `HERMES_INFERENCE_PROVIDER` and `OPENAI_BASE_URL`
- `hermes config get` lacking nested key traversal

Fix
- Scoped `_API_KEY` interception to ignore nested keys
- Added `api_base → base_url` normalization in `load_config`
- Hydrated provider settings from env vars at runtime
- Implemented nested key traversal for `config get`

Restores reliable configuration for custom providers and fixes CLI config behavior.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

 #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

