### PR TITLE
feat(gateway): enforce strict Telegram topic routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -241,6 +241,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
+from gateway.topic_routing import route_from_session_source
 from hermes_constants import get_hermes_dir
 
 
@@ -988,7 +989,7 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
-    async def send_typing(self, chat_id: str, metadata=None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[dict] = None) -> None:
         """
         Send a typing indicator.
         
@@ -996,6 +997,13 @@ class BasePlatformAdapter(ABC):
         metadata: optional dict with platform-specific context (e.g. thread_id for Slack).
         """
         pass
+
+    def _build_reply_metadata(self, source: Optional[SessionSource]) -> Optional[dict]:
+        """Build outbound routing metadata from the inbound session source."""
+        route = route_from_session_source(source)
+        if not route or (not route.thread_id and not route.topic_name):
+            return None
+        return route.to_metadata()
 
     async def stop_typing(self, chat_id: str) -> None:
         """Stop a persistent typing indicator (if the platform uses one).
@@ -1022,7 +1030,7 @@ class BasePlatformAdapter(ABC):
         """
         # Fallback: send URL as text (subclasses override for native images)
         text = f"{caption}\n{image_url}" if caption else image_url
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
     
     async def send_animation(
         self,
@@ -1113,7 +1121,7 @@ class BasePlatformAdapter(ABC):
         text = f"🔊 Audio: {audio_path}"
         if caption:
             text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=kwargs.get("metadata"))
 
     async def play_tts(
         self,
@@ -1146,7 +1154,7 @@ class BasePlatformAdapter(ABC):
         text = f"🎬 Video: {video_path}"
         if caption:
             text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=kwargs.get("metadata"))
 
     async def send_document(
         self,
@@ -1166,7 +1174,7 @@ class BasePlatformAdapter(ABC):
         text = f"📎 File: {file_path}"
         if caption:
             text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=kwargs.get("metadata"))
 
     async def send_image_file(
         self,
@@ -1186,7 +1194,7 @@ class BasePlatformAdapter(ABC):
         text = f"🖼️ Image: {image_path}"
         if caption:
             text = f"{caption}\n{text}"
-        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
+        return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=kwargs.get("metadata"))
 
     @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
