### PR TITLE
fix(migration): handle non-UTF-8 files in OpenClaw migration

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -312,7 +312,7 @@ def sha256_file(path: Path) -> str:
 
 
 def read_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 def normalize_text(text: str) -> str:
@@ -349,8 +349,11 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
 def load_yaml_file(path: Path) -> Dict[str, Any]:
     if yaml is None or not path.exists():
         return {}
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    return data if isinstance(data, dict) else {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
+        return data if isinstance(data, dict) else {}
+    except (yaml.YAMLError, UnicodeDecodeError):
+        return {}
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
@@ -367,7 +370,7 @@ def parse_env_file(path: Path) -> Dict[str, str]:
     if not path.exists():
         return {}
     data: Dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -1262,9 +1265,9 @@ class Migrator:
             config_path = self.source_root / name
             if config_path.exists():
                 try:
-                    data = json.loads(config_path.read_text(encoding="utf-8"))
+                    data = json.loads(config_path.read_text(encoding="utf-8", errors="replace"))
                     return data if isinstance(data, dict) else {}
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     continue
         return {}
 
@@ -1901,8 +1904,11 @@ class Migrator:
 
         all_incoming: List[str] = []
         for md_file in md_files:
-            entries = extract_markdown_entries(read_text(md_file))
-            all_incoming.extend(entries)
+            try:
+                entries = extract_markdown_entries(read_text(md_file))
+                all_incoming.extend(entries)
+            except (OSError, UnicodeDecodeError):
+                continue
 
         if not all_incoming:
             self.record("daily-memory", source_dir, destination, "skipped", "No importable entries found in daily memory files")

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -293,7 +293,7 @@ def sha256_file(path: Path) -> str:
 
 
 def read_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 def normalize_text(text: str) -> str:
@@ -330,8 +330,11 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
 def load_yaml_file(path: Path) -> Dict[str, Any]:
     if yaml is None or not path.exists():
         return {}
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    return data if isinstance(data, dict) else {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
+        return data if isinstance(data, dict) else {}
+    except (yaml.YAMLError, UnicodeDecodeError):
+        return {}
 
 
 def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
@@ -348,7 +351,7 @@ def parse_env_file(path: Path) -> Dict[str, str]:
     if not path.exists():
         return {}
     data: Dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -957,9 +960,9 @@ class Migrator:
             config_path = self.source_root / name
             if config_path.exists():
                 try:
-                    data = json.loads(config_path.read_text(encoding="utf-8"))
+                    data = json.loads(config_path.read_text(encoding="utf-8", errors="replace"))
                     return data if isinstance(data, dict) else {}
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, UnicodeDecodeError):
                     continue
         return {}
 
@@ -1573,8 +1576,11 @@ class Migrator:
 
         all_incoming: List[str] = []
         for md_file in md_files:
-            entries = extract_markdown_entries(read_text(md_file))
-            all_incoming.extend(entries)
+            try:
+                entries = extract_markdown_entries(read_text(md_file))
+                all_incoming.extend(entries)
+            except (OSError, UnicodeDecodeError):
+                continue
 
         if not all_incoming:
             self.record("daily-memory", source_dir, destination, "skipped", "No importable entries found in daily memory files")

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -972,6 +972,92 @@ def test_migrate_soul_rebrands_content(tmp_path):
     assert "You are Hermes" in result
 
 
+# ── Unicode / encoding regression tests (#8901) ────────────────
+
+
+def test_read_text_handles_non_utf8_bytes(tmp_path: Path):
+    """read_text() should replace invalid bytes instead of crashing."""
+    mod = load_module()
+    bad_file = tmp_path / "bad.md"
+    # Write raw GBK bytes that are invalid UTF-8
+    bad_file.write_bytes(b"hello \xb3\xc9\xb9\xa6 world")
+    result = mod.read_text(bad_file)
+    assert "hello" in result
+    assert "world" in result
+    # Invalid bytes should be replaced, not crash
+    assert "\ufffd" in result
+
+
+def test_load_yaml_file_handles_non_utf8(tmp_path: Path):
+    """load_yaml_file() should return {} for files with invalid encoding."""
+    mod = load_module()
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_bytes(b"key: \xb3\xc9\xb9\xa6\n")
+    result = mod.load_yaml_file(bad_yaml)
+    assert isinstance(result, dict)
+
+
+def test_parse_env_file_handles_non_utf8(tmp_path: Path):
+    """parse_env_file() should not crash on non-UTF-8 .env files."""
+    mod = load_module()
+    bad_env = tmp_path / ".env"
+    bad_env.write_bytes(b"API_KEY=good_value\nBAD_KEY=\xb3\xc9\xb9\xa6\n")
+    result = mod.parse_env_file(bad_env)
+    assert "API_KEY" in result
+    assert result["API_KEY"] == "good_value"
+
+
+def test_load_openclaw_config_handles_non_utf8(tmp_path: Path):
+    """load_openclaw_config() should not crash on non-UTF-8 config files."""
+    mod = load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    # Write a config file with invalid UTF-8 bytes inside JSON
+    (source / "openclaw.json").write_bytes(b'{"name": "\xb3\xc9\xb9\xa6"}')
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+    )
+    result = migrator.load_openclaw_config()
+    assert isinstance(result, dict)
+
+
+def test_migrate_daily_memory_skips_unreadable_files(tmp_path: Path):
+    """migrate_daily_memory() should skip files it can't read, not crash."""
+    mod = load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "config.yaml").write_text("command_allowlist: []\n", encoding="utf-8")
+
+    mem_dir = source / "workspace" / "memory"
+    mem_dir.mkdir(parents=True)
+    # One good file and one with binary content
+    (mem_dir / "2024-01-01.md").write_text("# Memory\n\n- valid entry\n", encoding="utf-8")
+    (mem_dir / "2024-01-02.md").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00binary garbage")
+    (mem_dir / "2024-01-02.md").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00binary garbage")
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=target / "migration-report",
+        selected_options={"memory"},
+    )
+    # Should not raise — binary file is handled gracefully
+    report = migrator.migrate()
+
+
 # ── migrate_model_config: alias resolution (issue #16745) ──────────────────
 
 def _run_model_migration(tmp_path: Path, openclaw_json: dict) -> dict:

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -849,3 +849,88 @@ def test_migrate_soul_rebrands_content(tmp_path):
     result = (target_root / "SOUL.md").read_text(encoding="utf-8")
     assert "OpenClaw" not in result
     assert "You are Hermes" in result
