### PR TITLE
fix(memory): discover user-installed memory providers from HERMES_HOME

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -224,7 +224,7 @@ def cmd_setup(args) -> None:
 
     if not providers:
         print("\n  No memory provider plugins detected.")
-        print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
+        print("  Install a plugin to ~/.hermes/plugins/memory/<name>/ and try again.\n")
         return
 
     # Build picker items
@@ -424,7 +424,7 @@ def cmd_status(args) -> None:
                     break
         else:
             print(f"\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/memory/{provider_name}/")
 
     providers = _get_available_providers()
     if providers:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -1,12 +1,13 @@
 """Memory provider plugin discovery.
 
-Scans ``plugins/memory/<name>/`` directories for memory provider plugins.
-Each subdirectory must contain ``__init__.py`` with a class implementing
-the MemoryProvider ABC.
+Scans both bundled ``plugins/memory/<name>/`` and user-installed
+``$HERMES_HOME/plugins/memory/<name>/`` directories for memory provider
+plugins.  Each subdirectory must contain ``__init__.py`` with a class
+implementing the MemoryProvider ABC.
 
-Memory providers are separate from the general plugin system — they live
-in the repo and are always available without user installation. Only ONE
-can be active at a time, selected via ``memory.provider`` in config.yaml.
+Only ONE provider can be active at a time, selected via
+``memory.provider`` in config.yaml.  Bundled providers take precedence
+over user-installed providers on name collisions.
 
 Usage:
     from plugins.memory import discover_memory_providers, load_memory_provider
@@ -29,25 +30,25 @@ logger = logging.getLogger(__name__)
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
 
 
-def discover_memory_providers() -> List[Tuple[str, str, bool]]:
-    """Scan plugins/memory/ for available providers.
+def _get_user_memory_dir() -> Path:
+    """Return the user memory-plugins directory under HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "plugins" / "memory"
 
-    Returns list of (name, description, is_available) tuples.
-    Does NOT import the providers — just reads plugin.yaml for metadata
-    and does a lightweight availability check.
-    """
+
+def _scan_provider_dir(search_dir: Path) -> List[Tuple[str, str, bool]]:
+    """Scan a single directory for memory provider subdirectories."""
     results = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
+    if not search_dir.is_dir():
         return results
 
-    for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
+    for child in sorted(search_dir.iterdir()):
         if not child.is_dir() or child.name.startswith(("_", ".")):
             continue
         init_file = child / "__init__.py"
         if not init_file.exists():
             continue
 
-        # Read description from plugin.yaml if available
         desc = ""
         yaml_file = child / "plugin.yaml"
         if yaml_file.exists():
@@ -59,7 +60,6 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
             except Exception:
                 pass
 
-        # Quick availability check — try loading and calling is_available()
         available = True
         try:
             provider = _load_provider_from_dir(child)
@@ -75,14 +75,48 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     return results
 
 
+def discover_memory_providers() -> List[Tuple[str, str, bool]]:
+    """Scan bundled and user plugin directories for available providers.
+
+    Returns list of (name, description, is_available) tuples.
+    Bundled providers take precedence over user providers on name
+    collisions.
+    """
+    results = _scan_provider_dir(_MEMORY_PLUGINS_DIR)
+    seen = {name for name, _, _ in results}
+
+    for name, desc, avail in _scan_provider_dir(_get_user_memory_dir()):
+        if name not in seen:
+            results.append((name, desc, avail))
+            seen.add(name)
+
+    return results
+
+
+def _find_provider_dir(name: str) -> Optional[Path]:
+    """Locate a provider directory by name, checking bundled first."""
+    bundled = _MEMORY_PLUGINS_DIR / name
+    if bundled.is_dir():
+        return bundled
+    user_dir = _get_user_memory_dir() / name
+    if user_dir.is_dir():
+        return user_dir
+    return None
+
+
 def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     """Load and return a MemoryProvider instance by name.
 
-    Returns None if the provider is not found or fails to load.
+    Checks the bundled plugins/memory/ directory first, then
+    $HERMES_HOME/plugins/memory/.  Returns None if the provider is
+    not found or fails to load.
     """
