### PR TITLE
fix(cli): sanitize surrogate characters in handle_paste

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8695,6 +8695,9 @@ class HermesCLI:
             if _should_auto_attach_clipboard_image_on_paste(pasted_text) and self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:
+                # Sanitize surrogate characters (e.g. from Word/Google Docs paste) before writing
+                from run_agent import _sanitize_surrogates
+                pasted_text = _sanitize_surrogates(pasted_text)
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
                 if line_count >= 5 and not buf.text.strip().startswith('/'):


### PR DESCRIPTION
Salvage of #8924 by @XiaoXiao0221 — cherry-picked onto current main.

## What this does

Sanitizes lone surrogate characters (U+D800-U+DFFF) in `handle_paste()` before writing pasted text to disk. Word and Google Docs embed these surrogates in rich text, which are invalid UTF-8 and cause `UnicodeEncodeError` at `paste_file.write_text()`.

Reuses the existing `_sanitize_surrogates()` helper from `run_agent.py`.

## Changes

- `cli.py`: 3 lines added — sanitize surrogates right after the `if pasted_text:` guard in `handle_paste()`, before both the file-write and buffer-insert paths.

## Tests

- `tests/cli/test_surrogate_sanitization.py`: 14/14 passed
- `py_compile cli.py`: OK