### PR TITLE
feat(security): add optional workspace_root guardrails

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -258,6 +258,7 @@ terminal:
 # Docs: https://github.com/sheeki03/tirith
 #
 # security:
+#   workspace_root: "/absolute/path/to/workspace"  # Optional: constrain file tools, terminal cwd/workdir, and @file/@folder refs to one workspace
 #   tirith_enabled: true        # Enable/disable tirith scanning
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -258,7 +258,7 @@ terminal:
 # Docs: https://github.com/sheeki03/tirith
 #
 # security:
-#   workspace_root: "/absolute/path/to/workspace"  # Optional: constrain file tools, terminal cwd/workdir, and @file/@folder refs to one workspace
+#   workspace_root: "/absolute/path/to/workspace"  # Optional: constrain host-side @file/@folder refs plus local file tools and terminal cwd/workdir
 #   tirith_enabled: true        # Enable/disable tirith scanning
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds

--- a/cli.py
+++ b/cli.py
@@ -516,6 +516,11 @@ def load_cli_config() -> Dict[str, Any]:
         redact = security_config.get("redact_secrets")
         if redact is not None:
             os.environ["HERMES_REDACT_SECRETS"] = str(redact).lower()
+        workspace_root = str(security_config.get("workspace_root", "") or "").strip()
+        if workspace_root:
+            os.environ["HERMES_WORKSPACE_ROOT"] = workspace_root
+            # Keep the legacy write-only guard aligned with the new workspace root.
+            os.environ["HERMES_WRITE_SAFE_ROOT"] = workspace_root
 
     return defaults
 
@@ -7608,8 +7613,14 @@ class HermesCLI:
                 from agent.model_metadata import get_model_context_length
                 _ctx_len = get_model_context_length(
                     self.model, base_url=self.base_url or "", api_key=self.api_key or "")
