### PR TITLE
fix(docker): add git to system dependencies for npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## What
Added `git` to the `apt-get install` line in the Dockerfile.

## Why
Docker builds fail at `npm install` because some transitive npm dependencies are fetched via git, which is not present in the base image.

## How
One-word addition to the existing `apt-get install` line in `Dockerfile`.

## Test plan
- [x] Verified `git` is not currently in the apt-get install list
- [x] Build should succeed with `docker build .`

## Platform
Docker

Closes #8439