### PR TITLE
feat: add API server console with persisted tool traces

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,24 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-fork-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # Fork-only workflow: no-op on the upstream repository.
+    if: github.event.repository.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync default branch from upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh repo sync "${{ github.repository }}" -b main

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -571,19 +571,43 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        # Expose the real provider/model so web consoles can display it.
+        backend_model = ""
+        backend_provider = ""
+        try:
+            from gateway.run import _resolve_gateway_model, _load_gateway_config
+            backend_model = _resolve_gateway_model() or ""
+            cfg = _load_gateway_config()
+            model_cfg = cfg.get("model", {})
+            if isinstance(model_cfg, dict):
+                backend_provider = model_cfg.get("provider", "")
+        except Exception:
+            pass
+
+        provider = backend_provider
+        actual_model = backend_model
+        if not provider and "/" in backend_model:
+            provider, actual_model = backend_model.split("/", 1)
+
+        model_obj: Dict[str, Any] = {
+            "id": self._model_name,
+            "object": "model",
+            "created": int(time.time()),
+            "owned_by": provider or "hermes",
+            "permission": [],
+            "root": self._model_name,
+            "parent": None,
+        }
+        if backend_model or provider:
+            model_obj["meta"] = {
+                "provider": provider or "unknown",
+                "model": actual_model or self._model_name,
+                "backend": backend_model,
+            }
+
         return web.json_response({
             "object": "list",
-            "data": [
-                {
-                    "id": self._model_name,
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": self._model_name,
-                    "parent": None,
-                }
-            ],
+            "data": [model_obj],
         })
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
@@ -722,18 +746,34 @@ class APIServerAdapter(BasePlatformAdapter):
                 history.  Clients that don't understand the custom event type
                 silently ignore it per the SSE specification.
                 """
-                if event_type != "tool.started":
-                    return
-                if name.startswith("_"):
+                if name and name.startswith("_"):
                     return
                 from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
-                _stream_q.put(("__tool_progress__", {
-                    "tool": name,
-                    "emoji": emoji,
-                    "label": label,
-                }))
+                emoji = get_tool_emoji(name) if name else ""
+                if event_type == "tool.started":
+                    label = preview or name
+                    payload = {
+                        "type": "started",
+                        "tool": name,
+                        "emoji": emoji,
+                        "label": label,
+                    }
+                    if args:
+                        args_str = str(args) if not isinstance(args, str) else args
+                        if len(args_str) > 500:
+                            args_str = args_str[:500] + "..."
+                        payload["args"] = args_str
+                    _stream_q.put(("__tool_progress__", payload))
+                elif event_type == "tool.completed":
+                    duration = kwargs.get("duration", 0)
+                    is_error = kwargs.get("is_error", False)
+                    _stream_q.put(("__tool_progress__", {
+                        "type": "completed",
+                        "tool": name or "",
+                        "emoji": emoji,
+                        "duration": round(duration, 3) if duration else None,
+                        "error": is_error,
+                    }))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -56,6 +56,8 @@ MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_SESSION_LIST_LIMIT = 200
+MAX_LOG_LINES = 500
 
 
 def _normalize_chat_content(
@@ -504,6 +506,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    @staticmethod
+    def _parse_bool_query(value: Optional[str]) -> bool:
+        """Parse a permissive boolean query-string flag."""
+        if value is None:
+            return False
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -609,6 +618,347 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "list",
             "data": [model_obj],
         })
+
+    async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions — list persisted Hermes sessions."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response({"sessions": []})
+
+        query = request.rel_url.query
+        source = (query.get("source") or "").strip() or None
+        exclude_sources = [
+            item.strip()
+            for item in (query.get("exclude_sources") or "").split(",")
+            if item.strip()
+        ] or None
+
+        try:
+            limit = max(1, min(int(query.get("limit", "80")), MAX_SESSION_LIST_LIMIT))
+            offset = max(0, int(query.get("offset", "0")))
+        except ValueError:
+            return web.json_response(
+                _openai_error("Invalid pagination parameter.", code="invalid_pagination"),
+                status=400,
+            )
+
+        include_children = self._parse_bool_query(query.get("include_children"))
+
+        try:
+            sessions = db.list_sessions_rich(
+                source=source,
+                exclude_sources=exclude_sources,
+                limit=limit,
+                offset=offset,
+                include_children=include_children,
+            )
+        except Exception as exc:
+            logger.exception("[api_server] GET /api/sessions failed: %s", exc)
+            return web.json_response(
+                _openai_error("Failed to load sessions.", err_type="server_error", code="session_list_failed"),
+                status=500,
+            )
+
+        now = time.time()
+        for session in sessions:
+            last_active = session.get("last_active", session.get("started_at", 0)) or 0
+            session["is_active"] = (
+                session.get("ended_at") is None
+                and isinstance(last_active, (int, float))
+                and (now - last_active) < 300
+            )
+
+        return web.json_response({"sessions": sessions})
+
+    async def _handle_get_session(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id} — fetch session metadata."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable.", err_type="server_error", code="session_db_unavailable"),
+                status=503,
+            )
+
+        requested_id = request.match_info.get("session_id", "")
+        session_id = db.resolve_session_id(requested_id)
+        if not session_id:
+            return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+
+        session = db.get_session(session_id)
+        if not session:
+            return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+
+        last_active = session.get("last_active", session.get("started_at", 0)) or 0
+        session["is_active"] = (
+            session.get("ended_at") is None
+            and isinstance(last_active, (int, float))
+            and (time.time() - last_active) < 300
+        )
+        return web.json_response(session)
+
+    async def _handle_get_session_messages(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/messages — fetch persisted session transcript."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable.", err_type="server_error", code="session_db_unavailable"),
+                status=503,
+            )
+
+        requested_id = request.match_info.get("session_id", "")
+        session_id = db.resolve_session_id(requested_id)
+        if not session_id:
+            return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+
+        try:
+            messages = db.get_messages(session_id)
+        except Exception as exc:
+            logger.exception("[api_server] GET /api/sessions/%s/messages failed: %s", session_id, exc)
+            return web.json_response(
+                _openai_error("Failed to load session messages.", err_type="server_error", code="session_messages_failed"),
+                status=500,
+            )
+
+        return web.json_response({"session_id": session_id, "messages": messages})
+
+    async def _handle_create_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions — create an empty persisted web session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable.", err_type="server_error", code="session_db_unavailable"),
+                status=503,
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        requested_id = body.get("session_id")
+        title = body.get("title")
+        source = str(body.get("source") or "api_server").strip() or "api_server"
+        model = str(body.get("model") or self._model_name).strip() or self._model_name
+        system_prompt = body.get("system_prompt")
+
+        if source != "api_server":
+            return web.json_response(_openai_error("Only api_server sessions can be created here.", code="invalid_session_source"), status=400)
+
+        if requested_id is not None and not isinstance(requested_id, str):
+            return web.json_response(_openai_error("session_id must be a string.", code="invalid_session_id"), status=400)
+        if title is not None and not isinstance(title, str):
+            return web.json_response(_openai_error("title must be a string.", code="invalid_session_title"), status=400)
+        if system_prompt is not None and not isinstance(system_prompt, str):
+            return web.json_response(_openai_error("system_prompt must be a string.", code="invalid_system_prompt"), status=400)
+
+        session_id = (requested_id or f"web-{uuid.uuid4().hex[:16]}").strip()
+        if not session_id or re.search(r'[\r\n\x00]', session_id):
+            return web.json_response(_openai_error("Invalid session ID.", code="invalid_session_id"), status=400)
+
+        try:
+            db.create_session(
+                session_id=session_id,
+                source=source,
+                model=model,
+                system_prompt=system_prompt,
+            )
+            if title:
+                db.set_session_title(session_id, title)
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_session_title"), status=400)
+        except Exception as exc:
+            logger.exception("[api_server] POST /api/sessions failed: %s", exc)
+            return web.json_response(
+                _openai_error("Failed to create session.", err_type="server_error", code="session_create_failed"),
+                status=500,
+            )
+
+        session = db.get_session(session_id) or {"id": session_id, "source": source, "model": model}
+        session["is_active"] = True
+        return web.json_response(session, status=201)
+
+    async def _handle_update_session(self, request: "web.Request") -> "web.Response":
+        """PATCH /api/sessions/{session_id} — update session metadata such as title."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable.", err_type="server_error", code="session_db_unavailable"),
+                status=503,
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        if "title" not in body:
+            return web.json_response(_openai_error("Missing title field.", code="missing_session_title"), status=400)
+        if body["title"] is not None and not isinstance(body["title"], str):
+            return web.json_response(_openai_error("title must be a string.", code="invalid_session_title"), status=400)
+
+        requested_id = request.match_info.get("session_id", "")
+        session_id = db.resolve_session_id(requested_id)
+        if not session_id:
+            return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+
+        try:
+            if not db.set_session_title(session_id, body.get("title")):
+                return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_session_title"), status=400)
+        except Exception as exc:
+            logger.exception("[api_server] PATCH /api/sessions/%s failed: %s", session_id, exc)
+            return web.json_response(
+                _openai_error("Failed to update session.", err_type="server_error", code="session_update_failed"),
+                status=500,
+            )
+
+        session = db.get_session(session_id) or {"id": session_id}
+        last_active = session.get("last_active", session.get("started_at", 0)) or 0
+        session["is_active"] = (
+            session.get("ended_at") is None
+            and isinstance(last_active, (int, float))
+            and (time.time() - last_active) < 300
+        )
+        return web.json_response(session)
+
+    async def _handle_delete_session(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/sessions/{session_id} — delete a persisted session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        db = self._ensure_session_db()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable.", err_type="server_error", code="session_db_unavailable"),
+                status=503,
+            )
+
+        requested_id = request.match_info.get("session_id", "")
+        session_id = db.resolve_session_id(requested_id)
+        if not session_id:
+            return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+
+        try:
+            if not db.delete_session(session_id):
+                return web.json_response(_openai_error("Session not found.", code="session_not_found"), status=404)
+        except Exception as exc:
+            logger.exception("[api_server] DELETE /api/sessions/%s failed: %s", session_id, exc)
+            return web.json_response(
+                _openai_error("Failed to delete session.", err_type="server_error", code="session_delete_failed"),
+                status=500,
+            )
+
+        return web.json_response({"ok": True, "session_id": session_id})
+
+    async def _handle_logs(self, request: "web.Request") -> "web.Response":
+        """GET /api/logs — tail Hermes log files for the web console."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        query = request.rel_url.query
+        log_file = (query.get("file") or "gateway").strip().lower() or "gateway"
+
+        try:
+            lines = max(1, min(int(query.get("lines", "160")), MAX_LOG_LINES))
+        except ValueError:
+            return web.json_response(_openai_error("Invalid log line count.", code="invalid_log_lines"), status=400)
+
+        level = (query.get("level") or "").strip().upper() or None
+        if level and level not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+            return web.json_response(_openai_error("Invalid log level.", code="invalid_log_level"), status=400)
+
+        component = (query.get("component") or "").strip().lower() or None
+        session_filter = (query.get("session") or "").strip() or None
+        since_raw = (query.get("since") or "").strip()
+
+        try:
+            from hermes_cli.logs import LOG_FILES, _parse_since, _read_tail
+        except Exception as exc:
+            logger.exception("[api_server] log helpers unavailable: %s", exc)
+            return web.json_response(
+                _openai_error("Log viewer unavailable.", err_type="server_error", code="log_helpers_unavailable"),
+                status=500,
+            )
+
+        if log_file not in LOG_FILES:
+            return web.json_response(_openai_error(f"Unknown log file: {log_file}", code="unknown_log_file"), status=400)
+
+        try:
+            from hermes_logging import COMPONENT_PREFIXES
+        except Exception:
+            COMPONENT_PREFIXES = {}
+
+        if component and component not in COMPONENT_PREFIXES:
+            return web.json_response(_openai_error("Unknown log component.", code="unknown_log_component"), status=400)
+
+        since = None
+        if since_raw:
+            since = _parse_since(since_raw)
+            if since is None:
+                return web.json_response(_openai_error("Invalid since filter.", code="invalid_since_filter"), status=400)
+
+        try:
+            from hermes_constants import get_hermes_home
+
+            log_path = get_hermes_home() / "logs" / LOG_FILES[log_file]
+            component_prefixes = COMPONENT_PREFIXES.get(component) if component else None
+            has_filters = bool(level or session_filter or since or component_prefixes)
+            line_items = (
+                _read_tail(
+                    log_path,
+                    lines,
+                    has_filters=has_filters,
+                    min_level=level,
+                    session_filter=session_filter,
+                    since=since,
+                    component_prefixes=component_prefixes,
+                )
+                if log_path.exists()
+                else []
+            )
+        except Exception as exc:
+            logger.exception("[api_server] GET /api/logs failed: %s", exc)
+            return web.json_response(
+                _openai_error("Failed to read logs.", err_type="server_error", code="log_read_failed"),
+                status=500,
+            )
+
+        return web.json_response(
+            {
+                "file": log_file,
+                "lines": line_items,
+                "requested_lines": lines,
+                "level": level,
+                "component": component,
+                "session": session_filter,
+                "available_files": sorted(LOG_FILES),
+                "available_components": sorted(COMPONENT_PREFIXES),
+                "refreshed_at": time.time(),
+            }
+        )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -1819,6 +2169,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._run_streams.pop(run_id, None)
                 self._run_streams_created.pop(run_id, None)
 
+    def _register_routes(self, app: "web.Application") -> None:
+        """Register API server routes on an aiohttp application."""
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/v1/health", self._handle_health)
+        app.router.add_get("/v1/models", self._handle_models)
+        app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
+        app.router.add_post("/v1/responses", self._handle_responses)
+        app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
+        app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+        app.router.add_get("/api/sessions", self._handle_list_sessions)
+        app.router.add_post("/api/sessions", self._handle_create_session)
+        app.router.add_get("/api/sessions/{session_id}", self._handle_get_session)
+        app.router.add_patch("/api/sessions/{session_id}", self._handle_update_session)
+        app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)
+        app.router.add_get("/api/sessions/{session_id}/messages", self._handle_get_session_messages)
+        app.router.add_get("/api/logs", self._handle_logs)
+        app.router.add_get("/api/jobs", self._handle_list_jobs)
+        app.router.add_post("/api/jobs", self._handle_create_job)
+        app.router.add_get("/api/jobs/{job_id}", self._handle_get_job)
+        app.router.add_patch("/api/jobs/{job_id}", self._handle_update_job)
+        app.router.add_delete("/api/jobs/{job_id}", self._handle_delete_job)
+        app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
+        app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
+        app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+        app.router.add_post("/v1/runs", self._handle_runs)
+        app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
     # ------------------------------------------------------------------
@@ -1833,25 +2210,7 @@ class APIServerAdapter(BasePlatformAdapter):
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
             self._app["api_server_adapter"] = self
-            self._app.router.add_get("/health", self._handle_health)
-            self._app.router.add_get("/v1/health", self._handle_health)
-            self._app.router.add_get("/v1/models", self._handle_models)
-            self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
-            self._app.router.add_post("/v1/responses", self._handle_responses)
-            self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
-            self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
-            # Cron jobs management API
-            self._app.router.add_get("/api/jobs", self._handle_list_jobs)
-            self._app.router.add_post("/api/jobs", self._handle_create_job)
-            self._app.router.add_get("/api/jobs/{job_id}", self._handle_get_job)
-            self._app.router.add_patch("/api/jobs/{job_id}", self._handle_update_job)
-            self._app.router.add_delete("/api/jobs/{job_id}", self._handle_delete_job)
-            self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
-            self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
-            self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
-            # Structured event streaming
-            self._app.router.add_post("/v1/runs", self._handle_runs)
-            self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._register_routes(self._app)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -767,13 +767,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 elif event_type == "tool.completed":
                     duration = kwargs.get("duration", 0)
                     is_error = kwargs.get("is_error", False)
-                    _stream_q.put(("__tool_progress__", {
+                    payload = {
                         "type": "completed",
                         "tool": name or "",
                         "emoji": emoji,
                         "duration": round(duration, 3) if duration else None,
                         "error": is_error,
-                    }))
+                    }
+                    result_preview = kwargs.get("result_preview")
+                    if result_preview:
+                        payload["result"] = result_preview
+                    _stream_q.put(("__tool_progress__", payload))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
@@ -1563,22 +1567,29 @@ class APIServerAdapter(BasePlatformAdapter):
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
             if event_type == "tool.started":
-                _push({
+                payload = {
                     "event": "tool.started",
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name,
                     "preview": preview,
-                })
+                }
+                if args:
+                    payload["args"] = args
+                _push(payload)
             elif event_type == "tool.completed":
-                _push({
+                payload = {
                     "event": "tool.completed",
                     "run_id": run_id,
                     "timestamp": ts,
                     "tool": tool_name,
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
-                })
+                }
+                result_preview = kwargs.get("result_preview")
+                if result_preview:
+                    payload["result"] = result_preview
+                _push(payload)
             elif event_type == "reasoning.available":
                 _push({
                     "event": "reasoning.available",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2142,8 +2142,8 @@ def _is_service_installed() -> bool:
     return False
 
 
-def _is_service_running() -> bool:
-    """Check if the gateway service is currently running."""
+def _is_managed_service_running() -> bool:
+    """Return True only when a system-managed gateway service is active."""
     if supports_systemd_services():
         user_unit_exists = get_systemd_unit_path(system=False).exists()
         system_unit_exists = get_systemd_unit_path(system=True).exists()
@@ -2180,7 +2180,15 @@ def _is_service_running() -> bool:
             return result.returncode == 0
         except subprocess.TimeoutExpired:
             return False
-    # Check for manual processes
+    return False
+
+
+def _is_service_running() -> bool:
+    """Check if the gateway is currently running in any mode."""
+    if _is_managed_service_running():
+        return True
+    # Fall back to manually started gateway processes when no managed service is
+    # active, so status commands still report foreground runs correctly.
     return len(find_gateway_pids()) > 0
 
 
@@ -2677,8 +2685,10 @@ def gateway_setup():
         print(color("─" * 58, Colors.DIM))
         service_installed = _is_service_installed()
         service_running = _is_service_running()
+        managed_service_running = _is_managed_service_running()
+        manual_gateway_running = service_running and not managed_service_running
 
-        if service_running:
+        if managed_service_running:
             if prompt_yes_no("  Restart the gateway to pick up changes?", True):
                 try:
                     if supports_systemd_services():
@@ -2690,6 +2700,12 @@ def gateway_setup():
                         print_info("Start manually: hermes gateway")
                 except subprocess.CalledProcessError as e:
                     print_error(f"  Restart failed: {e}")
+        elif manual_gateway_running:
+            platform_name = "systemd" if supports_systemd_services() else "launchd" if is_macos() else "service manager"
+            print_info(f"  Gateway is already running manually (not as a {platform_name} service).")
+            print_info("  Restart it manually to pick up changes:")
+            print_info("    hermes gateway stop")
+            print_info("    hermes gateway run")
         elif service_installed:
             if prompt_yes_no("  Start the gateway service?", True):
                 try:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2231,6 +2231,7 @@ def setup_gateway(config: dict):
 
         from hermes_cli.gateway import (
             _is_service_installed,
+            _is_managed_service_running,
             _is_service_running,
             supports_systemd_services,
             has_conflicting_systemd_units,
@@ -2245,6 +2246,8 @@ def setup_gateway(config: dict):
 
         service_installed = _is_service_installed()
         service_running = _is_service_running()
+        managed_service_running = _is_managed_service_running()
+        manual_gateway_running = service_running and not managed_service_running
         supports_systemd = supports_systemd_services()
         supports_service_manager = supports_systemd or _is_macos
 
@@ -2253,7 +2256,7 @@ def setup_gateway(config: dict):
             print_systemd_scope_conflict_warning()
             print()
 
-        if service_running:
+        if managed_service_running:
             if prompt_yes_no("  Restart the gateway to pick up changes?", True):
                 try:
                     if supports_systemd:
@@ -2262,6 +2265,12 @@ def setup_gateway(config: dict):
                         launchd_restart()
                 except Exception as e:
                     print_error(f"  Restart failed: {e}")
+        elif manual_gateway_running:
+            svc_name = "systemd" if supports_systemd else "launchd" if _is_macos else "service manager"
+            print_info(f"  Gateway is already running manually (not as a {svc_name} service).")
+            print_info("  Restart it manually to pick up changes:")
+            print_info("    hermes gateway stop")
+            print_info("    hermes gateway run")
         elif service_installed:
             if prompt_yes_no("  Start the gateway service?", True):
                 try:

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,58 +70,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -172,55 +120,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -255,9 +154,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -295,14 +194,14 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.27.0.tgz",
-      "integrity": "sha512-9y8z7ugIbU6ycKrA2SqCpKh1/hobut2rDq9CLt/BNVzSlebBBVOTMiAt1XroZzcPnA7/ZqpbkpOsbpPUaAQuNQ==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.24.0.tgz",
+      "integrity": "sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==",
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.0",
-        "@wdio/utils": "9.27.0",
+        "@wdio/types": "9.24.0",
+        "@wdio/utils": "9.24.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0",
@@ -310,73 +209,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@wdio/logger": {
@@ -396,9 +228,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.27.0.tgz",
-      "integrity": "sha512-rIk69BsY1+6uU2PEN5FiRpI6K7HJ86YHzZRFBe4iRzKXQgGNk1zWzbdVJIuNFoOWsnmYUkK42KSSOT4Le6EmiQ==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.24.0.tgz",
+      "integrity": "sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==",
       "license": "MIT"
     },
     "node_modules/@wdio/repl": {
@@ -414,9 +246,9 @@
       }
     },
     "node_modules/@wdio/types": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.0.tgz",
-      "integrity": "sha512-DQJ+OdRBqUBcQ30DN2Z651hEVh3OoxnlDUSRqlWy9An2AY6v9rYWTj825B6zsj5pLLEToYO1tfwWq0ab183pXg==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.24.0.tgz",
+      "integrity": "sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
@@ -426,14 +258,14 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.27.0.tgz",
-      "integrity": "sha512-fUasd5OKJTy2seJfWnYZ9xlxTtY0p/Kyeuh7Tbb8kcofBqmBi2fTvM3sfZlo1tGQX9yCh+IS2N7hlfyFMmuZ+w==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.24.0.tgz",
+      "integrity": "sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==",
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.27.0",
+        "@wdio/types": "9.24.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^6.1.2",
@@ -451,9 +283,9 @@
       }
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.26",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
-      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.21.tgz",
+      "integrity": "sha512-fkyzXISE3IMrstDO1AgPkJCx14MYHP/suIGiAovEYEuBjq3mffsuL6aMV7ohOSjW4rXtuACuUfpA3GtITgdtYg==",
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
@@ -534,15 +366,12 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -582,165 +411,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
       }
     },
     "node_modules/aria-query": {
@@ -814,13 +484,10 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
@@ -837,10 +504,11 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
-      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
+      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -861,10 +529,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
-      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -874,28 +543,26 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
-      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
+      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "streamx": "^2.25.0",
+        "streamx": "^2.21.0",
         "teex": "^1.0.1"
       },
       "peerDependencies": {
-        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
         "bare-buffer": {
           "optional": true
         },
@@ -905,10 +572,11 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -946,18 +614,18 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -986,6 +654,44 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -1018,6 +724,33 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1025,15 +758,12 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/browserslist": {
@@ -1070,9 +800,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -1090,7 +820,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -1181,6 +911,93 @@
       },
       "peerDependencies": {
         "playwright-core": "*"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/camoufox-js/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1286,6 +1103,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1296,6 +1148,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone-deep": {
@@ -1333,12 +1202,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/compress-commons": {
@@ -1355,46 +1224,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/compress-commons/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -1474,46 +1303,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1600,12 +1389,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -1795,9 +1592,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1923,9 +1720,9 @@
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1948,18 +1745,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -2171,6 +1956,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -2190,29 +1990,6 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
-    },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "2.0.1",
@@ -2242,9 +2019,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
-      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
       "funding": [
         {
           "type": "github",
@@ -2254,8 +2031,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.4.0",
-        "strnum": "^2.2.3"
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2293,6 +2070,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fingerprint-generator": {
       "version": "2.1.82",
@@ -2477,9 +2269,9 @@
       }
     },
     "node_modules/get-port": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
-      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -2530,29 +2322,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/get-uri/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/get-uri/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -2560,17 +2329,21 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "18 || 20 || >=22"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2718,29 +2491,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -2754,36 +2504,13 @@
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -3475,15 +3202,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3552,18 +3279,18 @@
       }
     },
     "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.4.tgz",
+      "integrity": "sha512-5ixBi7pY+H8z3MKExsipXPq6S/Q27KpSY0K+NnIyLQLr58mNeZVhT9TkYcqa74H52DabOyrmGLhT5D7TZ/x26Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {
@@ -3582,9 +3309,9 @@
       }
     },
     "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -3722,29 +3449,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
@@ -3829,9 +3533,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "funding": [
         {
           "type": "github",
@@ -3862,28 +3566,19 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3958,29 +3653,6 @@
         }
       }
     },
-    "node_modules/playwright-extra/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/playwright-extra/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -4006,6 +3678,48 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process": {
@@ -4064,23 +3778,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -4090,12 +3787,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4103,9 +3794,9 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -4164,29 +3855,6 @@
         }
       }
     },
-    "node_modules/puppeteer-extra-plugin-stealth/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-stealth/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/puppeteer-extra-plugin-user-data-dir": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
@@ -4214,12 +3882,6 @@
         }
       }
     },
-    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -4228,23 +3890,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/glob": {
@@ -4279,12 +3924,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/rimraf": {
       "version": "3.0.2",
@@ -4328,52 +3967,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/puppeteer-extra-plugin-user-preferences/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-user-preferences/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-extra-plugin/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -4420,6 +4013,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -4436,17 +4041,19 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readdir-glob": {
@@ -4456,21 +4063,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
@@ -4533,73 +4125,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/safaridriver": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
@@ -4630,9 +4155,9 @@
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.0.tgz",
-      "integrity": "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
       "funding": [
         {
           "type": "github",
@@ -4646,9 +4171,6 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.5.0"
-      },
-      "bin": {
-        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safer-buffer": {
@@ -4702,10 +4224,19 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/serialize-error": {
@@ -5004,29 +4535,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5081,9 +4589,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -5101,17 +4609,20 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width-cjs": {
@@ -5138,6 +4649,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -5150,34 +4667,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.2.2"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
         "node": ">=12"
@@ -5218,9 +4714,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",
@@ -5242,31 +4738,28 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "license": "MIT",
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "license": "MIT",
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/teen_process": {
@@ -5290,6 +4783,7 @@
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "streamx": "^2.12.5"
       }
@@ -5416,9 +4910,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -5556,6 +5050,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/wait-port/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wait-port/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5572,51 +5081,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/wait-port/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/wait-port/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wait-port/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/webdriver": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.27.0.tgz",
-      "integrity": "sha512-w07ThZND48SIr0b4S7eFougYUyclmoUwdmju8yXvEJiXYjDjeYUpl8wZrYPEYRBylxpSx+sBHfEUBrPQkcTTRQ==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.24.0.tgz",
+      "integrity": "sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.27.0",
+        "@wdio/config": "9.24.0",
         "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.0",
-        "@wdio/types": "9.27.0",
-        "@wdio/utils": "9.27.0",
+        "@wdio/protocols": "9.24.0",
+        "@wdio/types": "9.24.0",
+        "@wdio/utils": "9.24.0",
         "deepmerge-ts": "^7.0.3",
         "https-proxy-agent": "^7.0.6",
         "undici": "^6.21.3",
@@ -5636,19 +5113,19 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.0.tgz",
-      "integrity": "sha512-Y4FbMf4bKBXpPB0lYpglzQ2GfDDe6uojmMZl85uPyrDx18NW7mqN84ZawGoIg/FRvcLaVhcOzc98WOPo725Rag==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.24.0.tgz",
+      "integrity": "sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.27.0",
+        "@wdio/config": "9.24.0",
         "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.27.0",
+        "@wdio/protocols": "9.24.0",
         "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.27.0",
-        "@wdio/utils": "9.27.0",
+        "@wdio/types": "9.24.0",
+        "@wdio/utils": "9.24.0",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -5665,7 +5142,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.27.0"
+        "webdriver": "9.24.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -5690,18 +5167,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -5729,17 +5194,17 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -5772,28 +5237,42 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5812,9 +5291,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5890,6 +5369,47 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -5921,46 +5441,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/run_agent.py
+++ b/run_agent.py
@@ -109,6 +109,59 @@ from agent.trajectory import (
 from utils import atomic_json_write, env_var_enabled
 
 
+_TOOL_PROGRESS_RESULT_MAX_CHARS = 800
+
+
+def _truncate_tool_progress_text(text: Any, max_chars: int = _TOOL_PROGRESS_RESULT_MAX_CHARS) -> Optional[str]:
+    """Trim tool progress text to a bounded preview for UI/event payloads."""
+    if text is None:
+        return None
+    rendered = str(text).strip()
+    if not rendered:
+        return None
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[: max_chars - 3].rstrip() + "..."
+
+
+def _summarize_tool_progress_result(result: Any) -> Optional[str]:
+    """Build a compact result preview for tool progress callbacks."""
+    if result is None:
+        return None
+
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except Exception:
+            return _truncate_tool_progress_text(result)
+    else:
+        parsed = result
+
+    if isinstance(parsed, dict):
+        for key in ("message", "error", "summary", "content", "output", "result", "preview"):
+            preview = _truncate_tool_progress_text(parsed.get(key))
+            if preview:
+                return preview
+
+        entries = parsed.get("entries")
+        if isinstance(entries, list) and entries:
+            first_entry = _truncate_tool_progress_text(entries[0], max_chars=500)
+            if first_entry:
+                extra = len(entries) - 1
+                suffix = f"\n... (+{extra} more entries)" if extra > 0 else ""
+                return _truncate_tool_progress_text(f"{first_entry}{suffix}")
+
+        return _truncate_tool_progress_text(
+            json.dumps(parsed, ensure_ascii=False, indent=2)
+        )
+
+    if isinstance(parsed, list):
+        return _truncate_tool_progress_text(
+            json.dumps(parsed[:3], ensure_ascii=False, indent=2)
+        )
+
+    return _truncate_tool_progress_text(parsed)
+
 
 class _SafeWriter:
     """Transparent stdio wrapper that catches OSError/ValueError from broken pipes.
