### PR TITLE
fix(memory): create OpenViking session server-side instead of reusing Hermes session_id

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -291,7 +291,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
         self._api_key = os.environ.get("OPENVIKING_API_KEY", "")
-        self._session_id = session_id
+        self._session_id = ""
         self._turn_count = 0
 
         try:
@@ -303,9 +303,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
 
-        # Register as the last active provider for atexit safety net
-        global _last_active_provider
-        _last_active_provider = self
+        # Create a server-side OpenViking session — OpenViking generates its
+        # own session IDs and rejects unknown ones with 500 errors.
+        if self._client:
+            try:
+                resp = self._client.post("/api/v1/sessions", {"query": f"hermes:{session_id}"})
+                result = resp.get("result") or {}
+                self._session_id = result.get("session_id", "") if isinstance(result, dict) else ""
+                if not self._session_id:
+                    logger.warning("OpenViking /sessions returned no session_id")
+                    self._client = None
+            except Exception as e:
+                logger.warning("OpenViking session creation failed: %s", e)
+                self._client = None
+
+        # Register as the last active provider for atexit safety net —
+        # only when fully functional so the atexit handler doesn't hold
+        # a reference to a disabled provider.
+        if self._client:
+            global _last_active_provider
+            _last_active_provider = self
 
     def system_prompt_block(self) -> str:
         if not self._client:

--- a/tests/plugins/memory/test_openviking_session.py
+++ b/tests/plugins/memory/test_openviking_session.py
@@ -1,0 +1,83 @@
+"""Tests for OpenViking session creation in initialize()."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+    monkeypatch.delenv("OPENVIKING_ENDPOINT", raising=False)
+    monkeypatch.delenv("OPENVIKING_API_KEY", raising=False)
+
+
+def _mock_httpx(json_return=None):
+    mock = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_return or {}
+    mock.get.return_value = resp
+    mock.post.return_value = resp
+    return mock
+
+
+class TestOpenVikingSessionCreation:
+    def test_initialize_creates_server_side_session(self, monkeypatch):
+        """Session ID must come from the OpenViking server, not from Hermes."""
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1933")
+        mock = _mock_httpx({"result": {"session_id": "ov-abc123"}})
+
+        with patch("plugins.memory.openviking._get_httpx", return_value=mock):
+            from plugins.memory.openviking import OpenVikingMemoryProvider
+            p = OpenVikingMemoryProvider()
+            p.initialize("hermes-uuid-12345")
+
+            assert p._session_id == "ov-abc123"
+            assert p._session_id != "hermes-uuid-12345"
+            assert p._client is not None
+
+    def test_initialize_disables_on_missing_session_id(self, monkeypatch):
+        """Plugin must disable when server returns no session_id."""
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1933")
+        mock = _mock_httpx({"result": {}})
+
+        with patch("plugins.memory.openviking._get_httpx", return_value=mock):
+            from plugins.memory.openviking import OpenVikingMemoryProvider
+            p = OpenVikingMemoryProvider()
+            p.initialize("hermes-uuid-99999")
+
+            assert p._client is None
+            assert p._session_id == ""
+
+    def test_initialize_disables_on_post_exception(self, monkeypatch):
+        """Plugin must disable when session creation POST raises."""
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1933")
+        mock = _mock_httpx()
+        # Health check passes, but POST /sessions fails
+        mock.post.side_effect = Exception("Connection refused")
+        health_resp = MagicMock()
+        health_resp.status_code = 200
+        mock.get.return_value = health_resp
+
+        with patch("plugins.memory.openviking._get_httpx", return_value=mock):
+            from plugins.memory.openviking import OpenVikingMemoryProvider
+            p = OpenVikingMemoryProvider()
+            p.initialize("hermes-uuid-error")
+
+            assert p._client is None
+
+    def test_initialize_handles_non_dict_result(self, monkeypatch):
+        """Plugin must handle when 'result' is not a dict (e.g. a list or string)."""
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1933")
+        mock = _mock_httpx({"result": ["unexpected", "list"]})
+
+        with patch("plugins.memory.openviking._get_httpx", return_value=mock):
+            from plugins.memory.openviking import OpenVikingMemoryProvider
+            p = OpenVikingMemoryProvider()
+            p.initialize("hermes-uuid-weird")
+
+            # Should gracefully disable, not crash with AttributeError
+            assert p._client is None
+            assert p._session_id == ""


### PR DESCRIPTION
## What changed and why

The OpenViking memory plugin stored the Hermes agent's session_id directly and used it in API calls to `/api/v1/sessions/{id}/messages`. OpenViking generates its own session IDs server-side and rejects unknown ones with 500 errors, so all writes (`sync_turn`, `viking_remember`, `on_memory_write`) failed silently.

The fix calls `POST /api/v1/sessions` during `initialize()` and stores the server-returned session_id. If session creation fails for any reason, the plugin gracefully disables itself.

## Changes

- `plugins/memory/openviking/__init__.py`:
  - Create server-side session via `POST /api/v1/sessions` in `initialize()`
  - Type-safe response parsing with `isinstance(result, dict)` guard
  - Only register `_last_active_provider` when plugin is fully functional
- `tests/plugins/memory/test_openviking_session.py`: New test file with 4 tests:
  - Successful session creation from server response
  - Graceful degradation when server returns no session_id
  - Graceful degradation when POST raises an exception
  - Safe handling of non-dict `result` in response

## How to test

```bash
pytest tests/plugins/memory/test_openviking_session.py -v
```

With a running OpenViking server:
1. Configure `OPENVIKING_ENDPOINT` in `~/.hermes/.env`
2. Start a conversation — `viking_remember` and `sync_turn` should no longer return 500 errors
3. Check server logs for successful session creation

## Platform tested

- macOS (Darwin 24.6.0, Python 3.14)

Closes #8705