### PR TITLE
fix(copilot): resolve GHE token poisoning when GITHUB_TOKEN is set

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -127,6 +127,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url=DEFAULT_GITHUB_MODELS_BASE_URL,
         api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        base_url_env_var="COPILOT_API_BASE_URL",
     ),
     "copilot-acp": ProviderConfig(
         id="copilot-acp",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -308,44 +308,6 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     return default_url
 
 
-def _gh_cli_candidates() -> list[str]:
-    """Return candidate ``gh`` binary paths, including common Homebrew installs."""
-    candidates: list[str] = []
-
-    resolved = shutil.which("gh")
-    if resolved:
-        candidates.append(resolved)
-
-    for candidate in (
-        "/opt/homebrew/bin/gh",
-        "/usr/local/bin/gh",
-        str(Path.home() / ".local" / "bin" / "gh"),
-    ):
-        if candidate in candidates:
-            continue
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            candidates.append(candidate)
-
-    return candidates
-
-
-def _try_gh_cli_token() -> Optional[str]:
-    """Return a token from ``gh auth token`` when the GitHub CLI is available."""
-    for gh_path in _gh_cli_candidates():
-        try:
-            result = subprocess.run(
-                [gh_path, "auth", "token"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)
-            continue
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    return None
-
 
 _PLACEHOLDER_SECRET_VALUES = {
     "*",

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -117,14 +117,30 @@ def _gh_cli_candidates() -> list[str]:
 
 
 def _try_gh_cli_token() -> Optional[str]:
-    """Return a token from ``gh auth token`` when the GitHub CLI is available."""
+    """Return a token from ``gh auth token`` when the GitHub CLI is available.
+
+    When COPILOT_GH_HOST is set, passes ``--hostname`` so gh returns the
+    correct host's token.  Also strips GITHUB_TOKEN / GH_TOKEN from the
+    subprocess environment so ``gh`` reads from its own credential store
+    (hosts.yml) instead of just echoing the env var back.
+    """
+    hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+
+    # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
+    clean_env = {k: v for k, v in os.environ.items()
+                 if k not in ("GITHUB_TOKEN", "GH_TOKEN")}
+
     for gh_path in _gh_cli_candidates():
+        cmd = [gh_path, "auth", "token"]
+        if hostname:
+            cmd += ["--hostname", hostname]
         try:
             result = subprocess.run(
-                [gh_path, "auth", "token"],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=clean_env,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -23,9 +23,9 @@ from hermes_cli.auth import (
     get_auth_status,
     AuthError,
     KIMI_CODE_BASE_URL,
-    _try_gh_cli_token,
     _resolve_kimi_base_url,
 )
+from hermes_cli.copilot_auth import _try_gh_cli_token
 
 
 # =============================================================================
@@ -68,7 +68,7 @@ class TestProviderRegistry:
     def test_copilot_env_vars(self):
         pconfig = PROVIDER_REGISTRY["copilot"]
         assert pconfig.api_key_env_vars == ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
-        assert pconfig.base_url_env_var == ""
+        assert pconfig.base_url_env_var == "COPILOT_API_BASE_URL"
 
     def test_kimi_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kimi-coding"]
@@ -381,13 +381,13 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["source"] == "gh auth token"
 
     def test_try_gh_cli_token_uses_homebrew_path_when_not_on_path(self, monkeypatch):
-        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+        monkeypatch.setattr("hermes_cli.copilot_auth.shutil.which", lambda command: None)
         monkeypatch.setattr(
-            "hermes_cli.auth.os.path.isfile",
+            "hermes_cli.copilot_auth.os.path.isfile",
             lambda path: path == "/opt/homebrew/bin/gh",
         )
         monkeypatch.setattr(
-            "hermes_cli.auth.os.access",
+            "hermes_cli.copilot_auth.os.access",
             lambda path, mode: path == "/opt/homebrew/bin/gh" and mode == os.X_OK,
         )
 
@@ -397,11 +397,11 @@ class TestResolveApiKeyProviderCredentials:
             returncode = 0
             stdout = "gh-cli-secret\n"
 
-        def _fake_run(cmd, capture_output, text, timeout):
+        def _fake_run(cmd, **kwargs):
             calls.append(cmd)
             return _Result()
 
-        monkeypatch.setattr("hermes_cli.auth.subprocess.run", _fake_run)
+        monkeypatch.setattr("hermes_cli.copilot_auth.subprocess.run", _fake_run)
 
         assert _try_gh_cli_token() == "gh-cli-secret"
         assert calls == [["/opt/homebrew/bin/gh", "auth", "token"]]


### PR DESCRIPTION
## Summary

Salvage of #8874 by @HearthCore onto current main, plus dead code cleanup.

**What this fixes:** When `GITHUB_TOKEN` is set in the environment (common for `gh` CLI, CI, etc.), Copilot auth against GitHub Enterprise instances fails because:

1. `copilot` ProviderConfig had no `base_url_env_var`, so `COPILOT_API_BASE_URL` was silently ignored — all requests went to public `api.githubcopilot.com`
2. `gh auth token` treats `GITHUB_TOKEN` as an override and echoes it back instead of reading from its credential store (`hosts.yml`), so a valid `gho_` OAuth token in `hosts.yml` never gets used

**Changes (cherry-picked from #8874):**
- `auth.py`: Add `base_url_env_var="COPILOT_API_BASE_URL"` to copilot ProviderConfig
- `copilot_auth.py`: Strip `GITHUB_TOKEN`/`GH_TOKEN` from subprocess env when calling `gh auth token`; pass `--hostname` from `COPILOT_GH_HOST` for GHE-specific token retrieval

**Follow-up cleanup:**
- Remove duplicate dead `_try_gh_cli_token()` / `_gh_cli_candidates()` from `auth.py` (zero production callers — only `copilot_auth.py` versions are used)
- Redirect test imports to the live copy in `copilot_auth.py`
- Update test assertion for new `base_url_env_var` value

**Tests:** 152 passed (test_api_key_providers + test_copilot_auth)