@@ -7077,9 +7130,11 @@ class AIAgent:
 
                 if self.tool_progress_callback:
                     try:
+                        result_preview = _summarize_tool_progress_result(function_result)
                         self.tool_progress_callback(
                             "tool.completed", function_name, None, None,
                             duration=tool_duration, is_error=is_error,
+                            result_preview=result_preview,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -7411,9 +7466,11 @@ class AIAgent:
 
             if self.tool_progress_callback:
                 try:
+                    result_preview = _summarize_tool_progress_result(function_result)
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=_is_error_result,
+                        result_preview=result_preview,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -27,6 +27,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _CORS_HEADERS,
     _derive_chat_session_id,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -216,16 +217,10 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
-    app.router.add_get("/health", adapter._handle_health)
-    app.router.add_get("/v1/health", adapter._handle_health)
-    app.router.add_get("/v1/models", adapter._handle_models)
-    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
-    app.router.add_post("/v1/responses", adapter._handle_responses)
-    app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
-    app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    adapter._register_routes(app)
     return app
 
 
@@ -345,6 +340,164 @@ class TestModelsEndpoint:
                 headers={"Authorization": "Bearer sk-secret"},
             )
             assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# Session browser + logs endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestConsoleDataEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_sessions_returns_persisted_sessions(self, adapter):
+        now = time.time()
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = [
+            {
+                "id": "wechat-session-123",
+                "source": "wechat",
+                "title": "Alice",
+                "preview": "你好",
+                "started_at": now - 90,
+                "last_active": now - 5,
+                "ended_at": None,
+                "message_count": 3,
+            }
+        ]
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions?exclude_sources=api_server&limit=40")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert len(data["sessions"]) == 1
+        assert data["sessions"][0]["id"] == "wechat-session-123"
+        assert data["sessions"][0]["is_active"] is True
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["api_server"],
+            limit=40,
+            offset=0,
+            include_children=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_sessions_require_auth_when_configured(self, auth_adapter):
+        auth_adapter._session_db = MagicMock()
+        app = _create_app(auth_adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions")
+
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_session_messages_resolve_prefix(self, adapter):
+        mock_db = MagicMock()
+        mock_db.resolve_session_id.return_value = "wechat-session-123"
+        mock_db.get_messages.return_value = [
+            {"id": 1, "role": "user", "content": "hi", "timestamp": 123.0},
+            {"id": 2, "role": "assistant", "content": "hello", "timestamp": 124.0},
+        ]
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/wechat-session/messages")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["session_id"] == "wechat-session-123"
+        assert len(data["messages"]) == 2
+        mock_db.resolve_session_id.assert_called_once_with("wechat-session")
+        mock_db.get_messages.assert_called_once_with("wechat-session-123")
+
+    @pytest.mark.asyncio
+    async def test_logs_endpoint_reads_gateway_log(self, adapter, tmp_path):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "gateway.log").write_text(
+            "2026-04-14 00:00:00 INFO gateway.run: connected\n",
+            encoding="utf-8",
+        )
+        app = _create_app(adapter)
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/logs?file=gateway&lines=20&component=gateway")
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["file"] == "gateway"
+        assert "gateway" in data["available_files"]
+        assert "gateway" in data["available_components"]
+        assert any("connected" in line for line in data["lines"])
+
+    @pytest.mark.asyncio
+    async def test_create_session_returns_new_api_server_session(self, adapter):
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "web-abc123",
+            "source": "api_server",
+            "title": "新会话",
+            "started_at": time.time(),
+            "ended_at": None,
+        }
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions", json={"session_id": "web-abc123", "title": "新会话"})
+            assert resp.status == 201
+            data = await resp.json()
+
+        assert data["id"] == "web-abc123"
+        assert data["is_active"] is True
+        mock_db.create_session.assert_called_once()
+        mock_db.set_session_title.assert_called_once_with("web-abc123", "新会话")
+
+    @pytest.mark.asyncio
+    async def test_update_session_title(self, adapter):
+        now = time.time()
+        mock_db = MagicMock()
+        mock_db.resolve_session_id.return_value = "web-abc123"
+        mock_db.set_session_title.return_value = True
+        mock_db.get_session.return_value = {
+            "id": "web-abc123",
+            "source": "api_server",
+            "title": "重命名后",
+            "started_at": now - 10,
+            "last_active": now - 2,
+            "ended_at": None,
+        }
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/sessions/web-abc123", json={"title": "重命名后"})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["title"] == "重命名后"
+        mock_db.set_session_title.assert_called_once_with("web-abc123", "重命名后")
+
+    @pytest.mark.asyncio
+    async def test_delete_session_endpoint(self, adapter):
+        mock_db = MagicMock()
+        mock_db.resolve_session_id.return_value = "web-abc123"
+        mock_db.delete_session.return_value = True
+        adapter._session_db = mock_db
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/sessions/web-abc123")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data == {"ok": True, "session_id": "web-abc123"}
+        mock_db.delete_session.assert_called_once_with("web-abc123")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -223,6 +223,66 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_setup_gateway_does_not_restart_launchd_for_manual_run(monkeypatch, capsys):
+    env = {
+        "TELEGRAM_BOT_TOKEN": "token",
+        "TELEGRAM_HOME_CHANNEL": "",
+        "DISCORD_BOT_TOKEN": "",
+        "DISCORD_HOME_CHANNEL": "",
+        "SLACK_BOT_TOKEN": "",
+        "SLACK_HOME_CHANNEL": "",
+        "SIGNAL_HTTP_URL": "",
+        "EMAIL_ADDRESS": "",
+        "TWILIO_ACCOUNT_SID": "",
+        "MATTERMOST_TOKEN": "",
+        "MATRIX_ACCESS_TOKEN": "",
+        "MATRIX_PASSWORD": "",
+        "WHATSAPP_ENABLED": "",
+        "DINGTALK_CLIENT_ID": "",
+        "FEISHU_APP_ID": "",
+        "WECOM_BOT_ID": "",
+        "WEIXIN_ACCOUNT_ID": "",
+        "BLUEBUBBLES_SERVER_URL": "",
+        "BLUEBUBBLES_HOME_CHANNEL": "",
+        "WEBHOOK_ENABLED": "",
+    }
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+    monkeypatch.setattr(
+        setup_mod,
+        "_GATEWAY_PLATFORMS",
+        [("Telegram", "TELEGRAM_BOT_TOKEN", lambda: None)],
+    )
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *args, **kwargs: [0])
+
+    def _unexpected_prompt(*args, **kwargs):
+        raise AssertionError(f"Unexpected prompt_yes_no call: {args[0] if args else ''}")
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", _unexpected_prompt)
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+
+    import hermes_cli.gateway as gateway_mod
+
+    calls = []
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: True)
+    monkeypatch.setattr(gateway_mod, "_is_managed_service_running", lambda: False)
+    monkeypatch.setattr(gateway_mod, "has_conflicting_systemd_units", lambda: False)
+    monkeypatch.setattr(gateway_mod, "launchd_restart", lambda: calls.append("restart"))
+    monkeypatch.setattr(gateway_mod, "launchd_start", lambda: calls.append("start"))
+    monkeypatch.setattr(gateway_mod, "launchd_install", lambda force=False: calls.append(("install", force)))
+
+    setup_mod.setup_gateway({})
+
+    out = capsys.readouterr().out
+    assert "running manually" in out
+    assert "hermes gateway stop" in out
+    assert "hermes gateway run" in out
+    assert calls == []
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -49,6 +49,8 @@ curl http://localhost:8642/v1/chat/completions \
 
 Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI integration guide](/docs/user-guide/messaging/open-webui) for step-by-step instructions.
 
