### PR TITLE
feat(gateway/dingtalk): download inbound pictures for vision models

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -303,6 +303,9 @@ class GatewayConfig:
             # BlueBubbles uses extra dict for local server config
             elif platform == Platform.BLUEBUBBLES and config.extra.get("server_url") and config.extra.get("password"):
                 connected.append(platform)
+            # DingTalk uses extra dict for app credentials
+            elif platform == Platform.DINGTALK and config.extra.get("client_id"):
+                connected.append(platform)
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
@@ -1084,6 +1087,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
+            )
+
+    # DingTalk
+    dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
+    dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
+    if dingtalk_client_id and dingtalk_client_secret:
+        if Platform.DINGTALK not in config.platforms:
+            config.platforms[Platform.DINGTALK] = PlatformConfig()
+        config.platforms[Platform.DINGTALK].enabled = True
+        config.platforms[Platform.DINGTALK].extra.update({
+            "client_id": dingtalk_client_id,
+            "client_secret": dingtalk_client_secret,
+        })
+        dingtalk_allowed_users = os.getenv("DINGTALK_ALLOWED_USERS", "")
+        if dingtalk_allowed_users:
+            config.platforms[Platform.DINGTALK].extra["allowed_users"] = [
+                u.strip() for u in dingtalk_allowed_users.split(",") if u.strip()
+            ]
+        dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
+        if dingtalk_home:
+            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+                platform=Platform.DINGTALK,
+                chat_id=dingtalk_home,
+                name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
             )
 
     # BlueBubbles (iMessage)

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -57,6 +57,14 @@ RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
 
+# DingTalk Stream only delivers these three msgtypes to chatbot callbacks.
+# The SDK exposes them as raw string literals, so we pin our own constants
+# to keep dispatch sites from growing divergent typos.
+_MSGTYPE_TEXT = "text"
+_MSGTYPE_PICTURE = "picture"
+_MSGTYPE_RICH_TEXT = "richText"
+_PICTURE_PLACEHOLDER = "[图片]"
+
 
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured."""
@@ -181,10 +189,19 @@ class DingTalkAdapter(BasePlatformAdapter):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
 
-        text = self._extract_text(message)
+        msgtype = getattr(message, "message_type", None) or ""
+        text = self._extract_text(message, msgtype)
+
+        # Empty plain-text is usually a stripped at-mention or keep-alive — drop it.
+        # Every other msgtype still dispatches with a placeholder so the agent
+        # knows something non-text arrived.
         if not text:
-            logger.debug("[%s] Empty message, skipping", self.name)
-            return
+            if msgtype in ("", _MSGTYPE_TEXT):
+                logger.debug("[%s] Empty text message, skipping", self.name)
+                return
+            text = f"[未能解析的 {msgtype} 类型消息]"
+
+        event_type = MessageType.PHOTO if msgtype == _MSGTYPE_PICTURE else MessageType.TEXT
 
         # Chat context
         conversation_id = getattr(message, "conversation_id", "") or ""
@@ -226,7 +243,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=event_type,
             source=source,
             message_id=msg_id,
             raw_message=message,
@@ -238,22 +255,61 @@ class DingTalkAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     @staticmethod
-    def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
-        if isinstance(text, dict):
-            content = text.get("content", "").strip()
-        else:
-            content = str(text).strip()
+    def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:
+        """Render a DingTalk chatbot message as human-readable text.
 
