### PR TITLE
fix(cli): preserve explicit model switch across turns

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1669,6 +1669,7 @@ class HermesCLI:
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
+        self._explicit_model_switch = False  # Set True when user switches via /model
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
@@ -2128,6 +2129,10 @@ class HermesCLI:
 
     def _normalize_model_for_provider(self, resolved_provider: str) -> bool:
         """Normalize provider-specific model IDs and routing."""
+        # Skip normalization if user explicitly switched model via /model.
+        # Their choice takes precedence over provider-specific transformations.
+        if getattr(self, "_explicit_model_switch", False):
+            return False
         current_model = (self.model or "").strip()
         changed = False
 
@@ -2730,9 +2735,11 @@ class HermesCLI:
         # `hermes chat --model <provider-name>` sends the provider name
         # (e.g. "my-provider") as the model string to the API instead of
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
+        # Skip if user explicitly switched model via /model (preserve their choice).
         runtime_model = runtime.get("model")
         if runtime_model and isinstance(runtime_model, str):
-            self.model = runtime_model
+            if not getattr(self, "_explicit_model_switch", False):
+                self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
         # without `hermes model`), fall back to the provider's first catalog
@@ -4550,6 +4557,7 @@ class HermesCLI:
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
+        self._explicit_model_switch = True  # Prevent runtime resolver from overwriting
         if result.api_key:
             self.api_key = result.api_key
             self._explicit_api_key = result.api_key
@@ -4763,10 +4771,12 @@ class HermesCLI:
         # Apply to CLI state.
         # Update requested_provider so _ensure_runtime_credentials() doesn't
         # overwrite the switch on the next turn (it re-resolves from this).
+        # Set _explicit_model_switch flag so runtime resolver skips its model override.
         old_model = self.model
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
+        self._explicit_model_switch = True  # Prevent runtime resolver from overwriting
         if result.api_key:
             self.api_key = result.api_key
             self._explicit_api_key = result.api_key

