### PR TITLE
fix(config): preserve legacy compression summary overrides during migration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2203,38 +2203,26 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             s_provider = comp.pop("summary_provider", None)
             s_base_url = comp.pop("summary_base_url", None)
             migrated_keys = []
-            removed_keys = []
             aux = config.get("auxiliary", {})
             if not isinstance(aux, dict):
                 aux = {}
             aux_comp = aux.get("compression", {})
             if not isinstance(aux_comp, dict):
                 aux_comp = {}
-
-            current_aux_provider = str(aux_comp.get("provider", "")).strip()
-            current_aux_base_url = str(aux_comp.get("base_url", "")).strip()
             summary_provider = str(s_provider).strip() if s_provider is not None else ""
             summary_base_url = str(s_base_url).strip() if s_base_url is not None else ""
 
-            # A legacy provider-qualified model like "google/gemini-..." only
-            # remains meaningful after migration when compression also has an
-            # explicit provider/base_url target. Otherwise it can break auto
-            # routing by forcing a model slug onto the wrong provider.
-            effective_provider = current_aux_provider or (
-                summary_provider if summary_provider not in ("", "auto") else ""
-            )
-            effective_base_url = current_aux_base_url or summary_base_url
             # Migrate non-empty, non-default values to auxiliary.compression
             if s_model and str(s_model).strip():
                 summary_model = str(s_model).strip()
-                if effective_provider or effective_base_url or "/" not in summary_model:
-                    aux = config.setdefault("auxiliary", {})
-                    aux_comp = aux.setdefault("compression", {})
-                    if not aux_comp.get("model"):
-                        aux_comp["model"] = summary_model
-                        migrated_keys.append(f"model={summary_model}")
-                else:
-                    removed_keys.append(f"model={summary_model}")
+                # Keep migrating the model override, including provider="auto".
+                # The auxiliary runtime already drops incompatible OpenRouter-
+                # style model slugs after it resolves the actual provider.
+                aux = config.setdefault("auxiliary", {})
+                aux_comp = aux.setdefault("compression", {})
+                if not aux_comp.get("model"):
+                    aux_comp["model"] = summary_model
+                    migrated_keys.append(f"model={summary_model}")
             if summary_provider not in ("", "auto"):
                 aux = config.setdefault("auxiliary", {})
                 aux_comp = aux.setdefault("compression", {})
@@ -2253,16 +2241,6 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if not quiet:
                     if migrated_keys:
                         print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
-                        if removed_keys:
-                            print(
-                                "  ✓ Removed incompatible compression.summary_* values: "
-                                + ", ".join(removed_keys)
-                            )
-                    elif removed_keys:
-                        print(
-                            "  ✓ Removed incompatible compression.summary_* values: "
-                            + ", ".join(removed_keys)
-                        )
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2203,31 +2203,66 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             s_provider = comp.pop("summary_provider", None)
             s_base_url = comp.pop("summary_base_url", None)
             migrated_keys = []
+            removed_keys = []
+            aux = config.get("auxiliary", {})
+            if not isinstance(aux, dict):
+                aux = {}
+            aux_comp = aux.get("compression", {})
+            if not isinstance(aux_comp, dict):
+                aux_comp = {}
+
+            current_aux_provider = str(aux_comp.get("provider", "")).strip()
+            current_aux_base_url = str(aux_comp.get("base_url", "")).strip()
+            summary_provider = str(s_provider).strip() if s_provider is not None else ""
+            summary_base_url = str(s_base_url).strip() if s_base_url is not None else ""
+
+            # A legacy provider-qualified model like "google/gemini-..." only
+            # remains meaningful after migration when compression also has an
+            # explicit provider/base_url target. Otherwise it can break auto
+            # routing by forcing a model slug onto the wrong provider.
+            effective_provider = current_aux_provider or (
+                summary_provider if summary_provider not in ("", "auto") else ""
+            )
+            effective_base_url = current_aux_base_url or summary_base_url
             # Migrate non-empty, non-default values to auxiliary.compression
             if s_model and str(s_model).strip():
-                aux = config.setdefault("auxiliary", {})
-                aux_comp = aux.setdefault("compression", {})
-                if not aux_comp.get("model"):
-                    aux_comp["model"] = str(s_model).strip()
-                    migrated_keys.append(f"model={s_model}")
-            if s_provider and str(s_provider).strip() not in ("", "auto"):
+                summary_model = str(s_model).strip()
+                if effective_provider or effective_base_url or "/" not in summary_model:
+                    aux = config.setdefault("auxiliary", {})
+                    aux_comp = aux.setdefault("compression", {})
+                    if not aux_comp.get("model"):
+                        aux_comp["model"] = summary_model
+                        migrated_keys.append(f"model={summary_model}")
+                else:
+                    removed_keys.append(f"model={summary_model}")
+            if summary_provider not in ("", "auto"):
                 aux = config.setdefault("auxiliary", {})
                 aux_comp = aux.setdefault("compression", {})
                 if not aux_comp.get("provider") or aux_comp.get("provider") == "auto":
