### PR TITLE
feat(cron): preserve skill context on replies to multi-chunk cron deliveries

### DIFF
--- a/cron/delivery_registry.py
+++ b/cron/delivery_registry.py
@@ -1,0 +1,150 @@
+"""Persistent registry of cron delivery message_ids → job_name.
+
+Lets the gateway recover skill context when a user replies to a cron
+delivery — including replies to *secondary chunks* of a delivery that was
+split across multiple platform messages (e.g. Discord's 2000-character
+limit, where only chunk 0 carries the ``Cronjob Response: <name>`` header).
+
+Storage is an append-only JSONL file at
+``~/.hermes/cron/deliveries.jsonl``. Each line is a single delivery entry::
+
+    {"platform": "discord", "chat_id": "123", "message_id": "456", "job_name": "mail-triage"}
+
+The file is bounded to roughly ``_MAX_ENTRIES`` lines via opportunistic
+truncation on register. Lookups are reverse-chronological so the newest
+matching entry wins.
+
+This persistence pattern matches the rest of ``cron/`` (json-on-disk in
+``~/.hermes/cron/``) — no SQLite required.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from threading import Lock
+from typing import Iterable, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_MAX_ENTRIES = 512
+_TRUNCATE_TRIGGER = int(_MAX_ENTRIES * 1.5)  # only rewrite the file every ~256 extra entries
+
+_lock = Lock()
+_path_cache: Optional[Path] = None
+
+
+def _registry_path() -> Path:
+    global _path_cache
+    if _path_cache is None:
+        _path_cache = get_hermes_home() / "cron" / "deliveries.jsonl"
+        try:
+            _path_cache.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning("Could not create cron deliveries dir: %s", exc)
+    return _path_cache
+
+
+def register(
+    platform: str,
+    chat_id: str,
+    message_ids: Iterable[str],
+    job_name: str,
+) -> None:
+    """Record one or more delivery message ids for a cron job.
+
+    Silently no-ops when ``job_name`` or ``chat_id`` is empty, and
+    swallows I/O errors so a failed registration never breaks delivery.
+    """
+    if not job_name or not chat_id:
+        return
+
+    plat = str(platform or "")
+    chat = str(chat_id)
+    job = str(job_name)
+
+    entries = []
+    for mid in message_ids or []:
+        if mid:
+            entries.append(
+                {
+                    "platform": plat,
+                    "chat_id": chat,
+                    "message_id": str(mid),
+                    "job_name": job,
+                }
+            )
+    if not entries:
+        return
+
+    path = _registry_path()
+    with _lock:
+        try:
+            with open(path, "a", encoding="utf-8") as fh:
+                for entry in entries:
+                    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            logger.warning("Could not append to cron deliveries registry: %s", exc)
+            return
+        _maybe_truncate(path)
+
+
+def lookup(platform: str, chat_id: str, message_id: str) -> Optional[str]:
+    """Return the job name that produced ``message_id``, or None.
+
+    Searches newest entries first so reused message ids (rare across
+    chat_id boundaries) prefer the most recent delivery.
+    """
+    if not message_id or not chat_id:
+        return None
+
+    target_plat = str(platform or "")
+    target_chat = str(chat_id)
+    target_mid = str(message_id)
+
+    path = _registry_path()
+    if not path.exists():
+        return None
+
+    with _lock:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError as exc:
+            logger.warning("Could not read cron deliveries registry: %s", exc)
+            return None
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            entry.get("platform") == target_plat
+            and entry.get("chat_id") == target_chat
+            and entry.get("message_id") == target_mid
+        ):
+            return entry.get("job_name")
+
+    return None
+
+
+def _maybe_truncate(path: Path) -> None:
+    """Rewrite the file to keep the most recent ``_MAX_ENTRIES`` lines."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+        if len(lines) <= _TRUNCATE_TRIGGER:
+            return
+        keep = lines[-_MAX_ENTRIES:]
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.writelines(keep)
+        os.replace(tmp, path)
+    except OSError as exc:
+        logger.warning("Could not truncate cron deliveries registry: %s", exc)

