### PR TITLE
fix(agent): preserve MiniMax context length on delta-only overflow errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9277,9 +9277,30 @@ class AIAgent:
                         # Error is about the INPUT being too large — reduce context_length.
                         # Try to parse the actual limit from the error message
                         parsed_limit = parse_context_limit_from_error(error_msg)
+                        _provider_lower = (getattr(self, "provider", "") or "").lower()
+                        _base_lower = (getattr(self, "base_url", "") or "").rstrip("/").lower()
+                        is_minimax_provider = (
+                            _provider_lower in {"minimax", "minimax-cn"}
+                            or _base_lower.startswith((
+                                "https://api.minimax.io/anthropic",
+                                "https://api.minimaxi.com/anthropic",
+                            ))
+                        )
+                        minimax_delta_only_overflow = (
+                            is_minimax_provider
+                            and parsed_limit is None
+                            and "context window exceeds limit (" in error_msg
+                        )
                         if parsed_limit and parsed_limit < old_ctx:
                             new_ctx = parsed_limit
-                            self._vprint(f"{self.log_prefix}⚠️  Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                            self._vprint(f"{self.log_prefix}Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})", force=True)
+                        elif minimax_delta_only_overflow:
+                            new_ctx = old_ctx
+                            self._vprint(
+                                f"{self.log_prefix}Provider reported overflow amount only; "
+                                f"keeping context_length at {old_ctx:,} tokens and compressing.",
+                                force=True,
+                            )
                         else:
                             # Step down to the next probe tier
                             new_ctx = get_next_probe_tier(old_ctx)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -618,6 +618,10 @@ class TestParseContextLimitFromError:
         msg = "Error: context window of 4096 tokens exceeded"
         assert parse_context_limit_from_error(msg) == 4096
 
+    def test_minimax_delta_only_message_returns_none(self):
+        msg = "invalid params, context window exceeds limit (2013)"
+        assert parse_context_limit_from_error(msg) is None
+
     def test_completely_unrelated_error(self):
         assert parse_context_limit_from_error("Invalid API key") is None
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2113,6 +2113,89 @@ class TestRunConversation:
         assert result["final_response"] == "Recovered after compression"
         assert result["completed"] is True
 
+    def test_minimax_delta_overflow_keeps_known_context_length(self, agent):
+        """MiniMax reports overflow deltas like 'limit (2013)' without the real window.
+
+        Keep the known 204,800-token window and compress instead of probing down
+        to the generic 128K fallback tier.
+        """
+        self._setup_agent(agent)
+        agent.provider = "minimax"
+        agent.model = "MiniMax-M2.7-highspeed"
+        agent.base_url = "https://api.minimax.io/anthropic"
+        agent.context_compressor.context_length = 204_800
+        agent.context_compressor.threshold_tokens = int(
+            agent.context_compressor.context_length * agent.context_compressor.threshold_percent
+        )
+
+        err_400 = Exception(
+            "HTTP 400: invalid params, context window exceeds limit (2013)"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.context_compressor.context_length == 204_800
+        assert agent.context_compressor._context_probed is False
+        assert result["final_response"] == "Recovered after compression"
+        assert result["completed"] is True
+
+    def test_non_minimax_delta_overflow_still_probes_down(self, agent):
+        """Non-MiniMax providers should keep the generic probe-down behavior."""
+        self._setup_agent(agent)
+        agent.provider = "openrouter"
+        agent.model = "some/unknown-model"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = int(
+            agent.context_compressor.context_length * agent.context_compressor.threshold_percent
+        )
+
+        err_400 = Exception(
+            "HTTP 400: invalid params, context window exceeds limit (2013)"
+        )
+        err_400.status_code = 400
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_400, ok_resp]
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}],
+                "compressed system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert agent.context_compressor.context_length == 128_000
+        assert result["final_response"] == "Recovered after compression"
+        assert result["completed"] is True
+
     def test_length_finish_reason_requests_continuation(self, agent):
         """Normal truncation (partial real content) triggers continuation."""
         self._setup_agent(agent)


