### PR TITLE
fix(openviking): correct account header, session commit on /new, explicit session creation

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -282,6 +282,27 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def restart_session(self, new_session_id: str) -> None:
+        """Transition external providers to a new session without full teardown.
+
+        Called by /new AFTER on_session_end() has committed the old session.
+        Providers that implement reset_session() are transitioned cheaply;
+        others fall back to a full initialize().
+        """
+        for provider in self._providers:
+            if provider.name == "builtin":
+                continue
+            try:
+                if hasattr(provider, "reset_session"):
+                    provider.reset_session(new_session_id)
+                else:
+                    provider.initialize(session_id=new_session_id)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' restart_session failed: %s",
+                    provider.name, e,
+                )
+
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
         """Notify all providers before context compression.
 

--- a/cli.py
+++ b/cli.py
@@ -4096,6 +4096,13 @@ class HermesCLI:
                 self.agent.flush_memories(self.conversation_history)
             except (Exception, KeyboardInterrupt):
                 pass
+            # Commit OpenViking session BEFORE session_id changes so memory
+            # extraction runs against the correct session.
+            if hasattr(self.agent, "commit_memory_session"):
+                try:
+                    self.agent.commit_memory_session(self.conversation_history)
+                except Exception:
+                    pass
             self._notify_session_boundary("on_session_finalize")
         elif self.agent:
             # First session or empty history — still finalize the old session
@@ -4119,6 +4126,13 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
+            # Reinitialize external memory providers with the new session_id so
+            # subsequent turns are tracked in the new session.
+            if hasattr(self.agent, "reinitialize_memory_session"):
+                try:
+                    self.agent.reinitialize_memory_session(self.session_id)
+                except Exception:
+                    pass
             self.agent.reset_session_state()
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,7 +10,7 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account (default: root)
+  OPENVIKING_ACCOUNT   — Tenant account (default: default)
   OPENVIKING_USER      — Tenant user (default: default)
 
 Capabilities:
@@ -83,7 +83,7 @@ class _VikingClient:
                  account: str = "", user: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
+        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._httpx = _get_httpx()
         if self._httpx is None:
@@ -292,9 +292,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "api_key",
-                "description": "OpenViking API key",
+                "description": "OpenViking API key (leave blank for local dev mode)",
                 "secret": True,
                 "env_var": "OPENVIKING_API_KEY",
+            },
+            {
+                "key": "account",
+                "description": "OpenViking tenant account ID (default: default)",
+                "default": "default",
+                "env_var": "OPENVIKING_ACCOUNT",
+            },
+            {
+                "key": "user",
+                "description": "OpenViking user ID within the account (default: default)",
+                "default": "default",
+                "env_var": "OPENVIKING_USER",
             },
         ]
 
@@ -452,6 +464,36 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.info("OpenViking session %s committed (%d turns)", self._session_id, self._turn_count)
         except Exception as e:
             logger.warning("OpenViking session commit failed: %s", e)
+
+    def reset_session(self, new_session_id: str) -> None:
+        """Start a new OpenViking session after the old one has been committed.
+
+        Called by the CLI after /new. Lighter than initialize() — keeps the
+        existing HTTP client but updates the session_id and resets per-session
+        counters. Must be called AFTER on_session_end() has committed the old
+        session.
+        """
+        # Wait for any in-flight background threads before switching session_id
+        for t in (self._sync_thread, self._prefetch_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+
+        self._session_id = new_session_id
+        self._turn_count = 0
+        self._prefetch_result = ""
+        self._sync_thread = None
+        self._prefetch_thread = None
+
+        if self._client:
+            try:
+                self._client.post("/api/v1/sessions", {"session_id": self._session_id})
+                logger.info("OpenViking new session %s created", self._session_id)
+            except Exception as e:
+                logger.debug("OpenViking new session creation: %s", e)
+
+        # Keep the atexit reference pointing at the active provider
+        global _last_active_provider
+        _last_active_provider = self
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes to OpenViking as explicit memories."""

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -106,7 +106,12 @@ class _VikingClient:
         resp = self._httpx.get(
             self._url(path), headers=self._headers(), timeout=_TIMEOUT, **kwargs
         )
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except Exception as e:
+            logger.debug("OpenViking request failed: %s %s, status: %s, response: %s",
+                         "GET", path, resp.status_code, resp.text)
+            raise
         return resp.json()
 
     def post(self, path: str, payload: dict = None, **kwargs) -> dict:
@@ -114,7 +119,12 @@ class _VikingClient:
             self._url(path), json=payload or {}, headers=self._headers(),
             timeout=_TIMEOUT, **kwargs
         )
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except Exception as e:
+            logger.debug("OpenViking request failed: %s %s, status: %s, response: %s",
+                         "POST", path, resp.status_code, resp.text)
+            raise
         return resp.json()
 
     def health(self) -> bool:
@@ -299,6 +309,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if not self._client.health():
                 logger.warning("OpenViking server at %s is not reachable", self._endpoint)
                 self._client = None
+            else:
+                # Explicitly create the session to ensure it exists
+                try:
+                    self._client.post("/api/v1/sessions", {"session_id": self._session_id})
+                    logger.info("OpenViking session %s created", self._session_id)
+                except Exception as e:
+                    logger.debug("OpenViking session creation failed (may already exist): %s", e)
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
@@ -325,7 +342,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 "(abstract/overview/full), viking_browse to explore.\n"
                 "Use viking_remember to store facts, viking_add_resource to index URLs/docs."
             )
-        except Exception:
+        except Exception as e:
+            logger.warning("OpenViking system_prompt_block failed: %s", e)
             return (
                 "# OpenViking Knowledge Base\n"
                 f"Active. Endpoint: {self._endpoint}\n"

--- a/run_agent.py
+++ b/run_agent.py
@@ -2985,6 +2985,33 @@ class AIAgent:
             except Exception:
                 pass
     
+    def commit_memory_session(self, messages: list = None) -> None:
+        """Commit the current OpenViking session without shutting down providers.
+
+        Called by /new BEFORE the session_id is updated. Triggers memory
+        extraction for the current session so that context accumulated during
+        this session is not lost when the session_id changes.
+        """
+        if not self._memory_manager:
+            return
+        try:
+            self._memory_manager.on_session_end(messages or [])
+        except Exception as e:
+            logger.debug("commit_memory_session failed: %s", e)
+
+    def reinitialize_memory_session(self, new_session_id: str) -> None:
+        """Reinitialize external memory providers for a new session_id.
+
+        Called by /new AFTER the session_id is updated. External providers
+        are transitioned to the new session without full teardown.
+        """
+        if not self._memory_manager:
+            return
+        try:
+            self._memory_manager.restart_session(new_session_id)
+        except Exception as e:
+            logger.debug("reinitialize_memory_session failed: %s", e)
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the OpenViking memory provider that caused silent failures in most usage scenarios.

---

### Bug 1: Wrong X-OpenViking-Account default ("root" → "default")

`_VikingClient` defaulted `OPENVIKING_ACCOUNT` to `"root"`. OpenViking uses this header to determine the tenant namespace:

- **Dev mode** (no API key): server uses `x_openviking_account or "default"` — sending `"root"` routes all session data to the `root/` namespace, while `ov ls viking://user/default/memories` queries `default/` — writes appear to succeed but data is invisible
- **Trusted/root-key mode**: same issue — data lands in a `"root"` account namespace the user never sees

Fix: change default `"root"` → `"default"`. Also expose `account` and `user` in `get_config_schema()` so `hermes memory setup` lets users configure them for non-default deployments.

### Bug 2: /new did not commit the OpenViking session

`on_session_end()` (which POSTs `/api/v1/sessions/{id}/commit` to trigger memory extraction) was only called at:
- CLI exit (atexit handler)
- Gateway session expiry / shutdown

Running `/new` called `flush_memories()` (writes MEMORY.md) but never committed the OpenViking session — all context accumulated in the session was discarded without extraction.

Fix: new call sequence in `new_session()`:
1. `flush_memories()` — LLM writes important facts to MEMORY.md *(unchanged)*
2. **`commit_memory_session(history)`** — commits OpenViking session *before* session_id changes
3. assign new session_id
4. **`reinitialize_memory_session(new_session_id)`** — calls `reset_session()` on the provider (lighter than full `initialize()`; keeps HTTP client, resets per-session counters, creates new OV session)

New methods:
- `OpenVikingMemoryProvider.reset_session(new_session_id)` — cheap session transition
- `MemoryManager.restart_session(new_session_id)` — delegates to `reset_session()` or `initialize()` fallback
- `AIAgent.commit_memory_session(messages)` — wraps `memory_manager.on_session_end()`
- `AIAgent.reinitialize_memory_session(new_session_id)` — wraps `memory_manager.restart_session()`

### Bug 3: Explicit session creation + improved error logging *(previous commit)*

- Sessions are now explicitly created at `initialize()` time via `POST /api/v1/sessions` rather than relying on auto-creation in the message endpoint
- HTTP errors are now logged at DEBUG level with status code and response body, making failures diagnosable

---

## Test plan

- [ ] Local dev mode (no API key): have a conversation, run `/new`, verify memories appear in `ov ls viking://user/default/memories`
- [ ] With user API key: same test — data lands in correct account namespace
- [ ] With root API key + account/user set: verify correct routing
- [ ] Run `/new` multiple times — each old session committed, each new session gets fresh OV session
- [ ] CLI exit without `/new` — atexit handler still fires (no regression)
- [ ] `hermes memory setup` — account/user fields appear with "default" as default

the reproduce and the issue: https://bytedance.larkoffice.com/wiki/V9IIwURPIipHhHksnMoc4eSGnLd

this PR fix direction lgtm, details pending review and eval
