### PR TITLE
fix(webui): harden dashboard session and cron visibility

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7141,10 +7141,12 @@ class GatewayRunner:
         return user_text
 
     async def _inject_watch_notification(self, synth_text: str, original_event) -> None:
-        """Inject a watch-pattern notification as a synthetic message event.
+        """Deliver a watch-pattern notification directly to the originating chat.
 
-        Uses the source from the original user event to route the notification
-        back to the correct chat/adapter.
+        Watch-pattern matches are operator status signals, not new user turns.
+        Routing them back through ``adapter.handle_message()`` causes the agent to
+        answer the synthetic ``[SYSTEM: ...]`` text conversationally in-channel,
+        which is noisy and misleading. Deliver the notification directly instead.
         """
         source = getattr(original_event, "source", None)
         if not source:
@@ -7158,17 +7160,11 @@ class GatewayRunner:
         if not adapter:
             return
         try:
-            from gateway.platforms.base import MessageEvent, MessageType
-            synth_event = MessageEvent(
-                text=synth_text,
-                message_type=MessageType.TEXT,
-                source=source,
-                internal=True,
-            )
-            logger.info("Watch pattern notification — injecting for %s", platform_name)
-            await adapter.handle_message(synth_event)
+            send_meta = {"thread_id": source.thread_id} if source.thread_id else None
+            logger.info("Watch pattern notification — direct send for %s", platform_name)
+            await adapter.send(source.chat_id, synth_text, metadata=send_meta)
         except Exception as e:
-            logger.error("Watch notification injection error: %s", e)
+            logger.error("Watch notification delivery error: %s", e)
 
     async def _run_process_watcher(self, watcher: dict) -> None:
         """
@@ -8087,7 +8083,11 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3559,6 +3559,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                persist_user_message_immediately=not bool(history),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -7396,6 +7397,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        persist_user_message_immediately: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -8087,6 +8089,7 @@ class GatewayRunner:
                     message,
                     conversation_history=agent_history,
                     task_id=session_id,
+                    persist_user_message_immediately=persist_user_message_immediately,
                 )
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -301,7 +301,7 @@ def _load_webui_session_snapshot(session_id: str) -> Optional[Dict[str, Any]]:
             return json.loads(session_path.read_text(encoding="utf-8"))
         except Exception:
             _log.warning("Failed to load WebUI session snapshot: %s", session_path, exc_info=True)
-            return None
+            continue
     return None
 
 
@@ -356,7 +356,7 @@ def _normalize_webui_messages(messages: Any) -> List[Dict[str, Any]]:
                 "tool_calls": tool_calls,
                 "tool_name": raw.get("tool_name"),
                 "tool_call_id": raw.get("tool_call_id"),
-                "timestamp": raw.get("timestamp") or raw.get("_ts"),
+                "timestamp": _coerce_session_timestamp(raw.get("timestamp") or raw.get("_ts")),
             }
         )
     return normalized
@@ -430,7 +430,7 @@ def _normalize_cron_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
     return {
         **job,
-        "schedule": schedule_text,
+        "schedule_display": job.get("schedule_display") or schedule_text,
         "status": status,
         "error": job.get("last_error") or job.get("error"),
     }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,8 @@ import os
 import secrets
 import sys
 import time
