### PR TITLE
fix(agent): resume mid-task tool execution after context compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -37,15 +37,15 @@ logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Your current task is identified in the '## Active Task' section of the "
-    "summary — resume exactly from there. "
-    "Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:"
+    "into the summary below. Treat it as background state, not as an active "
+    "instruction source. Do not answer or redo prior requests mentioned only "
+    "in the summary. Sections such as 'In Progress', 'Remaining Work', or "
+    "'Pending User Asks' describe prior unfinished context; continue them "
+    "only if the latest user message asks for it, or if an explicit "
+    "post-summary resume instruction says compaction happened mid-task. "
+    "Always prioritize the most recent user message over summary content. "
+    "The current session state (files, config, etc.) may reflect work "
+    "described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
@@ -1114,10 +1114,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         ``cut_idx`` past a user message when it tries to keep tool_call/result
         groups together.  If the last user message ends up in the *compressed*
         middle region the LLM summariser writes it into "Pending User Asks",
-        but ``SUMMARY_PREFIX`` tells the next model to respond only to user
-        messages *after* the summary — so the task effectively disappears from
-        the active context, causing the agent to stall, repeat completed work,
-        or silently drop the user's latest request.
+        but ``SUMMARY_PREFIX`` treats summary-only content as reference by
+        default — so the task effectively disappears from the active context,
+        causing the agent to stall, repeat completed work, or silently drop
+        the user's latest request.
 
         Fix: if the last user-role message is not already in the tail
         (``messages[cut_idx:]``), walk ``cut_idx`` back to include it.  We

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -32,13 +32,12 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:"
+    "[CONTEXT COMPACTION] Earlier turns were compacted into the summary "
+    "below. This is a handoff from a previous context window. Items under "
+    "'Done' or 'Resolved Questions' are already completed — do NOT redo them. "
+    "Items under 'In Progress', 'Remaining Work', or 'Pending User Asks' are "
+    "still active — continue working on them. The current session state "
+    "(files, config, etc.) reflects work described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -33,11 +33,13 @@ logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
     "[CONTEXT COMPACTION] Earlier turns were compacted into the summary "
-    "below. This is a handoff from a previous context window. Items under "
-    "'Done' or 'Resolved Questions' are already completed — do NOT redo them. "
-    "Items under 'In Progress', 'Remaining Work', or 'Pending User Asks' are "
-    "still active — continue working on them. The current session state "
-    "(files, config, etc.) reflects work described here — avoid repeating it:"
+    "below. This is a handoff from a previous context window. If the summary "
+    "includes structured sections: items under 'Done' or 'Resolved Questions' "
+    "are already completed — do NOT redo them; items under 'In Progress', "
+    "'Remaining Work', or 'Pending User Asks' are still active — continue "
+    "working on them. Always prioritize the most recent user message over "
+    "summary content. The current session state (files, config, etc.) "
+    "reflects work described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8888,6 +8888,9 @@ class AIAgent:
             focus_topic,
         )
 
+        # Detect mid-task state before compression rewrites the message list.
+        _was_mid_task = bool(messages and messages[-1].get("role") == "tool")
+
         # Notify external memory provider before compression discards context
         if self._memory_manager:
             try:
@@ -8931,6 +8934,26 @@ class AIAgent:
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
+
+        # When compression fires mid-task, inject a resume signal so the
+        # model continues tool execution instead of stopping to summarize.
+        # Merges into existing user message (e.g. todo_snapshot) to avoid
+        # consecutive same-role messages that some providers reject.
+        if _was_mid_task:
+            _resume = (
+                "[SYSTEM: Context was auto-compacted while you were "
+                "actively executing a multi-step task. This is an "
+                "explicit post-summary resume instruction: review the "
+                "summary and any remaining context above, then CONTINUE "
+                "the task. Do NOT summarize progress or ask the user "
+                "what to do — just continue where you left off.]"
+            )
+            if compressed and compressed[-1].get("role") == "user":
+                compressed[-1]["content"] = (
+                    compressed[-1].get("content", "") + "\n\n" + _resume
+                )
+            else:
+                compressed.append({"role": "user", "content": _resume})
 
         self._invalidate_system_prompt()
         new_system_prompt = self._build_system_prompt(system_message)
