### PR TITLE
fix: reset turn activity before startup work

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7708,6 +7708,9 @@ class AIAgent:
         from hermes_logging import set_session_context
         set_session_context(self.session_id)
 
+        self._current_tool = None
+        self._touch_activity("starting conversation turn")
+
         # If the previous turn activated fallback, restore the primary
         # runtime so this turn gets a fresh attempt with the preferred model.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).

--- a/tests/run_agent/test_turn_activity_reset.py
+++ b/tests/run_agent/test_turn_activity_reset.py
@@ -1,0 +1,43 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _StopTurn(Exception):
+    pass
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_run_conversation_resets_activity_before_startup_work():
+    agent = _make_agent()
+    agent._last_activity_ts = time.time() - 3600
+    agent._current_tool = "terminal"
+
+    def assert_activity_reset(_system_message=None):
+        summary = agent.get_activity_summary()
+        assert summary["seconds_since_activity"] < 5
+        assert summary["current_tool"] is None
+        raise _StopTurn
+
+    agent._cleanup_dead_connections = MagicMock(return_value=False)
+    agent._build_system_prompt = MagicMock(side_effect=assert_activity_reset)
+
+    with pytest.raises(_StopTurn):
+        agent.run_conversation("new message")


### PR DESCRIPTION
## Summary

Fixes gateway inactivity watchdog false positives when a cached session agent starts a new turn after being idle.

## Root cause

Cached `AIAgent` instances could carry `_last_activity_ts` and `_current_tool` from the previous turn into startup work for a fresh inbound message. If the watchdog polled before the first new API call, it could measure inactivity from the previous turn and classify the new turn as already timed out.

## Changes

- Reset `_current_tool` at the beginning of `run_conversation()`.
- Touch agent activity immediately with `starting conversation turn` before provider restoration, prompt assembly, memory prefetch, or API calls.
- Added focused regression coverage that verifies a stale activity timestamp is reset before startup work begins.

## Validation

- `python -m pytest tests/run_agent/test_turn_activity_reset.py -q -n0`
- `python -m pytest tests/run_agent/test_turn_activity_reset.py tests/gateway/test_gateway_inactivity_timeout.py tests/cron/test_cron_inactivity_timeout.py -q -n0`
- `python -m py_compile run_agent.py tests/run_agent/test_turn_activity_reset.py`
- `git diff --check`

Fixes #9051