### PR TITLE
fix(gateway): handle stale lock files in acquire_scoped_lock

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -290,6 +290,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
     }
 
     existing = _read_json_file(lock_path)
+    if existing is None and lock_path.exists():
+        # Lock file exists but is empty or contains invalid JSON — treat as
+        # stale.  This happens when a previous process was killed between
+        # O_CREAT|O_EXCL and the subsequent json.dump() (e.g. DNS failure
+        # during rapid Slack reconnect retries).
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     if existing:
         try:
             existing_pid = int(existing["pid"])

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -209,6 +209,33 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
+        """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("")  # simulate crash between O_CREAT and json.dump
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "slack"
+
+    def test_acquire_scoped_lock_recovers_corrupt_lock_file(self, tmp_path, monkeypatch):
+        """Lock file with invalid JSON should be treated as stale."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text("{truncated")  # simulate partial write
+
+        acquired, existing = status.acquire_scoped_lock("slack-app-token", "secret", metadata={"platform": "slack"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_release_scoped_lock_only_removes_current_owner(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
 


### PR DESCRIPTION
Salvage of #8892 by @WorldInnovationsDepartment — cherry-picked onto current main.

## What this fixes

Empty or corrupt lock files (from a crash between `O_CREAT|O_EXCL` and `json.dump()`) permanently block `acquire_scoped_lock()`. Slack (or any platform) cannot reconnect even after gateway restart.

The fix unlinks the stale file when it exists on disk but `_read_json_file()` returns `None`, mirroring the existing dead-PID cleanup pattern.

## Changes
- `gateway/status.py` — 9 lines: unlink empty/corrupt lock files before `O_CREAT|O_EXCL`
- `tests/gateway/test_status.py` — 2 tests: empty file + corrupt JSON recovery

## Test results
- 14/14 `test_status.py` tests pass (12 existing + 2 new)
- E2E verified: empty file, corrupt JSON, normal lock regression, full Slack deadlock scenario

Closes #8892