### PR TITLE
feat(spinner): expand THINKING_VERBS from 15 to 45 with 30 curated verbs

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -604,6 +604,13 @@ class KawaiiSpinner:
         "pondering", "contemplating", "musing", "cogitating", "ruminating",
         "deliberating", "mulling", "reflecting", "processing", "reasoning",
         "analyzing", "computing", "synthesizing", "formulating", "brainstorming",
+        "inferring", "deducing", "connecting", "envisioning", "examining",
+        # Expanded from curated list
+        "cerebrating", "orchestrating", "crystallizing", "deciphering", "manifesting",
+        "reticulating", "osmosing", "percolating", "calculating", "composing",
+        "architecting", "distilling", "harmonizing", "calibrating", "reconciling",
+        "interconnecting", "mustering", "concocting", "unraveling", "choreographing",
+        "tempering", "transmuting", "catalyzing", "perusing", "scheming",
     ]
 
     def __init__(self, message: str = "", spinner_type: str = 'dots', print_fn=None):


### PR DESCRIPTION
## What does this PR do?

Expands the `THINKING_VERBS` pool in `KawaiiSpinner` from 15 to 45 verbs — adding 30 curated verbs that match the Hermes kawaii/pensive personality.

New verbs added (in order of addition):

**From existing pool (restored):**
`inferring`, `deducing`, `connecting`, `envisioning`, `examining`

**Curated additions:**
`cerebrating`, `orchestrating`, `crystallizing`, `deciphering`, `manifesting`, `reticulating`, `osmosing`, `percolating`, `calculating`, `composing`, `architecting`, `distilling`, `harmonizing`, `calibrating`, `reconciling`, `interconnecting`, `mustering`, `concocting`, `unraveling`, `choreographing`, `tempering`, `transmuting`, `catalyzing`, `perusing`, `scheming`

Selection criteria: words that evoke thoughtful, technical, or creative work — matching the kawaii-but-competent Hermes persona.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/display.py`: Added 30 new verbs to `THINKING_VERBS` pool (+7 lines)

## How to Test

1. `hermes chat -q "hello"` — observe the thinking spinner verb rotation (now 45 options instead of 15)
2. Run tests: `python -m pytest tests/agent/test_display_spinner.py -v`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — pure Python, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
