### PR TITLE
fix(docker): add git to apt dependencies for npm git-based packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm git python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## Problem

The Docker build fails at `npm install` in the WhatsApp bridge step:

```
npm ERR! syscall spawn git
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent An unknown git error occurred
```

## Root Cause

The whatsapp-bridge `package.json` depends on `@whiskeysockets/baileys` via a GitHub branch reference:

```json
"@whiskeysockets/baileys": "WhiskeySockets/Baileys#fix/abprops-abt-fetch"
```

npm needs `git` to clone this dependency, but `git` is not installed in the Docker image.

## Fix

Add `git` to the `apt-get install` line in the Dockerfile (1 line, 1 word).
