### PR TITLE
fix(cli): wire general plugin commands into main parser

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5312,17 +5312,30 @@ Examples:
     # own argparse tree.  No hardcoded plugin commands in main.py.
     # =========================================================================
     try:
+        import logging as _log
+        from hermes_cli.plugins import discover_plugins, get_plugin_cli_commands
         from plugins.memory import discover_plugin_cli_commands
-        for cmd_info in discover_plugin_cli_commands():
+
+        discover_plugins()
+        dynamic_commands = list(discover_plugin_cli_commands())
+        dynamic_commands.extend(get_plugin_cli_commands().values())
+
+        for cmd_info in dynamic_commands:
+            cmd_name = cmd_info["name"]
+            if cmd_name in subparsers.choices:
+                _log.getLogger(__name__).warning(
+                    "Skipping plugin CLI command '%s': subcommand already exists",
+                    cmd_name,
+                )
+                continue
             plugin_parser = subparsers.add_parser(
-                cmd_info["name"],
+                cmd_name,
                 help=cmd_info["help"],
                 description=cmd_info.get("description", ""),
                 formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
             )
             cmd_info["setup_fn"](plugin_parser)
     except Exception as _exc:
-        import logging as _log
         _log.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
 
     # =========================================================================

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -575,6 +575,15 @@ def discover_plugins() -> None:
     get_plugin_manager().discover_and_load()
 
 
+def get_plugin_cli_commands() -> Dict[str, dict]:
+    """Return a shallow copy of plugin-registered CLI commands.
+
+    Kept as a small convenience wrapper so callers don't need to reach into
+    the plugin manager singleton's private ``_cli_commands`` attribute.
+    """
+    return dict(get_plugin_manager()._cli_commands)
+
+
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Invoke a lifecycle hook on all loaded plugins.
 

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -12,7 +12,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -20,6 +20,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    get_plugin_cli_commands,
 )
 
 
@@ -62,6 +63,124 @@ class TestRegisterCliCommand:
         ctx.register_cli_command("nocb", "test", MagicMock())
         assert mgr._cli_commands["nocb"]["handler_fn"] is None
 
+
+class TestGetPluginCliCommands:
+    def test_returns_dict(self):
+        mgr = PluginManager()
+        mgr._cli_commands["foo"] = {"name": "foo", "help": "bar"}
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
+            cmds = get_plugin_cli_commands()
+        assert cmds == {"foo": {"name": "foo", "help": "bar"}}
+        # Top-level is a copy — adding to result doesn't affect manager
+        cmds["new"] = {"name": "new"}
+        assert "new" not in mgr._cli_commands
+
+
+class TestMainParserPluginCliIntegration:
+    def test_general_plugin_command_is_wired_into_main_parser(self, monkeypatch):
+        import hermes_cli.main as main_mod
+        import hermes_cli.plugins as plugins_mod
+        import hermes_cli.config as config_mod
+        import plugins.memory as memory_plugins_mod
+
+        captured = {}
+
+        def fake_plugin_handler(args):
+            captured["command"] = args.command
+            captured["answer"] = args.answer
+
+        def fake_setup_fn(subparser):
+            subparser.add_argument("--answer", required=True)
+            subparser.set_defaults(func=fake_plugin_handler)
+
+        def fake_discover_plugins():
+            captured["discover_called"] = True
+
+        monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+        monkeypatch.setattr(plugins_mod, "discover_plugins", fake_discover_plugins)
+        monkeypatch.setattr(
+            plugins_mod,
+            "get_plugin_cli_commands",
+            lambda: {
+                "plugcmd": {
+                    "name": "plugcmd",
+                    "help": "Test plugin command",
+                    "description": "Plugin command registered through PluginContext",
+                    "setup_fn": fake_setup_fn,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            memory_plugins_mod,
+            "discover_plugin_cli_commands",
+            lambda: [],
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["hermes", "plugcmd", "--answer", "42"],
+        )
+
+        main_mod.main()
+
+        assert captured == {
+            "discover_called": True,
+            "command": "plugcmd",
+            "answer": "42",
+        }
+
+    def test_conflicting_plugin_command_does_not_block_later_plugin_commands(
+        self, monkeypatch, caplog
+    ):
+        import hermes_cli.main as main_mod
+        import hermes_cli.plugins as plugins_mod
+        import hermes_cli.config as config_mod
+        import plugins.memory as memory_plugins_mod
+
+        captured = {}
+
+        def fake_plugin_handler(args):
+            captured["command"] = args.command
+
+        def fake_setup_fn(subparser):
+            subparser.set_defaults(func=fake_plugin_handler)
+
+        monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins_mod,
+            "get_plugin_cli_commands",
+            lambda: {
+                "skills": {
+                    "name": "skills",
+                    "help": "Conflicts with built-in skills command",
+                    "setup_fn": fake_setup_fn,
+                },
+                "plugcmd": {
+                    "name": "plugcmd",
+                    "help": "A non-conflicting plugin command",
+                    "setup_fn": fake_setup_fn,
+                },
+            },
+        )
+        monkeypatch.setattr(
+            memory_plugins_mod,
+            "discover_plugin_cli_commands",
+            lambda: [],
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["hermes", "plugcmd"],
+        )
+
+        with caplog.at_level("WARNING"):
+            main_mod.main()
+
+        assert captured == {
+            "command": "plugcmd",
+        }
+        assert "Skipping plugin CLI command 'skills'" in caplog.text
 
 # ── Memory plugin CLI discovery ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- wire general plugin CLI commands from `hermes_cli.plugins` into the main argparse tree
- skip conflicting plugin subcommand names instead of aborting later plugin command registration
- add CLI integration coverage for general plugin command wiring and conflict handling

## Testing
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_plugin_cli_registration.py -q
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_chat_skills_flag.py -q
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_skills_install_flags.py -q
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_skills_subparser.py -q

## Notes
- full `python -m pytest tests/ -q` is not green in this environment; it reported many pre-existing failures and sandbox-related log write errors unrelated to this patch