+
+
+# ── Unicode / encoding regression tests (#8901) ────────────────
+
+
+def test_read_text_handles_non_utf8_bytes(tmp_path: Path):
+    """read_text() should replace invalid bytes instead of crashing."""
+    mod = load_module()
+    bad_file = tmp_path / "bad.md"
+    # Write raw GBK bytes that are invalid UTF-8
+    bad_file.write_bytes(b"hello \xb3\xc9\xb9\xa6 world")
+    result = mod.read_text(bad_file)
+    assert "hello" in result
+    assert "world" in result
+    # Invalid bytes should be replaced, not crash
+    assert "\ufffd" in result
+
+
+def test_load_yaml_file_handles_non_utf8(tmp_path: Path):
+    """load_yaml_file() should return {} for files with invalid encoding."""
+    mod = load_module()
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_bytes(b"key: \xb3\xc9\xb9\xa6\n")
+    result = mod.load_yaml_file(bad_yaml)
+    assert isinstance(result, dict)
+
+
+def test_parse_env_file_handles_non_utf8(tmp_path: Path):
+    """parse_env_file() should not crash on non-UTF-8 .env files."""
+    mod = load_module()
+    bad_env = tmp_path / ".env"
+    bad_env.write_bytes(b"API_KEY=good_value\nBAD_KEY=\xb3\xc9\xb9\xa6\n")
+    result = mod.parse_env_file(bad_env)
+    assert "API_KEY" in result
+    assert result["API_KEY"] == "good_value"
+
+
+def test_load_openclaw_config_handles_non_utf8(tmp_path: Path):
+    """load_openclaw_config() should not crash on non-UTF-8 config files."""
+    mod = load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    # Write a config file with invalid UTF-8 bytes inside JSON
+    (source / "openclaw.json").write_bytes(b'{"name": "\xb3\xc9\xb9\xa6"}')
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+    )
+    result = migrator.load_openclaw_config()
+    assert isinstance(result, dict)
+
+
+def test_migrate_daily_memory_skips_unreadable_files(tmp_path: Path):
+    """migrate_daily_memory() should skip files it can't read, not crash."""
+    mod = load_module()
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "config.yaml").write_text("command_allowlist: []\n", encoding="utf-8")
+
+    mem_dir = source / "workspace" / "memory"
+    mem_dir.mkdir(parents=True)
+    # One good file and one with binary content
+    (mem_dir / "2024-01-01.md").write_text("# Memory\n\n- valid entry\n", encoding="utf-8")
+    (mem_dir / "2024-01-02.md").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00binary garbage")
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=target / "migration-report",
+        selected_options={"memory"},
+    )
+    # Should not raise — binary file is handled gracefully
+    report = migrator.migrate()


### PR DESCRIPTION
## What does this PR do?

Fixed `UnicodeDecodeError` crash during `hermes claw migrate` on Windows systems with non-UTF-8 locales (e.g. GBK/cp936).

On Chinese/Japanese/Korean Windows, the default encoding is not UTF-8. The migration script crashed when encountering binary files (images, SQLite) or system-encoded text files, making it impossible to migrate from OpenClaw. This PR adds `errors="replace"` decoding (invalid bytes become U+FFFD instead of crashing) plus per-file try/except so a single bad file no longer aborts the whole migration.

## Related Issue

Closes #8901

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Five changes in `openclaw_to_hermes.py`, all consistent in approach:
1. `read_text()` — added `errors="replace"` so invalid bytes become U+FFFD instead of crashing
2. `load_yaml_file()` — added `errors="replace"` + `UnicodeDecodeError` in except clause
3. `parse_env_file()` — added `errors="replace"`
4. `load_openclaw_config()` — added `errors="replace"` + `UnicodeDecodeError` in except clause
5. `migrate_daily_memory()` — added per-file try/except so one bad file doesn't abort the entire migration

## How to Test

1. Run `pytest tests/skills/test_openclaw_migration.py -v` — all 37 tests pass (5 new + 32 existing)
2. New tests write actual non-UTF-8 bytes (GBK sequences, PNG header) to disk and verify graceful handling
3. Fix is safe on all platforms (Windows non-UTF-8 locales are the primary target)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/skills/test_openclaw_migration.py -v
# 37 passed (5 new + 32 existing)
```