-        # Fall back to rich text if present
-        if not content:
-            rich_text = getattr(message, "rich_text", None)
-            if rich_text and isinstance(rich_text, list):
-                parts = [item["text"] for item in rich_text
-                         if isinstance(item, dict) and item.get("text")]
-                content = " ".join(parts).strip()
-        return content
+        Picture downloads would require the ``robot/messageFiles/download``
+        OpenAPI scope which this adapter deliberately does not call —
+        picture segments are replaced with a ``[图片]`` placeholder so the
+        agent at least sees that something visual arrived.
+        """
+        if msgtype is None:
+            msgtype = getattr(message, "message_type", None) or ""
+
+        if msgtype == _MSGTYPE_TEXT:
+            return DingTalkAdapter._read_plain_text(message)
+        if msgtype == _MSGTYPE_RICH_TEXT:
+            return DingTalkAdapter._render_rich_text(message)
+        if msgtype == _MSGTYPE_PICTURE:
+            return _PICTURE_PLACEHOLDER
+        if msgtype:
+            return f"[未支持的消息类型: {msgtype}]"
+        return DingTalkAdapter._read_plain_text(message)
+
+    @staticmethod
+    def _read_plain_text(message: "ChatbotMessage") -> str:
+        text_attr = getattr(message, "text", None)
+        if text_attr is None:
+            return ""
+        if hasattr(text_attr, "content"):
+            return (text_attr.content or "").strip()
+        if isinstance(text_attr, dict):
+            return (text_attr.get("content") or "").strip()
+        return str(text_attr).strip()
+
+    @staticmethod
+    def _render_rich_text(message: "ChatbotMessage") -> str:
+        rich = getattr(message, "rich_text_content", None)
+        items = getattr(rich, "rich_text_list", None) if rich is not None else None
+        if not isinstance(items, list):
+            return ""
+
+        out = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text_val = item.get("text")
+            if text_val:
+                out.append(str(text_val))
+                continue
+            if item.get("downloadCode") or item.get("type") == "picture":
+                out.append(_PICTURE_PLACEHOLDER)
+                continue
+            if item.get("type") == "at":
+                who = item.get("name") or item.get("userId")
+                if who:
+                    out.append(f"@{who}")
+        return " ".join(out).strip()
 
     # -- Outbound messaging -------------------------------------------------
 

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -49,7 +49,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    cache_image_from_bytes,
+    cache_image_from_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -292,47 +292,43 @@ class DingTalkAdapter(BasePlatformAdapter):
         Returns a `(media_urls, media_types)` pair. Empty on any failure
         — callers fall back to the `[图片]` text placeholder.
         """
-        if self._handler is None or self._http_client is None:
+        if self._handler is None:
             return [], []
         try:
-            codes = message.get_image_list() or []
-        except Exception:
+            codes = [c for c in (message.get_image_list() or []) if c]
+        except AttributeError:
             logger.exception("[%s] get_image_list failed", self.name)
             return [], []
         if not codes:
             return [], []
 
-        paths: List[str] = []
-        types: List[str] = []
-        for code in codes:
-            if not code:
-                continue
-            try:
-                # SDK method is sync (requests-based); offload to a thread.
-                download_url = await asyncio.to_thread(
-                    self._handler.get_image_download_url, code
-                )
-            except Exception:
-                logger.exception("[%s] get_image_download_url failed", self.name)
-                continue
-            if not download_url:
-                logger.warning(
-                    "[%s] No downloadUrl returned for code %s…",
-                    self.name, code[:16],
-                )
-                continue
-            try:
-                resp = await self._http_client.get(download_url, timeout=30.0)
-                resp.raise_for_status()
-                cached = cache_image_from_bytes(resp.content, ext=".jpg")
-            except Exception:
-                logger.exception("[%s] Picture fetch failed for %s",
-                                 self.name, download_url[:80])
-                continue
-            paths.append(cached)
-            types.append("image/jpeg")
-            logger.info("[%s] Cached inbound picture at %s", self.name, cached)
-        return paths, types
+        paths = [p for p in await asyncio.gather(*(self._fetch_one(c) for c in codes)) if p]
+        if paths:
+            logger.info("[%s] Cached %d inbound picture(s)", self.name, len(paths))
+        return paths, ["image/jpeg"] * len(paths)
+
+    async def _fetch_one(self, code: str) -> Optional[str]:
+        """Exchange one downloadCode for a cached local path.
+
+        SDK's `get_image_download_url` is sync (requests-based) — offloaded
+        to a thread so a slow token refresh doesn't stall the event loop.
+        `cache_image_from_url` handles retries + SSRF guarding.
+        """
+        try:
+            download_url = await asyncio.to_thread(
+                self._handler.get_image_download_url, code
+            )
+        except Exception:
+            logger.exception("[%s] get_image_download_url failed", self.name)
+            return None
+        if not download_url:
+            logger.warning("[%s] No downloadUrl for code %s…", self.name, code[:16])
+            return None
+        try:
+            return await cache_image_from_url(download_url, ext=".jpg")
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("[%s] Picture cache failed: %s", self.name, e)
+            return None
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -18,6 +18,7 @@ Configuration in config.yaml:
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -113,9 +114,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             credential = dingtalk_stream.Credential(self._client_id, self._client_secret)
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
 
