### PR TITLE
Harden gateway Telegram regressions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gateway-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run gateway smoke tests
+        run: ./scripts/run_gateway_smoke_tests.sh
+        env:
+          # Ensure tests don't accidentally call real APIs
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -37,6 +37,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -640,19 +641,10 @@ def _read_codex_access_token() -> Optional[str]:
     fallback-to-Codex working when the pool state is stale but the stored OAuth
     token is still valid.
     """
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        token = _pool_runtime_api_key(entry)
-        if token:
-            return token
-
-    try:
-        from hermes_cli.auth import _read_codex_tokens
-        data = _read_codex_tokens()
-        tokens = data.get("tokens", {})
-        access_token = tokens.get("access_token")
-        if not isinstance(access_token, str) or not access_token.strip():
+    def _validated_codex_token(candidate: Any) -> Optional[str]:
+        if not isinstance(candidate, str) or not candidate.strip():
             return None
+        access_token = candidate.strip()
 
         # Check JWT expiry — expired tokens block the auto chain and
         # prevent fallback to working providers (e.g. Anthropic).
@@ -668,7 +660,19 @@ def _read_codex_access_token() -> Optional[str]:
         except Exception:
             pass  # Non-JWT token or decode error — use as-is
 
-        return access_token.strip()
+        return access_token
+
+    pool_present, entry = _select_pool_entry("openai-codex")
+    if pool_present:
+        token = _validated_codex_token(_pool_runtime_api_key(entry))
+        if token:
+            return token
+
+    try:
+        from hermes_cli.auth import _read_codex_tokens
+        data = _read_codex_tokens()
+        tokens = data.get("tokens", {})
+        return _validated_codex_token(tokens.get("access_token"))
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
         return None
@@ -1070,6 +1074,39 @@ def _is_connection_error(exc: Exception) -> bool:
     )):
         return True
     return False
+
+
+def _summarize_provider_error(exc: Exception) -> Optional[str]:
+    """Return a compact message for noisy provider errors, else None."""
+    raw = str(exc or "")
+    lowered = raw.lower()
+    if not raw:
+        return None
+
+    if not any(marker in lowered for marker in (
+        "<html",
+        "<!doctype html",
+        "challenge-error-text",
+        "enable javascript and cookies to continue",
+        "/cdn-cgi/challenge-platform/",
+        "__cf_chl",
+    )):
+        return None
+
+    status = getattr(exc, "status_code", None)
+    status_text = f"HTTP {status}" if isinstance(status, int) else "non-JSON error"
+    exc_name = type(exc).__name__ or "ProviderError"
+
+    hint = "provider returned an HTML challenge page instead of API JSON"
+    if "cloudflare" in lowered or "__cf_chl" in lowered or "challenge-error-text" in lowered:
+        hint += " (possible Cloudflare challenge or expired web session)"
+
+    title_match = re.search(r"<title>(.*?)</title>", raw, flags=re.IGNORECASE | re.DOTALL)
+    title = title_match.group(1).strip() if title_match else ""
+    if title:
+        hint += f"; page title={title!r}"
+
+    return f"{exc_name}: {status_text}; {hint}"
 
 
 def _try_payment_fallback(
@@ -2377,6 +2414,9 @@ def call_llm(
                     extra_body=extra_body)
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
+        summarized = _summarize_provider_error(first_err)
+        if summarized:
+            raise RuntimeError(summarized) from None
         raise
 
 
@@ -2559,4 +2599,7 @@ async def async_call_llm(
                     fb_kwargs["model"] = async_fb_model
                 return _validate_llm_response(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
+        summarized = _summarize_provider_error(first_err)
+        if summarized:
+            raise RuntimeError(summarized) from None
         raise

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -807,8 +807,6 @@ class SessionStore:
         to avoid resetting long-idle sessions that are harmless to resume.
         Returns the number of sessions that were suspended.
         """
-        from datetime import timedelta
-
         cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
         with self._lock:

