### PR TITLE
feat: add OpeniLink Hub platform adapter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -365,8 +365,8 @@ PLATFORM_HINTS = {
         "will be downloaded and sent as native media when possible."
     ),
     "openilink": (
-        "You are chatting via OpeniLink Hub (WeChat). Markdown formatting is not supported — "
-        "use plain text. Keep responses concise and chat-friendly."
+        "You are chatting via OpeniLink Hub (WeChat). Markdown formatting is supported, so you "
+        "may use it when it improves readability, but keep the message compact and chat-friendly."
     ),
     "wecom": (
         "You are on WeCom (企业微信 / Enterprise WeChat). Markdown formatting is supported. "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -364,6 +364,10 @@ PLATFORM_HINTS = {
         "documents. You can also include image URLs in markdown format ![alt](url) and they "
         "will be downloaded and sent as native media when possible."
     ),
+    "openilink": (
+        "You are chatting via OpeniLink Hub (WeChat). Markdown formatting is not supported — "
+        "use plain text. Keep responses concise and chat-friendly."
+    ),
     "wecom": (
         "You are on WeCom (企业微信 / Enterprise WeChat). Markdown formatting is supported. "
         "You CAN send media files natively — to deliver a file to the user, include "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
-    "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
+    "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles", "openilink",
 })
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
@@ -254,6 +254,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
         "bluebubbles": Platform.BLUEBUBBLES,
+        "openilink": Platform.OPENILINK,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -66,6 +66,7 @@ class Platform(Enum):
     WECOM_CALLBACK = "wecom_callback"
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
+    OPENILINK = "openilink"
 
 
 @dataclass
@@ -1108,6 +1109,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=bluebubbles_home,
             name=os.getenv("BLUEBUBBLES_HOME_CHANNEL_NAME", "Home"),
         )
+
+    # OpeniLink Hub
+    openilink_token = os.getenv("OPENILINK_TOKEN")
+    openilink_hub_url = os.getenv("OPENILINK_HUB_URL")
+    if openilink_token or openilink_hub_url:
+        if Platform.OPENILINK not in config.platforms:
+            config.platforms[Platform.OPENILINK] = PlatformConfig()
+        config.platforms[Platform.OPENILINK].enabled = True
+        if openilink_token:
+            config.platforms[Platform.OPENILINK].token = openilink_token
+        extra = config.platforms[Platform.OPENILINK].extra
+        if openilink_hub_url:
+            extra["hub_url"] = openilink_hub_url.rstrip("/")
 
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -88,6 +88,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "wecom":           _TIER_LOW,
     "wecom_callback":  _TIER_LOW,
     "dingtalk":        _TIER_LOW,
+    "openilink":       _TIER_LOW,
 
     # Tier 4 — batch or non-interactive delivery
     "email":           _TIER_MINIMAL,

