### PR TITLE
fix(memory): discover user-installed provider plugins

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -12,7 +12,7 @@ import os
 import sys
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 
 
 # ---------------------------------------------------------------------------
@@ -56,11 +56,15 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # ---------------------------------------------------------------------------
 
 def _install_dependencies(provider_name: str) -> None:
-    """Install pip dependencies declared in plugin.yaml."""
+    """Install pip dependencies declared in a memory provider manifest."""
     import subprocess
-    from pathlib import Path as _Path
 
-    plugin_dir = _Path(__file__).parent.parent / "plugins" / "memory" / provider_name
+    from plugins.memory import _find_provider_dir
+
+    plugin_dir = _find_provider_dir(provider_name)
+    if plugin_dir is None:
+        return
+
     yaml_path = plugin_dir / "plugin.yaml"
     if not yaml_path.exists():
         return
@@ -141,9 +145,9 @@ def _install_dependencies(provider_name: str) -> None:
 
 
 def _get_available_providers() -> list:
-    """Discover memory providers from plugins/memory/.
+    """Discover bundled and user-installed memory providers.
 
-    Returns list of (name, description, provider_instance) tuples.
+    Returns list of ``(name, description, provider_instance)`` tuples.
     """
     try:
         from plugins.memory import discover_memory_providers, load_memory_provider
@@ -224,7 +228,7 @@ def cmd_setup(args) -> None:
 
     if not providers:
         print("\n  No memory provider plugins detected.")
-        print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
+        print(f"  Install a plugin to {display_hermes_home()}/plugins/ and try again.\n")
         return
 
     # Build picker items
@@ -424,7 +428,7 @@ def cmd_status(args) -> None:
                     break
         else:
             print(f"\n  Plugin:    NOT installed ✗")
-            print(f"  Install the '{provider_name}' memory plugin to ~/.hermes/plugins/")
+            print(f"  Install the '{provider_name}' memory plugin to {display_hermes_home()}/plugins/")
 
     providers = _get_available_providers()
     if providers:

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -59,9 +59,9 @@ def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in a memory provider manifest."""
     import subprocess
 
-    from plugins.memory import _find_provider_dir
+    from plugins.memory import find_provider_dir
 
-    plugin_dir = _find_provider_dir(provider_name)
+    plugin_dir = find_provider_dir(provider_name)
     if plugin_dir is None:
         return
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -244,6 +244,23 @@ class PluginContext:
             self.manifest.name, engine.name,
         )
 
+    # -- memory provider registration ---------------------------------------
+
+    def register_memory_provider(self, provider) -> None:
+        """Ignore memory-provider registration in the general plugin manager.
+
+        Memory providers have their own discovery and activation flow under
+        ``plugins.memory``. User-installed provider plugins may still live
+        under ``$HERMES_HOME/plugins``, so the general plugin loader should
+        tolerate ``register_memory_provider()`` instead of marking them as
+        broken regular plugins.
+        """
+        logger.debug(
+            "Plugin %s registered a memory provider via the general plugin manager; "
+            "ignoring because memory providers are handled separately",
+            self.manifest.name,
+        )
+
     # -- hook registration --------------------------------------------------
 
     def register_hook(self, hook_name: str, callback: Callable) -> None:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -1,12 +1,13 @@
 """Memory provider plugin discovery.
 
-Scans ``plugins/memory/<name>/`` directories for memory provider plugins.
+Scans bundled ``plugins/memory/<name>/`` directories and user-installed
+``$HERMES_HOME/plugins/<name>/`` directories for memory provider plugins.
 Each subdirectory must contain ``__init__.py`` with a class implementing
 the MemoryProvider ABC.
 
-Memory providers are separate from the general plugin system — they live
-in the repo and are always available without user installation. Only ONE
-can be active at a time, selected via ``memory.provider`` in config.yaml.
+Bundled providers take precedence when a user plugin reuses the same name.
+Only ONE memory provider can be active at a time, selected via
+``memory.provider`` in config.yaml.
 
 Usage:
     from plugins.memory import discover_memory_providers, load_memory_provider
@@ -22,31 +23,60 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
 
 
-def discover_memory_providers() -> List[Tuple[str, str, bool]]:
-    """Scan plugins/memory/ for available providers.
+def _get_user_memory_plugins_dir() -> Path:
+    """Return the third-party memory provider directory under HERMES_HOME."""
+    return get_hermes_home() / "plugins"
 
