### PR TITLE
fix(homeassistant): resolve XML tool calling loop for nested data params

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -5,6 +5,7 @@ handler validation, and availability gating.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -302,6 +303,60 @@ class TestEntityIdValidation:
         }))
         if "error" in result:
             assert "Invalid entity_id" not in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# String-data deserialization (XML tool calling workaround)
+# ---------------------------------------------------------------------------
+
+
+class TestCallServiceStringData:
+    """data param may arrive as a JSON string (XML tool calling mode)."""
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    def test_string_data_deserialized(self, mock_run):
+        """JSON string data is parsed into a dict before dispatch."""
+        _handle_call_service({
+            "domain": "climate",
+            "service": "set_hvac_mode",
+            "entity_id": "climate.living_room",
+            "data": '{"hvac_mode": "heat"}',
+        })
+        call_args = mock_run.call_args[0][0]  # the coroutine arg
+        # _run_async was called, meaning we got past validation
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    def test_dict_data_passthrough(self, mock_run):
+        """Dict data (JSON tool calling mode) still works unchanged."""
+        _handle_call_service({
+            "domain": "light",
+            "service": "turn_on",
+            "entity_id": "light.bedroom",
+            "data": {"brightness": 255},
+        })
+        mock_run.assert_called_once()
+
+    def test_invalid_json_string_returns_error(self):
+        """Malformed JSON string in data returns a clear error."""
+        result = json.loads(_handle_call_service({
+            "domain": "light",
+            "service": "turn_on",
+            "entity_id": "light.bedroom",
+            "data": "{not valid json}",
+        }))
+        assert "error" in result
+        assert "Invalid JSON" in result["error"]
+
+    @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
+    def test_empty_string_data_becomes_none(self, mock_run):
+        """Empty/whitespace string data is treated as None."""
+        _handle_call_service({
+            "domain": "light",
+            "service": "turn_on",
+            "entity_id": "light.bedroom",
+            "data": "   ",
+        })
+        mock_run.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -458,10 +458,10 @@ HA_CALL_SERVICE_SCHEMA = {
             "data": {
                 "type": "string",
                 "description": (
-                    "Additional service data provided as a valid JSON string. Examples: "
-                    '\'{"brightness": 255, "color_name": "blue"}\' for lights, '
-                    '\'{"temperature": 22, "hvac_mode": "heat"}\' for climate, '
-                    '\'{"volume_level": 0.5}\' for media players.'
+                    "Additional service data as a JSON string. Examples: "
+                    '{"brightness": 255, "color_name": "blue"} for lights, '
+                    '{"temperature": 22, "hvac_mode": "heat"} for climate, '
+                    '{"volume_level": 0.5} for media players.'
                 ),
             },
         },

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -274,6 +274,12 @@ def _handle_call_service(args: dict, **kw) -> str:
         return tool_error(f"Invalid entity_id format: {entity_id}")
 
     data = args.get("data")
+    if isinstance(data, str):
+        try:
+            data = json.loads(data) if data.strip() else None
+        except json.JSONDecodeError as e:
+            return tool_error(f"Invalid JSON string in 'data' parameter: {e}")
+
     try:
         result = _run_async(_async_call_service(domain, service, entity_id, data))
         return json.dumps({"result": result})
@@ -450,12 +456,12 @@ HA_CALL_SERVICE_SCHEMA = {
                 ),
             },
             "data": {
-                "type": "object",
+                "type": "string",
                 "description": (
-                    "Additional service data. Examples: "
-                    '{"brightness": 255, "color_name": "blue"} for lights, '
-                    '{"temperature": 22, "hvac_mode": "heat"} for climate, '
-                    '{"volume_level": 0.5} for media players.'
+                    "Additional service data provided as a valid JSON string. Examples: "
+                    '\'{"brightness": 255, "color_name": "blue"}\' for lights, '
+                    '\'{"temperature": 22, "hvac_mode": "heat"}\' for climate, '
+                    '\'{"volume_level": 0.5}\' for media players.'
                 ),
             },
         },


### PR DESCRIPTION
## Summary

Salvage of PR #8918 by @dippwho. Fixes #8912.

When open-source models use XML tool calling, they can't properly format nested JSON objects inside XML tags — the `data` parameter of `ha_call_service` defaults to `{}`, causing infinite 400 Bad Request loops from Home Assistant.

**Fix:**
1. Schema: change `data` param type from `object` to `string` so models emit a serialized JSON string (easier to express in XML)
2. Runtime: `json.loads()` deserializer in `_handle_call_service` converts string back to dict before dispatching to HA
3. Defensive: dict data from JSON-mode models passes through untouched via `isinstance` guard

**Follow-up changes (on top of cherry-pick):**
- Cleaned up escaped backslash-quotes in schema description
- Added 4 tests for string-data deserialization (valid JSON, dict passthrough, invalid JSON, empty string)

## Test plan
```
python3 -m pytest tests/tools/test_homeassistant_tool.py — 68 passed
```