### PR TITLE
fix(file_tools): block /private/etc writes on macOS symlink bypass

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -79,5 +79,33 @@ class TestSafeWriteRoot:
         assert _is_write_denied(os.path.expanduser("~/.ssh/id_rsa")) is True
 
 
+class TestCheckSensitivePathMacOSBypass:
+    """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""
+
+    def test_etc_hosts_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/etc/hosts") is not None
+
+    def test_private_etc_hosts_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/etc/hosts") is not None
+
+    def test_private_etc_ssh_config_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/etc/ssh/sshd_config") is not None
+
+    def test_private_var_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/db/something") is not None
+
+    def test_boot_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
+
+    def test_safe_path_allowed(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/tmp/safe_file.txt") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -92,7 +92,10 @@ def _is_blocked_device(filepath: str) -> bool:
 
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
-_SENSITIVE_PATH_PREFIXES = ("/etc/", "/boot/", "/usr/lib/systemd/")
+_SENSITIVE_PATH_PREFIXES = (
+    "/etc/", "/boot/", "/usr/lib/systemd/",
+    "/private/etc/", "/private/var/",
+)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
@@ -102,17 +105,16 @@ def _check_sensitive_path(filepath: str) -> str | None:
         resolved = os.path.realpath(os.path.expanduser(filepath))
     except (OSError, ValueError):
         resolved = filepath
+    normalized = os.path.normpath(os.path.expanduser(filepath))
+    _err = (
+        f"Refusing to write to sensitive system path: {filepath}\n"
+        "Use the terminal tool with sudo if you need to modify system files."
+    )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix):
-            return (
-                f"Refusing to write to sensitive system path: {filepath}\n"
-                "Use the terminal tool with sudo if you need to modify system files."
-            )
-    if resolved in _SENSITIVE_EXACT_PATHS:
-        return (
-            f"Refusing to write to sensitive system path: {filepath}\n"
-            "Use the terminal tool with sudo if you need to modify system files."
-        )
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #8734 — on macOS, `/etc` is a symlink to `/private/etc`. `os.path.realpath()` resolves `/etc/hosts` → `/private/etc/hosts`, which bypassed the `/etc/` prefix in `_SENSITIVE_PATH_PREFIXES`.

### Changes
- Add `/private/etc/` and `/private/var/` to `_SENSITIVE_PATH_PREFIXES`
- Check both `realpath`-resolved and `normpath`-normalized paths against the blocklist
- Add regression tests for the macOS symlink bypass

### What was NOT changed
`_is_write_denied()` in `file_operations.py` already works correctly on macOS because both `WRITE_DENIED_PATHS` and `WRITE_DENIED_PREFIXES` are constructed using `os.path.realpath()` at module load time. No changes needed there.

### Attribution
Cherry-picked from konsisumer's PR #8746 (submitted first). Also fixes the same issue as ElhamDevelopmentStudio's PR #8829. Dropped the unnecessary `file_operations.py` changes and unrelated test noise from the original PR.

### Test plan
- `python -m pytest tests/tools/test_file_write_safety.py tests/tools/test_file_tools.py -q` — 40 passed
- E2E verified: all `/etc/*`, `/private/etc/*`, `/private/var/*` paths blocked; safe paths still allowed