### PR TITLE
fix(windows): add Windows-compatible PID checking and file locking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1599,9 +1599,9 @@ class GatewayRunner:
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    logger.info("[ok] %s connected", platform.value)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("[fail] %s failed to connect", platform.value)
                     if adapter.has_fatal_error:
                         self._update_platform_runtime_status(
                             platform.value,
@@ -1641,7 +1641,7 @@ class GatewayRunner:
                             "next_retry": time.monotonic() + 30,
                         }
             except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
+                logger.error("[fail] %s error: %s", platform.value, e)
                 self._update_platform_runtime_status(
                     platform.value,
                     platform_state="retrying",
@@ -1935,7 +1935,7 @@ class GatewayRunner:
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        logger.info("[ok] %s reconnected successfully", platform.value)
 
                         # Rebuild channel directory with the new adapter
                         try:
@@ -2047,9 +2047,9 @@ class GatewayRunner:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
                 try:
                     await adapter.disconnect()
-                    logger.info("✓ %s disconnected", platform.value)
+                    logger.info("[ok] %s disconnected", platform.value)
                 except Exception as e:
-                    logger.error("✗ %s disconnect error: %s", platform.value, e)
+                    logger.error("[fail] %s disconnect error: %s", platform.value, e)
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:
@@ -8800,7 +8800,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # setups (each profile using a distinct HERMES_HOME) will naturally
     # allow concurrent instances without tripping this guard.
     import time as _time
-    from gateway.status import get_running_pid, remove_pid_file, terminate_pid
+    from gateway.status import get_running_pid, remove_pid_file, terminate_pid, _pid_is_running
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
@@ -8820,11 +8820,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 return False
             # Wait up to 10 seconds for the old process to exit
             for _ in range(20):
-                try:
-                    os.kill(existing_pid, 0)
-                    _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
-                    break  # Process is gone
+                if not _pid_is_running(existing_pid):
+                    break
+                _time.sleep(0.5)
             else:
                 # Still alive after 10s — force kill
                 logger.warning(

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -29,6 +29,47 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 
 
+def _pid_is_running(pid: int) -> bool:
+    """Return True if a process *pid* appears to exist (best-effort).
+
+    Unix uses ``os.kill(pid, 0)``. Windows does not support signal 0 for
+    existence checks (``WinError 87``), so we use ``OpenProcess`` instead.
+    """
+    if pid <= 0:
+        return False
+    if _IS_WINDOWS:
+        return _pid_is_running_windows(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pid_is_running_windows(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.windll.kernel32
+    OpenProcess = kernel32.OpenProcess
+    OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    OpenProcess.restype = wintypes.HANDLE
+    CloseHandle = kernel32.CloseHandle
+    CloseHandle.argtypes = (wintypes.HANDLE,)
+    CloseHandle.restype = wintypes.BOOL
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    ERROR_ACCESS_DENIED = 5
+
+    handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if handle:
+        CloseHandle(handle)
+        return True
+    return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+
+
 def _get_pid_path() -> Path:
     """Return the path to the gateway PID file, respecting HERMES_HOME."""
     home = get_hermes_home()
@@ -311,9 +352,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
 
         stale = existing_pid is None
         if not stale:
-            try:
-                os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            if not _pid_is_running(existing_pid):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -324,7 +363,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 ):
                     stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still respond to os.kill(pid, 0) but are not
+                # processes still appear "alive" to _pid_is_running but are not
                 # actually running. Treat them as stale so --replace works.
                 if not stale:
                     try:
@@ -414,9 +453,7 @@ def get_running_pid() -> Optional[int]:
         remove_pid_file()
         return None
 
-    try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    if not _pid_is_running(pid):
         remove_pid_file()
         return None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
-from gateway.status import terminate_pid
+from gateway.status import terminate_pid, _pid_is_running
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
@@ -317,11 +317,9 @@ def stop_profile_gateway() -> bool:
     # Wait briefly for it to exit
     import time as _time
     for _ in range(20):
-        try:
-            os.kill(pid, 0)
-            _time.sleep(0.5)
-        except (ProcessLookupError, PermissionError):
+        if not _pid_is_running(pid):
             break
+        _time.sleep(0.5)
 
     remove_pid_file()
     return True

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional
 
+from gateway.status import _pid_is_running
+
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 # Directories bootstrapped inside every new profile
@@ -309,10 +311,8 @@ def _check_gateway_running(profile_dir: Path) -> bool:
             return False
         data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
         pid = int(data["pid"])
-        os.kill(pid, 0)  # existence check
-        return True
-    except (json.JSONDecodeError, KeyError, ValueError, TypeError,
-            ProcessLookupError, PermissionError, OSError):
+        return _pid_is_running(pid)
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError, OSError):
         return False
 
 
@@ -662,9 +662,7 @@ def _stop_gateway_process(profile_dir: Path) -> None:
         # Wait up to 10s for graceful shutdown
         for _ in range(20):
             _time.sleep(0.5)
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
+            if not _pid_is_running(pid):
                 print(f"✓ Gateway stopped (PID {pid})")
                 return
         # Force kill

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -530,16 +530,21 @@ def _reap_orphaned_browser_sessions():
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 
-        # Check if the daemon is still alive
-        try:
-            os.kill(daemon_pid, 0)  # signal 0 = existence check
-        except ProcessLookupError:
-            # Already dead, just clean up the dir
-            shutil.rmtree(socket_dir, ignore_errors=True)
-            continue
-        except PermissionError:
-            # Alive but owned by someone else — leave it alone
-            continue
+        # Check if the daemon is still alive (Windows: os.kill(pid, 0) is invalid)
+        if sys.platform == "win32":
+            from gateway.status import _pid_is_running
+
+            if not _pid_is_running(daemon_pid):
+                shutil.rmtree(socket_dir, ignore_errors=True)
+                continue
+        else:
+            try:
+                os.kill(daemon_pid, 0)  # signal 0 = existence check
+            except ProcessLookupError:
+                shutil.rmtree(socket_dir, ignore_errors=True)
+                continue
+            except PermissionError:
+                continue
 
         # Daemon is alive and not tracked — orphan. Kill it.
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,10 +23,18 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 import re
 import tempfile
 from contextlib import contextmanager
@@ -141,15 +149,33 @@ class MemoryStore:
 
         Uses a separate .lock file so the memory file itself can still be
         atomically replaced via os.replace().
+
+        Unix: ``fcntl.flock``. Windows: ``msvcrt.locking`` on the first byte
+        (``fcntl`` is not available on Windows).
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
+        fd = open(lock_path, "a+b")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            elif msvcrt:
+                fd.seek(0, os.SEEK_END)
+                if fd.tell() == 0:
+                    fd.write(b"\0")
+                    fd.flush()
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            try:
+                if fcntl:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                elif msvcrt:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
             fd.close()
 
     @staticmethod

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -231,11 +231,9 @@ class ProcessRegistry:
         """Best-effort liveness check for host-visible PIDs."""
         if not pid:
             return False
-        try:
-            os.kill(pid, 0)
-            return True
-        except (ProcessLookupError, PermissionError):
-            return False
+        from gateway.status import _pid_is_running
+
+        return _pid_is_running(pid)
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""


### PR DESCRIPTION
- Add _pid_is_running() using OpenProcess on Windows; os.kill(pid, 0) raises WinError 87 on Windows when the process does not exist, breaking every PID liveness check in the codebase
- Replace all bare os.kill(pid, 0) calls with _pid_is_running()
- Add msvcrt-based file locking for MemoryStore on Windows (fcntl unavailable)
- Import _pid_is_running into browser_tool, process_registry, gateway, profiles
- Normalise emoji log markers to [ok]/[fail] for Windows console compatibility

## What does this PR do?

On Windows, os.kill(pid, 0) raises WinError 87 ("The parameter is incorrect") instead of ProcessLookupError when the target process does not exist. This means every PID liveness check across the codebase silently mis-classifies dead processes as alive (or crashes unexpectedly), breaking gateway lock handling, browser tool lifecycle tracking, process registry management, and profile session detection.

This PR introduces a single cross-platform _pid_is_running() helper that uses OpenProcess on Windows and falls back to os.kill(pid, 0) on POSIX. All seven call-sites that previously used the raw os.kill pattern are replaced with this helper. The PR also adds msvcrt-based file locking for MemoryStore (since fcntl is unavailable on Windows) and normalises emoji log markers (✓/✗) to plain [ok]/[fail] so output is readable on Windows console code pages that cannot render those characters.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- gateway/status.py — Add _pid_is_running() using ctypes.windll.kernel32.OpenProcess on Windows with os.kill(pid, 0) POSIX fallback; replace all bare os.kill(pid, 0) liveness checks with _pid_is_running()

- gateway/run.py — Replace os.kill(pid, 0) with _pid_is_running(); normalise emoji log markers to [ok]/[fail]

- hermes_cli/gateway.py — Import and use _pid_is_running() in place of raw os.kill calls

- hermes_cli/profiles.py — Import and use _pid_is_running() for session liveness detection

- tools/browser_tool.py — Import and use _pid_is_running(); replace emoji markers with [ok]/[fail]

- tools/memory_tool.py — Add msvcrt-based _lock_file() / _unlock_file() for Windows alongside the existing fcntl path; guard import behind sys.platform

- tools/process_registry.py — Import and use _pid_is_running() in process liveness checks

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. PID check regression (Windows) — Start a gateway session, note the PID, kill the process from Task Manager, then run hermes status. Confirm it reports the gateway as stopped rather than hanging or raising WinError 87.

2. MemoryStore file locking (Windows) — Run pytest tests/ -q -k memory on Windows and confirm no AttributeError: module 'fcntl' or lock-related failures.

3. Emoji / console output (Windows) — Run any hermes command that previously emitted ✓/✗ markers (e.g., hermes gateway start) in a Windows cmd.exe or PowerShell window with a non-UTF-8 code page (e.g., chcp 437) and confirm output is clean with [ok]/[fail] instead of garbled characters.

4. POSIX regression — Run the full test suite on Linux/macOS (pytest tests/ -q) and confirm no regressions.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

