### PR TITLE
fix(approval): add glob matching for command_allowlist entries

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,6 +9,7 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+import fnmatch
 import logging
 import os
 import re
@@ -606,6 +607,12 @@ def check_dangerous_command(command: str, env_type: str,
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}
+
+    # Check glob-based allowlist BEFORE pattern-key lookup.
+    # command_allowlist entries like "python3 << *" are glob patterns, not pattern keys.
+    with _lock:
+        if any(fnmatch.fnmatch(command, p) for p in _permanent_approved):
+            return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
     if is_approved(session_key, pattern_key):


### PR DESCRIPTION
## Problem

`command_allowlist` entries (e.g. `python3 << *`) are glob patterns, but `is_approved()` was doing only set membership checks against pattern keys like `script execution via heredoc`. This means glob entries in `command_allowlist` never matched and commands always required approval.

## Fix

Add `fnmatch`-based glob checking **before** the pattern-key lookup in `check_dangerous_command()`. Now glob patterns like `python3 << *` correctly bypass approval prompts.

```python
# In check_dangerous_command(), after detect_dangerous_command():
with _lock:
    if any(fnmatch.fnmatch(command, p) for p in _permanent_approved):
        return {"approved": True, "message": None}
```

## Testing

```python
check_dangerous_command("python3 << EOF\nprint(1)\nEOF", "local")
# => {"approved": True, "message": None}  # was: approval_required

check_dangerous_command("pdftotext /root/test.pdf", "local")
# => {"approved": True, "message": None}  # already worked
```

## Files changed

- `tools/approval.py`: +1 import (`fnmatch`), +6 lines (glob pre-check)