### PR TITLE
fix: memory_setup.py - write non-secret env vars, check all fields in status

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -324,6 +324,9 @@ def cmd_setup(args) -> None:
                 val = _prompt(desc, default=str(effective_default) if effective_default else None)
                 if val:
                     provider_config[key] = val
+                    # Also write to .env if this field has an env_var
+                    if env_var and env_var not in env_writes:
+                        env_writes[env_var] = val
 
     # Write activation key to config.yaml
     config["memory"]["provider"] = name
@@ -409,12 +412,13 @@ def cmd_status(args) -> None:
                     else:
                         print(f"  Status:    not available ✗")
                         schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
-                        secrets = [f for f in schema if f.get("secret")]
-                        if secrets:
+                        # Check all fields that have env_var (both secret and non-secret)
+                        required_fields = [f for f in schema if f.get("env_var")]
+                        if required_fields:
                             print(f"  Missing:")
-                            for s in secrets:
-                                env_var = s.get("env_var", "")
-                                url = s.get("url", "")
+                            for f in required_fields:
+                                env_var = f.get("env_var", "")
+                                url = f.get("url", "")
                                 is_set = bool(os.environ.get(env_var))
                                 mark = "✓" if is_set else "✗"
                                 line = f"    {mark} {env_var}"


### PR DESCRIPTION
bug fixes on setup:

1. Non-secret fields with env_var (like OPENVIKING_ENDPOINT) were never written to .env - _Fixed by adding them to env_writes_
2. Status output only showed secret fields as missing - Fixed by checking all fields with env_var

Reproduce:
<img width="1010" height="1982" alt="image" src="https://github.com/user-attachments/assets/53125834-8b3d-46e5-b1a3-9fdf1027e019" />

<img width="1250" height="1418" alt="image" src="https://github.com/user-attachments/assets/9b223c4f-82cb-4bb3-9114-53e2d5ab8975" />

