### PR TITLE
fix: tolerate MCP structured content discriminators

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -402,6 +402,47 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_discovery_allows_known_structured_content_discriminators(self):
+        """Discovery relaxes output schemas before SDK call_tool validation."""
+        from tools.mcp_tool import MCPServerTask
+
+        relation_schema = {
+            "type": "object",
+            "properties": {
+                "relations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "from": {"type": "string"},
+                            "to": {"type": "string"},
+                            "relationType": {"type": "string"},
+                        },
+                        "required": ["from", "to", "relationType"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+        }
+        mock_tool = _make_mcp_tool("search")
+        mock_tool.outputSchema = relation_schema
+        mock_session = SimpleNamespace(
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[mock_tool])),
+            _tool_output_schemas={"search": relation_schema},
+        )
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server.session = mock_session
+
+            await server._discover_tools()
+
+            item_schema = server._tools[0].outputSchema["properties"]["relations"]["items"]
+            assert "type" in item_schema["properties"]
+            assert mock_session._tool_output_schemas["search"] is server._tools[0].outputSchema
+
+        asyncio.run(_test())
+
     def test_no_command_raises(self):
         """Missing 'command' in config raises ValueError."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -799,6 +799,7 @@ class MCPServerTask:
             # 1. Fetch current tool list from server
             tools_result = await self.session.list_tools()
             new_mcp_tools = tools_result.tools if hasattr(tools_result, "tools") else []
+            new_mcp_tools = _sanitize_mcp_tool_output_schemas(self.session, new_mcp_tools)
 
             # 2. Remove old tools from hermes-* umbrella toolsets
             for ts_name, ts in TOOLSETS.items():
@@ -957,6 +958,7 @@ class MCPServerTask:
             if hasattr(tools_result, "tools")
             else []
         )
+        self._tools = _sanitize_mcp_tool_output_schemas(self.session, self._tools)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -1497,6 +1499,66 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         return {**schema, "properties": {}}
 
     return schema
+
+
+_MCP_DISCRIMINATOR_SHAPES = (
+    frozenset({"name", "entityType", "observations"}),
+    frozenset({"from", "to", "relationType"}),
+)
+
+
+def _sanitize_mcp_output_schema(schema: Any) -> Any:
+    """Allow harmless MCP structuredContent discriminator fields.
+
+    Some MCP servers return objects with a ``type`` discriminator while their
+    advertised schema uses ``additionalProperties: false``.  Relax only the
+    known strict object shapes so SDK-side validation can accept the payload
+    without broadly disabling schema checks.
+    """
+    if isinstance(schema, list):
+        return [_sanitize_mcp_output_schema(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    normalized = {
+        key: _sanitize_mcp_output_schema(value)
+        for key, value in schema.items()
+    }
+    properties = normalized.get("properties")
+    required = normalized.get("required")
+    if (
+        normalized.get("type") == "object"
+        and normalized.get("additionalProperties") is False
+        and isinstance(properties, dict)
+        and isinstance(required, list)
+        and "type" not in properties
+    ):
+        required_fields = frozenset(str(item) for item in required)
+        if any(shape.issubset(required_fields) for shape in _MCP_DISCRIMINATOR_SHAPES):
+            normalized["properties"] = {
+                **properties,
+                "type": {"type": "string"},
+            }
+    return normalized
+
+
+def _sanitize_mcp_tool_output_schemas(session: Any, tools: list) -> list:
+    """Sanitize MCP tool output schemas and the SDK validation cache."""
+    cache = getattr(session, "_tool_output_schemas", None)
+    for tool in tools:
+        output_schema = getattr(tool, "outputSchema", None)
+        if not isinstance(output_schema, dict):
+            continue
+        sanitized = _sanitize_mcp_output_schema(output_schema)
+        if sanitized is output_schema:
+            continue
+        try:
+            setattr(tool, "outputSchema", sanitized)
+        except Exception:
+            pass
+        if isinstance(cache, dict):
+            cache[getattr(tool, "name", "")] = sanitized
+    return tools
 
 
 def sanitize_mcp_name_component(value: str) -> str:


### PR DESCRIPTION
## Summary
- Relax MCP output schemas for known structuredContent discriminator shapes during tool discovery.
- Update the MCP SDK output-schema cache when it is present, so later `call_tool()` validation sees the sanitized schema.
- Cover the relation-shaped discriminator case with a regression test.

## Root cause
Some MCP servers return harmless discriminator fields such as `type` in otherwise valid structured result objects. When the advertised `outputSchema` sets `additionalProperties: false`, the MCP SDK can reject the result inside `ClientSession.call_tool()` before Hermes receives it. Adapting the returned payload is therefore too late.

## Changes
- Added recursive output-schema sanitization for known entity/relation object shapes.
- Applied sanitization during initial MCP tool discovery and dynamic tool refresh.
- Kept strict schema validation intact for unrelated object shapes.

## Validation
- `python -m pytest tests/tools/test_mcp_tool.py::TestMCPServerTask::test_discovery_allows_known_structured_content_discriminators -q -n0` (failed before the code change, passed after)
- `python -m pytest tests/tools/test_mcp_tool.py::TestMCPServerTask tests/tools/test_mcp_dynamic_discovery.py -q -n0`
- `python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py`
- `git diff --check`

Fixes #9075
