### PR TITLE
fix(gateway): #8978 resolve Windows startup crash caused by os.kill(0…

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -415,8 +415,24 @@ def get_running_pid() -> Optional[int]:
         return None
 
     try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+        if _IS_WINDOWS:
+            # os.kill(pid, 0) throws WinError 87 on Windows. Native fallback:
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            # 0x1000 = PROCESS_QUERY_LIMITED_INFORMATION
+            handle = kernel32.OpenProcess(0x1000, False, pid)
+            if handle == 0:
+                raise ProcessLookupError
+            
+            exit_code = ctypes.c_ulong()
+            kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+            kernel32.CloseHandle(handle)
+            
+            if exit_code.value != 259:  # 259 = STILL_ACTIVE
+                raise ProcessLookupError
+        else:
+            os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
+    except (ProcessLookupError, PermissionError, OSError):
         remove_pid_file()
         return None
 


### PR DESCRIPTION
…) WinError 87

## What does this PR do?

Resolves #8978

### 🚨 Architectural Defect
A critical OS-compatibility issue was identified in `gateway/status.py`. The `get_running_pid()` function relies on `os.kill(pid, 0)` for process existence checking. While this is a standard POSIX convention, passing a `0` signal on Windows immediately raises an `OSError (WinError 87: The parameter is incorrect)`. This caused the gateway daemon to crash unconditionally during its startup health-check sequence on Windows machines.

### 🛠️ Mitigation Strategy
Implemented a robust, zero-dependency cross-platform branching logic:
* **Windows (`nt`):** Interfaced directly with `ctypes.windll.kernel32` to use `OpenProcess` and `GetExitCodeProcess`. This safely determines process vitality (`STILL_ACTIVE`) without triggering signal errors or spawning heavy subshells.
* **POSIX:** Retained the lightning-fast `os.kill(pid, 0)` check.
* **Broadened Error Handling:** Added `OSError` to the exception catch block to gracefully handle any underlying permission/access anomalies on both operating systems, preventing future hard crashes.

### 📈 System Impact
* Full gateway runtime restored for Windows 10/11 environments.
* No added external dependencies (e.g., `psutil`), maintaining a lightweight core.