### PR TITLE
fix(agent): strip temperature for kimi providers in _build_call_kwargs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1953,7 +1953,11 @@ def _build_call_kwargs(
     }
 
     if temperature is not None:
-        kwargs["temperature"] = temperature
+        # kimi-coding (kimi-k2.5, kimi-k2-thinking, etc.) only accepts temperature=1.
+        # Sending any other value causes a 400 "invalid temperature: only 1 is allowed
+        # for this model" error. Omitting the parameter lets the API use its default (1).
+        if provider not in {"kimi-coding", "kimi", "moonshot"}:
+            kwargs["temperature"] = temperature
 
     if max_tokens is not None:
         # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1166,3 +1166,49 @@ def test_resolve_api_key_provider_skips_unconfigured_anthropic(monkeypatch):
 
     assert "anthropic" not in called, \
         "_try_anthropic() should not be called when anthropic is not explicitly configured"
+
+
+class TestBuildCallKwargsKimiTemperature:
+    """kimi-coding (kimi-k2.5 etc.) only accepts temperature=1.
+
+    Sending any other value causes a 400 invalid temperature: only 1 is
+    allowed for this model error.  _build_call_kwargs must omit the
+    temperature key for all Kimi provider aliases so callers never need
+    to special-case the provider themselves.
+    """
+
+    @pytest.mark.parametrize("provider", ["kimi-coding", "kimi", "moonshot"])
+    def test_kimi_temperature_omitted_when_nondefault(self, provider):
+        from agent.auxiliary_client import _build_call_kwargs
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="kimi-k2.5",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.1,
+        )
+        assert "temperature" not in kwargs, (
+            f"{provider}: temperature=0.1 must be omitted — "
+            "Kimi rejects non-1 values with 400 'invalid temperature'")
+
+    @pytest.mark.parametrize("provider", ["kimi-coding", "kimi", "moonshot"])
+    def test_kimi_temperature_none_not_sent(self, provider):
+        from agent.auxiliary_client import _build_call_kwargs
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="kimi-k2.5",
+            messages=[],
+            temperature=None,
+        )
+        assert "temperature" not in kwargs
+
+    @pytest.mark.parametrize("provider", ["openai-codex", "zai", "custom", "nous"])
+    def test_non_kimi_temperature_preserved(self, provider):
+        from agent.auxiliary_client import _build_call_kwargs
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="some-model",
+            messages=[],
+            temperature=0.3,
+        )
+        assert kwargs.get("temperature") == 0.3, (
+            f"{provider} should pass temperature through unchanged")


### PR DESCRIPTION
## Problem

kimi-coding (kimi-k2.5, kimi-k2-thinking, etc.) only accepts temperature=1.
Sending any other value returns a 400 error:

    invalid temperature: only 1 is allowed for this model

This surfaces when auxiliary.vision or auxiliary.session_search is set to
provider: auto and the active main provider is kimi-coding. Both tasks
hardcode temperature=0.1 in their callers, so every auxiliary call fails
silently with a 400, breaking image analysis and session summarisation.

Observed in errors.log:
    BadRequestError: Error code: 400 - invalid temperature: only 1 is allowed for this model

Affected call sites: vision_tools.py:407, session_search_tool.py:161.

## Fix

Omit the temperature kwarg in _build_call_kwargs for all Kimi provider
aliases (kimi-coding, kimi, moonshot), mirroring the existing pattern
for the Codex adapter which already strips unsupported parameters to avoid
400 errors (see line 290 comment).

## Tests

Added TestBuildCallKwargsKimiTemperature in test_auxiliary_client.py:

- Verifies temperature is omitted for all three Kimi aliases when a
  non-default value is passed (was causing the 400).
- Verifies temperature=None is still not sent (unchanged behaviour).
- Verifies other providers (openai-codex, zai, custom, nous) still
  receive the temperature parameter unchanged.

Result: 10 passed in 0.28s
