### PR TITLE
fix(web): CronPage crash when rendering schedule object

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -222,12 +222,14 @@ export interface CronJob {
   id: string;
   name?: string;
   prompt: string;
-  schedule: string;
-  status: "enabled" | "paused" | "error";
+  schedule: { kind: string; expr: string; display: string };
+  schedule_display: string;
+  enabled: boolean;
+  state: string;
   deliver?: string;
   last_run_at?: string | null;
   next_run_at?: string | null;
-  error?: string | null;
+  last_error?: string | null;
 }
 
 export interface SkillInfo {

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -22,10 +22,8 @@ const STATUS_VARIANT: Record<string, "success" | "warning" | "destructive"> = {
   scheduled: "success",
   paused: "warning",
   error: "destructive",
-  exhausted: "destructive",
+  completed: "destructive",
 };
-
-
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -19,9 +19,13 @@ function formatTime(iso?: string | null): string {
 
 const STATUS_VARIANT: Record<string, "success" | "warning" | "destructive"> = {
   enabled: "success",
+  scheduled: "success",
   paused: "warning",
   error: "destructive",
+  exhausted: "destructive",
 };
+
+
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
@@ -75,7 +79,8 @@ export default function CronPage() {
 
   const handlePauseResume = async (job: CronJob) => {
     try {
-      if (job.status === "paused") {
+      const isPaused = job.state === "paused";
+      if (isPaused) {
         await api.resumeCronJob(job.id);
         showToast(`Resumed "${job.name || job.prompt.slice(0, 30)}"`, "success");
       } else {
@@ -212,8 +217,8 @@ export default function CronPage() {
                   <span className="font-medium text-sm truncate">
                     {job.name || job.prompt.slice(0, 60) + (job.prompt.length > 60 ? "..." : "")}
                   </span>
-                  <Badge variant={STATUS_VARIANT[job.status] ?? "secondary"}>
-                    {job.status}
+                  <Badge variant={STATUS_VARIANT[job.state] ?? "secondary"}>
+                    {job.state}
                   </Badge>
                   {job.deliver && job.deliver !== "local" && (
                     <Badge variant="outline">{job.deliver}</Badge>
@@ -225,12 +230,12 @@ export default function CronPage() {
                   </p>
                 )}
                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                  <span className="font-mono">{job.schedule}</span>
+                  <span className="font-mono">{job.schedule_display}</span>
                   <span>Last: {formatTime(job.last_run_at)}</span>
                   <span>Next: {formatTime(job.next_run_at)}</span>
                 </div>
-                {job.error && (
-                  <p className="text-xs text-destructive mt-1">{job.error}</p>
+                {job.last_error && (
+                  <p className="text-xs text-destructive mt-1">{job.last_error}</p>
                 )}
               </div>
 
@@ -239,11 +244,11 @@ export default function CronPage() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  title={job.status === "paused" ? "Resume" : "Pause"}
-                  aria-label={job.status === "paused" ? "Resume job" : "Pause job"}
+                  title={job.state === "paused" ? "Resume" : "Pause"}
+                  aria-label={job.state === "paused" ? "Resume job" : "Pause job"}
                   onClick={() => handlePauseResume(job)}
                 >
-                  {job.status === "paused" ? (
+                  {job.state === "paused" ? (
                     <Play className="h-4 w-4 text-success" />
                   ) : (
                     <Pause className="h-4 w-4 text-warning" />


### PR DESCRIPTION
## Summary

Salvage of #8917 by @yoniebans onto current main.

Fixes a React crash on the Cron dashboard page. The cron API returns `schedule` as an object `{kind, expr, display}`, but the frontend TypeScript interface declared it as `string` and tried to render it directly as a React child — crashing with *Objects are not valid as a React child*.

## Changes

- **`web/src/lib/api.ts`**: Updated `CronJob` interface to match actual API response (`schedule` as object, `schedule_display`, `state`, `enabled`, `last_error`)
- **`web/src/pages/CronPage.tsx`**: Use `job.schedule_display` instead of `job.schedule`, `job.state` instead of `job.status`, `job.last_error` instead of `job.error`. Added `scheduled` and `completed` to status badge variant map.

## Follow-up fixes (on top of cherry-pick)

- Replaced `exhausted` with `completed` in `STATUS_VARIANT` — the cron backend uses `completed` (not `exhausted`) when repeat count is reached
- Removed extra blank lines

## Tests

- 82 tests passed (web_server + api_server_jobs)