--- a/gateway/platforms/openilink.py
+++ b/gateway/platforms/openilink.py
@@ -1,0 +1,320 @@
+"""
+OpeniLink Hub platform adapter.
+
+Connects Hermes Agent to messaging platforms (WeChat, etc.) via OpeniLink Hub's
+WebSocket Bot API. Hub manages the platform connection; this adapter handles
+event delivery and message sending over ``wss://host/bot/v1/ws?token=TOKEN``.
+
+Protocol:
+- Server sends ``{"type": "init", "data": {...}}`` on connect.
+- Server delivers events as ``{"type": "event", "v": 1, "event": {...}}``.
+- Client sends ``{"type": "send", "to": "...", "content": "...", "req_id": "..."}``.
+- Server acknowledges with ``{"type": "ack", "ok": true, "req_id": "..."}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    import aiohttp
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_url,
+    safe_url_for_log,
+)
+
+
+def check_openilink_requirements() -> bool:
+    """Return True when deps and config are available."""
+    if not AIOHTTP_AVAILABLE:
+        return False
+    token = os.getenv("OPENILINK_TOKEN", "")
+    hub_url = os.getenv("OPENILINK_HUB_URL", "")
+    return bool(token or hub_url)
+
+
+class OpeniLinkAdapter(BasePlatformAdapter):
+    """Connects to OpeniLink Hub via WebSocket to send/receive messages."""
+
+    # Reconnection constants
+    _MAX_RECONNECT_ATTEMPTS = 10
+    _BASE_DELAY = 2.0
+    _MAX_DELAY = 60.0
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.OPENILINK)
+
+        hub_url = (config.extra.get("hub_url") or "").rstrip("/")
+        if not hub_url:
+            hub_url = "https://localhost:9800"
+        # Derive ws_url from hub_url
+        ws_scheme = "wss" if hub_url.startswith("https") else "ws"
+        http_base = hub_url.replace("https://", "").replace("http://", "")
+        self._ws_url = f"{ws_scheme}://{http_base}/bot/v1/ws"
+
+        self._token: str = config.token or ""
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._receive_task: Optional[asyncio.Task] = None
+        self._reconnect_attempts: int = 0
+        self._bot_id: str = ""
+        self._installation_id: str = ""
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        try:
+            if self._session is None or self._session.closed:
+                self._session = aiohttp.ClientSession()
+
+            url = f"{self._ws_url}?token={self._token}"
+            logger.info("[openilink] Connecting to %s", safe_url_for_log(url))
+            self._ws = await self._session.ws_connect(url, heartbeat=50)
+
+            self._reconnect_attempts = 0
+            self._receive_task = asyncio.create_task(self._receive_loop())
+            self._mark_connected()
+            logger.info("[openilink] Connected")
+            return True
+        except Exception as exc:
+            logger.error("[openilink] Connection failed: %s", exc)
+            return False
+
+    async def disconnect(self) -> None:
+        if self._receive_task:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+            self._receive_task = None
+
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+        self._mark_disconnected()
+        logger.info("[openilink] Disconnected")
+
+    # ------------------------------------------------------------------
+    # Receive loop
+    # ------------------------------------------------------------------
+
+    async def _receive_loop(self) -> None:
+        try:
+            async for msg in self._ws:  # type: ignore[union-attr]
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        payload = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        logger.warning("[openilink] Invalid JSON: %s", msg.data[:120])
+                        continue
+                    await self._dispatch(payload)
+                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
+                    logger.warning("[openilink] WebSocket %s", msg.type.name)
+                    break
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            logger.error("[openilink] Receive loop error: %s", exc)
+
+        # Connection lost — try to reconnect
+        await self._reconnect()
+
+    async def _dispatch(self, payload: dict) -> None:
+        msg_type = payload.get("type", "")
+
+        if msg_type == "init":
+            data = payload.get("data", {})
+            self._bot_id = data.get("bot_id", "")
+            self._installation_id = data.get("installation_id", "")
+            logger.info(
+                "[openilink] Init: bot=%s installation=%s",
+                self._bot_id, self._installation_id,
+            )
+
+        elif msg_type == "event":
+            await self._handle_event(payload)
+
+        elif msg_type == "ack":
+            ok = payload.get("ok", False)
+            req_id = payload.get("req_id", "")
+            if not ok:
+                logger.warning("[openilink] ACK failed req_id=%s", req_id)
+
+        elif msg_type == "pong":
+            pass  # heartbeat response
+
+        elif msg_type == "error":
+            logger.error("[openilink] Server error: %s", payload.get("error", ""))
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, payload: dict) -> None:
+        event_data = payload.get("event", {})
+        event_type = event_data.get("type", "")  # e.g. "message.text"
+        data = event_data.get("data", {})
+
+        sender = data.get("sender", {})
+        user_id = sender.get("id", "")
+        group = data.get("group")
+        items = data.get("items", [])
+        message_id = data.get("message_id", "")
+        trace_id = payload.get("trace_id", "")
+
+        # Determine chat_id: use group id if available, else user_id
+        chat_id = group.get("id") if group else user_id
+        if not chat_id:
+            return
+
+        chat_type = "group" if group else "dm"
+
+        # Extract text and media from items
+        text_parts = []
+        media_urls = []
+        media_types = []
+        for item in items:
+            item_type = item.get("type", "")
+            if item_type == "text":
+                text_parts.append(item.get("text", ""))
+            elif item_type in ("image", "video", "file", "voice"):
+                media = item.get("media", {})
+                media_url = media.get("url", "")
+                if media_url:
+                    try:
+                        ext = ".jpg" if item_type == "image" else f".{item_type}"
+                        cached = await cache_image_from_url(media_url, ext=ext)
+                        media_urls.append(cached)
+                        media_types.append(f"{item_type}/{ext.lstrip('.')}")
+                    except Exception as exc:
+                        logger.warning("[openilink] Cache media failed: %s", exc)
+
+        text = "\n".join(text_parts)
+
+        # Map event type to MessageType
+        if event_type == "message.image" or media_urls:
+            msg_type = MessageType.PHOTO
+        elif event_type == "message.voice":
+            msg_type = MessageType.VOICE
+        elif event_type == "message.video":
+            msg_type = MessageType.VIDEO
+        elif event_type == "message.file":
+            msg_type = MessageType.DOCUMENT
+        else:
+            msg_type = MessageType.TEXT
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=msg_type,
+            source=source,
+            raw_message=payload,
+            message_id=message_id,
+            media_urls=media_urls,
+            media_types=media_types,
+        )
+        await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Send
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._ws or self._ws.closed:
+            return SendResult(success=False, error="WebSocket not connected", retryable=True)
+
+        try:
+            chunks = self.truncate_message(content, max_length=4096)
+            last_req_id = ""
+            for chunk in chunks:
+                req_id = f"r_{uuid.uuid4().hex[:8]}"
+                await self._ws.send_json({
+                    "type": "send",
+                    "req_id": req_id,
+                    "to": chat_id,
+                    "content": chunk,
+                })
+                last_req_id = req_id
+            return SendResult(success=True, message_id=last_req_id)
+        except Exception as exc:
+            logger.error("[openilink] Send failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        if not self._ws or self._ws.closed:
+            return
+        try:
+            await self._ws.send_json({"type": "send_typing", "to": chat_id})
+        except Exception:
+            pass
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # Hub doesn't have a native image-send via WS; fall back to text with URL
+        text = f"![image]({image_url})"
+        if caption:
+            text = f"{caption}\n{text}"
+        return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "dm", "chat_id": chat_id}
+
+    # ------------------------------------------------------------------
+    # Reconnection
+    # ------------------------------------------------------------------
+
+    async def _reconnect(self) -> None:
+        if self._reconnect_attempts >= self._MAX_RECONNECT_ATTEMPTS:
+            msg = f"Reconnection exhausted after {self._MAX_RECONNECT_ATTEMPTS} attempts"
+            logger.error("[openilink] %s", msg)
+            self._set_fatal_error("openilink_reconnect", msg, retryable=True)
+            return
+
+        self._reconnect_attempts += 1
+        delay = min(self._BASE_DELAY * (2 ** (self._reconnect_attempts - 1)), self._MAX_DELAY)
+        logger.warning(
+            "[openilink] Reconnecting in %.0fs (attempt %d/%d)",
+            delay, self._reconnect_attempts, self._MAX_RECONNECT_ATTEMPTS,
+        )
+        await asyncio.sleep(delay)
+        await self.connect()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1499,6 +1499,7 @@ class GatewayRunner:
                        "WECOM_CALLBACK_ALLOWED_USERS",
                        "WEIXIN_ALLOWED_USERS",
                        "BLUEBUBBLES_ALLOWED_USERS",
+                       "OPENILINK_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -1512,7 +1513,8 @@ class GatewayRunner:
                        "WECOM_ALLOW_ALL_USERS",
                        "WECOM_CALLBACK_ALLOW_ALL_USERS",
                        "WEIXIN_ALLOW_ALL_USERS",
-                       "BLUEBUBBLES_ALLOW_ALL_USERS")
+                       "BLUEBUBBLES_ALLOW_ALL_USERS",
+                       "OPENILINK_ALLOW_ALL_USERS")
         )
         if not _any_allowlist and not _allow_all:
             logger.warning(
@@ -2255,6 +2257,13 @@ class GatewayRunner:
                 return None
             return BlueBubblesAdapter(config)
 
+        elif platform == Platform.OPENILINK:
+            from gateway.platforms.openilink import OpeniLinkAdapter, check_openilink_requirements
+            if not check_openilink_requirements():
+                logger.warning("OpeniLink: aiohttp missing or OPENILINK_TOKEN/OPENILINK_HUB_URL not configured")
+                return None
+            return OpeniLinkAdapter(config)
+
         return None
     
     def _is_user_authorized(self, source: SessionSource) -> bool:
@@ -2296,6 +2305,7 @@ class GatewayRunner:
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
+            Platform.OPENILINK: "OPENILINK_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -2313,6 +2323,7 @@ class GatewayRunner:
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
+            Platform.OPENILINK: "OPENILINK_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
@@ -6467,7 +6478,7 @@ class GatewayRunner:
         Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
-        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.LOCAL,
+        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.OPENILINK, Platform.LOCAL,
     })
 
     async def _handle_debug_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1913,6 +1913,28 @@ _PLATFORMS = [
              "help": "Phone number or Apple ID to deliver cron results and notifications to."},
         ],
     },
+    {
+        "key": "openilink",
+        "label": "OpeniLink Hub",
+        "emoji": "🔗",
+        "token_var": "OPENILINK_TOKEN",
+        "setup_instructions": [
+            "1. Deploy OpeniLink Hub: https://github.com/openilink/openilink-hub",
+            "2. In Hub, go to Apps → Hermes Agent → Install on your Bot",
+            "3. Copy the App Token from the installation page",
+            "4. Hermes connects to Hub via WebSocket and receives messages",
+            "5. Set OPENILINK_ALLOW_ALL_USERS=true to allow all users",
+        ],
+        "vars": [
+            {"name": "OPENILINK_HUB_URL", "prompt": "OpeniLink Hub URL (e.g. https://hub.example.com)", "password": False,
+             "help": "The URL of your OpeniLink Hub instance."},
+            {"name": "OPENILINK_TOKEN", "prompt": "App Token (from Hub installation page)", "password": True,
+             "help": "The token shown on the Hermes Agent app installation page in Hub."},
+            {"name": "OPENILINK_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, or leave empty)", "password": False,
+             "is_allowlist": True,
+             "help": "Optional — pre-authorize specific WeChat user IDs."},
+        ],
+    },
 ]
 
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -305,6 +305,7 @@ def show_status(args):
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
+        "OpeniLink": ("OPENILINK_TOKEN", None),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -160,6 +160,7 @@ def _handle_send(args):
         "wecom": Platform.WECOM,
         "wecom_callback": Platform.WECOM_CALLBACK,
         "weixin": Platform.WEIXIN,
+        "openilink": Platform.OPENILINK,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
     }

--- a/toolsets.py
+++ b/toolsets.py
@@ -383,10 +383,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-openilink": {
+        "description": "OpeniLink Hub toolset - messaging via OpeniLink Hub WebSocket API",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-openilink", "hermes-webhook"]
     }
 }
 


### PR DESCRIPTION
## Summary
- Add OpeniLink Hub as a new messaging platform, connecting Hermes to WeChat (and other platforms) via Hub's WebSocket Bot API
- New adapter: `gateway/platforms/openilink.py` — WebSocket-based, with reconnection and exponential backoff
- Registered across all 10 integration points per `ADDING_A_PLATFORM.md`

## Configuration
```bash
# ~/.hermes/.env
OPENILINK_HUB_URL=https://hub.example.com
OPENILINK_TOKEN=your_app_token
OPENILINK_ALLOW_ALL_USERS=true
```

## Files changed (10)
| File | Change |
|------|--------|
| `gateway/platforms/openilink.py` | New adapter (WebSocket connect, send, receive) |
| `gateway/config.py` | Platform enum + env var loading |
| `gateway/run.py` | Adapter factory + auth maps + allowlists |
| `gateway/display_config.py` | Display tier |
| `toolsets.py` | hermes-openilink toolset |
| `tools/send_message_tool.py` | Platform routing |
| `cron/scheduler.py` | Cron delivery support |
| `agent/prompt_builder.py` | Platform prompt hint |
| `hermes_cli/gateway.py` | Setup wizard entry |
| `hermes_cli/status.py` | Status display |

## Test plan
- [ ] `python -c "import ast; ast.parse(open('gateway/platforms/openilink.py').read())"` passes
- [ ] `hermes gateway setup` shows OpeniLink as an option
- [ ] Connect to a running Hub instance and verify message round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)