### PR TITLE
fix(memory): align OpenViking default account with server extraction default

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,7 +10,7 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account (default: root)
+  OPENVIKING_ACCOUNT   — Tenant account (default: default)
   OPENVIKING_USER      — Tenant user (default: default)
 
 Capabilities:
@@ -83,7 +83,7 @@ class _VikingClient:
                  account: str = "", user: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
+        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._httpx = _get_httpx()
         if self._httpx is None:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,0 +1,53 @@
+"""Tests for the OpenViking memory provider plugin."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure OpenViking env vars don't leak between tests."""
+    monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+    monkeypatch.delenv("OPENVIKING_ENDPOINT", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+
+
+def _mock_httpx(json_return=None):
+    """Return a mock httpx module with a configurable response."""
+    mock = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_return or {}
+    mock.get.return_value = resp
+    mock.post.return_value = resp
+    return mock
+
+
+class TestVikingClientDefaults:
+    def test_default_account_matches_server_extraction(self):
+        """The default account must be 'default' to match OpenViking's internal extraction."""
+        with patch("plugins.memory.openviking._get_httpx", return_value=_mock_httpx()):
+            from plugins.memory.openviking import _VikingClient
+            client = _VikingClient("http://localhost:1933")
+            assert client._account == "default"
+
+    def test_account_header_matches_default(self):
+        with patch("plugins.memory.openviking._get_httpx", return_value=_mock_httpx()):
+            from plugins.memory.openviking import _VikingClient
+            client = _VikingClient("http://localhost:1933")
+            assert client._headers()["X-OpenViking-Account"] == "default"
+
+    def test_env_override_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "custom-tenant")
+        with patch("plugins.memory.openviking._get_httpx", return_value=_mock_httpx()):
+            from plugins.memory.openviking import _VikingClient
+            client = _VikingClient("http://localhost:1933")
+            assert client._account == "custom-tenant"
+
+    def test_explicit_param_takes_precedence(self):
+        with patch("plugins.memory.openviking._get_httpx", return_value=_mock_httpx()):
+            from plugins.memory.openviking import _VikingClient
+            client = _VikingClient("http://localhost:1933", account="explicit")
+            assert client._account == "explicit"


### PR DESCRIPTION
## What changed and why

The OpenViking memory plugin's `_VikingClient` defaults `account` to `"root"`, but OpenViking's internal memory extraction process stores data under `account_id="default"`. This mismatch means writes go to one tenant partition while reads filter on another, causing `viking_search` to always return 0 results.

Changed the default from `"root"` to `"default"` to match the server-side extraction behavior. Users who explicitly set `OPENVIKING_ACCOUNT` env var are unaffected.

## Changes

- `plugins/memory/openviking/__init__.py`: Change default account from `"root"` to `"default"` in `_VikingClient.__init__()` and update docstring
- `tests/plugins/memory/test_openviking_provider.py`: New test file with 4 tests covering default value, header propagation, env var override, and explicit parameter

## How to test

```python
import os
os.environ.pop("OPENVIKING_ACCOUNT", None)
from plugins.memory.openviking import _VikingClient
client = _VikingClient("http://localhost:1933")
assert client._account == "default"
assert client._headers()["X-OpenViking-Account"] == "default"
```

```bash
pytest tests/plugins/memory/test_openviking_provider.py -v
```

## Platform tested

- macOS (Darwin 24.6.0, Python 3.14)

Closes #8742