### PR TITLE
fix(docker): add openssh-client for SSH terminal backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## What
Added `openssh-client` to the `apt-get install` line in the Dockerfile.

## Why
The SSH terminal backend documented in the user guide requires the `ssh` binary, but the Docker image did not include `openssh-client`, causing `ssh: command not found`.

## How
One-word addition to the existing `apt-get install` line in `Dockerfile`.

**Note:** This PR and #9143 (add `git`) both modify the same Dockerfile line. Whichever merges second will need a trivial rebase.

## Test plan
- [x] Verified `openssh-client` is not currently in the apt-get install list
- [x] Build should succeed with `docker build .`

## Platform
Docker

Closes #8186