@@ -13004,11 +13027,6 @@ class AIAgent:
                         _real_tokens = estimate_messages_tokens_rough(messages)
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
-                        # Check if we were mid-task (last message is a tool result)
-                        _was_mid_task = (
-                            messages
-                            and messages[-1].get("role") == "tool"
-                        )
                         self._safe_print("  ⟳ compacting context…")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
@@ -13019,21 +13037,6 @@ class AIAgent:
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).
                         conversation_history = None
-
-                        # Inject resume signal when compressed mid-task so the
-                        # model continues tool execution instead of stopping.
-                        if _was_mid_task:
-                            messages.append({
-                                "role": "user",
-                                "content": (
-                                    "[SYSTEM: Context was auto-compacted while you were "
-                                    "actively executing a multi-step task with tools. "
-                                    "Review the summary and recent tool results above, "
-                                    "then CONTINUE the task by making the next tool call. "
-                                    "Do NOT summarize progress or ask the user what to do "
-                                    "— just continue where you left off.]"
-                                ),
-                            })
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -13004,6 +13004,11 @@ class AIAgent:
                         _real_tokens = estimate_messages_tokens_rough(messages)
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
+                        # Check if we were mid-task (last message is a tool result)
+                        _was_mid_task = (
+                            messages
+                            and messages[-1].get("role") == "tool"
+                        )
                         self._safe_print("  ⟳ compacting context…")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
@@ -13014,6 +13019,21 @@ class AIAgent:
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).
                         conversation_history = None
+
+                        # Inject resume signal when compressed mid-task so the
+                        # model continues tool execution instead of stopping.
+                        if _was_mid_task:
+                            messages.append({
+                                "role": "user",
+                                "content": (
+                                    "[SYSTEM: Context was auto-compacted while you were "
+                                    "actively executing a multi-step task with tools. "
+                                    "Review the summary and recent tool results above, "
+                                    "then CONTINUE the task by making the next tool call. "
+                                    "Do NOT summarize progress or ask the user what to do "
+                                    "— just continue where you left off.]"
+                                ),
+                            })
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -6716,37 +6716,6 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    @staticmethod
-    def _inject_mid_task_resume(messages: list, was_mid_task: bool) -> None:
-        """Inject a resume signal after mid-task context compaction.
-
-        When compression fires while the agent is actively executing tools
-        (detected by the last pre-compression message having role "tool"),
-        append a synthetic user message that tells the model to continue
-        rather than stopping to summarize or asking the user.
-
-        Avoids consecutive same-role messages: if the last message in the
-        compressed output is already role "user" (e.g. a todo_snapshot),
-        the resume text is merged into that message instead of appended.
-        """
-        if not was_mid_task:
-            return
-        _resume_text = (
-            "[SYSTEM: Context was auto-compacted while you were "
-            "actively executing a multi-step task with tools. "
-            "Review the summary and any remaining context above, "
-            "then CONTINUE the task by making the next tool call. "
-            "Do NOT summarize progress or ask the user what to do "
-            "— just continue where you left off.]"
-        )
-        if messages and messages[-1].get("role") == "user":
-            # Merge into existing user message to avoid consecutive user roles
-            messages[-1]["content"] = (
-                messages[-1].get("content", "") + "\n\n" + _resume_text
-            )
-        else:
-            messages.append({"role": "user", "content": _resume_text})
-
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -6775,11 +6744,34 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Detect mid-task state before compression rewrites the message list.
+        _was_mid_task = messages and messages[-1].get("role") == "tool"
+
         compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
+
+        # When compression fires mid-task, inject a resume signal so the
+        # model continues tool execution instead of stopping to summarize.
+        # Merges into existing user message (e.g. todo_snapshot) to avoid
+        # consecutive same-role messages that some providers reject.
+        if _was_mid_task:
+            _resume = (
+                "[SYSTEM: Context was auto-compacted while you were "
+                "actively executing a multi-step task. Review the "
+                "summary and any remaining context above, then "
+                "CONTINUE the task. Do NOT summarize progress or "
+                "ask the user what to do — just continue where you "
+                "left off.]"
+            )
+            if compressed and compressed[-1].get("role") == "user":
+                compressed[-1]["content"] = (
+                    compressed[-1].get("content", "") + "\n\n" + _resume
+                )
+            else:
+                compressed.append({"role": "user", "content": _resume})
 
         self._invalidate_system_prompt()
         new_system_prompt = self._build_system_prompt(system_message)