-    provider_dir = _MEMORY_PLUGINS_DIR / name
-    if not provider_dir.is_dir():
-        logger.debug("Memory provider '%s' not found in %s", name, _MEMORY_PLUGINS_DIR)
+    provider_dir = _find_provider_dir(name)
+    if not provider_dir:
+        logger.debug(
+            "Memory provider '%s' not found in %s or %s",
+            name, _MEMORY_PLUGINS_DIR, _get_user_memory_dir(),
+        )
         return None
 
     try:
@@ -104,7 +138,8 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     - A top-level class that extends MemoryProvider — we instantiate it
     """
     name = provider_dir.name
-    module_name = f"plugins.memory.{name}"
+    is_bundled = _MEMORY_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _MEMORY_PLUGINS_DIR
+    module_name = f"plugins.memory.{name}" if is_bundled else f"_hermes_user_memory.{name}"
     init_file = provider_dir / "__init__.py"
 
     if not init_file.exists():
@@ -114,26 +149,39 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
     if module_name in sys.modules:
         mod = sys.modules[module_name]
     else:
-        # Handle relative imports within the plugin
-        # First ensure the parent packages are registered
-        for parent in ("plugins", "plugins.memory"):
-            if parent not in sys.modules:
-                parent_path = Path(__file__).parent
-                if parent == "plugins":
-                    parent_path = parent_path.parent
-                parent_init = parent_path / "__init__.py"
-                if parent_init.exists():
-                    spec = importlib.util.spec_from_file_location(
-                        parent, str(parent_init),
-                        submodule_search_locations=[str(parent_path)]
-                    )
-                    if spec:
-                        parent_mod = importlib.util.module_from_spec(spec)
-                        sys.modules[parent] = parent_mod
-                        try:
-                            spec.loader.exec_module(parent_mod)
-                        except Exception:
-                            pass
+        if is_bundled:
+            # Handle relative imports within the plugin
+            # First ensure the parent packages are registered
+            for parent in ("plugins", "plugins.memory"):
+                if parent not in sys.modules:
+                    parent_path = Path(__file__).parent
+                    if parent == "plugins":
+                        parent_path = parent_path.parent
+                    parent_init = parent_path / "__init__.py"
+                    if parent_init.exists():
+                        spec = importlib.util.spec_from_file_location(
+                            parent, str(parent_init),
+                            submodule_search_locations=[str(parent_path)]
+                        )
+                        if spec:
+                            parent_mod = importlib.util.module_from_spec(spec)
+                            sys.modules[parent] = parent_mod
+                            try:
+                                spec.loader.exec_module(parent_mod)
+                            except Exception:
+                                pass
+        else:
+            # Register synthetic parent packages for user plugins
+            parent_pkg = "_hermes_user_memory"
+            if parent_pkg not in sys.modules:
+                parent_dir = provider_dir.parent
+                pkg_spec = importlib.util.spec_from_file_location(
+                    parent_pkg, None,
+                    submodule_search_locations=[str(parent_dir)]
+                )
+                if pkg_spec:
+                    parent_mod = importlib.util.module_from_spec(pkg_spec)
+                    sys.modules[parent_pkg] = parent_mod
 
         # Now load the provider module
         spec = importlib.util.spec_from_file_location(
@@ -249,23 +297,21 @@ def discover_plugin_cli_commands() -> List[dict]:
     any provider is loaded.
     """
     results: List[dict] = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
 
     active_provider = _get_active_memory_provider()
     if not active_provider:
         return results
 
-    # Only look at the active provider's directory
-    plugin_dir = _MEMORY_PLUGINS_DIR / active_provider
-    if not plugin_dir.is_dir():
+    plugin_dir = _find_provider_dir(active_provider)
+    if not plugin_dir:
         return results
 
     cli_file = plugin_dir / "cli.py"
     if not cli_file.exists():
         return results
 
-    module_name = f"plugins.memory.{active_provider}.cli"
+    is_bundled = _MEMORY_PLUGINS_DIR in plugin_dir.parents or plugin_dir.parent == _MEMORY_PLUGINS_DIR
+    module_name = f"plugins.memory.{active_provider}.cli" if is_bundled else f"_hermes_user_memory.{active_provider}.cli"
     try:
         # Import the CLI module (lightweight — no SDK needed)
         if module_name in sys.modules:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -395,6 +395,60 @@ class TestPluginMemoryDiscovery:
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
 