--- a/scripts/run_gateway_smoke_tests.sh
+++ b/scripts/run_gateway_smoke_tests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VENV_DIR=""
+for candidate in ".venv" "venv"; do
+  if [[ -f "$candidate/bin/activate" ]]; then
+    VENV_DIR="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$VENV_DIR" ]]; then
+  # Reuse the local project venv when available.
+  # shellcheck disable=SC1091
+  source "$VENV_DIR/bin/activate"
+fi
+
+PYTHON_BIN=""
+if [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+  PYTHON_BIN="${VIRTUAL_ENV}/bin/python"
+elif [[ -n "$VENV_DIR" && -x "$VENV_DIR/bin/python" ]]; then
+  PYTHON_BIN="$VENV_DIR/bin/python"
+else
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+"$PYTHON_BIN" -m pytest \
+  tests/agent/test_auxiliary_client.py \
+  tests/agent/test_error_classifier.py \
+  tests/hermes_cli/test_gateway.py \
+  tests/hermes_cli/test_gateway_service.py \
+  tests/hermes_cli/test_gateway_wsl.py \
+  tests/gateway/test_session.py \
+  tests/gateway/test_telegram_*.py \
+  --tb=short \
+  -n0 \
+  -q

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -89,7 +89,8 @@ class TestReadCodexAccessToken:
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        result = _read_codex_access_token()
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            result = _read_codex_access_token()
         assert result is None
 
     def test_empty_token_returns_none(self, tmp_path, monkeypatch):
@@ -146,8 +147,25 @@ class TestReadCodexAccessToken:
             },
         }))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        result = _read_codex_access_token()
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            result = _read_codex_access_token()
         assert result is None, "Expired JWT should return None"
+
+    def test_expired_pool_jwt_returns_none(self):
+        """Expired JWT from the credential pool should also be skipped."""
+        import base64
+        import time as _time
+
+        header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+        payload_data = json.dumps({"exp": int(_time.time()) - 3600}).encode()
+        payload = base64.urlsafe_b64encode(payload_data).rstrip(b"=").decode()
+        expired_jwt = f"{header}.{payload}.fakesig"
+
+        with patch(
+            "agent.auxiliary_client._select_pool_entry",
+            return_value=(True, {"api_key": expired_jwt}),
+        ):
+            assert _read_codex_access_token() is None
 
     def test_valid_jwt_returns_token(self, tmp_path, monkeypatch):
         """Non-expired JWT tokens should be returned."""
@@ -365,7 +383,7 @@ class TestExpiredCodexFallback:
     def test_hermes_oauth_file_sets_oauth_flag(self, monkeypatch):
         """OAuth-style tokens should get is_oauth=*** (token is not sk-ant-api-*)."""
         # Mock resolve_anthropic_token to return an OAuth-style token
-        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="hermes-oauth-jwt-token"), \
+        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="eyJhbGciOiJSUzI1NiJ9.payload.sig"), \
              patch("agent.anthropic_adapter.build_anthropic_client") as mock_build, \
              patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
             mock_build.return_value = MagicMock()
@@ -420,7 +438,7 @@ class TestExpiredCodexFallback:
 
     def test_claude_code_oauth_env_sets_flag(self, monkeypatch):
         """CLAUDE_CODE_OAUTH_TOKEN env var should get is_oauth=True."""
-        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-oauth-token-test")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-cc-oauth-token-test")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
             mock_build.return_value = MagicMock()
@@ -585,7 +603,10 @@ class TestGetTextAuxiliaryClient:
         assert call_kwargs.kwargs["base_url"] == "http://localhost:1234/v1"
 
     def test_codex_fallback_when_nothing_else(self, codex_auth_dir):
-        with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openai-codex", None, None, None, None),
+        ), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_text_auxiliary_client()
         assert model == "gpt-5.2-codex"
@@ -624,6 +645,7 @@ class TestGetTextAuxiliaryClient:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
             client, model = get_text_auxiliary_client()
@@ -786,9 +808,10 @@ class TestAuxiliaryPoolAwareness:
             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="***"),
         ):
-            client, model = get_vision_auxiliary_client()
+            provider, client, model = resolve_vision_provider_client()
 
         assert client is not None
+        assert provider == "anthropic"
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
 
     def test_vision_auto_prefers_active_provider_over_openrouter(self, monkeypatch):
@@ -1426,6 +1449,52 @@ class TestAsyncCallLlmFallback:
 
         assert result is fb_response
         mock_fb.assert_called_once_with("auto", "compression", reason="connection error")
