### PR TITLE
fix(ssh): handle WinError 1314 symlink failure with shutil.copy2 fallback

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -91,7 +91,12 @@ class TestSSHBulkUpload:
         assert "/home/testuser/.hermes/credentials" in mkdir_str
 
     def test_staging_symlinks_mirror_remote_layout(self, mock_env, tmp_path):
-        """Symlinks in staging dir should mirror the remote path structure."""
+        """Staged file in staging dir should mirror the remote path structure.
+
+        On platforms where symlinks are available (Linux/macOS) the staged
+        entry is a symlink; on Windows it may be a regular copy.  Either way
+        the file must exist at the expected path and contain the right data.
+        """
         f1 = tmp_path / "local_a.txt"
         f1.write_text("content a")
 
@@ -106,13 +111,15 @@ class TestSSHBulkUpload:
                 # Capture the staging dir from -C argument
                 c_idx = cmd.index("-C")
                 staging_dir = cmd[c_idx + 1]
-                # Check the symlink exists
                 expected = os.path.join(
                     staging_dir, "home/testuser/.hermes/skills/my_skill.md"
                 )
                 staging_paths.append(expected)
-                assert os.path.islink(expected), f"Expected symlink at {expected}"
-                assert os.readlink(expected) == os.path.abspath(str(f1))
+                # File must exist (either as symlink or copy)
+                assert os.path.exists(expected), f"Expected staged file at {expected}"
+                # Content must match the source
+                with open(expected, "r") as fh:
+                    assert fh.read() == "content a"
 
             mock = MagicMock()
             mock.stdout = MagicMock()

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -8,6 +8,7 @@ view) and don't need this.
 
 import logging
 import os
+import posixpath
 import shlex
 import time
 from pathlib import Path
@@ -68,7 +69,7 @@ def quoted_mkdir_command(dirs: list[str]) -> str:
 
 def unique_parent_dirs(files: list[tuple[str, str]]) -> list[str]:
     """Extract sorted unique parent directories from (host, remote) pairs."""
-    return sorted({str(Path(remote).parent) for _, remote in files})
+    return sorted({posixpath.dirname(remote) for _, remote in files})
 
 
 class FileSyncManager:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -161,11 +161,16 @@ class SSHEnvironment(BaseEnvironment):
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
 
         # Symlink staging avoids fragile GNU tar --transform rules.
+        # On Windows, symlink creation requires admin rights or Developer Mode,
+        # so fall back to copying the file when os.symlink raises OSError.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
             for host_path, remote_path in files:
                 staged = os.path.join(staging, remote_path.lstrip("/"))
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
-                os.symlink(os.path.abspath(host_path), staged)
+                try:
+                    os.symlink(os.path.abspath(host_path), staged)
+                except OSError:
+                    shutil.copy2(host_path, staged)
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -161,16 +161,22 @@ class SSHEnvironment(BaseEnvironment):
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
 
         # Symlink staging avoids fragile GNU tar --transform rules.
-        # On Windows, symlink creation requires admin rights or Developer Mode,
-        # so fall back to copying the file when os.symlink raises OSError.
+        # On Windows without Developer Mode, symlink creation raises
+        # OSError with winerror 1314 (privilege not held).  Catch only
+        # that specific error and fall back to a plain copy; all other
+        # OSErrors (e.g. disk full, bad path) are re-raised as normal.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
             for host_path, remote_path in files:
                 staged = os.path.join(staging, remote_path.lstrip("/"))
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
                 try:
                     os.symlink(os.path.abspath(host_path), staged)
-                except OSError:
-                    shutil.copy2(host_path, staged)
+                except OSError as e:
+                    # WinError 1314: symlink privilege not held (Windows without Dev Mode)
+                    if getattr(e, "winerror", None) == 1314:
+                        shutil.copy2(host_path, staged)
+                    else:
+                        raise
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()


### PR DESCRIPTION
## Problem

On Windows, `os.symlink()` raises `OSError (WinError 1314 — A required
privilege is not held by the client)` unless the process runs with
Administrator rights or Developer Mode is enabled.

The SSH bulk-upload staging logic in `_ssh_bulk_upload()` used symlinks
to mirror the remote directory layout before piping through `tar`. This
caused all 9 `TestSSHBulkUpload` tests to fail on Windows, and
`unique_parent_dirs()` produced backslash-separated paths (`\remote\dir`)
that are invalid on the remote Linux host.

## Changes

### `tools/environments/ssh.py`
Wrap `os.symlink()` in a `try/except OSError` block and fall back to
`shutil.copy2()` when symlink creation fails. `shutil` was already
imported — no new dependency introduced. The `tar -h` (dereference)
flag ensures symlinks are followed on platforms where they work; the
copy path produces an equivalent plain file.

### `tools/environments/file_sync.py`
Replace `str(Path(remote).parent)` with `posixpath.dirname(remote)` in
`unique_parent_dirs()`. `pathlib.Path` uses the host OS path separator
(`\` on Windows), but these paths are remote POSIX paths sent over SSH
to a Linux server and must always use forward slashes.

### `tests/tools/test_ssh_bulk_upload.py`
Make `test_staging_symlinks_mirror_remote_layout` platform-agnostic:
assert that the staged file **exists** and its **content matches** the
source, instead of checking `os.path.islink()` + `os.readlink()`. On
Linux/macOS the staged entry is a symlink; on Windows it is a copy —
both satisfy the test.

## Test Results
20 passed in 2.14s  (previously 9 failed)


## Root Cause Summary

| File | Before | After |
|------|--------|-------|
| `ssh.py:168` | `os.symlink(...)` — crashes on Windows | `try: symlink / except OSError: copy2` |
| `file_sync.py:71` | `Path(remote).parent` → `\remote\dir` | `posixpath.dirname(remote)` → `/remote/dir` |
| `test_ssh_bulk_upload.py:114` | `assert os.path.islink(...)` | `assert os.path.exists(...)` + content check |

