### PR TITLE
fix(agent): handle whitespace-only input in build_plan_path

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -33,7 +33,8 @@ def build_plan_path(
     daytona, and similar terminal backends. That keeps the plan with the active
     workspace instead of the Hermes host's global home directory.
     """
-    slug_source = (user_instruction or "").strip().splitlines()[0] if user_instruction else ""
+    lines = (user_instruction or "").strip().splitlines()
+    slug_source = lines[0] if lines else ""
     slug = _PLAN_SLUG_RE.sub("-", slug_source.lower()).strip("-")
     if slug:
         slug = "-".join(part for part in slug.split("-")[:8] if part)[:48].strip("-")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -382,6 +382,19 @@ class TestPlanSkillHelpers:
 
         assert path == Path(".hermes") / "plans" / "2026-03-15_093045-implement-oauth-login-refresh-tokens.md"
 
+    def test_build_plan_path_whitespace_only_falls_back_to_default_slug(self):
+        """Regression test for #7576: whitespace-only input must not raise IndexError."""
+        path = build_plan_path("   \n   ", now=datetime(2026, 3, 15, 9, 30, 45))
+        assert "conversation-plan" in path.name
+
+    def test_build_plan_path_empty_string_falls_back_to_default_slug(self):
+        path = build_plan_path("", now=datetime(2026, 3, 15, 9, 30, 45))
+        assert "conversation-plan" in path.name
+
+    def test_build_plan_path_tabs_only_falls_back_to_default_slug(self):
+        path = build_plan_path("\t\t", now=datetime(2026, 3, 15, 9, 30, 45))
+        assert "conversation-plan" in path.name
+
     def test_plan_skill_message_can_include_runtime_save_path_note(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(


### PR DESCRIPTION
## What changed and why

`build_plan_path()` crashes with `IndexError` when `user_instruction` is whitespace-only (e.g. `"  \n  "`), because `.strip().splitlines()` returns an empty list and `[0]` is applied to it.

The fix splits the chained expression into two lines, guarding against the empty list before indexing.

## Changes

- `agent/skill_commands.py`: Guard empty `splitlines()` result, falling back to default `"conversation-plan"` slug
- `tests/agent/test_skill_commands.py`: Added 3 regression tests for whitespace-only, empty string, and tab-only input

## How to test

```python
from agent.skill_commands import build_plan_path
# All should return paths containing "conversation-plan" without raising IndexError:
build_plan_path("   \n   ")
build_plan_path("")
build_plan_path("\t\t")
# Normal input still works:
build_plan_path("Build a web scraper")  # contains "build-a-web-scraper"
```

```bash
pytest tests/agent/test_skill_commands.py::TestPlanSkillHelpers -v
```

## Platform tested

- macOS (Darwin 24.6.0, Python 3.14)

Closes #7576