### PR TITLE
feat: add display.show_tips and display.show_session_info config toggles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4008,10 +4008,24 @@ class GatewayRunner:
         })
 
         # Resolve session config info to surface to the user
+        # Gated by display.show_session_info (default: True)
+        _show_session_info = True
         try:
-            session_info = self._format_session_info()
+            _si_cfg_path = _hermes_home / "config.yaml"
+            if _si_cfg_path.exists():
+                import yaml as _si_yaml
+                with open(_si_cfg_path, encoding="utf-8") as _si_f:
+                    _si_data = _si_yaml.safe_load(_si_f) or {}
+                _show_session_info = _si_data.get("display", {}).get("show_session_info", True)
         except Exception:
-            session_info = ""
+            pass
+
+        session_info = ""
+        if _show_session_info:
+            try:
+                session_info = self._format_session_info()
+            except Exception:
+                session_info = ""
 
         if new_entry:
             header = "✨ Session reset! Starting fresh."
@@ -4030,11 +4044,25 @@ class GatewayRunner:
             pass
 
         # Append a random tip to the reset message
+        # Gated by display.show_tips (default: True)
+        _show_tips = True
         try:
-            from hermes_cli.tips import get_random_tip
-            _tip_line = f"\n✦ Tip: {get_random_tip()}"
+            _tips_cfg_path = _hermes_home / "config.yaml"
+            if _tips_cfg_path.exists():
+                import yaml as _tips_yaml
+                with open(_tips_cfg_path, encoding="utf-8") as _tips_f:
+                    _tips_data = _tips_yaml.safe_load(_tips_f) or {}
+                _show_tips = _tips_data.get("display", {}).get("show_tips", True)
         except Exception:
-            _tip_line = ""
+            pass
+
+        _tip_line = ""
+        if _show_tips:
+            try:
+                from hermes_cli.tips import get_random_tip
+                _tip_line = f"\n✦ Tip: {get_random_tip()}"
+            except Exception:
+                _tip_line = ""
 
         if session_info:
             return f"{header}\n\n{session_info}{_tip_line}"


### PR DESCRIPTION
## Summary

- Adds `display.show_tips: false` config option to suppress random tip lines on `/new` and session reset
- Adds `display.show_session_info: false` config option to suppress the model/provider/context block on `/new`
- Both default to `true` — zero change for existing users

## Use Case

Customer-facing gateway deployments (Telegram, Slack, API) where the agent runs under a custom brand. Tips reference Hermes CLI commands (`hermes profile export`, `/model`, etc.) and session info exposes model names, providers, and context lengths — all internal details that shouldn't reach end users in white-label deployments.

## Config

```yaml
display:
  show_tips: false
  show_session_info: false
```

## Implementation

Reads from the profile's `config.yaml` at session reset time (same pattern as `display.show_reasoning` and `display.busy_input_mode`). Falls back to `true` on any parse error. Config is read per-reset, not cached — changes take effect on next `/new` without restart.

## Test plan

- [x] Default behavior unchanged (both `true` when not set)
- [x] `show_tips: false` → no `✦ Tip:` line on `/new`
- [x] `show_session_info: false` → no `◆ Model:` / `◆ Provider:` / `◆ Context:` block on `/new`
- [x] Both `false` → `/new` shows only `✨ New session started!`
- [x] Parse errors gracefully fall back to showing tips/info

🤖 Generated with [Claude Code](https://claude.com/claude-code)