--- a/cron/reply_context.py
+++ b/cron/reply_context.py
@@ -1,0 +1,118 @@
+"""Resolve cron-job context for replies to cron deliveries.
+
+When a user replies to a message that originated from a cron delivery,
+the gateway needs to know:
+
+1. Which cron job produced the message (so we can find its bound skills).
+2. What instructions to inject so the agent can act on the follow-up
+   (e.g. delete an email after a mail-triage delivery), not just see the
+   quoted text.
+
+This module is the single entry point gateway code uses for that
+resolution. It encapsulates all knowledge of cron internals (the delivery
+registry, the job store, skill loading) so callers stay platform-agnostic.
+
+Resolution order:
+
+1. **Delivery registry** by message_id. Required for multi-chunk
+   deliveries (e.g. Discord splits long output into 2000-char messages
+   and only chunk 0 carries the ``Cronjob Response: <name>`` header).
+2. **"Cronjob Response: <name>" prefix** in the reply text. Fallback for
+   single-chunk deliveries when the registry has no record (e.g. after
+   a gateway restart that truncated old entries).
+"""
+
+import json
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+_CRON_DELIVERY_PREFIX = "Cronjob Response: "
+
+
+def resolve_skill_for_reply(
+    platform: str,
+    chat_id: str,
+    message_id: Optional[str],
+    reply_text: Optional[str],
+) -> Optional[str]:
+    """Return a system-prompt fragment to inject for a cron-reply, or None.
+
+    The returned string (when non-None) ends with ``\\n\\n`` so callers can
+    concatenate it directly in front of their own message text.
+    """
+    job_name = _resolve_job_name(platform, chat_id, message_id, reply_text)
+    if not job_name:
+        return None
+
+    skills = _load_job_skills(job_name)
+    if not skills:
+        return None
+
+    parts: List[str] = []
+    for sname in skills:
+        content = _load_skill_content(sname)
+        if content:
+            parts.append(
+                f'[SYSTEM: The original cron job used the "{sname}" skill. '
+                f"Follow its instructions to handle the user's request.]\n\n"
+                f"{content}"
+            )
+
+    if not parts:
+        return None
+    return "\n\n".join(parts) + "\n\n"
+
+
+def _resolve_job_name(
+    platform: str,
+    chat_id: str,
+    message_id: Optional[str],
+    reply_text: Optional[str],
+) -> Optional[str]:
+    if message_id:
+        try:
+            from cron.delivery_registry import lookup as _lookup_delivery
+
+            name = _lookup_delivery(platform, chat_id, message_id)
+            if name:
+                return name
+        except Exception:
+            logger.debug("delivery_registry lookup failed", exc_info=True)
+
+    if reply_text and reply_text.startswith(_CRON_DELIVERY_PREFIX):
+        first_line = reply_text.split("\n", 1)[0]
+        candidate = first_line[len(_CRON_DELIVERY_PREFIX):].strip()
+        return candidate or None
+
+    return None
+
+
+def _load_job_skills(job_name: str) -> List[str]:
+    try:
+        from cron.jobs import list_jobs
+
+        for job in list_jobs(include_disabled=True):
+            if job.get("name") == job_name or job.get("id") == job_name:
+                skills = job.get("skills") or []
+                if not skills:
+                    legacy = job.get("skill")
+                    if legacy:
+                        skills = [legacy]
+                return [str(s).strip() for s in skills if str(s).strip()]
+    except Exception:
+        logger.debug("Failed to load cron job skills for %s", job_name, exc_info=True)
+    return []
+
+
+def _load_skill_content(skill_name: str) -> Optional[str]:
+    try:
+        from tools.skills_tool import skill_view
+
+        loaded = json.loads(skill_view(skill_name))
+        if loaded.get("success") and loaded.get("content"):
+            return loaded["content"]
+    except Exception:
+        logger.debug("Failed to load skill '%s'", skill_name, exc_info=True)
+    return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -321,6 +321,32 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job["id"], platform_name, chat_id, err,
                     )
                     adapter_ok = False  # fall through to standalone path
+                elif send_result and getattr(send_result, "success", True):
+                    # Record every chunk's message id so a reply to any chunk
+                    # — not just the first one carrying "Cronjob Response:" —
+                    # can recover the job's skill context via the gateway's
+                    # cron.reply_context.resolve_skill_for_reply() helper.
+                    try:
+                        from cron.delivery_registry import register as _register_delivery
+                        raw = getattr(send_result, "raw_response", None) or {}
+                        mids: list = []
+                        raw_ids = raw.get("message_ids") if isinstance(raw, dict) else None
+                        if raw_ids:
+                            mids = list(raw_ids)
+                        elif getattr(send_result, "message_id", None):
+                            mids = [send_result.message_id]
+                        _register_delivery(
+                            platform_name,
+                            chat_id,
+                            mids,
+                            job.get("name", job["id"]),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Job '%s': could not register delivery message ids",
+                            job["id"],
+                            exc_info=True,
+                        )
 
             # Send extracted media files as native attachments via the live adapter
             if adapter_ok and media_files:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3056,7 +3056,30 @@ class GatewayRunner:
                 if msg.get("role") in ("assistant", "user", "tool")
             )
             if not found_in_history:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+                # Ask cron whether this reply needs extra skill context