-    Returns list of (name, description, is_available) tuples.
-    Does NOT import the providers — just reads plugin.yaml for metadata
-    and does a lightweight availability check.
+
+def _iter_provider_dirs() -> Iterator[tuple[Path, bool]]:
+    """Yield candidate provider directories with bundled providers first.
+
+    Returns ``(provider_dir, is_bundled)`` tuples. Name collisions are
+    de-duplicated so bundled providers always win.
+    """
+    seen_names: set[str] = set()
+    for root, is_bundled in ((_MEMORY_PLUGINS_DIR, True), (_get_user_memory_plugins_dir(), False)):
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name in seen_names:
+                continue
+            if not (child / "__init__.py").exists():
+                continue
+            seen_names.add(child.name)
+            yield child, is_bundled
+
+
+def _find_provider_dir(name: str) -> Optional[Path]:
+    """Resolve a provider directory by name, preferring bundled plugins."""
+    for provider_dir, _is_bundled in _iter_provider_dirs():
+        if provider_dir.name == name:
+            return provider_dir
+    return None
+
+
+def discover_memory_providers() -> List[Tuple[str, str, bool]]:
+    """Scan bundled and user-installed directories for available providers.
+
+    Returns list of ``(name, description, is_available)`` tuples. Bundled
+    providers are always listed. User-installed providers are listed only
+    when they can be resolved as memory providers, which avoids polluting
+    the memory picker with general-purpose plugins under ``$HERMES_HOME/plugins``.
     """
     results = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
 
-    for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-        if not child.is_dir() or child.name.startswith(("_", ".")):
-            continue
-        init_file = child / "__init__.py"
-        if not init_file.exists():
-            continue
-
+    for child, is_bundled in _iter_provider_dirs():
         # Read description from plugin.yaml if available
         desc = ""
         yaml_file = child / "plugin.yaml"
@@ -60,6 +90,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
                 pass
 
         # Quick availability check — try loading and calling is_available()
+        provider = None
         available = True
         try:
             provider = _load_provider_from_dir(child)
@@ -70,6 +101,9 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         except Exception:
             available = False
 
+        if provider is None and not is_bundled:
+            continue
+
         results.append((child.name, desc, available))
 
     return results
@@ -79,10 +113,11 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     """Load and return a MemoryProvider instance by name.
 
     Returns None if the provider is not found or fails to load.
+    Bundled providers take precedence over user-installed providers.
     """
-    provider_dir = _MEMORY_PLUGINS_DIR / name
-    if not provider_dir.is_dir():
-        logger.debug("Memory provider '%s' not found in %s", name, _MEMORY_PLUGINS_DIR)
+    provider_dir = _find_provider_dir(name)
+    if provider_dir is None:
+        logger.debug("Memory provider '%s' not found in bundled or user plugin dirs", name)
         return None
 
     try:
