### PR TITLE
feat: Add hide_info_panel skin option to disable info banner

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -533,4 +533,5 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
         console.print(_logo)
         console.print()
-    console.print(outer_panel)
+    if not (_bskin and hasattr(_bskin, 'hide_info_panel') and _bskin.hide_info_panel):
+        console.print(outer_panel)

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -121,6 +121,7 @@ class SkinConfig:
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    hide_info_panel: bool = False # Hide the version and tools panel
 
     def get_color(self, key: str, fallback: str = "") -> str:
         """Get a color value with fallback."""
@@ -551,6 +552,7 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         tool_emojis=data.get("tool_emojis", {}),
         banner_logo=data.get("banner_logo", ""),
         banner_hero=data.get("banner_hero", ""),
+        hide_info_panel=data.get("hide_info_panel", False),
     )
 
 


### PR DESCRIPTION
Adds a new skin configuration option `hide_info_panel` that allows skins to hide the version and tools info panel in the welcome banner.

## Changes

- Add `hide_info_panel: bool = False` field to SkinConfig dataclass
- Add `hide_info_panel=data.get("hide_info_panel", False)` to _build_skin_config()
- Add conditional check in build_welcome_banner() to skip printing outer_panel when hide_info_panel is True

## Usage in skin YAML

```yaml
hide_info_panel: true
```