### PR TITLE
fix(cron): run due jobs in parallel to prevent serial tick starvation

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -908,46 +908,80 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
-        executed = 0
-        for job in due_jobs:
-            try:
-                # For recurring jobs (cron/interval), advance next_run_at to the
-                # next future occurrence BEFORE execution.  This way, if the
-                # process crashes mid-run, the job won't re-fire on restart.
-                # One-shot jobs are left alone so they can retry on restart.
-                advance_next_run(job["id"])
+        # Resolve max parallel workers: env var > config.yaml > unbounded.
+          # Set HERMES_CRON_MAX_PARALLEL=1 to restore the old serial behaviour.
+          _max_workers: Optional[int] = None
+          try:
+              _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+              if _env_par:
+                  _max_workers = int(_env_par) or None
+          except (ValueError, TypeError):
+              logger.warning("Invalid HERMES_CRON_MAX_PARALLEL value; defaulting to unbounded")
+          if _max_workers is None:
+              try:
+                  _ucfg = load_config() or {}
+                  _cfg_par = (
+                      _ucfg.get("cron", {}) if isinstance(_ucfg, dict) else {}
+                  ).get("max_parallel_jobs")
+                  if _cfg_par is not None:
+                      _max_workers = int(_cfg_par) or None
+              except Exception:
+                  pass
 
-                success, output, final_response, error = run_job(job)
+          if verbose:
+              logger.info(
+                  "Running %d job(s) in parallel (max_workers=%s)",
+                  len(due_jobs),
+                  _max_workers if _max_workers else "unbounded",
+              )
 
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
+          def _process_job(job: dict) -> bool:
+              """Run one due job end-to-end: advance, execute, save, deliver, mark."""
+              try:
+                  advance_next_run(job["id"])
 
-                # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
+                  success, output, final_response, error = run_job(job)
 
-                delivery_error = None
-                if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
+                  output_file = save_job_output(job["id"], output)
+                  if verbose:
+                      logger.info("Output saved to: %s", output_file)
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-                executed += 1
+                  deliver_content = (
+                      final_response
+                      if success
+                      else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                  )
+                  should_deliver = bool(deliver_content)
+                  if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                      logger.info(
+                          "Job '%s': agent returned %s — skipping delivery",
+                          job["id"],
+                          SILENT_MARKER,
+                      )
+                      should_deliver = False
 
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
+                  delivery_error = None
+                  if should_deliver:
+                      try:
+                          delivery_error = _deliver_result(
+                              job, deliver_content, adapters=adapters, loop=loop
+                          )
+                      except Exception as de:
+                          delivery_error = str(de)
+                          logger.error("Delivery failed for job %s: %s", job["id"], de)
 
-        return executed
+                  mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                  return True
+
+              except Exception as e:
+                  logger.error("Error processing job %s: %s", job["id"], e)
+                  mark_job_run(job["id"], False, str(e))
+                  return False
+
+          with concurrent.futures.ThreadPoolExecutor(max_workers=_max_workers) as _tick_pool:
+              _job_results = list(_tick_pool.map(_process_job, due_jobs))
+
+          return sum(_job_results)
     finally:
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_UN)


### PR DESCRIPTION
## What does this PR do?

The serial job loop inside `tick()` caused all jobs after a long-running
  one to be silently delayed or skipped. If any job ran longer than the 60s
  gateway tick interval, the next tick would fail to acquire the file lock
  and return 0 with no warning — jobs that became due in the meantime were
  never executed.

  This replaces the serial `for` loop with a `ThreadPoolExecutor` so all
  jobs due in a single tick run concurrently. A slow job no longer blocks
  others.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #9086

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made


  - `cron/scheduler.py`: replaced serial `for job in due_jobs` loop in `tick()` with
  `ThreadPoolExecutor.map(_process_job, due_jobs)`
  - Max parallelism configurable via `HERMES_CRON_MAX_PARALLEL` env var or `cron.max_parallel_jobs` in `config.yaml`
  - Set `max_parallel_jobs: 1` to restore old serial behaviour if needed

- 

## How to Test

 1. Create two cron jobs — one with a long-running prompt (e.g. `sleep 120`), one short
  2. Set both to the same schedule so they fire together in one tick
  3. Confirm both jobs complete in the same tick instead of the short one waiting behind the long one

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