### PR DESCRIPTION
﻿## Summary

This fixes a MiniMax-specific context overflow recovery bug in `AIAgent`.

When MiniMax's Anthropic-compatible endpoint returns an error like:

`context window exceeds limit (2013)`

The number in parentheses is only the overflow delta, not the actual context window. Hermes already knows MiniMax's real context length, but the recovery path treated this error as "no limit available" and incorrectly probed down to the next generic tier.

This PR keeps the known MiniMax context length intact for that provider-specific error format and compresses the conversation without demoting the model to a smaller inferred window.

## Problem

Hermes handles context overflow in `run_agent.py` by:

1. trying to parse the real limit from the provider error message
2. if no real limit can be parsed, probing down via `get_next_probe_tier(old_ctx)`

That fallback is correct for genuinely unknown providers or endpoints, but it is wrong for MiniMax's delta-only overflow message.

In practice, this caused:

- known MiniMax context length: `204800`
- fallback probe tier: `128000`
- earlier compression than intended
- unnecessary reduction of the working context window for the rest of the turn

Because Hermes's in-loop `ContextCompressor` defaults to a 50% threshold, this effectively moved the compression trigger from `102400` tokens to `64000` tokens for the affected path.

## Root Cause

The root cause was not the generic parser.

`parse_context_limit_from_error()` correctly returns `None` for:

`context window exceeds limit (2013)`

because the message does not contain the actual context window.

The real bug was in the recovery logic: `AIAgent` treated "no parsed limit" as a reason to probe down even when the provider was MiniMax and the model context was already known.

## What Changed

### 1. MiniMax-specific recovery guard in `run_agent.py`

For MiniMax and MiniMax China provider resolution, and for MiniMax Anthropic-compatible base URLs, Hermes now detects the delta-only overflow format and:

- keeps `context_length` unchanged
- skips `get_next_probe_tier()`
- compresses and retries normally

### 2. Parser behavior remains generic

I did **not** change the generic parser semantics for small valid context windows.

This is important because Hermes already supports valid provider error formats that may report context limits such as:

- `32768`
- `4096`

Those should continue to work as before.

### 3. Regression coverage added

Added tests to cover:

- MiniMax delta-only overflow message returns `None` from the parser
- MiniMax keeps `204800` and compresses instead of probing down
- non-MiniMax providers still keep the generic probe-down behavior for the same text pattern

## Why This Approach

This repo's architecture separates:

- generic metadata parsing
- provider runtime resolution
- provider-specific recovery inside the main agent loop

Given that provider runtime selection is shared across CLI, gateway, cron, ACP, and auxiliary tasks, scoping this behavior to MiniMax is safer than weakening the generic overflow logic globally.

This keeps the PR focused and avoids regressions for other providers that may still need probe-down behavior when the real limit is unknown.

## Files Changed

- `run_agent.py`
- `tests/agent/test_model_metadata.py`
- `tests/run_agent/test_run_agent.py`

## Testing

Targeted tests run locally on Windows with Python 3.12:

```bash
.venv\\Scripts\\python -m pytest -q tests/agent/test_model_metadata.py tests/run_agent/test_run_agent.py -k "minimax_delta_only_message_returns_none or minimax_delta_overflow_keeps_known_context_length or non_minimax_delta_overflow_still_probes_down or glm_prompt_exceeds_max_length_triggers_compression"
.venv\\Scripts\\python -m pytest -q tests/agent/test_error_classifier.py tests/agent/test_minimax_provider.py tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_413_compression.py
```

Results:

- targeted MiniMax/parser/recovery coverage passed
- related overflow/classifier/MiniMax suites passed

## Scope / Non-Goals

This PR does not:

- change generic context limit parsing rules
- change gateway hygiene thresholds
- change session storage behavior
- change provider runtime resolution outside the MiniMax-specific recovery path

## Rationale

This follows Hermes's existing pattern of making provider and error-class-specific recovery decisions inside `AIAgent` rather than broadening a generic parser in ways that could regress other providers.
