### PR TITLE
fix(gateway): write clean-shutdown marker at start of stop() not end

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2013,6 +2013,16 @@ class GatewayRunner:
                 "Stopping gateway%s...",
                 " for restart" if self._restart_requested else "",
             )
+            # Write the clean-shutdown marker IMMEDIATELY on entry, not at the
+            # end of stop().  If systemd's TimeoutStopSec fires before we finish
+            # draining agents, the process gets SIGKILL and any late writes are
+            # lost.  Writing early ensures the next startup always sees the marker
+            # for a graceful shutdown, preventing unwanted session suspension.
+            try:
+                (_hermes_home / ".clean_shutdown").touch()
+            except Exception:
+                pass
+
             self._running = False
             self._draining = True
 
@@ -2083,15 +2093,6 @@ class GatewayRunner:
 
             from gateway.status import remove_pid_file
             remove_pid_file()
-
-            # Write a clean-shutdown marker so the next startup knows this
-            # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits — graceful shutdowns already drain
-            # active agents, so there's no stuck-session risk.
-            try:
-                (_hermes_home / ".clean_shutdown").touch()
-            except Exception:
-                pass
 
             if self._restart_requested and self._restart_via_service:
                 self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE


### PR DESCRIPTION
## Summary

Moves the `.clean_shutdown` marker write from the end of `_stop_impl()` to the very beginning, before any async work (draining, disconnecting, cleanup).

## Problem

`#8299` introduced the `.clean_shutdown` marker to prevent `suspend_recently_active()` from firing after graceful restarts. However, the marker was written near the **end** of `stop()`, after draining agents and disconnecting adapters. When the gateway runs as a systemd service with `TimeoutStopSec=60`, a long-running drain can push `stop()` past the timeout. systemd then sends SIGKILL, killing the process before the marker is written. The next startup sees no marker, assumes a crash, and suspends all recent sessions — causing unwanted auto-resets.

## Fix

Write the marker at the top of `_stop_impl()`, immediately on entry. The marker is idempotent (`touch`), so a false-positive (marker written but process crashes mid-drain) only skips one crash-recovery suspension — which is harmless since the drain was already attempted.

## Edge case considered

If the process receives SIGTERM, writes the marker, then genuinely crashes during drain — the next startup will skip `suspend_recently_active()`. This is acceptable because:
1. The drain was already initiated (agents were asked to stop)
2. The only risk is a "stuck" session, but systemd will restart the gateway anyway
3. The alternative (current behavior) is worse: losing ALL session context on every planned restart

## Test plan
- [x] Syntax check passes
- [x] Diff is clean against upstream main
- [x] No overlap with other open PRs (only touches `gateway/run.py` `stop()` method)
- [x] Verify: `hermes gateway restart` preserves session after this change