### PR TITLE
fix: harden codex responses continuity replay

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1088,8 +1088,19 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             full_history.append({"role": "assistant", "content": final_response})
 
-        # Build output items (includes tool calls + final message)
-        output_items = self._extract_output_items(result)
+        # Build output items from only the current turn's emitted assistant/tool
+        # messages. Some agent paths return the full replayed transcript plus the
+        # current user input; others return only new assistant/tool messages.
+        # Detect the echoed current user message before choosing the slice.
+        current_turn_start_index = len(conversation_history)
+        if agent_messages[current_turn_start_index:current_turn_start_index + 1] == [
+            {"role": "user", "content": user_message}
+        ]:
+            current_turn_start_index += 1
+        output_items = self._extract_output_items(
+            result,
+            start_index=current_turn_start_index,
+        )
 
         response_data = {
             "id": response_id,
@@ -1405,17 +1416,22 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _extract_output_items(
+        result: Dict[str, Any],
+        start_index: int = 0,
+    ) -> List[Dict[str, Any]]:
         """
-        Build the full output item array from the agent's messages.
+        Build the output item array from the agent's messages.
 
-        Walks *result["messages"]* and emits:
+        Walks *result["messages"]* starting at *start_index* and emits:
         - ``function_call`` items for each tool_call on assistant messages
         - ``function_call_output`` items for each tool-role message
         - a final ``message`` item with the assistant's text reply
         """
         items: List[Dict[str, Any]] = []
         messages = result.get("messages", [])
+        if start_index > 0:
+            messages = messages[start_index:]
 
         for msg in messages:
             role = msg.get("role")

--- a/run_agent.py
+++ b/run_agent.py
@@ -664,6 +664,12 @@ class AIAgent:
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
+        # Native OpenAI Responses threading state. We keep the prior response id
+        # plus a fingerprinted history boundary so resumed turns can safely send
+        # only the new delta instead of replaying the full conversation.
+        self._codex_previous_response_id = None
+        self._codex_previous_response_history_len = 0
+        self._codex_previous_response_history_fingerprint = None
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
@@ -3584,8 +3590,14 @@ class AIAgent:
                                 arguments = str(arguments)
                             arguments = arguments.strip() or "{}"
 
+                            response_item_id = tc.get("response_item_id")
+                            if not isinstance(response_item_id, str) or not response_item_id.strip():
+                                response_item_id = embedded_response_item_id
+                            response_item_id = self._derive_responses_function_call_id(call_id, response_item_id)
+
                             items.append({
                                 "type": "function_call",
+                                "id": response_item_id,
                                 "call_id": call_id,
                                 "name": fn_name,
                                 "arguments": arguments,
@@ -3610,6 +3622,103 @@ class AIAgent:
                 })
 
         return items
+
+    def _responses_history_fingerprint(self, messages: List[Dict[str, Any]]) -> str:
+        """Return a stable fingerprint for Responses-threading history matching."""
+        try:
+            payload = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except TypeError:
+            payload = json.dumps(messages, ensure_ascii=False, default=str, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+    def _history_messages_from_responses_payload(
+        self,
+        payload_messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Strip ephemeral Responses-only prefixes (for example prefill messages)."""
+        prefill_count = len(self.prefill_messages or [])
+        if prefill_count <= 0:
+            return payload_messages
+        return payload_messages[prefill_count:]
+
+    @staticmethod
+    def _normalize_messages_for_responses_threading(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Match the durable history shape used just before _build_api_kwargs()."""
+        normalized: List[Dict[str, Any]] = []
+        strip_keys = {"reasoning", "finish_reason", "_flush_sentinel", "_thinking_prefill"}
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            normalized.append({k: v for k, v in msg.items() if k not in strip_keys})
+        return normalized
+
+    def _build_codex_responses_turn_input(self, payload_messages: List[Dict[str, Any]]) -> tuple[Optional[str], List[Dict[str, Any]]]:
+        """Return (previous_response_id, input_items) for the next Codex request.
+
+        Native Responses threading is only used when the current history still
+        matches the prefix that produced the stored previous_response_id.
+        Otherwise we safely fall back to full replay.
+
+        Important: if the delta window begins with tool outputs, we must also
+        include the immediately preceding assistant tool-call message(s) that
+        generated those outputs. Responses rejects orphaned function_call_output
+        items that are not paired with matching function_call items in the same
+        request body.
+        """
+        history_messages = self._normalize_messages_for_responses_threading(
+            self._history_messages_from_responses_payload(payload_messages)
+        )
+        previous_response_id = getattr(self, "_codex_previous_response_id", None)
+        history_len = getattr(self, "_codex_previous_response_history_len", None)
+        history_fingerprint = getattr(self, "_codex_previous_response_history_fingerprint", None)
+
+        can_thread = (
+            isinstance(previous_response_id, str)
+            and previous_response_id.strip()
+            and isinstance(history_len, int)
+            and history_len >= 0
+            and isinstance(history_fingerprint, str)
+            and history_len <= len(history_messages)
+            and self._responses_history_fingerprint(history_messages[:history_len]) == history_fingerprint
+        )
+        if not can_thread:
+            return None, self._chat_messages_to_responses_input(payload_messages)
+
+        delta_start = history_len
+        if delta_start < len(history_messages):
+            first_delta = history_messages[delta_start]
+            if isinstance(first_delta, dict) and first_delta.get("role") == "tool":
+                back = delta_start - 1
+                while back >= 0:
+                    candidate = history_messages[back]
+                    if not isinstance(candidate, dict):
+                        break
+                    if candidate.get("role") == "assistant" and candidate.get("tool_calls"):
+                        delta_start = back
+                        break
+                    if candidate.get("role") in {"user", "system"}:
+                        break
+                    back -= 1
+
+        delta_messages = history_messages[delta_start:]
+        return previous_response_id.strip(), self._chat_messages_to_responses_input(delta_messages)
+
+    def _remember_codex_previous_response(self, response: Any, history_messages: List[Dict[str, Any]]) -> None:
+        """Persist the last successful Responses id plus its history boundary."""
+        response_id = getattr(response, "id", None)
+        if not isinstance(response_id, str) or not response_id.strip():
+            return
+
+        stored_history = history_messages
+        if stored_history and stored_history[0].get("role") == "system":
+            stored_history = stored_history[1:]
+        stored_history = self._normalize_messages_for_responses_threading(
+            self._history_messages_from_responses_payload(stored_history)
+        )
+
+        self._codex_previous_response_id = response_id.strip()
+        self._codex_previous_response_history_len = len(stored_history)
+        self._codex_previous_response_history_fingerprint = self._responses_history_fingerprint(stored_history)
 
     def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
         if not isinstance(raw_items, list):
@@ -3776,7 +3885,7 @@ class AIAgent:
         allowed_keys = {
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
-            "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
+            "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier", "previous_response_id",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3811,6 +3920,36 @@ class AIAgent:
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
+
+        previous_response_id = api_kwargs.get("previous_response_id")
+        if previous_response_id is not None:
+            if not isinstance(previous_response_id, str) or not previous_response_id.strip():
+                raise ValueError("Codex Responses request 'previous_response_id' must be a non-empty string when provided.")
+            paired_call_ids = {
+                item["call_id"]
+                for item in normalized_input
+                if item.get("type") == "function_call" and item.get("call_id")
+            }
+            missing_call_ids = sorted(
+                {
+                    item["call_id"]
+                    for item in normalized_input
+                    if item.get("type") == "function_call_output"
+                    and item.get("call_id")
+                    and item["call_id"] not in paired_call_ids
+                }
+            )
+            if missing_call_ids:
+                logger.error(
+                    "Malformed Codex replay window: previous_response_id=%s missing function_call pair(s) for call_id(s)=%s",
+                    previous_response_id,
+                    ", ".join(missing_call_ids),
+                )
+                raise ValueError(
+                    "Codex replay window is malformed: function_call_output items must include matching function_call items in the same request body. "
+                    f"Missing call_id(s): {', '.join(missing_call_ids)}"
+                )
+            normalized["previous_response_id"] = previous_response_id.strip()
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -6114,15 +6253,23 @@ class AIAgent:
                 elif self.reasoning_config.get("effort"):
                     reasoning_effort = self.reasoning_config["effort"]
 
+            previous_response_id = None
+            input_items = self._chat_messages_to_responses_input(payload_messages)
+            if not is_github_responses:
+                previous_response_id, input_items = self._build_codex_responses_turn_input(payload_messages)
+
             kwargs = {
                 "model": self.model,
                 "instructions": instructions,
-                "input": self._chat_messages_to_responses_input(payload_messages),
+                "input": input_items,
                 "tools": self._responses_tools(),
                 "tool_choice": "auto",
                 "parallel_tool_calls": True,
                 "store": False,
             }
+
+            if previous_response_id:
+                kwargs["previous_response_id"] = previous_response_id
 
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
@@ -9594,6 +9741,10 @@ class AIAgent:
             try:
                 if self.api_mode == "codex_responses":
                     assistant_message, finish_reason = self._normalize_codex_response(response)
+                    self._remember_codex_previous_response(
+                        response,
+                        messages + [self._build_assistant_message(assistant_message, finish_reason)],
+                    )
                 elif self.api_mode == "anthropic_messages":
                     from agent.anthropic_adapter import normalize_anthropic_response
                     assistant_message, finish_reason = normalize_anthropic_response(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1371,6 +1371,115 @@ class TestToolCallsInOutput:
             assert output[2]["content"][0]["text"] == "The result is 42."
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_does_not_reemit_historical_tool_items(self, adapter):
+        """Chained responses should emit only current-turn output items."""
+        first_turn_result = {
+            "final_response": "The result is 42.",
+            "messages": [
+                {"role": "user", "content": "What is 6*7?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "function": {
+                                "name": "calculator",
+                                "arguments": '{"expression": "6*7"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc123",
+                    "content": "42",
+                },
+                {
+                    "role": "assistant",
+                    "content": "The result is 42.",
+                },
+            ],
+            "api_calls": 2,
+        }
+
+        second_turn_result = {
+            "final_response": "Still 42.",
+            "messages": [
+                {"role": "user", "content": "What is 6*7?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "function": {
+                                "name": "calculator",
+                                "arguments": '{"expression": "6*7"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc123",
+                    "content": "42",
+                },
+                {
+                    "role": "assistant",
+                    "content": "The result is 42.",
+                },
+                {"role": "user", "content": "And what was that result again?"},
+                {"role": "assistant", "content": "Still 42."},
+            ],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    first_turn_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "What is 6*7?"},
+                )
+
+            assert resp1.status == 200
+            response_id = (await resp1.json())["id"]
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    second_turn_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "And what was that result again?",
+                        "previous_response_id": response_id,
+                    },
+                )
+
+            assert resp2.status == 200
+            data2 = await resp2.json()
+            assert data2["output"] == [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Still 42.",
+                        }
+                    ],
+                }
+            ]
+
+    @pytest.mark.asyncio
     async def test_no_tool_calls_still_works(self, adapter):
         """Without tool calls, output is just a message."""
         mock_result = {"final_response": "Hello!", "messages": [], "api_calls": 1}

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -414,6 +414,135 @@ class TestBuildApiKwargsCodex:
         assert "function" not in tools[0]
 
 