-            # Capture the current event loop for cross-thread dispatch
-            loop = asyncio.get_running_loop()
-            handler = _IncomingHandler(self, loop)
+            handler = _IncomingHandler(self)
             self._stream_client.register_callback_handler(
                 dingtalk_stream.ChatbotMessage.TOPIC, handler
             )
@@ -134,7 +133,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await asyncio.to_thread(self._stream_client.start)
+                # dingtalk-stream >= 0.24 made start() a coroutine
+                if asyncio.iscoroutinefunction(self._stream_client.start):
+                    await self._stream_client.start()
+                else:
+                    await asyncio.to_thread(self._stream_client.start)
             except asyncio.CancelledError:
                 return
             except Exception as e:
@@ -239,12 +242,22 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
-        if isinstance(text, dict):
-            content = text.get("content", "").strip()
+        """Extract plain text from a DingTalk chatbot message.
+
+        dingtalk-stream >= 0.24 exposes ``message.text`` as a ``TextContent``
+        dataclass instead of a raw dict; fall back to the old dict/str paths
+        for SDK versions that still deliver those shapes.
+        """
+        text = getattr(message, "text", None)
+        if text is not None:
+            if hasattr(text, "content"):
+                content = (text.content or "").strip()
+            elif isinstance(text, dict):
+                content = (text.get("content") or "").strip()
+            else:
+                content = str(text).strip()
         else:
-            content = str(text).strip()
+            content = ""
 
         # Fall back to rich text if present
         if not content:
@@ -309,25 +322,28 @@ class DingTalkAdapter(BasePlatformAdapter):
 class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
     """dingtalk-stream ChatbotHandler that forwards messages to the adapter."""
 
-    def __init__(self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop):
+    def __init__(self, adapter: DingTalkAdapter):
         if DINGTALK_STREAM_AVAILABLE:
             super().__init__()
         self._adapter = adapter
-        self._loop = loop
 
-    def process(self, message: "ChatbotMessage"):
-        """Called by dingtalk-stream in its thread when a message arrives.
+    async def process(self, callback):
+        """Called by dingtalk-stream when a message arrives.
 
