### PR TITLE
feat: add configurable compression.summary_ratio for summary detail control

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -107,6 +107,7 @@ class ContextCompressor(ContextEngine):
         protect_first_n: int = 3,
         protect_last_n: int = 20,
         summary_target_ratio: float = 0.20,
+        summary_ratio: float = 0.20,       # fraction of compressed content allocated to summary detail
         quiet_mode: bool = False,
         summary_model_override: str = None,
         base_url: str = "",
@@ -124,6 +125,7 @@ class ContextCompressor(ContextEngine):
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
+        self.summary_ratio = max(0.10, min(summary_ratio, 0.80))
         self.quiet_mode = quiet_mode
 
         self.context_length = get_model_context_length(
@@ -247,12 +249,14 @@ class ContextCompressor(ContextEngine):
     def _compute_summary_budget(self, turns_to_summarize: List[Dict[str, Any]]) -> int:
         """Scale summary token budget with the amount of content being compressed.
 
+        Uses the configurable ``summary_ratio`` (default 0.20, clamped 0.10–0.80)
+        to determine how much of the compressed content survives into the summary.
         The maximum scales with the model's context window (5% of context,
         capped at ``_SUMMARY_TOKENS_CEILING``) so large-context models get
         richer summaries instead of being hard-capped at 8K tokens.
         """
         content_tokens = estimate_messages_tokens_rough(turns_to_summarize)
-        budget = int(content_tokens * _SUMMARY_RATIO)
+        budget = int(content_tokens * self.summary_ratio)
         return max(_MIN_SUMMARY_TOKENS, min(budget, self.max_summary_tokens))
 
     # Truncation limits for the summarizer input.  These bound how much of

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -304,6 +304,12 @@ compression:
   # Range: 0.10 - 0.80
   target_ratio: 0.20
 
+  # Fraction of compressed content to allocate to the summary (default: 0.20 = 20%)
+  # Higher values = more detailed summaries (less lossy).  Lower values = shorter summaries.
+  # e.g. 100K tokens being compressed at 0.20 → ~20K summary; at 0.50 → ~50K summary.
+  # Range: 0.10 - 0.80
+  summary_ratio: 0.20
+
   # Number of most-recent messages to always preserve (default: 20 ≈ 10 full turns)
   # Higher values keep more recent conversation intact at the cost of more aggressive
   # compression of older turns.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -413,6 +413,7 @@ DEFAULT_CONFIG = {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
+        "summary_ratio": 0.20,        # fraction of compressed content allocated to summary detail (0.10–0.80)
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
 
     },

--- a/run_agent.py
+++ b/run_agent.py
@@ -1248,6 +1248,7 @@ class AIAgent:
         compression_threshold = float(_compression_cfg.get("threshold", 0.50))
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+        compression_summary_ratio = float(_compression_cfg.get("summary_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
 
         # Read explicit context_length override from model config
@@ -1335,6 +1336,7 @@ class AIAgent:
                 protect_first_n=3,
                 protect_last_n=compression_protect_last,
                 summary_target_ratio=compression_target_ratio,
+                summary_ratio=compression_summary_ratio,
                 summary_model_override=None,
                 quiet_mode=self.quiet_mode,
                 base_url=self.base_url,

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -179,7 +179,7 @@ template:
 ```
 
 Summary budget scales with the amount of content being compressed:
-- Formula: `content_tokens × 0.20` (the `_SUMMARY_RATIO` constant)
+- Formula: `content_tokens × summary_ratio` (configurable via `compression.summary_ratio`, default 0.20, clamped 0.10–0.80)
 - Minimum: 2,000 tokens
 - Maximum: `min(context_length × 0.05, 12,000)` tokens
 


### PR DESCRIPTION
## Problem

Context compression has two different "ratio" concepts but only one is configurable:

| Setting | Controls | Configurable? |
|---------|----------|---------------|
| \`compression.target_ratio\` | Tail budget — how much *recent context* is kept raw | YES |
| \`_SUMMARY_RATIO\` (hardcoded 0.20) | Summary detail — how much of compressed content survives into the summary | NO |

Users who set \`compression.target_ratio: 0.5\` expecting richer summaries will be disappointed — the summary itself always compresses at 20:1 regardless.

## Fix

Add \`compression.summary_ratio\` as a user-configurable setting (default \`0.20\` for backward compat), clamped to \`0.10–0.80\`.

## Files Changed

- \`hermes_cli/config.py\` — add \`summary_ratio: 0.20\` to DEFAULT_CONFIG compression section
- \`run_agent.py\` — parse \`compression.summary_ratio\`, pass to ContextCompressor
- \`agent/context_compressor.py\` — accept \`summary_ratio\` param, use in \`_compute_summary_budget\` instead of hardcoded \`_SUMMARY_RATIO\`
- \`cli-config.yaml.example\` — document new setting
- \`website/docs/developer-guide/context-compression-and-caching.md\` — update formula description

## Usage

\`\`\`yaml
compression:
  summary_ratio: 0.50  # richer summaries (was: hardcoded to 0.20)\n\`\`\`

Closes #9108