+import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -243,6 +245,197 @@ def _build_schema_from_config(
 CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
 
 
+def _candidate_webui_state_dirs() -> List[Path]:
+    """Return plausible Hermes WebUI state directories.
+
+    The dashboard often runs inside a Hermes profile where HOME points at
+    ~/.hermes/profiles/<name>/home. Hermes WebUI state, however, usually lives
+    under the base ~/.hermes tree, so we derive both profile-local and base-home
+    candidates.
+    """
+    hermes_home = get_hermes_home().resolve()
+    base_hermes_home = hermes_home
+    if hermes_home.parent.name == "profiles":
+        base_hermes_home = hermes_home.parent.parent
+
+    home_candidates = [Path.home().resolve()]
+    profile_home = Path(os.getenv("HOME", "")).expanduser().resolve() if os.getenv("HOME") else None
+    if profile_home and profile_home not in home_candidates:
+        home_candidates.append(profile_home)
+    if base_hermes_home.parent not in home_candidates:
+        home_candidates.append(base_hermes_home.parent)
+
+    candidates: list[Path] = []
+    raw_candidates = [
+        os.getenv("HERMES_WEBUI_STATE_DIR"),
+        str(base_hermes_home / "webui-mvp"),
+        str(base_hermes_home / "webui"),
+        str(hermes_home / "webui-mvp"),
+        str(hermes_home / "webui"),
+    ] + [
+        str(home / ".hermes" / suffix)
+        for home in home_candidates
+        for suffix in ("webui-mvp", "webui")
+    ]
+    seen: set[str] = set()
+    for raw in raw_candidates:
+        if not raw:
+            continue
+        path = Path(raw).expanduser().resolve()
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(path)
+    return candidates
+
+
+
+def _load_webui_session_snapshot(session_id: str) -> Optional[Dict[str, Any]]:
+    """Load a Hermes WebUI session JSON snapshot by ID, if available."""
+    for state_dir in _candidate_webui_state_dirs():
+        session_path = state_dir / "sessions" / f"{session_id}.json"
+        if not session_path.exists():
+            continue
+        try:
+            return json.loads(session_path.read_text(encoding="utf-8"))
+        except Exception:
+            _log.warning("Failed to load WebUI session snapshot: %s", session_path, exc_info=True)
+            return None
+    return None
+
+
+
+def _normalize_message_content(content: Any) -> Optional[str]:
+    """Convert structured message content into plain text for the dashboard."""
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and item.get("text"):
+                    parts.append(str(item.get("text")))
+                elif item.get("content"):
+                    parts.append(str(item.get("content")))
+            elif item is not None:
+                parts.append(str(item))
+        text = "\n".join(part for part in parts if part)
+        return text or None
+    if isinstance(content, dict):
+        if content.get("type") == "text" and content.get("text"):
+            return str(content.get("text"))
+        if content.get("content"):
+            return str(content.get("content"))
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except Exception:
+            return str(content)
+    return str(content)
+
+
+
+def _normalize_webui_messages(messages: Any) -> List[Dict[str, Any]]:
+    """Normalize Hermes WebUI JSON messages to the admin dashboard API shape."""
+    normalized: list[dict[str, Any]] = []
+    for raw in messages or []:
+        if not isinstance(raw, dict):
+            continue
+        tool_calls = raw.get("tool_calls")
+        if isinstance(tool_calls, str):
+            try:
+                tool_calls = json.loads(tool_calls)
+            except Exception:
+                tool_calls = []
+        normalized.append(
+            {
+                "role": raw.get("role") or "system",
+                "content": _normalize_message_content(raw.get("content")),
+                "tool_calls": tool_calls,
+                "tool_name": raw.get("tool_name"),
+                "tool_call_id": raw.get("tool_call_id"),
+                "timestamp": raw.get("timestamp") or raw.get("_ts"),
+            }
+        )
+    return normalized
+
+
+
+def _session_preview_from_messages(messages: List[Dict[str, Any]]) -> str:
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        text = (msg.get("content") or "").strip()
+        if text:
+            return text[:60] + ("..." if len(text) > 60 else "")
+    return ""
+
+
+
+def _coerce_session_timestamp(value: Any) -> Optional[float]:
+    """Coerce WebUI/session timestamp values to epoch seconds when possible."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+
+def _hydrate_webui_session_record(session: Dict[str, Any]) -> Dict[str, Any]:
+    """Backfill preview/timestamps for state.db-backed WebUI sessions."""
+    if session.get("source") != "webui":
+        return session
+    snapshot = _load_webui_session_snapshot(session.get("id", ""))
+    if not snapshot:
+        return session
+    messages = _normalize_webui_messages(snapshot.get("messages"))
+    if not session.get("preview"):
+        session["preview"] = _session_preview_from_messages(messages)
+    snapshot_updated_at = _coerce_session_timestamp(snapshot.get("updated_at"))
+    if snapshot_updated_at is not None:
+        session["last_active"] = snapshot_updated_at
+    return session
+
+
+
+def _normalize_cron_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate cron.jobs records into the shape expected by the dashboard SPA."""
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        schedule_text = job.get("schedule_display") or schedule.get("display") or schedule.get("expr") or schedule.get("run_at") or ""
+    else:
+        schedule_text = str(schedule or job.get("schedule_display") or "")
+
+    if job.get("state") == "paused" or job.get("enabled") is False:
+        status = "paused"
+    elif job.get("last_status") == "error":
+        status = "error"
+    else:
+        status = "enabled"
+
+    return {
+        **job,
+        "schedule": schedule_text,
+        "status": status,
+        "error": job.get("last_error") or job.get("error"),
+    }
+
+
 class ConfigUpdate(BaseModel):
     config: dict
 
@@ -342,6 +535,7 @@ async def get_sessions():
             sessions = db.list_sessions_rich(limit=20)
             now = time.time()
             for s in sessions:
+                _hydrate_webui_session_record(s)
                 s["is_active"] = (
                     s.get("ended_at") is None
                     and (now - s.get("last_active", s.get("started_at", 0))) < 300
@@ -580,6 +774,12 @@ async def get_session_messages(session_id: str):
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
         messages = db.get_messages(sid)
+        if not messages:
+            session = db.get_session(sid)
+            if session and session.get("source") == "webui":
+                snapshot = _load_webui_session_snapshot(sid)
+                if snapshot:
+                    messages = _normalize_webui_messages(snapshot.get("messages"))
         return {"session_id": sid, "messages": messages}
     finally:
         db.close()
@@ -653,7 +853,7 @@ class CronJobUpdate(BaseModel):
 @app.get("/api/cron/jobs")
 async def list_cron_jobs():
     from cron.jobs import list_jobs
-    return list_jobs(include_disabled=True)
+    return [_normalize_cron_job(job) for job in list_jobs(include_disabled=True)]
 
 
 @app.get("/api/cron/jobs/{job_id}")
@@ -662,7 +862,7 @@ async def get_cron_job(job_id: str):
     job = get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _normalize_cron_job(job)
 
 
 @app.post("/api/cron/jobs")
@@ -671,7 +871,7 @@ async def create_cron_job(body: CronJobCreate):
     try:
         job = create_job(prompt=body.prompt, schedule=body.schedule,
                          name=body.name, deliver=body.deliver)
-        return job
+        return _normalize_cron_job(job)
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")
         raise HTTPException(status_code=400, detail=str(e))
@@ -683,7 +883,7 @@ async def update_cron_job(job_id: str, body: CronJobUpdate):
     job = update_job(job_id, body.updates)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _normalize_cron_job(job)
 
 
 @app.post("/api/cron/jobs/{job_id}/pause")
@@ -692,7 +892,7 @@ async def pause_cron_job(job_id: str):
     job = pause_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _normalize_cron_job(job)
 
 
 @app.post("/api/cron/jobs/{job_id}/resume")
@@ -701,7 +901,7 @@ async def resume_cron_job(job_id: str):
     job = resume_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _normalize_cron_job(job)
 
 
 @app.post("/api/cron/jobs/{job_id}/trigger")
@@ -710,7 +910,7 @@ async def trigger_cron_job(job_id: str):
     job = trigger_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _normalize_cron_job(job)
 
 
 @app.delete("/api/cron/jobs/{job_id}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -7679,6 +7679,7 @@ class AIAgent:
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
+        persist_user_message_immediately: bool = False,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -7694,6 +7695,11 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
+            persist_user_message_immediately: When True, flush the just-added
+                user turn to the SQLite session DB immediately after it is
+                appended to the in-memory message list. Intended for fresh
+                gateway sessions so dashboards can show the first inbound
+                message before the assistant reply completes.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -7810,6 +7816,8 @@ class AIAgent:
         messages.append(user_msg)
         current_turn_user_idx = len(messages) - 1
         self._persist_user_message_idx = current_turn_user_idx
+        if persist_user_message_immediately and self.persist_session and self._session_db:
+            self._flush_messages_to_session_db(messages, conversation_history)
         
         if not self.quiet_mode:
             self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")

--- a/run_agent.py
+++ b/run_agent.py
@@ -7694,7 +7694,6 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
-                    or queuing follow-up prefetch work.
 
         Returns:
             Dict: Complete conversation result with final response and message history

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -100,6 +100,40 @@ async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_watch_notification_is_sent_directly_not_via_agent(monkeypatch, tmp_path):
+    """Watch-pattern notifications should go straight to the chat.
+
+    Regression test for the bug where watch matches were injected as synthetic
+    user turns, causing the agent to respond conversationally to
+    ``[SYSTEM: Background process ... matched watch pattern ...]`` messages.
+    """
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+
+    runner = GatewayRunner(GatewayConfig())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.DISCORD] = adapter
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        thread_id="456",
+        chat_type="group",
+        user_id="user-1",
+        user_name="Jordan",
+    )
+    event = MessageEvent(text="original request", source=source)
+    synth = "[SYSTEM: Background process proc_1 matched watch pattern \"ready\"]"
+
+    await runner._inject_watch_notification(synth, event)
+
+    adapter.send.assert_awaited_once_with("123", synth, metadata={"thread_id": "456"})
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
     """An internal event should skip _is_user_authorized entirely."""
     import gateway.run as gateway_run

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -112,6 +112,94 @@ async def test_status_command_includes_session_title_when_present():
 
 
 @pytest.mark.asyncio
+async def test_handle_message_marks_first_turn_for_immediate_user_persistence(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner.session_store.load_transcript.return_value = []
+
+    captured = {}
+
+    async def _fake_run_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+
+    runner._run_agent = _fake_run_agent
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello"))
+
+    assert result == "ok"
+    assert captured["persist_user_message_immediately"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_message_does_not_mark_continuations_for_immediate_user_persistence(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner.session_store.load_transcript.return_value = [{"role": "user", "content": "earlier"}]
+
+    captured = {}
+
+    async def _fake_run_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 1,
+            "last_prompt_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": "openai/test-model",
+        }
+
+    runner._run_agent = _fake_run_agent
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello again"))
+
+    assert result == "ok"
+    assert captured["persist_user_message_immediately"] is False
+
+
+@pytest.mark.asyncio
 async def test_handle_message_persists_agent_token_counts(monkeypatch):
     import gateway.run as gateway_run
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -505,10 +505,113 @@ class TestNewEndpoints:
         resp = self.client.get("/api/logs?file=nonexistent")
         assert resp.status_code == 400
 
+    def test_get_sessions_hydrates_webui_preview_from_snapshot(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+
+        webui_state = tmp_path / "webui-mvp"
+        session_dir = webui_state / "sessions"
+        session_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(webui_state))
+
+        db = SessionDB()
+        try:
+            db.ensure_session("webui123", source="webui", model="gpt-5.4")
+            db.set_session_title("webui123", None)
+            db._execute_write(
+                lambda conn: conn.execute(
+                    "UPDATE sessions SET message_count = ? WHERE id = ?",
+                    (3, "webui123"),
+                )
+            )
+        finally:
+            db.close()
+
+        (session_dir / "webui123.json").write_text(json.dumps({
+            "session_id": "webui123",
+            "updated_at": "2026-04-12T13:35:28.927929+00:00",
+            "messages": [
+                {"role": "user", "content": "This came from the web ui snapshot and should show up"},
+                {"role": "assistant", "content": "Acknowledged"},
+            ],
+        }), encoding="utf-8")
+
+        resp = self.client.get("/api/sessions")
+        assert resp.status_code == 200
+        session = next(s for s in resp.json() if s["id"] == "webui123")
+        assert session["preview"].startswith("This came from the web ui snapshot")
+        assert session["last_active"] == 1776000928.927929
+
+    def test_get_session_messages_falls_back_to_webui_snapshot(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+
+        webui_state = tmp_path / "webui-mvp"
+        session_dir = webui_state / "sessions"
+        session_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(webui_state))
+
+        db = SessionDB()
+        try:
+            db.ensure_session("webui456", source="webui", model="gpt-5.4")
+        finally:
+            db.close()
+
+        (session_dir / "webui456.json").write_text(json.dumps({
+            "session_id": "webui456",
+            "messages": [
+                {"role": "user", "content": "Show this in the dashboard"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Here is the answer."},
+                    ],
+                    "tool_calls": [
+                        {"id": "call_1", "function": {"name": "search_files", "arguments": "{}"}}
+                    ],
+                },
+            ],
+        }), encoding="utf-8")
+
+        resp = self.client.get("/api/sessions/webui456/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "webui456"
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["content"] == "Show this in the dashboard"
+        assert data["messages"][1]["content"] == "Here is the answer."
+        assert data["messages"][1]["tool_calls"][0]["function"]["name"] == "search_files"
+
     def test_cron_list(self):
         resp = self.client.get("/api/cron/jobs")
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+
+    def test_cron_list_normalizes_dashboard_shape(self, monkeypatch):
+        import cron.jobs as cron_jobs
+
+        monkeypatch.setattr(
+            cron_jobs,
+            "list_jobs",
+            lambda include_disabled=True: [{
+                "id": "job-1",
+                "name": "Nightly report",
+                "prompt": "Run nightly report",
+                "schedule": {"kind": "cron", "expr": "0 9 * * *", "display": "0 9 * * *"},
+                "schedule_display": "0 9 * * *",
+                "enabled": False,
+                "state": "paused",
+                "last_status": "ok",
+                "deliver": "discord",
+                "last_run_at": "2026-04-12T09:00:00-07:00",
+                "next_run_at": "2026-04-13T09:00:00-07:00",
+            }],
+        )
+
+        resp = self.client.get("/api/cron/jobs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["schedule"] == "0 9 * * *"
+        assert data[0]["status"] == "paused"
+        assert data[0]["deliver"] == "discord"
 
     def test_cron_job_not_found(self):
         resp = self.client.get("/api/cron/jobs/nonexistent-id")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -609,7 +609,8 @@ class TestNewEndpoints:
         resp = self.client.get("/api/cron/jobs")
         assert resp.status_code == 200
         data = resp.json()
-        assert data[0]["schedule"] == "0 9 * * *"
+        assert data[0]["schedule"]["expr"] == "0 9 * * *"
+        assert data[0]["schedule_display"] == "0 9 * * *"
         assert data[0]["status"] == "paused"
         assert data[0]["deliver"] == "discord"
 


### PR DESCRIPTION
## Summary

Fixes a narrow dashboard regression set where WebUI-backed sessions and cron jobs can become partially invisible or malformed in Hermes surfaces, especially before the first assistant turn completes.

## Root cause

- Dashboard session views assume session previews/messages come from the SQLite session store, but WebUI sessions can exist primarily as JSON snapshots.
- The dashboard needs stable cron metadata, but flattening the returned `schedule` payload would narrow the existing API contract.
- Fresh gateway sessions were only visible after the assistant turn completed because the first inbound user message was not flushed immediately.
- Watch-pattern process notifications were being treated like synthetic user turns instead of operator status signals.

## What this changes

- Hydrates missing WebUI session previews from snapshot user messages.
- Falls back to snapshot message content when `/api/sessions/{id}/messages` has no DB-backed rows.
- Normalizes structured snapshot content into dashboard-friendly plain text.
- Coerces snapshot session/message timestamps into epoch seconds for stable dashboard rendering.
- Continues searching alternate snapshot directories if one candidate file is stale or malformed.
- Preserves the structured cron `schedule` object while guaranteeing `schedule_display`, `status`, and `error` fields for dashboard consumers.
- Flushes the first inbound gateway user message to SQLite immediately for fresh sessions only.
- Sends watch-pattern notifications directly to the originating chat instead of reinjecting them through the agent loop.

## Why this fits upstream

- Fixes generic Hermes product behavior rather than local operator workflow.
- Reduces dashboard invisibility/confusion for WebUI and cron users.
- Preserves the existing structured cron API instead of introducing a narrower shape.
- Adds focused regression coverage for the affected dashboard/gateway paths.

## Verification

- [x] `python -m pytest tests/hermes_cli/test_web_server.py tests/gateway/test_status_command.py tests/gateway/test_internal_event_bypass_pairing.py -q`
  - result: `64 passed`
- [x] Static added-lines security scan on the staged diff
  - result: no findings for hardcoded secrets, shell injection, unsafe eval/exec, pickle deserialization, or SQL string formatting patterns

## Scope

- intentionally limited to dashboard/session/cron/watch-notification behavior
- does not include Night Mode, private Discord workflow customizations, or unrelated fork-local changes

## Files

- `gateway/run.py`
- `hermes_cli/web_server.py`
- `run_agent.py`
- `tests/gateway/test_internal_event_bypass_pairing.py`
- `tests/gateway/test_status_command.py`
- `tests/hermes_cli/test_web_server.py`

## Notes

No upstream PR has been opened yet. The current branch is prepared for review only.