### PR TITLE
fix(nix): bump Python 3.11 → 3.12 to resolve sphinx 9.1.0 build failure

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -1,6 +1,6 @@
 # nix/python.nix — uv2nix virtual environment builder
 {
-  python311,
+  python312,
   lib,
   callPackage,
   uv2nix,
@@ -37,28 +37,28 @@ let
 
   pythonPackageOverrides = final: _prev:
     if isAarch64Darwin then {
-      numpy = mkPrebuiltOverride final python311.pkgs.numpy { };
+      numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
 
-      av = mkPrebuiltOverride final python311.pkgs.av { };
+      av = mkPrebuiltOverride final python312.pkgs.av { };
 
-      humanfriendly = mkPrebuiltOverride final python311.pkgs.humanfriendly { };
+      humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
 
-      coloredlogs = mkPrebuiltOverride final python311.pkgs.coloredlogs {
+      coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
         humanfriendly = [ ];
       };
 
-      onnxruntime = mkPrebuiltOverride final python311.pkgs.onnxruntime {
+      onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
         coloredlogs = [ ];
         numpy = [ ];
         packaging = [ ];
       };
 
-      ctranslate2 = mkPrebuiltOverride final python311.pkgs.ctranslate2 {
+      ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
         numpy = [ ];
         pyyaml = [ ];
       };
 
-      faster-whisper = mkPrebuiltOverride final python311.pkgs.faster-whisper {
+      faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
         av = [ ];
         ctranslate2 = [ ];
         huggingface-hub = [ ];
@@ -70,7 +70,7 @@ let
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
-      python = python311;
+      python = python312;
     }).overrideScope
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default


### PR DESCRIPTION
## Problem
`nix build` fails on current main with:
```
error: sphinx-9.1.0 not supported for interpreter python3.11
```

Sphinx 9.1.0 (pulled transitively via `pyproject-build-systems`) dropped Python 3.11 support.

## Fix
Bump `nix/python.nix` from `python311` → `python312`. The project's `pyproject.toml` requires `>=3.11`, so 3.12 is fully compatible.

## Tested
- `nix build` succeeds on `aarch64-darwin` (M2 Max, macOS)
- `hermes setup`, `hermes doctor`, and `hermes chat` all work correctly
- `hermes doctor` confirms Python 3.12.13