### PR TITLE
feat(nix): add home-manager module for per-user hermes-agent service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         ./nix/packages.nix
         ./nix/overlays.nix
         ./nix/nixosModules.nix
+        ./nix/homeManagerModules.nix
         ./nix/checks.nix
         ./nix/devShell.nix
       ];

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -339,6 +339,9 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 
 _MANAGED_TRUE_VALUES = ("true", "1", "yes")
 _MANAGED_SYSTEM_NAMES = {
+    "home-manager": "Home Manager",
+    "hm": "Home Manager",
+    "home-manager-nixos": "Home Manager (NixOS)",
     "nix": "NixOS",
     "nixos": "NixOS",
 }
@@ -367,7 +370,13 @@ def get_managed_system() -> Optional[str]:
 
     managed_marker = get_hermes_home() / ".managed"
     if managed_marker.exists():
-        return "NixOS"
+        # Read marker content to distinguish NixOS vs home-manager.
+        # Legacy (empty) markers default to NixOS for backwards compat.
+        try:
+            content = managed_marker.read_text().strip().lower()
+        except (OSError, UnicodeDecodeError):
+            content = ""
+        return _MANAGED_SYSTEM_NAMES.get(content, "NixOS")
     return None
 
 
@@ -390,6 +399,10 @@ _NIX_UPDATE_MSG = (
 def get_managed_update_command() -> Optional[str]:
     """Return the preferred upgrade command for a managed install."""
     managed_system = get_managed_system()
+    if managed_system == "Home Manager (NixOS)":
+        return "sudo nixos-rebuild switch"
+    if managed_system == "Home Manager":
+        return "home-manager switch"
     if managed_system == "NixOS":
         return _NIX_UPDATE_MSG
     return None
@@ -632,6 +645,24 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
             f"(HERMES_MANAGED={env_hint}).\n"
             "Edit services.hermes-agent.settings in your configuration.nix and run:\n"
             "  sudo nixos-rebuild switch"
+        )
+
+    if managed_system == "Home Manager (NixOS)":
+        env_hint = raw or "home-manager-nixos"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Home Manager "
+            f"(via NixOS module, HERMES_MANAGED={env_hint}).\n"
+            "Edit programs.hermes-agent.settings in your NixOS configuration and run:\n"
+            "  sudo nixos-rebuild switch"
+        )
+
+    if managed_system == "Home Manager":
+        env_hint = raw or "home-manager"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Home Manager "
+            f"(HERMES_MANAGED={env_hint}).\n"
+            "Edit programs.hermes-agent.settings in your home-manager config and run:\n"
+            "  home-manager switch"
         )
 
     return (

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -337,6 +337,9 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 
 _MANAGED_TRUE_VALUES = ("true", "1", "yes")
 _MANAGED_SYSTEM_NAMES = {
+    "home-manager": "Home Manager",
+    "hm": "Home Manager",
+    "home-manager-nixos": "Home Manager (NixOS)",
     "nix": "NixOS",
     "nixos": "NixOS",
 }
@@ -365,7 +368,13 @@ def get_managed_system() -> Optional[str]:
 
     managed_marker = get_hermes_home() / ".managed"
     if managed_marker.exists():
-        return "NixOS"
+        # Read marker content to distinguish NixOS vs home-manager.
+        # Legacy (empty) markers default to NixOS for backwards compat.
+        try:
+            content = managed_marker.read_text().strip().lower()
+        except (OSError, UnicodeDecodeError):
+            content = ""
+        return _MANAGED_SYSTEM_NAMES.get(content, "NixOS")
     return None
 
 
@@ -388,6 +397,10 @@ _NIX_UPDATE_MSG = (
 def get_managed_update_command() -> Optional[str]:
     """Return the preferred upgrade command for a managed install."""
     managed_system = get_managed_system()
+    if managed_system == "Home Manager (NixOS)":
+        return "sudo nixos-rebuild switch"
+    if managed_system == "Home Manager":
+        return "home-manager switch"
     if managed_system == "NixOS":
         return _NIX_UPDATE_MSG
     return None
@@ -622,6 +635,24 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
             f"(HERMES_MANAGED={env_hint}).\n"
             "Edit services.hermes-agent.settings in your configuration.nix and run:\n"
             "  sudo nixos-rebuild switch"
+        )
+
+    if managed_system == "Home Manager (NixOS)":
+        env_hint = raw or "home-manager-nixos"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Home Manager "
+            f"(via NixOS module, HERMES_MANAGED={env_hint}).\n"
+            "Edit programs.hermes-agent.settings in your NixOS configuration and run:\n"
+            "  sudo nixos-rebuild switch"
+        )
+
+    if managed_system == "Home Manager":
+        env_hint = raw or "home-manager"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Home Manager "
+            f"(HERMES_MANAGED={env_hint}).\n"
+            "Edit programs.hermes-agent.settings in your home-manager config and run:\n"
+            "  home-manager switch"
         )
 
     return (

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7511,7 +7511,7 @@ def _gateway_command_inner(args):
     # Service management commands
     if subcmd == "install":
         if is_managed():
-            managed_error("install gateway service (managed by NixOS)")
+            managed_error("install gateway service")
             return
         force = getattr(args, "force", False)
         system = getattr(args, "system", False)
@@ -7623,7 +7623,7 @@ def _gateway_command_inner(args):
 
     elif subcmd == "uninstall":
         if is_managed():
-            managed_error("uninstall gateway service (managed by NixOS)")
+            managed_error("uninstall gateway service")
             return
         system = getattr(args, "system", False)
         if is_termux():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6883,7 +6883,7 @@ def _gateway_command_inner(args):
     # Service management commands
     if subcmd == "install":
         if is_managed():
-            managed_error("install gateway service (managed by NixOS)")
+            managed_error("install gateway service")
             return
         force = getattr(args, "force", False)
         system = getattr(args, "system", False)
@@ -6995,7 +6995,7 @@ def _gateway_command_inner(args):
 
     elif subcmd == "uninstall":
         if is_managed():
-            managed_error("uninstall gateway service (managed by NixOS)")
+            managed_error("uninstall gateway service")
             return
         system = getattr(args, "system", False)
         if is_termux():

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -360,6 +360,52 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           ${self'.packages.messaging.hermesVenv}/bin/python3 -c \
             "import discord; print(discord.__version__)"
           echo "PASS: discord.py importable from messaging variant venv"
+
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
+        # Verify HERMES_MANAGED=home-manager guard works on mutation commands
+        home-manager-guard = pkgs.runCommand "hermes-home-manager-guard" { } ''
+          set -e
+          export HOME=$(mktemp -d)
+
+          check_blocked() {
+            local label="$1"
+            shift
+            OUTPUT=$(HERMES_MANAGED=home-manager "$@" 2>&1 || true)
+            echo "$OUTPUT" | grep -q "managed by Home Manager" || (echo "FAIL: $label not guarded"; echo "$OUTPUT"; exit 1)
+            echo "PASS: $label blocked in home-manager managed mode"
+          }
+
+          echo "=== Checking HERMES_MANAGED=home-manager guards ==="
+          check_blocked "config set" ${hermes-agent}/bin/hermes config set model foo
+          check_blocked "config edit" ${hermes-agent}/bin/hermes config edit
+
+          echo "=== All home-manager guard checks passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
+        # Verify HERMES_MANAGED=home-manager-nixos guard (NixOS module mode)
+        home-manager-nixos-guard = pkgs.runCommand "hermes-home-manager-nixos-guard" { } ''
+          set -e
+          export HOME=$(mktemp -d)
+
+          check_blocked() {
+            local label="$1"
+            shift
+            OUTPUT=$(HERMES_MANAGED=home-manager-nixos "$@" 2>&1 || true)
+            echo "$OUTPUT" | grep -q "managed by Home Manager" || (echo "FAIL: $label not guarded"; echo "$OUTPUT"; exit 1)
+            echo "$OUTPUT" | grep -q "sudo nixos-rebuild switch" || (echo "FAIL: $label missing nixos-rebuild hint"; echo "$OUTPUT"; exit 1)
+            echo "PASS: $label blocked in home-manager-nixos managed mode"
+          }
+
+          echo "=== Checking HERMES_MANAGED=home-manager-nixos guards ==="
+          check_blocked "config set" ${hermes-agent}/bin/hermes config set model foo
+          check_blocked "config edit" ${hermes-agent}/bin/hermes config edit
+
+          echo "=== All home-manager-nixos guard checks passed ==="
           mkdir -p $out
           echo "ok" > $out/result
         '';

--- a/nix/homeManagerModules.nix
+++ b/nix/homeManagerModules.nix
@@ -1,0 +1,619 @@
+# nix/homeManagerModules.nix — Home Manager module for hermes-agent
+#
+# Runs hermes-agent as a per-user service under home-manager.
+#   Linux:   systemd.user.services
+#   macOS:   launchd.agents
+# Container mode is not supported (requires system-level docker/podman).
+#
+{ inputs, ... }:
+
+{
+  flake.homeManagerModules.default =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+
+    let
+      cfg = config.programs.hermes-agent;
+      hermes-agent = inputs.self.packages.${pkgs.system}.default;
+
+      # Deep-merge config type (same as nixosModules.nix)
+      deepConfigType = lib.types.mkOptionType {
+        name = "hermes-config-attrs";
+        description = "Hermes YAML config (attrset), merged deeply via lib.recursiveUpdate.";
+        check = builtins.isAttrs;
+        merge = _loc: defs: lib.foldl' lib.recursiveUpdate { } (map (d: d.value) defs);
+      };
+
+      # Generate config.yaml from Nix attrset (YAML is a superset of JSON)
+      configJson = builtins.toJSON cfg.settings;
+      generatedConfigFile = pkgs.writeText "hermes-config.yaml" configJson;
+      configFile = if cfg.configFile != null then cfg.configFile else generatedConfigFile;
+
+      configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
+
+      # Generate .env from non-secret environment attrset
+      envFileContent = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment);
+
+      # Build documents derivation
+      documentDerivation = pkgs.runCommand "hermes-documents" { } (
+        ''
+          mkdir -p $out
+        ''
+        + lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            name: value:
+            if builtins.isPath value || lib.isStorePath value then
+              "cp ${value} $out/${name}"
+            else
+              "cat > $out/${name} <<'HERMES_DOC_EOF'\n${value}\nHERMES_DOC_EOF"
+          ) cfg.documents
+        )
+      );
+
+    in
+    {
+      options.programs.hermes-agent = {
+        enable = lib.mkEnableOption "Hermes Agent gateway service";
+
+        # ── Package ──────────────────────────────────────────────────────────
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = hermes-agent;
+          description = "The hermes-agent package to use.";
+        };
+
+        # ── Directories ──────────────────────────────────────────────────────
+        stateDir = lib.mkOption {
+          type = lib.types.str;
+          default = "${config.home.homeDirectory}/.local/share/hermes";
+          defaultText = lib.literalExpression ''"''${config.home.homeDirectory}/.local/share/hermes"'';
+          description = "State directory. Contains .hermes/ subdir (HERMES_HOME).";
+        };
+
+        workingDirectory = lib.mkOption {
+          type = lib.types.str;
+          default = "${cfg.stateDir}/workspace";
+          defaultText = lib.literalExpression ''"''${cfg.stateDir}/workspace"'';
+          description = "Working directory for the agent (MESSAGING_CWD).";
+        };
+
+        # ── Declarative config ───────────────────────────────────────────────
+        configFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = ''
+            Path to an existing config.yaml. If set, takes precedence over
+            the declarative `settings` option.
+          '';
+        };
+
+        settings = lib.mkOption {
+          type = deepConfigType;
+          default = { };
+          description = ''
+            Declarative Hermes config (attrset). Deep-merged across module
+            definitions and rendered as config.yaml.
+          '';
+          example = lib.literalExpression ''
+            {
+              model = "anthropic/claude-sonnet-4";
+              terminal.backend = "local";
+              compression = { enabled = true; threshold = 0.85; };
+              toolsets = [ "all" ];
+            }
+          '';
+        };
+
+        # ── Secrets / environment ────────────────────────────────────────────
+        environmentFiles = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = ''
+            Paths to environment files containing secrets (API keys, tokens).
+            Contents are merged into $HERMES_HOME/.env at activation time.
+            Hermes reads this file on every startup via load_hermes_dotenv().
+          '';
+        };
+
+        environment = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = { };
+          description = ''
+            Non-secret environment variables. Merged into $HERMES_HOME/.env
+            at activation time. Do NOT put secrets here — use environmentFiles.
+          '';
+        };
+
+        authFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = ''
+            Path to an auth.json seed file (OAuth credentials).
+            Only copied on first deploy — existing auth.json is preserved.
+          '';
+        };
+
+        authFileForceOverwrite = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Always overwrite auth.json from authFile on activation.";
+        };
+
+        # ── Documents ────────────────────────────────────────────────────────
+        documents = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.either lib.types.str lib.types.path);
+          default = { };
+          description = ''
+            Workspace files (SOUL.md, USER.md, etc.). Keys are filenames,
+            values are inline strings or paths. Installed into workingDirectory.
+          '';
+          example = lib.literalExpression ''
+            {
+              "SOUL.md" = "You are a helpful AI assistant.";
+              "USER.md" = ./documents/USER.md;
+            }
+          '';
+        };
+
+        # ── MCP Servers ──────────────────────────────────────────────────────
+        mcpServers = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              options = {
+                # Stdio transport
+                command = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "MCP server command (stdio transport).";
+                };
+                args = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = "Command-line arguments (stdio transport).";
+                };
+                env = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.str;
+                  default = { };
+                  description = "Environment variables for the server process (stdio transport).";
+                };
+
+                # HTTP/StreamableHTTP transport
+                url = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "MCP server endpoint URL (HTTP/StreamableHTTP transport).";
+                };
+                headers = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.str;
+                  default = { };
+                  description = "HTTP headers, e.g. for authentication (HTTP transport).";
+                };
+
+                # Authentication
+                auth = lib.mkOption {
+                  type = lib.types.nullOr (lib.types.enum [ "oauth" ]);
+                  default = null;
+                  description = ''
+                    Authentication method. Set to "oauth" for OAuth 2.1 PKCE flow
+                    (remote MCP servers). Tokens are stored in $HERMES_HOME/mcp-tokens/.
+                  '';
+                };
+
+                # Enable/disable
+                enabled = lib.mkOption {
+                  type = lib.types.bool;
+                  default = true;
+                  description = "Enable or disable this MCP server.";
+                };
+
+                # Common options
+                timeout = lib.mkOption {
+                  type = lib.types.nullOr lib.types.int;
+                  default = null;
+                  description = "Tool call timeout in seconds (default: 120).";
+                };
+                connect_timeout = lib.mkOption {
+                  type = lib.types.nullOr lib.types.int;
+                  default = null;
+                  description = "Initial connection timeout in seconds (default: 60).";
+                };
+
+                # Tool filtering
+                tools = lib.mkOption {
+                  type = lib.types.nullOr (
+                    lib.types.submodule {
+                      options = {
+                        include = lib.mkOption {
+                          type = lib.types.listOf lib.types.str;
+                          default = [ ];
+                          description = "Tool allowlist — only these tools are registered.";
+                        };
+                        exclude = lib.mkOption {
+                          type = lib.types.listOf lib.types.str;
+                          default = [ ];
+                          description = "Tool blocklist — these tools are hidden.";
+                        };
+                      };
+                    }
+                  );
+                  default = null;
+                  description = "Filter which tools are exposed by this server.";
+                };
+
+                # Sampling (server-initiated LLM requests)
+                sampling = lib.mkOption {
+                  type = lib.types.nullOr (
+                    lib.types.submodule {
+                      options = {
+                        enabled = lib.mkOption {
+                          type = lib.types.bool;
+                          default = true;
+                          description = "Enable sampling.";
+                        };
+                        model = lib.mkOption {
+                          type = lib.types.nullOr lib.types.str;
+                          default = null;
+                          description = "Override model for sampling requests.";
+                        };
+                        max_tokens_cap = lib.mkOption {
+                          type = lib.types.nullOr lib.types.int;
+                          default = null;
+                          description = "Max tokens per request.";
+                        };
+                        timeout = lib.mkOption {
+                          type = lib.types.nullOr lib.types.int;
+                          default = null;
+                          description = "LLM call timeout in seconds.";
+                        };
+                        max_rpm = lib.mkOption {
+                          type = lib.types.nullOr lib.types.int;
+                          default = null;
+                          description = "Max requests per minute.";
+                        };
+                        max_tool_rounds = lib.mkOption {
+                          type = lib.types.nullOr lib.types.int;
+                          default = null;
+                          description = "Max tool-use rounds per sampling request.";
+                        };
+                        allowed_models = lib.mkOption {
+                          type = lib.types.listOf lib.types.str;
+                          default = [ ];
+                          description = "Models the server is allowed to request.";
+                        };
+                        log_level = lib.mkOption {
+                          type = lib.types.nullOr (
+                            lib.types.enum [
+                              "debug"
+                              "info"
+                              "warning"
+                            ]
+                          );
+                          default = null;
+                          description = "Audit log level for sampling requests.";
+                        };
+                      };
+                    }
+                  );
+                  default = null;
+                  description = "Sampling configuration for server-initiated LLM requests.";
+                };
+              };
+            }
+          );
+          default = { };
+          description = ''
+            MCP server configurations (merged into settings.mcp_servers).
+            Each server uses either stdio (command/args) or HTTP (url) transport.
+          '';
+          example = lib.literalExpression ''
+            {
+              filesystem = {
+                command = "npx";
+                args = [ "-y" "@modelcontextprotocol/server-filesystem" "/home/user" ];
+              };
+              remote-api = {
+                url = "http://my-server:8080/v0/mcp";
+                headers = { Authorization = "Bearer ..."; };
+              };
+              remote-oauth = {
+                url = "https://mcp.example.com/mcp";
+                auth = "oauth";
+              };
+            }
+          '';
+        };
+
+        # ── Service behavior ─────────────────────────────────────────────────
+        extraArgs = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Extra command-line arguments for `hermes gateway`.";
+        };
+
+        extraPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [ ];
+          description = "Extra packages available on PATH.";
+        };
+
+        restart = lib.mkOption {
+          type = lib.types.str;
+          default = "always";
+          description = ''
+            Restart policy. Maps to systemd Restart= (Linux) or
+            launchd KeepAlive (macOS).
+          '';
+        };
+
+        restartSec = lib.mkOption {
+          type = lib.types.int;
+          default = 5;
+          description = ''
+            Seconds between restart attempts. Maps to systemd RestartSec=
+            (Linux) or launchd ThrottleInterval (macOS, minimum 10s).
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+
+          # ── Merge MCP servers into settings ────────────────────────────────
+          (lib.mkIf (cfg.mcpServers != { }) {
+            programs.hermes-agent.settings.mcp_servers = lib.mapAttrs (
+              _name: srv:
+              # Stdio transport
+              lib.optionalAttrs (srv.command != null) { inherit (srv) command args; }
+              // lib.optionalAttrs (srv.env != { }) { inherit (srv) env; }
+              # HTTP transport
+              // lib.optionalAttrs (srv.url != null) { inherit (srv) url; }
+              // lib.optionalAttrs (srv.headers != { }) { inherit (srv) headers; }
+              # Auth
+              // lib.optionalAttrs (srv.auth != null) { inherit (srv) auth; }
+              # Enable/disable
+              // {
+                inherit (srv) enabled;
+              }
+              # Common options
+              // lib.optionalAttrs (srv.timeout != null) { inherit (srv) timeout; }
+              // lib.optionalAttrs (srv.connect_timeout != null) { inherit (srv) connect_timeout; }
+              # Tool filtering
+              // lib.optionalAttrs (srv.tools != null) {
+                tools = lib.filterAttrs (_: v: v != [ ]) {
+                  inherit (srv.tools) include exclude;
+                };
+              }
+              # Sampling
+              // lib.optionalAttrs (srv.sampling != null) {
+                sampling = lib.filterAttrs (_: v: v != null && v != [ ]) {
+                  inherit (srv.sampling)
+                    enabled
+                    model
+                    max_tokens_cap
+                    timeout
+                    max_rpm
+                    max_tool_rounds
+                    allowed_models
+                    log_level
+                    ;
+                };
+              }
+            ) cfg.mcpServers;
+          })
+
+          # ── Packages & environment ─────────────────────────────────────────
+          {
+            home.packages = [ cfg.package ] ++ cfg.extraPackages;
+            home.sessionVariables.HERMES_HOME = "${cfg.stateDir}/.hermes";
+          }
+
+          # ── Activation: directories, config, auth, env, documents ─────────
+          {
+            home.activation.hermesAgentSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+              # Ensure directories exist
+              mkdir -p ${cfg.stateDir}/.hermes
+              mkdir -p ${cfg.stateDir}/.hermes/cron
+              mkdir -p ${cfg.stateDir}/.hermes/sessions
+              mkdir -p ${cfg.stateDir}/.hermes/logs
+              mkdir -p ${cfg.stateDir}/.hermes/memories
+              mkdir -p ${cfg.workingDirectory}
+
+              # Merge Nix settings into existing config.yaml.
+              # Preserves user-added keys; Nix keys win.
+              ${
+                if cfg.configFile != null then
+                  ''
+                    install -m 0640 -D ${configFile} ${cfg.stateDir}/.hermes/config.yaml
+                  ''
+                else
+                  ''
+                    ${configMergeScript} ${generatedConfigFile} ${cfg.stateDir}/.hermes/config.yaml
+                    chmod 0640 ${cfg.stateDir}/.hermes/config.yaml
+                  ''
+              }
+
+              # Managed mode marker
+              touch ${cfg.stateDir}/.hermes/.managed
+
+              # Seed auth file if provided
+              ${lib.optionalString (cfg.authFile != null) (
+                if cfg.authFileForceOverwrite then
+                  ''
+                    install -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
+                  ''
+                else
+                  ''
+                    if [ ! -f ${cfg.stateDir}/.hermes/auth.json ]; then
+                      install -m 0600 ${cfg.authFile} ${cfg.stateDir}/.hermes/auth.json
+                    fi
+                  ''
+              )}
+
+              # Seed .env from non-secret environment only.
+              # Secret environmentFiles are appended at service start via ExecStartPre,
+              # after agenix/sops have decrypted them.
+              ${lib.optionalString (cfg.environment != { }) ''
+                ENV_FILE="${cfg.stateDir}/.hermes/.env"
+                install -m 0640 /dev/null "$ENV_FILE"
+                cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
+                ${envFileContent}
+                HERMES_NIX_ENV_EOF
+              ''}
+
+              # Link documents into workspace
+              ${lib.concatStringsSep "\n" (
+                lib.mapAttrsToList (name: _value: ''
+                  install -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
+                '') cfg.documents
+              )}
+            '';
+          }
+
+          # ── Linux: systemd user service ────────────────────────────────────
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+            systemd.user.services.hermes-agent = {
+              Unit = {
+                Description = "Hermes Agent Gateway";
+                After = [ "network-online.target" ] ++ lib.optional (cfg.environmentFiles != [ ]) "agenix.service";
+                Wants = [ "network-online.target" ] ++ lib.optional (cfg.environmentFiles != [ ]) "agenix.service";
+              };
+
+              Service =
+                let
+                  servicePath = lib.makeBinPath (
+                    [
+                      cfg.package
+                      pkgs.bash
+                      pkgs.coreutils
+                      pkgs.git
+                    ]
+                    ++ cfg.extraPackages
+                  );
+
+                  # Script to append secret environmentFiles to .env at service
+                  # start time. Runs after agenix/sops have decrypted secrets,
+                  # unlike the activation script which runs before systemd.
+                  envSeedScript = pkgs.writeShellScript "hermes-seed-envfiles" ''
+                    ENV_FILE="${cfg.stateDir}/.hermes/.env"
+                    ${lib.concatStringsSep "\n" (
+                      map (f: ''
+                        if [ -f "${f}" ]; then
+                          echo "" >> "$ENV_FILE"
+                          cat "${f}" >> "$ENV_FILE"
+                        fi
+                      '') cfg.environmentFiles
+                    )}
+                  '';
+                in
+                lib.mkMerge [
+                  {
+                    Environment = [
+                      "HOME=${config.home.homeDirectory}"
+                      "HERMES_HOME=${cfg.stateDir}/.hermes"
+                      "HERMES_MANAGED=true"
+                      "MESSAGING_CWD=${cfg.workingDirectory}"
+                      ("PATH=" + servicePath + "\${PATH:+:$PATH}")
+                    ];
+
+                    ExecStart = lib.concatStringsSep " " (
+                      [
+                        "${cfg.package}/bin/hermes"
+                        "gateway"
+                      ]
+                      ++ cfg.extraArgs
+                    );
+
+                    Restart = cfg.restart;
+                    RestartSec = cfg.restartSec;
+
+                    WorkingDirectory = cfg.workingDirectory;
+                  }
+
+                  (lib.mkIf (cfg.environmentFiles != [ ]) {
+                    ExecStartPre = "${envSeedScript}";
+                  })
+                ];
+
+              Install.WantedBy = [ "default.target" ];
+            };
+          })
+
+          # ── Darwin: launchd agent ──────────────────────────────────────────
+          (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+            launchd.agents.hermes-agent = {
+              enable = true;
+              config =
+                let
+                  # launchd has no ExecStartPre, so we wrap env seeding +
+                  # gateway into a single script.
+                  gatewayWrapper = pkgs.writeShellScript "hermes-gateway-wrapper" ''
+                    # Append secret environmentFiles to .env (agenix decrypts
+                    # via its own launchd agent with RunAtLoad, same as us —
+                    # the script gracefully skips missing files).
+                    ${lib.optionalString (cfg.environmentFiles != [ ]) ''
+                      ENV_FILE="${cfg.stateDir}/.hermes/.env"
+                      ${lib.concatStringsSep "\n" (
+                        map (f: ''
+                          if [ -f "${f}" ]; then
+                            echo "" >> "$ENV_FILE"
+                            cat "${f}" >> "$ENV_FILE"
+                          fi
+                        '') cfg.environmentFiles
+                      )}
+                    ''}
+
+                    exec ${
+                      lib.concatStringsSep " " (
+                        [
+                          "${cfg.package}/bin/hermes"
+                          "gateway"
+                        ]
+                        ++ cfg.extraArgs
+                      )
+                    }
+                  '';
+
+                  # Map systemd restart policy to launchd KeepAlive.
+                  keepAlive =
+                    if cfg.restart == "always" then
+                      true
+                    else if cfg.restart == "on-failure" then
+                      { SuccessfulExit = false; }
+                    else
+                      false;
+                in
+                {
+                  ProgramArguments = [ "${gatewayWrapper}" ];
+                  RunAtLoad = true;
+                  KeepAlive = keepAlive;
+                  ThrottleInterval = cfg.restartSec;
+                  WorkingDirectory = cfg.workingDirectory;
+                  EnvironmentVariables = {
+                    HOME = config.home.homeDirectory;
+                    HERMES_HOME = "${cfg.stateDir}/.hermes";
+                    HERMES_MANAGED = "true";
+                    MESSAGING_CWD = cfg.workingDirectory;
+                    PATH = lib.makeBinPath (
+                      [
+                        cfg.package
+                        pkgs.bash
+                        pkgs.coreutils
+                        pkgs.git
+                      ]
+                      ++ cfg.extraPackages
+                    );
+                  };
+                  StandardOutPath = "${cfg.stateDir}/.hermes/logs/launchd-stdout.log";
+                  StandardErrorPath = "${cfg.stateDir}/.hermes/logs/launchd-stderr.log";
+                  ProcessType = "Background";
+                };
+            };
+          })
+        ]
+      );
+    };
+}