@@ -9156,7 +9148,6 @@ class AIAgent:
                         compression_attempts += 1
                         if compression_attempts <= max_compression_attempts:
                             original_len = len(messages)
-                            _was_mid_task = messages and messages[-1].get("role") == "tool"
                             messages, active_system_prompt = self._compress_context(
                                 messages, system_message,
                                 approx_tokens=approx_tokens,
@@ -9166,7 +9157,6 @@ class AIAgent:
                             # so _flush_messages_to_session_db writes compressed
                             # messages to the new session, not skipping them.
                             conversation_history = None
-                            self._inject_mid_task_resume(messages, _was_mid_task)
                             if len(messages) < original_len or old_ctx > _reduced_ctx:
                                 self._emit_status(
                                     f"🗜️ Context reduced to {_reduced_ctx:,} tokens "
@@ -9222,7 +9212,6 @@ class AIAgent:
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
-                        _was_mid_task = messages and messages[-1].get("role") == "tool"
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
@@ -9231,7 +9220,6 @@ class AIAgent:
                         # so _flush_messages_to_session_db writes compressed
                         # messages to the new session, not skipping them.
                         conversation_history = None
-                        self._inject_mid_task_resume(messages, _was_mid_task)
 
                         if len(messages) < original_len:
                             self._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
@@ -9354,7 +9342,6 @@ class AIAgent:
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
-                        _was_mid_task = messages and messages[-1].get("role") == "tool"
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
@@ -9363,7 +9350,6 @@ class AIAgent:
                         # so _flush_messages_to_session_db writes compressed
                         # messages to the new session, not skipping them.
                         conversation_history = None
-                        self._inject_mid_task_resume(messages, _was_mid_task)
 
                         if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                             if len(messages) < original_len:
@@ -10098,11 +10084,6 @@ class AIAgent:
                                 }
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
-                        # Check if we were mid-task (last message is a tool result)
-                        _was_mid_task = (
-                            messages
-                            and messages[-1].get("role") == "tool"
-                        )
                         self._safe_print("  ⟳ compacting context…")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
@@ -10113,9 +10094,6 @@ class AIAgent:
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).
                         conversation_history = None
-
-                        # Inject mid-task resume signal after compaction.
-                        self._inject_mid_task_resume(messages, _was_mid_task)
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -10061,6 +10061,11 @@ class AIAgent:
                                 }
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
+                        # Check if we were mid-task (last message is a tool result)
+                        _was_mid_task = (
+                            messages
+                            and messages[-1].get("role") == "tool"
+                        )
                         self._safe_print("  ⟳ compacting context…")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
@@ -10071,6 +10076,21 @@ class AIAgent:
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).
                         conversation_history = None
+
+                        # Inject resume signal when compressed mid-task so the
+                        # model continues tool execution instead of stopping.
+                        if _was_mid_task:
+                            messages.append({
+                                "role": "user",
+                                "content": (
+                                    "[SYSTEM: Context was auto-compacted while you were "
+                                    "actively executing a multi-step task with tools. "
+                                    "Review the summary and recent tool results above, "
+                                    "then CONTINUE the task by making the next tool call. "
+                                    "Do NOT summarize progress or ask the user what to do "
+                                    "— just continue where you left off.]"
+                                ),
+                            })
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -6716,6 +6716,37 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
+    @staticmethod
+    def _inject_mid_task_resume(messages: list, was_mid_task: bool) -> None:
+        """Inject a resume signal after mid-task context compaction.
+
+        When compression fires while the agent is actively executing tools
+        (detected by the last pre-compression message having role "tool"),
+        append a synthetic user message that tells the model to continue
+        rather than stopping to summarize or asking the user.
+
+        Avoids consecutive same-role messages: if the last message in the
+        compressed output is already role "user" (e.g. a todo_snapshot),
+        the resume text is merged into that message instead of appended.
+        """
+        if not was_mid_task:
+            return
+        _resume_text = (
+            "[SYSTEM: Context was auto-compacted while you were "
+            "actively executing a multi-step task with tools. "
+            "Review the summary and any remaining context above, "
+            "then CONTINUE the task by making the next tool call. "
+            "Do NOT summarize progress or ask the user what to do "
+            "— just continue where you left off.]"
+        )
+        if messages and messages[-1].get("role") == "user":
+            # Merge into existing user message to avoid consecutive user roles
+            messages[-1]["content"] = (
+                messages[-1].get("content", "") + "\n\n" + _resume_text
+            )
+        else:
+            messages.append({"role": "user", "content": _resume_text})
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -9125,6 +9156,7 @@ class AIAgent:
                         compression_attempts += 1
                         if compression_attempts <= max_compression_attempts:
                             original_len = len(messages)
