### PR TITLE
feat(web): support TAVILY_BASE_URL env var for custom proxy endpoints

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -281,7 +281,7 @@ def _get_async_parallel_client():
 
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
-_TAVILY_BASE_URL = "https://api.tavily.com"
+_TAVILY_BASE_URL = os.getenv("TAVILY_BASE_URL", "https://api.tavily.com")
 
 
 def _tavily_request(endpoint: str, payload: dict) -> dict:


### PR DESCRIPTION
Make the Tavily client respect a TAVILY_BASE_URL environment variable, defaulting to https://api.tavily.com for backward compatibility. Consistent with FIRECRAWL_API_URL pattern already used in this module.