### PR TITLE
fix(cron): #9086 differentiate scheduler-blocking from gateway downti…

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -26,6 +26,7 @@ try:
     HAS_CRONITER = True
 except ImportError:
     HAS_CRONITER = False
+_PROCESS_START_TIME = _hermes_now()
 
 # =============================================================================
 # Configuration
@@ -702,29 +703,32 @@ def get_due_jobs() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
             grace = _compute_grace_seconds(schedule)
             if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
-                # Job is past its catch-up grace window — this is a stale missed run.
-                # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
-                new_next = compute_next_run(schedule, now.isoformat())
-                if new_next:
-                    logger.info(
-                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
-                        "Fast-forwarding to next run: %s",
-                        job.get("name", job["id"]),
-                        next_run,
-                        grace,
-                        new_next,
+                # Distinguish between gateway downtime and scheduler blocking.
+                # If the job was scheduled AFTER the process started, we were alive
+                # but blocked by other long-running jobs. In that case, we MUST
+                # run it late to prevent silent data loss.
+                if next_run_dt >= _PROCESS_START_TIME:
+                    logger.warning(
+                        "Job '%s' is running %ds late (%s) because the scheduler was blocked. Executing now.",
+                        job.get("name", job["id"]), (now - next_run_dt).total_seconds(), next_run
                     )
-                    # Update the job in storage
-                    for rj in raw_jobs:
-                        if rj["id"] == job["id"]:
-                            rj["next_run_at"] = new_next
-                            needs_save = True
-                            break
-                    continue  # Skip this run
+                else:
+                    # Gateway was actually down. Fast-forward to prevent burst execution.
+                    new_next = compute_next_run(schedule, now.isoformat())
+                    if new_next:
+                        logger.warning(
+                            "Job '%s' missed its scheduled time while gateway was offline (%s). "
+                            "Fast-forwarding to next run: %s",
+                            job.get("name", job["id"]), next_run, new_next
+                        )
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["next_run_at"] = new_next
+                                needs_save = True
+                                break
+                        continue  # Skip this run
 
             due.append(job)
 


### PR DESCRIPTION
…me in job grace logic

## What does this PR do?

--------------------------------------------------------------------------------------------------------------------------------------------



bug
A silent data loss issue was occurring where valid cron jobs were being fast-forwarded and skipped. Because the scheduler uses a serial `tick()` loop, a long-running LLM job (e.g., 15 mins) would block the scheduler. By the time it finished, subsequent jobs had exceeded their `_compute_grace_seconds()` window. The system couldn't tell if the job was late because the gateway was down, or if the scheduler was just busy.

--------------------------------------------------------------------------------------------------------------------------------------------
Instead of heavily refactoring the execution loop into a ThreadPool (which introduces unwanted complexity), I implemented a lightweight logic check within `jobs.py`:
* Introduced `_PROCESS_START_TIME`.
* **Gateway Offline (Restart scenario):** If `next_run_dt < _PROCESS_START_TIME`, the system was genuinely offline. Safe to fast-forward.
* **Scheduler Blocked (Serial queuing):** If `next_run_dt >= _PROCESS_START_TIME`, the gateway was online but busy running other jobs. The job is retained and executed late, completely eliminating silent data loss.
* Upgraded log levels to `WARNING` with clear explanations of *why* a job was skipped or delayed.

--------------------------------------------------------------------------------------------------------------------------------------------

* Zero architectural overhead.
* Resolves silent skipping of overlapping scheduled tasks.

fix  #9086

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

