### PR TITLE
fix(cli): honor api_key from config.yaml for anthropic provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1866,9 +1866,9 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
-        # Allow base URL override from config.yaml model.base_url, but only
-        # when the configured provider is anthropic — otherwise a non-Anthropic
-        # base_url (e.g. Codex endpoint) would leak into Anthropic requests.
+        # Allow base URL / api_key overrides from config.yaml model.* — but
+        # only when the configured provider is anthropic, otherwise a
+        # non-Anthropic base_url or key would leak into Anthropic requests.
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = ""
         if cfg_provider == "anthropic":
@@ -1894,6 +1894,7 @@ def resolve_runtime_provider(
             # Azure Foundry guide and read by most Hermes-compatible importers).
             # Matches the config.yaml examples in website/docs/guides/azure-foundry.md.
             token = ""
+            source = "env"
             for hint_key in ("key_env", "api_key_env"):
                 env_var = str(model_cfg.get(hint_key) or "").strip()
                 if env_var:
@@ -1904,6 +1905,8 @@ def resolve_runtime_provider(
             # setups that want to avoid env-var juggling).
             if not token:
                 token = str(model_cfg.get("api_key") or "").strip()
+                if token:
+                    source = "config"
             # Finally fall back to the historical fixed names.
             if not token:
                 token = (
@@ -1917,8 +1920,18 @@ def resolve_runtime_provider(
                     "config.yaml model section at a custom env var."
                 )
         else:
-            from agent.anthropic_adapter import resolve_anthropic_token
-            token = resolve_anthropic_token()
+            cfg_api_key = (
+                str(model_cfg.get("api_key") or "").strip()
+                if cfg_provider == "anthropic"
+                else ""
+            )
+            if cfg_api_key:
+                token = cfg_api_key
+                source = "config"
+            else:
+                from agent.anthropic_adapter import resolve_anthropic_token
+                token = resolve_anthropic_token()
+                source = "env"
             if not token:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
@@ -1929,7 +1942,7 @@ def resolve_runtime_provider(
             "api_mode": "anthropic_messages",
             "base_url": base_url,
             "api_key": token,
-            "source": "env",
+            "source": source,
             "requested_provider": requested_provider,
         }
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -526,7 +526,7 @@ def _resolve_explicit_runtime(
             if not api_key:
                 raise AuthError(
                     "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                    "run 'claude setup-token', or authenticate with 'claude /login'."
+                    "add api_key to config.yaml, run 'claude setup-token', or authenticate with 'claude /login'."
                 )
         return {
             "provider": "anthropic",
@@ -797,27 +797,32 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
-        from agent.anthropic_adapter import resolve_anthropic_token
-        token = resolve_anthropic_token()
+        # Allow config.yaml overrides only when configured provider is anthropic
+        # — prevents non-Anthropic values from leaking into Anthropic requests.
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_api_key = ""
+        cfg_base_url = ""
+        if cfg_provider == "anthropic":
+            cfg_api_key = str(model_cfg.get("api_key") or "").strip()
+            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        token = cfg_api_key
+        source = "config"
+        if not token:
+            from agent.anthropic_adapter import resolve_anthropic_token
+            token = resolve_anthropic_token()
+            source = "env"
         if not token:
             raise AuthError(
                 "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                "run 'claude setup-token', or authenticate with 'claude /login'."
+                "add api_key to config.yaml, run 'claude setup-token', or authenticate with 'claude /login'."
             )
-        # Allow base URL override from config.yaml model.base_url, but only
-        # when the configured provider is anthropic — otherwise a non-Anthropic
-        # base_url (e.g. Codex endpoint) would leak into Anthropic requests.
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == "anthropic":
-            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or "https://api.anthropic.com"
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",
             "base_url": base_url,
             "api_key": token,
-            "source": "env",
+            "source": source,
             "requested_provider": requested_provider,
         }
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3416,3 +3416,45 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+# --- Anthropic config.yaml api_key tests (#9105) ---
+
+def _patch_anthropic_short_circuit(monkeypatch):
+    """Bypass everything before the provider-specific anthropic branch."""
+    monkeypatch.setattr(rp, "resolve_requested_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    # Force the pool path to yield nothing so we fall through to the
+    # anthropic-specific code block.
+    monkeypatch.setattr(rp, "load_pool", lambda *a: (_ for _ in ()).throw(Exception("no pool")))
+
+
+def test_anthropic_config_api_key_is_used(monkeypatch):
+    """Non-Azure branch: config.yaml model.api_key must be honoured."""
+    _patch_anthropic_short_circuit(monkeypatch)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "anthropic", "api_key": "***"})
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "***"
+    assert resolved["source"] == "config"
+
+
+def test_anthropic_config_api_key_falls_back_to_env(monkeypatch):
+    """When no config api_key, fall back to resolve_anthropic_token()."""
+    _patch_anthropic_short_circuit(monkeypatch)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "anthropic"})
+    monkeypatch.setattr("agent.anthropic_adapter.resolve_anthropic_token", lambda: "sk-ant-env")
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "sk-ant-env"
+    assert resolved["source"] == "env"
+
+
+def test_anthropic_config_api_key_no_cross_provider_leak(monkeypatch):
+    """A config api_key from a *different* provider must not leak in."""
+    _patch_anthropic_short_circuit(monkeypatch)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter", "api_key": "sk-or-leak"})
+    monkeypatch.setattr("agent.anthropic_adapter.resolve_anthropic_token", lambda: "sk-ant-env")
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "sk-ant-env"
+    assert resolved["api_key"] != "sk-or-leak"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1326,3 +1326,68 @@ def test_named_custom_runtime_no_model_when_absent(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert "model" not in resolved
+
+
+# --- Anthropic config.yaml api_key tests (#7579) ---
+
+
+def test_anthropic_config_api_key_is_used(monkeypatch):
+    """When provider is anthropic and config.yaml has api_key, it should be used."""
+    monkeypatch.setattr(rp, "resolve_requested_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "load_pool", lambda *a: (_ for _ in ()).throw(Exception("no pool")))
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "anthropic", "api_key": "sk-ant-from-config"},
+    )
+
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "sk-ant-from-config"
+    assert resolved["source"] == "config"
+
+
+def test_anthropic_config_api_key_falls_back_to_env(monkeypatch):
+    """When config has no api_key, resolve_anthropic_token() env fallback is used."""
+    monkeypatch.setattr(rp, "resolve_requested_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "load_pool", lambda *a: (_ for _ in ()).throw(Exception("no pool")))
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "anthropic"},
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: "sk-ant-from-env",
+    )
+
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "sk-ant-from-env"
+    assert resolved["source"] == "env"
+
+
+def test_anthropic_config_api_key_no_cross_provider_leak(monkeypatch):
+    """Config api_key must not leak when cfg_provider is not anthropic."""
+    monkeypatch.setattr(rp, "resolve_requested_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "load_pool", lambda *a: (_ for _ in ()).throw(Exception("no pool")))
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openrouter", "api_key": "sk-or-should-not-leak"},
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: "sk-ant-from-env",
+    )
+
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["api_key"] == "sk-ant-from-env"
+    assert resolved["api_key"] != "sk-or-should-not-leak"


### PR DESCRIPTION
## What does this PR do?

Runtime provider resolution did not honor `model.api_key` from `config.yaml` for the Anthropic provider in the intended scoped path. This PR allows configured Anthropic API keys to be used for Anthropic only, avoiding cross-provider key leakage.

## Related Issue

Related to Anthropic runtime provider config resolution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Honor `model.api_key` in `hermes_cli/runtime_provider.py` when the configured provider is Anthropic.
- Keep provider scoping strict so the configured key is not leaked to unrelated providers.
- Add focused runtime provider resolution regression coverage.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_runtime_provider_resolution.py -q`
3. Expected result: 131 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_runtime_provider_resolution.py -q` — 131 passed
```
