### PR TITLE
fix(delegate): anchor tool names in child system prompt for unreliable FC providers

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -78,6 +78,7 @@ def _build_child_system_prompt(
     context: Optional[str] = None,
     *,
     workspace_path: Optional[str] = None,
+    available_tools: Optional[List[str]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent."""
     parts = [
@@ -93,8 +94,24 @@ def _build_child_system_prompt(
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
         )
+    # Inject concrete tool names so the model knows exactly which functions exist.
+    # This is critical for providers (e.g. GLM) whose function calling is
+    # unreliable without explicit tool-name anchoring in the system prompt.
+    if available_tools:
+        parts.append(
+            "\nYOUR AVAILABLE TOOLS (call these by name via function calling):\n"
+            + "\n".join(f"- {name}" for name in available_tools)
+        )
     parts.append(
-        "\nComplete this task using the tools available to you. "
+        "\n## CRITICAL: Tool Usage Rules\n"
+        "You MUST use the tools provided to you via function calling (the tools API). "
+        "Never simulate, guess, or fabricate tool results in plain text. "
+        "Never write XML/JSON snippets that look like tool calls — actually invoke the tool.\n"
+        "For example:\n"
+        "- To browse a webpage: call `browser_navigate` with the URL.\n"
+        "- To run a command: call `terminal` with the command.\n"
+        "- To read a file: call `read_file` with the path.\n"
+        "Do NOT describe what you would do — DO it by calling the tool.\n\n"
         "When finished, provide a clear, concise summary of:\n"
         "- What you did\n"
         "- What you found or accomplished\n"
@@ -277,6 +294,8 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    # Build prompt WITHOUT tool names first — we'll inject them after
+    # the AIAgent is constructed (because tool resolution happens inside __init__).
     child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -364,6 +383,17 @@ def _build_child_agent(
     child._print_fn = getattr(parent_agent, '_print_fn', None)
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+
+    # Post-construction: inject resolved tool names into the ephemeral system
+    # prompt.  This anchors the model to the exact function names it can call,
+    # which is critical for providers whose function calling is unreliable
+    # without explicit tool-name hints (e.g. GLM-5 via ZAI).
+    if child.valid_tool_names:
+        child.ephemeral_system_prompt = _build_child_system_prompt(
+            goal, context,
+            workspace_path=workspace_hint,
+            available_tools=sorted(child.valid_tool_names),
+        )
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.


### PR DESCRIPTION
## Problem

Providers with unreliable function calling (e.g. GLM-5 via ZAI) often **fabricate tool results in plain text** instead of actually invoking the tools API. Child agents running on these providers produce completely useless output — they describe what they *would* do rather than doing it.

## Solution

Two changes to `_build_child_system_prompt()` and `_build_child_agent()`:

1. **Tool name injection** — After `AIAgent` construction (when tool resolution is complete), inject the sorted list of resolved tool names into the child's system prompt. This anchors the model to the exact functions it can call.

2. **Explicit tool usage rules** — Replace the generic "Complete this task using the tools available to you" with a `## CRITICAL: Tool Usage Rules` section that:
   - Forbids simulated/fabricated tool results
   - Forbids writing XML/JSON snippets that look like tool calls
   - Provides concrete examples (e.g. "call \`browser_navigate\` with the URL")

## Why post-construction injection?

Tool resolution happens inside `AIAgent.__init__()`. We build the initial prompt *before* construction, then rebuild it after construction using `child.valid_tool_names` — which gives us the actual, filtered set of available tools.

## Testing

- Verified GLM-5 subagents now consistently call tools via the API instead of fabricating results
- No regression on Claude/GPT providers (tool names in system prompt are informational only)