@@ -249,16 +284,14 @@ def discover_plugin_cli_commands() -> List[dict]:
     any provider is loaded.
     """
     results: List[dict] = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
 
     active_provider = _get_active_memory_provider()
     if not active_provider:
         return results
 
     # Only look at the active provider's directory
-    plugin_dir = _MEMORY_PLUGINS_DIR / active_provider
-    if not plugin_dir.is_dir():
+    plugin_dir = _find_provider_dir(active_provider)
+    if plugin_dir is None:
         return results
 
     cli_file = plugin_dir / "cli.py"
@@ -300,8 +333,7 @@ def discover_plugin_cli_commands() -> List[dict]:
             except Exception:
                 pass
 
-        handler_fn = getattr(cli_mod, f"{active_provider}_command", None) or \
-                     getattr(cli_mod, "honcho_command", None)
+        handler_fn = getattr(cli_mod, f"{active_provider}_command", None) or                      getattr(cli_mod, "honcho_command", None)
 
         results.append({
             "name": active_provider,

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -58,12 +58,32 @@ def _iter_provider_dirs() -> Iterator[tuple[Path, bool]]:
             yield child, is_bundled
 
 
-def _find_provider_dir(name: str) -> Optional[Path]:
+def find_provider_dir(name: str) -> Optional[Path]:
     """Resolve a provider directory by name, preferring bundled plugins."""
     for provider_dir, _is_bundled in _iter_provider_dirs():
         if provider_dir.name == name:
             return provider_dir
     return None
+
+
+def _looks_like_memory_provider(provider_dir: Path) -> bool:
+    """Return True when a directory appears to define a memory provider.
+
+    This lightweight check keeps unrelated general plugins under
+    ``$HERMES_HOME/plugins`` out of the memory provider list while still
+    surfacing installed providers whose imports currently fail because
+    dependencies are missing.
+    """
+    init_file = provider_dir / "__init__.py"
+    try:
+        contents = init_file.read_text()
+    except OSError:
+        return False
+    return "register_memory_provider" in contents
+
+
+# Backward-compatible alias for internal callers updated incrementally.
+_find_provider_dir = find_provider_dir
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
@@ -101,7 +121,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         except Exception:
             available = False
 
-        if provider is None and not is_bundled:
+        if provider is None and not is_bundled and not _looks_like_memory_provider(child):
             continue
 
         results.append((child.name, desc, available))
@@ -115,7 +135,7 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     Returns None if the provider is not found or fails to load.
     Bundled providers take precedence over user-installed providers.
     """
-    provider_dir = _find_provider_dir(name)
+    provider_dir = find_provider_dir(name)
     if provider_dir is None:
         logger.debug("Memory provider '%s' not found in bundled or user plugin dirs", name)
         return None
@@ -290,7 +310,7 @@ def discover_plugin_cli_commands() -> List[dict]:
         return results
 
     # Only look at the active provider's directory
-    plugin_dir = _find_provider_dir(active_provider)
+    plugin_dir = find_provider_dir(active_provider)
     if plugin_dir is None:
         return results
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,8 +1,12 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
-import pytest
+import os
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from agent.memory_provider import MemoryProvider
 from agent.memory_manager import MemoryManager
@@ -373,7 +377,34 @@ class TestMemoryManager:
 
 
 class TestPluginMemoryDiscovery:
-    """Memory providers are discovered from plugins/memory/ directory."""
+    """Memory providers are discovered from bundled and user plugin directories."""
+
+    def _make_user_memory_plugin(self, name: str, description: str = "User test provider") -> Path:
+        plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+        plugin_dir = plugins_dir / name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "class TestUserProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            f"        return {name!r}\n"
+            "    def is_available(self):\n"
+            "        return True\n"
+            "    def initialize(self, session_id, **kwargs):\n"
+            "        pass\n"
+            "    def get_tool_schemas(self):\n"
+            "        return []\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(TestUserProvider())\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {name}\n"
+            f"description: {description}\n"
+        )
+        return plugin_dir
 
     def test_discover_finds_providers(self):
         """discover_memory_providers returns available providers."""