+class TestCodexPreviousResponseIdThreading:
+    def _make_codex_agent(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "openai-codex",
+            api_mode="codex_responses",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        monkeypatch.setattr(agent, "_build_system_prompt", lambda *a, **k: "system prompt")
+        monkeypatch.setattr(agent, "_save_session_log", lambda *a, **k: None)
+        monkeypatch.setattr(agent, "_persist_session", lambda *a, **k: None)
+        agent.model = "codex-mini-latest"
+        agent.client = MagicMock()
+        return agent
+
+    @staticmethod
+    def _codex_response(response_id, text):
+        return SimpleNamespace(
+            id=response_id,
+            model="codex-mini-latest",
+            status="completed",
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    phase="final_answer",
+                    content=[SimpleNamespace(type="output_text", text=text)],
+                )
+            ],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5, total_tokens=15),
+        )
+
+    def test_first_turn_does_not_send_previous_response_id(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        kwargs_seen = []
+
+        def fake_api(kwargs):
+            kwargs_seen.append(kwargs)
+            return self._codex_response("resp_1", "First reply")
+
+        monkeypatch.setattr(agent, "_interruptible_api_call", fake_api)
+
+        result = agent.run_conversation("hello", conversation_history=[])
+
+        assert result["final_response"] == "First reply"
+        assert len(kwargs_seen) == 1
+        assert "previous_response_id" not in kwargs_seen[0]
+        assert kwargs_seen[0]["input"] == [{"role": "user", "content": "hello"}]
+
+    def test_follow_up_turn_threads_previous_response_id_and_only_new_input(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        kwargs_seen = []
+        responses = iter(
+            [
+                self._codex_response("resp_1", "First reply"),
+                self._codex_response("resp_2", "Second reply"),
+            ]
+        )
+
+        def fake_api(kwargs):
+            kwargs_seen.append(kwargs)
+            return next(responses)
+
+        monkeypatch.setattr(agent, "_interruptible_api_call", fake_api)
+
+        first = agent.run_conversation("hello", conversation_history=[])
+        second = agent.run_conversation("follow up", conversation_history=first["messages"])
+
+        assert first["final_response"] == "First reply"
+        assert second["final_response"] == "Second reply"
+        assert len(kwargs_seen) == 2
+        assert "previous_response_id" not in kwargs_seen[0]
+        assert kwargs_seen[1]["previous_response_id"] == "resp_1"
+        assert kwargs_seen[1]["input"] == [{"role": "user", "content": "follow up"}]
+
+    def test_delta_starting_with_tool_output_replays_matching_function_call(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+        tool_call_message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_abc|fc_abc",
+                "call_id": "call_abc",
+                "response_item_id": "fc_abc",
+                "function": {"name": "calculator", "arguments": '{"expression":"6*7"}'},
+            }],
+        }
+        payload_messages = [
+            {"role": "user", "content": "What is 6*7?"},
+            tool_call_message,
+            {"role": "tool", "tool_call_id": "call_abc", "content": "42"},
+            {"role": "assistant", "content": "The result is 42.", "finish_reason": "stop"},
+            {"role": "user", "content": "Thanks"},
+        ]
+        prefix = payload_messages[:2]
+        agent._codex_previous_response_id = "resp_1"
+        agent._codex_previous_response_history_len = len(prefix)
+        agent._codex_previous_response_history_fingerprint = agent._responses_history_fingerprint(prefix)
+
+        kwargs = agent._build_api_kwargs(payload_messages)
+
+        assert kwargs["previous_response_id"] == "resp_1"
+        assert [item["type"] for item in kwargs["input"][:2]] == ["function_call", "function_call_output"]
+        assert kwargs["input"][0]["call_id"] == "call_abc"
+        assert kwargs["input"][0]["id"] == "fc_abc"
+        assert kwargs["input"][1]["call_id"] == "call_abc"
+        assert kwargs["input"][-1] == {"role": "user", "content": "Thanks"}
+
+    def test_malformed_replay_window_is_rejected(self, monkeypatch):
+        agent = self._make_codex_agent(monkeypatch)
+
+        with pytest.raises(ValueError, match="Codex replay window is malformed"):
+            agent._preflight_codex_api_kwargs(
+                {
+                    "model": "codex-mini-latest",
+                    "instructions": "system prompt",
+                    "previous_response_id": "resp_1",
+                    "input": [
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_orphan",
+                            "output": "42",
+                        }
+                    ],
+                }
+            )
+
+
 # ── Message conversion tests ────────────────────────────────────────────────
 
 class TestChatMessagesToResponsesInput:


### PR DESCRIPTION
What does this PR do?

Fixes a real Codex continuity / Responses replay regression in Hermes by tightening the turn-boundary contract for `/v1/responses` and hardening threaded Codex replay so tool-call pairs stay valid across follow-up turns.

Root cause

Hermes was serializing response output from transcript-shaped `result["messages"]` data instead of a turn-local slice. On chained `previous_response_id` turns, that could re-emit historical `function_call` / `function_call_output` items in the new response body.

Separately, Codex threaded replay could start with orphaned `function_call_output` items when the replay delta began after the matching assistant tool-call item.

That produced the 400 family seen in practice:
- `No tool output found for function call ...`
- `No tool call found for function call output ...`
- `previous_response_id` replay mismatch variants

Final behavior in this PR

- `/v1/responses` returns turn-local output instead of replaying historical tool artifacts
- full transcript continuity is still preserved for stored session/replay state where needed
- Codex threaded replay rewinds to include the matching assistant tool-call item when a delta would otherwise begin with tool outputs
- malformed replay windows are rejected locally before they hit the provider as vague 400s
- `previous_response_id` threading stays intact for the supported continuity path instead of drifting into invalid function-call/function-call-output pairings

Related context

This supersedes the older continuity lane in #8088. That earlier PR captured useful continuity intent, but this PR is the cleaner review surface on top of current `main` for the replay-mismatch seam that was still biting live usage.

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- updated `gateway/platforms/api_server.py` so `/v1/responses` output extraction is turn-local instead of whole-transcript shaped
- hardened `run_agent.py` replay-window construction for Codex threaded follow-up turns
- preserved valid `function_call` ↔ `function_call_output` pairing when replay deltas start inside a tool sequence
- added local malformed replay-window protection before provider submission
- added focused regression coverage in:
  - `tests/gateway/test_api_server.py`
  - `tests/run_agent/test_provider_parity.py`

How to Test

1. Run the focused gateway continuity lane:
   `pytest tests/gateway/test_api_server.py -q -k 'tool_calls_in_output or previous_response_id'`

2. Run the focused replay/provider parity lane:
   `pytest tests/run_agent/test_provider_parity.py -q -k 'previous_response_id or sanitize or replay or tool_call'`

3. Confirm results:
   - chained `/v1/responses` turns do not re-emit historical tool items
   - replay deltas that begin with tool outputs include the preceding assistant tool-call item
   - malformed replay windows are caught locally
   - the repeated replay-mismatch 400 family no longer reproduces under the covered scenarios

Checklist

Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Screenshots / Logs

Focused verification run in a clean worktree for this PR:

- `pytest tests/gateway/test_api_server.py -q -k 'tool_calls_in_output or previous_response_id'`
  - Result: 5 passed

- `pytest tests/run_agent/test_provider_parity.py -q -k 'previous_response_id or sanitize or replay or tool_call'`
  - Result: 11 passed