-        Schedules the async handler on the main event loop.
+        dingtalk-stream >= 0.24 made this an async callback and passes a
+        ``CallbackMessage`` instead of a ``ChatbotMessage``. Convert the
+        payload so downstream code always sees ``ChatbotMessage``.
         """
-        loop = self._loop
-        if loop is None or loop.is_closed():
-            logger.error("[DingTalk] Event loop unavailable, cannot dispatch message")
-            return dingtalk_stream.AckMessage.STATUS_OK, "OK"
-
-        future = asyncio.run_coroutine_threadsafe(self._adapter._on_message(message), loop)
         try:
-            future.result(timeout=60)
+            if isinstance(callback, dingtalk_stream.chatbot.ChatbotMessage):
+                message = callback
+            else:
+                # CallbackMessage — parse .data into ChatbotMessage
+                data = callback.data
+                if isinstance(data, str):
+                    data = json.loads(data)
+                message = dingtalk_stream.ChatbotMessage.from_dict(data)
+            await self._adapter._on_message(message)
         except Exception:
             logger.exception("[DingTalk] Error processing incoming message")
 

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -25,7 +25,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import dingtalk_stream
@@ -49,6 +49,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_image_from_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._stream_client: Any = None
         self._stream_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        # Registered callback handler — kept around so picture downloads can
+        # piggyback on the SDK's access-token plumbing.
+        self._handler: Any = None
 
         # Message deduplication
         self._dedup = MessageDeduplicator(max_size=1000)
@@ -126,6 +130,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._stream_client.register_callback_handler(
                 dingtalk_stream.ChatbotMessage.TOPIC, handler
             )
+            # register_callback_handler wires `handler.dingtalk_client = self`,
+            # giving us access_token + credential for OpenAPI calls.
+            self._handler = handler
 
             self._stream_task = asyncio.create_task(self._run_stream())
             self._mark_connected()
@@ -179,6 +186,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._http_client = None
 
         self._stream_client = None
+        self._handler = None
         self._session_webhooks.clear()
         self._dedup.clear()
         logger.info("[%s] Disconnected", self.name)
@@ -244,6 +252,18 @@ class DingTalkAdapter(BasePlatformAdapter):
         except (ValueError, OSError, TypeError):
             timestamp = datetime.now(tz=timezone.utc)
 
+        # Download picture attachments so the vision model sees real bytes
+        # instead of the [图片] placeholder. Applies to both `picture` and
+        # `richText` msgtypes (richText can carry inline images).
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        if msgtype in (_MSGTYPE_PICTURE, _MSGTYPE_RICH_TEXT):
+            media_urls, media_types = await self._fetch_picture_attachments(message)
+            if media_urls and msgtype == _MSGTYPE_PICTURE:
+                # Swap the bare placeholder for a short caption so the agent
+                # knows to look at the attachment list.
+                text = f"[图片 × {len(media_urls)}]"
+
         event = MessageEvent(
             text=text,
             message_type=event_type,
@@ -251,11 +271,68 @@ class DingTalkAdapter(BasePlatformAdapter):
             message_id=msg_id,
             raw_message=message,
             timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         logger.debug("[%s] Message from %s in %s: %s",
                       self.name, sender_nick, chat_id[:20] if chat_id else "?", text[:50])
         await self.handle_message(event)
+
+    async def _fetch_picture_attachments(
+        self, message: "ChatbotMessage"
+    ) -> Tuple[List[str], List[str]]:
+        """Download every picture referenced by an inbound message.
+
+        Uses the SDK's `get_image_download_url` (sync) to exchange each
+        downloadCode for a short-lived CDN URL, then fetches the bytes
+        via the adapter's async httpx client and caches them locally so
+        the vision tool can read them as file paths.
+
+        Returns a `(media_urls, media_types)` pair. Empty on any failure
+        — callers fall back to the `[图片]` text placeholder.
+        """
+        if self._handler is None or self._http_client is None:
+            return [], []
+        try:
+            codes = message.get_image_list() or []
+        except Exception:
+            logger.exception("[%s] get_image_list failed", self.name)
+            return [], []
+        if not codes:
+            return [], []
+
+        paths: List[str] = []
+        types: List[str] = []
+        for code in codes:
+            if not code:
+                continue
+            try:
+                # SDK method is sync (requests-based); offload to a thread.
+                download_url = await asyncio.to_thread(
+                    self._handler.get_image_download_url, code
+                )
+            except Exception:
+                logger.exception("[%s] get_image_download_url failed", self.name)
+                continue
+            if not download_url:
+                logger.warning(
+                    "[%s] No downloadUrl returned for code %s…",
+                    self.name, code[:16],
+                )
+                continue
+            try:
+                resp = await self._http_client.get(download_url, timeout=30.0)
+                resp.raise_for_status()
+                cached = cache_image_from_bytes(resp.content, ext=".jpg")
+            except Exception:
+                logger.exception("[%s] Picture fetch failed for %s",
+                                 self.name, download_url[:80])
+                continue
+            paths.append(cached)
+            types.append("image/jpeg")
+            logger.info("[%s] Cached inbound picture at %s", self.name, cached)
+        return paths, types
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -83,30 +83,56 @@ class TestExtractText:
     def test_extracts_dict_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = {"content": "  hello world  "}
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == "hello world"
 
     def test_extracts_string_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = "plain text"
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == "plain text"
-
-    def test_falls_back_to_rich_text(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
-        assert DingTalkAdapter._extract_text(msg) == "part1 part2"
 
     def test_returns_empty_for_no_content(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         msg = MagicMock()
+        msg.message_type = "text"
         msg.text = ""
-        msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == ""
+
+    def test_picture_msgtype_returns_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "picture"
+        assert DingTalkAdapter._extract_text(msg) == "[图片]"
+
+    def test_rich_text_renders_segments_and_at_mentions(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "richText"
+        rich = MagicMock()
+        rich.rich_text_list = [
+            {"text": "hi"},
+            {"type": "at", "name": "Yoji"},
+            {"downloadCode": "abc"},
+            {"text": "there"},
+        ]
+        msg.rich_text_content = rich
+        assert DingTalkAdapter._extract_text(msg) == "hi @Yoji [图片] there"
+
+    def test_unsupported_msgtype_returns_labelled_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "audio"
+        assert DingTalkAdapter._extract_text(msg) == "[未支持的消息类型: audio]"
+
+    def test_explicit_msgtype_arg_wins_over_attribute(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "text"
+        msg.text = "ignored"
+        assert DingTalkAdapter._extract_text(msg, msgtype="picture") == "[图片]"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -309,20 +309,13 @@ class TestFetchPictureAttachments:
     """Exercise the messageFiles/download flow via mocked SDK handler."""
 
     @staticmethod
-    def _make_adapter(get_url_return, http_content=b"\xff\xd8\xffJPEG-like"):
+    def _make_adapter(get_url_return):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
-        adapter = DingTalkAdapter(config)
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"}))
         handler = MagicMock()
         handler.get_image_download_url = MagicMock(return_value=get_url_return)
         adapter._handler = handler
-        http_resp = MagicMock()
-        http_resp.content = http_content
-        http_resp.raise_for_status = MagicMock()
-        http_client = MagicMock()
-        http_client.get = AsyncMock(return_value=http_resp)
-        adapter._http_client = http_client
-        return adapter, handler, http_client
+        return adapter, handler
 
     def test_returns_empty_when_handler_missing(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
@@ -334,52 +327,43 @@ class TestFetchPictureAttachments:
         assert urls == [] and types == []
 
     def test_downloads_and_caches_single_image(self):
-        adapter, handler, http_client = self._make_adapter("https://cdn.example/img.jpg")
+        adapter, handler = self._make_adapter("https://cdn.example/img.jpg")
         msg = MagicMock()
         msg.get_image_list.return_value = ["code1"]
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/cached.jpg") as cache_fn:
+        cache_fn = AsyncMock(return_value="/tmp/cached.jpg")
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
             urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
         assert urls == ["/tmp/cached.jpg"]
         assert types == ["image/jpeg"]
         handler.get_image_download_url.assert_called_once_with("code1")
-        http_client.get.assert_awaited_once()
-        cache_fn.assert_called_once()
+        cache_fn.assert_awaited_once()
 
     def test_skips_codes_that_return_empty_url(self):
-        adapter, handler, http_client = self._make_adapter("")  # SDK returns "" on failure
+        adapter, handler = self._make_adapter("")  # SDK returns "" on failure
         msg = MagicMock()
         msg.get_image_list.return_value = ["code1", "code2"]
-        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        cache_fn = AsyncMock()
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
         assert urls == [] and types == []
         assert handler.get_image_download_url.call_count == 2
-        http_client.get.assert_not_called()
+        cache_fn.assert_not_called()
 
-    def test_continues_after_single_http_failure(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
-        adapter = DingTalkAdapter(config)
-        handler = MagicMock()
-        handler.get_image_download_url = MagicMock(side_effect=["https://cdn/a.jpg", "https://cdn/b.jpg"])
-        adapter._handler = handler
-
-        good_resp = MagicMock(); good_resp.content = b"img"; good_resp.raise_for_status = MagicMock()
-        http_client = MagicMock()
-        http_client.get = AsyncMock(side_effect=[Exception("network blip"), good_resp])
-        adapter._http_client = http_client
-
+    def test_continues_after_single_cache_failure(self):
+        import httpx as _httpx
+        adapter, handler = self._make_adapter(None)
+        handler.get_image_download_url.side_effect = ["https://cdn/a.jpg", "https://cdn/b.jpg"]
         msg = MagicMock()
         msg.get_image_list.return_value = ["c1", "c2"]
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/b.jpg"):
+        cache_fn = AsyncMock(side_effect=[_httpx.HTTPError("blip"), "/tmp/b.jpg"])
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
             urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
-        # First failed, second succeeded — only one entry.
         assert urls == ["/tmp/b.jpg"]
         assert types == ["image/jpeg"]
 
     def test_on_message_picture_populates_media_urls(self):
         """End-to-end: picture msgtype flows through to MessageEvent.media_urls."""
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        adapter, handler, _http = self._make_adapter("https://cdn.example/img.jpg")
-        handler.get_image_download_url.return_value = "https://cdn.example/img.jpg"
+        adapter, handler = self._make_adapter("https://cdn.example/img.jpg")
 
         msg = MagicMock()
         msg.message_id = "m1"
@@ -399,7 +383,7 @@ class TestFetchPictureAttachments:
             captured.append(event)
         adapter.handle_message = _capture
 
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/pic.jpg"):
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", AsyncMock(return_value="/tmp/pic.jpg")):
             asyncio.run(adapter._on_message(msg))
 
         assert len(captured) == 1

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -299,3 +299,113 @@ class TestPlatformEnum:
 
     def test_dingtalk_in_platform_enum(self):
         assert Platform.DINGTALK.value == "dingtalk"
+
+
+# ---------------------------------------------------------------------------
+# Picture attachment download
+# ---------------------------------------------------------------------------
+
+class TestFetchPictureAttachments:
+    """Exercise the messageFiles/download flow via mocked SDK handler."""
+
+    @staticmethod
+    def _make_adapter(get_url_return, http_content=b"\xff\xd8\xffJPEG-like"):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
+        adapter = DingTalkAdapter(config)
+        handler = MagicMock()
+        handler.get_image_download_url = MagicMock(return_value=get_url_return)
+        adapter._handler = handler
+        http_resp = MagicMock()
+        http_resp.content = http_content
+        http_resp.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(return_value=http_resp)
+        adapter._http_client = http_client
+        return adapter, handler, http_client
+
+    def test_returns_empty_when_handler_missing(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"}))
+        assert adapter._handler is None
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1"]
+        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == [] and types == []
+
+    def test_downloads_and_caches_single_image(self):
+        adapter, handler, http_client = self._make_adapter("https://cdn.example/img.jpg")
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1"]
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/cached.jpg") as cache_fn:
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == ["/tmp/cached.jpg"]
+        assert types == ["image/jpeg"]
+        handler.get_image_download_url.assert_called_once_with("code1")
+        http_client.get.assert_awaited_once()
+        cache_fn.assert_called_once()
+
+    def test_skips_codes_that_return_empty_url(self):
+        adapter, handler, http_client = self._make_adapter("")  # SDK returns "" on failure
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1", "code2"]
+        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == [] and types == []
+        assert handler.get_image_download_url.call_count == 2
+        http_client.get.assert_not_called()
+
+    def test_continues_after_single_http_failure(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
+        adapter = DingTalkAdapter(config)
+        handler = MagicMock()
+        handler.get_image_download_url = MagicMock(side_effect=["https://cdn/a.jpg", "https://cdn/b.jpg"])
+        adapter._handler = handler
+
+        good_resp = MagicMock(); good_resp.content = b"img"; good_resp.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(side_effect=[Exception("network blip"), good_resp])
+        adapter._http_client = http_client
+
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["c1", "c2"]
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/b.jpg"):
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        # First failed, second succeeded — only one entry.
+        assert urls == ["/tmp/b.jpg"]
+        assert types == ["image/jpeg"]
+
+    def test_on_message_picture_populates_media_urls(self):
+        """End-to-end: picture msgtype flows through to MessageEvent.media_urls."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter, handler, _http = self._make_adapter("https://cdn.example/img.jpg")
+        handler.get_image_download_url.return_value = "https://cdn.example/img.jpg"
+
+        msg = MagicMock()
+        msg.message_id = "m1"
+        msg.message_type = "picture"
+        msg.conversation_id = "cid1"
+        msg.conversation_type = "2"
+        msg.sender_id = "s1"
+        msg.sender_nick = "Yoji"
+        msg.sender_staff_id = "yoji"
+        msg.conversation_title = "group"
+        msg.create_at = 1712_000_000_000
+        msg.session_webhook = None
+        msg.get_image_list.return_value = ["code1"]
+
+        captured = []
+        async def _capture(event):
+            captured.append(event)
+        adapter.handle_message = _capture
+
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/pic.jpg"):
+            asyncio.run(adapter._on_message(msg))
+
+        assert len(captured) == 1
+        ev = captured[0]
+        assert ev.media_urls == ["/tmp/pic.jpg"]
+        assert ev.media_types == ["image/jpeg"]
+        assert ev.text == "[图片 × 1]"
+        from gateway.platforms.base import MessageType
+        assert ev.message_type == MessageType.PHOTO