+                _ctx_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+                _ctx_allowed_root = os.getenv("HERMES_WORKSPACE_ROOT") or _ctx_cwd
                 _ctx_result = preprocess_context_references(
-                    message, cwd=os.getcwd(), context_length=_ctx_len)
+                    message,
+                    cwd=_ctx_cwd,
+                    context_length=_ctx_len,
+                    allowed_root=_ctx_allowed_root,
+                )
                 if _ctx_result.expanded or _ctx_result.blocked:
                     if _ctx_result.references:
                         _cprint(

--- a/cli.py
+++ b/cli.py
@@ -519,8 +519,6 @@ def load_cli_config() -> Dict[str, Any]:
         workspace_root = str(security_config.get("workspace_root", "") or "").strip()
         if workspace_root:
             os.environ["HERMES_WORKSPACE_ROOT"] = workspace_root
-            # Keep the legacy write-only guard aligned with the new workspace root.
-            os.environ["HERMES_WRITE_SAFE_ROOT"] = workspace_root
 
     return defaults
 
@@ -7613,7 +7611,7 @@ class HermesCLI:
                 from agent.model_metadata import get_model_context_length
                 _ctx_len = get_model_context_length(
                     self.model, base_url=self.base_url or "", api_key=self.api_key or "")
-                _ctx_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+                _ctx_cwd = os.getcwd()
                 _ctx_allowed_root = os.getenv("HERMES_WORKSPACE_ROOT") or _ctx_cwd
                 _ctx_result = preprocess_context_references(
                     message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -205,6 +205,10 @@ if _config_path.exists():
             _redact = _security_cfg.get("redact_secrets")
             if _redact is not None:
                 os.environ["HERMES_REDACT_SECRETS"] = str(_redact).lower()
+            _workspace_root = str(_security_cfg.get("workspace_root", "") or "").strip()
+            if _workspace_root:
+                os.environ["HERMES_WORKSPACE_ROOT"] = _workspace_root
+                os.environ["HERMES_WRITE_SAFE_ROOT"] = _workspace_root
     except Exception:
         pass  # Non-fatal; gateway can still run with .env values
 
@@ -3075,7 +3079,7 @@ class GatewayRunner:
                     message_text,
                     cwd=_msg_cwd,
                     context_length=_msg_ctx_len,
-                    allowed_root=_msg_cwd,
+                    allowed_root=os.environ.get("HERMES_WORKSPACE_ROOT") or _msg_cwd,
                 )
                 if _ctx_result.blocked:
                     _adapter = self.adapters.get(source.platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -208,7 +208,6 @@ if _config_path.exists():
             _workspace_root = str(_security_cfg.get("workspace_root", "") or "").strip()
             if _workspace_root:
                 os.environ["HERMES_WORKSPACE_ROOT"] = _workspace_root
-                os.environ["HERMES_WRITE_SAFE_ROOT"] = _workspace_root
     except Exception:
         pass  # Non-fatal; gateway can still run with .env values
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2304,8 +2304,9 @@ _SECURITY_COMMENT = """
 # tirith pre-exec scanning is enabled by default when the tirith binary
 # is available. Configure via security.tirith_* keys or env vars
 # (TIRITH_ENABLED, TIRITH_BIN, TIRITH_TIMEOUT, TIRITH_FAIL_OPEN).
-# workspace_root optionally constrains file tools, terminal cwd/workdir,
-# and @file/@folder references to a single workspace tree.
+# workspace_root optionally constrains host-side @file/@folder references
+# plus local built-in file tools and terminal cwd/workdir to one workspace.
+# Non-local terminal backends keep their existing path semantics.
 #
 # security:
 #   redact_secrets: false
@@ -2356,6 +2357,8 @@ _COMMENTED_SECTIONS = """
 # ── Security ──────────────────────────────────────────────────────────
 # API keys, tokens, and passwords are redacted from tool output by default.
 # Set to false to see full values (useful for debugging auth issues).
+# workspace_root constrains host-side @file/@folder refs plus local built-in
+# file tools and terminal cwd/workdir to one workspace when configured.
 #
 # security:
 #   redact_secrets: false

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -666,6 +666,9 @@ DEFAULT_CONFIG = {
     # Pre-exec security scanning via tirith
     "security": {
         "redact_secrets": True,
+        # Optional absolute path that bounds file/terminal/context-ref access.
+        # Empty string disables workspace-root enforcement.
+        "workspace_root": "",
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,
@@ -2301,9 +2304,12 @@ _SECURITY_COMMENT = """
 # tirith pre-exec scanning is enabled by default when the tirith binary
 # is available. Configure via security.tirith_* keys or env vars
 # (TIRITH_ENABLED, TIRITH_BIN, TIRITH_TIMEOUT, TIRITH_FAIL_OPEN).
+# workspace_root optionally constrains file tools, terminal cwd/workdir,
+# and @file/@folder references to a single workspace tree.
 #
 # security:
 #   redact_secrets: false
+#   workspace_root: /absolute/path/to/workspace
 #   tirith_enabled: true
 #   tirith_path: "tirith"
 #   tirith_timeout: 5
@@ -2353,6 +2359,7 @@ _COMMENTED_SECTIONS = """
 #
 # security:
 #   redact_secrets: false
+#   workspace_root: /absolute/path/to/workspace
 
 # ── Fallback Model ────────────────────────────────────────────────────
 # Automatic provider failover when primary is unavailable.

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -331,6 +331,36 @@ class TestRootLevelProviderOverride:
         assert "provider" not in result  # root key still cleaned up
 
 
+class TestWorkspaceRootBridge:
+    """security.workspace_root should bridge into process env for tools."""
+
+    def test_load_cli_config_bridges_workspace_root(self, tmp_path, monkeypatch):
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_WORKSPACE_ROOT", raising=False)
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(yaml.safe_dump({
+            "security": {
+                "workspace_root": str(workspace),
+            },
+        }))
+
+        import cli
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cli.load_cli_config()
+
+        assert os.environ["HERMES_WORKSPACE_ROOT"] == str(workspace)
+        assert os.environ["HERMES_WRITE_SAFE_ROOT"] == str(workspace)
+
+
 class TestProviderResolution:
     def test_api_key_is_string_or_none(self):
         cli = _make_cli()

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -343,7 +343,6 @@ class TestWorkspaceRootBridge:
         workspace.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("HERMES_WORKSPACE_ROOT", raising=False)
-        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
 
         config_path = hermes_home / "config.yaml"
         config_path.write_text(yaml.safe_dump({
@@ -358,7 +357,6 @@ class TestWorkspaceRootBridge:
         cli.load_cli_config()
 
         assert os.environ["HERMES_WORKSPACE_ROOT"] == str(workspace)
-        assert os.environ["HERMES_WRITE_SAFE_ROOT"] == str(workspace)
 
 
 class TestProviderResolution:

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -59,7 +59,6 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
         workspace_root = str(security_cfg.get("workspace_root", "") or "").strip()
         if workspace_root:
             env["HERMES_WORKSPACE_ROOT"] = workspace_root
-            env["HERMES_WRITE_SAFE_ROOT"] = workspace_root
 
     # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
     configured_cwd = env.get("TERMINAL_CWD", "")
@@ -159,10 +158,8 @@ class TestTopLevelCwdAlias:
         cfg = {"security": {"workspace_root": "/srv/agents/agent-a"}}
         result = _simulate_config_bridge(cfg)
         assert result["HERMES_WORKSPACE_ROOT"] == "/srv/agents/agent-a"
-        assert result["HERMES_WRITE_SAFE_ROOT"] == "/srv/agents/agent-a"
 
     def test_empty_workspace_root_not_bridged(self):
         cfg = {"security": {"workspace_root": "  "}}
         result = _simulate_config_bridge(cfg)
         assert "HERMES_WORKSPACE_ROOT" not in result
-        assert "HERMES_WRITE_SAFE_ROOT" not in result

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -53,6 +53,14 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
             if isinstance(alias_val, str) and alias_val.strip():
                 env[alias_env] = alias_val.strip()
 
+    # --- Replicate security workspace-root bridge ---
+    security_cfg = cfg.get("security", {})
+    if isinstance(security_cfg, dict):
+        workspace_root = str(security_cfg.get("workspace_root", "") or "").strip()
+        if workspace_root:
+            env["HERMES_WORKSPACE_ROOT"] = workspace_root
+            env["HERMES_WRITE_SAFE_ROOT"] = workspace_root
+
     # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
     configured_cwd = env.get("TERMINAL_CWD", "")
     if not configured_cwd or configured_cwd in (".", "auto", "cwd"):
@@ -146,3 +154,15 @@ class TestTopLevelCwdAlias:
         cfg = {"cwd": "/from/config"}
         result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/from/env"})
         assert result["TERMINAL_CWD"] == "/from/config"
+
+    def test_workspace_root_bridged_to_security_env_vars(self):
+        cfg = {"security": {"workspace_root": "/srv/agents/agent-a"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["HERMES_WORKSPACE_ROOT"] == "/srv/agents/agent-a"
+        assert result["HERMES_WRITE_SAFE_ROOT"] == "/srv/agents/agent-a"
+
+    def test_empty_workspace_root_not_bridged(self):
+        cfg = {"security": {"workspace_root": "  "}}
+        result = _simulate_config_bridge(cfg)
+        assert "HERMES_WORKSPACE_ROOT" not in result
+        assert "HERMES_WRITE_SAFE_ROOT" not in result

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -17,6 +17,13 @@ from tools.file_tools import (
 )
 
 
+def _make_mock_ops(cwd: str = "/tmp"):
+    mock_ops = MagicMock()
+    mock_ops.cwd = cwd
+    mock_ops._expand_path.side_effect = lambda p: p
+    return mock_ops
+
+
 class TestFileToolsList:
     def test_has_expected_entries(self):
         names = {t["name"] for t in FILE_TOOLS}
@@ -37,7 +44,7 @@ class TestFileToolsList:
 class TestReadFileHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_returns_file_content(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.content = "line1\nline2"
         result_obj.to_dict.return_value = {"content": "line1\nline2", "total_lines": 2}
@@ -52,7 +59,7 @@ class TestReadFileHandler:
 
     @patch("tools.file_tools._get_file_ops")
     def test_custom_offset_and_limit(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.content = "line10"
         result_obj.to_dict.return_value = {"content": "line10", "total_lines": 50}
@@ -72,11 +79,26 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_blocks_reads_outside_workspace_root(self, mock_get, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        mock_ops = _make_mock_ops(str(workspace))
+        mock_get.return_value = mock_ops
+        monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("../secret.txt"))
+
+        assert "workspace_root" in result["error"]
+        mock_ops.read_file.assert_not_called()
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_writes_content(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/out.txt", "bytes": 13}
         mock_ops.write_file.return_value = result_obj
@@ -109,11 +131,26 @@ class TestWriteFileHandler:
         assert result["error"] == "boom"
         assert any("write_file error" in r.getMessage() for r in caplog.records)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_blocks_writes_outside_workspace_root(self, mock_get, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        mock_ops = _make_mock_ops(str(workspace))
+        mock_get.return_value = mock_ops
+        monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("../secret.txt", "data"))
+
+        assert "workspace_root" in result["error"]
+        mock_ops.write_file.assert_not_called()
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_calls_patch_replace(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
         mock_ops.patch_replace.return_value = result_obj
@@ -129,7 +166,7 @@ class TestPatchHandler:
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "replacements": 5}
         mock_ops.patch_replace.return_value = result_obj
@@ -148,13 +185,14 @@ class TestPatchHandler:
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_strings_errors(self, mock_get):
+        mock_get.return_value = _make_mock_ops()
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="replace", path="/tmp/f.py", old_string=None, new_string="b"))
         assert "error" in result
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_mode_calls_patch_v4a(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"status": "ok", "operations": 1}
         mock_ops.patch_v4a.return_value = result_obj
@@ -178,11 +216,31 @@ class TestPatchHandler:
         assert "error" in result
         assert "Unknown mode" in result["error"]
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_blocks_patch_outside_workspace_root(self, mock_get, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        mock_ops = _make_mock_ops(str(workspace))
+        mock_get.return_value = mock_ops
+        monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="../secret.txt",
+            old_string="foo",
+            new_string="bar",
+        ))
+
+        assert "workspace_root" in result["error"]
+        mock_ops.patch_replace.assert_not_called()
+
 
 class TestSearchHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_search_calls_file_ops(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"matches": ["file1.py:3:match"]}
         mock_ops.search.return_value = result_obj
@@ -195,7 +253,7 @@ class TestSearchHandler:
 
     @patch("tools.file_tools._get_file_ops")
     def test_search_passes_all_params(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"matches": []}
         mock_ops.search.return_value = result_obj
@@ -217,6 +275,21 @@ class TestSearchHandler:
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_blocks_searches_outside_workspace_root(self, mock_get, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        mock_ops = _make_mock_ops(str(workspace))
+        mock_get.return_value = mock_ops
+        monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+        from tools.file_tools import search_tool
+        result = json.loads(search_tool(pattern="TODO", path="../other"))
+
+        assert "workspace_root" in result["error"]
+        mock_ops.search.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Tool result hint tests (#722)
@@ -227,7 +300,7 @@ class TestPatchHints:
 
     @patch("tools.file_tools._get_file_ops")
     def test_no_match_includes_hint(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {
             "error": "Could not find match for old_string in foo.py"
@@ -242,7 +315,7 @@ class TestPatchHints:
 
     @patch("tools.file_tools._get_file_ops")
     def test_success_no_hint(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {"success": True, "diff": "--- a\n+++ b"}
         mock_ops.patch_replace.return_value = result_obj
@@ -263,7 +336,7 @@ class TestSearchHints:
 
     @patch("tools.file_tools._get_file_ops")
     def test_truncated_results_hint(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {
             "total_count": 100,
@@ -280,7 +353,7 @@ class TestSearchHints:
 
     @patch("tools.file_tools._get_file_ops")
     def test_non_truncated_no_hint(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {
             "total_count": 3,
@@ -295,7 +368,7 @@ class TestSearchHints:
 
     @patch("tools.file_tools._get_file_ops")
     def test_truncated_hint_with_nonzero_offset(self, mock_get):
-        mock_ops = MagicMock()
+        mock_ops = _make_mock_ops()
         result_obj = MagicMock()
         result_obj.to_dict.return_value = {
             "total_count": 150,
@@ -309,6 +382,3 @@ class TestSearchHints:
         raw = search_tool(pattern="foo", offset=50, limit=50)
         assert "[Hint:" in raw
         assert "offset=100" in raw
-
-
-

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -94,6 +94,26 @@ class TestReadFileHandler:
         assert "workspace_root" in result["error"]
         mock_ops.read_file.assert_not_called()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_workspace_root_not_applied_for_non_local_backend(self, mock_get, monkeypatch, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        mock_ops = _make_mock_ops("/root")
+        result_obj = MagicMock()
+        result_obj.content = "ok"
+        result_obj.to_dict.return_value = {"content": "ok", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("../secret.txt"))
+
+        assert result["content"] == "ok"
+        mock_ops.read_file.assert_called_once_with("../secret.txt", 1, 500)
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_terminal_workspace_root.py
+++ b/tests/tools/test_terminal_workspace_root.py
@@ -1,0 +1,49 @@
+"""Tests for terminal workspace-root enforcement."""
+
+import json
+from unittest.mock import patch
+
+
+def test_get_env_config_defaults_local_cwd_to_workspace_root(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+    from tools.terminal_tool import _get_env_config
+
+    config = _get_env_config()
+    assert config["cwd"] == str(workspace)
+    assert config["workspace_root"] == str(workspace)
+
+
+def test_terminal_tool_blocks_workdir_outside_workspace_root(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    config = {
+        "env_type": "local",
+        "cwd": str(workspace),
+        "workspace_root": str(workspace),
+        "timeout": 60,
+    }
+
+    with (
+        patch("tools.terminal_tool._get_env_config", return_value=config),
+        patch("tools.terminal_tool._start_cleanup_thread") as mock_cleanup,
+        patch("tools.terminal_tool._create_environment") as mock_create,
+    ):
+        from tools.terminal_tool import terminal_tool
+
+        result = json.loads(
+            terminal_tool("pwd", task_id="workspace-root-test", workdir=str(outside))
+        )
+
+    assert result["status"] == "blocked"
+    assert "workspace_root" in result["error"]
+    mock_cleanup.assert_not_called()
+    mock_create.assert_not_called()

--- a/tests/tools/test_terminal_workspace_root.py
+++ b/tests/tools/test_terminal_workspace_root.py
@@ -19,6 +19,21 @@ def test_get_env_config_defaults_local_cwd_to_workspace_root(monkeypatch, tmp_pa
     assert config["workspace_root"] == str(workspace)
 
 
+def test_get_env_config_ignores_workspace_root_for_docker(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setenv("HERMES_WORKSPACE_ROOT", str(workspace))
+
+    from tools.terminal_tool import _get_env_config
+
+    config = _get_env_config()
+    assert config["cwd"] == "/root"
+    assert config["workspace_root"] == ""
+
+
 def test_terminal_tool_blocks_workdir_outside_workspace_root(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -129,6 +129,13 @@ def _resolve_tool_path(path: str, file_ops: ShellFileOperations) -> Path:
     return resolve_user_path(expanded, base_dir=file_ops.cwd, expand_user=False)
 
 
+def _get_file_tool_workspace_root() -> Path | None:
+    """Return the workspace root for local file-tool backends only."""
+    if os.getenv("TERMINAL_ENV", "local") != "local":
+        return None
+    return get_workspace_root()
+
+
 def _check_workspace_path(
     path: str,
     file_ops: ShellFileOperations,
@@ -137,7 +144,7 @@ def _check_workspace_path(
 ) -> tuple[Path, str | None]:
     """Resolve *path* and enforce the optional workspace-root boundary."""
     resolved = _resolve_tool_path(path, file_ops)
-    workspace_root = get_workspace_root()
+    workspace_root = _get_file_tool_workspace_root()
     if workspace_root is None:
         return resolved, None
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -9,6 +9,11 @@ import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import ShellFileOperations
+from tools.path_security import (
+    get_workspace_root,
+    resolve_user_path,
+    validate_within_dir,
+)
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -116,6 +121,34 @@ def _check_sensitive_path(filepath: str) -> str | None:
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
     return None
+
+
+def _resolve_tool_path(path: str, file_ops: ShellFileOperations) -> Path:
+    """Resolve a file-tool path against the active file-ops cwd."""
+    expanded = file_ops._expand_path(path)
+    return resolve_user_path(expanded, base_dir=file_ops.cwd, expand_user=False)
+
+
+def _check_workspace_path(
+    path: str,
+    file_ops: ShellFileOperations,
+    *,
+    label: str = "path",
+) -> tuple[Path, str | None]:
+    """Resolve *path* and enforce the optional workspace-root boundary."""
+    resolved = _resolve_tool_path(path, file_ops)
+    workspace_root = get_workspace_root()
+    if workspace_root is None:
+        return resolved, None
+
+    error = validate_within_dir(resolved, workspace_root)
+    if error:
+        return (
+            resolved,
+            f"Blocked: {label} resolves outside the configured workspace_root ({workspace_root}): {path}",
+        )
+
+    return resolved, None
 
 
 def _is_expected_write_exception(exc: Exception) -> bool:
@@ -282,18 +315,21 @@ def clear_file_ops_cache(task_id: str = None):
 def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
+        file_ops = _get_file_ops(task_id)
+        _resolved, workspace_err = _check_workspace_path(path, file_ops)
+        if workspace_err:
+            return tool_error(workspace_err)
+
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        if _is_blocked_device(path):
+        if _is_blocked_device(path) or _is_blocked_device(str(_resolved)):
             return json.dumps({
                 "error": (
                     f"Cannot read '{path}': this is a device file that would "
                     "block or produce infinite output."
                 ),
             })
-
-        _resolved = Path(path).expanduser().resolve()
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -357,7 +393,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
@@ -572,19 +607,22 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
 
 def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     """Write content to a file."""
-    sensitive_err = _check_sensitive_path(path)
-    if sensitive_err:
-        return tool_error(sensitive_err)
     try:
-        stale_warning = _check_file_staleness(path, task_id)
         file_ops = _get_file_ops(task_id)
+        resolved_path, workspace_err = _check_workspace_path(path, file_ops)
+        if workspace_err:
+            return tool_error(workspace_err)
+        sensitive_err = _check_sensitive_path(str(resolved_path))
+        if sensitive_err:
+            return tool_error(sensitive_err)
+        stale_warning = _check_file_staleness(str(resolved_path), task_id)
         result = file_ops.write_file(path, content)
         result_dict = result.to_dict()
         if stale_warning:
             result_dict["_warning"] = stale_warning
         # Refresh the stored timestamp so consecutive writes by this
         # task don't trigger false staleness warnings.
-        _update_read_timestamp(path, task_id)
+        _update_read_timestamp(str(resolved_path), task_id)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -598,27 +636,31 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default") -> str:
     """Patch a file using replace mode or V4A patch format."""
-    # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
-    _paths_to_check = []
-    if path:
-        _paths_to_check.append(path)
-    if mode == "patch" and patch:
-        import re as _re
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            _paths_to_check.append(_m.group(1).strip())
-    for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p)
-        if sensitive_err:
-            return tool_error(sensitive_err)
     try:
+        file_ops = _get_file_ops(task_id)
+        # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
+        _paths_to_check = []
+        if path:
+            _paths_to_check.append(path)
+        if mode == "patch" and patch:
+            import re as _re
+            for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
+                _paths_to_check.append(_m.group(1).strip())
+        _resolved_paths: dict[str, Path] = {}
+        for _p in _paths_to_check:
+            _resolved, workspace_err = _check_workspace_path(_p, file_ops)
+            if workspace_err:
+                return tool_error(workspace_err)
+            _resolved_paths[_p] = _resolved
+            sensitive_err = _check_sensitive_path(str(_resolved))
+            if sensitive_err:
+                return tool_error(sensitive_err)
         # Check staleness for all files this patch will touch.
         stale_warnings = []
         for _p in _paths_to_check:
-            _sw = _check_file_staleness(_p, task_id)
+            _sw = _check_file_staleness(str(_resolved_paths[_p]), task_id)
             if _sw:
                 stale_warnings.append(_sw)
-
-        file_ops = _get_file_ops(task_id)
         
         if mode == "replace":
             if not path:
@@ -640,7 +682,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # consecutive edits by this task don't trigger false warnings.
         if not result_dict.get("error"):
             for _p in _paths_to_check:
-                _update_read_timestamp(_p, task_id)
+                _update_read_timestamp(str(_resolved_paths[_p]), task_id)
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when old_string not found — saves iterations where the agent
         # retries with stale content instead of re-reading the file.
@@ -657,6 +699,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
+        file_ops = _get_file_ops(task_id)
+        resolved_path, workspace_err = _check_workspace_path(path, file_ops, label="search path")
+        if workspace_err:
+            return tool_error(workspace_err)
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
         # results without tripping the repeated-search guard.
@@ -690,10 +736,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "pattern": pattern,
                 "already_searched": count,
             }, ensure_ascii=False)
-
-        file_ops = _get_file_ops(task_id)
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=str(resolved_path), target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         if hasattr(result, 'matches'):

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -6,6 +6,7 @@ skills_hub, cronjob_tools, and credential_files.
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -41,3 +42,84 @@ def has_traversal_component(path_str: str) -> bool:
     """
     parts = Path(path_str).parts
     return ".." in parts
+
+
+def get_workspace_root() -> Path | None:
+    """Return the configured workspace root, or ``None`` when unset.
+
+    Environment variables take precedence so CLI/gateway bridges can make the
+    value available process-wide without every tool re-reading config.yaml.
+    """
+    env_root = os.environ.get("HERMES_WORKSPACE_ROOT")
+    if env_root is not None:
+        env_root = env_root.strip()
+        if not env_root:
+            return None
+        try:
+            return Path(env_root).expanduser().resolve()
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+    try:
+        from hermes_cli.config import load_config
+
+        security_cfg = (load_config().get("security") or {})
+        raw_root = str(security_cfg.get("workspace_root", "") or "").strip()
+        if raw_root:
+            return Path(raw_root).expanduser().resolve()
+    except Exception:
+        pass
+
+    return None
+
+
+def resolve_user_path(
+    path: str | Path,
+    *,
+    base_dir: str | Path | None = None,
+    expand_user: bool = True,
+) -> Path:
+    """Resolve a user-supplied path against an optional base directory."""
+    candidate = Path(path)
+    if expand_user:
+        candidate = candidate.expanduser()
+
+    if not candidate.is_absolute():
+        if base_dir is not None:
+            base = Path(base_dir)
+            if expand_user:
+                base = base.expanduser()
+            candidate = base.resolve() / candidate
+        else:
+            candidate = Path.cwd().resolve() / candidate
+
+    return candidate.resolve()
+
+
+def validate_workspace_path(
+    path: str | Path,
+    *,
+    base_dir: str | Path | None = None,
+    workspace_root: str | Path | None = None,
+    label: str = "path",
+    expand_user: bool = True,
+) -> tuple[Path, Path | None, str | None]:
+    """Resolve *path* and validate that it stays within the workspace root."""
+    resolved = resolve_user_path(path, base_dir=base_dir, expand_user=expand_user)
+    root = (
+        resolve_user_path(workspace_root, expand_user=True)
+        if workspace_root is not None
+        else get_workspace_root()
+    )
+    if root is None:
+        return resolved, None, None
+
+    error = validate_within_dir(resolved, root)
+    if error:
+        return (
+            resolved,
+            root,
+            f"Blocked: {label} resolves outside the configured workspace_root ({root}): {path}",
+        )
+
+    return resolved, root, None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -143,6 +143,7 @@ from tools.approval import (
     check_dangerous_command as _check_dangerous_command_impl,
     check_all_command_guards as _check_all_guards_impl,
 )
+from tools.path_security import get_workspace_root, validate_workspace_path
 
 
 def _check_all_guards(command: str, env_type: str) -> dict:
@@ -177,6 +178,36 @@ def _validate_workdir(workdir: str) -> str | None:
                 )
         return "Blocked: workdir contains disallowed characters."
     return None
+
+
+def _validate_workspace_workdir(
+    path_value: str,
+    *,
+    base_dir: str,
+    env_type: str,
+    workspace_root: str | None,
+    label: str,
+) -> tuple[str | None, str]:
+    """Validate cwd/workdir against the configured workspace root."""
+    if not workspace_root:
+        return None, path_value
+
+    resolved, _root, error = validate_workspace_path(
+        path_value,
+        base_dir=base_dir,
+        workspace_root=workspace_root,
+        label=label,
+        expand_user=(env_type == "local"),
+    )
+    if error:
+        return error, path_value
+
+    # Normalize local workdirs to absolute paths so subprocess cwd resolution
+    # matches the same boundary check we just performed.
+    if env_type == "local":
+        return None, str(resolved)
+
+    return None, path_value
 
 
 def _handle_sudo_failure(output: str, env_type: str) -> str:
@@ -603,6 +634,7 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
+    workspace_root = get_workspace_root()
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
 
@@ -623,6 +655,8 @@ def _get_env_config() -> Dict[str, Any]:
     cwd = os.getenv("TERMINAL_CWD", default_cwd)
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
+    if workspace_root is not None and env_type == "local" and "TERMINAL_CWD" not in os.environ:
+        cwd = str(workspace_root)
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
@@ -651,6 +685,7 @@ def _get_env_config() -> Dict[str, Any]:
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
         "cwd": cwd,
+        "workspace_root": str(workspace_root) if workspace_root is not None else "",
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
@@ -1207,8 +1242,47 @@ def terminal_tool(
             image = ""
 
         cwd = overrides.get("cwd") or config["cwd"]
+        workspace_root = overrides.get("workspace_root") or config.get("workspace_root", "")
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
+
+        # Validate workdir against shell injection before any environment work.
+        if workdir:
+            workdir_error = _validate_workdir(workdir)
+            if workdir_error:
+                logger.warning("Blocked dangerous workdir: %s (command: %s)",
+                               workdir[:200], _safe_command_preview(command))
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": workdir_error,
+                    "status": "blocked"
+                }, ensure_ascii=False)
+
+        workdir_label = "workdir" if workdir else "cwd"
+        effective_cwd_value = workdir or cwd
+        workspace_error, normalized_workdir = _validate_workspace_workdir(
+            effective_cwd_value,
+            base_dir=cwd,
+            env_type=env_type,
+            workspace_root=workspace_root,
+            label=workdir_label,
+        )
+        if workspace_error:
+            logger.warning(
+                "Blocked %s outside workspace_root: %s (command: %s)",
+                workdir_label,
+                effective_cwd_value,
+                _safe_command_preview(command),
+            )
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": workspace_error,
+                "status": "blocked",
+            }, ensure_ascii=False)
+        effective_workdir = normalized_workdir if workdir else None
+        env_cwd = effective_workdir or cwd
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
@@ -1287,7 +1361,7 @@ def terminal_tool(
                         new_env = _create_environment(
                             env_type=env_type,
                             image=image,
-                            cwd=cwd,
+                            cwd=env_cwd,
                             timeout=effective_timeout,
                             ssh_config=ssh_config,
                             container_config=container_config,
@@ -1346,19 +1420,6 @@ def terminal_tool(
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
-        # Validate workdir against shell injection
-        if workdir:
-            workdir_error = _validate_workdir(workdir)
-            if workdir_error:
-                logger.warning("Blocked dangerous workdir: %s (command: %s)",
-                               workdir[:200], _safe_command_preview(command))
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": workdir_error,
-                    "status": "blocked"
-                }, ensure_ascii=False)
-
         # Prepare command for execution
         pty_disabled_reason = None
         effective_pty = pty
@@ -1379,7 +1440,7 @@ def terminal_tool(
             from tools.process_registry import process_registry
 
             session_key = get_current_session_key(default="")
-            effective_cwd = workdir or cwd
+            effective_cwd = effective_workdir or cwd
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -1465,8 +1526,8 @@ def terminal_tool(
             while retry_count <= max_retries:
                 try:
                     execute_kwargs = {"timeout": effective_timeout}
-                    if workdir:
-                        execute_kwargs["cwd"] = workdir
+                    if effective_workdir:
+                        execute_kwargs["cwd"] = effective_workdir
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -634,7 +634,9 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
-    workspace_root = get_workspace_root()
+    # workspace_root is a host-path constraint. Apply it only to the local
+    # backend until non-local backends have an explicit path-mapping contract.
+    workspace_root = get_workspace_root() if env_type == "local" else None
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
 


### PR DESCRIPTION
## What does this PR do?

Adds optional `security.workspace_root` guardrails for Hermes host-side context refs and local built-in path operations.

When `workspace_root` is set:

- CLI and gateway `@file` / `@folder` expansion are limited to that root
- local built-in file tools (`read`, `write`, `patch`, `search`) reject paths outside that root
- local terminal sessions default to that root when no `cwd` is configured
- local terminal `cwd` / `workdir` overrides outside that root are rejected

When `workspace_root` is unset, existing behavior is unchanged.

Non-local terminal backends keep their existing path semantics in this PR.

## Related Issue

Partial progress on #8926

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `security.workspace_root` config support
- bridged `workspace_root` into CLI and gateway runtime env handling for host-side context processing
- constrained local terminal `cwd` / `workdir`
- constrained local built-in file `read`, `write`, `patch`, and `search`
- applied the same boundary to CLI and gateway `@file` / `@folder` context expansion
- documented the scope in config comments and `cli-config.yaml.example`
- added regression tests, including coverage to ensure non-local backends do not inherit host-path enforcement

## How to Test

1. Set `security.workspace_root` to an absolute local workspace path.
2. On the local backend, verify normal file-tool operations still work inside that workspace.
3. Verify local Hermes blocks:
   - file reads/writes/patches/searches outside the workspace
   - terminal `cwd` / `workdir` outside the workspace
   - `@file` / `@folder` references outside the workspace
4. Verify behavior is unchanged when `workspace_root` is unset.
5. Verify a non-local backend such as docker keeps its existing backend path semantics.

Focused validation run locally:

- `source venv/bin/activate && pytest tests/tools/test_file_tools.py tests/tools/test_terminal_workspace_root.py tests/cli/test_cli_init.py tests/gateway/test_config_cwd_bridge.py tests/agent/test_context_references.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_file_write_safety.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

This PR does not sandbox arbitrary shell commands inside the terminal tool. It only constrains host-side context resolution plus local built-in file-tool paths and local terminal `cwd` / `workdir`.

## Screenshots / Logs

Focused validation passed locally:

- `122 passed` on the targeted test slice above.
