### PR TITLE
fix(memory): resolve user-installed providers

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -58,9 +58,13 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
-    from pathlib import Path as _Path
 
-    plugin_dir = _Path(__file__).parent.parent / "plugins" / "memory" / provider_name
+    from plugins.memory import find_memory_provider_dir
+
+    plugin_dir = find_memory_provider_dir(provider_name)
+    if plugin_dir is None:
+        return
+
     yaml_path = plugin_dir / "plugin.yaml"
     if not yaml_path.exists():
         return

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -24,29 +24,62 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
 
 
+def _iter_provider_dirs() -> List[Path]:
+    """Return candidate provider directories, preferring bundled names.
+
+    Bundled memory providers live under ``plugins/memory/<name>``. User-installed
+    provider plugins live under ``$HERMES_HOME/plugins/<name>`` alongside general
+    plugins. When both locations contain the same provider name, the bundled
+    provider takes precedence.
+    """
+    provider_dirs: List[Path] = []
+    seen_names: set[str] = set()
+
+    for base_dir in (_MEMORY_PLUGINS_DIR, get_hermes_home() / "plugins"):
+        if not base_dir.is_dir():
+            continue
+        for child in sorted(base_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name in seen_names:
+                continue
+            if not (child / "__init__.py").exists():
+                continue
+            provider_dirs.append(child)
+            seen_names.add(child.name)
+
+    return provider_dirs
+
+
+def find_memory_provider_dir(name: str) -> Optional[Path]:
+    """Resolve a memory provider directory by name.
+
+    Searches bundled providers first, then user-installed plugins under
+    ``$HERMES_HOME/plugins``.
+    """
+    for provider_dir in _iter_provider_dirs():
+        if provider_dir.name == name:
+            return provider_dir
+    return None
+
+
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
-    """Scan plugins/memory/ for available providers.
+    """Scan bundled and user-installed memory provider directories.
 
     Returns list of (name, description, is_available) tuples.
     Does NOT import the providers — just reads plugin.yaml for metadata
     and does a lightweight availability check.
     """
     results = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
 
-    for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-        if not child.is_dir() or child.name.startswith(("_", ".")):
-            continue
-        init_file = child / "__init__.py"
-        if not init_file.exists():
-            continue
-
+    for child in _iter_provider_dirs():
         # Read description from plugin.yaml if available
         desc = ""
         yaml_file = child / "plugin.yaml"
@@ -63,10 +96,9 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         available = True
         try:
             provider = _load_provider_from_dir(child)
-            if provider:
-                available = provider.is_available()
-            else:
-                available = False
+            if provider is None:
+                continue
+            available = provider.is_available()
         except Exception:
             available = False
 
@@ -80,9 +112,9 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
 
     Returns None if the provider is not found or fails to load.
     """
-    provider_dir = _MEMORY_PLUGINS_DIR / name
-    if not provider_dir.is_dir():
-        logger.debug("Memory provider '%s' not found in %s", name, _MEMORY_PLUGINS_DIR)
+    provider_dir = find_memory_provider_dir(name)
+    if provider_dir is None or not provider_dir.is_dir():
+        logger.debug("Memory provider '%s' not found in bundled or user plugin dirs", name)
         return None
 
     try:
@@ -132,6 +164,8 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
                         sys.modules[parent] = parent_mod
                         try:
                             spec.loader.exec_module(parent_mod)
+                            if parent == "plugins.memory" and "plugins" in sys.modules:
+                                setattr(sys.modules["plugins"], "memory", parent_mod)
                         except Exception:
                             pass
 
@@ -162,6 +196,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
                     sys.modules[full_sub_name] = sub_mod
                     try:
                         sub_spec.loader.exec_module(sub_mod)
+                        setattr(mod, sub_name, sub_mod)
                     except Exception as e:
                         logger.debug("Failed to load submodule %s: %s", full_sub_name, e)
 
@@ -171,6 +206,10 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
             logger.debug("Failed to exec_module %s: %s", module_name, e)
             sys.modules.pop(module_name, None)
             return None
+
+    memory_pkg = sys.modules.get("plugins.memory")
+    if memory_pkg is not None:
+        setattr(memory_pkg, name, mod)
 
     # Try register(ctx) pattern first (how our plugins are written)
     if hasattr(mod, "register"):
@@ -257,8 +296,8 @@ def discover_plugin_cli_commands() -> List[dict]:
         return results
 
     # Only look at the active provider's directory
-    plugin_dir = _MEMORY_PLUGINS_DIR / active_provider
-    if not plugin_dir.is_dir():
+    plugin_dir = find_memory_provider_dir(active_provider)
+    if plugin_dir is None or not plugin_dir.is_dir():
         return results
 
     cli_file = plugin_dir / "cli.py"

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -24,11 +24,35 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+_MEMORY_PROVIDER_MARKERS = ("register_memory_provider", "MemoryProvider")
+
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
+
+
+def _looks_like_user_memory_provider_dir(provider_dir: Path) -> bool:
+    """Return True when a user plugin directory appears to provide memory.
+
+    User-installed providers share the general ``$HERMES_HOME/plugins`` root with
+    non-memory plugins, so avoid importing arbitrary plugin code during memory
+    provider discovery. We only treat a user plugin as a memory provider candidate
+    when it has a manifest and its ``__init__.py`` references memory provider
+    registration or the ``MemoryProvider`` base class.
+    """
+    yaml_file = provider_dir / "plugin.yaml"
+    init_file = provider_dir / "__init__.py"
+    if not yaml_file.exists() or not init_file.exists():
+        return False
+
+    try:
+        init_source = init_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+    return any(marker in init_source for marker in _MEMORY_PROVIDER_MARKERS)
 
 
 def _iter_provider_dirs() -> List[Path]:
@@ -42,7 +66,8 @@ def _iter_provider_dirs() -> List[Path]:
     provider_dirs: List[Path] = []
     seen_names: set[str] = set()
 
-    for base_dir in (_MEMORY_PLUGINS_DIR, get_hermes_home() / "plugins"):
+    bundled_dirs = (_MEMORY_PLUGINS_DIR, True), (get_hermes_home() / "plugins", False)
+    for base_dir, is_bundled in bundled_dirs:
         if not base_dir.is_dir():
             continue
         for child in sorted(base_dir.iterdir()):
@@ -50,7 +75,10 @@ def _iter_provider_dirs() -> List[Path]:
                 continue
             if child.name in seen_names:
                 continue
-            if not (child / "__init__.py").exists():
+            if is_bundled:
+                if not (child / "__init__.py").exists():
+                    continue
+            elif not _looks_like_user_memory_provider_dir(child):
                 continue
             provider_dirs.append(child)
             seen_names.add(child.name)
@@ -73,9 +101,11 @@ def find_memory_provider_dir(name: str) -> Optional[Path]:
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     """Scan bundled and user-installed memory provider directories.
 
-    Returns list of (name, description, is_available) tuples.
-    Does NOT import the providers — just reads plugin.yaml for metadata
-    and does a lightweight availability check.
+    Returns list of ``(name, description, is_available)`` tuples. Reads
+    ``plugin.yaml`` for metadata when present and performs an availability
+    check by loading the provider module and calling ``is_available()``.
+    Providers that look like memory providers but fail to load stay visible
+    with ``is_available=False`` so setup flows can still surface them.
     """
     results = []
 
@@ -92,13 +122,13 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
             except Exception:
                 pass
 
-        # Quick availability check — try loading and calling is_available()
-        available = True
+        # Availability check: load the provider and call is_available().
+        # Keep broken providers visible so setup flows can still surface them.
+        available = False
         try:
             provider = _load_provider_from_dir(child)
-            if provider is None:
-                continue
-            available = provider.is_available()
+            if provider is not None:
+                available = provider.is_available()
         except Exception:
             available = False
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,8 +1,12 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
-import pytest
+import os
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from agent.memory_provider import MemoryProvider
 from agent.memory_manager import MemoryManager
@@ -375,6 +379,33 @@ class TestMemoryManager:
 class TestPluginMemoryDiscovery:
     """Memory providers are discovered from plugins/memory/ directory."""
 
+    def _make_user_memory_plugin(self, name: str, description: str = "User test provider") -> Path:
+        plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+        plugin_dir = plugins_dir / name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "class TestUserProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            f"        return {name!r}\n"
+            "    def is_available(self):\n"
+            "        return True\n"
+            "    def initialize(self, session_id, **kwargs):\n"
+            "        pass\n"
+            "    def get_tool_schemas(self):\n"
+            "        return []\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(TestUserProvider())\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {name}\n"
+            f"description: {description}\n"
+        )
+        return plugin_dir
+
     def test_discover_finds_providers(self):
         """discover_memory_providers returns available providers."""
         from plugins.memory import discover_memory_providers