--- a/tests/cli/test_explicit_model_switch.py
+++ b/tests/cli/test_explicit_model_switch.py
@@ -1,0 +1,289 @@
+"""Tests for the _explicit_model_switch flag in HermesCLI.
+
+Bug: After switching models via /model, the runtime credential resolver
+and model normalizer would overwrite the user's choice on the next turn,
+reverting the status bar and actual model back to the provider's default.
+
+Fix: Added _explicit_model_switch flag. Once set True (by /model handlers),
+_ensure_runtime_credentials() skips its model override and
+_normalize_model_for_provider() returns False, preserving the user's choice.
+"""
+
+import importlib
+import sys
+import types
+from contextlib import nullcontext
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module isolation helpers (same pattern as test_cli_provider_resolution.py)
+# ---------------------------------------------------------------------------
+
+def _reset_modules(prefixes: tuple[str, ...]):
+    for name in list(sys.modules):
+        if any(name == p or name.startswith(p + ".") for p in prefixes):
+            sys.modules.pop(name, None)
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_and_tool_modules():
+    """Save and restore tools/cli/run_agent modules around every test."""
+    prefixes = ("tools", "cli", "run_agent")
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == p or name.startswith(p + ".") for p in prefixes)
+    }
+    try:
+        yield
+    finally:
+        _reset_modules(prefixes)
+        sys.modules.update(original_modules)
+
+
+def _install_prompt_toolkit_stubs():
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Condition:
+        def __init__(self, func):
+            self.func = func
+
+        def __bool__(self):
+            return bool(self.func())
+
+    class _ANSI(str):
+        pass
+
+    root = types.ModuleType("prompt_toolkit")
+    history = types.ModuleType("prompt_toolkit.history")
+    styles = types.ModuleType("prompt_toolkit.styles")
+    patch_stdout = types.ModuleType("prompt_toolkit.patch_stdout")
+    application = types.ModuleType("prompt_toolkit.application")
+    layout = types.ModuleType("prompt_toolkit.layout")
+    processors = types.ModuleType("prompt_toolkit.layout.processors")
+    filters = types.ModuleType("prompt_toolkit.filters")
+    dimension = types.ModuleType("prompt_toolkit.layout.dimension")
+    menus = types.ModuleType("prompt_toolkit.layout.menus")
+    widgets = types.ModuleType("prompt_toolkit.widgets")
+    key_binding = types.ModuleType("prompt_toolkit.key_binding")
+    completion = types.ModuleType("prompt_toolkit.completion")
+    formatted_text = types.ModuleType("prompt_toolkit.formatted_text")
+
+    history.FileHistory = _Dummy
+    styles.Style = _Dummy
+    patch_stdout.patch_stdout = lambda *args, **kwargs: nullcontext()
+    application.Application = _Dummy
+    layout.Layout = _Dummy
+    layout.HSplit = _Dummy
+    layout.Window = _Dummy
+    layout.FormattedTextControl = _Dummy
+    layout.ConditionalContainer = _Dummy
+    processors.Processor = _Dummy
+    processors.Transformation = _Dummy
+    processors.PasswordProcessor = _Dummy
+    processors.ConditionalProcessor = _Dummy
+    filters.Condition = _Condition
+    dimension.Dimension = _Dummy
+    menus.CompletionsMenu = _Dummy
+    widgets.TextArea = _Dummy
+    key_binding.KeyBindings = _Dummy
+    completion.Completer = _Dummy
+    completion.Completion = _Dummy
+    formatted_text.ANSI = _ANSI
+    root.print_formatted_text = lambda *args, **kwargs: None
+
+    sys.modules.setdefault("prompt_toolkit", root)
+    sys.modules.setdefault("prompt_toolkit.history", history)
+    sys.modules.setdefault("prompt_toolkit.styles", styles)
+    sys.modules.setdefault("prompt_toolkit.patch_stdout", patch_stdout)
+    sys.modules.setdefault("prompt_toolkit.application", application)
+    sys.modules.setdefault("prompt_toolkit.layout", layout)
+    sys.modules.setdefault("prompt_toolkit.layout.processors", processors)
+    sys.modules.setdefault("prompt_toolkit.filters", filters)
+    sys.modules.setdefault("prompt_toolkit.layout.dimension", dimension)
+    sys.modules.setdefault("prompt_toolkit.layout.menus", menus)
+    sys.modules.setdefault("prompt_toolkit.widgets", widgets)
+    sys.modules.setdefault("prompt_toolkit.key_binding", key_binding)
+    sys.modules.setdefault("prompt_toolkit.completion", completion)
+    sys.modules.setdefault("prompt_toolkit.formatted_text", formatted_text)
+
+
+def _import_cli():
+    for name in list(sys.modules):
+        if name == "cli" or name == "run_agent" or name == "tools" or name.startswith("tools."):
+            sys.modules.pop(name, None)
+
+    if "firecrawl" not in sys.modules:
+        sys.modules["firecrawl"] = types.SimpleNamespace(Firecrawl=object)
+
+    try:
+        importlib.import_module("prompt_toolkit")
+    except ModuleNotFoundError:
+        _install_prompt_toolkit_stubs()
+    return importlib.import_module("cli")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_explicit_model_switch_defaults_to_false(monkeypatch):
+    """_explicit_model_switch must be False on a fresh HermesCLI instance."""
+    cli = _import_cli()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider",
+                        lambda **kw: {"provider": "openrouter", "api_mode": "chat_completions",
+                                      "base_url": "https://openrouter.ai/api/v1",
+                                      "api_key": "***", "source": "env/config"})
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    assert shell._explicit_model_switch is False
+
+
+def test_runtime_resolver_does_not_overwrite_explicit_model_switch(monkeypatch):
+    """When _explicit_model_switch is True, _ensure_runtime_credentials()
+    must NOT replace self.model with the runtime's configured default model.
+
+    This is the core bug: before the fix, the runtime resolver unconditionally
+    overwrote self.model on every turn, reverting the user's /model choice.
+    """
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "source": "env/config",
+            "model": "anthropic/claude-opus-4-6",  # default model that should NOT overwrite
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="anthropic/claude-sonnet-4", compact=True, max_turns=1)
+
+    # Set the flag as if the user used /model to switch
+    shell._explicit_model_switch = True
+    shell.model = "google/gemini-3-pro"
+
+    # _ensure_runtime_credentials should preserve the explicit model
+    shell._ensure_runtime_credentials()
+    assert shell.model == "google/gemini-3-pro", (
+        "Runtime resolver overwrote the user's explicit model choice"
+    )
+    assert shell._explicit_model_switch is True
+
+
+def test_runtime_resolver_overwrites_when_no_explicit_switch(monkeypatch):
+    """When _explicit_model_switch is False (the default), the runtime
+    resolver SHOULD update self.model from the runtime config's model field.
+    This is the normal startup/credential-refresh path."""
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "source": "env/config",
+            "model": "anthropic/claude-opus-4-6",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="some-model", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://openrouter.ai/api/v1"
+    shell.api_key = "existing-key"
+
+    assert shell._explicit_model_switch is False
+    shell._ensure_runtime_credentials()
+    # Model should be updated to the runtime default since no explicit switch
+    assert shell.model == "anthropic/claude-opus-4-6"
+
+
+def test_normalize_model_skips_when_explicit_switch(monkeypatch):
+    """_normalize_model_for_provider() must return False and NOT modify
+    self.model when _explicit_model_switch is True."""
+    cli = _import_cli()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider",
+                        lambda **kw: {"provider": "openrouter", "api_mode": "chat_completions",
+                                      "base_url": "https://openrouter.ai/api/v1",
+                                      "api_key": "***", "source": "env/config"})
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="custom/weird-model-name", compact=True, max_turns=1)
+    shell._explicit_model_switch = True
+
+    changed = shell._normalize_model_for_provider("openrouter")
+    assert changed is False
+    assert shell.model == "custom/weird-model-name", (
+        "Normalizer modified model despite explicit switch flag"
+    )
+
+
+def test_normalize_model_works_when_no_explicit_switch(monkeypatch):
+    """_normalize_model_for_provider() should still function normally
+    when _explicit_model_switch is False."""
+    cli = _import_cli()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider",
+                        lambda **kw: {"provider": "openai-codex", "api_mode": "codex_responses",
+                                      "base_url": "https://chatgpt.com/backend-api/codex",
+                                      "api_key": "***", "source": "env/config"})
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+    monkeypatch.setattr("hermes_cli.codex_models.get_codex_model_ids",
+                        lambda access_token=None: ["gpt-5.2-codex"])
+
+    shell = cli.HermesCLI(model="openai/gpt-5.3-codex", compact=True, max_turns=1)
+    shell._explicit_model_switch = False
+
+    # This should strip the "openai/" prefix via normalization
+    shell._normalize_model_for_provider("openai-codex")
+    assert shell.model == "gpt-5.3-codex", (
+        "Normalizer didn't process model when flag was False"
+    )
+
+
+def test_explicit_model_switch_survives_multiple_runtime_resolves(monkeypatch):
+    """The flag must persist across multiple calls to _ensure_runtime_credentials(),
+    ensuring the user's model choice survives turn after turn."""
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "source": "env/config",
+            "model": "anthropic/claude-opus-4-6",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error",
+                        lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell._explicit_model_switch = True
+    shell.model = "google/gemini-3-pro"
+
+    # Simulate multiple turns — each calls _ensure_runtime_credentials()
+    for _ in range(5):
+        shell._ensure_runtime_credentials()
+        assert shell.model == "google/gemini-3-pro", (
+            "Model reverted after multiple runtime resolves"
+        )


### PR DESCRIPTION
After switching models via /model, _ensure_runtime_credentials() would unconditionally overwrite self.model with the provider's configured default on every turn, and _normalize_model_for_provider() would further transform the model ID. This caused the status bar and actual model to revert to the provider default on the next message.

Add _explicit_model_switch flag to HermesCLI:
- Initialized to False in __init__
- Set True in _apply_model_switch_result() (model picker UI) and _handle_model_switch() (text /model command)
- Guard in _ensure_runtime_credentials() skips runtime model override when flag is True
- Guard in _normalize_model_for_provider() returns False early when flag is True, preserving the user's model ID as-is

Includes 6 regression tests covering:
- Flag defaults to False
- Runtime resolver does NOT overwrite with flag set
- Runtime resolver DOES overwrite without flag (normal path)
- Normalizer skips with flag set
- Normalizer works normally without flag
- Flag survives multiple runtime resolve calls (multi-turn)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

