### PR TITLE
fix(model): support providers: dict for custom endpoints in /model (salvage #8827)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -944,9 +944,16 @@ def list_authenticated_providers(
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
 
+            # Build models list from both default_model and full models array
             models_list = []
             if default_model:
                 models_list.append(default_model)
+            # Also include the full models list from config
+            cfg_models = ep_cfg.get("models", [])
+            if isinstance(cfg_models, list):
+                for m in cfg_models:
+                    if m and m not in models_list:
+                        models_list.append(m)
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -275,6 +275,41 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             return None
 
     config = load_config()
+    
+    # First check providers: dict (new-style user-defined providers)
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for ep_name, entry in providers.items():
+            if not isinstance(entry, dict):
+                continue
+            # Match exact name or normalized name
+            name_norm = _normalize_custom_provider_name(ep_name)
+            if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
+                # Found match by provider key
+                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                if base_url:
+                    return {
+                        "name": entry.get("name", ep_name),
+                        "base_url": base_url.strip(),
+                        "api_key": str(entry.get("key_env", "") or "").strip(),
+                        "model": entry.get("default_model", ""),
+                    }
+            # Also check the 'name' field if present
+            display_name = entry.get("name", "")
+            if display_name:
+                display_norm = _normalize_custom_provider_name(display_name)
+                if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
+                    # Found match by display name
+                    base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                    if base_url:
+                        return {
+                            "name": display_name,
+                            "base_url": base_url.strip(),
+                            "api_key": str(entry.get("key_env", "") or "").strip(),
+                            "model": entry.get("default_model", ""),
+                        }
+
+    # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")
     if not isinstance(custom_providers, list):
         if isinstance(custom_providers, dict):

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -284,6 +284,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
+            # Resolve the API key from the env var name stored in key_env
+            key_env = str(entry.get("key_env", "") or "").strip()
+            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
@@ -291,7 +295,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     return {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
-                        "api_key": str(entry.get("key_env", "") or "").strip(),
+                        "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
             # Also check the 'name' field if present
@@ -305,7 +309,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         return {
                             "name": display_name,
                             "base_url": base_url.strip(),
-                            "api_key": str(entry.get("key_env", "") or "").strip(),
+                            "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -1,0 +1,280 @@
+"""Tests for user-defined providers (providers: dict) in /model.
+
+These tests ensure that providers defined in the config.yaml ``providers:`` section
+are properly resolved for model switching and that their full ``models:`` lists
+are exposed in the model picker.
+"""
+
+import pytest
+from hermes_cli.model_switch import list_authenticated_providers, switch_model
+from hermes_cli import runtime_provider as rp
+
+
+# =============================================================================
+# Tests for list_authenticated_providers including full models list
+# =============================================================================
+
+def test_list_authenticated_providers_includes_full_models_list_from_user_providers(monkeypatch):
+    """User-defined providers should expose both default_model and full models list.
+    
+    Regression test: previously only default_model was shown in /model picker.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    
+    user_providers = {
+        "local-ollama": {
+            "name": "Local Ollama",
+            "api": "http://localhost:11434/v1",
+            "default_model": "minimax-m2.7:cloud",
+            "models": [
+                "minimax-m2.7:cloud",
+                "kimi-k2.5:cloud",
+                "glm-5.1:cloud",
+                "qwen3.5:cloud",
+            ],
+        }
+    }
+    
+    providers = list_authenticated_providers(
+        current_provider="local-ollama",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+    
+    # Find our user provider
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "local-ollama"),
+        None
+    )
+    
+    assert user_prov is not None, "User provider 'local-ollama' should be in results"
+    assert user_prov["total_models"] == 4, f"Expected 4 models, got {user_prov['total_models']}"
+    assert "minimax-m2.7:cloud" in user_prov["models"]
+    assert "kimi-k2.5:cloud" in user_prov["models"]
+    assert "glm-5.1:cloud" in user_prov["models"]
+    assert "qwen3.5:cloud" in user_prov["models"]
+
+
+def test_list_authenticated_providers_dedupes_models_when_default_in_list(monkeypatch):
+    """When default_model is also in models list, don't duplicate."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    
+    user_providers = {
+        "my-provider": {
+            "api": "http://example.com/v1",
+            "default_model": "model-a",  # Included in models list below
+            "models": ["model-a", "model-b", "model-c"],
+        }
+    }
+    
+    providers = list_authenticated_providers(
+        current_provider="my-provider",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+    
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined")),
+        None
+    )
+    
+    assert user_prov is not None
+    assert user_prov["total_models"] == 3, "Should have 3 unique models, not 4"
+    assert user_prov["models"].count("model-a") == 1, "model-a should not be duplicated"
+
+
+def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
+    """When no models array is provided, should fall back to default_model."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    
+    user_providers = {
+        "simple-provider": {
+            "name": "Simple Provider",
+            "api": "http://example.com/v1",
+            "default_model": "single-model",
+            # No 'models' key
+        }
+    }
+    
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+    
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined")),
+        None
+    )
+    
+    assert user_prov is not None
+    assert user_prov["total_models"] == 1
+    assert user_prov["models"] == ["single-model"]
+
+
+# =============================================================================
+# Tests for _get_named_custom_provider with providers: dict
+# =============================================================================
+
+def test_get_named_custom_provider_finds_user_providers_by_key(monkeypatch, tmp_path):
+    """Should resolve providers from providers: dict (new-style), not just custom_providers."""
+    config = {
+        "providers": {
+            "local-localhost:11434": {
+                "api": "http://localhost:11434/v1",
+                "name": "Local (localhost:11434)",
+                "default_model": "minimax-m2.7:cloud",
+            }
+        }
+    }
+    
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    result = rp._get_named_custom_provider("local-localhost:11434")
+    
+    assert result is not None
+    assert result["base_url"] == "http://localhost:11434/v1"
+    assert result["name"] == "Local (localhost:11434)"
+
+
+def test_get_named_custom_provider_finds_by_display_name(monkeypatch, tmp_path):
+    """Should match providers by their 'name' field as well as key."""
+    config = {
+        "providers": {
+            "my-ollama-xyz": {
+                "api": "http://ollama.example.com/v1",
+                "name": "My Production Ollama",
+                "default_model": "llama3",
+            }
+        }
+    }
+    
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    # Should find by display name (normalized)
+    result = rp._get_named_custom_provider("my-production-ollama")
+    
+    assert result is not None
+    assert result["base_url"] == "http://ollama.example.com/v1"
+
+
+def test_get_named_custom_provider_falls_back_to_legacy_format(monkeypatch, tmp_path):
+    """Should still work with custom_providers: list format."""
+    config = {
+        "providers": {},
+        "custom_providers": [
+            {
+                "name": "Custom Endpoint",
+                "base_url": "http://custom.example.com/v1",
+            }
+        ]
+    }
+    
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    result = rp._get_named_custom_provider("custom-endpoint")
+    
+    assert result is not None
+
+
+def test_get_named_custom_provider_returns_none_for_unknown(monkeypatch, tmp_path):
+    """Should return None for providers that don't exist."""
+    config = {
+        "providers": {
+            "known-provider": {
+                "api": "http://known.example.com/v1",
+            }
+        }
+    }
+    
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    result = rp._get_named_custom_provider("other-provider")
+    
+    # "unknown-provider" partial-matches "known-provider" because "unknown" doesn't match
+    # but our matching is loose (substring). Let's verify a truly non-matching provider
+    result = rp._get_named_custom_provider("completely-different-name")
+    assert result is None
+
+
+def test_get_named_custom_provider_skips_empty_base_url(monkeypatch, tmp_path):
+    """Should skip providers without a base_url."""
+    config = {
+        "providers": {
+            "incomplete-provider": {
+                "name": "Incomplete",
+                # No api/base_url field
+            }
+        }
+    }
+    
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    result = rp._get_named_custom_provider("incomplete-provider")
+    
+    assert result is None
+
+
+# =============================================================================
+# Integration test for switch_model with user providers
+# =============================================================================
+
+def test_switch_model_resolves_user_provider_credentials(monkeypatch, tmp_path):
+    """/model switch should resolve credentials for providers: dict providers."""
+    import yaml
+    
+    config = {
+        "providers": {
+            "local-ollama": {
+                "api": "http://localhost:11434/v1",
+                "name": "Local Ollama",
+                "default_model": "minimax-m2.7:cloud",
+            }
+        }
+    }
+    
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    
+    # Mock validation to pass
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {"accepted": True, "persist": True, "recognized": True, "message": None}
+    )
+    
+    result = switch_model(
+        raw_input="kimi-k2.5:cloud",
+        current_provider="local-ollama",
+        current_model="minimax-m2.7:cloud",
+        current_base_url="http://localhost:11434/v1",
+        is_global=False,
+        user_providers=config["providers"],
+    )
+    
+    assert result.success is True
+    assert result.error_message == ""


### PR DESCRIPTION
## Summary

Salvage of PR #8827 by @geoffwellman — cherry-picked onto current main with a bug fix.

**Two fixes for user-defined providers in config.yaml:**

1. **`list_authenticated_providers()`** — now includes the full `models:` array from provider config, not just `default_model`. Fixes `/model` showing only one model when multiple are configured.

2. **`_get_named_custom_provider()`** — now checks `providers:` dict (new-style) in addition to `custom_providers:` list (legacy). Fixes credential resolution errors when switching models via `/model` command.

**Bug fix on top of original PR:** The original code passed the `key_env` value (an env var NAME like `MY_API_KEY`) directly as the `api_key` field. The caller's `has_usable_secret()` check would reject the var name string, so the actual API key was never resolved. Fixed by calling `os.getenv(key_env)` to get the real key value.

Both changes are backwards compatible with existing `custom_providers` list format.

## Test plan
- 9 new unit tests (all pass)
- E2E tested: key_env resolution, display name matching, empty key_env, full models list
- 1927 passed in hermes_cli suite (11 pre-existing failures unrelated to this change)

Closes #8827