### PR TITLE
fix: retry transient Telegram direct sends

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -707,6 +707,23 @@ class TestSendTelegramHtmlDetection:
         second_call = bot.send_message.await_args_list[1].kwargs
         assert second_call["parse_mode"] is None
 
+    def test_transient_bad_gateway_retries_text_send(self, monkeypatch):
+        bot = self._make_bot()
+        bot.send_message = AsyncMock(
+            side_effect=[
+                Exception("502 Bad Gateway"),
+                SimpleNamespace(message_id=2),
+            ]
+        )
+        _install_telegram_mock(monkeypatch, bot)
+
+        with patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = asyncio.run(_send_telegram("tok", "123", "hello"))
+
+        assert result["success"] is True
+        assert bot.send_message.await_count == 2
+        sleep_mock.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # Tests for Discord thread_id support

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -5,6 +5,7 @@ Sends a message to a user or channel on any connected messaging platform
 human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -46,6 +47,49 @@ def _sanitize_error_text(text) -> str:
 def _error(message: str) -> dict:
     """Build a standardized error payload with redacted content."""
     return {"error": _sanitize_error_text(message)}
+
+
+def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is not None:
+        try:
+            return max(float(retry_after), 0.0)
+        except (TypeError, ValueError):
+            return 1.0
+
+    text = str(exc).lower()
+    if "timed out" in text or "timeout" in text:
+        return None
+    if (
+        "bad gateway" in text
+        or "502" in text
+        or "too many requests" in text
+        or "429" in text
+        or "service unavailable" in text
+        or "503" in text
+        or "gateway timeout" in text
+        or "504" in text
+    ):
+        return float(2 ** attempt)
+    return None
+
+
+async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs):
+    for attempt in range(attempts):
+        try:
+            return await bot.send_message(**kwargs)
+        except Exception as exc:
+            delay = _telegram_retry_delay(exc, attempt)
+            if delay is None or attempt >= attempts - 1:
+                raise
+            logger.warning(
+                "Transient Telegram send failure (attempt %d/%d), retrying in %.1fs: %s",
+                attempt + 1,
+                attempts,
+                delay,
+                _sanitize_error_text(exc),
+            )
+            await asyncio.sleep(delay)
 
 
 SEND_MESSAGE_SCHEMA = {
@@ -482,7 +526,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
         if formatted.strip():
             try:
-                last_msg = await bot.send_message(
+                last_msg = await _send_telegram_message_with_retry(
+                    bot,
                     chat_id=int_chat_id, text=formatted,
                     parse_mode=send_parse_mode, **thread_kwargs
                 )
@@ -502,7 +547,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             plain = message
                     else:
                         plain = message
-                    last_msg = await bot.send_message(
+                    last_msg = await _send_telegram_message_with_retry(
+                        bot,
                         chat_id=int_chat_id, text=plain,
                         parse_mode=None, **thread_kwargs
                     )


### PR DESCRIPTION
## Summary
- Retry transient Telegram text-send failures in the direct send path.
- Honor `retry_after` when present and retry common 429/5xx responses with backoff.
- Keep timeout-like errors non-retried to avoid duplicate delivery risk.

## Root cause
The gateway adapter already has retry handling for transient Telegram delivery failures, but the direct `send_message` Telegram path only retried parse-mode failures. A single transient 502 or 429 could therefore fail an otherwise valid delivery.

## Changes
- Added a small retry helper around Telegram `send_message` calls used by the direct send path.
- Reused it for both formatted text and plain-text fallback sends.
- Added regression coverage for a 502 followed by a successful retry.

## Validation
- `python -m pytest tests/tools/test_send_message_tool.py::TestSendTelegramHtmlDetection::test_transient_bad_gateway_retries_text_send -q -n0` (failed before the code change, passed after)
- `python -m pytest tests/tools/test_send_message_tool.py::TestSendTelegramHtmlDetection -q -n0`
- `python -m pytest tests/tools/test_send_message_tool.py -q -n0`
- `python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py`
- `git diff --check`

Refs #8844