@@ -394,6 +425,72 @@ class TestPluginMemoryDiscovery:
         """load_memory_provider returns None for unknown names."""
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
+
+    def test_discovers_user_installed_provider_from_hermes_home_plugins(self):
+        """User-installed providers under HERMES_HOME/plugins are discovered."""
+        plugin_name = "brainctl_test_provider"
+        self._make_user_memory_plugin(plugin_name, description="Brainctl-style provider")
+
+        from plugins.memory import discover_memory_providers
+
+        providers = discover_memory_providers()
+        names = [name for name, _, _ in providers]
+
+        try:
+            assert plugin_name in names
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
+    def test_loads_user_installed_provider_from_hermes_home_plugins(self):
+        """load_memory_provider supports providers installed under HERMES_HOME/plugins."""
+        plugin_name = "brainctl_load_provider"
+        self._make_user_memory_plugin(plugin_name)
+
+        from plugins.memory import load_memory_provider
+
+        try:
+            provider = load_memory_provider(plugin_name)
+            assert provider is not None
+            assert provider.name == plugin_name
+            assert provider.is_available()
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
+    def test_bundled_provider_takes_precedence_over_user_plugin_name_collision(self):
+        """Bundled providers win when a user plugin reuses an existing provider name."""
+        plugin_name = "holographic"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "class CollidingProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'collision'\n"
+            "    def is_available(self):\n"
+            "        return True\n"
+            "    def initialize(self, session_id, **kwargs):\n"
+            "        pass\n"
+            "    def get_tool_schemas(self):\n"
+            "        return []\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(CollidingProvider())\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: holographic\n"
+            "description: Colliding user provider\n"
+        )
+
+        from plugins.memory import load_memory_provider
+
+        try:
+            provider = load_memory_provider(plugin_name)
+            assert provider is not None
+            assert provider.name == "holographic"
+        finally:
+            sys.modules.pop("plugins.memory.holographic", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -492,6 +492,48 @@ class TestPluginMemoryDiscovery:
         finally:
             sys.modules.pop("plugins.memory.holographic", None)
 
+    def test_broken_user_memory_provider_stays_visible_as_unavailable(self):
+        """Broken memory providers stay discoverable so setup can surface them."""
+        plugin_name = "broken_memory_provider"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "raise RuntimeError('boom')\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {plugin_name}\n"
+            "description: Broken memory provider\n"
+        )
+
+        from plugins.memory import discover_memory_providers
+
+        try:
+            providers = {name: available for name, _, available in discover_memory_providers()}
+            assert providers[plugin_name] is False
+        finally:
+            sys.modules.pop(f"plugins.memory.{plugin_name}", None)
+
+    def test_non_memory_user_plugin_is_not_treated_as_memory_provider(self):
+        """General user plugins should be ignored by memory provider discovery."""
+        plugin_name = "general_tool_plugin"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    raise RuntimeError('should not be imported')\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {plugin_name}\n"
+            "description: General plugin, not memory\n"
+        )
+
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        providers = [name for name, _, _ in discover_memory_providers()]
+        assert plugin_name not in providers
+        assert load_memory_provider(plugin_name) is None
+
 
 # ---------------------------------------------------------------------------
 # Sequential dispatch routing tests

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,65 @@
+"""Tests for hermes memory setup provider discovery and dependency resolution."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _make_user_memory_plugin(name: str, hermes_home: Path, plugin_yaml: str) -> Path:
+    plugin_dir = hermes_home / "plugins" / name
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.memory_provider import MemoryProvider\n"
+        "\n"
+        "class TestProvider(MemoryProvider):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        f"        return {name!r}\n"
+        "    def is_available(self):\n"
+        "        return True\n"
+        "    def initialize(self, session_id, **kwargs):\n"
+        "        pass\n"
+        "    def get_tool_schemas(self):\n"
+        "        return []\n"
+        "\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(TestProvider())\n"
+    )
+    (plugin_dir / "plugin.yaml").write_text(plugin_yaml)
+    return plugin_dir
+
+
+def test_install_dependencies_reads_user_plugin_manifest(tmp_path, monkeypatch):
+    """Dependency installation should use the user-installed provider manifest."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugin_name = "brainctl_deps"
+    _make_user_memory_plugin(
+        plugin_name,
+        hermes_home,
+        "name: brainctl_deps\n"
+        "pip_dependencies:\n"
+        "  - totally-missing-package\n",
+    )
+
+    import hermes_cli.memory_setup as memory_setup
+
+    original_import = __import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "totally_missing_package":
+            raise ImportError("missing on purpose")
+        return original_import(name, *args, **kwargs)
+
+    with (
+        patch("builtins.__import__", side_effect=_fake_import),
+        patch("shutil.which", return_value="/usr/bin/uv"),
+        patch("subprocess.run") as mock_run,
+    ):
+        memory_setup._install_dependencies(plugin_name)
+
+    assert mock_run.called
+    install_cmd = mock_run.call_args.args[0]
+    assert install_cmd[:4] == ["/usr/bin/uv", "pip", "install", "--python"]
+    assert "totally-missing-package" in install_cmd
+    sys.modules.pop(f"plugins.memory.{plugin_name}", None)

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -126,6 +126,40 @@ class TestMemoryPluginCliDiscovery:
         assert callable(cmds[0]["setup_fn"])
         assert cmds[0]["handler_fn"].__name__ == "testplugin_command"
 
