### PR TITLE
fix: use ps without environment for gateway scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,7 +222,7 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
+                ["ps", "ww", "-ax", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -774,6 +774,27 @@ class TestFindGatewayPidsExclude:
         assert 100 in pids
         assert 200 in pids
 
+    def test_unix_process_scan_does_not_include_environment(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        seen_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            seen_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="100 /usr/local/bin/python -m hermes_cli.main gateway run\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert pids == [100]
+        assert ["ps", "ww", "-ax", "-o", "pid=,command="] in seen_cmds
+
     def test_filters_to_current_profile(self, monkeypatch, tmp_path):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Use `ps ww` for Unix gateway process discovery so the command column does not include environment variables.
- Add a regression test covering the expected process scan command.

## Root cause
On FreeBSD, `ps eww -ax -o pid=,command=` prefixes the command column with the process environment. That can prevent the gateway command patterns from matching reliably, so `hermes cron list` and `hermes cron status` may warn that the gateway is not running even when it is active.

## Changes
- Removed the `e` flag from the Unix `ps` invocation while keeping wide output.
- Added focused coverage for Unix process scanning.

## Validation
- `python -m pytest tests/hermes_cli/test_update_gateway_restart.py::TestFindGatewayPidsExclude::test_unix_process_scan_does_not_include_environment -q -n0` (failed before the code change, passed after)
- `python -m pytest tests/hermes_cli/test_update_gateway_restart.py::TestFindGatewayPidsExclude -q -n0`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_update_gateway_restart.py`
- `git diff --check`

I also ran `python -m pytest tests/hermes_cli/test_update_gateway_restart.py -q -n0`; unrelated Windows-local failures remain in existing launchd/POSIX PATH tests.

Fixes #9069
