### PR TITLE
fix(model): pass api_mode through validation chain and support custom:name:model triple syntax

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4701,21 +4701,18 @@ class HermesCLI:
 
         user_provs = None
         custom_provs = None
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = cfg.get("custom_providers")
+        except Exception:
+            pass
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
             model_display = self.model or "unknown"
             provider_display = get_label(self.provider) if self.provider else "unknown"
-
-            user_provs = None
-            custom_provs = None
-            try:
-                from hermes_cli.config import load_config
-                cfg = load_config()
-                user_provs = cfg.get("providers")
-                custom_provs = cfg.get("custom_providers")
-            except Exception:
-                pass
 
             try:
                 providers = list_authenticated_providers(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -454,6 +454,7 @@ def switch_model(
     """
     from hermes_cli.models import (
         detect_provider_for_model,
+        parse_model_input,
         validate_requested_model,
         opencode_model_api_mode,
     )
@@ -612,7 +613,18 @@ def switch_model(
             "localhost" in _base or "127.0.0.1" in _base
         )
 
-        if (
+        # Always attempt to parse ``custom:<name>:<model>`` triple syntax
+        # even when currently on a custom provider, so users can switch
+        # between named custom providers (e.g. custom:cch_anthropic:glm-5-turbo).
+        # ``parse_model_input`` handles this; ``detect_provider_for_model``
+        # only matches against known provider catalogs and misses custom slugs.
+        if new_model.startswith("custom:") and ":" in new_model[len("custom:"):]:
+            parsed_provider, parsed_model = parse_model_input(new_model, current_provider)
+            if parsed_provider != current_provider or parsed_model != new_model:
+                target_provider = parsed_provider
+                new_model = parsed_model
+                is_custom = False  # provider changed, re-evaluate
+        elif (
             target_provider == current_provider
             and not is_custom
             and not resolved_alias
@@ -686,6 +698,7 @@ def switch_model(
             target_provider,
             api_key=api_key,
             base_url=base_url,
+            api_mode=api_mode,
         )
     except Exception:
         validation = {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1006,6 +1006,17 @@ def list_authenticated_providers(
             if default_model:
                 models_list.append(default_model)
 
+            # Also include models from the "models" field (dict or list)
+            cfg_models = entry.get("models")
+            if isinstance(cfg_models, dict):
+                for m in cfg_models:
+                    if m and m not in models_list:
+                        models_list.append(m)
+            elif isinstance(cfg_models, list):
+                for m in cfg_models:
+                    if isinstance(m, str) and m not in models_list:
+                        models_list.append(m)
+
             results.append({
                 "slug": slug,
                 "name": display_name,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1785,7 +1785,7 @@ def validate_requested_model(
             "message": "Model names cannot contain spaces.",
         }
 
-    if normalized == "custom":
+    if normalized == "custom" or normalized.startswith("custom:"):
         probe = probe_api_models(api_key, base_url, api_mode=api_mode)
         api_models = probe.get("models")
         if api_models is not None:
@@ -1864,7 +1864,7 @@ def validate_requested_model(
             }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
 
     if api_models is not None:
         if requested_for_lookup in set(api_models):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1625,8 +1625,14 @@ def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Probe an OpenAI-compatible ``/models`` endpoint with light URL heuristics."""
+    """Probe an OpenAI-compatible ``/models`` endpoint with light URL heuristics.
+
+    When *api_mode* is ``"anthropic_messages"``, an ``anthropic-version`` header
+    is included so that Anthropic-compatible proxies (e.g. Claude Code Hub) return
+    their Anthropic model catalog instead of the OpenAI one.
+    """
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
         return {
@@ -1662,6 +1668,8 @@ def probe_api_models(
         headers["Authorization"] = f"Bearer {api_key}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
+    if api_mode == "anthropic_messages":
+        headers["anthropic-version"] = "2023-06-01"
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
@@ -1720,13 +1728,14 @@ def fetch_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout).get("models")
+    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
 
 
 def validate_requested_model(
@@ -1735,6 +1744,7 @@ def validate_requested_model(
     *,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -1776,7 +1786,7 @@ def validate_requested_model(
         }
 
     if normalized == "custom":
-        probe = probe_api_models(api_key, base_url)
+        probe = probe_api_models(api_key, base_url, api_mode=api_mode)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):


### PR DESCRIPTION
## Summary

Four fixes for model switching with custom providers:

### 1. api_mode not propagated to validate_requested_model / probe_api_models
Closes #9137

`switch_model()` resolved `api_mode` from `resolve_runtime_provider()` but never passed it to `validate_requested_model()`. This caused Anthropic-compatible proxies (e.g. Claude Code Hub) to probe `/models` without the `anthropic-version` header, returning the OpenAI model catalog instead of the Anthropic one.

**Fix:** Add `api_mode` parameter to `probe_api_models()`, `fetch_api_models()`, and `validate_requested_model()`. When `api_mode == "anthropic_messages"`, include `anthropic-version: 2023-06-01` in probe requests.

### 2. `custom:<name>:<model>` triple syntax broken on custom providers
Closes #9138

Introduced by #2110 (commit `1055d435`) — the `not is_custom` guard skips `detect_provider_for_model()` when currently on a custom provider, which also prevents triple-suffix parsing. #2799 preserved this behavior during the refactor into `switch_model()`.

**Fix:** Use `parse_model_input()` (which has dedicated triple-suffix parsing) before the `is_custom` guard so users can switch between named custom providers even while currently on one.

### 3. CLI `/model` handler missing custom_providers config read
Closes #9139

`user_provs` / `custom_provs` were only loaded inside the picker-only branch (no args). When a model_input was provided, they stayed `None`.

**Fix:** Move config loading before the branch so `switch_model()` always receives the full provider list.

### 4. `/model` picker shows 0 models for custom_providers with `models:` field
Closes #9140

`list_authenticated_providers()` only read the singular `model` field (default model string) from `custom_providers` entries, ignoring the `models:` dict/list entirely. The `providers:` dict path already handles both formats.

**Fix:** Handle both dict and list formats for the `models:` field in custom providers, same as the `providers:` dict path.

## Testing
- 80 existing model-switch tests pass (custom providers, variant tags, validation, CLI picker, switch context)
- Verified `parse_model_input('custom:cch_anthropic:glm-5-turbo', 'custom')` correctly returns `('custom:cch_anthropic', 'glm-5-turbo')`
- Verified `resolve_runtime_provider(requested='custom:cch_anthropic')` returns correct `api_mode='anthropic_messages'`
- Verified `list_authenticated_providers()` now correctly lists models from `models:` dict in custom_providers