@@ -394,6 +425,72 @@ class TestPluginMemoryDiscovery:
         """load_memory_provider returns None for unknown names."""
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
+
+    def test_discovers_user_installed_provider_from_hermes_home_plugins(self):
+        """User-installed providers under HERMES_HOME/plugins are discovered."""
+        plugin_name = "brainctl_test_provider"
+        self._make_user_memory_plugin(plugin_name, description="Brainctl-style provider")
+
+        from plugins.memory import discover_memory_providers
+
+        providers = discover_memory_providers()
+        names = [name for name, _, _ in providers]
+
+        try:
+            assert plugin_name in names
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
+    def test_loads_user_installed_provider_from_hermes_home_plugins(self):
+        """load_memory_provider supports providers installed under HERMES_HOME/plugins."""
+        plugin_name = "brainctl_load_provider"
+        self._make_user_memory_plugin(plugin_name)
+
+        from plugins.memory import load_memory_provider
+
+        try:
+            provider = load_memory_provider(plugin_name)
+            assert provider is not None
+            assert provider.name == plugin_name
+            assert provider.is_available()
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
+    def test_bundled_provider_takes_precedence_over_user_plugin_name_collision(self):
+        """Bundled providers win when a user plugin reuses an existing provider name."""
+        plugin_name = "holographic"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "class CollidingProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'collision'\n"
+            "    def is_available(self):\n"
+            "        return True\n"
+            "    def initialize(self, session_id, **kwargs):\n"
+            "        pass\n"
+            "    def get_tool_schemas(self):\n"
+            "        return []\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(CollidingProvider())\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: holographic\n"
+            "description: Colliding user provider\n"
+        )
+
+        from plugins.memory import load_memory_provider
+
+        try:
+            provider = load_memory_provider(plugin_name)
+            assert provider is not None
+            assert provider.name == "holographic"
+        finally:
+            sys.modules.pop("plugins.memory.holographic", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -441,6 +441,32 @@ class TestPluginMemoryDiscovery:
         finally:
             sys.modules.pop(f"plugins.memory.{plugin_name}", None)
 
+    def test_user_installed_provider_with_missing_deps_is_listed_unavailable(self):
+        """Installed providers remain discoverable when imports fail due to missing deps."""
+        plugin_name = "brainctl_missing_dep"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "import definitely_missing_dependency\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(object())\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {plugin_name}\n"
+            "description: Missing dependency provider\n"
+        )
+
+        from plugins.memory import discover_memory_providers
+
+        try:
+            providers = {
+                name: available for name, _desc, available in discover_memory_providers()
+            }
+            assert providers[plugin_name] is False
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
     def test_loads_user_installed_provider_from_hermes_home_plugins(self):
         """load_memory_provider supports providers installed under HERMES_HOME/plugins."""
         plugin_name = "brainctl_load_provider"

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,65 @@
+"""Tests for hermes memory setup provider discovery and dependency resolution."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _make_user_memory_plugin(name: str, hermes_home: Path, plugin_yaml: str) -> Path:
+    plugin_dir = hermes_home / "plugins" / name
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.memory_provider import MemoryProvider\n"
+        "\n"
+        "class TestProvider(MemoryProvider):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        f"        return {name!r}\n"
+        "    def is_available(self):\n"
+        "        return True\n"
+        "    def initialize(self, session_id, **kwargs):\n"
+        "        pass\n"
+        "    def get_tool_schemas(self):\n"
+        "        return []\n"
+        "\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(TestProvider())\n"
+    )
+    (plugin_dir / "plugin.yaml").write_text(plugin_yaml)
+    return plugin_dir
+
+
+def test_install_dependencies_reads_user_plugin_manifest(tmp_path, monkeypatch):
+    """Dependency installation should use the user-installed provider manifest."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugin_name = "brainctl_deps"
+    _make_user_memory_plugin(
+        plugin_name,
+        hermes_home,
+        "name: brainctl_deps\n"
+        "pip_dependencies:\n"
+        "  - totally-missing-package\n",
+    )
+
+    import hermes_cli.memory_setup as memory_setup
+
+    original_import = __import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "totally_missing_package":
+            raise ImportError("missing on purpose")
+        return original_import(name, *args, **kwargs)
+
+    with (
+        patch("builtins.__import__", side_effect=_fake_import),
+        patch("shutil.which", return_value="/usr/bin/uv"),
+        patch("subprocess.run") as mock_run,
+    ):
+        memory_setup._install_dependencies(plugin_name)
+
+    assert mock_run.called
+    install_cmd = mock_run.call_args.args[0]
+    assert install_cmd[:4] == ["/usr/bin/uv", "pip", "install", "--python"]
+    assert "totally-missing-package" in install_cmd
+    sys.modules.pop(f"plugins.memory.{plugin_name}", None)

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -126,6 +126,40 @@ class TestMemoryPluginCliDiscovery:
         assert callable(cmds[0]["setup_fn"])
         assert cmds[0]["handler_fn"].__name__ == "testplugin_command"
 
