### PR TITLE
chore(install): add --depth=1 to git clone for faster installation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -442,7 +442,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlSsh $InstallDir
+            git -c windows.appendAtomically=false clone --depth=1 --branch $Branch --recurse-submodules $RepoUrlSsh $InstallDir
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -451,7 +451,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlHttps $InstallDir
+                git -c windows.appendAtomically=false clone --depth=1 --branch $Branch --recurse-submodules $RepoUrlHttps $InstallDir
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -740,12 +740,12 @@ clone_repo() {
         # so SSH fails fast instead of hanging when no key is configured.
         log_info "Trying SSH clone..."
         if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+           git clone --depth=1 --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
             log_success "Cloned via SSH"
         else
             rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
             log_info "SSH failed, trying HTTPS..."
-            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+            if git clone --depth=1 --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
                 log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"


### PR DESCRIPTION
## Summary
- Add `--depth=1` to all `git clone` commands in install scripts (`install.sh` and `install.ps1`) to perform shallow clones, reducing download size and speeding up installation
- Applies to both SSH and HTTPS fallback paths on Linux/macOS and Windows

## Why
Full git history is not needed for installation. Shallow clone significantly reduces clone time and bandwidth usage, especially for users with slow connections.

## Platforms tested
- Linux/macOS (`scripts/install.sh`)
- Windows (`scripts/install.ps1`)

## Test plan
- [ ] Run `scripts/install.sh` on Linux/macOS and verify successful shallow clone
- [ ] Run `scripts/install.ps1` on Windows and verify successful shallow clone
- [ ] Verify SSH → HTTPS fallback still works correctly
- [ ] Verify `--recurse-submodules` still functions with `--depth=1`

## Note
By the way, the changes from the previous PR were lost because Pull Bot force-pushed over it:
https://github.com/NousResearch/hermes-agent/pull/8396
