### PR TITLE
fix(model): api_mode propagation, triple syntax, and custom provider model listing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1006,6 +1006,18 @@ def list_authenticated_providers(
             if default_model:
                 models_list.append(default_model)
 
+            # Also include models from the "models" field (dict or list).
+            # Users define models as {name: {context_length: N}} or [name, ...].
+            cfg_models = entry.get("models")
+            if isinstance(cfg_models, dict):
+                for m in cfg_models:
+                    if m and m not in models_list:
+                        models_list.append(m)
+            elif isinstance(cfg_models, list):
+                for m in cfg_models:
+                    if isinstance(m, str) and m not in models_list:
+                        models_list.append(m)
+
             results.append({
                 "slug": slug,
                 "name": display_name,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -686,6 +686,7 @@ def switch_model(
             target_provider,
             api_key=api_key,
             base_url=base_url,
+            api_mode=api_mode,
         )
     except Exception:
         validation = {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -454,6 +454,7 @@ def switch_model(
     """
     from hermes_cli.models import (
         detect_provider_for_model,
+        parse_model_input,
         validate_requested_model,
         opencode_model_api_mode,
     )
@@ -612,7 +613,18 @@ def switch_model(
             "localhost" in _base or "127.0.0.1" in _base
         )
 
-        if (
+        # Always attempt to parse ``custom:<name>:<model>`` triple syntax
+        # even when currently on a custom provider, so users can switch
+        # between named custom providers (e.g. custom:cch_anthropic:glm-5-turbo).
+        # ``parse_model_input`` handles this; ``detect_provider_for_model``
+        # only matches against known provider catalogs and misses custom slugs.
+        if new_model.startswith("custom:") and ":" in new_model[len("custom:"):]:
+            parsed_provider, parsed_model = parse_model_input(new_model, current_provider)
+            if parsed_provider != current_provider or parsed_model != new_model:
+                target_provider = parsed_provider
+                new_model = parsed_model
+                is_custom = False  # provider changed, re-evaluate
+        elif (
             target_provider == current_provider
             and not is_custom
             and not resolved_alias

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1625,8 +1625,14 @@ def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Probe an OpenAI-compatible ``/models`` endpoint with light URL heuristics."""
+    """Probe an OpenAI-compatible ``/models`` endpoint with light URL heuristics.
+
+    When *api_mode* is ``"anthropic_messages"``, an ``anthropic-version`` header
+    is included so that Anthropic-compatible proxies (e.g. Claude Code Hub) return
+    their Anthropic model catalog instead of the OpenAI one.
+    """
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
         return {
@@ -1662,6 +1668,8 @@ def probe_api_models(
         headers["Authorization"] = f"Bearer {api_key}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
+    if api_mode == "anthropic_messages":
+        headers["anthropic-version"] = "2023-06-01"
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
@@ -1720,13 +1728,14 @@ def fetch_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout).get("models")
+    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
 
 
 def validate_requested_model(
@@ -1735,6 +1744,7 @@ def validate_requested_model(
     *,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -1775,8 +1785,8 @@ def validate_requested_model(
             "message": "Model names cannot contain spaces.",
         }
 
-    if normalized == "custom":
-        probe = probe_api_models(api_key, base_url)
+    if normalized == "custom" or normalized.startswith("custom:"):
+        probe = probe_api_models(api_key, base_url, api_mode=api_mode)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -1854,7 +1864,7 @@ def validate_requested_model(
             }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
 
     if api_models is not None:
         if requested_for_lookup in set(api_models):

--- a/tests/hermes_cli/test_model_switch_custom_provider_fixes.py
+++ b/tests/hermes_cli/test_model_switch_custom_provider_fixes.py
@@ -1,0 +1,331 @@
+"""Tests for custom provider model switching fixes.
+
+Covers three bugs:
+1. api_mode not passed to model validation/probe (wrong catalog for Anthropic proxies)
+2. custom:<name>:<model> triple syntax broken when currently on a custom provider
+3. /model picker shows 0 models for custom_providers with models: dict
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# =============================================================================
+# 1. parse_model_input — triple syntax
+# =============================================================================
+
+class TestParseModelInputTripleSyntax:
+    """Regression: custom:<name>:<model> must resolve correctly."""
+
+    def test_triple_syntax_returns_named_provider(self):
+        from hermes_cli.models import parse_model_input
+        provider, model = parse_model_input("custom:cch_anthropic:glm-5-turbo", "custom:cch_openai")
+        assert provider == "custom:cch_anthropic"
+        assert model == "glm-5-turbo"
+
+    def test_triple_syntax_from_non_custom_provider(self):
+        from hermes_cli.models import parse_model_input
+        provider, model = parse_model_input("custom:cch_openai:MiniMax-M2.1", "openai")
+        assert provider == "custom:cch_openai"
+        assert model == "MiniMax-M2.1"
+
+    def test_single_colon_custom_still_works(self):
+        from hermes_cli.models import parse_model_input
+        provider, model = parse_model_input("custom:glm-5-turbo", "openai")
+        assert provider == "custom"
+        assert model == "glm-5-turbo"
+
+    def test_non_custom_input_returns_current_provider(self):
+        from hermes_cli.models import parse_model_input
+        provider, model = parse_model_input("glm-5-turbo", "openai")
+        assert provider == "openai"
+        assert model == "glm-5-turbo"
+
+
+# =============================================================================
+# 2. validate_requested_model — api_mode propagation
+# =============================================================================
+
+class TestValidateRequestedModelApiMode:
+    """Regression: api_mode must be forwarded to probe_api_models."""
+
+    def test_custom_provider_with_anthropic_api_mode_sends_header(self):
+        """When api_mode=anthropic_messages, probe must include anthropic-version header."""
+        from hermes_cli.models import validate_requested_model
+
+        fake_models = ["glm-5-turbo", "MiniMax-M2.1"]
+        probe_result = {"models": fake_models, "probed_url": "http://localhost:23000/v1/models"}
+
+        with patch("hermes_cli.models.probe_api_models", return_value=probe_result) as mock_probe:
+            result = validate_requested_model(
+                "glm-5-turbo",
+                "custom:cch_anthropic",
+                api_key="sk-test",
+                base_url="http://localhost:23000/v1",
+                api_mode="anthropic_messages",
+            )
+
+        mock_probe.assert_called_once()
+        call_kwargs = mock_probe.call_args
+        assert call_kwargs.kwargs.get("api_mode") == "anthropic_messages", \
+            "probe_api_models should receive api_mode='anthropic_messages'"
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_named_custom_provider_recognized(self):
+        """custom:<name> prefix must be recognized as custom, not fall through to OpenAI."""
+        from hermes_cli.models import validate_requested_model
+
+        fake_models = ["glm-5-turbo"]
+        probe_result = {"models": fake_models, "probed_url": "http://localhost:23000/v1/models"}
+
+        with patch("hermes_cli.models.probe_api_models", return_value=probe_result) as mock_probe:
+            result = validate_requested_model(
+                "glm-5-turbo",
+                "custom:cch_anthropic",
+                api_key="sk-test",
+                base_url="http://localhost:23000/v1",
+            )
+
+        # Must call probe (custom provider path), not skip to generic OpenAI
+        mock_probe.assert_called_once()
+        assert result["accepted"] is True
+
+    def test_plain_custom_without_api_mode(self):
+        """Plain custom provider (no api_mode) should still work."""
+        from hermes_cli.models import validate_requested_model
+
+        fake_models = ["my-local-model"]
+        probe_result = {"models": fake_models, "probed_url": "http://localhost:8000/v1/models"}
+
+        with patch("hermes_cli.models.probe_api_models", return_value=probe_result) as mock_probe:
+            result = validate_requested_model(
+                "my-local-model",
+                "custom",
+                api_key="sk-test",
+                base_url="http://localhost:8000/v1",
+            )
+
+        mock_probe.assert_called_once()
+        call_kwargs = mock_probe.call_args
+        assert call_kwargs.kwargs.get("api_mode") is None, \
+            "Plain custom should not pass api_mode"
+        assert result["accepted"] is True
+
+
+# =============================================================================
+# 3. probe_api_models — anthropic-version header
+# =============================================================================
+
+class TestProbeApiModelsAnthropicHeader:
+    """Ensure anthropic-version header is added when api_mode=anthropic_messages."""
+
+    def test_anthropic_mode_includes_header(self):
+        from hermes_cli.models import probe_api_models
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.read.return_value = b'{"data": [{"id": "glm-5-turbo"}]}'
+        fake_response.__enter__ = MagicMock(return_value=fake_response)
+        fake_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+            result = probe_api_models(
+                api_key="sk-test",
+                base_url="http://localhost:23000/v1",
+                api_mode="anthropic_messages",
+            )
+
+        # Check the request was made with anthropic-version header
+        req = mock_urlopen.call_args[0][0]
+        # urllib.request.Request stores headers with original casing
+        header_found = any(
+            k.lower() == "anthropic-version" and v == "2023-06-01"
+            for k, v in req.headers.items()
+        )
+        assert header_found, \
+            "anthropic-version header must be present for anthropic_messages mode"
+        assert "glm-5-turbo" in (result.get("models") or [])
+
+    def test_non_anthropic_mode_omits_header(self):
+        from hermes_cli.models import probe_api_models
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.read.return_value = b'{"data": [{"id": "gpt-5"}]}'
+        fake_response.__enter__ = MagicMock(return_value=fake_response)
+        fake_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+            result = probe_api_models(
+                api_key="sk-test",
+                base_url="http://localhost:8000/v1",
+            )
+
+        req = mock_urlopen.call_args[0][0]
+        has_anthropic_header = any(
+            k.lower() == "anthropic-version" for k in req.headers
+        )
+        assert not has_anthropic_header, \
+            "anthropic-version header must NOT be present for non-anthropic mode"
+
+
+# =============================================================================
+# 4. list_authenticated_providers — models: dict from custom_providers
+# =============================================================================
+
+class TestCustomProvidersModelsDict:
+    """Regression: models: dict in custom_providers must appear in picker listing."""
+
+    def test_models_dict_format(self, monkeypatch):
+        """models: {name: {context_length: N}} should list all model names."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+        custom_providers = [
+            {
+                "name": "CCH Anthropic",
+                "base_url": "http://localhost:23000/v1",
+                "api_key": "sk-test",
+                "api_mode": "anthropic_messages",
+                "models": {
+                    "glm-5-turbo": {"context_length": 202752},
+                    "MiniMax-M2.1": {"context_length": 196608},
+                },
+            }
+        ]
+
+        providers = list_authenticated_providers(
+            current_provider="custom",
+            custom_providers=custom_providers,
+        )
+
+        custom = next((p for p in providers if p.get("is_user_defined")), None)
+        assert custom is not None, "Custom provider should appear in listing"
+        assert custom["total_models"] == 2, f"Expected 2 models, got {custom['total_models']}"
+        assert "glm-5-turbo" in custom["models"]
+        assert "MiniMax-M2.1" in custom["models"]
+
+    def test_models_list_format(self, monkeypatch):
+        """models: [name, ...] should list all model names."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+        custom_providers = [
+            {
+                "name": "My Local",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "sk-test",
+                "models": ["model-a", "model-b", "model-c"],
+            }
+        ]
+
+        providers = list_authenticated_providers(
+            current_provider="custom",
+            custom_providers=custom_providers,
+        )
+
+        custom = next((p for p in providers if p.get("is_user_defined")), None)
+        assert custom is not None
+        assert custom["total_models"] == 3
+        assert "model-a" in custom["models"]
+        assert "model-b" in custom["models"]
+        assert "model-c" in custom["models"]
+
+    def test_models_dict_dedupes_with_default_model(self, monkeypatch):
+        """If model (singular) is also in models dict, don't duplicate."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+        custom_providers = [
+            {
+                "name": "Dup Test",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "sk-test",
+                "model": "glm-5-turbo",  # default, also in models dict
+                "models": {
+                    "glm-5-turbo": {"context_length": 202752},
+                    "other-model": {"context_length": 8192},
+                },
+            }
+        ]
+
+        providers = list_authenticated_providers(
+            current_provider="custom",
+            custom_providers=custom_providers,
+        )
+
+        custom = next((p for p in providers if p.get("is_user_defined")), None)
+        assert custom is not None
+        assert custom["total_models"] == 2, \
+            f"Expected 2 unique models (deduped), got {custom['total_models']}"
+        assert custom["models"].count("glm-5-turbo") == 1
+
+    def test_no_models_field_still_works(self, monkeypatch):
+        """Providers without models: field should still work (backward compat)."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+        monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+        custom_providers = [
+            {
+                "name": "Simple Provider",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "sk-test",
+                "model": "default-model",
+            }
+        ]
+
+        providers = list_authenticated_providers(
+            current_provider="custom",
+            custom_providers=custom_providers,
+        )
+
+        custom = next((p for p in providers if p.get("is_user_defined")), None)
+        assert custom is not None
+        assert custom["total_models"] == 1
+        assert custom["models"] == ["default-model"]
+
+
+# =============================================================================
+# 5. fetch_api_models — api_mode passthrough
+# =============================================================================
+
+class TestFetchApiModelsApiMode:
+    """Ensure fetch_api_models forwards api_mode to probe_api_models."""
+
+    def test_passes_api_mode_through(self):
+        from hermes_cli.models import fetch_api_models
+
+        probe_result = {"models": ["glm-5-turbo"]}
+        with patch("hermes_cli.models.probe_api_models", return_value=probe_result) as mock_probe:
+            result = fetch_api_models(
+                api_key="sk-test",
+                base_url="http://localhost:23000/v1",
+                api_mode="anthropic_messages",
+            )
+
+        mock_probe.assert_called_once_with(
+            "sk-test",
+            "http://localhost:23000/v1",
+            timeout=5.0,
+            api_mode="anthropic_messages",
+        )
+        assert result == ["glm-5-turbo"]
+
+    def test_default_no_api_mode(self):
+        from hermes_cli.models import fetch_api_models
+
+        probe_result = {"models": ["gpt-5"]}
+        with patch("hermes_cli.models.probe_api_models", return_value=probe_result) as mock_probe:
+            fetch_api_models(api_key="sk-test", base_url="http://localhost:8000/v1")
+
+        call_kwargs = mock_probe.call_args.kwargs
+        assert "api_mode" not in call_kwargs or call_kwargs.get("api_mode") is None


### PR DESCRIPTION
## Summary

Three fixes for model switching with custom providers (e.g. Claude Code Hub).

### 1. api_mode not passed to model validation — wrong catalog returned
Closes #9146

**Scenario:** Switch to `custom:cch_anthropic:glm-5-turbo` where the provider has `api_mode: anthropic_messages`. Validation probes `/models` without the `anthropic-version` header → proxy returns OpenAI catalog → warns "Similar models: gpt-5-pro".

**Root cause:** Three gaps in the validation chain:
- `probe_api_models()` has no `api_mode` param, can't include `anthropic-version` header
- `validate_requested_model()` doesn't accept `api_mode` at all
- Named custom providers (`custom:<name>`) don't match `normalized == "custom"`, fall through to generic OpenAI probe

**Fix:** Add `api_mode` param through the chain (`probe_api_models` → `fetch_api_models` → `validate_requested_model`). Match `custom:<name>` prefix. Pass resolved `api_mode` from `switch_model()`.

### 2. `custom:<name>:<model>` triple syntax broken on custom providers
Closes #9147

**Scenario:** Currently on `custom:cch_openai`, type `/model custom:cch_anthropic:glm-5-turbo`. Entire string treated as model name.

**Root cause:** PR #2110 added `not is_custom` guard to skip `detect_provider_for_model()` on custom providers. `parse_model_input()` has triple-suffix parsing but is only called via `detect_provider_for_model()`, which gets skipped.

**Fix:** Call `parse_model_input()` before the `is_custom` guard in `switch_model()` to handle triple syntax explicitly.

### 3. `/model` picker shows 0 models for custom_providers with `models:` dict
Closes #9148

**Scenario:** Custom provider defines models as `{name: {context_length: N}}` dict. Picker shows `(0 models)`.

**Root cause:** `list_authenticated_providers()` only reads `entry.get("model")` (singular string). `entry.get("models")` (dict/list) completely ignored. The `providers:` dict path already handles both formats.

**Fix:** Parse both dict and list formats for `models:` field in custom providers.

## Relationship with upstream

Commit `76eecf38` (recently merged to main) fixes a similar issue for the **new-style `providers:` dict** path in `list_authenticated_providers()` and adds `_get_named_custom_provider()` lookup for `providers:` config. Our fix #3 covers the **legacy `custom_providers:` list** path, which `76eecf38` does not touch. The two PRs are **complementary, not overlapping**.

## Testing

- 15 new unit tests covering all three fixes (parse_model_input, validate_requested_model, probe_api_models, fetch_api_models, list_authenticated_providers)
- 33 existing model-switch tests continue to pass
- Verified triple syntax parsing, api_mode header propagation, and models dict listing
