### PR TITLE
fix(cron): derive copilot api_mode from job model, not config default

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -695,6 +695,38 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
+        # `resolve_runtime_provider()` derives the copilot api_mode from
+        # `model.default` in config.yaml, but a cron job may override the
+        # model (e.g. `copilot/gpt-5.4-mini` while config.yaml's default is
+        # `qwen3.5-auto`).  Re-derive api_mode from the job's actual model
+        # so GPT-5 jobs hit Responses API and GPT-4.x jobs hit Chat
+        # Completions.  Mirrors the fix applied to the delegation path in
+        # PR #6647.
+        if str(runtime.get("provider") or "").strip().lower() == "copilot" and model:
+            try:
+                from hermes_cli.models import copilot_model_api_mode
+                corrected_mode = copilot_model_api_mode(
+                    model,
+                    api_key=runtime.get("api_key"),
+                )
+                if corrected_mode and corrected_mode != runtime.get("api_mode"):
+                    logger.info(
+                        "Job '%s': corrected copilot api_mode for model %r: %s -> %s",
+                        job_id,
+                        model,
+                        runtime.get("api_mode"),
+                        corrected_mode,
+                    )
+                    runtime["api_mode"] = corrected_mode
+            except Exception as exc:
+                logger.warning(
+                    "Job '%s': failed to re-derive copilot api_mode for model %r: %s",
+                    job_id,
+                    model,
+                    exc,
+                    exc_info=True,
+                )
+
         from agent.smart_model_routing import resolve_turn_route
         turn_route = resolve_turn_route(
             prompt,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -711,6 +711,110 @@ class TestRunJobSessionPersistence:
         # But the output log should show the placeholder
         assert "(No response generated)" in output
 
+    def test_run_job_corrects_copilot_api_mode_for_job_model(self, tmp_path):
+        """Cron jobs that override the model must get api_mode re-derived.
+
+        resolve_runtime_provider() picks api_mode from config.yaml's default
+        model.  When a cron job overrides with a different model on the same
+        copilot provider (e.g. default is GPT-4.x → chat_completions but the
+        job uses GPT-5 → codex_responses), run_job must re-derive api_mode
+        from the job's actual model before handing it to the agent.
+
+        Regression test for the sibling of PR #6647, which fixed the same
+        bug pattern in tools/delegate_tool.py.
+        """
+        job = {
+            "id": "copilot-gpt5-job",
+            "name": "copilot gpt5 test",
+            "prompt": "hello",
+            "model": "copilot/gpt-5.4-mini",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "copilot-token",
+                     "base_url": "https://api.githubcopilot.com",
+                     "provider": "copilot",
+                     # Wrong mode — derived from config.yaml default,
+                     # not from the job's model.  The fix must correct it.
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch(
+                 "hermes_cli.models.copilot_model_api_mode",
+                 return_value="codex_responses",
+             ) as mock_api_mode, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+
+        # copilot_model_api_mode must have been called with the job's model,
+        # not the config.yaml default.
+        mock_api_mode.assert_called_once()
+        called_args, called_kwargs = mock_api_mode.call_args
+        assert (called_args and called_args[0] == "copilot/gpt-5.4-mini") or \
+               called_kwargs.get("model_id") == "copilot/gpt-5.4-mini"
+
+        # The agent must receive the corrected api_mode.
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["api_mode"] == "codex_responses"
+        assert kwargs["provider"] == "copilot"
+
+    def test_run_job_leaves_api_mode_alone_for_non_copilot_providers(self, tmp_path):
+        """Non-copilot providers must not trigger the api_mode override."""
+        job = {
+            "id": "openrouter-job",
+            "name": "openrouter test",
+            "prompt": "hello",
+            "model": "anthropic/claude-sonnet-4.5",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://openrouter.ai/api/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch(
+                 "hermes_cli.models.copilot_model_api_mode",
+                 return_value="codex_responses",
+             ) as mock_api_mode, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _fr, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        # Must NOT be called for non-copilot providers.
+        mock_api_mode.assert_not_called()
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["api_mode"] == "chat_completions"
+        assert kwargs["provider"] == "openrouter"
+
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
             "id": "test-job",


### PR DESCRIPTION
## What does this PR do?

`resolve_runtime_provider()` derives the Copilot `api_mode` from the default model in `config.yaml`, but a cron job may override the model. For example, with `model.default: qwen3.5-auto` and a cron job pinned to `copilot/gpt-5.4-mini`, the job inherits `api_mode: chat_completions` when it should be `codex_responses` (GPT-5 family). The request then hits `https://api.githubcopilot.com/chat/completions` with a model that only supports the Responses API and fails with HTTP 400.

After `resolve_runtime_provider()`, re-derive `api_mode` via `copilot_model_api_mode()` using the cron job's *actual* model whenever the provider is `copilot`. Non-copilot providers are left untouched.

## Related Issue

Related: #6647 — same root cause and fix pattern applied to the delegation subagent path (`tools/delegate_tool.py`). This PR applies the equivalent fix to the cron scheduler path (`cron/scheduler.py`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: after `resolve_runtime_provider()` in `run_job()`, re-derive `api_mode` via `copilot_model_api_mode(model, api_key=...)` when `provider == \"copilot\"`. Logs the correction at INFO and falls back gracefully on exception (logged at WARNING with `exc_info=True`).
- `tests/cron/test_scheduler.py`: two new tests in `TestRunJobSessionPersistence`:
  - `test_run_job_corrects_copilot_api_mode_for_job_model` — confirms a `copilot/gpt-5.4-mini` job receives the corrected `codex_responses` mode even when `resolve_runtime_provider` returns `chat_completions`.
  - `test_run_job_leaves_api_mode_alone_for_non_copilot_providers` — confirms non-copilot providers don't trigger the override.

## How to Test

1. Configure a Copilot provider in `config.yaml` with a non-GPT-5 default model (e.g. `model.default: copilot/gpt-4.1`).
2. Create a cron job that overrides the model to `copilot/gpt-5.4-mini` (or any GPT-5 family model).
3. Trigger the job (`hermes cron trigger <job-id>`).
4. **Before this fix:** the job fails with `HTTP 400: model gpt-5.4-mini is not supported via Chat Completions`.
5. **After this fix:** the cron log shows `corrected copilot api_mode for model 'copilot/gpt-5.4-mini': chat_completions -> codex_responses` and the job runs successfully.
6. Run `pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence -q` — all 5 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#6647 is the sibling fix for the delegation path; no PR exists for the cron path)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.4 (Darwin 25.4.0), Python 3.11.14

### Documentation & Housekeeping

- [x] N/A — no doc changes
- [x] N/A — no config keys
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform: pure Python logic, no OS-specific calls
- [x] N/A — no tool schema changes