### PR DESCRIPTION
## Summary

Closes the last gap preventing DingTalk vision use cases: previously every `picture` (and inline `richText` image) was replaced with the literal text `[图片]`, so vision tools had no image bytes to work with.

This PR exchanges each `downloadCode` for the temporary CDN URL via \`/v1.0/robot/messageFiles/download\`, fetches the bytes, caches them locally, and populates `MessageEvent.media_urls` — exactly the pattern Telegram/Slack/WhatsApp already use.

### Implementation notes

- Piggybacks on dingtalk-stream's built-in helpers: `register_callback_handler` wires `handler.dingtalk_client = stream_client` so the SDK's access-token plumbing and `get_image_download_url` are reachable without re-implementing token caching. Adapter keeps the handler reference on `self._handler`.
- `get_image_download_url` is sync (requests-based) — offloaded via `asyncio.to_thread` to keep the event loop clean.
- Failures at any stage (missing code, empty URL, HTTP error) degrade gracefully: the event still dispatches with the `[图片]` text placeholder so the agent knows something arrived but couldn't be decoded.
- `message.get_image_list()` handles both `picture` and `richText` msgtypes, so inline pictures in rich messages are handled the same way.
- On successful download the placeholder text is swapped for `[图片 × N]` as a short caption that accompanies the attached media list.
- **No DingTalk permission point needs to be enabled** for this — the robot app's existing AppKey/AppSecret scope already covers messageFiles download for its own inbound messages.

### Test plan

- [x] Unit tests (29 total, +5 new):
  - missing handler → empty result
  - single image end-to-end success
  - SDK returns empty URL → skipped
  - HTTP failure on first image, success on second → continues
  - `_on_message` picture dispatch → populates `MessageEvent.media_urls` and rewrites text to `[图片 × 1]`
- [ ] Live-tested locally: sending a photo to the bot now reaches `vision_analyze` with real bytes via onehub/gemini-3-pro-latest.

### Stacking

Depends on:
- #8954 (SDK 0.24 async process + TextContent reading) — needed because the picture-download path runs inside the async handler
- #8960 (msgtype dispatch) — where the picture/richText branches live

This branch merges #8954 inline so it applies against `main` directly, but reviewers should merge in order #8954 → #8957 → #8960 → this one to keep history tidy.