-                    aux_comp["provider"] = str(s_provider).strip()
-                    migrated_keys.append(f"provider={s_provider}")
-            if s_base_url and str(s_base_url).strip():
+                    aux_comp["provider"] = summary_provider
+                    migrated_keys.append(f"provider={summary_provider}")
+            if summary_base_url:
                 aux = config.setdefault("auxiliary", {})
                 aux_comp = aux.setdefault("compression", {})
                 if not aux_comp.get("base_url"):
-                    aux_comp["base_url"] = str(s_base_url).strip()
-                    migrated_keys.append(f"base_url={s_base_url}")
+                    aux_comp["base_url"] = summary_base_url
+                    migrated_keys.append(f"base_url={summary_base_url}")
             if migrated_keys or s_model is not None or s_provider is not None or s_base_url is not None:
                 config["compression"] = comp
                 save_config(config)
                 if not quiet:
                     if migrated_keys:
                         print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
+                        if removed_keys:
+                            print(
+                                "  ✓ Removed incompatible compression.summary_* values: "
+                                + ", ".join(removed_keys)
+                            )
+                    elif removed_keys:
+                        print(
+                            "  ✓ Removed incompatible compression.summary_* values: "
+                            + ", ".join(removed_keys)
+                        )
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -592,7 +592,7 @@ class TestCustomProviderCompatibility:
 class TestCompressionSummaryMigration:
     """Version 16 → 17 migration of legacy compression summary settings."""
 
-    def test_v16_upgrade_drops_provider_scoped_summary_model_without_target_provider(self, tmp_path):
+    def test_v16_upgrade_keeps_summary_model_with_auto_provider(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump(
@@ -616,7 +616,7 @@ class TestCompressionSummaryMigration:
         assert "summary_provider" not in raw["compression"]
         assert "summary_base_url" not in raw["compression"]
         aux_comp = raw.get("auxiliary", {}).get("compression", {})
-        assert aux_comp["model"] == ""
+        assert aux_comp["model"] == "google/gemini-3-flash-preview"
         assert aux_comp["provider"] == "auto"
         assert aux_comp["base_url"] == ""
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -589,6 +589,65 @@ class TestCustomProviderCompatibility:
         assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
 
 
+class TestCompressionSummaryMigration:
+    """Version 16 → 17 migration of legacy compression summary settings."""
+
+    def test_v16_upgrade_drops_provider_scoped_summary_model_without_target_provider(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 16,
+                    "compression": {
+                        "summary_model": "google/gemini-3-flash-preview",
+                        "summary_provider": "auto",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 17
+        assert "summary_model" not in raw["compression"]
+        assert "summary_provider" not in raw["compression"]
+        assert "summary_base_url" not in raw["compression"]
+        aux_comp = raw.get("auxiliary", {}).get("compression", {})
+        assert aux_comp["model"] == ""
+        assert aux_comp["provider"] == "auto"
+        assert aux_comp["base_url"] == ""
+
+    def test_v16_upgrade_keeps_summary_model_when_provider_is_explicit(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 16,
+                    "compression": {
+                        "summary_model": "google/gemini-3-flash-preview",
+                        "summary_provider": "openrouter",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 17
+        assert "summary_model" not in raw["compression"]
+        assert "summary_provider" not in raw["compression"]
+        assert "summary_base_url" not in raw["compression"]
+        aux_comp = raw["auxiliary"]["compression"]
+        assert aux_comp["model"] == "google/gemini-3-flash-preview"
+        assert aux_comp["provider"] == "openrouter"
+
+
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes config migration for legacy `compression.summary_*` settings so `hermes doctor --fix` preserves valid summary model overrides while removing the legacy keys.

In particular, legacy `summary_provider: auto` + OpenRouter-style model overrides like `google/gemini-3-flash-preview` remain valid after migration. Hermes already has runtime logic to drop incompatible model slugs only after it resolves the actual auxiliary provider.

## Related Issue

Fixes #9161

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: migrate legacy `compression.summary_model` into `auxiliary.compression.model`, including the valid `provider: auto` case.
- `hermes_cli/config.py`: keep migrating explicit legacy `summary_provider` / `summary_base_url` into `auxiliary.compression.*` while removing the old keys from `compression`.
- `tests/hermes_cli/test_config.py`: add coverage for both the `provider: auto` migration case and the explicit-provider migration case.

## How to Test

1. Create a v16 config with `compression.summary_model: google/gemini-3-flash-preview` and `compression.summary_provider: auto`.
2. Run `hermes doctor --fix` or `migrate_config()` and verify the legacy `summary_*` keys are removed while `auxiliary.compression.model` is preserved.
3. Repeat with `compression.summary_provider: openrouter` and verify the model/provider migrate into `auxiliary.compression.*`.
4. Run `python -m pytest tests/hermes_cli/test_config.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest tests/hermes_cli/test_config.py -q` → `49 passed`