--- a/nix/homeManagerModules.nix
+++ b/nix/homeManagerModules.nix
@@ -357,6 +357,16 @@
             (Linux) or launchd ThrottleInterval (macOS, minimum 10s).
           '';
         };
+
+        managedMode = lib.mkOption {
+          type = lib.types.enum [ "home-manager" "nixos" ];
+          default = "home-manager";
+          description = ''
+            How home-manager is invoked:
+            - "home-manager": standalone home-manager (update via home-manager switch)
+            - "nixos": home-manager used as a NixOS module (update via sudo nixos-rebuild switch)
+          '';
+        };
       };
 
       config = lib.mkIf cfg.enable (
@@ -408,7 +418,10 @@
           # ── Packages & environment ─────────────────────────────────────────
           {
             home.packages = [ cfg.package ] ++ cfg.extraPackages;
-            home.sessionVariables.HERMES_HOME = "${cfg.stateDir}/.hermes";
+            home.sessionVariables = {
+              HERMES_HOME = "${cfg.stateDir}/.hermes";
+              HERMES_MANAGED = if cfg.managedMode == "nixos" then "home-manager-nixos" else "home-manager";
+            };
           }
 
           # ── Activation: directories, config, auth, env, documents ─────────
@@ -436,8 +449,10 @@
                   ''
               }
 
