### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /venv/
 /_pycache/
 *.pyc*


### PR DESCRIPTION
Filter out .DS_Store (Desktop Services Store)

Each Mac generates a unique .DS_Store file, which can affect macOS users during updates. Simply filtering them out will resolve the issue.

