### PR TITLE
feat(cli): make /resume session preview message configurable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -382,6 +382,7 @@ def load_cli_config() -> Dict[str, Any]:
         "display": {
             "compact": False,
             "resume_display": "full",
+            "resume_preview_message": "last",
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
@@ -1839,6 +1840,9 @@ class HermesCLI:
         self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
+        # resume_preview_message: "last" (most recent user message) | "first" (opening user message)
+        _rpm = str(CLI_CONFIG["display"].get("resume_preview_message", "last")).strip().lower()
+        self.resume_preview_message = _rpm if _rpm in ("first", "last") else "last"
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
@@ -4480,6 +4484,7 @@ class HermesCLI:
                 source="cli",
                 exclude_sources=["tool"],
                 limit=limit,
+                preview_message=self.resume_preview_message,
             )
         except Exception:
             return []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -628,6 +628,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
+        "resume_preview_message": "last",
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
         "show_reasoning": False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8293,6 +8293,10 @@ Examples:
             return
 
         action = args.sessions_action
+        display_cfg = load_config().get("display", {})
+        preview_message = str(display_cfg.get("resume_preview_message", "last")).strip().lower()
+        if preview_message not in ("first", "last"):
+            preview_message = "last"
 
         # Hide third-party tool sessions by default, but honour explicit --source
         _source = getattr(args, "source", None)
@@ -8300,7 +8304,10 @@ Examples:
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+                preview_message=preview_message,
             )
             if not sessions:
                 print("No sessions found.")
@@ -8404,7 +8411,10 @@ Examples:
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                preview_message=preview_message,
             )
             db.close()
             if not sessions:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8283,6 +8283,7 @@ Examples:
 
     def cmd_sessions(args):
         import json as _json
+        from hermes_cli.config import load_config as _load_config
 
         try:
             from hermes_state import SessionDB
@@ -8293,8 +8294,10 @@ Examples:
             return
 
         action = args.sessions_action
-        display_cfg = load_config().get("display", {})
-        preview_message = str(display_cfg.get("resume_preview_message", "last")).strip().lower()
+        display_cfg = _load_config().get("display", {})
+        preview_message = str(
+            display_cfg.get("resume_preview_message", "last")
+        ).strip().lower()
         if preview_message not in ("first", "last"):
             preview_message = "last"
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -78,6 +78,12 @@ _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
 _REVEAL_WINDOW_SECONDS = 30
 
+
+def _session_preview_message() -> str:
+    """Return the configured session preview selection mode."""
+    value = str(load_config().get("display", {}).get("resume_preview_message", "last")).strip().lower()
+    return value if value in ("first", "last") else "last"
+
 # CORS: restrict to localhost origins only.  The web UI is intended to run
 # locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
 # read/modify config and secrets.
@@ -279,6 +285,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "type": "select",
         "description": "How resumed sessions display history",
         "options": ["minimal", "full", "off"],
+    },
+    "display.resume_preview_message": {
+        "type": "select",
+        "description": "Which user message to show in session previews",
+        "options": ["last", "first"],
     },
     "display.busy_input_mode": {
         "type": "select",
@@ -721,7 +732,11 @@ async def get_sessions(limit: int = 20, offset: int = 0):
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
+            sessions = db.list_sessions_rich(
+                limit=limit,
+                offset=offset,
+                preview_message=_session_preview_message(),
+            )
             total = db.session_count()
             now = time.time()
             for s in sessions:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -839,7 +839,7 @@ class SessionDB:
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
+                     ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -799,10 +799,10 @@ class SessionDB:
         include_children: bool = False,
         project_compression_tips: bool = True,
     ) -> List[Dict[str, Any]]:
-        """List sessions with preview (first user message) and last active timestamp.
+        """List sessions with preview (most recent user message) and last active timestamp.
 
         Returns dicts with keys: id, source, model, title, started_at, ended_at,
-        message_count, preview (first 60 chars of first user message),
+        message_count, preview (first 60 chars of the most recent user message),
         last_active (timestamp of last message).
 
         Uses a single query with correlated subqueries instead of N+2 queries.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -798,11 +798,12 @@ class SessionDB:
         offset: int = 0,
         include_children: bool = False,
         project_compression_tips: bool = True,
+        preview_message: str = "last",
     ) -> List[Dict[str, Any]]:
-        """List sessions with preview (most recent user message) and last active timestamp.
+        """List sessions with preview (first or most recent user message) and last active timestamp.
 
         Returns dicts with keys: id, source, model, title, started_at, ended_at,
-        message_count, preview (first 60 chars of the most recent user message),
+        message_count, preview (first 60 chars of the selected user message),
         last_active (timestamp of last message).
 
         Uses a single query with correlated subqueries instead of N+2 queries.
@@ -818,6 +819,15 @@ class SessionDB:
         delegate subagents and branches hidden. Pass ``False`` to return the
         raw root rows (useful for admin/debug UIs).
         """
+        preview_message = str(preview_message or "last").strip().lower()
+        if preview_message not in {"first", "last"}:
+            raise ValueError("preview_message must be 'first' or 'last'")
+        preview_order_sql = (
+            "m.timestamp, m.id"
+            if preview_message == "first"
+            else "m.timestamp DESC, m.id DESC"
+        )
+
         where_clauses = []
         params = []
 
@@ -839,7 +849,7 @@ class SessionDB:
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
+                     ORDER BY {preview_order_sql} LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(
@@ -883,7 +893,9 @@ class SessionDB:
                 if tip_id == s["id"]:
                     projected.append(s)
                     continue
-                tip_row = self._get_session_rich_row(tip_id)
+                tip_row = self._get_session_rich_row(
+                    tip_id, preview_message=preview_message
+                )
                 if not tip_row:
                     projected.append(s)
                     continue
@@ -903,18 +915,30 @@ class SessionDB:
 
         return sessions
 
-    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def _get_session_rich_row(
+        self,
+        session_id: str,
+        preview_message: str = "last",
+    ) -> Optional[Dict[str, Any]]:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the
         session doesn't exist.
         """
