### PR TITLE
fix: add open.bigmodel.cn to URL→provider mapping for Zhipu GLM

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,6 +210,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
     "api.z.ai": "zai",
+    "open.bigmodel.cn": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.kimi.com": "kimi-coding",
     "api.minimax": "minimax",


### PR DESCRIPTION
## Bug

The `_URL_TO_PROVIDER` dict in `agent/model_metadata.py` maps base URLs to provider names for context length resolution. It had `api.z.ai` mapped to `"zai"` but was missing `open.bigmodel.cn` — Zhipu/BigModel's other API domain.

This caused any user using `open.bigmodel.cn` as their `base_url` to hit the unknown-endpoint code path, which returns the 128K fallback context length instead of querying models.dev (which correctly returns 200K for `glm-5.1`). The result was a false compression warning whenever the conversation exceeded 128K tokens.

## Fix

One-line addition:

```python
"open.bigmodel.cn": "zai",
```

added to the `_URL_TO_PROVIDER` dict alongside the existing `"api.z.ai": "zai"` entry.

## Impact

Any user configured with `open.bigmodel.cn` as their base URL will now correctly resolve to the `zai` provider and get the proper 200K context length for GLM models, eliminating false compression warnings.