### PR TITLE
Add configurable think-tag display for gateway output

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -530,6 +530,9 @@ class GatewayRunner:
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    _THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
+    _OPEN_THINK_TAIL_RE = re.compile(r"<think\b[^>]*>.*$", re.IGNORECASE | re.DOTALL)
+    _CLOSE_THINK_RE = re.compile(r"</think>", re.IGNORECASE)
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -1188,6 +1191,41 @@ class GatewayRunner:
         except Exception:
             pass
         return False
+
+    def _show_reasoning_for_source(self, source) -> bool:
+        """Resolve the effective reasoning display toggle for a platform source."""
+        try:
+            from gateway.display_config import resolve_display_setting as _rds
+            return bool(_rds(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "show_reasoning",
+                getattr(self, "_show_reasoning", False),
+            ))
+        except Exception:
+            return bool(getattr(self, "_show_reasoning", False))
+
+    @classmethod
+    def _response_contains_think_tags(cls, text: str) -> bool:
+        return "<think" in text.lower() or "</think>" in text.lower()
+
+    @classmethod
+    def _strip_hidden_reasoning(cls, text: str) -> str:
+        """Remove inline <think> blocks from displayed text."""
+        if not cls._response_contains_think_tags(text):
+            return text
+        cleaned = cls._THINK_BLOCK_RE.sub("", text)
+        cleaned = cls._OPEN_THINK_TAIL_RE.sub("", cleaned)
+        cleaned = cls._CLOSE_THINK_RE.sub("", cleaned)
+        return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+
+    def _prepare_display_response(self, text: str, source) -> str:
+        """Prepare a response for messaging output based on display settings."""
+        if not text:
+            return text
+        if self._show_reasoning_for_source(source):
+            return text
+        return self._strip_hidden_reasoning(text)
 
     @staticmethod
     def _load_busy_input_mode() -> str:
@@ -3614,17 +3652,12 @@ class GatewayRunner:
                 session_entry.session_id = agent_result["session_id"]
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
-            try:
-                from gateway.display_config import resolve_display_setting as _rds
-                _show_reasoning_effective = _rds(
-                    _load_gateway_config(),
-                    _platform_config_key(source.platform),
-                    "show_reasoning",
-                    getattr(self, "_show_reasoning", False),
-                )
-            except Exception:
-                _show_reasoning_effective = getattr(self, "_show_reasoning", False)
-            if _show_reasoning_effective and response:
+            _show_reasoning_effective = self._show_reasoning_for_source(source)
+            if (
+                _show_reasoning_effective
+                and response
+                and not self._response_contains_think_tags(response)
+            ):
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
                     # Collapse long reasoning to keep messages readable
@@ -3635,6 +3668,7 @@ class GatewayRunner:
                     else:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+            response = self._prepare_display_response(response, source)
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -5382,6 +5416,7 @@ class GatewayRunner:
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
+            response = self._prepare_display_response(response, source)
 
             # Extract media files from the response
             if response:
@@ -5567,6 +5602,8 @@ class GatewayRunner:
                 response = f"Error: {result['error']}"
             if not response:
                 response = "(No response generated)"
+            else:
+                response = self._prepare_display_response(response, source)
 
             media_files, response = adapter.extract_media(response)
             images, text_content = adapter.extract_images(response)
@@ -7818,6 +7855,7 @@ class GatewayRunner:
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
                             cursor=_effective_cursor,
+                            show_reasoning=self._show_reasoning_for_source(source),
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -43,6 +43,7 @@ class StreamConsumerConfig:
     edit_interval: float = 1.0
     buffer_threshold: int = 40
     cursor: str = " ▉"
+    show_reasoning: bool = False
 
 
 class GatewayStreamConsumer:
@@ -287,9 +288,21 @@ class GatewayStreamConsumer:
     # Matches the simple cleanup regex used by the non-streaming path in
     # gateway/platforms/base.py for post-processing.
     _MEDIA_RE = re.compile(r'''[`"']?MEDIA:\s*\S+[`"']?''')
+    _THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
+    _OPEN_THINK_TAIL_RE = re.compile(r"<think\b[^>]*>.*$", re.IGNORECASE | re.DOTALL)
+    _CLOSE_THINK_RE = re.compile(r"</think>", re.IGNORECASE)
+
+    @classmethod
+    def _strip_hidden_reasoning(cls, text: str) -> str:
+        """Remove inline <think> blocks from user-visible output."""
+        if "<think" not in text.lower() and "</think>" not in text.lower():
+            return text
+        cleaned = cls._THINK_BLOCK_RE.sub("", text)
+        cleaned = cls._OPEN_THINK_TAIL_RE.sub("", cleaned)
+        return cls._CLOSE_THINK_RE.sub("", cleaned).strip()
 
     @staticmethod
-    def _clean_for_display(text: str) -> str:
+    def _clean_for_display(text: str, show_reasoning: bool = False) -> str:
         """Strip MEDIA: directives and internal markers from text before display.
 
         The streaming path delivers raw text chunks that may include
@@ -299,9 +312,14 @@ class GatewayStreamConsumer:
         stream finishes — we just need to hide the raw directives from the
         user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
+        if (
+            "MEDIA:" not in text
+            and "[[audio_as_voice]]" not in text
+            and (show_reasoning or ("<think" not in text.lower() and "</think>" not in text.lower()))
+        ):
             return text
-        cleaned = text.replace("[[audio_as_voice]]", "")
+        cleaned = text if show_reasoning else GatewayStreamConsumer._strip_hidden_reasoning(text)
+        cleaned = cleaned.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
@@ -313,7 +331,7 @@ class GatewayStreamConsumer:
 
         Returns the message_id so callers can thread subsequent chunks.
         """
-        text = self._clean_for_display(text)
+        text = self._clean_for_display(text, self.cfg.show_reasoning)
         if not text.strip():
             return reply_to_id
         try:
@@ -341,7 +359,7 @@ class GatewayStreamConsumer:
         prefix = self._last_sent_text or ""
         if self.cfg.cursor and prefix.endswith(self.cfg.cursor):
             prefix = prefix[:-len(self.cfg.cursor)]
-        return self._clean_for_display(prefix)
+        return self._clean_for_display(prefix, self.cfg.show_reasoning)
 
     def _continuation_text(self, final_text: str) -> str:
         """Return only the part of final_text the user has not already seen."""
@@ -372,7 +390,7 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
-        final_text = self._clean_for_display(text)
+        final_text = self._clean_for_display(text, self.cfg.show_reasoning)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
@@ -464,7 +482,7 @@ class GatewayStreamConsumer:
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
-        text = self._clean_for_display(text)
+        text = self._clean_for_display(text, self.cfg.show_reasoning)
         if not text.strip():
             return False
         try:
@@ -490,7 +508,7 @@ class GatewayStreamConsumer:
         # Strip MEDIA: directives so they don't appear as visible text.
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
-        text = self._clean_for_display(text)
+        text = self._clean_for_display(text, self.cfg.show_reasoning)
         if not text.strip():
             return True  # nothing to send is "success"
         try:


### PR DESCRIPTION
## Summary
- restore the stream consumer to the current repo baseline before changing behavior
- use the existing display.show_reasoning toggle to control whether inline <think> blocks are shown in gateway output
- keep streaming, background task, and /btw responses consistent with the same toggle

## Validation
- python -m py_compile gateway/run.py gateway/stream_consumer.py
- spot-check show_reasoning true/false handling for full and partial <think> output