### PR TITLE
fix: initialize plugin context engine metadata

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -523,6 +523,36 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _update_context_engine_model(
+    engine,
+    *,
+    model: str,
+    base_url: str,
+    api_key: str,
+    provider: str,
+    api_mode: str,
+    config_context_length: int | None = None,
+) -> None:
+    """Initialize a pluggable context engine with active model metadata."""
+    from agent.model_metadata import get_model_context_length
+
+    context_length = get_model_context_length(
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        config_context_length=config_context_length,
+        provider=provider,
+    )
+    engine.update_model(
+        model=model,
+        context_length=context_length,
+        base_url=base_url,
+        api_key=api_key,
+        provider=provider,
+        api_mode=api_mode,
+    )
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1325,6 +1355,15 @@ class AIAgent:
         # else: config says "compressor" — use built-in, don't auto-activate plugins
 
         if _selected_engine is not None:
+            _update_context_engine_model(
+                _selected_engine,
+                model=self.model,
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                provider=self.provider,
+                api_mode=self.api_mode,
+                config_context_length=_config_context_length,
+            )
             self.context_compressor = _selected_engine
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)

--- a/tests/run_agent/test_context_engine_initial_model.py
+++ b/tests/run_agent/test_context_engine_initial_model.py
@@ -1,0 +1,36 @@
+"""Tests for initial context-engine model metadata sync."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import _update_context_engine_model
+
+
+def test_update_context_engine_model_resolves_context_length():
+    engine = MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=204_800) as ctx_len:
+        _update_context_engine_model(
+            engine,
+            model="minimax-m2.7",
+            base_url="https://api.example.test/v1",
+            api_key="sk-test",
+            provider="minimax",
+            api_mode="anthropic_messages",
+            config_context_length=101_000,
+        )
+
+    ctx_len.assert_called_once_with(
+        "minimax-m2.7",
+        base_url="https://api.example.test/v1",
+        api_key="sk-test",
+        config_context_length=101_000,
+        provider="minimax",
+    )
+    engine.update_model.assert_called_once_with(
+        model="minimax-m2.7",
+        context_length=204_800,
+        base_url="https://api.example.test/v1",
+        api_key="sk-test",
+        provider="minimax",
+        api_mode="anthropic_messages",
+    )


### PR DESCRIPTION
## Summary
- Initialize pluggable context engines with the active model metadata during agent startup.
- Resolve the initial context length the same way the live model-switch path does.
- Add focused coverage for the context-engine metadata update helper.

## Root cause
The built-in compressor resolves `context_length` during construction, and `switch_model()` updates it after a live model change. Pluggable context engines were assigned directly during startup without an initial `update_model()` call, leaving `context_length` at its default value and causing the CLI status bar to show `ctx --`.

## Changes
- Added a helper that resolves context length via `get_model_context_length()` and calls `update_model()` on the selected context engine.
- Applied it immediately before assigning a pluggable context engine as the active context compressor.
- Covered the helper's model/base URL/provider/api mode/config override forwarding.

## Validation
- `python -m pytest tests/run_agent/test_context_engine_initial_model.py -q -n0` (failed before the code change, passed after)
- `python -m pytest tests/run_agent/test_context_engine_initial_model.py tests/run_agent/test_switch_model_context.py -q -n0`
- `python -m py_compile run_agent.py tests/run_agent/test_context_engine_initial_model.py tests/run_agent/test_switch_model_context.py`
- `git diff --check`

Fixes #9071
