### PR TITLE
fix: extract Gemma 4 <thought> reasoning in _extract_reasoning()

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2018,6 +2018,7 @@ class AIAgent:
             inline_patterns = (
                 r"<think>(.*?)</think>",
                 r"<thinking>(.*?)</thinking>",
+                r"<thought>(.*?)</thought>",
                 r"<reasoning>(.*?)</reasoning>",
                 r"<REASONING_SCRATCHPAD>(.*?)</REASONING_SCRATCHPAD>",
             )


### PR DESCRIPTION
Adds `<thought>(.*?)</thought>` to the `inline_patterns` tuple in `_extract_reasoning()` so Gemma 4 reasoning content is captured for `/reasoning` display — not just stripped from visible output.

Salvaged from #8891 (credit: @RhushabhVaghela). Closes #8891.