+    def test_discovers_active_user_installed_plugin_cli(self, monkeypatch):
+        """Active user-installed memory plugin CLI commands are discovered."""
+        plugin_name = "brainctl_cli"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text("pass\n")
+        (plugin_dir / "cli.py").write_text(
+            "def register_cli(subparser):\n"
+            "    subparser.add_argument('--brain')\n"
+            "\n"
+            f"def {plugin_name}_command(args):\n"
+            "    pass\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {plugin_name}\n"
+            "description: User-installed provider\n"
+        )
+
+        import plugins.memory as pm
+
+        mod_key = f"plugins.memory.{plugin_name}.cli"
+        sys.modules.pop(mod_key, None)
+        monkeypatch.setattr(pm, "_get_active_memory_provider", lambda: plugin_name)
+        try:
+            cmds = pm.discover_plugin_cli_commands()
+        finally:
+            sys.modules.pop(mod_key, None)
+
+        assert len(cmds) == 1
+        assert cmds[0]["name"] == plugin_name
+        assert cmds[0]["help"] == "User-installed provider"
+        assert callable(cmds[0]["setup_fn"])
+        assert cmds[0]["handler_fn"].__name__ == f"{plugin_name}_command"
+
     def test_returns_nothing_when_no_active_provider(self, tmp_path, monkeypatch):
         """No commands when memory.provider is not set in config."""
         plugin_dir = tmp_path / "testplugin"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -62,6 +62,23 @@ class TestPluginDiscovery:
         assert "hello_plugin" in mgr._plugins
         assert mgr._plugins["hello_plugin"].enabled
 
+    def test_memory_provider_only_plugins_do_not_fail_general_discovery(self, tmp_path, monkeypatch):
+        """Memory-provider plugins in the user plugin root are tolerated by PluginManager."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "memory_only_plugin",
+            register_body='ctx.register_memory_provider(object())',
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "memory_only_plugin" in mgr._plugins
+        assert mgr._plugins["memory_only_plugin"].enabled
+        assert mgr._plugins["memory_only_plugin"].error is None
+
     def test_discover_project_plugins(self, tmp_path, monkeypatch):
         """Plugins in ./.hermes/plugins/ are discovered."""
         project_dir = tmp_path / "project"


### PR DESCRIPTION
Fixes #9099

Summary
- discover memory providers from both bundled `plugins/memory/<name>` and `$HERMES_HOME/plugins/<name>`
- keep bundled providers first on name collisions
- route memory dependency installs and active memory plugin CLI discovery through the same provider lookup
- use the profile-safe Hermes home display path in `hermes memory` install guidance

Root cause
- memory-provider discovery and setup code were hardcoded to the bundled `plugins/memory/<name>` tree, so third-party providers installed under `$HERMES_HOME/plugins/<name>` were invisible to `hermes memory status/setup` and their `plugin.yaml` dependency declarations were never read

Changes
- add a shared provider-directory resolver in `plugins/memory/__init__.py`
- scan bundled and user plugin roots with bundled precedence
- use the shared resolver for `load_memory_provider()`, active memory plugin CLI discovery, and `_install_dependencies()`
- add regression coverage for user-installed provider discovery, loading, CLI discovery, dependency installation, and bundled-name collision precedence

Validation
- `source venv/bin/activate && python -m pytest tests/agent/test_memory_provider.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_plugins_cmd.py -q -n0` ✅ (`123 passed`)
- `source venv/bin/activate && python -m py_compile plugins/memory/__init__.py hermes_cli/memory_setup.py tests/agent/test_memory_provider.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_plugin_cli_registration.py` ✅
- `git diff --check` ✅
- `source venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` ⚠️ local checkout still has unrelated pre-existing failures/errors outside the touched memory-provider area (for example optional-dependency import errors for `acp` and `fastapi`)
