### PR TITLE
fix(bluebubbles): replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -362,7 +362,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -402,7 +402,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## What does this PR do?

Replaces the deprecated `datetime.utcnow()` calls in `gateway/platforms/bluebubbles.py` with the recommended `datetime.now(timezone.utc)` and adds `timezone` to the import.

## Type of Change
- [x] Bug fix

## Changes Made
- `from datetime import datetime` → `from datetime import datetime, timezone`
- Line 365: `datetime.utcnow().timestamp()` → `datetime.now(timezone.utc).timestamp()`
- Line 405: `datetime.utcnow().timestamp()` → `datetime.now(timezone.utc).timestamp()`

## How to Test
Run the BlueBubbles adapter and verify `tempGuid` generation works correctly. No functional change — only deprecation warning eliminated.

## Checklist
- [x] Code follows project style
- [x] No new dependencies
- [x] Tested locally