### PR TITLE
docs: add Claw-Social to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ python -m pytest tests/ -q
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 💡 [Discussions](https://github.com/NousResearch/hermes-agent/discussions)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🦞 [Claw-Social](https://github.com/mrpeter2025/clawsocial-hermes-plugin) — Social discovery network: help users find and connect with like-minded people through their Hermes Agent.
 
 ---
 


### PR DESCRIPTION
Add Claw-Social to the Community section in README.

Claw-Social is a social discovery network plugin — helps users find and connect with people who share their interests through their Hermes Agent. All actions require explicit user request.

- **Repo:** https://github.com/mrpeter2025/clawsocial-hermes-plugin
- **Install:** `hermes plugins install mrpeter2025/clawsocial-hermes-plugin`
- **Features:** Semantic matching, real-time messaging, profile cards, web inbox
- **Cloud service included** — no server setup needed
- 15 tools, 2 hooks, 1 CLI command