+    def test_discover_scans_user_dir(self, tmp_path):
+        """discover_memory_providers finds providers in HERMES_HOME/plugins/memory/."""
+        from plugins.memory import discover_memory_providers
+        from unittest.mock import patch
+
+        user_mem_dir = tmp_path / "plugins" / "memory" / "fakeprov"
+        user_mem_dir.mkdir(parents=True)
+        (user_mem_dir / "__init__.py").write_text(
+            "class FakeProvider:\n"
+            "    name = 'fakeprov'\n"
+            "    def is_available(self): return True\n"
+        )
+        with patch("plugins.memory._get_user_memory_dir", return_value=tmp_path / "plugins" / "memory"):
+            providers = discover_memory_providers()
+        names = [n for n, _, _ in providers]
+        assert "fakeprov" in names
+
+    def test_bundled_takes_precedence_over_user(self, tmp_path):
+        """Bundled providers shadow user providers with the same name."""
+        from plugins.memory import discover_memory_providers
+        from unittest.mock import patch
+
+        user_mem_dir = tmp_path / "plugins" / "memory" / "holographic"
+        user_mem_dir.mkdir(parents=True)
+        (user_mem_dir / "__init__.py").write_text("raise RuntimeError('should not be loaded')\n")
+        with patch("plugins.memory._get_user_memory_dir", return_value=tmp_path / "plugins" / "memory"):
+            providers = discover_memory_providers()
+        holo = [(n, d, a) for n, d, a in providers if n == "holographic"]
+        assert len(holo) == 1
+
+    def test_load_from_user_dir(self, tmp_path):
+        """load_memory_provider finds providers in user directory."""
+        from plugins.memory import load_memory_provider
+        from unittest.mock import patch
+
+        user_mem_dir = tmp_path / "plugins" / "memory" / "testmem"
+        user_mem_dir.mkdir(parents=True)
+        (user_mem_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class TestMemProvider(MemoryProvider):\n"
+            "    name = 'testmem'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, *a, **kw): pass\n"
+            "    def system_prompt_block(self): return ''\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return {}\n"
+        )
+        with patch("plugins.memory._get_user_memory_dir", return_value=tmp_path / "plugins" / "memory"):
+            with patch("plugins.memory._find_provider_dir") as mock_find:
+                mock_find.return_value = user_mem_dir
+                p = load_memory_provider("testmem")
+        assert p is not None
+        assert p.name == "testmem"
+
 
 # ---------------------------------------------------------------------------
 # Sequential dispatch routing tests


### PR DESCRIPTION
## Summary

- Memory provider discovery (`discover_memory_providers()`, `load_memory_provider()`) only scanned the bundled `plugins/memory/` directory, ignoring user-installed providers in `$HERMES_HOME/plugins/memory/`. This caused `hermes memory status` to report third-party providers (e.g. brainctl) as "NOT installed" even when correctly placed in the user plugin directory.
- Now scans both bundled and `$HERMES_HOME/plugins/memory/` directories, with bundled providers taking precedence on name collisions.
- Fixes install-path hints in the setup/status CLI to point to the correct `~/.hermes/plugins/memory/<name>/` path.

Closes #9099

## Changes

- `plugins/memory/__init__.py`: Added `_get_user_memory_dir()`, `_find_provider_dir()`, `_scan_provider_dir()` helpers. Updated `discover_memory_providers()`, `load_memory_provider()`, `discover_plugin_cli_commands()`, and `_load_provider_from_dir()` to search both bundled and user directories.
- `hermes_cli/memory_setup.py`: Fixed install-path messages to reference `~/.hermes/plugins/memory/<name>/`.
- `tests/agent/test_memory_provider.py`: Added 3 tests covering user-dir discovery, bundled-takes-precedence behavior, and loading from user dir.

## Test plan

- All 6 `TestPluginMemoryDiscovery` tests pass (3 existing + 3 new).