### PR TITLE
fix(agent): restore compatibility helpers and defensive defaults

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1743,6 +1743,25 @@ def resolve_vision_provider_client(
     return requested, client, final_model
 
 
+def get_vision_auxiliary_client(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    async_mode: bool = False,
+):
+    """Backward-compatible wrapper returning only (client, model) for vision tasks."""
+    _provider, client, final_model = resolve_vision_provider_client(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        async_mode=async_mode,
+    )
+    return client, final_model
+
+
 def get_auxiliary_extra_body() -> dict:
     """Return extra_body kwargs for auxiliary API calls.
     

--- a/agent/builtin_memory_provider.py
+++ b/agent/builtin_memory_provider.py
@@ -1,0 +1,30 @@
+"""Compatibility built-in memory provider used by MemoryManager tests.
+
+The durable MEMORY.md / USER.md behavior still lives in the core memory tool.
+This provider exists so the provider-manager abstraction always has a concrete
+builtin provider type with the canonical name `builtin`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+
+class BuiltinMemoryProvider(MemoryProvider):
+    """Minimal built-in provider shim for the memory-manager abstraction."""
+
+    @property
+    def name(self) -> str:
+        return "builtin"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self.session_id = session_id
+        self.init_kwargs = dict(kwargs)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []

--- a/run_agent.py
+++ b/run_agent.py
@@ -2894,7 +2894,7 @@ class AIAgent:
         # Signal all tools to abort any in-flight operations immediately.
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.
-        _set_interrupt(True, self._execution_thread_id)
+        _set_interrupt(True, getattr(self, "_execution_thread_id", None))
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -2910,7 +2910,7 @@ class AIAgent:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
-        _set_interrupt(False, self._execution_thread_id)
+        _set_interrupt(False, getattr(self, "_execution_thread_id", None))
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""
@@ -6074,6 +6074,7 @@ class AIAgent:
             ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
             if ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None  # consume immediately
+            request_overrides = getattr(self, "request_overrides", None) or {}
             return build_anthropic_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
@@ -6084,7 +6085,7 @@ class AIAgent:
                 preserve_dots=self._anthropic_preserve_dots(),
                 context_length=ctx_len,
                 base_url=getattr(self, "_anthropic_base_url", None),
-                fast_mode=(self.request_overrides or {}).get("speed") == "fast",
+                fast_mode=request_overrides.get("speed") == "fast",
             )
 
         if self.api_mode == "codex_responses":
@@ -6141,8 +6142,9 @@ class AIAgent:
             elif not is_github_responses:
                 kwargs["include"] = []
 
-            if self.request_overrides:
-                kwargs.update(self.request_overrides)
+            request_overrides = getattr(self, "request_overrides", None) or {}
+            if request_overrides:
+                kwargs.update(request_overrides)
 
             if self.max_tokens is not None and not is_codex_backend:
                 kwargs["max_output_tokens"] = self.max_tokens
@@ -6325,8 +6327,9 @@ class AIAgent:
 
         # Priority Processing / generic request overrides (e.g. service_tier).
         # Applied last so overrides win over any defaults set above.
-        if self.request_overrides:
-            api_kwargs.update(self.request_overrides)
+        request_overrides = getattr(self, "request_overrides", None) or {}
+        if request_overrides:
+            api_kwargs.update(request_overrides)
 
         return api_kwargs
 
@@ -7549,9 +7552,10 @@ class AIAgent:
                 effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
-            if self.prefill_messages:
+            prefill_messages = getattr(self, "prefill_messages", None) or []
+            if prefill_messages:
                 sys_offset = 1 if effective_system else 0
-                for idx, pfm in enumerate(self.prefill_messages):
+                for idx, pfm in enumerate(prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
             summary_extra_body = {}
@@ -8123,9 +8127,10 @@ class AIAgent:
 
             # Inject ephemeral prefill messages right after the system prompt
             # but before conversation history. Same API-call-time-only pattern.
-            if self.prefill_messages:
+            prefill_messages = getattr(self, "prefill_messages", None) or []
+            if prefill_messages:
                 sys_offset = 1 if effective_system else 0
-                for idx, pfm in enumerate(self.prefill_messages):
+                for idx, pfm in enumerate(prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
             # Apply Anthropic prompt caching for Claude models via OpenRouter.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.auxiliary_client import (
     get_text_auxiliary_client,
+    get_vision_auxiliary_client,
     get_available_vision_backends,
     resolve_vision_provider_client,
     resolve_provider_client,

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -429,6 +429,10 @@ class AudioRecorder:
         """Current audio input RMS level (0-32767). Updated each audio chunk."""
         return self._current_rms
 
+    @property
+    def is_recording(self) -> bool:
+        return self._recording
+
     # -- public methods ------------------------------------------------------
 
     def _ensure_stream(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a small set of compatibility regressions and defensive-default gaps that can otherwise surface as avoidable runtime errors after recent internal refactors.

## Root cause

- Older call sites still expect `get_vision_auxiliary_client()` even though the main implementation moved to `resolve_vision_provider_client()`.
- The memory-provider abstraction no longer had a canonical built-in provider implementation to reference.
- Some `run_agent.py` paths assumed attributes like `request_overrides`, `prefill_messages`, or `_execution_thread_id` were always present.
- `AudioRecorder` exposed recording state internally but not through a small stable convenience property.

## What this changes

- Restores `get_vision_auxiliary_client()` as a compatibility wrapper around `resolve_vision_provider_client()`.
- Adds a minimal built-in `BuiltinMemoryProvider` so the abstraction still has a canonical `builtin` implementation.
- Guards several `run_agent.py` paths with `getattr(..., default)` so missing optional attributes do not raise `AttributeError`.
- Exposes `AudioRecorder.is_recording` as a small public convenience property.
- Adds auxiliary-client import coverage for the restored vision helper path.

## Why this fits upstream

- These are generic correctness and compatibility fixes.
- They reduce breakage from initialization-order assumptions and renamed helpers.
- They keep older callers/tests working without introducing fork-local behavior.

## Verification

- [x] `python -m pytest tests/agent/test_auxiliary_client.py -q`
  - result: `94 passed, 2 failed`
  - note: the remaining 2 failures are pre-existing upstream-baseline failures around Anthropic OAuth flag expectations; this branch did not introduce new failures and removes one baseline failure by restoring the vision-helper import path
- [x] Static added-lines security scan on the branch diff
  - result: no findings for hardcoded secrets, shell injection, unsafe eval/exec, pickle deserialization, or SQL string formatting patterns

## Scope

- intentionally limited to compatibility shims and defensive defaults
- does not include local eval/sample-case work or other unrelated fork-only changes

## Files

- `agent/auxiliary_client.py`
- `agent/builtin_memory_provider.py`
- `run_agent.py`
- `tests/agent/test_auxiliary_client.py`
- `tools/voice_mode.py`

## Notes

This is a narrow compatibility PR, not a refactor.