### PR TITLE
fix(tools): unwrap {parameters: '...'} envelope emitted by Qwen3-family models

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -384,6 +384,21 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not args or not isinstance(args, dict):
         return args
 
+    # Unwrap {"parameters": "<json string>"} envelope emitted by some models
+    # (e.g. Qwen3-family via qwen3_coder vLLM parser) that confuse the tool
+    # schema's "parameters" field name with a literal argument key.
+    if (
+        len(args) == 1
+        and "parameters" in args
+        and isinstance(args["parameters"], str)
+    ):
+        try:
+            inner = json.loads(args["parameters"])
+            if isinstance(inner, dict):
+                args = inner
+        except (json.JSONDecodeError, ValueError):
+            pass
+
     schema = registry.get_schema(tool_name)
     if not schema:
         return args

--- a/run_agent.py
+++ b/run_agent.py
@@ -264,6 +264,37 @@ def _is_destructive_command(cmd: str) -> bool:
     return False
 
 
+def _unwrap_parameters(args: dict) -> dict:
+    """Unwrap the {'parameters': '<json string>'} envelope that some models emit.
+
+    Qwen3-family models (and occasionally others) sometimes encode all tool
+    arguments as a single ``parameters`` key whose value is a JSON-encoded
+    string of the real argument dict, e.g.:
+
+        {"parameters": "{\"action\": \"add\", \"target\": \"memory\", ...}"}
+
+    instead of the expected flat dict:
+
+        {"action": "add", "target": "memory", ...}
+
+    When this pattern is detected the inner JSON string is parsed and returned.
+    Any other shape is returned unchanged.
+    """
+    if (
+        args
+        and len(args) == 1
+        and "parameters" in args
+        and isinstance(args["parameters"], str)
+    ):
+        try:
+            inner = json.loads(args["parameters"])
+            if isinstance(inner, dict):
+                return inner
+        except json.JSONDecodeError:
+            pass
+    return args
+
+
 def _should_parallelize_tool_batch(tool_calls) -> bool:
     """Return True when a tool-call batch is safe to run concurrently."""
     if len(tool_calls) <= 1:
@@ -277,7 +308,7 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
     for tool_call in tool_calls:
         tool_name = tool_call.function.name
         try:
-            function_args = json.loads(tool_call.function.arguments)
+            function_args = _unwrap_parameters(json.loads(tool_call.function.arguments))
         except Exception:
             logging.debug(
                 "Could not parse args for %s — defaulting to sequential; raw=%s",
@@ -6791,7 +6822,7 @@ class AIAgent:
                 self._iters_since_skill = 0
 
             try:
-                function_args = json.loads(tool_call.function.arguments)
+                function_args = _unwrap_parameters(json.loads(tool_call.function.arguments))
             except json.JSONDecodeError:
                 function_args = {}
             if not isinstance(function_args, dict):
@@ -6994,7 +7025,7 @@ class AIAgent:
                 self._iters_since_skill = 0
 
             try:
-                function_args = json.loads(tool_call.function.arguments)
+                function_args = _unwrap_parameters(json.loads(tool_call.function.arguments))
             except json.JSONDecodeError as e:
                 logging.warning(f"Unexpected JSON error after validation: {e}")
                 function_args = {}


### PR DESCRIPTION
## What changed and why

- Qwen3-family models served via vLLM's \`qwen3_coder\` tool parser sometimes confuse the JSON Schema field name \`parameters\` with a literal argument key, emitting all tool arguments wrapped in a single envelope: \`{"parameters": "{\"action\": \"add\", ...}"}\` instead of a flat dict.
- This causes silent failures across any tool: \`function_args.get("action")\` returns \`None\`, \`function_args.get("path")\` returns \`""\`, etc. Observed on \`memory\`, \`write_file\`, and \`execute_code\`.
- Added \`_unwrap_parameters()\` in \`run_agent.py\` applied at all three \`json.loads\` tool dispatch sites, and an equivalent inline check in \`coerce_tool_args()\` in \`model_tools.py\`. The unwrap only fires when args is a single-key dict \`{"parameters": "<json string>"}\` whose value parses as a dict — no hermes tool has a legitimate top-level argument named \`parameters\`, so there are no false positives for other models.

## How to reproduce

Serve any Qwen3 model with \`--tool-call-parser qwen3_coder\` via vLLM and point hermes at it. Ask the agent to save a memory. Raw tool call arguments arrive as:

\`\`\`json
{"parameters": "{\"action\": \"add\", \"target\": \"memory\", \"content\": \"...\"}"}
\`\`\`

Result before fix: \`{"error": "Unknown action 'None'. Use: add, replace, remove", "success": false}\`

Result after fix: memory saved correctly.

## Platforms tested

- [x] Linux

## Notes

The unwrap is a no-op for all standard OpenAI-compatible models (GPT-4o, Claude, Gemini, Kimi, Nemotron). Verified no hermes tool schema uses \`parameters\` as a property name.