+    def test_discovers_active_user_installed_plugin(self, monkeypatch):
+        """Active memory plugins installed under HERMES_HOME/plugins expose CLI commands."""
+        plugin_name = "brainctl_cli_provider"
+        plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "__init__.py").write_text("pass\n")
+        (plugin_dir / "cli.py").write_text(
+            "def register_cli(subparser):\n"
+            "    subparser.add_argument('--brain')\n"
+            "\n"
+            f"def {plugin_name}_command(args):\n"
+            "    pass\n"
+        )
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {plugin_name}\n"
+            "description: Brainctl-style CLI plugin\n"
+        )
+
+        import plugins.memory as pm
+
+        mod_key = f"plugins.memory.{plugin_name}.cli"
+        sys.modules.pop(mod_key, None)
+        monkeypatch.setattr(pm, "_get_active_memory_provider", lambda: plugin_name)
+        try:
+            cmds = pm.discover_plugin_cli_commands()
+        finally:
+            sys.modules.pop(mod_key, None)
+
+        assert len(cmds) == 1
+        assert cmds[0]["name"] == plugin_name
+        assert cmds[0]["help"] == "Brainctl-style CLI plugin"
+        assert callable(cmds[0]["setup_fn"])
+        assert cmds[0]["handler_fn"].__name__ == f"{plugin_name}_command"
+
     def test_returns_nothing_when_no_active_provider(self, tmp_path, monkeypatch):
         """No commands when memory.provider is not set in config."""
         plugin_dir = tmp_path / "testplugin"

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -84,7 +84,12 @@ class TestMemoryPluginCliDiscovery:
         """Only the active memory provider's CLI commands are discovered."""
         plugin_dir = tmp_path / "testplugin"
         plugin_dir.mkdir()
