### PR TITLE
fix(config): respect model.context_length override for sub-64K models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1450,10 +1450,14 @@ def init_agent(
     agent.compression_enabled = compression_enabled
 
     # Reject models whose context window is below the minimum required
-    # for reliable tool-calling workflows (64K tokens).
+    # for reliable tool-calling workflows (64K tokens). Skip the check when
+    # the user explicitly set model.context_length in config.yaml — they
+    # accept the reduced window and the error message itself tells them to
+    # do this.
     from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
     _ctx = getattr(agent.context_compressor, "context_length", 0)
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+    _config_ctx_override = getattr(agent, "_config_context_length", None)
+    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_ctx_override is None:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/run_agent.py
+++ b/run_agent.py
@@ -324,6 +324,27 @@ class _StreamErrorEvent(Exception):
         }
 
 
+def validate_minimum_context(
+    model_name: str, context_length: int, config_context_length: int | None
+) -> None:
+    """Raise ValueError if the model context is below 64K and no config override is set.
+
+    Skip the check when the user explicitly set model.context_length in
+    config.yaml — they accept the reduced window and the error message
+    itself tells them to do this.
+    """
+    from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+
+    if context_length and context_length < MINIMUM_CONTEXT_LENGTH and config_context_length is None:
+        raise ValueError(
+            f"Model {model_name} has a context window of {context_length:,} tokens, "
+            f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
+            f"by Hermes Agent.  Choose a model with at least "
+            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
+            f"model.context_length in config.yaml to override."
+        )
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.

--- a/run_agent.py
+++ b/run_agent.py
@@ -523,6 +523,27 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def validate_minimum_context(
+    model_name: str, context_length: int, config_context_length: int | None
+) -> None:
+    """Raise ValueError if the model context is below 64K and no config override is set.
+
+    Skip the check when the user explicitly set model.context_length in
+    config.yaml — they accept the reduced window and the error message
+    itself tells them to do this.
+    """
+    from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+
+    if context_length and context_length < MINIMUM_CONTEXT_LENGTH and config_context_length is None:
+        raise ValueError(
+            f"Model {model_name} has a context window of {context_length:,} tokens, "
+            f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
+            f"by Hermes Agent.  Choose a model with at least "
+            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
+            f"model.context_length in config.yaml to override."
+        )
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1349,14 +1370,7 @@ class AIAgent:
         # for reliable tool-calling workflows (64K tokens).
         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
         _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
-            raise ValueError(
-                f"Model {self.model} has a context window of {_ctx:,} tokens, "
-                f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
-                f"by Hermes Agent.  Choose a model with at least "
-                f"{MINIMUM_CONTEXT_LENGTH // 1000}K context, or set "
-                f"model.context_length in config.yaml to override."
-            )
+        validate_minimum_context(self.model, _ctx, self._config_context_length)
 
         # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand)
         self._context_engine_tool_names: set = set()

--- a/tests/run_agent/test_minimum_context_length.py
+++ b/tests/run_agent/test_minimum_context_length.py
@@ -1,0 +1,38 @@
+"""Tests for the minimum context_length validation during agent init.
+
+Regression tests for #8430: when the user explicitly sets model.context_length
+in config.yaml, the minimum-64K check should be skipped — the user accepts the
+reduced window and the error message itself tells them to do this.
+"""
+
+import pytest
+from run_agent import validate_minimum_context
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+
+
+class TestMinimumContextLengthCheck:
+    def test_rejects_small_context_without_config_override(self):
+        """Models below 64K should be rejected when no config override is set."""
+        with pytest.raises(ValueError, match="below the minimum"):
+            validate_minimum_context("test-model", 32_000, config_context_length=None)
+
+    def test_allows_small_context_with_config_override(self):
+        """Models below 64K should be accepted when user explicitly sets context_length."""
+        validate_minimum_context("test-model", 32_768, config_context_length=32_768)
+
+    def test_still_rejects_without_override_even_at_boundary(self):
+        """Models at exactly MINIMUM_CONTEXT_LENGTH - 1 should still be rejected."""
+        with pytest.raises(ValueError, match="below the minimum"):
+            validate_minimum_context(
+                "test-model", MINIMUM_CONTEXT_LENGTH - 1, config_context_length=None
+            )
+
+    def test_accepts_at_minimum_without_override(self):
+        """Models at exactly MINIMUM_CONTEXT_LENGTH should be accepted without override."""
+        validate_minimum_context(
+            "test-model", MINIMUM_CONTEXT_LENGTH, config_context_length=None
+        )
+
+    def test_accepts_zero_context_length(self):
+        """Zero context length (unknown model) should not trigger the check."""
+        validate_minimum_context("test-model", 0, config_context_length=None)


### PR DESCRIPTION
## What does this PR do?

When the user explicitly sets `model.context_length` in `config.yaml`, the minimum 64K context check is now bypassed. Previously the check rejected models below 64K even when the user had already configured the override that the error message itself recommended.

**Why:** Users of smaller models (e.g. Qwen3-235B-A22B with 32K context) were blocked from using Hermes Agent even after following the error message's instructions to set `model.context_length` in config.

**How:**
- Extracted `validate_minimum_context()` function from `AIAgent.__init__` so the validation logic is testable
- Added `config_context_length is None` guard so explicit overrides bypass the check
- 5 regression tests covering: reject without override, accept with override, boundary conditions, zero context

## Related Issue

Closes #8430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extracted `validate_minimum_context()` function from `AIAgent.__init__` so the validation logic is testable
- Added `config_context_length is None` guard so explicit overrides bypass the check
- `tests/run_agent/test_minimum_context_length.py` — 5 regression tests (reject without override, accept with override, boundary conditions, zero context)

## How to Test

1. `pytest tests/run_agent/test_minimum_context_length.py -v` — 5 tests pass
2. `pytest tests/run_agent/test_switch_model_context.py -v` — related tests pass (no regression)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/run_agent/test_minimum_context_length.py -v
5 tests pass
```