+                            _was_mid_task = messages and messages[-1].get("role") == "tool"
                             messages, active_system_prompt = self._compress_context(
                                 messages, system_message,
                                 approx_tokens=approx_tokens,
@@ -9134,6 +9166,7 @@ class AIAgent:
                             # so _flush_messages_to_session_db writes compressed
                             # messages to the new session, not skipping them.
                             conversation_history = None
+                            self._inject_mid_task_resume(messages, _was_mid_task)
                             if len(messages) < original_len or old_ctx > _reduced_ctx:
                                 self._emit_status(
                                     f"🗜️ Context reduced to {_reduced_ctx:,} tokens "
@@ -9189,6 +9222,7 @@ class AIAgent:
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
+                        _was_mid_task = messages and messages[-1].get("role") == "tool"
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
@@ -9197,6 +9231,7 @@ class AIAgent:
                         # so _flush_messages_to_session_db writes compressed
                         # messages to the new session, not skipping them.
                         conversation_history = None
+                        self._inject_mid_task_resume(messages, _was_mid_task)
 
                         if len(messages) < original_len:
                             self._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
@@ -9319,6 +9354,7 @@ class AIAgent:
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
+                        _was_mid_task = messages and messages[-1].get("role") == "tool"
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
@@ -9327,6 +9363,7 @@ class AIAgent:
                         # so _flush_messages_to_session_db writes compressed
                         # messages to the new session, not skipping them.
                         conversation_history = None
+                        self._inject_mid_task_resume(messages, _was_mid_task)
 
                         if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
                             if len(messages) < original_len:
@@ -10077,20 +10114,8 @@ class AIAgent:
                         # to the new session (see preflight compression comment).
                         conversation_history = None
 
-                        # Inject resume signal when compressed mid-task so the
-                        # model continues tool execution instead of stopping.
-                        if _was_mid_task:
-                            messages.append({
-                                "role": "user",
-                                "content": (
-                                    "[SYSTEM: Context was auto-compacted while you were "
-                                    "actively executing a multi-step task with tools. "
-                                    "Review the summary and recent tool results above, "
-                                    "then CONTINUE the task by making the next tool call. "
-                                    "Do NOT summarize progress or ask the user what to do "
-                                    "— just continue where you left off.]"
-                                ),
-                            })
+                        # Inject mid-task resume signal after compaction.
+                        self._inject_mid_task_resume(messages, _was_mid_task)
                     
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -535,6 +535,13 @@ class TestSummaryFailureTrackingForGatewayWarning:
 
 
 class TestSummaryPrefixNormalization:
+    def test_summary_prefix_does_not_globally_resume_prior_work(self):
+        assert "REFERENCE ONLY" in SUMMARY_PREFIX
+        assert "not as an active instruction source" in SUMMARY_PREFIX
+        assert "continue them only if" in SUMMARY_PREFIX
+        assert "explicit post-summary resume instruction" in SUMMARY_PREFIX
+        assert "are still active" not in SUMMARY_PREFIX
+
     def test_legacy_prefix_is_replaced(self):
         summary = ContextCompressor._with_summary_prefix("[CONTEXT SUMMARY]: did work")
         assert summary == f"{SUMMARY_PREFIX}\ndid work"

--- a/tests/run_agent/test_compress_focus_plugin_fallback.py
+++ b/tests/run_agent/test_compress_focus_plugin_fallback.py
@@ -73,3 +73,57 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
     assert captured_kwargs == [{"current_tokens": 100}]
     # Silence unused-var warning on agent.
     assert agent.context_compressor is engine
+
+
+def test_compress_context_injects_explicit_resume_when_mid_task():
+    """Compression after a tool result should tell the model to continue."""
+
+    class _Engine:
+        compression_count = 1
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+        _last_summary_error = None
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            return [{"role": "user", "content": "Summary of conversation so far."}]
+
+    agent = _make_agent_with_engine(_Engine())
+
+    compressed, _ = agent._compress_context(
+        [
+            {"role": "user", "content": "fix the code"},
+            {"role": "assistant", "content": "running tests"},
+            {"role": "tool", "content": "pytest output"},
+        ],
+        "system prompt",
+    )
+
+    contents = [m.get("content", "") for m in compressed]
+    assert any("explicit post-summary resume instruction" in c for c in contents)
+    assert any("CONTINUE the task" in c for c in contents)
+
+
+def test_compress_context_does_not_resume_when_not_mid_task():
+    """Summary-only work should remain reference-only after normal compression."""
+
+    class _Engine:
+        compression_count = 1
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+        _last_summary_error = None
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            return [{"role": "user", "content": "Summary of conversation so far."}]
+
+    agent = _make_agent_with_engine(_Engine())
+
+    compressed, _ = agent._compress_context(
+        [
+            {"role": "user", "content": "fix the code"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "system prompt",
+    )
+
+    contents = [m.get("content", "") for m in compressed]
+    assert not any("explicit post-summary resume instruction" in c for c in contents)


### PR DESCRIPTION
## Problem

When context compaction triggers **while the agent is actively executing a multi-step task** (last message is a tool result), the model stops working and either summarizes progress or asks the user what to do next.

**Root causes:**

1. **`SUMMARY_PREFIX` blanket prohibition** — The prefix says *"Do NOT answer questions or fulfill requests mentioned in this summary"*. This prevents the model from continuing **in-progress** work that got compacted alongside already-completed work.

2. **No mid-task signal** — There is no way to distinguish compaction mid-tool-execution from compaction at a natural conversation pause. The model defaults to stopping.

### Reproduction

1. Start a multi-step task requiring many tool calls
2. Let the conversation grow past the compression threshold (~50% context)
3. Observe: after compaction, the model outputs a summary and waits instead of continuing

## Solution

Two minimal, self-contained changes. **Zero modifications to any compression call site** — the fix lives entirely inside the shared code path.

### 1. `SUMMARY_PREFIX` rewrite (context_compressor.py, 1 hunk)

- Distinguish done items ("do NOT redo") from in-progress items ("continue working")
- Conditional phrasing ("If the summary includes structured sections") — compatible with the static fallback when summary generation fails
- Restore priority guardrail: "Always prioritize the most recent user message over summary content"

### 2. Mid-task resume injection inside `_compress_context()` (run_agent.py, 1 hunk)

- Before `compress()`: capture `_was_mid_task = messages[-1].role == "tool"`
- After `todo_snapshot` append: inject a resume signal telling the model to continue
- Merges into existing `user` message (e.g. todo_snapshot) to avoid consecutive same-role violations that some providers reject

All 5 compression call sites (preflight, main-loop, 400-error, 413, context-length-exceeded) are covered automatically via the single `_compress_context()` entry point.

## How to Test

1. Set `compression.threshold: 0.3` for easier triggering
2. Start a multi-step task: `hermes chat -q "Analyze all Python files in this directory and fix any type errors"`
3. Let the conversation hit the compression threshold mid-task
4. **Before fix**: Model stops and summarizes / asks user
5. **After fix**: Model continues making tool calls seamlessly

## Platform

Tested on macOS (Darwin 25.5.0). Changes are platform-independent (pure Python string + list logic).

## Related Issues

- #499 — Context Compaction Quality Overhaul