+If you want a lightweight first-party browser client inside the docs site, open the built-in [Hermes Web Console](/console). It talks directly to the same API server and is useful for local testing, demos, and operator workflows. When using it from a different origin than the API server, remember to allow that origin with `API_SERVER_CORS_ORIGINS`.
+
 ## Endpoints
 
 ### POST /v1/chat/completions

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -85,6 +85,11 @@ const config: Config = {
           label: 'Docs',
         },
         {
+          to: '/console',
+          label: 'Console',
+          position: 'left',
+        },
+        {
           to: '/skills',
           label: 'Skills',
           position: 'left',

--- a/website/src/pages/console/index.tsx
+++ b/website/src/pages/console/index.tsx
@@ -20,6 +20,7 @@ interface ConsoleSession {
   createdAt: number;
   updatedAt: number;
   messages: ChatMessage[];
+  toolEvents: ToolEvent[];
   serverSessionId?: string;
   totalUsage?: Usage;
 }
@@ -34,6 +35,7 @@ interface ToolEvent {
   duration?: number;
   error?: boolean;
   args?: string;
+  result?: string;
 }
 
 interface ImageAttachment {
@@ -132,6 +134,7 @@ function createSession(): ConsoleSession {
     createdAt: now,
     updatedAt: now,
     messages: [],
+    toolEvents: [],
   };
 }
 
@@ -431,7 +434,6 @@ export default function ConsolePage(): React.JSX.Element {
   const [currentSessionId, setCurrentSessionId] = useState<string>('');
   const [settings, setSettings] = useState<ConsoleSettings>(DEFAULT_SETTINGS);
   const [composer, setComposer] = useState('');
-  const [toolEvents, setToolEvents] = useState<ToolEvent[]>([]);
   const [requestState, setRequestState] = useState<RequestState>({status: 'idle'});
   const [connectionState, setConnectionState] = useState<ConnectionState>({
     state: 'idle',
@@ -476,6 +478,7 @@ export default function ConsolePage(): React.JSX.Element {
       const restoredSessions = (parsed.sessions?.length ? parsed.sessions : [createSession()]).map((session) => ({
         ...session,
         title: session.title === 'New thread' ? '新会话' : session.title,
+        toolEvents: Array.isArray(session.toolEvents) ? session.toolEvents : [],
       }));
       const restoredSettings = parsed.settings ? {...DEFAULT_SETTINGS, ...parsed.settings} : DEFAULT_SETTINGS;
 
@@ -510,6 +513,7 @@ export default function ConsolePage(): React.JSX.Element {
     () => sessions.find((session) => session.id === currentSessionId) ?? sessions[0],
     [currentSessionId, sessions],
   );
+  const toolEvents = currentSession?.toolEvents ?? [];
 
   useEffect(() => {
     if (!currentSession && sessions.length) {
@@ -584,9 +588,23 @@ export default function ConsolePage(): React.JSX.Element {
     }));
   }
 
-  function appendToolEvent(event: {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string}): void {
+  function patchSessionToolEvents(
+    sessionId: string,
+    updater: (events: ToolEvent[]) => ToolEvent[],
+  ): void {
+    patchSession(sessionId, (session) => ({
+      ...session,
+      updatedAt: Date.now(),
+      toolEvents: updater(session.toolEvents ?? []),
+    }));
+  }
+
+  function appendToolEvent(
+    sessionId: string,
+    event: {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string; result?: string},
+  ): void {
     if (event.type === 'completed') {
-      setToolEvents((prev) => {
+      patchSessionToolEvents(sessionId, (prev) => {
         const idx = prev.findIndex((e) => e.tool === event.tool && e.type === 'started');
         if (idx >= 0) {
           const updated = [...prev];
@@ -595,17 +613,28 @@ export default function ConsolePage(): React.JSX.Element {
             type: 'completed',
             duration: event.duration,
             error: event.error,
+            result: event.result ?? updated[idx].result,
           };
           return updated;
         }
         return [
-          {id: makeId('tool'), type: 'completed', tool: event.tool, label: event.label ?? event.tool, emoji: event.emoji, timestamp: Date.now(), duration: event.duration, error: event.error},
+          {
+            id: makeId('tool'),
+            type: 'completed',
+            tool: event.tool,
+            label: event.label ?? event.tool,
+            emoji: event.emoji,
+            timestamp: Date.now(),
+            duration: event.duration,
+            error: event.error,
+            result: event.result,
+          },
           ...prev,
         ];
       });
       return;
     }
-    setToolEvents((prev) => [
+    patchSessionToolEvents(sessionId, (prev) => [
       {
         id: makeId('tool'),
         type: 'started',
@@ -614,6 +643,7 @@ export default function ConsolePage(): React.JSX.Element {
         emoji: event.emoji,
         timestamp: Date.now(),
         args: event.args,
+        result: event.result,
       },
       ...prev,
     ]);
@@ -727,8 +757,8 @@ export default function ConsolePage(): React.JSX.Element {
 
       if (eventName === 'hermes.tool.progress') {
         try {
-          const payload = JSON.parse(data) as {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string};
-          appendToolEvent(payload);
+          const payload = JSON.parse(data) as {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string; result?: string};
+          appendToolEvent(sessionId, payload);
           setRequestState((prev) => ({
             ...prev,
             status: prev.status === 'connecting' ? 'streaming' : prev.status,
@@ -864,7 +894,6 @@ export default function ConsolePage(): React.JSX.Element {
 
     setComposer('');
     setImageAttachment(null);
-    setToolEvents([]);
     setRequestState({
       status: 'connecting',
       startedAt: now,
@@ -1292,7 +1321,6 @@ export default function ConsolePage(): React.JSX.Element {
       }
       return next;
     });
-    setToolEvents([]);
     setRequestState({status: 'idle'});
   }
 
@@ -1301,7 +1329,6 @@ export default function ConsolePage(): React.JSX.Element {
     setSessions((prev) => [session, ...prev]);
     setCurrentSessionId(session.id);
     setComposer('');
-    setToolEvents([]);
     setRequestState({status: 'idle'});
   }
 
@@ -1317,11 +1344,11 @@ export default function ConsolePage(): React.JSX.Element {
       title: '新会话',
       updatedAt: Date.now(),
       messages: [],
+      toolEvents: [],
       serverSessionId: undefined,
       totalUsage: undefined,
     }));
     setComposer('');
-    setToolEvents([]);
     setRequestState({status: 'idle'});
   }
 
@@ -1429,7 +1456,6 @@ export default function ConsolePage(): React.JSX.Element {
                     className={styles.sessionContent}
                     onClick={() => {
                       setCurrentSessionId(session.id);
-                      setToolEvents([]);
                       setRequestState({status: 'idle'});
                     }}
                   >
@@ -1779,7 +1805,16 @@ hermes gateway`}</code>
                       </div>
                       {event.label && <p className={styles.traceLabel}>{event.label}</p>}
                       {event.args && (
-                        <pre className={styles.traceArgs}>{event.args}</pre>
+                        <>
+                          <p className={styles.traceMetaLabel}>输入</p>
+                          <pre className={styles.traceArgs}>{event.args}</pre>
+                        </>
+                      )}
+                      {event.result && (
+                        <>
+                          <p className={styles.traceMetaLabel}>输出</p>
+                          <pre className={styles.traceArgs}>{event.result}</pre>
+                        </>
                       )}
                     </div>
                   ))

--- a/website/src/pages/console/index.tsx
+++ b/website/src/pages/console/index.tsx
@@ -1,0 +1,1803 @@
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+import Layout from '@theme/Layout';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+type MessageRole = 'user' | 'assistant' | 'error';
+type RunStatus = 'idle' | 'connecting' | 'streaming' | 'complete' | 'error' | 'cancelled';
+
+interface ChatMessage {
+  id: string;
+  role: MessageRole;
+  content: string;
+  createdAt: number;
+  pending?: boolean;
+}
+
+interface ConsoleSession {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: ChatMessage[];
+  serverSessionId?: string;
+  totalUsage?: Usage;
+}
+
+interface ToolEvent {
+  id: string;
+  type: 'started' | 'completed';
+  tool: string;
+  label: string;
+  emoji?: string;
+  timestamp: number;
+  duration?: number;
+  error?: boolean;
+  args?: string;
+}
+
+interface ImageAttachment {
+  name: string;
+  dataUrl: string;
+  size: number;
+}
+
+interface Usage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface RequestState {
+  status: RunStatus;
+  startedAt?: number;
+  endedAt?: number;
+  usage?: Usage;
+  error?: string;
+}
+
+interface ConsoleSettings {
+  endpoint: string;
+  apiKey: string;
+  model: string;
+  systemPrompt: string;
+  stream: boolean;
+  personality: string;
+  reasoning: string;
+  yolo: boolean;
+}
+
+interface ConnectionState {
+  state: 'idle' | 'probing' | 'ready' | 'error';
+  message: string;
+}
+
+const STORAGE_KEY = 'hermes-web-console:v1';
+const DEFAULT_MODEL = 'hermes-agent';
+const DEFAULT_SETTINGS: ConsoleSettings = {
+  endpoint: 'http://localhost:8642/v1',
+  apiKey: 'change-me-local-dev',
+  model: DEFAULT_MODEL,
+  systemPrompt: '',
+  stream: true,
+  personality: '',
+  reasoning: 'medium',
+  yolo: false,
+};
+
+const PERSONALITIES: {name: string; label: string; prompt: string}[] = [
+  {name: 'default', label: '默认', prompt: ''},
+  {name: 'concise', label: '简洁', prompt: 'Be concise. Respond with the minimum necessary words. No fluff, no filler.'},
+  {name: 'expert', label: '专家', prompt: 'You are a senior staff engineer. Provide thorough, technically precise responses with concrete examples and edge-case analysis.'},
+  {name: 'teacher', label: '教师', prompt: 'Explain concepts step by step as if teaching a student. Use analogies and examples.'},
+  {name: 'creative', label: '创意', prompt: 'Be creative, think outside the box. Explore unconventional approaches and novel solutions.'},
+  {name: 'reviewer', label: '审查员', prompt: 'Act as a meticulous code reviewer. Focus on correctness, security, performance, and maintainability.'},
+];
+
+const REASONING_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+
+const QUICK_PROMPTS = [
+  '检查当前项目并总结整体架构。',
+  '列出可用工具，并说明各自适合的场景。',
+  '审查仓库里的新手入门问题。',
+  '为当前分支起草一份发布检查清单。',
+];
+
+const SLASH_COMMANDS = [
+  {name: '/help', description: '显示可用命令列表'},
+  {name: '/clear', description: '清空当前会话'},
+  {name: '/new', description: '创建新会话'},
+  {name: '/retry', description: '重新发送上一条消息'},
+  {name: '/undo', description: '撤销最近一轮对话'},
+  {name: '/title', description: '设置会话标题 (/title 新标题)'},
+  {name: '/usage', description: '显示当前会话 Token 用量'},
+  {name: '/model', description: '显示/切换模型信息'},
+  {name: '/tools', description: '显示工具执行记录'},
+  {name: '/status', description: '显示会话详细状态'},
+  {name: '/personality', description: '切换人格预设 (/personality expert)'},
+  {name: '/reasoning', description: '设置推理深度 (/reasoning high)'},
+  {name: '/yolo', description: '切换 YOLO 模式 (跳过确认)'},
+  {name: '/export', description: '导出当前会话为 JSON'},
+];
+
+function makeId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createSession(): ConsoleSession {
+  const now = Date.now();
+  return {
+    id: makeId('session'),
+    title: '新会话',
+    createdAt: now,
+    updatedAt: now,
+    messages: [],
+  };
+}
+
+function normalizeEndpoint(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+function extractHost(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '--';
+  }
+  try {
+    const url = new URL(trimmed.includes('://') ? trimmed : `http://${trimmed}`);
+    return url.host;
+  } catch {
+    return trimmed;
+  }
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const diffSeconds = Math.max(1, Math.round((Date.now() - timestamp) / 1000));
+  if (diffSeconds < 60) {
+    return `${diffSeconds} 秒前`;
+  }
+  const diffMinutes = Math.round(diffSeconds / 60);
+  if (diffMinutes < 60) {
+    return `${diffMinutes} 分钟前`;
+  }
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `${diffHours} 小时前`;
+  }
+  return `${Math.round(diffHours / 24)} 天前`;
+}
+
+function formatDuration(state: RequestState): string {
+  if (!state.startedAt) {
+    return '空闲';
+  }
+  const end = state.endedAt ?? Date.now();
+  const diff = Math.max(0, end - state.startedAt);
+  if (diff < 1000) {
+    return `${diff} ms`;
+  }
+  return `${(diff / 1000).toFixed(diff < 10000 ? 1 : 0)} s`;
+}
+
+function summarizeSessionTitle(input: string): string {
+  const compact = input.trim().replace(/\s+/g, ' ');
+  if (!compact) {
+    return '新会话';
+  }
+  return compact.length > 44 ? `${compact.slice(0, 44)}...` : compact;
+}
+
+function formatRole(role: MessageRole): string {
+  switch (role) {
+    case 'user':
+      return '用户';
+    case 'assistant':
+      return 'Hermes';
+    case 'error':
+      return '错误';
+    default:
+      return role;
+  }
+}
+
+function formatRunStatus(status: RunStatus): string {
+  switch (status) {
+    case 'idle':
+      return '空闲';
+    case 'connecting':
+      return '连接中';
+    case 'streaming':
+      return '流式返回中';
+    case 'complete':
+      return '已完成';
+    case 'error':
+      return '失败';
+    case 'cancelled':
+      return '已取消';
+    default:
+      return status;
+  }
+}
+
+function buildRequestMessages(
+  messages: ChatMessage[],
+  systemPrompt: string,
+): Array<{role: 'system' | 'user' | 'assistant'; content: string}> {
+  const history: Array<{role: 'user' | 'assistant'; content: string}> = messages
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .map((message) => ({
+      role: message.role === 'user' ? 'user' : 'assistant',
+      content: message.content,
+    }));
+
+  if (!systemPrompt.trim()) {
+    return history;
+  }
+
+  return [
+    {role: 'system', content: systemPrompt.trim()},
+    ...history,
+  ];
+}
+
+function parseErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload && 'error' in payload) {
+    const inner = (payload as {error?: {message?: string}}).error;
+    if (inner?.message) {
+      return inner.message;
+    }
+  }
+  return fallback;
+}
+
+function accumulateUsage(prev: Usage | undefined, delta: Usage | undefined): Usage {
+  if (!delta) {
+    return prev ?? {};
+  }
+  return {
+    prompt_tokens: (prev?.prompt_tokens ?? 0) + (delta.prompt_tokens ?? 0),
+    completion_tokens: (prev?.completion_tokens ?? 0) + (delta.completion_tokens ?? 0),
+    total_tokens: (prev?.total_tokens ?? 0) + (delta.total_tokens ?? 0),
+  };
+}
+
+function renderInlineTokens(text: string): React.ReactNode[] {
+  // Handle: **bold**, *italic*, `inline code`, [link](url)
+  const regex = /(\*\*[^*]+\*\*|\*[^*]+\*|`[^`\n]+`|\[[^\]]+\]\([^)]+\))/g;
+  const parts = text.split(regex);
+  return parts.map((part, i) => {
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return <strong key={i}>{part.slice(2, -2)}</strong>;
+    }
+    if (part.startsWith('*') && part.endsWith('*') && !part.startsWith('**')) {
+      return <em key={i}>{part.slice(1, -1)}</em>;
+    }
+    if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+      return <code key={i} className={styles.inlineCode}>{part.slice(1, -1)}</code>;
+    }
+    const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (linkMatch) {
+      return <a key={i} className={styles.mdLink} href={linkMatch[2]} target="_blank" rel="noopener noreferrer">{linkMatch[1]}</a>;
+    }
+    return part;
+  });
+}
+
+function CodeBlock({lang, code}: {lang: string; code: string}): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy(): void {
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <pre className={styles.codeBlock}>
+      <div className={styles.codeHeader}>
+        {lang ? <span className={styles.codeLang}>{lang}</span> : <span />}
+        <button type="button" className={styles.codeCopyBtn} onClick={handleCopy}>
+          {copied ? '已复制' : '复制'}
+        </button>
+      </div>
+      <code>{code}</code>
+    </pre>
+  );
+}
+
+function renderBlock(line: string, key: string | number): React.ReactNode {
+  // Headings
+  const headingMatch = line.match(/^(#{1,4})\s+(.+)$/);
+  if (headingMatch) {
+    const level = headingMatch[1].length;
+    const Tag = `h${Math.min(level + 2, 6)}` as keyof React.JSX.IntrinsicElements;
+    return <Tag key={key} className={styles.mdHeading}>{renderInlineTokens(headingMatch[2])}</Tag>;
+  }
+  // Horizontal rule
+  if (/^[-*_]{3,}\s*$/.test(line)) {
+    return <hr key={key} className={styles.mdHr} />;
+  }
+  return null;
+}
+
+function renderMessageContent(content: string): React.ReactNode {
+  if (!content) {
+    return null;
+  }
+
+  // Split by fenced code blocks first
+  const segments = content.split(/(```[\s\S]*?```)/g);
+  const elements: React.ReactNode[] = [];
+
+  segments.forEach((segment, segIdx) => {
+    if (segment.startsWith('```') && segment.endsWith('```')) {
+      const body = segment.slice(3, -3);
+      const nlPos = body.indexOf('\n');
+      const lang = nlPos >= 0 ? body.slice(0, nlPos).trim() : '';
+      const code = nlPos >= 0 ? body.slice(nlPos + 1) : body;
+      elements.push(<CodeBlock key={`code-${segIdx}`} lang={lang} code={code} />);
+      return;
+    }
+
+    if (!segment.trim()) {
+      return;
+    }
+
+    // Process line-level markdown within non-code segments
+    const lines = segment.split('\n');
+    let listBuffer: {ordered: boolean; items: string[]} | null = null;
+
+    const flushList = (): void => {
+      if (!listBuffer) {
+        return;
+      }
+      const Tag = listBuffer.ordered ? 'ol' : 'ul';
+      elements.push(
+        <Tag key={`list-${segIdx}-${elements.length}`} className={styles.mdList}>
+          {listBuffer.items.map((item, li) => (
+            <li key={li}>{renderInlineTokens(item)}</li>
+          ))}
+        </Tag>,
+      );
+      listBuffer = null;
+    };
+
+    lines.forEach((line, lineIdx) => {
+      const lineKey = `${segIdx}-${lineIdx}`;
+
+      // Unordered list item
+      const ulMatch = line.match(/^(\s*)[-*+]\s+(.+)$/);
+      if (ulMatch) {
+        if (listBuffer && listBuffer.ordered) {
+          flushList();
+        }
+        if (!listBuffer) {
+          listBuffer = {ordered: false, items: []};
+        }
+        listBuffer.items.push(ulMatch[2]);
+        return;
+      }
+
+      // Ordered list item
+      const olMatch = line.match(/^(\s*)\d+[.)]\s+(.+)$/);
+      if (olMatch) {
+        if (listBuffer && !listBuffer.ordered) {
+          flushList();
+        }
+        if (!listBuffer) {
+          listBuffer = {ordered: true, items: []};
+        }
+        listBuffer.items.push(olMatch[2]);
+        return;
+      }
+
+      flushList();
+
+      // Block-level elements
+      const block = renderBlock(line, lineKey);
+      if (block) {
+        elements.push(block);
+        return;
+      }
+
+      // Plain text (preserve whitespace/newlines)
+      if (line === '') {
+        elements.push(<br key={lineKey} />);
+      } else {
+        elements.push(
+          <span key={lineKey} className={styles.proseText}>
+            {renderInlineTokens(line)}
+            {'\n'}
+          </span>,
+        );
+      }
+    });
+
+    flushList();
+  });
+
+  return <div className={styles.mdBody}>{elements}</div>;
+}
+
+export default function ConsolePage(): React.JSX.Element {
+  const [hydrated, setHydrated] = useState(false);
+  const [sessions, setSessions] = useState<ConsoleSession[]>([]);
+  const [currentSessionId, setCurrentSessionId] = useState<string>('');
+  const [settings, setSettings] = useState<ConsoleSettings>(DEFAULT_SETTINGS);
+  const [composer, setComposer] = useState('');
+  const [toolEvents, setToolEvents] = useState<ToolEvent[]>([]);
+  const [requestState, setRequestState] = useState<RequestState>({status: 'idle'});
+  const [connectionState, setConnectionState] = useState<ConnectionState>({
+    state: 'idle',
+    message: '等待连接检测',
+  });
+  const [models, setModels] = useState<string[]>([DEFAULT_MODEL]);
+  const [backendMeta, setBackendMeta] = useState<{provider: string; model: string} | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const messagesRef = useRef<HTMLDivElement | null>(null);
+  const userScrolledUpRef = useRef(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [imageAttachment, setImageAttachment] = useState<ImageAttachment | null>(null);
+  const [sessionSearch, setSessionSearch] = useState('');
+  const [showSlashMenu, setShowSlashMenu] = useState(false);
+  const [slashFilter, setSlashFilter] = useState('');
+  const [slashSelectedIdx, setSlashSelectedIdx] = useState(0);
+
+  useEffect(() => {
+    setHydrated(true);
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        const session = createSession();
+        setSessions([session]);
+        setCurrentSessionId(session.id);
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as {
+        settings?: ConsoleSettings;
+        sessions?: ConsoleSession[];
+        currentSessionId?: string;
+      };
+
+      const restoredSessions = (parsed.sessions?.length ? parsed.sessions : [createSession()]).map((session) => ({
+        ...session,
+        title: session.title === 'New thread' ? '新会话' : session.title,
+      }));
+      const restoredSettings = parsed.settings ? {...DEFAULT_SETTINGS, ...parsed.settings} : DEFAULT_SETTINGS;
+
+      setSessions(restoredSessions);
+      setSettings(restoredSettings);
+      setCurrentSessionId(parsed.currentSessionId && restoredSessions.some((item) => item.id === parsed.currentSessionId)
+        ? parsed.currentSessionId
+        : restoredSessions[0].id);
+    } catch {
+      const session = createSession();
+      setSessions([session]);
+      setCurrentSessionId(session.id);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated || typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        settings,
+        sessions,
+        currentSessionId,
+      }),
+    );
+  }, [currentSessionId, hydrated, sessions, settings]);
+
+  const currentSession = useMemo(
+    () => sessions.find((session) => session.id === currentSessionId) ?? sessions[0],
+    [currentSessionId, sessions],
+  );
+
+  useEffect(() => {
+    if (!currentSession && sessions.length) {
+      setCurrentSessionId(sessions[0].id);
+    }
+  }, [currentSession, sessions]);
+
+  function scrollMessagesToBottom(instant?: boolean): void {
+    const container = messagesRef.current;
+    if (!container) {
+      return;
+    }
+    if (instant) {
+      container.scrollTop = container.scrollHeight;
+    } else {
+      container.scrollTo({top: container.scrollHeight, behavior: 'smooth'});
+    }
+  }
+
+  function handleMessagesScroll(): void {
+    const container = messagesRef.current;
+    if (!container) {
+      return;
+    }
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    userScrolledUpRef.current = distanceFromBottom > 120;
+  }
+
+  useEffect(() => {
+    if (userScrolledUpRef.current) {
+      return;
+    }
+    // Streaming: instant scroll so it keeps up; otherwise smooth
+    scrollMessagesToBottom(requestState.status === 'streaming');
+  }, [currentSession?.messages, requestState.status, toolEvents]);
+
+  // Always scroll to bottom when user sends a new message
+  useEffect(() => {
+    if (requestState.status === 'connecting') {
+      userScrolledUpRef.current = false;
+      scrollMessagesToBottom(true);
+    }
+  }, [requestState.status]);
+
+  const transcriptCount = currentSession?.messages.filter((message) => message.role !== 'error').length ?? 0;
+  const endpoint = normalizeEndpoint(settings.endpoint);
+
+  function patchSession(sessionId: string, updater: (session: ConsoleSession) => ConsoleSession): void {
+    setSessions((prev) => prev.map((session) => (
+      session.id === sessionId ? updater(session) : session
+    )));
+  }
+
+  function patchCurrentSession(updater: (session: ConsoleSession) => ConsoleSession): void {
+    if (!currentSessionId) {
+      return;
+    }
+    patchSession(currentSessionId, updater);
+  }
+
+  function patchMessage(
+    sessionId: string,
+    messageId: string,
+    updater: (message: ChatMessage) => ChatMessage,
+  ): void {
+    patchSession(sessionId, (session) => ({
+      ...session,
+      updatedAt: Date.now(),
+      messages: session.messages.map((message) => (
+        message.id === messageId ? updater(message) : message
+      )),
+    }));
+  }
+
+  function appendToolEvent(event: {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string}): void {
+    if (event.type === 'completed') {
+      setToolEvents((prev) => {
+        const idx = prev.findIndex((e) => e.tool === event.tool && e.type === 'started');
+        if (idx >= 0) {
+          const updated = [...prev];
+          updated[idx] = {
+            ...updated[idx],
+            type: 'completed',
+            duration: event.duration,
+            error: event.error,
+          };
+          return updated;
+        }
+        return [
+          {id: makeId('tool'), type: 'completed', tool: event.tool, label: event.label ?? event.tool, emoji: event.emoji, timestamp: Date.now(), duration: event.duration, error: event.error},
+          ...prev,
+        ];
+      });
+      return;
+    }
+    setToolEvents((prev) => [
+      {
+        id: makeId('tool'),
+        type: 'started',
+        tool: event.tool,
+        label: event.label ?? event.tool,
+        emoji: event.emoji,
+        timestamp: Date.now(),
+        args: event.args,
+      },
+      ...prev,
+    ]);
+  }
+
+  async function probeModels(): Promise<void> {
+    if (!endpoint || !settings.apiKey.trim()) {
+      setConnectionState({
+        state: 'error',
+        message: '请先填写接口地址和 API Key。',
+      });
+      return;
+    }
+
+    setConnectionState({
+      state: 'probing',
+      message: '正在检查 /v1/models ...',
+    });
+
+    try {
+      const response = await fetch(`${endpoint}/models`, {
+        headers: {
+          Authorization: `Bearer ${settings.apiKey.trim()}`,
+        },
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Model probe failed with ${response.status}`));
+      }
+
+      const dataItems = Array.isArray(payload?.data) ? payload.data : [];
+
+      const ids = dataItems
+        .map((item: {id?: string}) => item?.id)
+        .filter((value: unknown): value is string => typeof value === 'string' && Boolean(value));
+
+      const firstItem = dataItems[0] as {meta?: {provider?: string; model?: string}} | undefined;
+      if (firstItem?.meta?.provider && firstItem?.meta?.model) {
+        setBackendMeta({provider: firstItem.meta.provider, model: firstItem.meta.model});
+      } else {
+        setBackendMeta(null);
+      }
+
+      const nextModels = ids.length ? ids : [DEFAULT_MODEL];
+      setModels(nextModels);
+      setSettings((prev) => ({
+        ...prev,
+        model: nextModels.includes(prev.model) ? prev.model : nextModels[0],
+      }));
+      setConnectionState({
+        state: 'ready',
+        message: `已连接，发现 ${nextModels.length} 个模型。`,
+      });
+    } catch (error) {
+      setConnectionState({
+        state: 'error',
+        message: error instanceof Error ? error.message : '无法连接 Hermes API Server。',
+      });
+    }
+  }
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    void probeModels();
+  }, [hydrated]);
+
+  async function consumeStreamingResponse(
+    response: Response,
+    sessionId: string,
+    assistantMessageId: string,
+  ): Promise<void> {
+    if (!response.body) {
+      throw new Error('流式响应体不存在。');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let assistantText = '';
+    let finalUsage: Usage | undefined;
+
+    const handleEvent = (rawEvent: string): boolean => {
+      const lines = rawEvent.split(/\r?\n/);
+      let eventName = 'message';
+      const dataLines: string[] = [];
+
+      for (const line of lines) {
+        if (!line || line.startsWith(':')) {
+          continue;
+        }
+        if (line.startsWith('event:')) {
+          eventName = line.slice(6).trim();
+          continue;
+        }
+        if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+
+      if (!dataLines.length) {
+        return false;
+      }
+
+      const data = dataLines.join('\n');
+      if (data === '[DONE]') {
+        return true;
+      }
+
+      if (eventName === 'hermes.tool.progress') {
+        try {
+          const payload = JSON.parse(data) as {type?: string; tool: string; label?: string; emoji?: string; duration?: number; error?: boolean; args?: string};
+          appendToolEvent(payload);
+          setRequestState((prev) => ({
+            ...prev,
+            status: prev.status === 'connecting' ? 'streaming' : prev.status,
+          }));
+        } catch {
+          // Ignore malformed tool events; they are auxiliary.
+        }
+        return false;
+      }
+
+      const payload = JSON.parse(data) as {
+        choices?: Array<{delta?: {content?: string}; finish_reason?: string | null}>;
+        usage?: Usage;
+      };
+      const delta = payload.choices?.[0]?.delta?.content;
+
+      if (delta) {
+        assistantText += delta;
+        patchMessage(sessionId, assistantMessageId, (message) => ({
+          ...message,
+          content: assistantText,
+          pending: true,
+        }));
+        setRequestState((prev) => ({
+          ...prev,
+          status: 'streaming',
+        }));
+      }
+
+      if (payload.usage) {
+        finalUsage = payload.usage;
+      }
+
+      return false;
+    };
+
+    while (true) {
+      const {value, done} = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, {stream: true}).replace(/\r\n/g, '\n');
+
+      let boundary = buffer.indexOf('\n\n');
+      while (boundary !== -1) {
+        const rawEvent = buffer.slice(0, boundary).trim();
+        buffer = buffer.slice(boundary + 2);
+        if (rawEvent) {
+          const reachedDone = handleEvent(rawEvent);
+          if (reachedDone) {
+            patchMessage(sessionId, assistantMessageId, (message) => ({
+              ...message,
+              pending: false,
+            }));
+            setRequestState((prev) => ({
+              ...prev,
+              status: 'complete',
+              endedAt: Date.now(),
+              usage: finalUsage,
+            }));
+            return;
+          }
+        }
+        boundary = buffer.indexOf('\n\n');
+      }
+    }
+
+    patchMessage(sessionId, assistantMessageId, (message) => ({
+      ...message,
+      pending: false,
+    }));
+    setRequestState((prev) => ({
+      ...prev,
+      status: 'complete',
+      endedAt: Date.now(),
+      usage: finalUsage,
+    }));
+  }
+
+  async function sendMessage(text: string): Promise<void> {
+    if (!currentSession || !text.trim() || requestState.status === 'connecting' || requestState.status === 'streaming') {
+      return;
+    }
+
+    if (!endpoint || !settings.apiKey.trim()) {
+      setConnectionState({
+        state: 'error',
+        message: '发送前请先填写接口地址和 API Key。',
+      });
+      return;
+    }
+
+    const sessionId = currentSession.id;
+    const now = Date.now();
+    const userMessage: ChatMessage = {
+      id: makeId('user'),
+      role: 'user',
+      content: imageAttachment ? `${text.trim()}\n\n📷 *已附加图片: ${imageAttachment.name}*` : text.trim(),
+      createdAt: now,
+    };
+
+    const assistantMessage: ChatMessage = {
+      id: makeId('assistant'),
+      role: 'assistant',
+      content: '',
+      createdAt: now,
+      pending: true,
+    };
+
+    const outboundMessages = buildRequestMessages(
+      [...currentSession.messages, userMessage],
+      settings.systemPrompt,
+    );
+
+    // If there's an image attachment, make the last user message multimodal
+    if (imageAttachment) {
+      const lastIdx = outboundMessages.length - 1;
+      if (lastIdx >= 0 && outboundMessages[lastIdx].role === 'user') {
+        (outboundMessages[lastIdx] as any).content = [
+          {type: 'image_url', image_url: {url: imageAttachment.dataUrl}},
+          {type: 'text', text: text.trim()},
+        ];
+      }
+    }
+
+    patchSession(sessionId, (session) => ({
+      ...session,
+      title: session.messages.length === 0 ? summarizeSessionTitle(text) : session.title,
+      updatedAt: now,
+      messages: [...session.messages, userMessage, assistantMessage],
+    }));
+
+    setComposer('');
+    setImageAttachment(null);
+    setToolEvents([]);
+    setRequestState({
+      status: 'connecting',
+      startedAt: now,
+    });
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const requestHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${settings.apiKey.trim()}`,
+      };
+      if (currentSession.serverSessionId) {
+        requestHeaders['X-Hermes-Session-Id'] = currentSession.serverSessionId;
+      }
+
+      const response = await fetch(`${endpoint}/chat/completions`, {
+        method: 'POST',
+        headers: requestHeaders,
+        body: JSON.stringify({
+          model: settings.model || DEFAULT_MODEL,
+          stream: settings.stream,
+          messages: outboundMessages,
+          ...(settings.reasoning && settings.reasoning !== 'medium' ? {reasoning_effort: settings.reasoning} : {}),
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        let message = `Request failed with ${response.status}`;
+        try {
+          const payload = await response.json();
+          message = parseErrorMessage(payload, message);
+        } catch {
+          const textPayload = await response.text();
+          if (textPayload) {
+            message = textPayload;
+          }
+        }
+        throw new Error(message);
+      }
+
+      const returnedSessionId = response.headers.get('X-Hermes-Session-Id');
+      if (returnedSessionId) {
+        patchSession(sessionId, (session) => ({...session, serverSessionId: returnedSessionId}));
+      }
+
+      let requestUsage: Usage | undefined;
+
+      if (settings.stream) {
+        await consumeStreamingResponse(response, sessionId, assistantMessage.id);
+        // Read usage that was set during streaming
+        setRequestState((prev) => {
+          requestUsage = prev.usage;
+          return prev;
+        });
+      } else {
+        const payload = await response.json();
+        const content = payload?.choices?.[0]?.message?.content ?? '（未生成回复）';
+        requestUsage = payload?.usage;
+        patchMessage(sessionId, assistantMessage.id, (message) => ({
+          ...message,
+          content,
+          pending: false,
+        }));
+        setRequestState({
+          status: 'complete',
+          startedAt: now,
+          endedAt: Date.now(),
+          usage: requestUsage,
+        });
+      }
+
+      // Accumulate token usage into session for persistent tracking
+      if (requestUsage) {
+        patchSession(sessionId, (session) => ({
+          ...session,
+          totalUsage: accumulateUsage(session.totalUsage, requestUsage),
+        }));
+      }
+
+      setConnectionState({
+        state: 'ready',
+        message: '连接正常，可继续对话。',
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        patchMessage(sessionId, assistantMessage.id, (message) => ({
+          ...message,
+          pending: false,
+          content: message.content || '本次运行已取消。',
+        }));
+        setRequestState((prev) => ({
+          ...prev,
+          status: 'cancelled',
+          endedAt: Date.now(),
+        }));
+      } else {
+        const message = error instanceof Error ? error.message : '请求失败。';
+        patchMessage(sessionId, assistantMessage.id, () => ({
+          id: assistantMessage.id,
+          role: 'error',
+          content: message,
+          createdAt: now,
+          pending: false,
+        }));
+        setRequestState({
+          status: 'error',
+          startedAt: now,
+          endedAt: Date.now(),
+          error: message,
+        });
+        setConnectionState({
+          state: 'error',
+          message,
+        });
+      }
+    } finally {
+      abortRef.current = null;
+    }
+  }
+
+  // ── Slash commands ────────────────────────────────
+  const filteredSlashCommands = useMemo(() => {
+    if (!slashFilter) return SLASH_COMMANDS;
+    const q = slashFilter.toLowerCase();
+    return SLASH_COMMANDS.filter((cmd) => cmd.name.startsWith(q));
+  }, [slashFilter]);
+
+  function executeSlashCommand(command: string): void {
+    const parts = command.trim().split(/\s+/);
+    const cmd = parts[0].toLowerCase();
+    const arg = parts.slice(1).join(' ').trim();
+    const insertInfoMessage = (content: string): void => {
+      if (!currentSession) return;
+      const msg: ChatMessage = {
+        id: makeId('sys'),
+        role: 'assistant',
+        content,
+        createdAt: Date.now(),
+      };
+      patchCurrentSession((s) => ({
+        ...s,
+        updatedAt: Date.now(),
+        messages: [...s.messages, msg],
+      }));
+    };
+
+    if (cmd === '/help') {
+      const lines = SLASH_COMMANDS.map((c) => `\`${c.name}\` — ${c.description}`).join('\n- ');
+      insertInfoMessage(`## 📋 可用命令\n\n- ${lines}\n\n> 在输入框中键入 \`/\` 可快速选择命令。`);
+
+    } else if (cmd === '/clear') {
+      clearCurrentSession();
+
+    } else if (cmd === '/new') {
+      createNewSession();
+
+    } else if (cmd === '/retry') {
+      if (!currentSession) return;
+      const lastUserMsg = [...currentSession.messages].reverse().find((m) => m.role === 'user');
+      if (!lastUserMsg) {
+        insertInfoMessage('⚠️ 没有可重发的用户消息。');
+      } else {
+        // Remove the last user+assistant pair and resend
+        const msgs = currentSession.messages;
+        const lastUserIdx = msgs.lastIndexOf(lastUserMsg);
+        patchCurrentSession((s) => ({
+          ...s,
+          updatedAt: Date.now(),
+          messages: s.messages.slice(0, lastUserIdx),
+        }));
+        setComposer('');
+        setShowSlashMenu(false);
+        setTimeout(() => void sendMessage(lastUserMsg.content), 50);
+        return;
+      }
+
+    } else if (cmd === '/undo') {
+      if (!currentSession || currentSession.messages.length === 0) {
+        insertInfoMessage('⚠️ 没有可撤销的对话。');
+      } else {
+        // Remove last user+assistant pair
+        const msgs = [...currentSession.messages];
+        let removed = 0;
+        while (msgs.length > 0 && removed < 2) {
+          const last = msgs[msgs.length - 1];
+          if (last.role === 'user' || last.role === 'assistant') removed++;
+          msgs.pop();
+        }
+        patchCurrentSession((s) => ({
+          ...s,
+          updatedAt: Date.now(),
+          messages: msgs,
+        }));
+        insertInfoMessage('↩️ 已撤销最近一轮对话。');
+        return;
+      }
+
+    } else if (cmd === '/title') {
+      if (!arg) {
+        insertInfoMessage(`当前标题: **${currentSession?.title ?? '新会话'}**\n\n用法: \`/title 新标题\``);
+      } else {
+        patchCurrentSession((s) => ({...s, title: arg, updatedAt: Date.now()}));
+        insertInfoMessage(`✏️ 会话标题已更新为: **${arg}**`);
+      }
+
+    } else if (cmd === '/usage') {
+      const u = currentSession?.totalUsage;
+      const msgCount = currentSession?.messages.filter((m) => m.role !== 'error').length ?? 0;
+      insertInfoMessage(
+        `## 📊 Token 用量\n\n` +
+        `| 指标 | 值 |\n|------|------|\n` +
+        `| 输入 Token | ${u?.prompt_tokens?.toLocaleString() ?? '--'} |\n` +
+        `| 输出 Token | ${u?.completion_tokens?.toLocaleString() ?? '--'} |\n` +
+        `| 总计 Token | ${u?.total_tokens?.toLocaleString() ?? '--'} |\n` +
+        `| 会话消息数 | ${msgCount} |\n` +
+        `| 创建时间 | ${currentSession ? new Date(currentSession.createdAt).toLocaleString() : '--'} |`,
+      );
+
+    } else if (cmd === '/model') {
+      if (arg) {
+        // Switch model
+        if (models.includes(arg)) {
+          setSettings((prev) => ({...prev, model: arg}));
+          insertInfoMessage(`🤖 模型已切换为: **${arg}**`);
+        } else {
+          insertInfoMessage(`⚠️ 未知模型: \`${arg}\`\n\n可用模型: ${models.map((m) => `\`${m}\``).join(', ')}`);
+        }
+      } else {
+        insertInfoMessage(
+          `## 🤖 模型信息\n\n` +
+          `- **接口模型**: ${settings.model}\n` +
+          `- **提供商**: ${backendMeta?.provider ?? '未知'}\n` +
+          `- **实际模型**: ${backendMeta?.model ?? settings.model}\n` +
+          `- **端点**: ${settings.endpoint}\n` +
+          `- **可用模型**: ${models.map((m) => `\`${m}\``).join(', ')}`,
+        );
+      }
+
+    } else if (cmd === '/tools') {
+      if (!toolEvents.length) {
+        insertInfoMessage('## 🔧 工具记录\n\n当前会话暂无工具执行记录。');
+      } else {
+        const lines = toolEvents.slice(0, 30).map((e) => {
+          const status = e.error ? '❌' : e.type === 'completed' ? '✅' : '⏳';
+          const dur = e.duration != null ? ` (${e.duration.toFixed(1)}s)` : '';
+          return `- ${status} ${e.emoji ?? '🔧'} **${e.tool}**${dur} — ${e.label}`;
+        }).join('\n');
+        insertInfoMessage(`## 🔧 工具执行记录 (最近 ${Math.min(toolEvents.length, 30)} 条)\n\n${lines}`);
+      }
+
+    } else if (cmd === '/status') {
+      const session = currentSession;
+      const u = session?.totalUsage;
+      insertInfoMessage(
+        `## 📋 会话状态\n\n` +
+        `- **会话 ID**: \`${session?.id ?? '--'}\`\n` +
+        `- **服务端 Session**: \`${session?.serverSessionId ?? '未建立'}\`\n` +
+        `- **标题**: ${session?.title ?? '--'}\n` +
+        `- **消息数**: ${session?.messages.length ?? 0}\n` +
+        `- **累计 Token**: ${u?.total_tokens?.toLocaleString() ?? '--'}\n` +
+        `- **创建时间**: ${session ? new Date(session.createdAt).toLocaleString() : '--'}\n` +
+        `- **最后更新**: ${session ? new Date(session.updatedAt).toLocaleString() : '--'}\n` +
+        `- **流式模式**: ${settings.stream ? '✅ 开启' : '❌ 关闭'}\n` +
+        `- **YOLO 模式**: ${settings.yolo ? '✅ 开启' : '❌ 关闭'}\n` +
+        `- **人格**: ${settings.personality || '默认'}\n` +
+        `- **推理深度**: ${settings.reasoning}\n` +
+        `- **连接状态**: ${connectionState.message}`,
+      );
+
+    } else if (cmd === '/personality') {
+      if (!arg) {
+        const lines = PERSONALITIES.map((p) => `- \`${p.name}\` — ${p.label}${settings.personality === p.name ? ' ✅ 当前' : ''}`).join('\n');
+        insertInfoMessage(`## 🎭 人格预设\n\n${lines}\n\n用法: \`/personality <name>\``);
+      } else {
+        const match = PERSONALITIES.find((p) => p.name === arg.toLowerCase());
+        if (match) {
+          setSettings((prev) => ({
+            ...prev,
+            personality: match.name,
+            systemPrompt: match.prompt,
+          }));
+          insertInfoMessage(`🎭 已切换人格为: **${match.label}** (${match.name})`);
+        } else {
+          insertInfoMessage(`⚠️ 未知人格: \`${arg}\`\n\n可用: ${PERSONALITIES.map((p) => `\`${p.name}\``).join(', ')}`);
+        }
+      }
+
+    } else if (cmd === '/reasoning') {
+      if (!arg) {
+        insertInfoMessage(`## 🧠 推理深度\n\n当前: **${settings.reasoning}**\n\n可用级别: ${REASONING_LEVELS.map((l) => `\`${l}\``).join(', ')}\n\n用法: \`/reasoning <level>\``);
+      } else {
+        const level = arg.toLowerCase();
+        if ((REASONING_LEVELS as readonly string[]).includes(level)) {
+          setSettings((prev) => ({...prev, reasoning: level}));
+          insertInfoMessage(`🧠 推理深度已设为: **${level}**`);
+        } else {
+          insertInfoMessage(`⚠️ 未知推理级别: \`${arg}\`\n\n可用: ${REASONING_LEVELS.map((l) => `\`${l}\``).join(', ')}`);
+        }
+      }
+
+    } else if (cmd === '/yolo') {
+      setSettings((prev) => ({...prev, yolo: !prev.yolo}));
+      insertInfoMessage(`⚡ YOLO 模式已${settings.yolo ? '关闭' : '开启'}。${!settings.yolo ? '\n\n> 危险操作将不再弹出确认提示。' : ''}`);
+
+    } else if (cmd === '/export') {
+      if (!currentSession) return;
+      const exportData = {
+        id: currentSession.id,
+        title: currentSession.title,
+        createdAt: new Date(currentSession.createdAt).toISOString(),
+        updatedAt: new Date(currentSession.updatedAt).toISOString(),
+        messages: currentSession.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          createdAt: new Date(m.createdAt).toISOString(),
+        })),
+        totalUsage: currentSession.totalUsage,
+        settings: {
+          model: settings.model,
+          personality: settings.personality,
+          reasoning: settings.reasoning,
+        },
+      };
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], {type: 'application/json'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `hermes-session-${currentSession.id}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      insertInfoMessage(`📥 会话已导出为 \`hermes-session-${currentSession.id}.json\``);
+
+    } else {
+      insertInfoMessage(`未知命令: \`${cmd}\`\n\n输入 \`/help\` 查看可用命令。`);
+    }
+    setComposer('');
+    setShowSlashMenu(false);
+  }
+
+  // ── Image handling ──────────────────────────────────
+  function handleImageUpload(event: React.ChangeEvent<HTMLInputElement>): void {
+    const file = event.target.files?.[0];
+    if (!file || !file.type.startsWith('image/')) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setImageAttachment({name: file.name, dataUrl: e.target?.result as string, size: file.size});
+    };
+    reader.readAsDataURL(file);
+    event.target.value = '';
+  }
+
+  function handleComposerPaste(event: React.ClipboardEvent): void {
+    const items = event.clipboardData.items;
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        event.preventDefault();
+        const file = item.getAsFile();
+        if (!file) continue;
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          setImageAttachment({name: file.name || 'clipboard.png', dataUrl: e.target?.result as string, size: file.size});
+        };
+        reader.readAsDataURL(file);
+        break;
+      }
+    }
+  }
+
+  function handleComposerKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>): void {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+    // Slash menu keyboard navigation
+    if (showSlashMenu && filteredSlashCommands.length > 0) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setSlashSelectedIdx((prev) => Math.min(prev + 1, filteredSlashCommands.length - 1));
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setSlashSelectedIdx((prev) => Math.max(prev - 1, 0));
+        return;
+      }
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        executeSlashCommand(filteredSlashCommands[slashSelectedIdx].name);
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setShowSlashMenu(false);
+        return;
+      }
+    }
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      if (composer.startsWith('/')) {
+        executeSlashCommand(composer.trim());
+      } else {
+        void sendMessage(composer);
+      }
+    }
+  }
+
+  function deleteSession(sessionId: string): void {
+    if (requestState.status === 'streaming' || requestState.status === 'connecting') {
+      if (sessionId === currentSessionId) {
+        stopCurrentRun();
+      }
+    }
+    setSessions((prev) => {
+      const next = prev.filter((session) => session.id !== sessionId);
+      if (!next.length) {
+        const fresh = createSession();
+        setCurrentSessionId(fresh.id);
+        return [fresh];
+      }
+      if (sessionId === currentSessionId) {
+        const sorted = [...next].sort((a, b) => b.updatedAt - a.updatedAt);
+        setCurrentSessionId(sorted[0].id);
+      }
+      return next;
+    });
+    setToolEvents([]);
+    setRequestState({status: 'idle'});
+  }
+
+  function createNewSession(): void {
+    const session = createSession();
+    setSessions((prev) => [session, ...prev]);
+    setCurrentSessionId(session.id);
+    setComposer('');
+    setToolEvents([]);
+    setRequestState({status: 'idle'});
+  }
+
+  function clearCurrentSession(): void {
+    if (!currentSession) {
+      return;
+    }
+    if (currentSession.messages.length > 0 && !window.confirm('确认清空当前会话的所有消息？')) {
+      return;
+    }
+    patchCurrentSession((session) => ({
+      ...session,
+      title: '新会话',
+      updatedAt: Date.now(),
+      messages: [],
+      serverSessionId: undefined,
+      totalUsage: undefined,
+    }));
+    setComposer('');
+    setToolEvents([]);
+    setRequestState({status: 'idle'});
+  }
+
+  function stopCurrentRun(): void {
+    abortRef.current?.abort();
+  }
+
+  const sessionItems = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+  const filteredSessions = useMemo(() => {
+    if (!sessionSearch.trim()) return sessionItems;
+    const q = sessionSearch.trim().toLowerCase();
+    return sessionItems.filter((s) =>
+      s.title.toLowerCase().includes(q) ||
+      s.messages.some((m) => m.content.toLowerCase().includes(q)),
+    );
+  }, [sessionItems, sessionSearch]);
+  const lastUsage = requestState.usage;
+  const totalUsage = currentSession?.totalUsage;
+
+  return (
+    <Layout
+      title="Hermes 网页控制台"
+      description="用于直连 Hermes API Server 的浏览器控制台。"
+    >
+      <div className={styles.page}>
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <span className={styles.heroEyebrow}>浏览器控制台</span>
+            <h1 className={styles.heroTitle}>Hermes 网页控制台</h1>
+            <p className={styles.heroText}>
+              一个面向操作者的中性色 Hermes 前端。会话保存在当前浏览器里，回复支持实时流式返回，
+              工具执行进度也能在右侧直接观察，不需要离开文档站。
+            </p>
+          </div>
+          <div className={styles.heroStats}>
+            <div className={styles.heroStat}>
+              <span className={styles.heroStatValue}>{backendMeta?.provider ?? extractHost(settings.endpoint)}</span>
+              <span className={styles.heroStatLabel}>提供商</span>
+            </div>
+            <div className={styles.heroStat}>
+              <span className={styles.heroStatValue}>{backendMeta?.model ?? settings.model ?? DEFAULT_MODEL}</span>
+              <span className={styles.heroStatLabel}>模型</span>
+            </div>
+            <div className={styles.heroStat}>
+              <span className={styles.heroStatValue}>
+                {sessionItems.length}
+                <span className={styles.heroStatSep}>/</span>
+                {transcriptCount}
+              </span>
+              <span className={styles.heroStatLabel}>会话 / 消息</span>
+            </div>
+            <div className={styles.heroStat}>
+              <span className={styles.heroStatValue}>
+                {totalUsage?.total_tokens != null
+                  ? totalUsage.total_tokens.toLocaleString()
+                  : '--'}
+              </span>
+              <span className={styles.heroStatLabel}>累计 Token</span>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.shell}>
+          <aside className={clsx(styles.panel, styles.sidebar)}>
+            <div className={styles.panelHeader}>
+              <div>
+                <p className={styles.panelEyebrow}>会话</p>
+                <h2 className={styles.panelTitle}>本地线程列表</h2>
+              </div>
+              <button className={styles.primaryButton} type="button" onClick={createNewSession}>
+                新建会话
+              </button>
+            </div>
+
+            <div className={styles.sessionSearchWrap}>
+              <input
+                type="text"
+                className={styles.sessionSearchInput}
+                placeholder="搜索会话..."
+                value={sessionSearch}
+                onChange={(e) => setSessionSearch(e.target.value)}
+              />
+              {sessionSearch && (
+                <button
+                  type="button"
+                  className={styles.sessionSearchClear}
+                  onClick={() => setSessionSearch('')}
+                >×</button>
+              )}
+            </div>
+
+            <div className={styles.sessionList}>
+              {filteredSessions.length === 0 && sessionSearch ? (
+                <div className={styles.traceEmpty} style={{textAlign: 'center', fontSize: '0.85rem'}}>
+                  未找到匹配的会话
+                </div>
+              ) : null}
+              {filteredSessions.map((session) => (
+                <div
+                  key={session.id}
+                  className={clsx(styles.sessionItem, session.id === currentSession?.id && styles.sessionItemActive)}
+                >
+                  <button
+                    type="button"
+                    className={styles.sessionContent}
+                    onClick={() => {
+                      setCurrentSessionId(session.id);
+                      setToolEvents([]);
+                      setRequestState({status: 'idle'});
+                    }}
+                  >
+                    <span className={styles.sessionTitle}>{session.title}</span>
+                    <span className={styles.sessionMeta}>
+                      {session.messages.length} 条消息 · {formatRelativeTime(session.updatedAt)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.sessionDeleteBtn}
+                    title="删除会话"
+                    onClick={() => deleteSession(session.id)}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.panelBlock}>
+              <p className={styles.blockLabel}>快捷提示</p>
+              <div className={styles.promptGrid}>
+                {QUICK_PROMPTS.map((prompt) => (
+                  <button
+                    key={prompt}
+                    type="button"
+                    className={styles.promptChip}
+                    onClick={() => setComposer(prompt)}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className={styles.panelBlock}>
+              <p className={styles.blockLabel}>启动检查</p>
+              <ul className={styles.checkList}>
+                <li>在 <code>~/.hermes/.env</code> 里设置 <code>API_SERVER_ENABLED=true</code>。</li>
+                <li>如果浏览器直接请求 Hermes，需要给当前来源开放 CORS。</li>
+                <li>启动 <code>hermes gateway</code>，然后检测 <code>/v1/models</code>。</li>
+              </ul>
+            </div>
+          </aside>
+
+          <main className={clsx(styles.panel, styles.chatPanel)}>
+            <div className={styles.chatHeader}>
+              <div>
+                <p className={styles.panelEyebrow}>对话</p>
+                <h2 className={styles.panelTitle}>{currentSession?.title ?? '新会话'}</h2>
+              </div>
+              <div className={styles.chatHeaderActions}>
+                <button className={styles.ghostButton} type="button" onClick={clearCurrentSession}>
+                  清空会话
+                </button>
+                {requestState.status === 'connecting' || requestState.status === 'streaming' ? (
+                  <button className={styles.dangerButton} type="button" onClick={stopCurrentRun}>
+                    停止运行
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className={styles.messages} ref={messagesRef} onScroll={handleMessagesScroll}>
+              {!currentSession?.messages.length ? (
+                <div className={styles.emptyState}>
+                  <span className={styles.emptyEyebrow}>等待第一轮输入</span>
+                  <h3>直接在浏览器里和 Hermes 对话。</h3>
+                  <p>
+                    这个页面会把 OpenAI 兼容请求直接发到 Hermes API Server。
+                    线程历史保存在当前浏览器里，而 Hermes 仍然使用完整工具集运行。
+                  </p>
+                  <pre className={styles.commandBlock}>
+                    <code>{`API_SERVER_ENABLED=true
+API_SERVER_KEY=change-me-local-dev
+API_SERVER_CORS_ORIGINS=http://localhost:3000
+hermes gateway`}</code>
+                  </pre>
+                </div>
+              ) : (
+                currentSession?.messages.map((message) => (
+                  <article
+                    key={message.id}
+                    className={clsx(
+                      styles.messageCard,
+                      message.role === 'user' && styles.messageUser,
+                      message.role === 'assistant' && styles.messageAssistant,
+                      message.role === 'error' && styles.messageError,
+                    )}
+                  >
+                    <div className={styles.messageHeader}>
+                      <span className={styles.messageRole}>{formatRole(message.role)}</span>
+                      <span className={styles.messageTime}>{new Date(message.createdAt).toLocaleTimeString()}</span>
+                    </div>
+                    <div className={styles.messageBody}>
+                      {message.content
+                        ? renderMessageContent(message.content)
+                        : (message.pending ? '正在等待回复...' : '')}
+                    </div>
+                    {message.pending ? <div className={styles.pendingBar} /> : null}
+                  </article>
+                ))
+              )}
+              <div ref={bottomRef} aria-hidden="true" />
+            </div>
+
+            <div className={styles.composerWrap}>
+              <label className={styles.composerLabel} htmlFor="hermes-console-composer">
+                输入消息
+              </label>
+
+              {/* Image preview */}
+              {imageAttachment && (
+                <div className={styles.imagePreview}>
+                  <img src={imageAttachment.dataUrl} alt={imageAttachment.name} className={styles.imagePreviewThumb} />
+                  <span className={styles.imagePreviewName}>{imageAttachment.name}</span>
+                  <span className={styles.imagePreviewSize}>
+                    {imageAttachment.size < 1024 * 1024
+                      ? `${(imageAttachment.size / 1024).toFixed(0)} KB`
+                      : `${(imageAttachment.size / 1024 / 1024).toFixed(1)} MB`}
+                  </span>
+                  <button type="button" className={styles.imageRemoveBtn} onClick={() => setImageAttachment(null)}>×</button>
+                </div>
+              )}
+
+              {/* Slash command menu */}
+              {showSlashMenu && filteredSlashCommands.length > 0 && (
+                <div className={styles.slashMenu}>
+                  {filteredSlashCommands.map((cmd, idx) => (
+                    <button
+                      key={cmd.name}
+                      type="button"
+                      className={clsx(styles.slashItem, idx === slashSelectedIdx && styles.slashItemActive)}
+                      onMouseEnter={() => setSlashSelectedIdx(idx)}
+                      onClick={() => executeSlashCommand(cmd.name)}
+                    >
+                      <span className={styles.slashName}>{cmd.name}</span>
+                      <span className={styles.slashDesc}>{cmd.description}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              <textarea
+                id="hermes-console-composer"
+                className={styles.composer}
+                rows={1}
+                value={composer}
+                placeholder="输入消息，或键入 / 使用命令..."
+                onChange={(event) => {
+                  const val = event.target.value;
+                  setComposer(val);
+                  // Slash command detection
+                  if (val.startsWith('/')) {
+                    setShowSlashMenu(true);
+                    setSlashFilter(val);
+                    setSlashSelectedIdx(0);
+                  } else {
+                    setShowSlashMenu(false);
+                  }
+                  // Auto-grow
+                  const el = event.target;
+                  el.style.height = 'auto';
+                  el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
+                }}
+                onKeyDown={handleComposerKeyDown}
+                onPaste={handleComposerPaste}
+              />
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                style={{display: 'none'}}
+                onChange={handleImageUpload}
+              />
+
+              <div className={styles.composerActions}>
+                <p className={styles.composerHint}>
+                  Enter 发送 · Shift+Enter 换行 · 键入 / 查看命令 · 可粘贴或上传图片
+                </p>
+                <div className={styles.composerButtons}>
+                  <button
+                    className={styles.ghostButton}
+                    type="button"
+                    title="上传图片"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    📎
+                  </button>
+                  <button
+                    className={styles.primaryButton}
+                    type="button"
+                    onClick={() => {
+                      if (composer.startsWith('/')) {
+                        executeSlashCommand(composer.trim());
+                      } else {
+                        void sendMessage(composer);
+                      }
+                    }}
+                    disabled={!composer.trim() || requestState.status === 'connecting' || requestState.status === 'streaming'}
+                  >
+                    发送
+                  </button>
+                </div>
+              </div>
+            </div>
+          </main>
+
+          <aside className={clsx(styles.panel, styles.inspector)}>
+            <div className={styles.panelHeader}>
+              <div>
+                <p className={styles.panelEyebrow}>运行时</p>
+                <h2 className={styles.panelTitle}>连接与执行追踪</h2>
+              </div>
+              <span
+                className={clsx(
+                  styles.statusBadge,
+                  connectionState.state === 'ready' && styles.statusReady,
+                  connectionState.state === 'probing' && styles.statusWorking,
+                  connectionState.state === 'error' && styles.statusError,
+                )}
+              >
+                {connectionState.message}
+              </span>
+            </div>
+
+            <div className={styles.formGrid}>
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>API 地址</span>
+                <input
+                  className={styles.fieldInput}
+                  type="text"
+                  value={settings.endpoint}
+                  onChange={(event) => setSettings((prev) => ({...prev, endpoint: event.target.value}))}
+                  placeholder="http://localhost:8642/v1"
+                />
+              </label>
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>API Key</span>
+                <input
+                  className={styles.fieldInput}
+                  type="password"
+                  value={settings.apiKey}
+                  onChange={(event) => setSettings((prev) => ({...prev, apiKey: event.target.value}))}
+                  placeholder="change-me-local-dev"
+                />
+              </label>
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>接口模型</span>
+                <div className={styles.modelRow}>
+                  <select
+                    className={styles.fieldInput}
+                    value={settings.model}
+                    onChange={(event) => setSettings((prev) => ({...prev, model: event.target.value}))}
+                  >
+                    {models.map((model) => (
+                      <option key={model} value={model}>
+                        {model}
+                      </option>
+                    ))}
+                  </select>
+                  <button className={styles.ghostButton} type="button" onClick={() => void probeModels()}>
+                    刷新
+                  </button>
+                </div>
+                {backendMeta ? (
+                  <span className={styles.fieldHint}>
+                    实际后端：{backendMeta.provider} / {backendMeta.model}
+                  </span>
+                ) : null}
+              </label>
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>系统提示词</span>
+                <textarea
+                  className={styles.fieldTextarea}
+                  rows={5}
+                  value={settings.systemPrompt}
+                  onChange={(event) => setSettings((prev) => ({...prev, systemPrompt: event.target.value}))}
+                  placeholder="可选。给这个浏览器客户端额外叠加的指令。"
+                />
+              </label>
+              <label className={styles.toggleRow}>
+                <input
+                  type="checkbox"
+                  checked={settings.stream}
+                  onChange={(event) => setSettings((prev) => ({...prev, stream: event.target.checked}))}
+                />
+                <span>启用流式返回</span>
+              </label>
+            </div>
+
+            <div className={styles.panelBlock}>
+              <p className={styles.blockLabel}>运行摘要</p>
+              <div className={styles.metricGrid}>
+                <div className={styles.metricCard}>
+                  <span className={styles.metricLabel}>状态</span>
+                  <span className={styles.metricValue}>{formatRunStatus(requestState.status)}</span>
+                </div>
+                <div className={styles.metricCard}>
+                  <span className={styles.metricLabel}>耗时</span>
+                  <span className={styles.metricValue}>{formatDuration(requestState)}</span>
+                </div>
+                <div className={styles.metricCard}>
+                  <span className={styles.metricLabel}>输入 Token</span>
+                  <span className={styles.metricValue}>{lastUsage?.prompt_tokens?.toLocaleString() ?? '--'}</span>
+                </div>
+                <div className={styles.metricCard}>
+                  <span className={styles.metricLabel}>输出 Token</span>
+                  <span className={styles.metricValue}>{lastUsage?.completion_tokens?.toLocaleString() ?? '--'}</span>
+                </div>
+              </div>
+
+              {requestState.error ? <p className={styles.errorNote}>{requestState.error}</p> : null}
+            </div>
+
+            <div className={styles.panelBlock}>
+              <p className={styles.blockLabel}>工具追踪</p>
+              <div className={styles.traceList}>
+                {!toolEvents.length ? (
+                  <div className={styles.traceEmpty}>
+                    Hermes 会把工具启动事件作为自定义 SSE 推送到这里展示，不会污染会话历史。
+                  </div>
+                ) : (
+                  toolEvents.map((event) => (
+                    <div
+                      key={event.id}
+                      className={clsx(
+                        styles.traceItem,
+                        event.type === 'completed' && !event.error && styles.traceDone,
+                        event.error && styles.traceError,
+                      )}
+                    >
+                      <div className={styles.traceHeading}>
+                        <span className={styles.traceTool}>
+                          {event.emoji ? `${event.emoji} ` : ''}
+                          {event.tool}
+                          {event.type === 'started' && <span className={styles.traceRunning}> ●</span>}
+                          {event.type === 'completed' && !event.error && <span className={styles.traceCheck}> ✓</span>}
+                          {event.error && <span className={styles.traceErrorMark}> ✗</span>}
+                        </span>
+                        <span className={styles.traceTime}>
+                          {event.duration != null ? `${event.duration.toFixed(1)}s · ` : ''}
+                          {new Date(event.timestamp).toLocaleTimeString()}
+                        </span>
+                      </div>
+                      {event.label && <p className={styles.traceLabel}>{event.label}</p>}
+                      {event.args && (
+                        <pre className={styles.traceArgs}>{event.args}</pre>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className={styles.panelBlock}>
+              <p className={styles.blockLabel}>浏览器说明</p>
+              <p className={styles.noteText}>
+                如果这个页面和 Hermes API Server 不在同一个来源下，请先设置
+                <code> API_SERVER_CORS_ORIGINS </code>
+                为当前文档站来源，再直接从浏览器发请求。
+              </p>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </Layout>
+  );
+}

--- a/website/src/pages/console/index.tsx
+++ b/website/src/pages/console/index.tsx
@@ -3,8 +3,10 @@ import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
-type MessageRole = 'user' | 'assistant' | 'error';
+type MessageRole = 'user' | 'assistant' | 'error' | 'system' | 'tool';
 type RunStatus = 'idle' | 'connecting' | 'streaming' | 'complete' | 'error' | 'cancelled';
+type SessionView = 'web' | 'gateway';
+type RemoteState = 'idle' | 'loading' | 'ready' | 'error';
 
 interface ChatMessage {
   id: string;
@@ -12,6 +14,7 @@ interface ChatMessage {
   content: string;
   createdAt: number;
   pending?: boolean;
+  toolName?: string;
 }
 
 interface ConsoleSession {
@@ -19,6 +22,8 @@ interface ConsoleSession {
   title: string;
   createdAt: number;
   updatedAt: number;
+  preview?: string;
+  messageCount?: number;
   messages: ChatMessage[];
   toolEvents: ToolEvent[];
   serverSessionId?: string;
@@ -36,6 +41,39 @@ interface ToolEvent {
   error?: boolean;
   args?: string;
   result?: string;
+}
+
+interface GatewaySessionSummary {
+  id: string;
+  source: string;
+  model?: string | null;
+  title?: string | null;
+  preview?: string;
+  started_at: number;
+  ended_at?: number | null;
+  last_active?: number;
+  message_count?: number;
+  is_active?: boolean;
+}
+
+interface GatewayMessageState {
+  status: RemoteState;
+  messages: ChatMessage[];
+  error?: string;
+  refreshedAt?: number;
+}
+
+interface LogViewerState {
+  file: string;
+  level: string;
+  component: string;
+  lines: number;
+  entries: string[];
+  status: RemoteState;
+  error?: string;
+  refreshedAt?: number;
+  availableFiles: string[];
+  availableComponents: string[];
 }
 
 interface ImageAttachment {
@@ -97,6 +135,17 @@ const PERSONALITIES: {name: string; label: string; prompt: string}[] = [
 ];
 
 const REASONING_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+const LOG_LEVEL_OPTIONS = ['', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] as const;
+const DEFAULT_LOG_STATE: LogViewerState = {
+  file: 'gateway',
+  level: '',
+  component: '',
+  lines: 160,
+  entries: [],
+  status: 'idle',
+  availableFiles: ['agent', 'errors', 'gateway'],
+  availableComponents: [],
+};
 
 const QUICK_PROMPTS = [
   '检查当前项目并总结整体架构。',
@@ -144,6 +193,14 @@ function normalizeEndpoint(input: string): string {
     return '';
   }
   return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+function normalizeApiRoot(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/v1') ? trimmed.slice(0, -3) : trimmed;
 }
 
 function extractHost(input: string): string {
@@ -201,11 +258,110 @@ function formatRole(role: MessageRole): string {
       return '用户';
     case 'assistant':
       return 'Hermes';
+    case 'system':
+      return '系统';
+    case 'tool':
+      return '工具';
     case 'error':
       return '错误';
     default:
       return role;
   }
+}
+
+function normalizeMessageRole(role: unknown): MessageRole {
+  if (role === 'user' || role === 'assistant' || role === 'error' || role === 'system' || role === 'tool') {
+    return role;
+  }
+  return 'assistant';
+}
+
+function normalizeMessageTimestamp(value: unknown): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return Date.now();
+  }
+  return value > 1_000_000_000_000 ? value : Math.round(value * 1000);
+}
+
+function formatSourceLabel(source: string | null | undefined): string {
+  if (!source) {
+    return 'unknown';
+  }
+  switch (source) {
+    case 'api_server':
+      return 'API Server';
+    case 'wechat':
+      return 'WeChat';
+    case 'telegram':
+      return 'Telegram';
+    case 'discord':
+      return 'Discord';
+    case 'slack':
+      return 'Slack';
+    case 'whatsapp':
+      return 'WhatsApp';
+    case 'cli':
+      return 'CLI';
+    default:
+      return source;
+  }
+}
+
+function formatMessageCount(value: number | undefined): string {
+  return typeof value === 'number' ? `${value} 条消息` : '--';
+}
+
+function mapGatewayMessage(message: Record<string, unknown>): ChatMessage {
+  const toolName = typeof message.tool_name === 'string' ? message.tool_name : undefined;
+  const content = typeof message.content === 'string'
+    ? message.content
+    : toolName
+      ? `工具 ${toolName} 已执行。`
+      : '';
+
+  return {
+    id: `gateway-${String(message.id ?? makeId('msg'))}`,
+    role: normalizeMessageRole(message.role),
+    content,
+    createdAt: normalizeMessageTimestamp(message.timestamp),
+    toolName,
+  };
+}
+
+function usageFromSessionSummary(summary: GatewaySessionSummary & Record<string, unknown>): Usage | undefined {
+  const prompt = typeof summary.input_tokens === 'number' ? summary.input_tokens : undefined;
+  const completion = typeof summary.output_tokens === 'number' ? summary.output_tokens : undefined;
+  const total = typeof summary.total_tokens === 'number'
+    ? summary.total_tokens
+    : (prompt ?? 0) + (completion ?? 0);
+
+  if (prompt == null && completion == null && !total) {
+    return undefined;
+  }
+
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: total || undefined,
+  };
+}
+
+function mapWebSessionSummary(
+  summary: GatewaySessionSummary & Record<string, unknown>,
+  existing?: ConsoleSession,
+): ConsoleSession {
+  return {
+    id: summary.id,
+    title: summary.title || summary.preview || existing?.title || '新会话',
+    createdAt: normalizeMessageTimestamp(summary.started_at),
+    updatedAt: normalizeMessageTimestamp(summary.last_active ?? summary.started_at),
+    preview: summary.preview || existing?.preview,
+    messageCount: typeof summary.message_count === 'number' ? summary.message_count : existing?.messageCount,
+    messages: existing?.messages ?? [],
+    toolEvents: existing?.toolEvents ?? [],
+    serverSessionId: summary.id,
+    totalUsage: usageFromSessionSummary(summary) ?? existing?.totalUsage,
+  };
 }
 
 function formatRunStatus(status: RunStatus): string {
@@ -432,6 +588,7 @@ export default function ConsolePage(): React.JSX.Element {
   const [hydrated, setHydrated] = useState(false);
   const [sessions, setSessions] = useState<ConsoleSession[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState<string>('');
+  const [sessionView, setSessionView] = useState<SessionView>('web');
   const [settings, setSettings] = useState<ConsoleSettings>(DEFAULT_SETTINGS);
   const [composer, setComposer] = useState('');
   const [requestState, setRequestState] = useState<RequestState>({status: 'idle'});
@@ -441,6 +598,14 @@ export default function ConsolePage(): React.JSX.Element {
   });
   const [models, setModels] = useState<string[]>([DEFAULT_MODEL]);
   const [backendMeta, setBackendMeta] = useState<{provider: string; model: string} | null>(null);
+  const [webSessionsState, setWebSessionsState] = useState<RemoteState>('idle');
+  const [webSessionsError, setWebSessionsError] = useState('');
+  const [gatewaySessions, setGatewaySessions] = useState<GatewaySessionSummary[]>([]);
+  const [gatewaySessionsState, setGatewaySessionsState] = useState<RemoteState>('idle');
+  const [gatewaySessionsError, setGatewaySessionsError] = useState('');
+  const [currentGatewaySessionId, setCurrentGatewaySessionId] = useState('');
+  const [gatewayMessagesBySession, setGatewayMessagesBySession] = useState<Record<string, GatewayMessageState>>({});
+  const [logState, setLogState] = useState<LogViewerState>(DEFAULT_LOG_STATE);
 
   const abortRef = useRef<AbortController | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
@@ -463,9 +628,6 @@ export default function ConsolePage(): React.JSX.Element {
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
       if (!raw) {
-        const session = createSession();
-        setSessions([session]);
-        setCurrentSessionId(session.id);
         return;
       }
 
@@ -473,9 +635,10 @@ export default function ConsolePage(): React.JSX.Element {
         settings?: ConsoleSettings;
         sessions?: ConsoleSession[];
         currentSessionId?: string;
+        sessionView?: SessionView;
       };
 
-      const restoredSessions = (parsed.sessions?.length ? parsed.sessions : [createSession()]).map((session) => ({
+      const restoredSessions = (parsed.sessions ?? []).map((session) => ({
         ...session,
         title: session.title === 'New thread' ? '新会话' : session.title,
         toolEvents: Array.isArray(session.toolEvents) ? session.toolEvents : [],
@@ -484,13 +647,11 @@ export default function ConsolePage(): React.JSX.Element {
 
       setSessions(restoredSessions);
       setSettings(restoredSettings);
-      setCurrentSessionId(parsed.currentSessionId && restoredSessions.some((item) => item.id === parsed.currentSessionId)
-        ? parsed.currentSessionId
-        : restoredSessions[0].id);
+      setSessionView(parsed.sessionView === 'gateway' ? 'gateway' : 'web');
+      setCurrentSessionId(parsed.currentSessionId ?? '');
     } catch {
-      const session = createSession();
-      setSessions([session]);
-      setCurrentSessionId(session.id);
+      setSessions([]);
+      setCurrentSessionId('');
     }
   }, []);
 
@@ -505,21 +666,51 @@ export default function ConsolePage(): React.JSX.Element {
         settings,
         sessions,
         currentSessionId,
+        sessionView,
       }),
     );
-  }, [currentSessionId, hydrated, sessions, settings]);
+  }, [currentSessionId, hydrated, sessionView, sessions, settings]);
 
   const currentSession = useMemo(
     () => sessions.find((session) => session.id === currentSessionId) ?? sessions[0],
     [currentSessionId, sessions],
   );
+  const currentGatewaySession = useMemo(
+    () => gatewaySessions.find((session) => session.id === currentGatewaySessionId) ?? gatewaySessions[0],
+    [currentGatewaySessionId, gatewaySessions],
+  );
   const toolEvents = currentSession?.toolEvents ?? [];
+  const currentGatewayMessageState = currentGatewaySession
+    ? gatewayMessagesBySession[currentGatewaySession.id]
+    : undefined;
 
   useEffect(() => {
     if (!currentSession && sessions.length) {
       setCurrentSessionId(sessions[0].id);
     }
   }, [currentSession, sessions]);
+
+  useEffect(() => {
+    if (!currentGatewaySession && gatewaySessions.length) {
+      setCurrentGatewaySessionId(gatewaySessions[0].id);
+    }
+  }, [currentGatewaySession, gatewaySessions]);
+
+  const endpoint = normalizeEndpoint(settings.endpoint);
+  const apiRoot = normalizeApiRoot(settings.endpoint);
+  const activeMessages = sessionView === 'gateway'
+    ? (currentGatewayMessageState?.messages ?? [])
+    : (currentSession?.messages ?? []);
+  const activeToolEvents = sessionView === 'gateway' ? [] : toolEvents;
+  const transcriptCount = currentSession?.messages.filter((message) => message.role !== 'error').length ?? 0;
+
+  function buildAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    const headers = {...extra};
+    if (settings.apiKey.trim()) {
+      headers.Authorization = `Bearer ${settings.apiKey.trim()}`;
+    }
+    return headers;
+  }
 
   function scrollMessagesToBottom(instant?: boolean): void {
     const container = messagesRef.current;
@@ -548,7 +739,7 @@ export default function ConsolePage(): React.JSX.Element {
     }
     // Streaming: instant scroll so it keeps up; otherwise smooth
     scrollMessagesToBottom(requestState.status === 'streaming');
-  }, [currentSession?.messages, requestState.status, toolEvents]);
+  }, [activeMessages, activeToolEvents, requestState.status]);
 
   // Always scroll to bottom when user sends a new message
   useEffect(() => {
@@ -557,9 +748,6 @@ export default function ConsolePage(): React.JSX.Element {
       scrollMessagesToBottom(true);
     }
   }, [requestState.status]);
-
-  const transcriptCount = currentSession?.messages.filter((message) => message.role !== 'error').length ?? 0;
-  const endpoint = normalizeEndpoint(settings.endpoint);
 
   function patchSession(sessionId: string, updater: (session: ConsoleSession) => ConsoleSession): void {
     setSessions((prev) => prev.map((session) => (
@@ -650,10 +838,10 @@ export default function ConsolePage(): React.JSX.Element {
   }
 
   async function probeModels(): Promise<void> {
-    if (!endpoint || !settings.apiKey.trim()) {
+    if (!endpoint) {
       setConnectionState({
         state: 'error',
-        message: '请先填写接口地址和 API Key。',
+        message: '请先填写接口地址。',
       });
       return;
     }
@@ -665,9 +853,7 @@ export default function ConsolePage(): React.JSX.Element {
 
     try {
       const response = await fetch(`${endpoint}/models`, {
-        headers: {
-          Authorization: `Bearer ${settings.apiKey.trim()}`,
-        },
+        headers: buildAuthHeaders(),
       });
 
       const payload = await response.json();
@@ -711,7 +897,364 @@ export default function ConsolePage(): React.JSX.Element {
       return;
     }
     void probeModels();
-  }, [hydrated]);
+  }, [hydrated, endpoint, settings.apiKey]);
+
+  async function fetchWebSessions(silent = false): Promise<void> {
+    if (!apiRoot) {
+      return;
+    }
+    if (!silent) {
+      setWebSessionsState('loading');
+      setWebSessionsError('');
+    }
+
+    try {
+      const response = await fetch(
+        `${apiRoot}/api/sessions?source=${encodeURIComponent('api_server')}&limit=80`,
+        {headers: buildAuthHeaders()},
+      );
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Web session fetch failed with ${response.status}`));
+      }
+
+      const items = Array.isArray(payload?.sessions) ? payload.sessions as Array<GatewaySessionSummary & Record<string, unknown>> : [];
+      setSessions((prev) => {
+        const previousById = new Map(prev.map((session) => [session.serverSessionId || session.id, session]));
+        return items.map((session) => mapWebSessionSummary(session, previousById.get(session.id)));
+      });
+      setWebSessionsState('ready');
+      setWebSessionsError('');
+      setCurrentSessionId((prev) => {
+        if (prev && items.some((item) => item.id === prev)) {
+          return prev;
+        }
+        return items[0]?.id ?? '';
+      });
+    } catch (error) {
+      setWebSessionsState('error');
+      setWebSessionsError(error instanceof Error ? error.message : '无法加载 Web 会话。');
+    }
+  }
+
+  async function fetchWebSessionMessages(sessionId: string, silent = false): Promise<void> {
+    if (!apiRoot || !sessionId) {
+      return;
+    }
+
+    patchSession(sessionId, (session) => ({
+      ...session,
+      messages: silent && session.messages.length ? session.messages : [],
+    }));
+
+    try {
+      const response = await fetch(`${apiRoot}/api/sessions/${encodeURIComponent(sessionId)}/messages`, {
+        headers: buildAuthHeaders(),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Message fetch failed with ${response.status}`));
+      }
+
+      const items = Array.isArray(payload?.messages) ? payload.messages : [];
+      patchSession(sessionId, (session) => ({
+        ...session,
+        updatedAt: Date.now(),
+        messages: items.map((message: Record<string, unknown>) => mapGatewayMessage(message)),
+        messageCount: items.length,
+        preview: session.preview || (typeof items[0]?.content === 'string' ? items[0].content.slice(0, 80) : session.preview),
+      }));
+    } catch (error) {
+      if (!silent) {
+        setRequestState({
+          status: 'error',
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+          error: error instanceof Error ? error.message : '无法加载 Web 会话消息。',
+        });
+      }
+    }
+  }
+
+  async function createPersistedWebSession(title = '新会话'): Promise<ConsoleSession | null> {
+    if (!apiRoot) {
+      setConnectionState({
+        state: 'error',
+        message: '请先填写接口地址。',
+      });
+      return null;
+    }
+
+    try {
+      const response = await fetch(`${apiRoot}/api/sessions`, {
+        method: 'POST',
+        headers: buildAuthHeaders({'Content-Type': 'application/json'}),
+        body: JSON.stringify({
+          title,
+          source: 'api_server',
+          model: settings.model || DEFAULT_MODEL,
+          system_prompt: settings.systemPrompt || undefined,
+        }),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Session create failed with ${response.status}`));
+      }
+
+      const session = mapWebSessionSummary(payload as GatewaySessionSummary & Record<string, unknown>);
+      setSessions((prev) => [session, ...prev.filter((item) => item.id !== session.id)]);
+      setCurrentSessionId(session.id);
+      setSessionView('web');
+      return session;
+    } catch (error) {
+      setConnectionState({
+        state: 'error',
+        message: error instanceof Error ? error.message : '无法创建 Web 会话。',
+      });
+      return null;
+    }
+  }
+
+  async function updatePersistedWebSession(sessionId: string, title: string): Promise<void> {
+    if (!apiRoot || !sessionId) {
+      return;
+    }
+    try {
+      const response = await fetch(`${apiRoot}/api/sessions/${encodeURIComponent(sessionId)}`, {
+        method: 'PATCH',
+        headers: buildAuthHeaders({'Content-Type': 'application/json'}),
+        body: JSON.stringify({title}),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Session update failed with ${response.status}`));
+      }
+
+      patchSession(sessionId, (session) => ({
+        ...session,
+        title: (payload.title as string) || title,
+        updatedAt: normalizeMessageTimestamp(payload.last_active ?? payload.started_at ?? Date.now()),
+      }));
+    } catch {
+      // Keep local title; failure is non-fatal.
+    }
+  }
+
+  async function deletePersistedWebSession(sessionId: string): Promise<void> {
+    if (!apiRoot || !sessionId) {
+      return;
+    }
+
+    const response = await fetch(`${apiRoot}/api/sessions/${encodeURIComponent(sessionId)}`, {
+      method: 'DELETE',
+      headers: buildAuthHeaders(),
+    });
+    if (!response.ok) {
+      let message = `Delete failed with ${response.status}`;
+      try {
+        const payload = await response.json();
+        message = parseErrorMessage(payload, message);
+      } catch {
+        // Ignore response parsing failure.
+      }
+      throw new Error(message);
+    }
+  }
+
+  async function fetchGatewaySessions(silent = false): Promise<void> {
+    if (!apiRoot) {
+      return;
+    }
+    if (!silent) {
+      setGatewaySessionsState('loading');
+      setGatewaySessionsError('');
+    }
+
+    try {
+      const response = await fetch(
+        `${apiRoot}/api/sessions?exclude_sources=${encodeURIComponent('api_server')}&limit=80`,
+        {
+          headers: buildAuthHeaders(),
+        },
+      );
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Session fetch failed with ${response.status}`));
+      }
+
+      const items = Array.isArray(payload?.sessions) ? payload.sessions : [];
+      setGatewaySessions(items as GatewaySessionSummary[]);
+      setGatewaySessionsState('ready');
+      setGatewaySessionsError('');
+      setCurrentGatewaySessionId((prev) => {
+        if (prev && items.some((item: GatewaySessionSummary) => item.id === prev)) {
+          return prev;
+        }
+        return items[0]?.id ?? '';
+      });
+    } catch (error) {
+      setGatewaySessionsState('error');
+      setGatewaySessionsError(error instanceof Error ? error.message : '无法加载服务端会话。');
+    }
+  }
+
+  async function fetchGatewayMessages(sessionId: string, silent = false): Promise<void> {
+    if (!apiRoot || !sessionId) {
+      return;
+    }
+
+    setGatewayMessagesBySession((prev) => ({
+      ...prev,
+      [sessionId]: {
+        status: silent && prev[sessionId]?.messages?.length ? prev[sessionId].status : 'loading',
+        messages: prev[sessionId]?.messages ?? [],
+        error: undefined,
+        refreshedAt: prev[sessionId]?.refreshedAt,
+      },
+    }));
+
+    try {
+      const response = await fetch(`${apiRoot}/api/sessions/${encodeURIComponent(sessionId)}/messages`, {
+        headers: buildAuthHeaders(),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Message fetch failed with ${response.status}`));
+      }
+
+      const items = Array.isArray(payload?.messages) ? payload.messages : [];
+      setGatewayMessagesBySession((prev) => ({
+        ...prev,
+        [sessionId]: {
+          status: 'ready',
+          messages: items.map((message: Record<string, unknown>) => mapGatewayMessage(message)),
+          error: undefined,
+          refreshedAt: Date.now(),
+        },
+      }));
+    } catch (error) {
+      setGatewayMessagesBySession((prev) => ({
+        ...prev,
+        [sessionId]: {
+          status: 'error',
+          messages: prev[sessionId]?.messages ?? [],
+          error: error instanceof Error ? error.message : '无法加载会话消息。',
+          refreshedAt: prev[sessionId]?.refreshedAt,
+        },
+      }));
+    }
+  }
+
+  async function fetchLogs(silent = false): Promise<void> {
+    if (!apiRoot) {
+      return;
+    }
+
+    setLogState((prev) => ({
+      ...prev,
+      status: silent && prev.entries.length ? prev.status : 'loading',
+      error: undefined,
+    }));
+
+    const params = new URLSearchParams({
+      file: logState.file,
+      lines: String(logState.lines),
+    });
+    if (logState.level) {
+      params.set('level', logState.level);
+    }
+    if (logState.component) {
+      params.set('component', logState.component);
+    }
+
+    try {
+      const response = await fetch(`${apiRoot}/api/logs?${params.toString()}`, {
+        headers: buildAuthHeaders(),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(parseErrorMessage(payload, `Log fetch failed with ${response.status}`));
+      }
+
+      setLogState((prev) => ({
+        ...prev,
+        entries: Array.isArray(payload?.lines) ? payload.lines : [],
+        status: 'ready',
+        error: undefined,
+        refreshedAt: Date.now(),
+        availableFiles: Array.isArray(payload?.available_files) && payload.available_files.length
+          ? payload.available_files
+          : prev.availableFiles,
+        availableComponents: Array.isArray(payload?.available_components)
+          ? payload.available_components
+          : prev.availableComponents,
+      }));
+    } catch (error) {
+      setLogState((prev) => ({
+        ...prev,
+        status: 'error',
+        error: error instanceof Error ? error.message : '无法读取日志。',
+      }));
+    }
+  }
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    void fetchWebSessions();
+    const timer = window.setInterval(() => {
+      void fetchWebSessions(true);
+    }, 15000);
+    return () => window.clearInterval(timer);
+  }, [apiRoot, hydrated, settings.apiKey]);
+
+  useEffect(() => {
+    if (!hydrated || !currentSessionId) {
+      return;
+    }
+    if (requestState.status === 'connecting' || requestState.status === 'streaming') {
+      return;
+    }
+    void fetchWebSessionMessages(currentSessionId);
+    const timer = window.setInterval(() => {
+      void fetchWebSessionMessages(currentSessionId, true);
+    }, sessionView === 'web' ? 5000 : 15000);
+    return () => window.clearInterval(timer);
+  }, [apiRoot, currentSessionId, hydrated, requestState.status, sessionView, settings.apiKey]);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    void fetchGatewaySessions();
+    const timer = window.setInterval(() => {
+      void fetchGatewaySessions(true);
+    }, 15000);
+    return () => window.clearInterval(timer);
+  }, [apiRoot, hydrated, settings.apiKey]);
+
+  useEffect(() => {
+    if (!hydrated || !currentGatewaySessionId) {
+      return;
+    }
+    void fetchGatewayMessages(currentGatewaySessionId);
+    const timer = window.setInterval(() => {
+      void fetchGatewayMessages(currentGatewaySessionId, true);
+    }, sessionView === 'gateway' ? 5000 : 15000);
+    return () => window.clearInterval(timer);
+  }, [apiRoot, currentGatewaySessionId, hydrated, sessionView, settings.apiKey]);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    void fetchLogs();
+    const timer = window.setInterval(() => {
+      void fetchLogs(true);
+    }, 6000);
+    return () => window.clearInterval(timer);
+  }, [apiRoot, hydrated, logState.component, logState.file, logState.level, logState.lines, settings.apiKey]);
 
   async function consumeStreamingResponse(
     response: Response,
@@ -840,19 +1383,24 @@ export default function ConsolePage(): React.JSX.Element {
   }
 
   async function sendMessage(text: string): Promise<void> {
-    if (!currentSession || !text.trim() || requestState.status === 'connecting' || requestState.status === 'streaming') {
+    if (!text.trim() || requestState.status === 'connecting' || requestState.status === 'streaming') {
       return;
     }
 
-    if (!endpoint || !settings.apiKey.trim()) {
+    if (!endpoint) {
       setConnectionState({
         state: 'error',
-        message: '发送前请先填写接口地址和 API Key。',
+        message: '发送前请先填写接口地址。',
       });
       return;
     }
 
-    const sessionId = currentSession.id;
+    const ensuredSession = currentSession ?? await createPersistedWebSession();
+    if (!ensuredSession) {
+      return;
+    }
+
+    const sessionId = ensuredSession.serverSessionId ?? ensuredSession.id;
     const now = Date.now();
     const userMessage: ChatMessage = {
       id: makeId('user'),
@@ -870,7 +1418,7 @@ export default function ConsolePage(): React.JSX.Element {
     };
 
     const outboundMessages = buildRequestMessages(
-      [...currentSession.messages, userMessage],
+      [userMessage],
       settings.systemPrompt,
     );
 
@@ -890,6 +1438,9 @@ export default function ConsolePage(): React.JSX.Element {
       title: session.messages.length === 0 ? summarizeSessionTitle(text) : session.title,
       updatedAt: now,
       messages: [...session.messages, userMessage, assistantMessage],
+      messageCount: (session.messageCount ?? session.messages.length) + 2,
+      preview: text.trim(),
+      serverSessionId: session.serverSessionId ?? session.id,
     }));
 
     setComposer('');
@@ -905,11 +1456,9 @@ export default function ConsolePage(): React.JSX.Element {
     try {
       const requestHeaders: Record<string, string> = {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${settings.apiKey.trim()}`,
+        ...buildAuthHeaders(),
       };
-      if (currentSession.serverSessionId) {
-        requestHeaders['X-Hermes-Session-Id'] = currentSession.serverSessionId;
-      }
+      requestHeaders['X-Hermes-Session-Id'] = sessionId;
 
       const response = await fetch(`${endpoint}/chat/completions`, {
         method: 'POST',
@@ -975,6 +1524,15 @@ export default function ConsolePage(): React.JSX.Element {
           totalUsage: accumulateUsage(session.totalUsage, requestUsage),
         }));
       }
+
+      if (ensuredSession.messages.length === 0) {
+        const nextTitle = summarizeSessionTitle(text);
+        patchSession(sessionId, (session) => ({...session, title: nextTitle}));
+        void updatePersistedWebSession(sessionId, nextTitle);
+      }
+
+      void fetchWebSessionMessages(sessionId, true);
+      void fetchWebSessions(true);
 
       setConnectionState({
         state: 'ready',
@@ -1048,49 +1606,25 @@ export default function ConsolePage(): React.JSX.Element {
       insertInfoMessage(`## 📋 可用命令\n\n- ${lines}\n\n> 在输入框中键入 \`/\` 可快速选择命令。`);
 
     } else if (cmd === '/clear') {
-      clearCurrentSession();
+      void clearCurrentSession();
 
     } else if (cmd === '/new') {
-      createNewSession();
+      void createNewSession();
 
     } else if (cmd === '/retry') {
       if (!currentSession) return;
-      const lastUserMsg = [...currentSession.messages].reverse().find((m) => m.role === 'user');
-      if (!lastUserMsg) {
-        insertInfoMessage('⚠️ 没有可重发的用户消息。');
-      } else {
-        // Remove the last user+assistant pair and resend
-        const msgs = currentSession.messages;
-        const lastUserIdx = msgs.lastIndexOf(lastUserMsg);
-        patchCurrentSession((s) => ({
-          ...s,
-          updatedAt: Date.now(),
-          messages: s.messages.slice(0, lastUserIdx),
-        }));
-        setComposer('');
-        setShowSlashMenu(false);
-        setTimeout(() => void sendMessage(lastUserMsg.content), 50);
-        return;
-      }
+      insertInfoMessage('⚠️ 持久化 Web 会话当前不支持 `/retry`，因为服务端历史已经写入 SessionDB。请直接重新发送一条消息。');
+      setComposer('');
+      setShowSlashMenu(false);
+      return;
 
     } else if (cmd === '/undo') {
       if (!currentSession || currentSession.messages.length === 0) {
         insertInfoMessage('⚠️ 没有可撤销的对话。');
       } else {
-        // Remove last user+assistant pair
-        const msgs = [...currentSession.messages];
-        let removed = 0;
-        while (msgs.length > 0 && removed < 2) {
-          const last = msgs[msgs.length - 1];
-          if (last.role === 'user' || last.role === 'assistant') removed++;
-          msgs.pop();
-        }
-        patchCurrentSession((s) => ({
-          ...s,
-          updatedAt: Date.now(),
-          messages: msgs,
-        }));
-        insertInfoMessage('↩️ 已撤销最近一轮对话。');
+        insertInfoMessage('⚠️ 持久化 Web 会话当前不支持 `/undo`，因为服务端历史已经写入 SessionDB。请新建会话或删除当前会话。');
+        setComposer('');
+        setShowSlashMenu(false);
         return;
       }
 
@@ -1099,6 +1633,9 @@ export default function ConsolePage(): React.JSX.Element {
         insertInfoMessage(`当前标题: **${currentSession?.title ?? '新会话'}**\n\n用法: \`/title 新标题\``);
       } else {
         patchCurrentSession((s) => ({...s, title: arg, updatedAt: Date.now()}));
+        if (currentSession?.id) {
+          void updatePersistedWebSession(currentSession.id, arg);
+        }
         insertInfoMessage(`✏️ 会话标题已更新为: **${arg}**`);
       }
 
@@ -1302,52 +1839,51 @@ export default function ConsolePage(): React.JSX.Element {
     }
   }
 
-  function deleteSession(sessionId: string): void {
+  async function deleteSession(sessionId: string): Promise<void> {
+    const hadOtherSessions = sessions.some((session) => session.id !== sessionId);
     if (requestState.status === 'streaming' || requestState.status === 'connecting') {
       if (sessionId === currentSessionId) {
         stopCurrentRun();
       }
     }
-    setSessions((prev) => {
-      const next = prev.filter((session) => session.id !== sessionId);
-      if (!next.length) {
-        const fresh = createSession();
-        setCurrentSessionId(fresh.id);
-        return [fresh];
+    try {
+      await deletePersistedWebSession(sessionId);
+      setSessions((prev) => {
+        const next = prev.filter((session) => session.id !== sessionId);
+        if (sessionId === currentSessionId) {
+          const sorted = [...next].sort((a, b) => b.updatedAt - a.updatedAt);
+          setCurrentSessionId(sorted[0]?.id ?? '');
+        }
+        return next;
+      });
+      setRequestState({status: 'idle'});
+      void fetchWebSessions(true);
+      if (sessionId === currentSessionId && !hadOtherSessions) {
+        void createNewSession();
       }
-      if (sessionId === currentSessionId) {
-        const sorted = [...next].sort((a, b) => b.updatedAt - a.updatedAt);
-        setCurrentSessionId(sorted[0].id);
-      }
-      return next;
-    });
-    setRequestState({status: 'idle'});
+    } catch (error) {
+      setConnectionState({
+        state: 'error',
+        message: error instanceof Error ? error.message : '删除会话失败。',
+      });
+    }
   }
 
-  function createNewSession(): void {
-    const session = createSession();
-    setSessions((prev) => [session, ...prev]);
-    setCurrentSessionId(session.id);
+  async function createNewSession(): Promise<void> {
+    await createPersistedWebSession();
+    setSessionView('web');
     setComposer('');
     setRequestState({status: 'idle'});
   }
 
-  function clearCurrentSession(): void {
+  async function clearCurrentSession(): Promise<void> {
     if (!currentSession) {
       return;
     }
     if (currentSession.messages.length > 0 && !window.confirm('确认清空当前会话的所有消息？')) {
       return;
     }
-    patchCurrentSession((session) => ({
-      ...session,
-      title: '新会话',
-      updatedAt: Date.now(),
-      messages: [],
-      toolEvents: [],
-      serverSessionId: undefined,
-      totalUsage: undefined,
-    }));
+    await deleteSession(currentSession.id);
     setComposer('');
     setRequestState({status: 'idle'});
   }
@@ -1357,16 +1893,34 @@ export default function ConsolePage(): React.JSX.Element {
   }
 
   const sessionItems = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+  const gatewaySessionItems = [...gatewaySessions].sort(
+    (a, b) => (b.last_active ?? b.started_at ?? 0) - (a.last_active ?? a.started_at ?? 0),
+  );
   const filteredSessions = useMemo(() => {
     if (!sessionSearch.trim()) return sessionItems;
     const q = sessionSearch.trim().toLowerCase();
     return sessionItems.filter((s) =>
       s.title.toLowerCase().includes(q) ||
+      (s.preview ?? '').toLowerCase().includes(q) ||
       s.messages.some((m) => m.content.toLowerCase().includes(q)),
     );
   }, [sessionItems, sessionSearch]);
+  const filteredGatewaySessions = useMemo(() => {
+    if (!sessionSearch.trim()) return gatewaySessionItems;
+    const q = sessionSearch.trim().toLowerCase();
+    return gatewaySessionItems.filter((session) =>
+      (session.title ?? '').toLowerCase().includes(q) ||
+      (session.preview ?? '').toLowerCase().includes(q) ||
+      formatSourceLabel(session.source).toLowerCase().includes(q),
+    );
+  }, [gatewaySessionItems, sessionSearch]);
   const lastUsage = requestState.usage;
   const totalUsage = currentSession?.totalUsage;
+  const isGatewayView = sessionView === 'gateway';
+  const visibleMessages = activeMessages;
+  const selectedRemoteMeta = currentGatewaySession;
+  const selectedRemoteState = currentGatewayMessageState;
+  const sessionListCount = isGatewayView ? filteredGatewaySessions.length : filteredSessions.length;
 
   return (
     <Layout
@@ -1379,8 +1933,9 @@ export default function ConsolePage(): React.JSX.Element {
             <span className={styles.heroEyebrow}>浏览器控制台</span>
             <h1 className={styles.heroTitle}>Hermes 网页控制台</h1>
             <p className={styles.heroText}>
-              一个面向操作者的中性色 Hermes 前端。会话保存在当前浏览器里，回复支持实时流式返回，
-              工具执行进度也能在右侧直接观察，不需要离开文档站。
+              一个面向操作者的 Hermes 控制台。除了浏览器里的 Web 会话，这里也能镜像查看
+              Hermes SessionDB 中的服务端会话，例如微信、Telegram、Slack，并直接查看 agent /
+              gateway / errors 日志，不需要离开文档站。
             </p>
           </div>
           <div className={styles.heroStats}>
@@ -1396,17 +1951,19 @@ export default function ConsolePage(): React.JSX.Element {
               <span className={styles.heroStatValue}>
                 {sessionItems.length}
                 <span className={styles.heroStatSep}>/</span>
-                {transcriptCount}
+                {gatewaySessionItems.length}
               </span>
-              <span className={styles.heroStatLabel}>会话 / 消息</span>
+              <span className={styles.heroStatLabel}>Web / Gateway 会话</span>
             </div>
             <div className={styles.heroStat}>
               <span className={styles.heroStatValue}>
-                {totalUsage?.total_tokens != null
-                  ? totalUsage.total_tokens.toLocaleString()
-                  : '--'}
+                {isGatewayView
+                  ? formatSourceLabel(selectedRemoteMeta?.source)
+                  : (totalUsage?.total_tokens != null
+                    ? totalUsage.total_tokens.toLocaleString()
+                    : 'Web Session')}
               </span>
-              <span className={styles.heroStatLabel}>累计 Token</span>
+              <span className={styles.heroStatLabel}>{isGatewayView ? '当前来源' : '累计 Token'}</span>
             </div>
           </div>
         </section>
@@ -1416,10 +1973,33 @@ export default function ConsolePage(): React.JSX.Element {
             <div className={styles.panelHeader}>
               <div>
                 <p className={styles.panelEyebrow}>会话</p>
-                <h2 className={styles.panelTitle}>本地线程列表</h2>
+                <h2 className={styles.panelTitle}>{isGatewayView ? '服务端会话镜像' : '持久化 Web 会话'}</h2>
               </div>
-              <button className={styles.primaryButton} type="button" onClick={createNewSession}>
-                新建会话
+              {isGatewayView ? (
+                <button className={styles.ghostButton} type="button" onClick={() => void fetchGatewaySessions()}>
+                  刷新列表
+                </button>
+              ) : (
+                <button className={styles.primaryButton} type="button" onClick={() => { void createNewSession(); }}>
+                  新建会话
+                </button>
+              )}
+            </div>
+
+            <div className={styles.viewToggle}>
+              <button
+                type="button"
+                className={clsx(styles.viewToggleButton, !isGatewayView && styles.viewToggleButtonActive)}
+                onClick={() => setSessionView('web')}
+              >
+                Web 会话
+              </button>
+              <button
+                type="button"
+                className={clsx(styles.viewToggleButton, isGatewayView && styles.viewToggleButtonActive)}
+                onClick={() => setSessionView('gateway')}
+              >
+                Gateway 会话
               </button>
             </div>
 
@@ -1427,7 +2007,7 @@ export default function ConsolePage(): React.JSX.Element {
               <input
                 type="text"
                 className={styles.sessionSearchInput}
-                placeholder="搜索会话..."
+                placeholder={isGatewayView ? '搜索来源、标题或预览...' : '搜索会话...'}
                 value={sessionSearch}
                 onChange={(e) => setSessionSearch(e.target.value)}
               />
@@ -1441,12 +2021,16 @@ export default function ConsolePage(): React.JSX.Element {
             </div>
 
             <div className={styles.sessionList}>
-              {filteredSessions.length === 0 && sessionSearch ? (
+              {sessionListCount === 0 ? (
                 <div className={styles.traceEmpty} style={{textAlign: 'center', fontSize: '0.85rem'}}>
-                  未找到匹配的会话
+                  {sessionSearch
+                    ? '未找到匹配的会话'
+                    : (isGatewayView
+                      ? (gatewaySessionsState === 'loading' ? '正在加载服务端会话...' : '暂时没有可镜像的服务端会话')
+                      : (webSessionsState === 'loading' ? '正在加载 Web 会话...' : '当前没有持久化 Web 会话'))}
                 </div>
               ) : null}
-              {filteredSessions.map((session) => (
+              {!isGatewayView && filteredSessions.map((session) => (
                 <div
                   key={session.id}
                   className={clsx(styles.sessionItem, session.id === currentSession?.id && styles.sessionItemActive)}
@@ -1457,98 +2041,185 @@ export default function ConsolePage(): React.JSX.Element {
                     onClick={() => {
                       setCurrentSessionId(session.id);
                       setRequestState({status: 'idle'});
+                      setSessionView('web');
                     }}
                   >
                     <span className={styles.sessionTitle}>{session.title}</span>
                     <span className={styles.sessionMeta}>
-                      {session.messages.length} 条消息 · {formatRelativeTime(session.updatedAt)}
+                      {(session.messageCount ?? session.messages.length)} 条消息 · {formatRelativeTime(session.updatedAt)}
                     </span>
+                    {session.preview ? <span className={styles.sessionPreview}>{session.preview}</span> : null}
                   </button>
                   <button
                     type="button"
                     className={styles.sessionDeleteBtn}
                     title="删除会话"
-                    onClick={() => deleteSession(session.id)}
+                    onClick={() => { void deleteSession(session.id); }}
                   >
                     ×
                   </button>
                 </div>
               ))}
+              {isGatewayView && filteredGatewaySessions.map((session) => (
+                <button
+                  key={session.id}
+                  type="button"
+                  className={clsx(styles.sessionItem, styles.remoteSessionItem, session.id === currentGatewaySession?.id && styles.sessionItemActive)}
+                  onClick={() => {
+                    setCurrentGatewaySessionId(session.id);
+                    void fetchGatewayMessages(session.id);
+                  }}
+                >
+                  <span className={styles.sessionContent}>
+                    <span className={styles.sessionRow}>
+                      <span className={styles.sessionTitle}>{session.title || session.id}</span>
+                      <span className={styles.sessionSourceTag}>{formatSourceLabel(session.source)}</span>
+                    </span>
+                    <span className={styles.sessionMeta}>
+                      {formatMessageCount(session.message_count)} · {formatRelativeTime(normalizeMessageTimestamp(session.last_active ?? session.started_at))}
+                    </span>
+                    {session.preview ? <span className={styles.sessionPreview}>{session.preview}</span> : null}
+                  </span>
+                </button>
+              ))}
             </div>
 
-            <div className={styles.panelBlock}>
-              <p className={styles.blockLabel}>快捷提示</p>
-              <div className={styles.promptGrid}>
-                {QUICK_PROMPTS.map((prompt) => (
-                  <button
-                    key={prompt}
-                    type="button"
-                    className={styles.promptChip}
-                    onClick={() => setComposer(prompt)}
-                  >
-                    {prompt}
-                  </button>
-                ))}
+            {!isGatewayView ? (
+              <>
+                <div className={styles.panelBlock}>
+                  <p className={styles.blockLabel}>快捷提示</p>
+                  <div className={styles.promptGrid}>
+                    {QUICK_PROMPTS.map((prompt) => (
+                      <button
+                        key={prompt}
+                        type="button"
+                        className={styles.promptChip}
+                        onClick={() => setComposer(prompt)}
+                      >
+                        {prompt}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className={styles.panelBlock}>
+                  <p className={styles.blockLabel}>启动检查</p>
+                  <ul className={styles.checkList}>
+                    <li>在 <code>~/.hermes/.env</code> 里设置 <code>API_SERVER_ENABLED=true</code>。</li>
+                    <li>如果浏览器直接请求 Hermes，需要给当前来源开放 CORS。</li>
+                    <li>启动 <code>hermes gateway</code>，然后检测 <code>/v1/models</code>。</li>
+                  </ul>
+                  {webSessionsError ? <p className={styles.errorNote}>{webSessionsError}</p> : null}
+                </div>
+              </>
+            ) : (
+              <div className={styles.panelBlock}>
+                <p className={styles.blockLabel}>镜像说明</p>
+                <p className={styles.noteText}>
+                  这里读取的是 Hermes `SessionDB` 中的服务端会话。适合查看刚接入的微信等平台消息，
+                  当前为只读镜像，不会替代原平台的收发链路。
+                </p>
+                {gatewaySessionsError ? <p className={styles.errorNote}>{gatewaySessionsError}</p> : null}
               </div>
-            </div>
-
-            <div className={styles.panelBlock}>
-              <p className={styles.blockLabel}>启动检查</p>
-              <ul className={styles.checkList}>
-                <li>在 <code>~/.hermes/.env</code> 里设置 <code>API_SERVER_ENABLED=true</code>。</li>
-                <li>如果浏览器直接请求 Hermes，需要给当前来源开放 CORS。</li>
-                <li>启动 <code>hermes gateway</code>，然后检测 <code>/v1/models</code>。</li>
-              </ul>
-            </div>
+            )}
           </aside>
 
           <main className={clsx(styles.panel, styles.chatPanel)}>
             <div className={styles.chatHeader}>
               <div>
-                <p className={styles.panelEyebrow}>对话</p>
-                <h2 className={styles.panelTitle}>{currentSession?.title ?? '新会话'}</h2>
+                <p className={styles.panelEyebrow}>{isGatewayView ? '平台会话' : '对话'}</p>
+                <h2 className={styles.panelTitle}>
+                  {isGatewayView
+                    ? (selectedRemoteMeta?.title || selectedRemoteMeta?.id || '未选择会话')
+                    : (currentSession?.title ?? '新会话')}
+                </h2>
               </div>
               <div className={styles.chatHeaderActions}>
-                <button className={styles.ghostButton} type="button" onClick={clearCurrentSession}>
-                  清空会话
-                </button>
-                {requestState.status === 'connecting' || requestState.status === 'streaming' ? (
-                  <button className={styles.dangerButton} type="button" onClick={stopCurrentRun}>
-                    停止运行
-                  </button>
-                ) : null}
+                {isGatewayView ? (
+                  <>
+                    <button
+                      className={styles.ghostButton}
+                      type="button"
+                      onClick={() => {
+                        if (currentGatewaySessionId) {
+                          void fetchGatewayMessages(currentGatewaySessionId);
+                        }
+                      }}
+                      disabled={!currentGatewaySessionId}
+                    >
+                      刷新会话
+                    </button>
+                    <button className={styles.ghostButton} type="button" onClick={() => setSessionView('web')}>
+                      切回 Web
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button className={styles.ghostButton} type="button" onClick={() => { void clearCurrentSession(); }}>
+                      清空会话
+                    </button>
+                    {requestState.status === 'connecting' || requestState.status === 'streaming' ? (
+                      <button className={styles.dangerButton} type="button" onClick={stopCurrentRun}>
+                        停止运行
+                      </button>
+                    ) : null}
+                  </>
+                )}
               </div>
             </div>
 
             <div className={styles.messages} ref={messagesRef} onScroll={handleMessagesScroll}>
-              {!currentSession?.messages.length ? (
+              {!visibleMessages.length ? (
                 <div className={styles.emptyState}>
-                  <span className={styles.emptyEyebrow}>等待第一轮输入</span>
-                  <h3>直接在浏览器里和 Hermes 对话。</h3>
-                  <p>
-                    这个页面会把 OpenAI 兼容请求直接发到 Hermes API Server。
-                    线程历史保存在当前浏览器里，而 Hermes 仍然使用完整工具集运行。
-                  </p>
-                  <pre className={styles.commandBlock}>
-                    <code>{`API_SERVER_ENABLED=true
+                  <span className={styles.emptyEyebrow}>{isGatewayView ? '等待服务端会话' : '等待第一轮输入'}</span>
+                  {isGatewayView ? (
+                    <>
+                      <h3>这里会镜像显示 Hermes 服务端会话。</h3>
+                      <p>
+                        打开左侧的 Gateway 会话后，消息会从 API server 的 `/api/sessions/*` 接口读取。
+                        如果刚接入了微信等平台，会在进入 SessionDB 后出现在这里。
+                      </p>
+                      {selectedRemoteState?.status === 'loading' ? (
+                        <p className={styles.noteText}>正在加载会话消息...</p>
+                      ) : null}
+                      {selectedRemoteState?.error ? (
+                        <p className={styles.errorNote}>{selectedRemoteState.error}</p>
+                      ) : null}
+                    </>
+                  ) : (
+                    <>
+                      <h3>直接在浏览器里和 Hermes 对话。</h3>
+                      <p>
+                        这个页面会把 OpenAI 兼容请求直接发到 Hermes API Server。
+                        Web 会话现在会持久化到 Hermes 的 SessionDB，不再依赖当前浏览器的 localStorage。
+                      </p>
+                      <pre className={styles.commandBlock}>
+                        <code>{`API_SERVER_ENABLED=true
 API_SERVER_KEY=change-me-local-dev
 API_SERVER_CORS_ORIGINS=http://localhost:3000
 hermes gateway`}</code>
-                  </pre>
+                      </pre>
+                    </>
+                  )}
                 </div>
               ) : (
-                currentSession?.messages.map((message) => (
+                visibleMessages.map((message) => (
                   <article
                     key={message.id}
                     className={clsx(
                       styles.messageCard,
                       message.role === 'user' && styles.messageUser,
                       message.role === 'assistant' && styles.messageAssistant,
+                      message.role === 'system' && styles.messageSystem,
+                      message.role === 'tool' && styles.messageTool,
                       message.role === 'error' && styles.messageError,
                     )}
                   >
                     <div className={styles.messageHeader}>
-                      <span className={styles.messageRole}>{formatRole(message.role)}</span>
+                      <div className={styles.messageHeaderMeta}>
+                        <span className={styles.messageRole}>{formatRole(message.role)}</span>
+                        {message.toolName ? <span className={styles.messageMetaChip}>{message.toolName}</span> : null}
+                      </div>
                       <span className={styles.messageTime}>{new Date(message.createdAt).toLocaleTimeString()}</span>
                     </div>
                     <div className={styles.messageBody}>
@@ -1564,105 +2235,113 @@ hermes gateway`}</code>
             </div>
 
             <div className={styles.composerWrap}>
-              <label className={styles.composerLabel} htmlFor="hermes-console-composer">
-                输入消息
-              </label>
-
-              {/* Image preview */}
-              {imageAttachment && (
-                <div className={styles.imagePreview}>
-                  <img src={imageAttachment.dataUrl} alt={imageAttachment.name} className={styles.imagePreviewThumb} />
-                  <span className={styles.imagePreviewName}>{imageAttachment.name}</span>
-                  <span className={styles.imagePreviewSize}>
-                    {imageAttachment.size < 1024 * 1024
-                      ? `${(imageAttachment.size / 1024).toFixed(0)} KB`
-                      : `${(imageAttachment.size / 1024 / 1024).toFixed(1)} MB`}
-                  </span>
-                  <button type="button" className={styles.imageRemoveBtn} onClick={() => setImageAttachment(null)}>×</button>
+              {isGatewayView ? (
+                <div className={styles.readOnlyState}>
+                  <p className={styles.composerLabel}>只读镜像</p>
+                  <p className={styles.noteText}>
+                    当前正在查看 Hermes 服务端会话。这里不会直接回写到微信等平台，适合排查消息流、
+                    对比 SessionDB 和结合右侧日志做诊断。
+                  </p>
                 </div>
-              )}
+              ) : (
+                <>
+                  <label className={styles.composerLabel} htmlFor="hermes-console-composer">
+                    输入消息
+                  </label>
 
-              {/* Slash command menu */}
-              {showSlashMenu && filteredSlashCommands.length > 0 && (
-                <div className={styles.slashMenu}>
-                  {filteredSlashCommands.map((cmd, idx) => (
-                    <button
-                      key={cmd.name}
-                      type="button"
-                      className={clsx(styles.slashItem, idx === slashSelectedIdx && styles.slashItemActive)}
-                      onMouseEnter={() => setSlashSelectedIdx(idx)}
-                      onClick={() => executeSlashCommand(cmd.name)}
-                    >
-                      <span className={styles.slashName}>{cmd.name}</span>
-                      <span className={styles.slashDesc}>{cmd.description}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
+                  {imageAttachment && (
+                    <div className={styles.imagePreview}>
+                      <img src={imageAttachment.dataUrl} alt={imageAttachment.name} className={styles.imagePreviewThumb} />
+                      <span className={styles.imagePreviewName}>{imageAttachment.name}</span>
+                      <span className={styles.imagePreviewSize}>
+                        {imageAttachment.size < 1024 * 1024
+                          ? `${(imageAttachment.size / 1024).toFixed(0)} KB`
+                          : `${(imageAttachment.size / 1024 / 1024).toFixed(1)} MB`}
+                      </span>
+                      <button type="button" className={styles.imageRemoveBtn} onClick={() => setImageAttachment(null)}>×</button>
+                    </div>
+                  )}
 
-              <textarea
-                id="hermes-console-composer"
-                className={styles.composer}
-                rows={1}
-                value={composer}
-                placeholder="输入消息，或键入 / 使用命令..."
-                onChange={(event) => {
-                  const val = event.target.value;
-                  setComposer(val);
-                  // Slash command detection
-                  if (val.startsWith('/')) {
-                    setShowSlashMenu(true);
-                    setSlashFilter(val);
-                    setSlashSelectedIdx(0);
-                  } else {
-                    setShowSlashMenu(false);
-                  }
-                  // Auto-grow
-                  const el = event.target;
-                  el.style.height = 'auto';
-                  el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
-                }}
-                onKeyDown={handleComposerKeyDown}
-                onPaste={handleComposerPaste}
-              />
+                  {showSlashMenu && filteredSlashCommands.length > 0 && (
+                    <div className={styles.slashMenu}>
+                      {filteredSlashCommands.map((cmd, idx) => (
+                        <button
+                          key={cmd.name}
+                          type="button"
+                          className={clsx(styles.slashItem, idx === slashSelectedIdx && styles.slashItemActive)}
+                          onMouseEnter={() => setSlashSelectedIdx(idx)}
+                          onClick={() => executeSlashCommand(cmd.name)}
+                        >
+                          <span className={styles.slashName}>{cmd.name}</span>
+                          <span className={styles.slashDesc}>{cmd.description}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
 
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                style={{display: 'none'}}
-                onChange={handleImageUpload}
-              />
-
-              <div className={styles.composerActions}>
-                <p className={styles.composerHint}>
-                  Enter 发送 · Shift+Enter 换行 · 键入 / 查看命令 · 可粘贴或上传图片
-                </p>
-                <div className={styles.composerButtons}>
-                  <button
-                    className={styles.ghostButton}
-                    type="button"
-                    title="上传图片"
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    📎
-                  </button>
-                  <button
-                    className={styles.primaryButton}
-                    type="button"
-                    onClick={() => {
-                      if (composer.startsWith('/')) {
-                        executeSlashCommand(composer.trim());
+                  <textarea
+                    id="hermes-console-composer"
+                    className={styles.composer}
+                    rows={1}
+                    value={composer}
+                    placeholder="输入消息，或键入 / 使用命令..."
+                    onChange={(event) => {
+                      const val = event.target.value;
+                      setComposer(val);
+                      if (val.startsWith('/')) {
+                        setShowSlashMenu(true);
+                        setSlashFilter(val);
+                        setSlashSelectedIdx(0);
                       } else {
-                        void sendMessage(composer);
+                        setShowSlashMenu(false);
                       }
+                      const el = event.target;
+                      el.style.height = 'auto';
+                      el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
                     }}
-                    disabled={!composer.trim() || requestState.status === 'connecting' || requestState.status === 'streaming'}
-                  >
-                    发送
-                  </button>
-                </div>
-              </div>
+                    onKeyDown={handleComposerKeyDown}
+                    onPaste={handleComposerPaste}
+                  />
+
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    style={{display: 'none'}}
+                    onChange={handleImageUpload}
+                  />
+
+                  <div className={styles.composerActions}>
+                    <p className={styles.composerHint}>
+                      Enter 发送 · Shift+Enter 换行 · 键入 / 查看命令 · 可粘贴或上传图片
+                    </p>
+                    <div className={styles.composerButtons}>
+                      <button
+                        className={styles.ghostButton}
+                        type="button"
+                        title="上传图片"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        📎
+                      </button>
+                      <button
+                        className={styles.primaryButton}
+                        type="button"
+                        onClick={() => {
+                          if (composer.startsWith('/')) {
+                            executeSlashCommand(composer.trim());
+                          } else {
+                            void sendMessage(composer);
+                          }
+                        }}
+                        disabled={!composer.trim() || requestState.status === 'connecting' || requestState.status === 'streaming'}
+                      >
+                        发送
+                      </button>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           </main>
 
@@ -1670,7 +2349,7 @@ hermes gateway`}</code>
             <div className={styles.panelHeader}>
               <div>
                 <p className={styles.panelEyebrow}>运行时</p>
-                <h2 className={styles.panelTitle}>连接与执行追踪</h2>
+                <h2 className={styles.panelTitle}>连接、追踪与日志</h2>
               </div>
               <span
                 className={clsx(
@@ -1752,31 +2431,70 @@ hermes gateway`}</code>
             <div className={styles.panelBlock}>
               <p className={styles.blockLabel}>运行摘要</p>
               <div className={styles.metricGrid}>
-                <div className={styles.metricCard}>
-                  <span className={styles.metricLabel}>状态</span>
-                  <span className={styles.metricValue}>{formatRunStatus(requestState.status)}</span>
-                </div>
-                <div className={styles.metricCard}>
-                  <span className={styles.metricLabel}>耗时</span>
-                  <span className={styles.metricValue}>{formatDuration(requestState)}</span>
-                </div>
-                <div className={styles.metricCard}>
-                  <span className={styles.metricLabel}>输入 Token</span>
-                  <span className={styles.metricValue}>{lastUsage?.prompt_tokens?.toLocaleString() ?? '--'}</span>
-                </div>
-                <div className={styles.metricCard}>
-                  <span className={styles.metricLabel}>输出 Token</span>
-                  <span className={styles.metricValue}>{lastUsage?.completion_tokens?.toLocaleString() ?? '--'}</span>
-                </div>
+                {isGatewayView ? (
+                  <>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>来源</span>
+                      <span className={styles.metricValue}>{formatSourceLabel(selectedRemoteMeta?.source)}</span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>状态</span>
+                      <span className={styles.metricValue}>
+                        {selectedRemoteState?.status === 'loading'
+                          ? '加载中'
+                          : selectedRemoteState?.status === 'error'
+                            ? '读取失败'
+                            : (selectedRemoteMeta?.is_active ? '活跃' : '已归档')}
+                      </span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>消息数</span>
+                      <span className={styles.metricValue}>{formatMessageCount(selectedRemoteMeta?.message_count)}</span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>最后活跃</span>
+                      <span className={styles.metricValue}>
+                        {selectedRemoteMeta?.last_active
+                          ? formatRelativeTime(normalizeMessageTimestamp(selectedRemoteMeta.last_active))
+                          : '--'}
+                      </span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>状态</span>
+                      <span className={styles.metricValue}>{formatRunStatus(requestState.status)}</span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>耗时</span>
+                      <span className={styles.metricValue}>{formatDuration(requestState)}</span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>输入 Token</span>
+                      <span className={styles.metricValue}>{lastUsage?.prompt_tokens?.toLocaleString() ?? '--'}</span>
+                    </div>
+                    <div className={styles.metricCard}>
+                      <span className={styles.metricLabel}>输出 Token</span>
+                      <span className={styles.metricValue}>{lastUsage?.completion_tokens?.toLocaleString() ?? '--'}</span>
+                    </div>
+                  </>
+                )}
               </div>
 
-              {requestState.error ? <p className={styles.errorNote}>{requestState.error}</p> : null}
+              {isGatewayView
+                ? (selectedRemoteState?.error ? <p className={styles.errorNote}>{selectedRemoteState.error}</p> : null)
+                : (requestState.error ? <p className={styles.errorNote}>{requestState.error}</p> : null)}
             </div>
 
             <div className={styles.panelBlock}>
               <p className={styles.blockLabel}>工具追踪</p>
               <div className={styles.traceList}>
-                {!toolEvents.length ? (
+                {isGatewayView ? (
+                  <div className={styles.traceEmpty}>
+                    实时工具追踪只对当前浏览器发起的 Web 会话生效。服务端平台会话的工具输出可在消息流和下方日志里排查。
+                  </div>
+                ) : !toolEvents.length ? (
                   <div className={styles.traceEmpty}>
                     Hermes 会把工具启动事件作为自定义 SSE 推送到这里展示，不会污染会话历史。
                   </div>
@@ -1820,6 +2538,68 @@ hermes gateway`}</code>
                   ))
                 )}
               </div>
+            </div>
+
+            <div className={styles.panelBlock}>
+              <div className={styles.blockHeaderRow}>
+                <p className={styles.blockLabel}>Hermes 日志</p>
+                <button className={styles.ghostButton} type="button" onClick={() => void fetchLogs()}>
+                  刷新日志
+                </button>
+              </div>
+              <div className={styles.logControls}>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>文件</span>
+                  <select
+                    className={styles.fieldInput}
+                    value={logState.file}
+                    onChange={(event) => setLogState((prev) => ({...prev, file: event.target.value}))}
+                  >
+                    {logState.availableFiles.map((file) => (
+                      <option key={file} value={file}>
+                        {file}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>级别</span>
+                  <select
+                    className={styles.fieldInput}
+                    value={logState.level}
+                    onChange={(event) => setLogState((prev) => ({...prev, level: event.target.value}))}
+                  >
+                    {LOG_LEVEL_OPTIONS.map((level) => (
+                      <option key={level || 'all'} value={level}>
+                        {level || '全部'}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.fieldLabel}>组件</span>
+                  <select
+                    className={styles.fieldInput}
+                    value={logState.component}
+                    onChange={(event) => setLogState((prev) => ({...prev, component: event.target.value}))}
+                  >
+                    <option value="">全部</option>
+                    {logState.availableComponents.map((component) => (
+                      <option key={component} value={component}>
+                        {component}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <p className={styles.logMeta}>
+                自动刷新 6 秒
+                {logState.refreshedAt ? ` · 最近更新 ${new Date(logState.refreshedAt).toLocaleTimeString()}` : ''}
+              </p>
+              {logState.error ? <p className={styles.errorNote}>{logState.error}</p> : null}
+              <pre className={styles.logViewer}>
+                {logState.entries.length ? logState.entries.join('') : '暂无匹配日志。'}
+              </pre>
             </div>
 
             <div className={styles.panelBlock}>

--- a/website/src/pages/console/styles.module.css
+++ b/website/src/pages/console/styles.module.css
@@ -1,0 +1,1229 @@
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap");
+
+/* ═══════════════════════════════════════════════════════
+   Hermes Console — aligned to docs/skills gold palette
+   Background #07070d · Accent #FFD700 · Text #e8e4dc
+   ═══════════════════════════════════════════════════════ */
+
+.page {
+  --console-bg: #07070d;
+  --console-bg-soft: #0f0f18;
+  --console-panel: rgba(15, 15, 24, 0.92);
+  --console-panel-strong: rgba(18, 18, 28, 0.98);
+  --console-panel-muted: rgba(255, 255, 255, 0.025);
+  --console-border: rgba(255, 215, 0, 0.08);
+  --console-border-strong: rgba(255, 215, 0, 0.18);
+  --console-text: #e8e4dc;
+  --console-text-secondary: #9a968e;
+  --console-text-muted: rgba(154, 150, 142, 0.6);
+  --console-accent: #FFD700;
+  --console-accent-soft: rgba(255, 215, 0, 0.08);
+  --console-success: #6ee7b7;
+  --console-danger: #fca5a5;
+  --console-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  background:
+    radial-gradient(ellipse at 20% 0%, rgba(255, 215, 0, 0.04), transparent 32rem),
+    radial-gradient(ellipse at 80% 0%, rgba(255, 215, 0, 0.02), transparent 28rem),
+    linear-gradient(180deg, #07070d, #050509);
+  color: var(--console-text);
+  min-height: calc(100vh - 60px);
+  padding: 1.5rem 1.25rem 3rem;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+}
+
+[data-theme='light'] .page {
+  --console-bg: #fafaf8;
+  --console-bg-soft: #f2f1ee;
+  --console-panel: rgba(255, 255, 255, 0.92);
+  --console-panel-strong: rgba(255, 255, 255, 0.98);
+  --console-panel-muted: rgba(0, 0, 0, 0.02);
+  --console-border: rgba(0, 0, 0, 0.08);
+  --console-border-strong: rgba(0, 0, 0, 0.14);
+  --console-text: #1a1a16;
+  --console-text-secondary: rgba(26, 26, 22, 0.65);
+  --console-text-muted: rgba(26, 26, 22, 0.4);
+  --console-accent: #b39600;
+  --console-accent-soft: rgba(179, 150, 0, 0.07);
+  --console-success: #0f766e;
+  --console-danger: #dc2626;
+  --console-shadow: 0 16px 48px rgba(0, 0, 0, 0.06);
+  background:
+    radial-gradient(ellipse at 20% 0%, rgba(179, 150, 0, 0.04), transparent 28rem),
+    linear-gradient(180deg, #fafaf8, #f2f1ee);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Hero
+   ═══════════════════════════════════════════════════════ */
+
+.hero {
+  max-width: 1480px;
+  margin: 0 auto 1rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(300px, 0.9fr);
+  gap: 0.75rem;
+}
+
+.heroCopy,
+.heroStats {
+  border: 1px solid var(--console-border);
+  background: var(--console-panel);
+  border-radius: 16px;
+  box-shadow: var(--console-shadow);
+  backdrop-filter: blur(16px);
+}
+
+.heroCopy {
+  padding: 1.5rem 1.75rem;
+}
+
+.heroEyebrow,
+.panelEyebrow,
+.blockLabel,
+.composerLabel,
+.fieldLabel,
+.heroStatLabel,
+.metricLabel,
+.messageRole,
+.sessionMeta {
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.heroEyebrow,
+.panelEyebrow {
+  color: rgba(255, 215, 0, 0.5);
+  font-size: 0.7rem;
+  margin: 0 0 0.5rem;
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: clamp(1.8rem, 3.5vw, 2.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+  color: #fafaf6;
+}
+
+.heroText {
+  margin: 0.7rem 0 0;
+  max-width: 58rem;
+  color: var(--console-text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.heroStats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0.65rem;
+  align-content: start;
+}
+
+.heroStat {
+  border-radius: 12px;
+  background: var(--console-panel-muted);
+  border: 1px solid var(--console-border);
+  padding: 0.7rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.heroStatValue {
+  font-size: 0.95rem;
+  line-height: 1.3;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.heroStatSep {
+  margin: 0 0.2em;
+  color: var(--console-text-muted);
+  font-weight: 400;
+}
+
+.heroStatLabel {
+  font-size: 0.62rem;
+  color: var(--console-text-muted);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Shell layout
+   ═══════════════════════════════════════════════════════ */
+
+.shell {
+  max-width: 1480px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(240px, 0.85fr) minmax(0, 1.8fr) minmax(300px, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.panel {
+  min-height: 42rem;
+  border-radius: 16px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--console-shadow);
+  overflow: hidden;
+}
+
+.sidebar,
+.inspector {
+  display: flex;
+  flex-direction: column;
+}
+
+.panelHeader,
+.chatHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1.1rem 1.1rem 0;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.panelBlock {
+  padding: 0 1.1rem 1rem;
+}
+
+.blockLabel,
+.composerLabel,
+.fieldLabel,
+.metricLabel {
+  display: block;
+  margin: 0 0 0.55rem;
+  font-size: 0.65rem;
+  color: var(--console-text-muted);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Buttons
+   ═══════════════════════════════════════════════════════ */
+
+.primaryButton,
+.ghostButton,
+.dangerButton,
+.promptChip,
+.sessionItem,
+.toggleRow {
+  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.primaryButton,
+.ghostButton,
+.dangerButton {
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  padding: 0.55rem 0.9rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.primaryButton {
+  background: linear-gradient(180deg, #FFD700, #E6C200);
+  color: #07070d;
+  border-color: rgba(255, 215, 0, 0.4);
+}
+
+.primaryButton:hover {
+  box-shadow: 0 0 16px rgba(255, 215, 0, 0.2);
+}
+
+.ghostButton:hover {
+  border-color: var(--console-border-strong);
+  background: rgba(255, 215, 0, 0.04);
+}
+
+.dangerButton:hover {
+  box-shadow: 0 0 12px rgba(252, 165, 165, 0.15);
+}
+
+.primaryButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.ghostButton {
+  background: var(--console-panel-muted);
+  color: var(--console-text-secondary);
+}
+
+.dangerButton {
+  background: rgba(252, 165, 165, 0.06);
+  color: var(--console-danger);
+  border-color: rgba(252, 165, 165, 0.2);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Session list
+   ═══════════════════════════════════════════════════════ */
+
+.sessionList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.75rem 1.1rem 1.1rem;
+}
+
+.sessionItem {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--console-panel-muted);
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+}
+
+.sessionContent {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.7rem 0.8rem;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.sessionDeleteBtn {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--console-text-muted);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 140ms ease, background-color 140ms ease, color 140ms ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sessionItem:hover .sessionDeleteBtn {
+  opacity: 1;
+}
+
+.sessionDeleteBtn:hover {
+  background: rgba(252, 165, 165, 0.1);
+  color: var(--console-danger);
+  border-color: rgba(252, 165, 165, 0.2);
+}
+
+.sessionItem:hover {
+  border-color: rgba(255, 215, 0, 0.12);
+}
+
+.sessionItemActive {
+  border-color: rgba(255, 215, 0, 0.2);
+  background: rgba(255, 215, 0, 0.04);
+}
+
+.sessionTitle {
+  display: block;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+  color: var(--console-text);
+}
+
+.sessionMeta {
+  color: var(--console-text-muted);
+  font-size: 0.62rem;
+}
+
+.promptGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.4rem;
+}
+
+.promptChip {
+  text-align: left;
+  width: 100%;
+  font-size: 0.88rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--console-panel-muted);
+  color: var(--console-text-secondary);
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  cursor: pointer;
+}
+
+.promptChip:hover {
+  border-color: rgba(255, 215, 0, 0.15);
+  color: var(--console-text);
+}
+
+.checkList {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--console-text-secondary);
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.checkList code,
+.commandBlock code,
+.noteText code {
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  color: var(--console-accent);
+  font-size: 0.85em;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Chat panel
+   ═══════════════════════════════════════════════════════ */
+
+.chatPanel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-height: calc(100vh - 12rem);
+  min-height: 32rem;
+}
+
+.chatHeader {
+  padding-bottom: 0.85rem;
+}
+
+.chatHeaderActions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ── Messages scroll area ─────────────────────────── */
+
+.messages {
+  padding: 0 1.1rem 1.1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  overscroll-behavior-y: contain;
+  scrollbar-width: thin;
+  scrollbar-color: #1a1a30 #07070d;
+}
+
+.messages::-webkit-scrollbar {
+  width: 5px;
+}
+
+.messages::-webkit-scrollbar-track {
+  background: #07070d;
+}
+
+.messages::-webkit-scrollbar-thumb {
+  background: #1a1a30;
+  border-radius: 3px;
+}
+
+.messages::-webkit-scrollbar-thumb:hover {
+  background: #2a2a40;
+}
+
+[data-theme='light'] .messages {
+  scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+}
+
+[data-theme='light'] .messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-theme='light'] .messages::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme='light'] .messages::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.2);
+}
+
+/* ── Message cards ────────────────────────────────── */
+
+.messageCard {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.85rem 1rem;
+  background: var(--console-panel-strong);
+}
+
+.messageUser {
+  background: rgba(255, 215, 0, 0.04);
+  border-color: rgba(255, 215, 0, 0.1);
+}
+
+.messageAssistant {
+  background: var(--console-panel-strong);
+}
+
+.messageError {
+  background: rgba(252, 165, 165, 0.06);
+  border-color: rgba(252, 165, 165, 0.15);
+}
+
+.messageHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.messageRole {
+  font-size: 0.62rem;
+  color: var(--console-text-muted);
+}
+
+.messageTime {
+  font-size: 0.72rem;
+  color: var(--console-text-muted);
+}
+
+.messageBody {
+  line-height: 1.65;
+  font-size: 0.94rem;
+  color: var(--console-text);
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Markdown body
+   ═══════════════════════════════════════════════════════ */
+
+.mdBody {
+  display: flex;
+  flex-direction: column;
+}
+
+.proseText {
+  white-space: pre-wrap;
+}
+
+.mdHeading {
+  margin: 0.7rem 0 0.25rem;
+  line-height: 1.3;
+  color: #fafaf6;
+}
+
+.mdHeading:first-child {
+  margin-top: 0;
+}
+
+.mdList {
+  margin: 0.3rem 0 0.4rem;
+  padding-left: 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  line-height: 1.6;
+}
+
+.mdList li::marker {
+  color: rgba(255, 215, 0, 0.4);
+}
+
+.mdHr {
+  border: none;
+  border-top: 1px solid var(--console-border);
+  margin: 0.6rem 0;
+}
+
+.mdLink {
+  color: var(--console-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 140ms ease;
+}
+
+.mdLink:hover {
+  color: #FFBF00;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Code blocks
+   ═══════════════════════════════════════════════════════ */
+
+.codeBlock {
+  margin: 0.45rem 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: #0f0f18;
+  overflow-x: auto;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  position: relative;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 215, 0, 0.06) transparent;
+}
+
+.codeBlock::-webkit-scrollbar {
+  height: 4px;
+}
+
+.codeBlock::-webkit-scrollbar-thumb {
+  background: rgba(255, 215, 0, 0.08);
+  border-radius: 2px;
+}
+
+[data-theme='light'] .codeBlock {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.codeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+  gap: 0.5rem;
+}
+
+.codeLang {
+  font-size: 0.65rem;
+  color: var(--console-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  user-select: none;
+}
+
+.codeCopyBtn {
+  padding: 0.15rem 0.45rem;
+  border-radius: 6px;
+  border: 1px solid var(--console-border);
+  background: rgba(255, 215, 0, 0.03);
+  color: var(--console-text-muted);
+  font-size: 0.65rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease, background 140ms ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.codeCopyBtn:hover {
+  color: var(--console-accent);
+  border-color: rgba(255, 215, 0, 0.25);
+  background: rgba(255, 215, 0, 0.06);
+}
+
+[data-theme='light'] .codeCopyBtn {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+[data-theme='light'] .codeCopyBtn:hover {
+  background: rgba(179, 150, 0, 0.06);
+}
+
+.inlineCode {
+  padding: 0.1em 0.35em;
+  border-radius: 5px;
+  background: rgba(255, 215, 0, 0.06);
+  border: 1px solid var(--console-border);
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.85em;
+  color: var(--console-accent);
+}
+
+[data-theme='light'] .inlineCode {
+  background: rgba(179, 150, 0, 0.06);
+  color: var(--console-accent);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Pending / loading
+   ═══════════════════════════════════════════════════════ */
+
+.pendingBar {
+  height: 2px;
+  width: 100%;
+  margin-top: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(255, 215, 0, 0.6), transparent);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.3;
+    transform: scaleX(0.92);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  100% {
+    opacity: 0.3;
+    transform: scaleX(0.92);
+  }
+}
+
+/* ═══════════════════════════════════════════════════════
+   Empty state
+   ═══════════════════════════════════════════════════════ */
+
+.emptyState {
+  border: 1px dashed var(--console-border-strong);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255, 215, 0, 0.02), transparent);
+  padding: 1.25rem;
+}
+
+.emptyEyebrow {
+  display: inline-flex;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: var(--console-accent-soft);
+  color: var(--console-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.emptyState h3 {
+  margin: 0.8rem 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.emptyState p {
+  margin: 0 0 0.85rem;
+  line-height: 1.65;
+  font-size: 0.9rem;
+  color: var(--console-text-secondary);
+}
+
+.commandBlock {
+  margin: 0;
+  padding: 0.85rem;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: #0f0f18;
+  overflow-x: auto;
+  font-size: 0.82rem;
+}
+
+[data-theme='light'] .commandBlock {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Composer
+   ═══════════════════════════════════════════════════════ */
+
+.composerWrap {
+  border-top: 1px solid var(--console-border);
+  padding: 0.85rem 1.1rem 1.1rem;
+  background: linear-gradient(180deg, rgba(255, 215, 0, 0.01), transparent);
+}
+
+.composer {
+  width: 100%;
+  resize: none;
+  min-height: 2.6rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  color: var(--console-text);
+  padding: 0.75rem 0.85rem;
+  font: inherit;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.fieldInput:focus,
+.fieldTextarea:focus,
+.composer:focus {
+  outline: none;
+  border-color: rgba(255, 215, 0, 0.4);
+  box-shadow: 0 0 0 3px rgba(255, 215, 0, 0.06);
+}
+
+.composerActions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.6rem;
+}
+
+.composerHint {
+  margin: 0;
+  color: var(--console-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  max-width: 40rem;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Inspector panel form
+   ═══════════════════════════════════════════════════════ */
+
+.formGrid {
+  padding: 0.85rem 1.1rem 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.field {
+  display: block;
+}
+
+.fieldInput,
+.fieldTextarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: rgba(15, 15, 24, 0.6);
+  color: var(--console-text);
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  font-size: 0.88rem;
+}
+
+.fieldTextarea {
+  resize: vertical;
+}
+
+.fieldHint {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--console-text-muted);
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+}
+
+.modelRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+}
+
+.toggleRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  color: var(--console-text-secondary);
+  cursor: pointer;
+  font-size: 0.88rem;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Status badges
+   ═══════════════════════════════════════════════════════ */
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  color: var(--console-text-secondary);
+  font-size: 0.72rem;
+  line-height: 1.3;
+  max-width: 16rem;
+  text-align: right;
+}
+
+.statusReady {
+  color: var(--console-success);
+  border-color: rgba(110, 231, 183, 0.25);
+  background: rgba(110, 231, 183, 0.06);
+}
+
+.statusWorking {
+  color: var(--console-accent);
+  border-color: rgba(255, 215, 0, 0.2);
+  background: rgba(255, 215, 0, 0.06);
+}
+
+.statusError {
+  color: var(--console-danger);
+  border-color: rgba(252, 165, 165, 0.2);
+  background: rgba(252, 165, 165, 0.06);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Metric grid
+   ═══════════════════════════════════════════════════════ */
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.metricCard {
+  border-radius: 12px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  padding: 0.7rem 0.8rem;
+}
+
+.metricValue {
+  display: block;
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.errorNote,
+.noteText {
+  margin: 0.7rem 0 0;
+  color: var(--console-text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.errorNote {
+  color: var(--console-danger);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Tool trace
+   ═══════════════════════════════════════════════════════ */
+
+.traceList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.traceItem,
+.traceEmpty {
+  border-radius: 12px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  padding: 0.7rem 0.8rem;
+  font-size: 0.88rem;
+}
+
+.traceHeading {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  align-items: baseline;
+}
+
+.traceTool {
+  font-weight: 600;
+  color: var(--console-accent);
+}
+
+.traceTime {
+  font-size: 0.7rem;
+  color: var(--console-text-muted);
+}
+
+.traceLabel,
+.traceEmpty {
+  margin: 0.3rem 0 0;
+  color: var(--console-text-secondary);
+  line-height: 1.5;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Session search
+   ═══════════════════════════════════════════════════════ */
+
+.sessionSearchWrap {
+  position: relative;
+  padding: 0 1.1rem 0.3rem;
+}
+
+.sessionSearchInput {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  color: var(--console-text);
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font: inherit;
+  font-size: 0.84rem;
+}
+
+.sessionSearchInput:focus {
+  outline: none;
+  border-color: rgba(255, 215, 0, 0.4);
+  box-shadow: 0 0 0 3px rgba(255, 215, 0, 0.06);
+}
+
+.sessionSearchInput::placeholder {
+  color: var(--console-text-muted);
+}
+
+.sessionSearchClear {
+  position: absolute;
+  right: 1.35rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--console-text-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+
+.sessionSearchClear:hover {
+  color: var(--console-text);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Image attachment preview
+   ═══════════════════════════════════════════════════════ */
+
+.imagePreview {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 215, 0, 0.15);
+  background: rgba(255, 215, 0, 0.04);
+}
+
+.imagePreviewThumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  object-fit: cover;
+  border: 1px solid var(--console-border);
+}
+
+.imagePreviewName {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.84rem;
+  color: var(--console-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.imagePreviewSize {
+  font-size: 0.72rem;
+  color: var(--console-text-muted);
+  flex-shrink: 0;
+}
+
+.imageRemoveBtn {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--console-text-muted);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.imageRemoveBtn:hover {
+  background: rgba(252, 165, 165, 0.1);
+  color: var(--console-danger);
+}
+
+/* ═══════════════════════════════════════════════════════
+   Slash command menu
+   ═══════════════════════════════════════════════════════ */
+
+.slashMenu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-bottom: 0.45rem;
+  border-radius: 12px;
+  border: 1px solid var(--console-border-strong);
+  background: var(--console-panel-strong);
+  padding: 0.35rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.slashItem {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--console-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.88rem;
+  text-align: left;
+  transition: background 100ms ease;
+}
+
+.slashItem:hover {
+  background: rgba(255, 215, 0, 0.06);
+}
+
+.slashItemActive {
+  background: rgba(255, 215, 0, 0.1);
+  border: 1px solid rgba(255, 215, 0, 0.15);
+}
+
+.slashName {
+  font-weight: 600;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.84rem;
+  color: var(--console-accent);
+  flex-shrink: 0;
+  min-width: 5rem;
+}
+
+.slashDesc {
+  color: var(--console-text-secondary);
+  font-size: 0.82rem;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Composer buttons row
+   ═══════════════════════════════════════════════════════ */
+
+.composerButtons {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Enhanced tool trace
+   ═══════════════════════════════════════════════════════ */
+
+.traceRunning {
+  color: var(--console-accent);
+  font-size: 0.7rem;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+.traceCheck {
+  color: var(--console-success);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.traceErrorMark {
+  color: var(--console-danger);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.traceDone {
+  border-color: rgba(110, 231, 183, 0.12);
+  background: rgba(110, 231, 183, 0.03);
+}
+
+.traceError {
+  border-color: rgba(252, 165, 165, 0.15);
+  background: rgba(252, 165, 165, 0.04);
+}
+
+.traceArgs {
+  margin: 0.3rem 0 0;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  background: rgba(255, 215, 0, 0.03);
+  border: 1px solid var(--console-border);
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--console-text-secondary);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 6rem;
+  overflow-y: auto;
+}
+
+/* ═══════════════════════════════════════════════════════
+   Responsive
+   ═══════════════════════════════════════════════════════ */
+
+@media (max-width: 1200px) {
+  .hero,
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    min-height: auto;
+  }
+
+  .chatPanel {
+    max-height: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .page {
+    padding: 0.75rem 0.5rem 2rem;
+  }
+
+  .heroCopy,
+  .heroStats,
+  .panel {
+    border-radius: 14px;
+  }
+
+  .metricGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .composerActions,
+  .chatHeader,
+  .panelHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .modelRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/website/src/pages/console/styles.module.css
+++ b/website/src/pages/console/styles.module.css
@@ -921,6 +921,44 @@
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+  max-height: min(48vh, 32rem);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+}
+
+.traceList::-webkit-scrollbar {
+  width: 10px;
+}
+
+.traceList::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.traceList::-webkit-scrollbar-thumb {
+  background: rgba(255, 215, 0, 0.16);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.traceList::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 215, 0, 0.26);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+[data-theme='light'] .traceList::-webkit-scrollbar-thumb {
+  background: rgba(179, 150, 0, 0.24);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+[data-theme='light'] .traceList::-webkit-scrollbar-thumb:hover {
+  background: rgba(179, 150, 0, 0.34);
+  border: 2px solid transparent;
+  background-clip: padding-box;
 }
 
 .traceItem,
@@ -954,6 +992,15 @@
   margin: 0.3rem 0 0;
   color: var(--console-text-secondary);
   line-height: 1.5;
+}
+
+.traceMetaLabel {
+  margin: 0.45rem 0 0.2rem;
+  font-size: 0.68rem;
+  color: var(--console-text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
 }
 
 /* ═══════════════════════════════════════════════════════

--- a/website/src/pages/console/styles.module.css
+++ b/website/src/pages/console/styles.module.css
@@ -209,6 +209,18 @@
   color: var(--console-text-muted);
 }
 
+.blockHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.55rem;
+}
+
+.blockHeaderRow .blockLabel {
+  margin-bottom: 0;
+}
+
 /* ═══════════════════════════════════════════════════════
    Buttons
    ═══════════════════════════════════════════════════════ */
@@ -272,6 +284,36 @@
   border-color: rgba(252, 165, 165, 0.2);
 }
 
+.viewToggle {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0 1.1rem 0.75rem;
+}
+
+.viewToggleButton {
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: var(--console-panel-muted);
+  color: var(--console-text-secondary);
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  font-size: 0.84rem;
+  cursor: pointer;
+  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
+}
+
+.viewToggleButton:hover {
+  border-color: rgba(255, 215, 0, 0.18);
+  color: var(--console-text);
+}
+
+.viewToggleButtonActive {
+  background: rgba(255, 215, 0, 0.08);
+  border-color: rgba(255, 215, 0, 0.22);
+  color: var(--console-accent);
+}
+
 /* ═══════════════════════════════════════════════════════
    Session list
    ═══════════════════════════════════════════════════════ */
@@ -296,6 +338,7 @@
 
 .sessionContent {
   flex: 1;
+  display: block;
   min-width: 0;
   text-align: left;
   background: none;
@@ -356,6 +399,44 @@
 .sessionMeta {
   color: var(--console-text-muted);
   font-size: 0.62rem;
+}
+
+.sessionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.sessionSourceTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 215, 0, 0.14);
+  background: rgba(255, 215, 0, 0.05);
+  color: var(--console-accent);
+  font-size: 0.66rem;
+  line-height: 1.2;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sessionPreview {
+  display: block;
+  margin-top: 0.45rem;
+  color: var(--console-text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.remoteSessionItem {
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 
 .promptGrid {
@@ -484,6 +565,16 @@
   background: var(--console-panel-strong);
 }
 
+.messageSystem {
+  background: rgba(116, 127, 255, 0.06);
+  border-color: rgba(116, 127, 255, 0.18);
+}
+
+.messageTool {
+  background: rgba(255, 215, 0, 0.03);
+  border-color: rgba(255, 215, 0, 0.14);
+}
+
 .messageError {
   background: rgba(252, 165, 165, 0.06);
   border-color: rgba(252, 165, 165, 0.15);
@@ -497,9 +588,29 @@
   margin-bottom: 0.5rem;
 }
 
+.messageHeaderMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
 .messageRole {
   font-size: 0.62rem;
   color: var(--console-text-muted);
+}
+
+.messageMetaChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.16rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid var(--console-border);
+  background: rgba(255, 215, 0, 0.04);
+  color: var(--console-text-secondary);
+  font-size: 0.66rem;
+  line-height: 1.2;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
 }
 
 .messageTime {
@@ -742,6 +853,13 @@
   border-top: 1px solid var(--console-border);
   padding: 0.85rem 1.1rem 1.1rem;
   background: linear-gradient(180deg, rgba(255, 215, 0, 0.01), transparent);
+}
+
+.readOnlyState {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 215, 0, 0.14);
+  background: rgba(255, 215, 0, 0.03);
+  padding: 0.9rem 0.95rem;
 }
 
 .composer {
@@ -1229,6 +1347,57 @@
   overflow-y: auto;
 }
 
+.logControls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.logMeta {
+  margin: 0.65rem 0 0.55rem;
+  color: var(--console-text-muted);
+  font-size: 0.75rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+}
+
+.logViewer {
+  margin: 0;
+  max-height: min(28vh, 18rem);
+  min-height: 10rem;
+  overflow: auto;
+  padding: 0.8rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--console-border);
+  background: #0a0b12;
+  color: #d7d3ca;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.76rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 215, 0, 0.18) transparent;
+}
+
+.logViewer::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.logViewer::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.logViewer::-webkit-scrollbar-thumb {
+  background: rgba(255, 215, 0, 0.16);
+  border-radius: 999px;
+}
+
+[data-theme='light'] .logViewer {
+  background: rgba(0, 0, 0, 0.035);
+  color: #2b2720;
+}
+
 /* ═══════════════════════════════════════════════════════
    Responsive
    ═══════════════════════════════════════════════════════ */
@@ -1271,6 +1440,11 @@
   }
 
   .modelRow {
+    grid-template-columns: 1fr;
+  }
+
+  .viewToggle,
+  .logControls {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add a Docusaurus-hosted web console page for the API server
- stream tool trace inputs and summarized outputs through the API server
- persist tool traces per session in the console UI and add a scrollable trace panel

## Testing
- source venv/bin/activate && python -m py_compile run_agent.py gateway/platforms/api_server.py
- npm --prefix website run typecheck
- npm --prefix website run build

## Notes
- the Docusaurus build still reports pre-existing broken links and broken anchors unrelated to this change