### PR TITLE
fix(tools): harden backend helpers and schema normalization

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,6 +4,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import copy
 import json
 import os
 from types import SimpleNamespace
@@ -125,6 +126,52 @@ class TestSchemaConversion:
         schema = _convert_mcp_schema("my_server", mcp_tool)
 
         assert schema["name"] == "mcp_my_server_list_dir"
+
+    def test_array_schema_without_items_gets_normalized_recursively(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        input_schema = {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "criteria": {
+                            "type": "array",
+                        },
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "values": {
+                                        "type": "array",
+                                    }
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+        }
+        original = copy.deepcopy(input_schema)
+        mcp_tool = _make_mcp_tool(
+            name="search_bill_payments",
+            description="Search bill payments",
+            input_schema=input_schema,
+        )
+
+        schema = _convert_mcp_schema("quickbooks", mcp_tool)
+
+        assert schema["parameters"]["properties"]["params"]["properties"]["criteria"] == {
+            "type": "array",
+            "items": {},
+        }
+        assert schema["parameters"]["properties"]["params"]["properties"]["filters"]["items"]["properties"]["values"] == {
+            "type": "array",
+            "items": {},
+        }
+        assert input_schema == original
 
     def test_hyphens_sanitized_to_underscores(self):
         """Hyphens in tool/server names are replaced with underscores for LLM compat."""

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -285,3 +285,14 @@ class TestResolveOpenaiAudioApiKey:
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "  voice-key  ")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         assert resolve_openai_audio_api_key() == "voice-key"
+
+    def test_refreshes_profile_env_when_process_env_missing(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text("OPENAI_API_KEY=test-audio-key\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        assert resolve_openai_audio_api_key() == "test-audio-key"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -481,6 +481,75 @@ class TestTranscribeLocalExtended:
         assert result["success"] is False
         assert "CUDA out of memory" in result["error"]
 
+    def test_gpu_backend_init_falls_back_to_cpu(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        calls = []
+
+        def fake_whisper_model(model_name, device="auto", compute_type="auto"):
+            calls.append((model_name, device, compute_type))
+            if len(calls) == 1:
+                raise RuntimeError("Library libcublas.so.12 is not found or cannot be loaded")
+            return mock_model
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", side_effect=fake_whisper_model), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello"
+        assert calls == [
+            ("base", "auto", "auto"),
+            ("base", "cpu", "int8"),
+        ]
+
+    def test_gpu_runtime_error_falls_back_to_cpu(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        first_model = MagicMock()
+        first_model.transcribe.side_effect = RuntimeError("Library libcublas.so.12 is not found or cannot be loaded")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+        second_model = MagicMock()
+        second_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        calls = []
+
+        def fake_whisper_model(model_name, device="auto", compute_type="auto"):
+            calls.append((model_name, device, compute_type))
+            return first_model if len(calls) == 1 else second_model
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", side_effect=fake_whisper_model), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello"
+        assert calls == [
+            ("base", "auto", "auto"),
+            ("base", "cpu", "int8"),
+        ]
+
     def test_multiple_segments_joined(self, tmp_path):
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1493,10 +1493,19 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     if not schema:
         return {"type": "object", "properties": {}}
 
-    if schema.get("type") == "object" and "properties" not in schema:
-        return {**schema, "properties": {}}
+    def _normalize_node(node):
+        if isinstance(node, dict):
+            normalized = {key: _normalize_node(value) for key, value in node.items()}
+            if normalized.get("type") == "object" and "properties" not in normalized:
+                normalized["properties"] = {}
+            if normalized.get("type") == "array" and "items" not in normalized:
+                normalized["items"] = {}
+            return normalized
+        if isinstance(node, list):
+            return [_normalize_node(item) for item in node]
+        return node
 
-    return schema
+    return _normalize_node(schema)
 
 
 def sanitize_mcp_name_component(value: str) -> str:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
+from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_constants import get_hermes_home
 from utils import env_var_enabled
 
 _DEFAULT_BROWSER_PROVIDER = "local"
@@ -81,8 +83,29 @@ def resolve_modal_backend_state(
     }
 
 
+def _refresh_hermes_env_if_needed(*keys: str) -> None:
+    """Lazily load the active Hermes .env when requested keys are missing.
+
+    Some long-lived processes can call helper modules before profile-local
+    credentials are in the environment. Refreshing here keeps audio helpers
+    usable without requiring every caller to remember to load .env first.
+    """
+    if any(os.getenv(key) for key in keys):
+        return
+    try:
+        load_hermes_dotenv(
+            hermes_home=get_hermes_home(),
+            project_env=Path(__file__).resolve().parents[1] / ".env",
+        )
+    except Exception:
+        # Best-effort refresh only — callers still handle missing creds normally.
+        pass
+
+
+
 def resolve_openai_audio_api_key() -> str:
     """Prefer the voice-tools key, but fall back to the normal OpenAI key."""
+    _refresh_hermes_env_if_needed("VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY")
     return (
         os.getenv("VOICE_TOOLS_OPENAI_KEY", "")
         or os.getenv("OPENAI_API_KEY", "")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -88,6 +88,10 @@ GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-lar
 _local_model: Optional[object] = None
 _local_model_name: Optional[str] = None
 
+# Optional env overrides for local STT backend selection.
+LOCAL_STT_DEVICE_ENV = "HERMES_LOCAL_STT_DEVICE"
+LOCAL_STT_COMPUTE_TYPE_ENV = "HERMES_LOCAL_STT_COMPUTE_TYPE"
+
 # ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------
@@ -310,6 +314,46 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_cuda_backend_error(exc: Exception) -> bool:
+    """Return True when the exception suggests a broken/missing CUDA backend."""
+    message = str(exc).lower()
+    return any(token in message for token in (
+        "libcublas",
+        "cublas",
+        "cudnn",
+        "cuda",
+        "gpu",
+    ))
+
+
+def _load_local_whisper_model(
+    model_name: str,
+    *,
+    device: Optional[str] = None,
+    compute_type: Optional[str] = None,
+    allow_cpu_fallback: bool = True,
+):
+    """Load faster-whisper with a CPU fallback when CUDA init fails."""
+    from faster_whisper import WhisperModel
+
+    resolved_device = (device or os.getenv(LOCAL_STT_DEVICE_ENV, "auto")).strip() or "auto"
+    resolved_compute_type = (compute_type or os.getenv(LOCAL_STT_COMPUTE_TYPE_ENV, "auto")).strip() or "auto"
+
+    try:
+        return WhisperModel(model_name, device=resolved_device, compute_type=resolved_compute_type)
+    except Exception as exc:
+        if not allow_cpu_fallback or resolved_device != "auto" or not _looks_like_cuda_backend_error(exc):
+            raise
+
+        fallback_compute = resolved_compute_type if resolved_compute_type != "auto" else "int8"
+        logger.warning(
+            "faster-whisper GPU init failed (%s); retrying on CPU with compute_type=%s",
+            exc,
+            fallback_compute,
+        )
+        return WhisperModel(model_name, device="cpu", compute_type=fallback_compute)
+
+
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
     global _local_model, _local_model_name
@@ -318,11 +362,10 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
-        from faster_whisper import WhisperModel
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')
         if _local_model is None or _local_model_name != model_name:
             logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
-            _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
+            _local_model = _load_local_whisper_model(model_name)
             _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
@@ -335,7 +378,30 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
 
-        segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+        try:
+            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+        except Exception as exc:
+            current_device = os.getenv(LOCAL_STT_DEVICE_ENV, "auto").strip() or "auto"
+            if current_device != "auto" or not _looks_like_cuda_backend_error(exc):
+                raise
+
+            fallback_compute = os.getenv(LOCAL_STT_COMPUTE_TYPE_ENV, "auto").strip() or "auto"
+            if fallback_compute == "auto":
+                fallback_compute = "int8"
+            logger.warning(
+                "faster-whisper GPU runtime failed (%s); retrying on CPU with compute_type=%s",
+                exc,
+                fallback_compute,
+            )
+            _local_model = _load_local_whisper_model(
+                model_name,
+                device="cpu",
+                compute_type=fallback_compute,
+                allow_cpu_fallback=False,
+            )
+            _local_model_name = model_name
+            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+
         transcript = " ".join(segment.text.strip() for segment in segments)
 
         logger.info(


### PR DESCRIPTION
## Summary

Hardens a few small but broadly useful tool backend paths around env hydration, local transcription fallback, and MCP schema normalization.

## Root cause

- Long-lived Hermes processes can miss profile-local `.env` updates when resolving OpenAI audio credentials.
- Local STT can fail hard on broken CUDA stacks even when a CPU fallback would still work.
- MCP schema normalization previously assumed only shallow/top-level fixes were needed, which could leave nested array/object inputs malformed.

## What this changes

- Refreshes the active Hermes `.env` on a best-effort basis before resolving OpenAI audio credentials when required keys are missing from the live environment.
- Adds `HERMES_LOCAL_STT_DEVICE` and `HERMES_LOCAL_STT_COMPUTE_TYPE` overrides for local STT backend selection.
- Falls back to CPU when faster-whisper fails during GPU initialization.
- Retries on CPU when the model loads but transcription later fails with a CUDA/backend runtime error.
- Walks MCP input schemas recursively so nested object/array nodes always get valid `properties` / `items` defaults.

## Why this fits upstream

- All three changes improve robustness in generic runtime paths.
- They help Hermes degrade gracefully instead of failing on environment drift or broken GPU stacks.
- They avoid malformed MCP tool schemas without introducing product-direction changes.

## Verification

- [x] `python -m pytest tests/tools/test_tool_backend_helpers.py tests/tools/test_transcription_tools.py tests/tools/test_mcp_tool.py -q`
  - result: `294 passed`
  - note: one pre-existing mock-related runtime warning remains in `tests/tools/test_mcp_tool.py::TestUtilityHandlers::test_list_prompts_success`
- [x] Static added-lines security scan on the branch diff
  - result: no findings for hardcoded secrets, shell injection, unsafe eval/exec, pickle deserialization, or SQL string formatting patterns

## Scope

- intentionally limited to generic backend robustness fixes
- does not include the larger local-model-eval tooling or other fork-local work

## Files

- `tools/tool_backend_helpers.py`
- `tools/transcription_tools.py`
- `tools/mcp_tool.py`
- `tests/tools/test_tool_backend_helpers.py`
- `tests/tools/test_transcription_tools.py`
- `tests/tools/test_mcp_tool.py`

## Notes

This is a narrow robustness PR, not a broader tooling expansion.