+
+
+class TestProviderErrorSanitization:
+    def test_call_llm_sanitizes_html_error_body(self):
+        primary_client = MagicMock()
+        html_err = Exception(
+            "<html><head><title>Attention Required!</title></head>"
+            "<body>Enable JavaScript and cookies to continue"
+            "<script>window.__cf_chl_opt={}</script></body></html>"
+        )
+        html_err.status_code = 403
+        primary_client.chat.completions.create.side_effect = html_err
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.2-codex")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("custom", "gpt-5.2-codex", "https://chatgpt.com/backend-api/codex", None, None)):
+            with pytest.raises(RuntimeError, match="HTML challenge page instead of API JSON") as excinfo:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        assert "Enable JavaScript and cookies to continue" not in str(excinfo.value)
+        assert "Attention Required!" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_sanitizes_html_error_body(self):
+        primary_client = MagicMock()
+        html_err = Exception(
+            "<html><head><title>Attention Required!</title></head>"
+            "<body>Enable JavaScript and cookies to continue"
+            "<script>window.__cf_chl_opt={}</script></body></html>"
+        )
+        html_err.status_code = 403
+        primary_client.chat.completions.create = AsyncMock(side_effect=html_err)
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.2-codex")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("custom", "gpt-5.2-codex", "https://chatgpt.com/backend-api/codex", None, None)):
+            with pytest.raises(RuntimeError, match="HTML challenge page instead of API JSON"):
+                await async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
 class TestStaleBaseUrlWarning:
     """_resolve_auto() warns when OPENAI_BASE_URL conflicts with config provider (#5161)."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
@@ -154,6 +155,26 @@ class TestLocalCliFactory:
         assert source.chat_id == "cli"
         assert source.chat_type == "dm"
         assert source.chat_name == "CLI terminal"
+
+
+class TestSessionSuspension:
+    def test_suspend_recently_active_uses_datetime_cutoff(self, tmp_path: Path):
+        store = SessionStore(tmp_path, GatewayConfig())
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+
+        recent_entry = store.get_or_create_session(source, force_new=True)
+        stale_entry = store.get_or_create_session(
+            SessionSource(platform=Platform.TELEGRAM, chat_id="456", chat_type="dm"),
+            force_new=True,
+        )
+        stale_entry.updated_at = stale_entry.updated_at - timedelta(minutes=10)
+        store._save()
+
+        suspended = store.suspend_recently_active(max_age_seconds=120)
+
+        assert suspended == 1
+        assert recent_entry.suspended is True
+        assert stale_entry.suspended is False
 
 
 class TestBuildSessionContextPrompt:

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -59,6 +59,12 @@ def _make_adapter():
     return adapter
 
 
+@pytest.fixture(autouse=True)
+def _clear_allowed_users(monkeypatch):
+    """Keep approval callback tests independent from local Telegram allowlists."""
+    monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+
+
 # ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -494,6 +494,11 @@ class TestDiscoverFallbackIps:
         client = FakeDoHClient(responses)
         monkeypatch.setattr(tnet.httpx, "AsyncClient", lambda **kw: client)
 
+        async def _fake_to_thread(func, /, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(tnet.asyncio, "to_thread", _fake_to_thread)
+
         if system_dns_ips is not None:
             addrs = [(None, None, None, None, (ip, 443)) for ip in system_dns_ips]
             monkeypatch.setattr(tnet.socket, "getaddrinfo", lambda *a, **kw: addrs)

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -29,7 +29,7 @@ def _make_runner():
 @pytest.mark.asyncio
 async def test_handle_message_does_not_priority_interrupt_photo_followup():
     runner = _make_runner()
-    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="12345")
     session_key = build_session_key(source)
     running_agent = MagicMock()
     runner._running_agents[session_key] = running_agent


### PR DESCRIPTION
## Summary
This PR hardens the Hermes gateway around the Telegram failure modes we hit in production and adds a dedicated smoke-test path so these regressions are caught earlier.

## What changed
- fixed session startup suspension logic in  by comparing  values consistently instead of mixing  and 
- improved provider error handling in  so HTML/Cloudflare challenge pages are summarized instead of dumped into logs
- hardened Codex token selection so expired JWTs are skipped correctly during fallback selection
- fixed Telegram test isolation issues in approval, network, and photo follow-up tests
- added 
- added a dedicated  GitHub Actions job in 

## Validation
- : 
- : 
- : 
- : 
- : 
- : 
- : 

## Notes
- this PR does not include unrelated working-tree changes in  or 