+                # (e.g. user replying to a mail-triage delivery to delete
+                # an email).  cron.reply_context owns the cron-specific
+                # resolution; the gateway stays platform-agnostic.
+                skill_context = ""
+                try:
+                    from cron.reply_context import resolve_skill_for_reply
+                    platform_str = source.platform.value if source.platform else ""
+                    extra_ctx = resolve_skill_for_reply(
+                        platform_str,
+                        source.chat_id,
+                        event.reply_to_message_id,
+                        event.reply_to_text,
+                    )
+                    if extra_ctx:
+                        skill_context = extra_ctx
+                        # Larger snippet for cron replies — they often
+                        # contain structured data (email IDs, etc.) the
+                        # agent needs to act on.
+                        reply_snippet = event.reply_to_text[:2000]
+                except Exception:
+                    logger.debug("cron reply context resolution failed", exc_info=True)
+
+                message_text = f'{skill_context}[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/tests/cron/test_delivery_registry.py
+++ b/tests/cron/test_delivery_registry.py
@@ -1,0 +1,129 @@
+"""Tests for cron/delivery_registry.py — persistent message_id → job_name map."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def isolated_registry(tmp_path, monkeypatch):
+    """Point the registry at a fresh tmp_path-backed file for each test."""
+    fake_home = tmp_path / "hermes_home"
+    fake_home.mkdir()
+
+    # Reset the cached path so the test gets a fresh file location.
+    import cron.delivery_registry as dr
+
+    monkeypatch.setattr("cron.delivery_registry.get_hermes_home", lambda: fake_home)
+    monkeypatch.setattr(dr, "_path_cache", None)
+
+    yield fake_home / "cron" / "deliveries.jsonl"
+
+    # Reset cache after the test so the next test starts clean.
+    monkeypatch.setattr(dr, "_path_cache", None)
+
+
+class TestRegisterAndLookup:
+    def test_register_then_lookup_roundtrip(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("discord", "chan1", ["msg1", "msg2", "msg3"], "mail-triage")
+
+        assert lookup("discord", "chan1", "msg1") == "mail-triage"
+        assert lookup("discord", "chan1", "msg2") == "mail-triage"
+        assert lookup("discord", "chan1", "msg3") == "mail-triage"
+
+    def test_lookup_returns_none_for_unknown_message(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("discord", "chan1", ["msg1"], "mail-triage")
+        assert lookup("discord", "chan1", "msg999") is None
+
+    def test_lookup_respects_platform_and_chat_id(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("discord", "chan1", ["msg1"], "job-a")
+        # Same message_id under a different chat_id must NOT cross-match.
+        assert lookup("discord", "chan2", "msg1") is None
+        assert lookup("telegram", "chan1", "msg1") is None
+        assert lookup("discord", "chan1", "msg1") == "job-a"
+
+    def test_register_no_op_for_empty_inputs(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("", "chan1", ["msg1"], "")
+        register("discord", "", ["msg1"], "job")
+        register("discord", "chan1", [], "job")
+        register("discord", "chan1", [""], "job")
+        assert lookup("discord", "chan1", "msg1") is None
+
+    def test_newest_entry_wins_when_message_id_reused(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("discord", "chan1", ["msg1"], "old-job")
+        register("discord", "chan1", ["msg1"], "new-job")
+        assert lookup("discord", "chan1", "msg1") == "new-job"
+
+
+class TestPersistence:
+    def test_survives_module_reset(self, isolated_registry, monkeypatch):
+        """A second import (simulating a process restart) sees prior writes."""
+        import cron.delivery_registry as dr
+
+        dr.register("discord", "chan1", ["msg1"], "mail-triage")
+
+        # Simulate restart: clear the path cache and re-resolve.
+        monkeypatch.setattr(dr, "_path_cache", None)
+
+        from cron.delivery_registry import lookup as fresh_lookup
+        assert fresh_lookup("discord", "chan1", "msg1") == "mail-triage"
+
+    def test_writes_jsonl_format(self, isolated_registry):
+        from cron.delivery_registry import register
+
+        register("discord", "chan1", ["msg1", "msg2"], "mail-triage")
+
+        assert isolated_registry.exists()
+        lines = isolated_registry.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+        for line in lines:
+            entry = json.loads(line)
+            assert entry["platform"] == "discord"
+            assert entry["chat_id"] == "chan1"
+            assert entry["job_name"] == "mail-triage"
+            assert entry["message_id"] in ("msg1", "msg2")
+
+
+class TestTruncation:
+    def test_truncate_keeps_recent_entries(self, isolated_registry, monkeypatch):
+        import cron.delivery_registry as dr
+
+        # Lower the thresholds so the test runs in milliseconds.
+        monkeypatch.setattr(dr, "_MAX_ENTRIES", 10)
+        monkeypatch.setattr(dr, "_TRUNCATE_TRIGGER", 15)
+
+        for i in range(20):
+            dr.register("discord", "chan1", [f"msg{i}"], f"job-{i}")
+
+        # Oldest entries should have been pruned.
+        assert dr.lookup("discord", "chan1", "msg0") is None
+        assert dr.lookup("discord", "chan1", "msg5") is None
+        # Most recent should still be present.
+        assert dr.lookup("discord", "chan1", "msg19") == "job-19"
+        assert dr.lookup("discord", "chan1", "msg15") == "job-15"
+
+    def test_corrupt_lines_are_skipped(self, isolated_registry):
+        from cron.delivery_registry import register, lookup
+
+        register("discord", "chan1", ["msg1"], "job-a")
+
+        # Inject a corrupt line between valid entries.
+        with open(isolated_registry, "a", encoding="utf-8") as f:
+            f.write("not valid json\n")
+
+        register("discord", "chan1", ["msg2"], "job-b")
+
+        assert lookup("discord", "chan1", "msg1") == "job-a"
+        assert lookup("discord", "chan1", "msg2") == "job-b"

--- a/tests/cron/test_reply_context.py
+++ b/tests/cron/test_reply_context.py
@@ -1,0 +1,173 @@
+"""Tests for cron/reply_context.py — the gateway-facing skill resolver."""
+
+import json
+from unittest.mock import patch
+
+
+class TestResolveJobName:
+    def test_returns_none_when_no_message_id_or_text(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        assert resolve_skill_for_reply("discord", "chan1", None, None) is None
+
+    def test_resolves_via_registry_when_message_id_known(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        with patch("cron.delivery_registry.lookup", return_value="mail-triage"), \
+             patch("cron.reply_context._load_job_skills", return_value=["mail-triage-skill"]), \
+             patch("cron.reply_context._load_skill_content", return_value="instructions"):
+            result = resolve_skill_for_reply("discord", "chan1", "msg-42", "")
+
+        assert result is not None
+        assert "mail-triage-skill" in result
+        assert "instructions" in result
+
+    def test_falls_back_to_prefix_when_registry_empty(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        with patch("cron.delivery_registry.lookup", return_value=None), \
+             patch("cron.reply_context._load_job_skills", return_value=["mail-skill"]), \
+             patch("cron.reply_context._load_skill_content", return_value="content"):
+            result = resolve_skill_for_reply(
+                "discord",
+                "chan1",
+                "msg-99",
+                "Cronjob Response: mail-triage\n-------------\n\nbody",
+            )
+
+        assert result is not None
+        assert "mail-skill" in result
+
+    def test_prefix_with_no_job_name_returns_none(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        with patch("cron.delivery_registry.lookup", return_value=None):
+            result = resolve_skill_for_reply(
+                "discord", "chan1", "msg-1", "Cronjob Response: \nbody"
+            )
+
+        assert result is None
+
+    def test_registry_takes_precedence_over_prefix(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        # Registry says "job-from-registry"; prefix says "job-from-prefix".
+        # Registry should win because it's the more reliable source for
+        # multi-chunk replies.
+        with patch("cron.delivery_registry.lookup", return_value="job-from-registry"), \
+             patch("cron.reply_context._load_job_skills") as mock_skills, \
+             patch("cron.reply_context._load_skill_content", return_value="x"):
+            mock_skills.return_value = ["skill"]
+            resolve_skill_for_reply(
+                "discord",
+                "chan1",
+                "msg-1",
+                "Cronjob Response: job-from-prefix\nbody",
+            )
+            mock_skills.assert_called_once_with("job-from-registry")
+
+
+class TestSkillLoading:
+    def test_returns_none_when_job_has_no_skills(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        with patch("cron.delivery_registry.lookup", return_value="bare-job"), \
+             patch("cron.reply_context._load_job_skills", return_value=[]):
+            result = resolve_skill_for_reply("discord", "chan1", "msg1", "")
+
+        assert result is None
+
+    def test_returns_none_when_all_skill_loads_fail(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        with patch("cron.delivery_registry.lookup", return_value="job"), \
+             patch("cron.reply_context._load_job_skills", return_value=["s1", "s2"]), \
+             patch("cron.reply_context._load_skill_content", return_value=None):
+            result = resolve_skill_for_reply("discord", "chan1", "msg1", "")
+
+        assert result is None
+
+    def test_loads_multiple_skills_in_order(self):
+        from cron.reply_context import resolve_skill_for_reply
+
+        contents = {"alpha": "A-content", "beta": "B-content"}
+        with patch("cron.delivery_registry.lookup", return_value="job"), \
+             patch("cron.reply_context._load_job_skills", return_value=["alpha", "beta"]), \
+             patch("cron.reply_context._load_skill_content", side_effect=lambda n: contents.get(n)):
+            result = resolve_skill_for_reply("discord", "chan1", "msg1", "")
+
+        assert result is not None
+        assert result.index("A-content") < result.index("B-content")
+        assert "alpha" in result
+        assert "beta" in result
+        assert result.endswith("\n\n")
+
+
+class TestJobSkillsLoader:
+    def test_load_job_skills_handles_skills_field(self):
+        from cron.reply_context import _load_job_skills
+
+        with patch(
+            "cron.jobs.list_jobs",
+            return_value=[{"name": "job-a", "skills": ["s1", "s2"]}],
+        ):
+            assert _load_job_skills("job-a") == ["s1", "s2"]
+
+    def test_load_job_skills_handles_legacy_skill_field(self):
+        from cron.reply_context import _load_job_skills
+
+        with patch(
+            "cron.jobs.list_jobs",
+            return_value=[{"name": "job-a", "skill": "legacy-skill"}],
+        ):
+            assert _load_job_skills("job-a") == ["legacy-skill"]
+
+    def test_load_job_skills_strips_and_filters_empty(self):
+        from cron.reply_context import _load_job_skills
+
+        with patch(
+            "cron.jobs.list_jobs",
+            return_value=[{"name": "job-a", "skills": ["  s1  ", "", "s2"]}],
+        ):
+            assert _load_job_skills("job-a") == ["s1", "s2"]
+
+    def test_load_job_skills_matches_by_id_too(self):
+        from cron.reply_context import _load_job_skills
+
+        with patch(
+            "cron.jobs.list_jobs",
+            return_value=[{"id": "abc123", "name": "job-a", "skills": ["s1"]}],
+        ):
+            assert _load_job_skills("abc123") == ["s1"]
+
+    def test_load_job_skills_returns_empty_when_unknown(self):
+        from cron.reply_context import _load_job_skills
+
+        with patch("cron.jobs.list_jobs", return_value=[]):
+            assert _load_job_skills("nope") == []
+
+
+class TestSkillContentLoader:
+    def test_load_skill_content_returns_content_on_success(self):
+        from cron.reply_context import _load_skill_content
+
+        with patch(
+            "tools.skills_tool.skill_view",
+            return_value=json.dumps({"success": True, "content": "instructions here"}),
+        ):
+            assert _load_skill_content("my-skill") == "instructions here"
+
+    def test_load_skill_content_returns_none_on_failure(self):
+        from cron.reply_context import _load_skill_content
+
+        with patch(
+            "tools.skills_tool.skill_view",
+            return_value=json.dumps({"success": False, "error": "not found"}),
+        ):
+            assert _load_skill_content("missing") is None
+
+    def test_load_skill_content_swallows_exceptions(self):
+        from cron.reply_context import _load_skill_content
+
+        with patch("tools.skills_tool.skill_view", side_effect=RuntimeError("boom")):
+            assert _load_skill_content("kaboom") is None


### PR DESCRIPTION
## What does this PR do?

When a user replies to a cron delivery (e.g. \"delete this email\" after a `mail-triage` cron job), the existing `[Replying to: \"...\"]` injection from #1594 gives the agent the *quoted text* but not the *skill* that the original cron job used. So the agent sees the email list but has no idea how to delete an email — the operational knowledge lives in the bound skill, which isn't propagated to the reply-handling session.

This is especially broken on Discord, where long cron deliveries get split across multiple 2000-char messages. Only the first chunk carries the `Cronjob Response: <name>` header, so any reply to a later chunk has no way to identify which cron job produced the message.

This PR adds:

1. A small persistent registry (`cron/delivery_registry.py`) mapping every sent chunk's `message_id` → originating job name. Backed by a JSONL file at `~/.hermes/cron/deliveries.jsonl`, opportunistically truncated to ~512 entries. Matches the existing `cron/` storage pattern (json files in `~/.hermes/cron/`) — no SQLite required.

2. A gateway-facing resolver (`cron/reply_context.py`) exposing `resolve_skill_for_reply(platform, chat_id, message_id, reply_text) -> Optional[str]`. Encapsulates *all* knowledge of cron internals (registry lookup, job → skills mapping, skill content loading) so the gateway stays platform-agnostic.

3. A small scheduler hook to register every chunk's `message_id` after a successful live-adapter send.

4. A small change in `gateway/run.py` (`_prepare_inbound_message_text`) that calls `resolve_skill_for_reply()` and prepends any returned skill instructions to the reply context.

## Related Issue

Fixes #9048

Related foundation: #1594 (added `reply_to_text` and the `[Replying to: \"...\"]` injection this PR builds on, merged 2026-03-17).

Adjacent: #8793 (proposes appending cron output to interactive session history). Complementary, not duplicative — #8793 gives the agent the cron *content*, this PR gives the agent the cron *capability*. Both could land independently.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/delivery_registry.py` (new, ~150 lines): persistent JSONL-backed `(platform, chat_id, message_id) → job_name` map. Thread-safe register/lookup. Opportunistic LRU truncation. Graceful degradation on I/O errors.
- `cron/reply_context.py` (new, ~120 lines): single entry point the gateway uses for cron-reply context resolution. Two-tier resolution: registry lookup by `message_id` first (handles multi-chunk replies), then `Cronjob Response: <name>` prefix scan as fallback (handles entries pruned from the registry).
- `cron/scheduler.py`: after `runtime_adapter.send()` returns success, register every chunk's `message_id` from `send_result.raw_response[\"message_ids\"]`.
- `gateway/run.py`: in `_prepare_inbound_message_text()`, call `cron.reply_context.resolve_skill_for_reply()` instead of inlining cron-specific logic. The gateway no longer imports `cron.jobs` or `tools.skills_tool` — only the single `cron.reply_context` helper.
- `tests/cron/test_delivery_registry.py` (new, 10 tests): register/lookup roundtrip, isolation by platform/chat_id, persistence across module reset, JSONL format validation, opportunistic truncation, corrupt-line handling.
- `tests/cron/test_reply_context.py` (new, 15 tests): registry vs prefix resolution order, multi-skill loading, legacy `skill` field support, error paths.

## How to Test

1. Configure a cron job bound to a skill that produces > 2000 chars of output (mail triage, RSS digest, etc.) and delivers to Discord.
2. Trigger the job and let it deliver to Discord — output is split into N messages.
3. Reply to message #2 (a non-first chunk) asking the agent to act on something in the list.
4. **Before this fix:** agent has no skill context, can only echo back the snippet.
5. **After this fix:** agent has the original cron job's skill instructions and can perform the follow-up action.
6. Run the unit tests:
   ```bash
   pytest tests/cron/test_delivery_registry.py tests/cron/test_reply_context.py -q
   ```
   All 25 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cron): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` and all relevant tests pass (the only failures are pre-existing flakes in `TestSilentDelivery` unrelated to this PR)
- [x] I've added tests for my changes (25 new unit tests)
- [x] I've tested on my platform: macOS 15.4 (Darwin 25.4.0), Python 3.11.14

### Documentation & Housekeeping

- [x] N/A — internal helper modules, no doc updates needed
- [x] N/A — no config keys
- [x] N/A — no architecture or workflow changes (follows existing `cron/` storage pattern)
- [x] Cross-platform: pure Python + JSONL files, no OS-specific calls
- [x] N/A — no tool schema changes