-        (plugin_dir / "__init__.py").write_text("pass\n")
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(None)\n"
+        )
         (plugin_dir / "cli.py").write_text(
             "def register_cli(subparser):\n"
             "    subparser.add_argument('--test')\n"
@@ -131,7 +136,12 @@ class TestMemoryPluginCliDiscovery:
         plugin_name = "brainctl_cli_provider"
         plugin_dir = Path(os.environ["HERMES_HOME"]) / "plugins" / plugin_name
         plugin_dir.mkdir(parents=True)
-        (plugin_dir / "__init__.py").write_text("pass\n")
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(None)\n"
+        )
         (plugin_dir / "cli.py").write_text(
             "def register_cli(subparser):\n"
             "    subparser.add_argument('--brain')\n"
@@ -164,7 +174,12 @@ class TestMemoryPluginCliDiscovery:
         """No commands when memory.provider is not set in config."""
         plugin_dir = tmp_path / "testplugin"
         plugin_dir.mkdir()
-        (plugin_dir / "__init__.py").write_text("pass\n")
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(None)\n"
+        )
         (plugin_dir / "cli.py").write_text(
             "def register_cli(subparser):\n    pass\n"
         )


### PR DESCRIPTION
## Summary
- discover memory providers from both bundled `plugins/memory/*` and user-installed `$HERMES_HOME/plugins/*`
- resolve the active memory provider CLI and setup manifest through the same provider lookup
- add regression tests for discovery, loading, CLI registration, and dependency installation of user-installed providers

## Root cause
Memory provider code only resolved providers from the bundled `plugins/memory/<name>` path. Providers installed through `hermes memory install` live under `$HERMES_HOME/plugins/<name>`, so they could be installed successfully but then fail discovery, loading, CLI registration, and dependency installation.

## Changes
- add a shared memory provider directory resolver that searches bundled providers first, then `$HERMES_HOME/plugins`
- reuse that resolver in `discover_memory_providers()`, `load_memory_provider()`, `discover_plugin_cli_commands()`, and `hermes_cli.memory_setup._install_dependencies()`
- preserve normal package attribute registration when dynamically loading provider modules and submodules
- add regression coverage for:
  - user-installed provider discovery and loading
  - bundled-vs-user name collision precedence
  - active user-installed provider CLI discovery
  - dependency installation from a user-installed provider manifest

## Validation
- `source venv/bin/activate && python -m pytest tests/agent/test_memory_provider.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_memory_setup.py -q -n0`
  - `63 passed`
- `source venv/bin/activate && python -m pytest tests/agent/test_memory_provider.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_memory_setup.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_doctor.py -q -n0`
  - `140 passed`
- `source venv/bin/activate && python -m py_compile plugins/memory/__init__.py hermes_cli/memory_setup.py tests/agent/test_memory_provider.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_memory_setup.py`
- `git diff --check`

Fixes #9099
