### PR TITLE
fix(primary): preserve routed client headers on auto-routed provider init

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -920,9 +920,18 @@ class AIAgent:
                         "api_key": _routed_client.api_key,
                         "base_url": str(_routed_client.base_url),
                     }
-                    # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    # Preserve any default_headers the router set.
+                    # OpenAI SDK stores headers passed via ``default_headers=``
+                    # on the client constructor in ``_custom_headers``; the
+                    # older ``_default_headers`` attribute is not exposed for
+                    # routed clients, so the original check silently failed
+                    # and provider-specific headers (Copilot Editor-Version,
+                    # Copilot-Integration-Id, Kimi User-Agent, etc.) were
+                    # lost on every request-client rebuild.  See PR #6076
+                    # for the same fix in the fallback activation path.
+                    _rh = getattr(_routed_client, '_custom_headers', None) or getattr(_routed_client, '_default_headers', None)
+                    if _rh:
+                        client_kwargs["default_headers"] = dict(_rh)
                 else:
                     # When the user explicitly chose a non-OpenRouter provider
                     # but no credentials were found, fail fast with a clear


### PR DESCRIPTION
## Bug

When the primary agent client is built via the **auto-routed** path (provider auto-detected, no explicit API key in `config.yaml`), `run_agent.py` checks `hasattr(_routed_client, '_default_headers')` to copy provider-specific headers into `self._client_kwargs`. The OpenAI SDK actually stores headers passed via `default_headers=` on the constructor in **`_custom_headers`**, so the check silently fails and `_client_kwargs` is saved without any headers.

Every subsequent request-client rebuild via `_create_request_openai_client` then constructs a bare `OpenAI(api_key, base_url)` client that drops the Copilot-required `Editor-Version` and `Copilot-Integration-Id` headers, causing hard `400 model_not_supported` responses from `api.githubcopilot.com/chat/completions` on every tool-call round after the first request.

The gateway path (WhatsApp, Telegram, Discord, etc.) is the easiest repro because each turn spawns a fresh `AIAgent` that immediately rebuilds its request client before any assistant output. The CLI path can be mostly unaffected for single-shot queries because the first request uses the original client directly.

## Reproduction

1. `model.default: gemini-3.1-pro-preview` + `model.provider: copilot` in `config.yaml`
2. No `COPILOT_API_KEY` env var — rely on `gh auth token` / `ghu_*` github user token, so the auto-route path at line ~914 is taken
3. Start `hermes gateway run`, send a message via a messaging platform that triggers a tool call
4. Gateway log:
```
⚠️ Non-retryable error (HTTP 400) — trying fallback...
❌ Non-retryable error (HTTP 400): HTTP 400: The requested model is not supported.
   📋 Details: {'message': 'The requested model is not supported.', 'code': 'model_not_supported', 'param': 'model', 'type': 'invalid_request_error'}
```

Inspecting the dumped outgoing request headers shows only `Authorization` and `Content-Type` — `Editor-Version` / `Copilot-Integration-Id` are missing, confirming the rebuilt client dropped them.

## Root cause

```python
from agent.auxiliary_client import resolve_provider_client
c, _ = resolve_provider_client("copilot", model="gemini-3.1-pro-preview", raw_codex=True)
print(hasattr(c, "_default_headers"))  # False
print(hasattr(c, "_custom_headers"))   # True
# _custom_headers contains: Editor-Version, User-Agent, Copilot-Integration-Id,
#                           Openai-Intent, x-initiator
```

`resolve_provider_client()` in `auxiliary_client.py` correctly passes the full copilot header set via `default_headers=` when constructing the OpenAI client, but the OpenAI SDK stashes them on `_custom_headers`, not `_default_headers`.

## Fix

Prefer `_custom_headers` and fall back to `_default_headers` for forward-compat with any routed client type that uses the older attribute name:

```python
_rh = getattr(_routed_client, '_custom_headers', None) or getattr(_routed_client, '_default_headers', None)
if _rh:
    client_kwargs["default_headers"] = dict(_rh)
```

This mirrors the pattern used in #6076, which fixed the same class of bug in `_try_activate_fallback()`. That PR only covered the fallback activation path — the auto-routed primary path was missed.

## Verified

After applying the patch + `systemctl --user restart hermes-gateway.service` + clearing `__pycache__`, repeated multi-tool-call sessions on `gemini-3.1-pro-preview` via Copilot now complete cleanly with zero `400 model_not_supported` errors. Primary no longer needs to hand off to the fallback chain on every request.

## Related

- #6075 — Original bug report (fallback path)
- #6076 — Fallback path fix (merged)