-        query = """
+        preview_message = str(preview_message or "last").strip().lower()
+        if preview_message not in {"first", "last"}:
+            raise ValueError("preview_message must be 'first' or 'last'")
+        preview_order_sql = (
+            "m.timestamp, m.id"
+            if preview_message == "first"
+            else "m.timestamp DESC, m.id DESC"
+        )
+        query = f"""
             SELECT s.*,
                 COALESCE(
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
+                     ORDER BY {preview_order_sql} LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(
@@ -1588,4 +1612,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -245,6 +245,21 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_recent_sessions_respect_resume_preview_message_config(self):
+        cli = _make_cli(config_overrides={"display": {"resume_preview_message": "first"}})
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = []
+
+        cli._list_recent_sessions(limit=7)
+
+        cli._session_db.list_sessions_rich.assert_called_once_with(
+            source="cli",
+            exclude_sources=["tool"],
+            limit=7,
+            preview_message="first",
+        )
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -645,3 +645,23 @@ class TestResumeDisplayConfig:
 
         display = config.get("display", {})
         assert display.get("resume_display") == "full"
+
+    def test_default_config_has_resume_preview_message(self):
+        """DEFAULT_CONFIG in hermes_cli/config.py includes resume_preview_message."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        display = DEFAULT_CONFIG.get("display", {})
+        assert display.get("resume_preview_message") == "last"
+
+    def test_cli_defaults_have_resume_preview_message(self):
+        """cli.py load_cli_config defaults include resume_preview_message."""
+        import cli as _cli_mod
+        from cli import load_cli_config
+
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            patch.dict("os.environ", {"LLM_MODEL": ""}, clear=False),
+        ):
+            config = load_cli_config()
+
+        display = config.get("display", {})
+        assert display.get("resume_preview_message") == "last"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1409,6 +1409,20 @@ class TestListSessionsRich:
         assert len(sessions) == 1
         assert "Actually, resume the deployment debugging" in sessions[0]["preview"]
 
+    def test_preview_can_use_first_user_message(self, db):
+        db.create_session("s1", "cli")
+        db.append_message("s1", "user", "Original opening request")
+        db.append_message("s1", "assistant", "Working on it.")
+        db.append_message("s1", "user", "Latest follow-up request")
+        sessions = db.list_sessions_rich(preview_message="first")
+        assert len(sessions) == 1
+        assert "Original opening request" in sessions[0]["preview"]
+
+    def test_preview_message_mode_must_be_valid(self, db):
+        db.create_session("s1", "cli")
+        with pytest.raises(ValueError, match="preview_message must be 'first' or 'last'"):
+            db.list_sessions_rich(preview_message="newest")
+
     def test_preview_truncated_at_60(self, db):
         db.create_session("s1", "cli")
         long_msg = "A" * 100
@@ -1567,6 +1581,22 @@ class TestCompressionChainProjection:
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
+
+    def test_projected_tip_preview_respects_preview_message_mode(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.append_message("tip1", "assistant", "ack")
+        db.append_message("tip1", "user", "newest tip follow-up")
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+        assert tip_row["preview"].startswith("newest tip follow-up")
+
+        sessions = db.list_sessions_rich(
+            source="cli", limit=20, preview_message="first"
+        )
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+        assert tip_row["preview"].startswith("latest message")
 
     def test_list_without_projection_returns_raw_root(self, db):
         """project_compression_tips=False returns the raw parent-NULL root
@@ -1912,4 +1942,3 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
-

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1399,14 +1399,15 @@ class TestTitleSqlWildcards:
 class TestListSessionsRich:
     """Tests for enhanced session listing with preview and last_active."""
 
-    def test_preview_from_first_user_message(self, db):
+    def test_preview_from_most_recent_user_message(self, db):
         db.create_session("s1", "cli")
         db.append_message("s1", "system", "You are a helpful assistant.")
         db.append_message("s1", "user", "Help me refactor the auth module please")
         db.append_message("s1", "assistant", "Sure, let me look at it.")
+        db.append_message("s1", "user", "Actually, resume the deployment debugging")
         sessions = db.list_sessions_rich()
         assert len(sessions) == 1
-        assert "Help me refactor the auth module" in sessions[0]["preview"]
+        assert "Actually, resume the deployment debugging" in sessions[0]["preview"]
 
     def test_preview_truncated_at_60(self, db):
         db.create_session("s1", "cli")


### PR DESCRIPTION
## Summary

- add `display.resume_preview_message` so users can choose which user message appears in session previews
- support `last` for the most recent user message and `first` for the opening user message
- thread that preference through `/resume`, recent-session history, `hermes sessions`, and the web sessions API
- add regression coverage for both preview modes and config defaults

## Why

Session previews are useful, but there is no universally correct ordering. Some users want to resume from the latest topic, while others want to keep the original opening prompt as the stable session label. This keeps the new behavior available without forcing one interpretation on everyone.

## Config

```yaml
display:
  resume_preview_message: last  # or first
```

## Testing

- `pytest -o addopts='' tests/test_hermes_state.py -q`
- local CLI-targeted tests could not be executed in this checkout because the available Python environment is missing `fire` and the repo test environment is not fully provisioned here