### PR TITLE
Fix custom provider API mode detection for OpenAI-compatible endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -42,6 +42,7 @@ import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from openai import OpenAI
 
@@ -53,6 +54,18 @@ logger = logging.getLogger(__name__)
 
 # Module-level flag: only warn once per process about stale OPENAI_BASE_URL.
 _stale_base_url_warned = False
+
+
+def _is_direct_openai_base_url(base_url: str) -> bool:
+    """Return True only for native OpenAI API hosts, not proxy paths."""
+    normalized = (base_url or "").strip()
+    if not normalized:
+        return False
+    try:
+        host = (urlparse(normalized).hostname or "").lower()
+    except Exception:
+        return False
+    return host == "api.openai.com"
 
 _PROVIDER_ALIASES = {
     "google": "gemini",
@@ -1388,8 +1401,7 @@ def resolve_provider_client(
         # Auto-detect: api.openai.com + codex model name pattern
         if api_mode and api_mode != "codex_responses":
             return False  # explicit non-codex mode
-        normalized_base = (base_url_str or "").strip().lower()
-        if "api.openai.com" in normalized_base and "openrouter" not in normalized_base:
+        if _is_direct_openai_base_url(base_url_str):
             model_lower = (model_str or "").lower()
             if "codex" in model_lower:
                 return True
@@ -1888,7 +1900,7 @@ def auxiliary_max_tokens_param(value: int) -> dict:
     # Only use max_completion_tokens for direct OpenAI custom endpoints
     if (not or_key
             and _read_nous_auth() is None
-            and "api.openai.com" in custom_base.lower()):
+            and _is_direct_openai_base_url(custom_base)):
         return {"max_completion_tokens": value}
     return {"max_tokens": value}
 
@@ -2310,7 +2322,7 @@ def _build_call_kwargs(
         # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
         if provider == "custom":
             custom_base = base_url or _current_custom_base_url()
-            if "api.openai.com" in custom_base.lower():
+            if _is_direct_openai_base_url(custom_base):
                 kwargs["max_completion_tokens"] = max_tokens
             else:
                 kwargs["max_tokens"] = max_tokens

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -22,8 +22,21 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+
+def _is_direct_openai_base_url(base_url: str) -> bool:
+    """Return True only for native OpenAI API hosts, not proxy paths."""
+    normalized = (base_url or "").strip()
+    if not normalized:
+        return False
+    try:
+        host = (urlparse(normalized).hostname or "").lower()
+    except Exception:
+        return False
+    return host == "api.openai.com"
 
 
 # -- Hermes overlay ----------------------------------------------------------
@@ -421,7 +434,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
         url_lower = base_url.rstrip("/").lower()
         if url_lower.endswith("/anthropic") or "api.anthropic.com" in url_lower:
             return "anthropic_messages"
-        if "api.openai.com" in url_lower:
+        if _is_direct_openai_base_url(base_url):
             return "codex_responses"
         if "bedrock-runtime" in url_lower and "amazonaws.com" in url_lower:
             return "bedrock_converse"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,18 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _is_direct_openai_base_url(base_url: str) -> bool:
+    """Return True only for native OpenAI API hosts, not proxy paths."""
+    normalized = (base_url or "").strip()
+    if not normalized:
+        return False
+    try:
+        host = (urlparse(normalized).hostname or "").lower()
+    except Exception:
+        return False
+    return host == "api.openai.com"
+
+
 def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     """Auto-detect api_mode from the resolved base URL.
 
@@ -44,7 +57,7 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     normalized = (base_url or "").strip().lower().rstrip("/")
     if "api.x.ai" in normalized:
         return "codex_responses"
-    if "api.openai.com" in normalized and "openrouter" not in normalized:
+    if _is_direct_openai_base_url(base_url):
         return "codex_responses"
     return None
 
@@ -500,11 +513,14 @@ def _resolve_openrouter_runtime(
     # Also provide a placeholder API key for local servers that don't require
     # authentication — the OpenAI SDK requires a non-empty api_key string.
     effective_provider = "custom" if requested_norm == "custom" else "openrouter"
+    configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    if not _provider_supports_explicit_api_mode(effective_provider, cfg_provider):
+        configured_mode = None
 
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
         pool_result = _try_resolve_from_custom_pool(
-            base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
+            base_url, effective_provider, configured_mode,
         )
         if pool_result:
             return pool_result
@@ -514,9 +530,7 @@ def _resolve_openrouter_runtime(
 
     return {
         "provider": effective_provider,
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": configured_mode or _detect_api_mode_for_url(base_url) or "chat_completions",
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -639,8 +653,9 @@ def _resolve_explicit_runtime(
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
+            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
             elif base_url.rstrip("/").endswith("/anthropic"):
                 api_mode = "anthropic_messages"

--- a/run_agent.py
+++ b/run_agent.py
@@ -36,6 +36,7 @@ import tempfile
 import time
 import threading
 from types import SimpleNamespace
+from urllib.parse import urlparse
 import uuid
 from typing import List, Dict, Any, Optional
 from openai import OpenAI
@@ -2024,8 +2025,14 @@ class AIAgent:
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
-        url = (base_url or self._base_url_lower).lower()
-        return "api.openai.com" in url and "openrouter" not in url
+        raw_url = base_url if base_url is not None else self._base_url
+        if not raw_url:
+            return False
+        try:
+            host = (urlparse(raw_url).hostname or "").lower()
+        except Exception:
+            return False
+        return host == "api.openai.com"
 
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -10,8 +10,6 @@ import pytest
 
 from agent.auxiliary_client import (
     get_text_auxiliary_client,
-    get_available_vision_backends,
-    resolve_vision_provider_client,
     resolve_provider_client,
     auxiliary_max_tokens_param,
     call_llm,
@@ -476,6 +474,60 @@ class TestGetTextAuxiliaryClient:
         assert isinstance(client, CodexAuxiliaryClient)
         assert model == "gpt-5.2-codex"
 
+    def test_returns_none_when_nothing_available(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
+            client, model = get_text_auxiliary_client()
+        assert client is None
+        assert model is None
+
+    def test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api(self):
+        with patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("https://api.openai.com/v1", "sk-test", "codex_responses")), \
+             patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.3-codex"), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client()
+
+        from agent.auxiliary_client import CodexAuxiliaryClient
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "gpt-5.3-codex"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://api.openai.com/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-test"
+
+    def test_resolve_provider_client_custom_proxy_url_does_not_wrap_codex(self):
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = resolve_provider_client(
+                "custom",
+                model="gpt-5.3-codex",
+                explicit_base_url="https://proxy.example.com/api.openai.com/v1",
+                explicit_api_key="sk-test",
+            )
+
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        assert not isinstance(client, CodexAuxiliaryClient)
+        assert model == "gpt-5.3-codex"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://proxy.example.com/api.openai.com/v1"
+
+    def test_auxiliary_max_tokens_param_custom_proxy_url_uses_max_tokens(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example.com/api.openai.com/v1")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._read_codex_access_token", return_value=None):
+            result = auxiliary_max_tokens_param(1024)
+
+        assert result == {"max_tokens": 1024}
+
+# The branch previously carried a large unrelated legacy test block here.
+# It referenced helpers that no longer exist on main and was not required
+# for the custom-provider API mode fix. Keep this PR scoped to the direct
+# runtime detection regression and its proxy/non-proxy cases.
 # ── Payment / credit exhaustion fallback ─────────────────────────────────
 
 

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -245,6 +245,11 @@ class TestMinimaxApiMode:
         result = determine_api_mode("deepseek")
         assert result == "chat_completions"
 
+    def test_proxy_path_containing_openai_does_not_force_responses(self):
+        from hermes_cli.providers import determine_api_mode
+        result = determine_api_mode("totally-unknown", "https://proxy.example.com/api.openai.com/v1")
+        assert result == "chat_completions"
+
 
 class TestMinimaxMaxOutput:
     """Verify _get_anthropic_max_output returns correct limits for MiniMax models.

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -833,6 +833,32 @@ def test_model_config_api_mode_ignored_when_provider_differs(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_custom_endpoint_stale_api_mode_ignored_when_provider_differs(monkeypatch):
+    """Custom endpoints must not inherit codex_responses from a previous provider."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "api_mode": "codex_responses",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_api_key="test-key",
+        explicit_base_url="http://127.0.0.1:9208/v1",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
+
+
 def test_invalid_api_mode_ignored(monkeypatch):
     """Invalid api_mode values should fall back to chat_completions."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
@@ -845,6 +871,29 @@ def test_invalid_api_mode_ignored(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="custom")
 
     assert resolved["api_mode"] == "chat_completions"
+
+
+def test_custom_proxy_url_with_openai_path_does_not_auto_detect_codex(monkeypatch):
+    """Proxy paths containing api.openai.com must still use chat_completions."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://proxy.example.com/api.openai.com/v1",
+        },
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://proxy.example.com/api.openai.com/v1"
 
 
 def test_named_custom_provider_api_mode(monkeypatch):
@@ -913,6 +962,24 @@ def test_api_key_provider_explicit_api_mode_config(monkeypatch):
 
     assert resolved["provider"] == "minimax"
     assert resolved["api_mode"] == "anthropic_messages"
+
+
+def test_explicit_api_key_provider_stale_api_mode_ignored_when_provider_differs(monkeypatch):
+    """Explicit API-key providers must not inherit api_mode from a different provider."""
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "opencode-go",
+        "api_mode": "anthropic_messages",
+    })
+
+    resolved = rp.resolve_runtime_provider(
+        requested="zai",
+        explicit_api_key="test-key",
+        explicit_base_url="https://api.z.ai/api/paas/v4",
+    )
+
+    assert resolved["provider"] == "zai"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.z.ai/api/paas/v4"
 
 
 def test_minimax_default_url_uses_anthropic_messages(monkeypatch):

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -142,3 +142,15 @@ class TestStrictApiValidation:
 
         # Should NOT sanitize for Codex
         assert agent._should_sanitize_tool_calls() is False
+
+    def test_custom_proxy_url_is_not_treated_as_direct_openai(self, monkeypatch):
+        """Reverse proxies with api.openai.com in the path must stay on chat completions."""
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://proxy.example.com/api.openai.com/v1",
+        )
+
+        assert agent._is_direct_openai_url() is False
+        assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
 Summary                                                                                                                                                                         
                                                                                                                                                                                  
  - Prevent stale model.api_mode from leaking into custom and explicit API-key provider runtimes                                                                                  
  - Tighten direct OpenAI detection so only the api.openai.com host is treated as native OpenAI, not proxy URLs that merely contain it in the path                                
  - Align main-agent runtime resolution, provider fallback helpers, and auxiliary clients on the same API-mode detection rules                                                    
                                                                                                                                                                                  
  Fixes #9064                                                                                                                                                                     
                                                                                                                                                                                  
  Problem                                                                                                                                                                         
                                                                                                                                                                                  
  Custom OpenAI-compatible endpoints could be misclassified as codex_responses instead of chat_completions.                                                                       
                                                                                                                                                                                  
  That caused Hermes to send Responses-style payloads to chat-completions backends, which broke request validation and produced errors such as:                                   
                                                                                                                                                                                  
  Key: 'GptVParam.Messages' Error:Field validation for 'Messages' failed on the 'required' tag                                                                                    
                                                                                                                                                                                  
  Fix                                                                                                                                                                             
                                                                                                                                                                                  
  - Add provider-family guards before honoring persisted model.api_mode                                                                                                           
  - Replace broad api.openai.com substring checks with hostname-based detection                                                                                                   
  - Keep proxy URLs that only include api.openai.com in the path on the chat_completions path                                                                                     
  - Apply the same detection logic across runtime provider resolution, main agent request routing, fallback helpers, and auxiliary clients                                        
                                                                                                                                                                                  
  Regression Coverage                                                                                                                                                             
                                                                                                                                                                                  
  - Stale api_mode does not leak into custom endpoints                                                                                                                            
  - Stale api_mode does not leak into explicit API-key providers                                                                                                                  
  - Proxy URLs containing api.openai.com in the path are not treated as native OpenAI                                                                                             
  - Auxiliary client wrapping and token-param selection follow the corrected detection logic                                                                                      
                                                                                                                                                                                  
  Validation                                                                                                                                                                      
                                                                                                                                                                                  
  venv\Scripts\python -m pytest -n 0 tests\agent\test_auxiliary_client.py                                                                                                         
  venv\Scripts\python -m pytest -n 0 tests\hermes_cli\test_runtime_provider_resolution.py
  venv\Scripts\python -m pytest -n 0 tests\run_agent\test_strict_api_validation.py                                                                                                
  venv\Scripts\python -m pytest -n 0 tests\agent\test_minimax_provider.p