### PR TITLE
fix(feishu): chunk send failures should not interrupt remaining chunks

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1324,47 +1324,70 @@ class FeishuAdapter(BasePlatformAdapter):
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
-        try:
-            for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
-                try:
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type=msg_type,
-                        payload=payload,
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                        raise
+        chunk_errors: list[str] = []
+        for chunk in chunks:
+            msg_type, payload = self._build_outbound_payload(chunk)
+            try:
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type=msg_type,
+                    payload=payload,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            except Exception as exc:
+                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
+                    try:
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    except Exception as fallback_exc:
+                        chunk_errors.append(str(fallback_exc))
+                        logger.warning("[Feishu] Chunk send failed after fallback: %s", fallback_exc)
+                        continue
+                else:
+                    chunk_errors.append(str(exc))
+                    logger.warning("[Feishu] Chunk send failed: %s", exc)
+                    continue
+            else:
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
                     logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                last_response = response
+                    try:
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    except Exception as fallback_exc:
+                        chunk_errors.append(str(fallback_exc))
+                        logger.warning("[Feishu] Chunk send failed after response fallback: %s", fallback_exc)
+                        continue
 
+            if self._response_succeeded(response):
+                last_response = response
+            else:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "send failed")
+                err_msg = f"[{code}] {msg}"
+                chunk_errors.append(err_msg)
+                logger.warning("[Feishu] Chunk send unsuccessful: %s", err_msg)
+
+        if last_response is not None:
             return self._finalize_send_result(last_response, "send failed")
-        except Exception as exc:
-            logger.error("[Feishu] Send error: %s", exc, exc_info=True)
-            return SendResult(success=False, error=str(exc))
+        if chunk_errors:
+            return SendResult(success=False, error=chunk_errors[-1])
+        return SendResult(success=False, error="send failed: no chunks")
 
     async def edit_message(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2559,6 +2559,79 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_chunk_send_failure_continues_with_remaining_chunks(self):
+        """A failed chunk must not interrupt other chunks."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # Force truncate_message to produce 3 chunks
+        adapter.MAX_MESSAGE_LENGTH = 50
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                # Second chunk fails with a generic error
+                if len(captured["calls"]) == 2:
+                    raise RuntimeError("network timeout")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id=f"om_{len(captured['calls'])}"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        # All 3 chunks should have been attempted despite chunk 2 failing
+        self.assertEqual(len(captured["calls"]), 3)
+        # Last chunk succeeded → overall success
+        self.assertTrue(result.success)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_all_chunks_fail_returns_failure(self):
+        """When every chunk fails, send returns failure."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.MAX_MESSAGE_LENGTH = 50
+
+        class _MessageAPI:
+            def create(self, request):
+                raise RuntimeError("connection refused")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertFalse(result.success)
+        self.assertIn("connection refused", result.error)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_advanced_markdown_lines(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Problem

When the Feishu adapter sends a multi-chunk message (content exceeding `MAX_MESSAGE_LENGTH`), if **any** chunk fails during send, the exception handler raises and interrupts the entire `for` loop — causing all remaining chunks to be silently dropped.

### Root cause

In `gateway/platforms/feishu.py`, the `send()` method's chunk loop has this logic:

```python
for chunk in chunks:
    msg_type, payload = self._build_outbound_payload(chunk)
    try:
        response = await self._feishu_send_with_retry(...)
    except Exception as exc:
        if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
            raise  # ← interrupts loop, remaining chunks lost
```

The `raise` condition is almost always true because:
- `_build_outbound_payload` re-evaluates each chunk independently — plain-text chunks get `msg_type="text"`
- Any non-post-content error (network timeout, rate limit, auth failure, etc.) triggers `raise`

### Impact

A 5-chunk message where chunk 2 fails means chunks 3/4/5 are never sent. The user sees a partial response with no indication that content was lost.

## Fix

Replace `raise` with `continue` so that individual chunk failures are logged and skipped rather than aborting the entire send. Key changes:

1. **Failed chunks → `continue`** instead of `raise` — remaining chunks still get sent
2. **Fallback failures also → `continue`** — the post→text fallback can also fail, handle it gracefully
3. **Track errors** in `chunk_errors` list for diagnostics
4. **Return success if any chunk succeeded** — `last_response` tracks the last successful send
5. **Error format preserved** — response errors use `[{code}] {msg}` format matching existing `_response_error_result`

## Tests

Two new tests:
- `test_chunk_send_failure_continues_with_remaining_chunks` — verifies all 3 chunks are attempted even when chunk 2 fails, and overall result is success
- `test_all_chunks_fail_returns_failure` — verifies all-chunks-fail returns the last error

All 112 existing feishu tests continue to pass.
