### PR TITLE
fix(telegram): pass proxy URL explicitly to HTTPXRequest when proxy env vars are set

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    resolve_proxy_url,
     SUPPORTED_DOCUMENT_TYPES,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -539,10 +540,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
 
-            proxy_configured = any(
-                (os.getenv(k) or "").strip()
-                for k in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy")
-            )
+            proxy_url = resolve_proxy_url()
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))
             fallback_ips = self._fallback_ips()
             if not fallback_ips:
@@ -553,7 +551,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     ", ".join(fallback_ips),
                 )
 
-            if fallback_ips and not proxy_configured and not disable_fallback:
+            if fallback_ips and not proxy_url and not disable_fallback:
                 logger.info(
                     "[%s] Telegram fallback IPs active: %s",
                     self.name,
@@ -569,10 +567,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs,
                     httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
                 )
+            elif proxy_url:
+                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
             else:
-                if proxy_configured:
-                    logger.info("[%s] Proxy configured; skipping Telegram fallback-IP transport", self.name)
-                elif disable_fallback:
+                if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs)
                 get_updates_request = HTTPXRequest(**request_kwargs)


### PR DESCRIPTION
## Summary

Salvaged from #8931 by @MaybeRichard.

When `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` env vars are set, the Telegram adapter correctly detects the proxy and skips the fallback-IP transport — but then creates `HTTPXRequest` **without** passing the proxy URL explicitly, relying on httpx's `trust_env` mechanism. This is unreliable for HTTP CONNECT proxies (e.g. Clash/ClashMac in fake-ip mode, common for users in China), causing intermittent `httpx.ConnectError` / `ConnectTimeout` failures.

### Changes

- Replaces the inline `proxy_configured` boolean (which checked env vars and discarded the result) with `proxy_url = resolve_proxy_url()` from `gateway/platforms/base.py` — the shared utility that already handles env vars + macOS system proxy detection
- Restructures the transport selection into a clean 3-way branch:
  1. **Fallback-IP transport** — when fallback IPs exist, no proxy, not disabled
  2. **Explicit proxy** — when proxy detected, pass `HTTPXRequest(proxy=proxy_url)` directly
  3. **Plain** — no proxy, no fallback IPs (or disabled)
- Also picks up macOS system proxy (`scutil --proxy`) for free via `resolve_proxy_url()`, matching how `TelegramFallbackTransport` already handles proxy

### Test plan

- Gateway test suite: 239 passed (4 pre-existing failures unrelated to proxy)
- E2E verified: `resolve_proxy_url()` returns correct URL with env vars set, returns None without, priority order correct (HTTPS_PROXY > HTTP_PROXY > ALL_PROXY)
- Compile check passed

Closes #8931