-              # Managed mode marker
-              touch ${cfg.stateDir}/.hermes/.managed
+              # Managed mode marker (content identifies the manager)
+              echo "${
+                if cfg.managedMode == "nixos" then "home-manager-nixos" else "home-manager"
+              }" > ${cfg.stateDir}/.hermes/.managed
 
               # Seed auth file if provided
               ${lib.optionalString (cfg.authFile != null) (
@@ -514,7 +529,9 @@
                     Environment = [
                       "HOME=${config.home.homeDirectory}"
                       "HERMES_HOME=${cfg.stateDir}/.hermes"
-                      "HERMES_MANAGED=true"
+                      "HERMES_MANAGED=${
+                        if cfg.managedMode == "nixos" then "home-manager-nixos" else "home-manager"
+                      }"
                       "MESSAGING_CWD=${cfg.workingDirectory}"
                       ("PATH=" + servicePath + "\${PATH:+:$PATH}")
                     ];
@@ -595,7 +612,7 @@
                   EnvironmentVariables = {
                     HOME = config.home.homeDirectory;
                     HERMES_HOME = "${cfg.stateDir}/.hermes";
-                    HERMES_MANAGED = "true";
+                    HERMES_MANAGED = if cfg.managedMode == "nixos" then "home-manager-nixos" else "home-manager";
                     MESSAGING_CWD = cfg.workingDirectory;
                     PATH = lib.makeBinPath (
                       [

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -1,7 +1,11 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.config import recommended_update_command
+from hermes_cli.config import (
+    format_managed_message,
+    get_managed_system,
+    recommended_update_command,
+)
 from hermes_cli.main import cmd_update
 from tools.skills_hub import OptionalSkillSource
 
@@ -27,3 +31,95 @@ def test_optional_skill_source_honors_env_override(monkeypatch, tmp_path):
     source = OptionalSkillSource()
 
     assert source._optional_dir == optional_dir
+
+
+# ── Home Manager detection tests ──────────────────────────────────────────────
+
+
+def test_get_managed_system_home_manager_env(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "home-manager")
+
+    assert get_managed_system() == "Home Manager"
+    assert recommended_update_command() == "home-manager switch"
+
+
+def test_get_managed_system_home_manager_nixos_env(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "home-manager-nixos")
+
+    assert get_managed_system() == "Home Manager (NixOS)"
+    assert recommended_update_command() == "sudo nixos-rebuild switch"
+
+
+def test_get_managed_system_home_manager_marker(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".managed").write_text("home-manager")
+
+    assert get_managed_system() == "Home Manager"
+
+
+def test_get_managed_system_home_manager_nixos_marker(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".managed").write_text("home-manager-nixos")
+
+    assert get_managed_system() == "Home Manager (NixOS)"
+
+
+def test_get_managed_system_empty_marker_still_nixos(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".managed").write_text("")
+
+    assert get_managed_system() == "NixOS"
+
+
+def test_get_managed_system_nixos_marker(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".managed").write_text("nixos")
+
+    assert get_managed_system() == "NixOS"
+
+
+def test_format_managed_message_home_manager(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "home-manager")
+
+    message = format_managed_message("update Hermes Agent")
+
+    assert "managed by Home Manager" in message
+    assert "home-manager switch" in message
+    assert "programs.hermes-agent.settings" in message
+
+
+def test_format_managed_message_home_manager_nixos(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "home-manager-nixos")
+
+    message = format_managed_message("update Hermes Agent")
+
+    assert "managed by Home Manager" in message
+    assert "via NixOS module" in message
+    assert "sudo nixos-rebuild switch" in message
+    assert "programs.hermes-agent.settings" in message
+
+
+def test_format_managed_message_nixos_unchanged(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "true")
+
+    message = format_managed_message("update Hermes Agent")
+
+    assert "managed by NixOS" in message
+    assert "sudo nixos-rebuild switch" in message
+    assert "services.hermes-agent.settings" in message
+
+
+def test_cmd_update_blocks_managed_home_manager(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_MANAGED", "home-manager")
+
+    with patch("hermes_cli.main.subprocess.run") as mock_run:
+        cmd_update(SimpleNamespace())
+
+    assert not mock_run.called
+    captured = capsys.readouterr()
+    assert "managed by Home Manager" in captured.err
+    assert "home-manager switch" in captured.err

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -12,13 +12,14 @@ Nix and NixOS are [Tier 2 platforms](./platform-support.md#tier-2). The flake an
 For a supported setup, use one of the standard [installation](./installation.md) paths - either Docker or an FHS environment.
 :::
 
-Hermes Agent ships a Nix flake & a NixOS module.
+Hermes Agent ships a Nix flake with four levels of integration:
 
 | Level | Who it's for | What you get |
 |-------|-------------|--------------|
 | **`nix run` / `nix profile install`** | Any Nix user (macOS, Linux) | Pre-built binary with all deps — then use the standard CLI workflow |
 | **NixOS module (native)** | NixOS server deployments | Declarative config, hardened systemd service, managed secrets |
 | **NixOS module (container)** | Agents that need self-modification | Everything above, plus a persistent Ubuntu container where the agent can `apt`/`pip`/`npm install` |
+| **Home Manager module** | home-manager users | Per-user systemd service, declarative config, managed secrets |
 
 :::info What's different from the standard install
 The `curl | bash` installer manages Python, Node, and dependencies itself. The Nix flake replaces all of that — every Python dependency is a Nix derivation built by [uv2nix](https://github.com/pyproject-nix/uv2nix), and runtime tools (Node.js, git, ripgrep, ffmpeg) are wrapped into the binary's PATH. There is no runtime pip, no venv activation, no `npm install`.
@@ -221,6 +222,78 @@ To enable container mode, add one line:
 :::info
 Container mode auto-enables `virtualisation.docker.enable` via `mkDefault`. If you use Podman instead, set `container.backend = "podman"` and `virtualisation.docker.enable = false`.
 :::
+
+---
+
+## Home Manager Module
+
+For users managing their environment with [home-manager](https://github.com/nix-community/home-manager) (standalone or as a NixOS module), hermes-agent provides `homeManagerModules.default`. This runs the gateway as a **per-user systemd service** instead of a system-level one.
+
+**Key differences from the NixOS module:**
+- Runs under your user account (no system user/group creation)
+- State lives in `~/.local/share/hermes` by default (XDG convention)
+- Uses `systemd.user.services` (Linux) or `launchd.agents` (macOS) instead of system-level services
+- No container mode (requires system-level Docker/Podman)
+- No system-level hardening (ProtectSystem, NoNewPrivileges, etc.)
+
+### Standalone home-manager
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, hermes-agent, ... }: {
+    homeConfigurations."you" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        hermes-agent.homeManagerModules.default
+        {
+          home.username = "you";
+          home.homeDirectory = "/home/you";
+          home.stateVersion = "25.05";
+
+          programs.hermes-agent = {
+            enable = true;
+            settings.model = "anthropic/claude-sonnet-4";
+            environmentFiles = [ ./secrets.env ];
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+### home-manager as NixOS module
+
+```nix
+{
+  home-manager.users.alice = { pkgs, ... }: {
+    imports = [ hermes-agent.homeManagerModules.default ];
+    programs.hermes-agent = {
+      enable = true;
+      settings.model = "anthropic/claude-sonnet-4";
+      mcpServers.filesystem = {
+        command = "npx";
+        args = [ "-y" "@modelcontextprotocol/server-filesystem" "/home/alice" ];
+      };
+    };
+  };
+}
+```
+
+The `programs.hermes-agent` options are the same as the NixOS module's `services.hermes-agent` options, minus `user`, `group`, `createUser`, `addToSystemPackages`, and `container.*`.
 
 ---
 
@@ -962,11 +1035,17 @@ All `docker` commands below work the same with `podman`. Substitute accordingly 
 ### Service Logs
 
 ```bash
-# Both modes use the same systemd unit
+# NixOS: Both modes use the same systemd unit
 journalctl -u hermes-agent -f
 
-# Container mode: also available directly
+# NixOS with container mode: also available directly
 docker logs -f hermes-agent
+
+# Home-manager on linux: use user-scoped systemd unit
+journalctl -u hermes-agent -f --user
+
+# Home-manager on darwin: use launchd
+log stream --predicate 'eventMessage CONTAINS "hermes-agent"' --info
 ```
 
 ### Container Inspection


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Adds homeManagerModules.default exposing programs.hermes-agent with the same declarative config, MCP servers, documents, and settings as the NixOS module, but adapted for home-manager's user-scoped architecture.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #9056

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- systemd.user.services / launchd.agents instead of system-level services
- State dir defaults to ~/.local/share/hermes (XDG convention)
- home.activation for setup, no user/group creation needed


secret management:

sops-nix compatibility: sops-nix decrypts secrets during `home.activation`, which completes before any services start. No explicit service dependency is needed — ExecStartPre (Linux) and the launchd wrapper (Darwin) find the decrypted files already in place.

agenix compatibility: environmentFiles are appended to .env via ExecStartPre (runs after agenix decrypts secrets), not in the activation script. The service unit adds After/Wants on agenix.service when environmentFiles is non-empty.

A potential issue is that the secret may have been appended multiple times to the `.env` file. This could be resolved after #10139 is merged.



## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Add the flake input (point at the feature branch for testing):                                                                
   `inputs.hermes-agent.url = "github:yzx9/hermes-agent/feat/home-manager";`
2. Import the module in your home-manager config:
   ```nix
   imports = [ hermes-agent.homeManagerModules.default ];
   programs.hermes-agent = {
     enable = true;                                                                                                                 
     settings.model = "anthropic/claude-sonnet-4";                                                                                  
     environmentFiles = [ config.sops.secrets.hermes-env.path ]; # optional                                                         
   };
   ```
4. Build and switch:
   ```bash
   # as nixos module
   sudo nixos-rebuild switch --flake .#your-profile
   # standalone
   home-manager switch --flake .#your-profile
   ```
5. Verify directory structure and config were generated:
   ```bash
   ls ~/.local/share/hermes/.hermes/config.yaml
   ls ~/.local/share/hermes/.hermes/.managed
   ```
6. Verify the service is running:
   ```
   # Linux
   systemctl --user status hermes-agent
   # macOS
   launchctl list | grep hermes
   ```
7. Verify secrets were injected (if using environmentFiles):
   ```bash
   cat ~/.local/share/hermes/.hermes/.env
   ```
8. Verify the gateway is healthy, say hello in the configured message platform

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> NixOS with latest nixpkgs-unstable and latest home-manager

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