@@ -1515,7 +1523,7 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
-                    _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                    _thread_meta = self._build_reply_metadata(event.source)
                     response = await self._message_handler(event)
                     if response:
                         await self._send_with_retry(
@@ -1611,7 +1619,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
-        _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        _thread_metadata = self._build_reply_metadata(event.source)
         typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
         
         try:
@@ -1832,7 +1840,7 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                _thread_metadata = self._build_reply_metadata(event.source)
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -815,6 +815,9 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = metadata.get("thread_id") if metadata else None
+            topic_boundary = metadata.get("topic_boundary") if metadata else None
+            topic_name = metadata.get("topic_name") if metadata else None
+            strict_topic = bool(thread_id and topic_boundary == "strict")
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -871,6 +874,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         if _BadReq and isinstance(send_err, _BadReq):
                             err_lower = str(send_err).lower()
                             if "thread not found" in err_lower and effective_thread_id is not None:
+                                if strict_topic:
+                                    logger.error(
+                                        "[%s] Strict topic delivery failed for thread %s (%s); refusing fallback to parent chat",
+                                        self.name,
+                                        effective_thread_id,
+                                        topic_name or "unknown topic",
+                                    )
+                                    raise
                                 # Thread doesn't exist — retry without
                                 # message_thread_id so the message still
                                 # reaches the chat.
@@ -934,7 +945,14 @@ class TelegramAdapter(BasePlatformAdapter):
             _to = locals().get("_TimedOut")
             err_str = str(e).lower()
             is_timeout = (_to and isinstance(e, _to)) or "timed out" in err_str
-            return SendResult(success=False, error=str(e), retryable=not is_timeout)
+            error_text = str(e)
+            strict_thread_missing = strict_topic and thread_id and "thread not found" in err_str
+            if strict_topic and thread_id:
+                error_text = (
+                    f"Topic-bound delivery failed for thread {thread_id} "
+                    f"({topic_name or 'unknown topic'}): {e}"
+                )
+            return SendResult(success=False, error=error_text, retryable=not (is_timeout or strict_thread_missing))
 
     async def edit_message(
         self,
@@ -1561,7 +1579,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_voice(chat_id, audio_path, caption, reply_to)
+            return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
     
     async def send_image_file(
         self,
@@ -1598,7 +1616,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_image_file(chat_id, image_path, caption, reply_to)
+            return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
 
     async def send_document(
         self,
@@ -1633,7 +1651,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send document: {e}")
-            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
+            return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_video(
         self,
@@ -1664,7 +1682,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send video: {e}")
-            return await super().send_video(chat_id, video_path, caption, reply_to)
+            return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
 
     async def send_image(
         self,
@@ -1713,11 +1731,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     resp.raise_for_status()
                     image_data = resp.content
                 
+                _upload_thread = metadata.get("thread_id") if metadata else None
                 msg = await self._bot.send_photo(
                     chat_id=int(chat_id),
                     photo=image_data,
                     caption=caption[:1024] if caption else None,
                     reply_to_message_id=int(reply_to) if reply_to else None,
+                    message_thread_id=int(_upload_thread) if _upload_thread else None,
                 )
                 return SendResult(success=True, message_id=str(msg.message_id))
             except Exception as e2:
@@ -1727,8 +1747,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     e2,
                     exc_info=True,
                 )
-                # Final fallback: send URL as text
-                return await super().send_image(chat_id, image_url, caption, reply_to)
+                # Final fallback: send URL as text while preserving routing metadata.
+                return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
     
     async def send_animation(
         self,
@@ -1760,7 +1780,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
             # Fallback: try as a regular photo
-            return await self.send_image(chat_id, animation_url, caption, reply_to)
+            return await self.send_image(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -251,6 +251,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
 )
+from gateway.topic_routing import route_from_session_source
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -694,6 +695,33 @@ class GatewayRunner:
         disabled_chats.update(
             chat_id for chat_id, mode in self._voice_mode.items() if mode == "off"
         )
+
+    def _build_reply_metadata(
+        self,
+        source: Optional[SessionSource] = None,
+        *,
+        platform: Optional[Platform] = None,
+        chat_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        topic_name: Optional[str] = None,
+        chat_type: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Build outbound routing metadata, preserving strict Telegram topic boundaries."""
+        if source is None:
+            if platform is None or not chat_id:
+                return None
+            normalized_chat_type = chat_type or ("group" if platform == Platform.TELEGRAM else "group")
+            source = SessionSource(
+                platform=platform,
+                chat_id=str(chat_id),
+                chat_type=normalized_chat_type,
+                thread_id=str(thread_id) if thread_id else None,
+                chat_topic=topic_name,
+            )
+        route = route_from_session_source(source)
+        if not route or (not route.thread_id and not route.topic_name):
+            return None
+        return route.to_metadata()
 
     # -----------------------------------------------------------------
 
@@ -1336,7 +1364,7 @@ class GatewayRunner:
         if not adapter:
             return True
 
-        thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        thread_meta = self._build_reply_metadata(event.source)
         if self._queue_during_drain_enabled():
             self._queue_or_replace_pending_event(session_key, event)
             message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
@@ -3121,7 +3149,8 @@ class GatewayRunner:
             })
         
         # Build session context
-        context = build_session_context(source, self.config, session_entry)
+        related_topics = self.session_store.list_related_topics(source)
+        context = build_session_context(source, self.config, session_entry, related_topics=related_topics)
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
@@ -3410,7 +3439,7 @@ class GatewayRunner:
                         f"{_compress_token_threshold:,}",
                     )
 
-                    _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    _hyg_meta = self._build_reply_metadata(source)
 
                     try:
                         from run_agent import AIAgent
@@ -3544,6 +3573,135 @@ class GatewayRunner:
         )
         if message_text is None:
             return
+
+        if _is_shared_thread and source.user_name:
+            message_text = f"[{source.user_name}] {message_text}"
+
+        if event.media_urls:
+            image_paths = []
+            for i, path in enumerate(event.media_urls):
+                # Check media_types if available; otherwise infer from message type
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                is_image = (
+                    mtype.startswith("image/")
+                    or event.message_type == MessageType.PHOTO
+                )
+                if is_image:
+                    image_paths.append(path)
+            if image_paths:
+                message_text = await self._enrich_message_with_vision(
+                    message_text, image_paths
+                )
+
+        # -----------------------------------------------------------------
+        # Auto-transcribe voice/audio messages sent by the user
+        # -----------------------------------------------------------------
+        if event.media_urls:
+            audio_paths = []
+            for i, path in enumerate(event.media_urls):
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                is_audio = (
+                    mtype.startswith("audio/")
+                    or event.message_type in (MessageType.VOICE, MessageType.AUDIO)
+                )
+                if is_audio:
+                    audio_paths.append(path)
+            if audio_paths:
+                message_text = await self._enrich_message_with_transcription(
+                    message_text, audio_paths
+                )
+                # If STT failed, send a direct message to the user so they
+                # know voice isn't configured — don't rely on the agent to
+                # relay the error clearly.
+                _stt_fail_markers = (
+                    "No STT provider",
+                    "STT is disabled",
+                    "can't listen",
+                    "VOICE_TOOLS_OPENAI_KEY",
+                )
+                if any(m in message_text for m in _stt_fail_markers):
+                    _stt_adapter = self.adapters.get(source.platform)
+                    _stt_meta = self._build_reply_metadata(source)
+                    if _stt_adapter:
+                        try:
+                            _stt_msg = (
+                                "🎤 I received your voice message but can't transcribe it — "
+                                "no speech-to-text provider is configured.\n\n"
+                                "To enable voice: install faster-whisper "
+                                "(`pip install faster-whisper` in the Hermes venv) "
+                                "and set `stt.enabled: true` in config.yaml, "
+                                "then /restart the gateway."
+                            )
+                            # Point to setup skill if it's installed
+                            if self._has_setup_skill():
+                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
+                            await _stt_adapter.send(
+                                source.chat_id, _stt_msg,
+                                metadata=_stt_meta,
+                            )
+                        except Exception:
+                            pass
+
+        # -----------------------------------------------------------------
+        # Enrich document messages with context notes for the agent
+        # -----------------------------------------------------------------
+        if event.media_urls and event.message_type == MessageType.DOCUMENT:
+            import mimetypes as _mimetypes
+            _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+            for i, path in enumerate(event.media_urls):
+                mtype = event.media_types[i] if i < len(event.media_types) else ""
+                # Fall back to extension-based detection when MIME type is unreliable.
+                if mtype in ("", "application/octet-stream"):
+                    import os as _os2
+                    _ext = _os2.path.splitext(path)[1].lower()
+                    if _ext in _TEXT_EXTENSIONS:
+                        mtype = "text/plain"
+                    else:
+                        guessed, _ = _mimetypes.guess_type(path)
+                        if guessed:
+                            mtype = guessed
+                if not mtype.startswith(("application/", "text/")):
+                    continue
+                # Extract display filename by stripping the doc_{uuid12}_ prefix
+                import os as _os
+                basename = _os.path.basename(path)
+                # Format: doc_<12hex>_<original_filename>
+                parts = basename.split("_", 2)
+                display_name = parts[2] if len(parts) >= 3 else basename
+                # Sanitize to prevent prompt injection via filenames
+                import re as _re
+                display_name = _re.sub(r'[^\w.\- ]', '_', display_name)
+
+                if mtype.startswith("text/"):
+                    context_note = (
+                        f"[The user sent a text document: '{display_name}'. "
+                        f"Its content has been included below. "
+                        f"The file is also saved at: {path}]"
+                    )
+                else:
+                    context_note = (
+                        f"[The user sent a document: '{display_name}'. "
+                        f"The file is saved at: {path}. "
+                        f"Ask the user what they'd like you to do with it.]"
+                    )
+                message_text = f"{context_note}\n\n{message_text}"
+
+        # -----------------------------------------------------------------
+        # Inject reply context when user replies to a message not in history.
+        # Telegram (and other platforms) let users reply to specific messages,
+        # but if the quoted message is from a previous session, cron delivery,
+        # or background task, the agent has no context about what's being
+        # referenced. Prepend the quoted text so the agent understands. (#1594)
+        # -----------------------------------------------------------------
+        if getattr(event, 'reply_to_text', None) and event.reply_to_message_id:
+            reply_snippet = event.reply_to_text[:500]
+            found_in_history = any(
+                reply_snippet[:200] in (msg.get("content") or "")
+                for msg in history
+                if msg.get("role") in ("assistant", "user", "tool")
+            )
+            if not found_in_history:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         try:
             # Emit agent:start hook
@@ -4423,7 +4581,7 @@ class GatewayRunner:
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 
-                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    metadata = self._build_reply_metadata(source)
                     result = await adapter.send_model_picker(
                         chat_id=source.chat_id,
                         providers=providers,
@@ -5142,7 +5300,7 @@ class GatewayRunner:
                     "reply_to": event.message_id,
                 }
                 if event.source.thread_id:
-                    send_kwargs["metadata"] = {"thread_id": event.source.thread_id}
+                    send_kwargs["metadata"] = self._build_reply_metadata(event.source)
                 await adapter.send_voice(**send_kwargs)
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
@@ -5172,7 +5330,7 @@ class GatewayRunner:
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
-            _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _thread_meta = self._build_reply_metadata(event.source)
 
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -5328,7 +5486,7 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
 
-        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        _thread_metadata = self._build_reply_metadata(source)
 
         try:
             user_config = _load_gateway_config()
@@ -5420,6 +5578,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             image_url=image_url,
                             caption=alt_text,
+                            metadata=_thread_metadata,
                         )
                     except Exception:
                         pass
@@ -5430,6 +5589,7 @@ class GatewayRunner:
                         await adapter.send_document(
                             chat_id=source.chat_id,
                             file_path=media_path,
+                            metadata=_thread_metadata,
                         )
                     except Exception:
                         pass
@@ -5500,7 +5660,7 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in /btw task %s", source.platform, task_id)
             return
 
-        _thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+        _thread_meta = self._build_reply_metadata(source)
 
         try:
             user_config = _load_gateway_config()
@@ -5597,13 +5757,22 @@ class GatewayRunner:
 
             for image_url, alt_text in (images or []):
                 try:
-                    await adapter.send_image(chat_id=source.chat_id, image_url=image_url, caption=alt_text)
+                    await adapter.send_image(
+                        chat_id=source.chat_id,
+                        image_url=image_url,
+                        caption=alt_text,
+                        metadata=_thread_meta,
+                    )
                 except Exception:
                     pass
 
             for media_path in (media_files or []):
                 try:
-                    await adapter.send_file(chat_id=source.chat_id, file_path=media_path)
+                    await adapter.send_file(
+                        chat_id=source.chat_id,
+                        file_path=media_path,
+                        metadata=_thread_meta,
+                    )
                 except Exception:
                     pass
 
@@ -7296,7 +7465,7 @@ class GatewayRunner:
                             break
                     if adapter and chat_id:
                         try:
-                            send_meta = {"thread_id": thread_id} if thread_id else None
+                            send_meta = self._build_reply_metadata(platform=_platform_enum, chat_id=chat_id, thread_id=thread_id)
                             await adapter.send(chat_id, message_text, metadata=send_meta)
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
@@ -7317,7 +7486,7 @@ class GatewayRunner:
                         break
                 if adapter and chat_id:
                     try:
-                        send_meta = {"thread_id": thread_id} if thread_id else None
+                        send_meta = self._build_reply_metadata(platform=_platform_enum, chat_id=chat_id, thread_id=thread_id)
                         await adapter.send(chat_id, message_text, metadata=send_meta)
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)
@@ -7553,7 +7722,13 @@ class GatewayRunner:
             _progress_thread_id = source.thread_id or event_message_id
         else:
             _progress_thread_id = source.thread_id
-        _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _progress_metadata = self._build_reply_metadata(
+            platform=source.platform,
+            chat_id=source.chat_id,
+            thread_id=_progress_thread_id,
+            topic_name=source.chat_topic,
+            chat_type=source.chat_type,
+        )
 
         async def send_progress_messages():
             if not progress_queue:
@@ -7714,7 +7889,7 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = _progress_metadata
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
@@ -7832,7 +8007,7 @@ class GatewayRunner:
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            metadata=_progress_metadata,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -152,6 +152,7 @@ class SessionContext:
     source: SessionSource
     connected_platforms: List[Platform]
     home_channels: Dict[Platform, HomeChannel]
+    related_topics: List[str] = field(default_factory=list)
     
     # Session metadata
     session_key: str = ""
@@ -166,6 +167,7 @@ class SessionContext:
             "home_channels": {
                 p.value: hc.to_dict() for p, hc in self.home_channels.items()
             },
+            "related_topics": list(self.related_topics),
             "session_key": self.session_key,
             "session_id": self.session_id,
             "created_at": self.created_at.isoformat() if self.created_at else None,
@@ -238,6 +240,23 @@ def build_session_context_prompt(
     # Channel topic (if available - provides context about the channel's purpose)
     if context.source.chat_topic:
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
+        if context.source.platform == Platform.TELEGRAM and context.source.thread_id:
+            lines.append(
+                "**Topic routing:** This conversation is bound to the current Telegram topic. "
+                "Do not treat the parent group or other topics as the same context."
+            )
+    elif (
+        context.source.platform == Platform.TELEGRAM
+        and context.source.chat_type == "group"
+        and not context.source.thread_id
+        and context.related_topics
+    ):
+        joined_topics = ", ".join(context.related_topics[:8])
+        lines.append(f"**Known Topics:** {joined_topics}")
+        lines.append(
+            "**General routing:** This is the parent Telegram group (general). "
+            "If the user refers to a known project/topic, keep the reply here concise and prefer continuing detailed work in that specific topic instead of expanding fully in general."
+        )
 
     # User identity.
     # In shared thread sessions (non-DM with thread_id), multiple users
@@ -680,6 +699,40 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    def list_related_topics(self, source: SessionSource) -> List[str]:
+        """Return known sibling topic names for the same Telegram group.
+
+        Used to make the parent Telegram group act as a light control plane:
+        the model can see which project topics exist and keep detailed work in
+        the appropriate topic instead of expanding everything in general.
+        """
+        if (
+            source.platform != Platform.TELEGRAM
+            or source.chat_type != "group"
+            or source.thread_id
+            or not source.chat_id
+        ):
+            return []
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            topics: set[str] = set()
+            for entry in self._entries.values():
+                origin = entry.origin
+                if not origin:
+                    continue
+                if origin.platform != Platform.TELEGRAM:
+                    continue
+                if origin.chat_type != "group":
+                    continue
+                if str(origin.chat_id or "") != str(source.chat_id):
+                    continue
+                if not origin.thread_id:
+                    continue
+                if origin.chat_topic:
+                    topics.add(origin.chat_topic)
+            return sorted(topics)
+
     def get_or_create_session(
         self,
         source: SessionSource,
@@ -1057,7 +1110,8 @@ class SessionStore:
 def build_session_context(
     source: SessionSource,
     config: GatewayConfig,
-    session_entry: Optional[SessionEntry] = None
+    session_entry: Optional[SessionEntry] = None,
+    related_topics: Optional[List[str]] = None,
 ) -> SessionContext:
     """
     Build a full session context from a source and config.
@@ -1076,6 +1130,7 @@ def build_session_context(
         source=source,
         connected_platforms=connected,
         home_channels=home_channels,
+        related_topics=list(related_topics or []),
     )
     
     if session_entry:

--- a/gateway/topic_routing.py
+++ b/gateway/topic_routing.py
@@ -1,0 +1,54 @@
+"""Topic-aware routing helpers for threaded messaging platforms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+@dataclass(frozen=True)
+class TopicRoute:
+    """Normalized routing context for outbound threaded replies."""
+
+    chat_id: str
+    thread_id: Optional[str] = None
+    topic_name: Optional[str] = None
+    boundary: str = "soft"
+
+    @property
+    def is_strict(self) -> bool:
+        return bool(self.thread_id and self.boundary == "strict")
+
+    def to_metadata(self) -> Optional[dict[str, str]]:
+        metadata: dict[str, str] = {}
+        if self.thread_id:
+            metadata["thread_id"] = self.thread_id
+        if self.topic_name:
+            metadata["topic_name"] = self.topic_name
+        if self.boundary:
+            metadata["topic_boundary"] = self.boundary
+        return metadata or None
+
+
+def route_from_session_source(source: Optional[SessionSource]) -> Optional[TopicRoute]:
+    """Derive a routing policy from inbound session context.
+
+    Telegram forum topics are strict routing boundaries. Other sources default to
+    soft routing so adapters may apply legacy fallback behavior if appropriate.
+    """
+    if not source or not source.chat_id:
+        return None
+
+    boundary = "soft"
+    if source.platform == Platform.TELEGRAM and source.thread_id:
+        boundary = "strict"
+
+    return TopicRoute(
+        chat_id=source.chat_id,
+        thread_id=source.thread_id,
+        topic_name=source.chat_topic,
+        boundary=boundary,
+    )

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -124,6 +124,7 @@ class TestBasePlatformTopicSessions:
         adapter._keep_typing = hold_typing
 
         event = _make_event("-1001", "17585")
+        event.source.chat_topic = "舆情监测"
         await adapter._process_message_background(event, build_session_key(event.source))
 
         assert adapter.sent == [
@@ -131,13 +132,21 @@ class TestBasePlatformTopicSessions:
                 "chat_id": "-1001",
                 "content": "ack",
                 "reply_to": "1",
-                "metadata": {"thread_id": "17585"},
+                "metadata": {
+                    "thread_id": "17585",
+                    "topic_name": "舆情监测",
+                    "topic_boundary": "strict",
+                },
             }
         ]
         assert typing_calls == [
             {
                 "chat_id": "-1001",
-                "metadata": {"thread_id": "17585"},
+                "metadata": {
+                    "thread_id": "17585",
+                    "topic_name": "舆情监测",
+                    "topic_boundary": "strict",
+                },
             }
         ]
         assert adapter.processing_hooks == [

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -249,6 +249,50 @@ class TestBuildSessionContextPrompt:
         assert "Discord" in prompt
         assert "**Channel Topic:** Planning and coordination for Project X" in prompt
 
+    def test_telegram_topic_prompt_declares_strict_topic_boundary(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_name="hermes",
+            chat_type="group",
+            thread_id="413",
+            chat_topic="舆情监测",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "舆情监测" in prompt
+        assert "**Topic routing:**" in prompt
+        assert "Do not treat the parent group or other topics as the same context." in prompt
+
+    def test_telegram_general_prompt_lists_known_topics(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_name="hermes",
+            chat_type="group",
+        )
+        ctx = build_session_context(
+            source,
+            config,
+            related_topics=["舆情监测", "每日代办事项"],
+        )
+        prompt = build_session_context_prompt(ctx)
+
+        assert "**Known Topics:** 舆情监测, 每日代办事项" in prompt
+        assert "**General routing:**" in prompt
+        assert "prefer continuing detailed work in that specific topic" in prompt
+
     def test_prompt_omits_channel_topic_when_none(self):
         """Channel Topic line should NOT appear when chat_topic is None."""
         config = GatewayConfig(
@@ -362,6 +406,60 @@ class TestBuildSessionContextPrompt:
 
         assert "**User:** Alice" in prompt
         assert "Multi-user thread" not in prompt
+
+
+class TestSessionStoreRelatedTopics:
+    @pytest.fixture()
+    def store(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            s = SessionStore(sessions_dir=tmp_path, config=config)
+        s._db = None
+        s._loaded = True
+        return s
+
+    def test_list_related_topics_returns_sibling_telegram_topics(self, store):
+        general_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+        )
+        topic_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="413",
+            chat_topic="舆情监测",
+        )
+        other_topic_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="120",
+            chat_topic="每日代办事项",
+        )
+        foreign_topic = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-2002",
+            chat_type="group",
+            thread_id="1",
+            chat_topic="别的群话题",
+        )
+
+        for origin in (topic_source, other_topic_source, foreign_topic):
+            store.get_or_create_session(origin)
+
+        assert store.list_related_topics(general_source) == ["每日代办事项", "舆情监测"]
+
+    def test_list_related_topics_empty_for_topic_message(self, store):
+        topic_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="413",
+            chat_topic="舆情监测",
+        )
+        assert store.list_related_topics(topic_source) == []
 
 
 class TestSessionStoreRewriteTranscript:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -84,7 +84,7 @@ def _make_adapter():
 
 @pytest.mark.asyncio
 async def test_send_retries_without_thread_on_thread_not_found():
-    """When message_thread_id causes 'thread not found', retry without it."""
+    """When message_thread_id causes 'thread not found', soft sends retry without it."""
     adapter = _make_adapter()
 
     call_log = []
@@ -101,7 +101,7 @@ async def test_send_retries_without_thread_on_thread_not_found():
     result = await adapter.send(
         chat_id="123",
         content="test message",
-        metadata={"thread_id": "99999"},
+        metadata={"thread_id": "99999", "topic_boundary": "soft"},
     )
 
     assert result.success is True
@@ -110,6 +110,36 @@ async def test_send_retries_without_thread_on_thread_not_found():
     assert len(call_log) == 2
     assert call_log[0]["message_thread_id"] == 99999
     assert call_log[1]["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_strict_topic_does_not_fallback_to_general_on_thread_not_found():
+    """Strict topic-bound sends must fail closed instead of retrying in general."""
+    adapter = _make_adapter()
+
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="topic-only message",
+        metadata={
+            "thread_id": "99999",
+            "topic_boundary": "strict",
+            "topic_name": "舆情监测",
+        },
+    )
+
+    assert result.success is False
+    assert "thread not found" in result.error.lower()
+    assert len(call_log) == 1
+    assert call_log[0]["message_thread_id"] == 99999
+    assert result.retryable is False
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_topic_routing.py
+++ b/tests/gateway/test_topic_routing.py
@@ -1,0 +1,87 @@
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.topic_routing import TopicRoute, route_from_session_source
+
+
+def test_route_from_telegram_topic_is_strict():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="413",
+        chat_topic="舆情监测",
+    )
+
+    route = route_from_session_source(source)
+
+    assert route == TopicRoute(
+        chat_id="-1001",
+        thread_id="413",
+        topic_name="舆情监测",
+        boundary="strict",
+    )
+    assert route.is_strict is True
+    assert route.to_metadata() == {
+        "thread_id": "413",
+        "topic_name": "舆情监测",
+        "topic_boundary": "strict",
+    }
+
+
+def test_route_from_non_threaded_group_is_soft():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+
+    route = route_from_session_source(source)
+
+    assert route == TopicRoute(
+        chat_id="-1001",
+        thread_id=None,
+        topic_name=None,
+        boundary="soft",
+    )
+    assert route.is_strict is False
+    assert route.to_metadata() == {"topic_boundary": "soft"}
+
+
+def test_route_from_discord_thread_is_soft():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="thread",
+        thread_id="abc",
+        chat_topic="dev thread",
+    )
+
+    route = route_from_session_source(source)
+
+    assert route == TopicRoute(
+        chat_id="123",
+        thread_id="abc",
+        topic_name="dev thread",
+        boundary="soft",
+    )
+    assert route.is_strict is False
+
+
+def test_route_from_telegram_dm_topic_is_strict():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        thread_id="9",
+        chat_topic="私人项目",
+    )
+
+    route = route_from_session_source(source)
+
+    assert route == TopicRoute(
+        chat_id="42",
+        thread_id="9",
+        topic_name="私人项目",
+        boundary="strict",
+    )
+    assert route.is_strict is True

--- a/tests/gateway/test_topic_routing_runner.py
+++ b/tests/gateway/test_topic_routing_runner.py
@@ -1,0 +1,33 @@
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def test_runner_build_reply_metadata_for_telegram_topic():
+    runner = GatewayRunner(GatewayConfig())
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="413",
+        chat_topic="舆情监测",
+    )
+
+    assert runner._build_reply_metadata(source) == {
+        "thread_id": "413",
+        "topic_name": "舆情监测",
+        "topic_boundary": "strict",
+    }
+
+
+def test_runner_build_reply_metadata_for_watcher_thread_only():
+    runner = GatewayRunner(GatewayConfig())
+
+    assert runner._build_reply_metadata(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        thread_id="413",
+    ) == {
+        "thread_id": "413",
+        "topic_boundary": "strict",
+    }


### PR DESCRIPTION
## Summary
- add a topic-routing helper that marks Telegram threaded conversations as strict routing boundaries
- propagate topic metadata through gateway reply, progress, background-task, watcher, and media delivery paths
- fail closed on Telegram `thread not found` for strict topic sends while preserving legacy soft fallback behavior
- enrich session context so topic chats and parent-group chats get explicit routing guidance

## Tests
- `python -m pytest tests/gateway/test_topic_routing.py tests/gateway/test_topic_routing_runner.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_session.py tests/gateway/test_telegram_thread_fallback.py -q`
- `python -m pytest tests/gateway/test_send_image_file.py -q`

## Notes
- scoped to framework/gateway routing behavior only
- no local secrets, tokens, or machine-specific config included