### PR TITLE
fix(cli): sanitize surrogate characters in collapsed paste fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1295,6 +1295,25 @@ def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
     return not pasted_text.strip()
 
 
+def _collapse_pasted_text_to_file(
+    pasted_text: str,
+    paste_dir: Path,
+    paste_index: int,
+    timestamp: str | None = None,
+) -> tuple[Path, str, int]:
+    """Sanitize pasted text, write it as UTF-8, and return the placeholder."""
+    from run_agent import _sanitize_surrogates
+
+    sanitized_text = _sanitize_surrogates(pasted_text)
+    paste_dir.mkdir(parents=True, exist_ok=True)
+    stamp = timestamp or datetime.now().strftime('%H%M%S')
+    paste_file = paste_dir / f"paste_{paste_index}_{stamp}.txt"
+    paste_file.write_text(sanitized_text, encoding="utf-8")
+    line_count = sanitized_text.count('\n')
+    placeholder = f"[Pasted text #{paste_index}: {line_count + 1} lines \u2192 {paste_file}]"
+    return paste_file, placeholder, line_count
+
+
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -8790,11 +8809,11 @@ class HermesCLI:
                 buf = event.current_buffer
                 if line_count >= 5 and not buf.text.strip().startswith('/'):
                     _paste_counter[0] += 1
-                    paste_dir = _hermes_home / "pastes"
-                    paste_dir.mkdir(parents=True, exist_ok=True)
-                    paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
-                    paste_file.write_text(pasted_text, encoding="utf-8")
-                    placeholder = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
+                    paste_file, placeholder, _ = _collapse_pasted_text_to_file(
+                        pasted_text,
+                        _hermes_home / "pastes",
+                        _paste_counter[0],
+                    )
                     prefix = ""
                     if buf.cursor_position > 0 and buf.text[buf.cursor_position - 1] != '\n':
                         prefix = "\n"
@@ -8928,14 +8947,14 @@ class HermesCLI:
             is_paste = chars_added > 1 or newlines_added >= 4
             if line_count >= 5 and is_paste and not text.startswith('/'):
                 _paste_counter[0] += 1
-                # Save to temp file
-                paste_dir = _hermes_home / "pastes"
-                paste_dir.mkdir(parents=True, exist_ok=True)
-                paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
-                paste_file.write_text(text, encoding="utf-8")
+                paste_file, placeholder, _ = _collapse_pasted_text_to_file(
+                    text,
+                    _hermes_home / "pastes",
+                    _paste_counter[0],
+                )
                 # Replace buffer with compact reference
                 _paste_just_collapsed[0] = True
-                buf.text = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
+                buf.text = placeholder
                 buf.cursor_position = len(buf.text)
 
         input_area.buffer.on_text_changed += _on_text_changed

--- a/tests/cli/test_surrogate_sanitization.py
+++ b/tests/cli/test_surrogate_sanitization.py
@@ -8,6 +8,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
+from cli import _collapse_pasted_text_to_file
 from run_agent import (
     _sanitize_surrogates,
     _sanitize_messages_surrogates,
@@ -152,3 +153,26 @@ class TestRunConversationSurrogateSanitization:
             if msg.get("role") == "user":
                 assert "\udce2" not in msg["content"], "Surrogate leaked into stored message"
                 assert "\ufffd" in msg["content"], "Replacement char not in stored message"
+
+
+class TestCollapsedPasteSurrogateSanitization:
+    """Regression: pasted text files must be UTF-8 writable even with surrogates."""
+
+    def test_collapsed_paste_file_sanitizes_surrogates_before_write(self, tmp_path):
+        dirty = "line1\nline2\nline3\nline4\nline5\udce2"
+
+        paste_file, placeholder, line_count = _collapse_pasted_text_to_file(
+            dirty,
+            tmp_path / "pastes",
+            7,
+            timestamp="123456",
+        )
+
+        assert paste_file.name == "paste_7_123456.txt"
+        assert line_count == 4
+        assert "5 lines" in placeholder
+
+        saved = paste_file.read_text(encoding="utf-8")
+        assert "\udce2" not in saved
+        assert "\ufffd" in saved
+        saved.encode("utf-8")


### PR DESCRIPTION
## What does this PR do?

Follow-up to #8980 (salvage of #8924).

`handle_paste()` already sanitizes lone surrogate characters before collapsing pasted text, but the fallback `_on_text_changed()` path still wrote raw buffer text to a paste file. On terminals that do not deliver bracketed paste, rich-text clipboard sources can still inject lone surrogates and trigger `UnicodeEncodeError` during `write_text(..., encoding="utf-8")`.

This PR extracts the collapse-and-write path into a shared `_collapse_pasted_text_to_file()` helper so both the bracketed-paste and fallback paths sanitize before UTF-8 write.

## Related Issue

Follow-up to #8980 (salvage of #8924). No standalone issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: add `_collapse_pasted_text_to_file()` to sanitize pasted text before UTF-8 file writes.
- `cli.py`: route both `handle_paste()` collapse and `_on_text_changed()` fallback collapse through the shared helper.
- `tests/cli/test_surrogate_sanitization.py`: add a regression test covering the collapsed-paste file-write path.

## How to Test

1. Run `python -m py_compile cli.py`
2. Run `pytest tests/cli/test_surrogate_sanitization.py -q`
3. Confirm the new regression test `TestCollapsedPasteSurrogateSanitization::test_collapsed_paste_file_sanitizes_surrogates_before_write` passes and that collapsed pasted text is written successfully as UTF-8.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15 (Hermes Windows venv)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m py_compile cli.py`: OK
- `pytest tests/cli/test_surrogate_sanitization.py -q`: 15 passed in 20.63s
- Manual smoke test: `_collapse_pasted_text_to_file()` wrote UTF-8 text with replacement characters and no surviving surrogates
- `pytest tests/ -q`: not claimed as passing for this PR
