### PR TITLE
feat: context enrichment (search preview, multi-lang file hints, compression checkpoint)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -17,8 +17,10 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import json
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm
@@ -55,6 +57,86 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+TASK_CHECKPOINT_PREFIX = "[TASK_CHECKPOINT]"
+_TASK_CHECKPOINT_MAX_CHARS = 500
+
+
+@dataclass
+class TaskCheckpoint:
+    """Compact, machine-parseable task state preserved across compression."""
+
+    pending_tool_calls: List[str] = field(default_factory=list)
+    recently_modified_files: List[str] = field(default_factory=list)
+    current_plan_step: str = ""
+    last_tool_batch_results: List[str] = field(default_factory=list)
+    version: int = 1
+
+    @staticmethod
+    def _clip(text: str, limit: int) -> str:
+        text = " ".join(str(text or "").split())
+        if len(text) <= limit:
+            return text
+        return text[: max(1, limit - 1)] + "…"
+
+    def is_empty(self) -> bool:
+        return not any([
+            self.pending_tool_calls,
+            self.recently_modified_files,
+            self.current_plan_step,
+            self.last_tool_batch_results,
+        ])
+
+    def format_for_injection(self, max_chars: int = _TASK_CHECKPOINT_MAX_CHARS) -> Optional[str]:
+        if self.is_empty():
+            return None
+
+        payload: Dict[str, Any] = {
+            "v": self.version,
+            "p": [self._clip(item, 56) for item in self.pending_tool_calls[:2] if item],
+            "f": [self._clip(item, 36) for item in self.recently_modified_files[:3] if item],
+            "s": self._clip(self.current_plan_step, 72),
+            "r": [self._clip(item, 56) for item in self.last_tool_batch_results[:2] if item],
+        }
+        payload = {k: v for k, v in payload.items() if v not in ("", [], None)}
+        if payload == {"v": self.version}:
+            return None
+
+        def _render(current: Dict[str, Any]) -> str:
+            return f"{TASK_CHECKPOINT_PREFIX} " + json.dumps(
+                current,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+
+        text = _render(payload)
+        if len(text) <= max_chars:
+            return text
+
+        shrunk = dict(payload)
+        for key in ("r", "p", "f"):
+            while shrunk.get(key) and len(_render(shrunk)) > max_chars:
+                shrunk[key] = shrunk[key][:-1]
+            if key in shrunk and not shrunk[key]:
+                shrunk.pop(key)
+
+        if len(_render(shrunk)) > max_chars and "s" in shrunk:
+            for limit in (56, 40, 24):
+                shrunk["s"] = self._clip(self.current_plan_step, limit)
+                if len(_render(shrunk)) <= max_chars:
+                    break
+            if not shrunk["s"]:
+                shrunk.pop("s")
+
+        if len(_render(shrunk)) > max_chars:
+            minimal: Dict[str, Any] = {"v": self.version}
+            if self.current_plan_step:
+                minimal["s"] = self._clip(self.current_plan_step, 24)
+            elif self.pending_tool_calls:
+                minimal["p"] = [self._clip(self.pending_tool_calls[0], 32)]
+            shrunk = minimal
+
+        text = _render(shrunk)
+        return text if len(text) <= max_chars else None
 
 
 class ContextCompressor(ContextEngine):
@@ -263,6 +345,203 @@ class ContextCompressor(ContextEngine):
     _CONTENT_TAIL = 1500      # chars kept from the end
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+
+    @staticmethod
+    def _compact_text(value: Any, limit: int = 80) -> str:
+        text = " ".join(str(value or "").split())
+        if len(text) <= limit:
+            return text
+        return text[: max(1, limit - 1)] + "…"
+
+    @staticmethod
+    def _strip_task_checkpoint(content: str) -> str:
+        text = content or ""
+        marker = text.find(TASK_CHECKPOINT_PREFIX)
+        if marker == -1:
+            return text
+        return text[:marker].rstrip()
+
+    @staticmethod
+    def _dedupe_keep_order(items: List[str], limit: int) -> List[str]:
+        seen = set()
+        result: List[str] = []
+        for item in items:
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+            if len(result) >= limit:
+                break
+        return result
+
+    @staticmethod
+    def _tool_call_name_and_args(tc) -> tuple:
+        if isinstance(tc, dict):
+            fn = tc.get("function", {})
+            name = fn.get("name", "?")
+            raw_args = fn.get("arguments", "")
+        else:
+            fn = getattr(tc, "function", None)
+            name = getattr(fn, "name", "?") if fn else "?"
+            raw_args = getattr(fn, "arguments", "") if fn else ""
+
+        if isinstance(raw_args, dict):
+            args = raw_args
+        else:
+            try:
+                args = json.loads(raw_args) if raw_args else {}
+            except (TypeError, json.JSONDecodeError):
+                args = {"_raw": str(raw_args or "")}
+        if not isinstance(args, dict):
+            args = {"_raw": str(raw_args or "")}
+        return name, args
+
+    def _describe_tool_call(self, name: str, args: Dict[str, Any]) -> str:
+        for key in ("path", "command", "query", "url", "action"):
+            value = args.get(key)
+            if value:
+                return f"{name}:{self._compact_text(value, 44)}"
+        if args:
+            key = next(iter(args))
+            return f"{name}:{key}={self._compact_text(args.get(key), 32)}"
+        return name
+
+    def _summarize_tool_result(self, name: str, content: Any) -> str:
+        text = str(content or "").strip()
+        if not text:
+            return f"{name}:ok"
+
+        try:
+            parsed = json.loads(text)
+        except (TypeError, json.JSONDecodeError):
+            parsed = None
+
+        if isinstance(parsed, dict):
+            path = parsed.get("path") or parsed.get("file") or parsed.get("target")
+            status = parsed.get("status")
+            error = parsed.get("error") or parsed.get("message")
+            if error:
+                return f"{name}:error {self._compact_text(error, 44)}"
+            if status and path:
+                return f"{name}:{status} {self._compact_text(path, 36)}"
+            if status:
+                return f"{name}:{self._compact_text(status, 44)}"
+            if path:
+                return f"{name}:{self._compact_text(path, 44)}"
+            for key in ("summary", "result", "output"):
+                if parsed.get(key):
+                    return f"{name}:{self._compact_text(parsed[key], 44)}"
+
+        first_line = text.splitlines()[0] if text else "ok"
+        return f"{name}:{self._compact_text(first_line, 44)}"
+
+    def _latest_plan_step_from_todos(self, messages: List[Dict[str, Any]]) -> str:
+        for msg in reversed(messages):
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content", "")
+            if '"todos"' not in content:
+                continue
+            try:
+                data = json.loads(content)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            todos = data.get("todos")
+            if not isinstance(todos, list):
+                continue
+            for status in ("in_progress", "pending"):
+                for item in todos:
+                    if str(item.get("status", "")).strip().lower() == status:
+                        return self._compact_text(item.get("content", ""), 96)
+        return ""
+
+    def _build_task_checkpoint(
+        self,
+        all_messages: List[Dict[str, Any]],
+        turns_to_summarize: List[Dict[str, Any]],
+    ) -> Optional[TaskCheckpoint]:
+        if not turns_to_summarize:
+            return None
+
+        result_ids = {
+            msg.get("tool_call_id")
+            for msg in all_messages
+            if msg.get("role") == "tool" and msg.get("tool_call_id")
+        }
+
+        pending_calls: List[str] = []
+        modified_files: List[str] = []
+        last_batch_results: List[str] = []
+
+        for idx, msg in enumerate(turns_to_summarize):
+            if msg.get("role") != "assistant":
+                continue
+            tool_calls = msg.get("tool_calls") or []
+            if not tool_calls:
+                continue
+
+            batch_results: List[str] = []
+            following_tools: Dict[str, Any] = {}
+            j = idx + 1
+            while j < len(turns_to_summarize) and turns_to_summarize[j].get("role") == "tool":
+                tool_msg = turns_to_summarize[j]
+                tool_call_id = tool_msg.get("tool_call_id")
+                if tool_call_id:
+                    following_tools[tool_call_id] = tool_msg.get("content", "")
+                j += 1
+
+            for tc in tool_calls:
+                tool_call_id = self._get_tool_call_id(tc)
+                name, args = self._tool_call_name_and_args(tc)
+                if tool_call_id and tool_call_id not in result_ids:
+                    pending_calls.append(self._describe_tool_call(name, args))
+                if name in ("write_file", "patch") and tool_call_id in following_tools:
+                    result_content = following_tools.get(tool_call_id, "")
+                    # Skip failed operations
+                    if '"error"' in result_content[:200]:
+                        continue
+                    path = args.get("path")
+                    if path:
+                        modified_files.append(str(path))
+                    # V4A patch mode: extract paths from patch argument
+                    if name == "patch" and not path and args.get("patch"):
+                        import re as _re_cp
+                        patch_text = args["patch"]
+                        # Unified diff headers: +++ b/path or --- a/path
+                        for pm in _re_cp.finditer(r'^(?:\+\+\+|---)\s+[ab]/(.+)$',
+                                                   patch_text, _re_cp.MULTILINE):
+                            fpath = pm.group(1)
+                            if fpath != "/dev/null" and fpath not in modified_files:
+                                modified_files.append(fpath)
+                        # V4A patch headers: *** Update File: path or *** Add/Delete File: path
+                        for pm in _re_cp.finditer(r'^\*\*\* (?:Update|Add|Delete) File: (.+)$',
+                                                   patch_text, _re_cp.MULTILINE):
+                            fpath = pm.group(1).strip()
+                            if fpath != "/dev/null" and fpath not in modified_files:
+                                modified_files.append(fpath)
+                if tool_call_id and tool_call_id in following_tools:
+                    batch_results.append(self._summarize_tool_result(name, following_tools[tool_call_id]))
+
+            if batch_results:
+                last_batch_results = batch_results
+
+        current_plan_step = self._latest_plan_step_from_todos(all_messages)
+        if not current_plan_step:
+            if pending_calls:
+                current_plan_step = pending_calls[0]
+            else:
+                for msg in reversed(turns_to_summarize):
+                    if msg.get("role") == "assistant" and msg.get("content"):
+                        current_plan_step = self._compact_text(msg.get("content"), 96)
+                        break
+
+        checkpoint = TaskCheckpoint(
+            pending_tool_calls=self._dedupe_keep_order(pending_calls, limit=2),
+            recently_modified_files=self._dedupe_keep_order(modified_files, limit=3),
+            current_plan_step=current_plan_step,
+            last_tool_batch_results=self._dedupe_keep_order(last_batch_results, limit=2),
+        )
+        return None if checkpoint.is_empty() else checkpoint
 
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
@@ -740,6 +1019,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Phase 3: Generate structured summary
         summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
+        # Phase 3b: Build task checkpoint for structural state preservation
+        checkpoint = self._build_task_checkpoint(messages, turns_to_summarize)
+        checkpoint_text = checkpoint.format_for_injection() if checkpoint else None
+        if checkpoint_text and not self.quiet_mode:
+            logger.info("TaskCheckpoint injected (%d chars)", len(checkpoint_text))
+
         # Phase 4: Assemble compressed message list
         compressed = []
         for i in range(compress_start):
@@ -786,8 +1071,21 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 # Merge the summary into the first tail message instead
                 # of inserting a standalone message that breaks alternation.
                 _merge_summary_into_tail = True
+        # Inject checkpoint as a separate system message for maximum model adherence.
+        # System messages have higher attention weight than user/assistant content.
+        _checkpoint_msg = None
+        if checkpoint_text:
+            # Rewrite prefix from machine-parseable [TASK_CHECKPOINT] to
+            # a human/LLM-readable "RESUME STATE:" format
+            readable_checkpoint = checkpoint_text.replace(
+                TASK_CHECKPOINT_PREFIX, "RESUME STATE — after compression, continue from:"
+            )
+            _checkpoint_msg = {"role": "system", "content": readable_checkpoint}
+
         if not _merge_summary_into_tail:
             compressed.append({"role": summary_role, "content": summary})
+            if _checkpoint_msg:
+                compressed.append(_checkpoint_msg)
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
@@ -800,6 +1098,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     + original
                 )
                 _merge_summary_into_tail = False
+                # Insert checkpoint as system message after the merged tail
+                if _checkpoint_msg:
+                    compressed.append(msg)
+                    compressed.append(_checkpoint_msg)
+                    _checkpoint_msg = None  # Don't double-insert
+                    continue  # Skip the normal append below
             compressed.append(msg)
 
         self.compression_count += 1

--- a/tests/test_context_enrichment_adversarial.py
+++ b/tests/test_context_enrichment_adversarial.py
@@ -1,0 +1,491 @@
+"""Adversarial tests for context enrichment features.
+
+Tests secret redaction, edge cases, boundary conditions, and
+integration between search preview, related paths, and TaskCheckpoint.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Feature 1: search_files preview_lines
+# ---------------------------------------------------------------------------
+
+class TestSearchPreviewLines:
+    """Adversarial tests for search_files preview_lines parameter."""
+
+    def test_preview_lines_zero_disables_preview(self, tmp_path):
+        """preview_lines=0 should produce no preview field in matches."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def hello():\n    return 'world'\n\ndef goodbye():\n    pass\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="def ", target="content", path=str(tmp_path), preview_lines=0)
+        data = json.loads(result)
+        assert "matches" in data
+        for m in data["matches"]:
+            assert "preview" not in m, f"preview should not exist when preview_lines=0: {m}"
+
+    def test_preview_lines_default_is_zero(self, tmp_path):
+        """Default preview_lines=0 should NOT include preview (opt-in feature)."""
+        lines = [f"line {i}" for i in range(10)]
+        lines[5] = "MATCH_HERE"
+        test_file = tmp_path / "test.py"
+        test_file.write_text("\n".join(lines) + "\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="MATCH_HERE", target="content", path=str(tmp_path))
+        data = json.loads(result)
+        assert "matches" in data
+        match = data["matches"][0]
+        assert "preview" not in match, "Default should be preview disabled (0)"
+
+    def test_preview_lines_explicit_two(self, tmp_path):
+        """Explicit preview_lines=2 should include preview with ~5 lines."""
+        # Create file with 10 lines
+        lines = [f"line {i}" for i in range(10)]
+        lines[5] = "MATCH_HERE"
+        test_file = tmp_path / "test.py"
+        test_file.write_text("\n".join(lines) + "\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="MATCH_HERE", target="content", path=str(tmp_path), preview_lines=2)
+        data = json.loads(result)
+        assert "matches" in data
+        match = data["matches"][0]
+        assert "preview" in match
+        preview_lines = match["preview"].strip().split("\n")
+        # Should have 5-6 lines (2 before + match + 2 after, allow trailing)
+        assert 5 <= len(preview_lines) <= 6, f"Expected 5-6 preview lines, got {len(preview_lines)}"
+
+    def test_preview_lines_cap_at_20(self, tmp_path):
+        """preview_lines > 20 should be capped at 20 (41 lines max window)."""
+        lines = [f"line {i}" for i in range(100)]
+        lines[50] = "MATCH_HERE"
+        test_file = tmp_path / "test.py"
+        test_file.write_text("\n".join(lines) + "\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="MATCH_HERE", target="content", path=str(tmp_path), preview_lines=50)
+        data = json.loads(result)
+        match = data["matches"][0]
+        assert "preview" in match
+        preview_lines_list = match["preview"].strip().split("\n")
+        # Max window = 20*2+1 = 41 (allow +1 for potential edge)
+        assert len(preview_lines_list) <= 42, f"Preview should be capped near 41 lines, got {len(preview_lines_list)}"
+
+    def test_preview_redacts_secrets(self, tmp_path):
+        """Preview content should be redacted for secrets like content is."""
+        test_file = tmp_path / "secrets.py"
+        test_file.write_text("# config\nAPI_KEY='sk-1234567890abcdef'\nNORMAL='ok'\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="API_KEY", target="content", path=str(tmp_path))
+        data = json.loads(result)
+        assert data["total_count"] >= 1, f"Should find API_KEY match, got: {data}"
+        match = data["matches"][0]
+        # Content should be redacted
+        assert "sk-1234567890abcdef" not in match.get("content", "")
+        # Preview should also be redacted
+        if "preview" in match:
+            assert "sk-1234567890abcdef" not in match["preview"]
+
+    def test_preview_on_first_match_of_file(self, tmp_path):
+        """Match on line 1 should show preview starting from line 1."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("MATCH line 1\nline 2\nline 3\nline 4\nline 5\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="MATCH", target="content", path=str(tmp_path), preview_lines=2)
+        data = json.loads(result)
+        match = data["matches"][0]
+        preview = match.get("preview", "")
+        # Should start at line 1, not try to go before
+        assert "MATCH line 1" in preview
+
+    def test_preview_on_last_line_of_file(self, tmp_path):
+        """Match on last line should show preview ending at last line."""
+        lines = [f"line {i}" for i in range(5)]
+        lines.append("MATCH_END")
+        test_file = tmp_path / "test.py"
+        test_file.write_text("\n".join(lines) + "\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="MATCH_END", target="content", path=str(tmp_path), preview_lines=2)
+        data = json.loads(result)
+        match = data["matches"][0]
+        preview = match.get("preview", "")
+        assert "MATCH_END" in preview
+
+    def test_preview_no_match_returns_no_preview(self, tmp_path):
+        """Search with no results should not produce any preview fields."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("nothing here\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="NONEXISTENT_PATTERN_XYZ", target="content", path=str(tmp_path))
+        data = json.loads(result)
+        assert data["total_count"] == 0
+
+    def test_preview_files_target_no_preview(self, tmp_path):
+        """File search (target=files) should not produce preview fields."""
+        test_file = tmp_path / "test_file.py"
+        test_file.write_text("content\n")
+        from tools.file_tools import search_tool
+        result = search_tool(pattern="test_file", target="files", path=str(tmp_path))
+        data = json.loads(result)
+        if "files" in data:
+            for f in data["files"]:
+                assert "preview" not in str(f)
+
+    def test_preview_caching_avoids_duplicate_reads(self, tmp_path):
+        """Multiple matches in same file near each other should share preview reads."""
+        lines = ["MATCH"] * 5 + [f"line {i}" for i in range(20)]
+        test_file = tmp_path / "test.py"
+        test_file.write_text("\n".join(lines) + "\n")
+        from tools.file_tools import search_tool
+        # Should not raise or produce garbage even with overlapping windows
+        result = search_tool(pattern="MATCH", target="content", path=str(tmp_path), limit=10)
+        data = json.loads(result)
+        assert data["total_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Feature 2: read_file _related_paths
+# ---------------------------------------------------------------------------
+
+class TestRelatedPaths:
+    """Adversarial tests for read_file _related_paths hints."""
+
+    def test_related_paths_injected_on_first_read(self, tmp_path, monkeypatch):
+        """_related_paths should appear on offset=1 reads when local imports exist."""
+        monkeypatch.chdir(tmp_path)
+        # Create local modules so _related_paths finds them
+        (tmp_path / "mylib.py").write_text("# library\n")
+        (tmp_path / "myutils.py").write_text("# utils\n")
+        src = tmp_path / "mymodule.py"
+        src.write_text("import mylib\nimport myutils\nimport os\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        paths = [e["path"] for e in related]
+        # Should find local modules (mylib.py, myutils.py) but not stdlib (os)
+        assert any("mylib" in p for p in paths), f"Should find mylib.py import, got: {paths}"
+
+    def test_related_paths_not_injected_on_paginated_read(self, tmp_path):
+        """_related_paths should NOT appear when offset > 1."""
+        src = tmp_path / "mymodule.py"
+        src.write_text("import os\n" * 100)
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=10, limit=10)
+        data = json.loads(result)
+        assert "_related_paths" not in data
+
+    def test_related_paths_only_existing_files(self, tmp_path):
+        """_related_paths should only include files that actually exist on disk."""
+        src = tmp_path / "mymodule.py"
+        src.write_text("import os\nimport nonexistent_module_xyz\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        for entry in related:
+            p = entry["path"]
+            # All returned paths should exist
+            assert (Path.cwd() / p).exists() or Path(p).exists(), f"Related path does not exist: {p}"
+
+    def test_related_paths_capped_at_five(self, tmp_path):
+        """_related_paths should have at most 5 entries."""
+        # Create a file with many imports
+        src = tmp_path / "mymodule.py"
+        imports = "\n".join([f"import os  # import {i}" for i in range(20)])
+        src.write_text(imports + "\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        assert len(related) <= 5, f"Expected at most 5 related paths, got {len(related)}"
+
+    def test_related_paths_no_self_reference(self, tmp_path):
+        """_related_paths should not include the file itself."""
+        src = tmp_path / "mymodule.py"
+        src.write_text("import os\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        for entry in related:
+            assert entry["path"] != str(src), "Should not include self"
+
+    def test_related_paths_with_test_companion(self, tmp_path, monkeypatch):
+        """Should detect test companion files."""
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "widget.py"
+        test = tmp_path / "test_widget.py"
+        src.write_text("class Widget:\n    pass\n")
+        test.write_text("from widget import Widget\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        paths = [e["path"] for e in related]
+        assert any("test_widget" in p for p in paths), f"Should find test companion, got: {paths}"
+
+    def test_related_paths_with_init_companion(self, tmp_path, monkeypatch):
+        """Should detect __init__.py companion for package files."""
+        monkeypatch.chdir(tmp_path)
+        pkg = tmp_path / "mypackage"
+        pkg.mkdir()
+        init = pkg / "__init__.py"
+        src = pkg / "module.py"
+        init.write_text("# package init\n")
+        src.write_text("def func():\n    pass\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        related = data.get("_related_paths", [])
+        paths = [e["path"] for e in related]
+        assert any("__init__" in p for p in paths), f"Should find __init__.py, got: {paths}"
+
+    def test_related_paths_on_non_python_file(self, tmp_path):
+        """Non-Python files should not crash, just return limited hints."""
+        src = tmp_path / "config.yaml"
+        src.write_text("key: value\n")
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path=str(src), offset=1, limit=10)
+        data = json.loads(result)
+        # Should not crash; may or may not have related paths
+        assert "error" not in data or data.get("error") is None
+
+    def test_related_paths_on_error_returns_none(self, tmp_path):
+        """When file has an error (not found), _related_paths should not be injected."""
+        from tools.file_tools import read_file_tool
+        result = read_file_tool(path="/nonexistent/path/file.py", offset=1, limit=10)
+        data = json.loads(result)
+        assert "_related_paths" not in data
+
+
+# ---------------------------------------------------------------------------
+# Feature 3: TaskCheckpoint in compression
+# ---------------------------------------------------------------------------
+
+class TestRelatedPathsMultiLanguage:
+    """Adversarial tests for multi-language related-path discovery."""
+
+    def test_js_ts_related_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "module.ts"
+        src.write_text("import { value } from './dep'\nconst x = require('./dep')\nexport * from './dep'\n")
+        (tmp_path / "dep.js").write_text("export const value = 1;\n")
+        (tmp_path / "module.test.ts").write_text("// test\n")
+        (tmp_path / "__tests__").mkdir()
+        (tmp_path / "__tests__" / "module.ts").write_text("// test\n")
+        from tools.file_tools import read_file_tool
+        data = json.loads(read_file_tool(path=str(src), offset=1, limit=20))
+        paths = [e["path"] for e in data.get("_related_paths", [])]
+        assert any(p.endswith("dep.js") for p in paths)
+        assert any("module.test.ts" in p for p in paths)
+        assert any("__tests__" in p for p in paths)
+
+    def test_go_related_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "main.go"
+        src.write_text("import (\n  \"fmt\"\n  \"./local\"\n)\n")
+        (tmp_path / "local.go").write_text("package main\n")
+        (tmp_path / "main_test.go").write_text("package main\n")
+        from tools.file_tools import read_file_tool
+        data = json.loads(read_file_tool(path=str(src), offset=1, limit=20))
+        paths = [e["path"] for e in data.get("_related_paths", [])]
+        assert any(p.endswith("local.go") for p in paths)
+        assert any(p.endswith("main_test.go") for p in paths)
+
+    def test_rust_related_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        pkg = tmp_path / "src"
+        pkg.mkdir()
+        src = pkg / "lib.rs"
+        src.write_text("mod module;\nuse crate::module;\n#[cfg(test)] mod tests;\n")
+        (pkg / "module.rs").write_text("pub fn f() {}\n")
+        (pkg / "tests").mkdir()
+        (pkg / "tests" / "lib.rs").write_text("#[test]\nfn t() {}\n")
+        from tools.file_tools import read_file_tool
+        data = json.loads(read_file_tool(path=str(src), offset=1, limit=20))
+        paths = [e["path"] for e in data.get("_related_paths", [])]
+        assert any(p.endswith("module.rs") for p in paths)
+        assert any("tests/lib.rs" in p for p in paths)
+
+    def test_config_shell_markdown_related_paths(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = tmp_path / "config.yml"
+        config.write_text("a: b\n")
+        (tmp_path / "config.yml.example").write_text("x: 1\n")
+        shell = tmp_path / "script.sh"
+        shell.write_text("source ./other.sh\n. ./other2.bash\n")
+        (tmp_path / "other.sh").write_text("echo hi\n")
+        (tmp_path / "other2.bash").write_text("echo hi\n")
+        md = tmp_path / "guide.md"
+        md.write_text("[more](./other.md)\n")
+        (tmp_path / "other.md").write_text("ok\n")
+        (tmp_path / "package.json").write_text('{"name":"x"}\n')
+        for d in ["src", "lib", "tests"]:
+            (tmp_path / d).mkdir(exist_ok=True)
+        from tools.file_tools import read_file_tool
+        config_data = json.loads(read_file_tool(path=str(config), offset=1, limit=20))
+        config_paths = [e["path"] for e in config_data.get("_related_paths", [])]
+        assert any("config.yml.example" in p for p in config_paths)
+
+        shell_data = json.loads(read_file_tool(path=str(shell), offset=1, limit=20))
+        shell_paths = [e["path"] for e in shell_data.get("_related_paths", [])]
+        assert any(p.endswith("other.sh") for p in shell_paths)
+        assert any(p.endswith("other2.bash") for p in shell_paths)
+
+        md_data = json.loads(read_file_tool(path=str(md), offset=1, limit=20))
+        md_paths = [e["path"] for e in md_data.get("_related_paths", [])]
+        assert any(p.endswith("other.md") for p in md_paths)
+
+
+class TestTaskCheckpointAdversarial:
+    """Adversarial tests for TaskCheckpoint injection during compression."""
+
+    def test_checkpoint_preserves_modified_files(self):
+        """Checkpoint should track files modified by write_file/patch tool calls."""
+        from agent.context_compressor import ContextCompressor, TaskCheckpoint
+        compressor = ContextCompressor(model="gpt-4o-mini", threshold_percent=0.50)
+
+        messages = [
+            {"role": "user", "content": "fix the bug"},
+            {"role": "assistant", "content": "Let me fix it.",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "patch", "arguments": json.dumps({"path": "src/app.py", "old_string": "bug", "new_string": "fix"})}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": json.dumps({"status": "ok", "diff": "-bug\n+fix"})},
+        ]
+
+        checkpoint = compressor._build_task_checkpoint(messages, messages[1:])
+        assert checkpoint is not None
+        assert "src/app.py" in checkpoint.recently_modified_files
+
+    def test_checkpoint_preserves_pending_tool_calls(self):
+        """Tool calls without results should be flagged as pending."""
+        from agent.context_compressor import ContextCompressor
+        compressor = ContextCompressor(model="gpt-4o-mini", threshold_percent=0.50)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "Working...",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "search_files", "arguments": json.dumps({"pattern": "test"})}}]},
+            # No tool result for call_1 — it's pending
+        ]
+
+        checkpoint = compressor._build_task_checkpoint(messages, messages[1:])
+        assert checkpoint is not None
+        assert any("search_files" in c for c in checkpoint.pending_tool_calls)
+
+    def test_checkpoint_format_empty_returns_none(self):
+        """Empty checkpoint should return None from format_for_injection."""
+        from agent.context_compressor import TaskCheckpoint
+        cp = TaskCheckpoint()
+        assert cp.format_for_injection() is None
+
+    def test_checkpoint_format_respects_max_chars(self):
+        """Formatted checkpoint should never exceed _TASK_CHECKPOINT_MAX_CHARS."""
+        from agent.context_compressor import TaskCheckpoint, _TASK_CHECKPOINT_MAX_CHARS
+        cp = TaskCheckpoint(
+            pending_tool_calls=["search_files:pattern=" + "x" * 200],
+            recently_modified_files=["file" + str(i) + ".py" * 50 for i in range(10)],
+            current_plan_step="A" * 300,
+            last_tool_batch_results=["result " + "y" * 200 for _ in range(5)],
+        )
+        text = cp.format_for_injection()
+        if text:
+            assert len(text) <= _TASK_CHECKPOINT_MAX_CHARS, f"Checkpoint {len(text)} > {_TASK_CHECKPOINT_MAX_CHARS}"
+
+    def test_checkpoint_survives_compression_with_tool_use(self):
+        """After full compression, checkpoint text should be in the compressed output."""
+        from agent.context_compressor import ContextCompressor
+        compressor = ContextCompressor(model="gpt-4o-mini", threshold_percent=0.50, quiet_mode=True)
+
+        messages = [{"role": "system", "content": "You are helpful."}]
+        # Add enough messages to trigger compression
+        for i in range(30):
+            messages.append({"role": "user", "content": f"Question {i}"})
+            messages.append({"role": "assistant", "content": f"Answer {i}",
+                             "tool_calls": [{"id": f"call_{i}", "type": "function",
+                                             "function": {"name": "read_file", "arguments": json.dumps({"path": f"file_{i}.py"})}}]})
+            messages.append({"role": "tool", "tool_call_id": f"call_{i}", "content": f"Content of file_{i}.py"})
+
+        # Mock the LLM call to avoid real API calls
+        with patch.object(compressor, '_generate_summary') as mock_summary:
+            mock_summary.return_value = "[CONTEXT COMPACTION] Summary of work done."
+            compressed = compressor.compress(messages, current_tokens=50000)
+
+        # Check that checkpoint text is present somewhere in compressed messages
+        all_content = " ".join(msg.get("content", "") for msg in compressed)
+        has_checkpoint = ("RESUME STATE" in all_content or
+                          "[TASK_CHECKPOINT]" in all_content or
+                          compressor._build_task_checkpoint(messages, messages[1:]).is_empty())
+        assert has_checkpoint, "Checkpoint should be injected or legitimately empty"
+
+    def test_checkpoint_json_parseable(self):
+        """The checkpoint text should be valid JSON after the prefix."""
+        from agent.context_compressor import TaskCheckpoint, TASK_CHECKPOINT_PREFIX
+        cp = TaskCheckpoint(
+            pending_tool_calls=["search_files:query"],
+            recently_modified_files=["src/main.py"],
+            current_plan_step="Fix the bug",
+            last_tool_batch_results=["search:ok"],
+        )
+        text = cp.format_for_injection()
+        if text:
+            assert text.startswith(TASK_CHECKPOINT_PREFIX)
+            json_part = text[len(TASK_CHECKPOINT_PREFIX):].strip()
+            parsed = json.loads(json_part)
+            assert "v" in parsed
+            assert "s" in parsed or "p" in parsed
+
+    def test_checkpoint_does_not_inflate_compressed_size(self):
+        """Compressed messages with checkpoint should not be dramatically larger."""
+        from agent.context_compressor import ContextCompressor
+        compressor = ContextCompressor(model="gpt-4o-mini", threshold_percent=0.50, quiet_mode=True)
+
+        messages = [{"role": "system", "content": "You are helpful."}]
+        for i in range(30):
+            messages.append({"role": "user", "content": f"Question {i}"})
+            messages.append({"role": "assistant", "content": f"Answer {i}"})
+
+        with patch.object(compressor, '_generate_summary') as mock_summary:
+            mock_summary.return_value = "[CONTEXT COMPACTION] Brief summary."
+            compressed = compressor.compress(messages, current_tokens=50000)
+
+        # Checkpoint is capped at 500 chars — shouldn't add more than 1-2% to output
+        total_chars = sum(len(msg.get("content", "")) for msg in compressed)
+        # Even with checkpoint, total should be reasonable
+        assert total_chars < 50000, f"Compressed output too large: {total_chars} chars"
+
+    def test_checkpoint_injected_as_system_message(self):
+        """Checkpoint should be a separate system message, not embedded in summary."""
+        from agent.context_compressor import ContextCompressor
+        compressor = ContextCompressor(model="gpt-4o-mini", threshold_percent=0.50, quiet_mode=True)
+
+        messages = [{"role": "system", "content": "You are helpful."}]
+        for i in range(30):
+            messages.append({"role": "user", "content": f"Question {i}"})
+            messages.append({"role": "assistant", "content": f"Answer {i}",
+                             "tool_calls": [{"id": f"call_{i}", "type": "function",
+                                             "function": {"name": "patch", "arguments": json.dumps({"path": f"file_{i}.py", "old_string": "a", "new_string": "b"})}}]})
+            messages.append({"role": "tool", "tool_call_id": f"call_{i}", "content": json.dumps({"status": "ok"})})
+
+        with patch.object(compressor, '_generate_summary') as mock_summary:
+            mock_summary.return_value = "[CONTEXT COMPACTION] Summary of work."
+            compressed = compressor.compress(messages, current_tokens=50000)
+
+        # Find system messages in compressed output
+        system_msgs = [m for m in compressed if m.get("role") == "system"]
+        resume_msgs = [m for m in system_msgs if "RESUME STATE" in (m.get("content") or "")]
+        # Should have at least one RESUME STATE system message (checkpoint)
+        # OR the checkpoint might be legitimately empty if no tool calls survived compression
+        checkpoint = compressor._build_task_checkpoint(messages, messages[1:])
+        if checkpoint and not checkpoint.is_empty():
+            assert len(resume_msgs) >= 1, (
+                f"Checkpoint should be injected as system message with 'RESUME STATE' prefix. "
+                f"System messages found: {len(system_msgs)}, RESUME STATE found: {len(resume_msgs)}"
+            )

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -206,7 +206,7 @@ class TestSearchHandler:
                     file_glob="*.py", limit=10, offset=5, output_mode="count", context=2)
         mock_ops.search.assert_called_once_with(
             pattern="class", path="/src", target="files", file_glob="*.py",
-            limit=10, offset=5, output_mode="count", context=2,
+            limit=10, offset=5, output_mode="count", context=2, preview_lines=0,
         )
 
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -186,6 +186,7 @@ class SearchMatch:
     path: str
     line_number: int
     content: str
+    preview: Optional[str] = None
     mtime: float = 0.0  # Modification time for sorting
 
 
@@ -203,7 +204,12 @@ class SearchResult:
         result = {"total_count": self.total_count}
         if self.matches:
             result["matches"] = [
-                {"path": m.path, "line": m.line_number, "content": m.content}
+                {
+                    "path": m.path,
+                    "line": m.line_number,
+                    "content": m.content,
+                    **({"preview": m.preview} if m.preview else {}),
+                }
                 for m in self.matches
             ]
         if self.files:
@@ -292,7 +298,7 @@ class FileOperations(ABC):
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0, preview_lines: int = 0) -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -822,7 +828,7 @@ class ShellFileOperations(FileOperations):
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0, preview_lines: int = 0) -> SearchResult:
         """
         Search for content or files.
         
@@ -854,7 +860,7 @@ class ShellFileOperations(FileOperations):
             return self._search_files(pattern, path, limit, offset)
         else:
             return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+                                        output_mode, context, preview_lines)
     
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
@@ -939,15 +945,15 @@ class ShellFileOperations(FileOperations):
         )
     
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int, preview_lines: int) -> SearchResult:
         """Search for content inside files (grep-like)."""
         # Try ripgrep first (fast), fallback to grep (slower but works)
         if self._has_command('rg'):
             return self._search_with_rg(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+                                        output_mode, context, preview_lines)
         elif self._has_command('grep'):
             return self._search_with_grep(pattern, path, file_glob, limit, offset,
-                                          output_mode, context)
+                                          output_mode, context, preview_lines)
         else:
             # Neither rg nor grep available (Windows without Git Bash, etc.)
             return SearchResult(
@@ -956,7 +962,7 @@ class ShellFileOperations(FileOperations):
             )
     
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int, preview_lines: int) -> SearchResult:
         """Search using ripgrep."""
         cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
         
@@ -1048,14 +1054,33 @@ class ShellFileOperations(FileOperations):
             
             total = len(matches)
             page = matches[offset:offset + limit]
-            return SearchResult(
+            result = SearchResult(
                 matches=page,
                 total_count=total,
                 truncated=total > offset + limit
             )
+            return self._attach_match_previews(result, preview_lines)
+
+    def _attach_match_previews(self, result: SearchResult, preview_lines: int) -> SearchResult:
+        preview_lines = max(0, min(20, int(preview_lines or 0)))
+        if preview_lines <= 0 or not result.matches:
+            return result
+
+        cache: dict[tuple[str, int, int], str] = {}
+        for match in result.matches:
+            start = max(1, match.line_number - preview_lines)
+            size = preview_lines * 2 + 1
+            key = (match.path, start, size)
+            preview = cache.get(key)
+            if preview is None:
+                preview = self.read_file(match.path, offset=start, limit=size).content
+                cache[key] = preview
+            match.preview = preview
+        return result
+
     
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
-                          limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                          limit: int, offset: int, output_mode: str, context: int, preview_lines: int) -> SearchResult:
         """Fallback search using grep."""
         cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
         
@@ -1145,8 +1170,11 @@ class ShellFileOperations(FileOperations):
             
             total = len(matches)
             page = matches[offset:offset + limit]
-            return SearchResult(
+            result = SearchResult(
                 matches=page,
                 total_count=total,
                 truncated=total > offset + limit
             )
+            return self._attach_match_previews(result, preview_lines)
+
+

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -361,6 +361,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
+        if offset == 1 and not result_dict.get("error") and result.content:
+            related = _discover_related_paths(path, result.content)
+            if related:
+                result_dict["_related_paths"] = related
+                logger.debug("read_file _related_paths: %s -> %d hints", path, len(related))
+
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
         # the best proxy we have.  If the read produced an unreasonable
@@ -444,9 +450,174 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        # ── Related file hints ──────────────────────────────────────
+        # Lightweight deterministic hints: imports, test companions, __init__.
+        # Only injected for first reads (offset==1), text content, no error.
+        if offset == 1 and not result_dict.get("error") and result.content:
+            related = _discover_related_paths(path, result.content)
+            if related:
+                result_dict["_related_paths"] = related
+                logger.debug("read_file _related_paths: %s -> %d hints", path, len(related))
+
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
+
+
+def _discover_related_paths(path: str, content: str | None) -> list[dict]:
+    """Return lightweight related-file hints for a read_file result.
+
+    Deterministic only — no learning, no preview injection.
+    Detects: imports, test companions, package/config neighbors, and docs links.
+    Each entry: {"path": str, "reason": str}. Only existing files.
+    """
+    import re as _re
+    from pathlib import PurePosixPath
+
+    resolved = Path(path).expanduser().resolve()
+    cwd = Path.cwd()
+    try:
+        rel_str = str(resolved.relative_to(cwd))
+    except ValueError:
+        rel_str = str(resolved)
+
+    pp = PurePosixPath(rel_str)
+    if pp.is_absolute():
+        return []
+
+    results: list[dict] = []
+    seen: set[str] = set()
+
+    def _add(candidate: str, reason: str):
+        if candidate not in seen and candidate != rel_str and (cwd / candidate).exists():
+            seen.add(candidate)
+            results.append({"path": candidate, "reason": reason})
+
+    def _strip_line_numbers(text: str) -> str:
+        raw_lines = []
+        for line in text.splitlines():
+            pipe = line.find("|")
+            if pipe >= 0 and line[:pipe].strip().isdigit():
+                raw_lines.append(line[pipe + 1:])
+            else:
+                raw_lines.append(line)
+        return "\n".join(raw_lines)
+
+    def _split_dir_with_dots(module: str) -> PurePosixPath:
+        return PurePosixPath(*[part for part in module.split("/") if part])
+
+    raw_content = _strip_line_numbers(content) if content else ""
+    suffix = pp.suffix.lower()
+    name = pp.name
+
+    if raw_content:
+        if suffix == ".py":
+            for m in _re.finditer(r'^\s*(?:from|import)\s+(\S+)', raw_content, _re.MULTILINE):
+                mod = m.group(1).split(",")[0].strip().split(" as ")[0].strip()
+                if not mod:
+                    continue
+                if mod.startswith('.'):
+                    leading = len(mod) - len(mod.lstrip('.'))
+                    remainder = mod[leading:]
+                    base = pp.parent
+                    for _ in range(max(leading - 1, 0)):
+                        base = base.parent
+                    if remainder:
+                        dotted = base.joinpath(*remainder.split('.'))
+                        _add(dotted.with_suffix('.py').as_posix(), f"local import ({mod})")
+                        _add((dotted / '__init__.py').as_posix(), f"local import ({mod})")
+                    else:
+                        _add((base / '__init__.py').as_posix(), f"local import ({mod})")
+                else:
+                    parts = mod.split('.')
+                    candidate_path = PurePosixPath(*parts)
+                    _add(candidate_path.with_suffix('.py').as_posix(), f"import ({mod})")
+                    _add((candidate_path / '__init__.py').as_posix(), f"import ({mod})")
+
+        elif suffix in {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}:
+            import_patterns = [
+                r'\bimport\s+(?:[^;]*?\s+from\s+)?["\'](.+?)["\']',
+                r'\brequire\(\s*["\'](.+?)["\']\s*\)',
+                r'\bexport\s+\*\s+from\s+["\'](.+?)["\']',
+            ]
+            for pattern in import_patterns:
+                for m in _re.finditer(pattern, raw_content, _re.MULTILINE):
+                    mod = m.group(1)
+                    if mod.startswith('.'):
+                        base = pp.parent / _split_dir_with_dots(mod)
+                        for ext in [".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"]:
+                            _add(base.with_suffix(ext).as_posix(), f"local import ({mod})")
+                        _add((base / 'index.js').as_posix(), f"local import ({mod})")
+            if name not in {"index.js", "index.ts", "index.jsx", "index.tsx"}:
+                stem = pp.stem
+                parent = pp.parent
+                for pattern in [f'{stem}.test{suffix}', f'{stem}.spec{suffix}']:
+                    _add((parent / pattern).as_posix(), f'test companion ({pattern})')
+                    _add(f'tests/{pattern}', f'test companion (tests/{pattern})')
+                _add((parent / '__tests__' / f'{stem}{suffix}').as_posix(), f'test companion (__tests__/{stem}{suffix})')
+
+        elif suffix == ".go":
+            for block in _re.finditer(r'^\s*import\s*\((.*?)\)', raw_content, _re.MULTILINE | _re.DOTALL):
+                for m in _re.finditer(r'["\`]([^"\`]+)["\`]', block.group(1)):
+                    mod = m.group(1)
+                    if mod.startswith('.') or mod.startswith('/'):
+                        base = pp.parent / _split_dir_with_dots(mod)
+                        _add(base.with_suffix('.go').as_posix(), f"local import ({mod})")
+                        _add((base / 'index.go').as_posix(), f"local import ({mod})")
+            if name.endswith('_test.go'):
+                pass
+
+        elif suffix == ".rs":
+            for m in _re.finditer(r'^\s*(?:use|mod)\s+([A-Za-z0-9_:]+)', raw_content, _re.MULTILINE):
+                mod = m.group(1).rstrip(';')
+                if '::' in mod or m.group(0).lstrip().startswith('mod '):
+                    base = pp.parent / PurePosixPath(*mod.split('::'))
+                    _add(base.with_suffix('.rs').as_posix(), f"rust module ({mod})")
+                    _add((base / 'mod.rs').as_posix(), f"rust module ({mod})")
+
+        elif suffix in {".sh", ".bash"}:
+            for m in _re.finditer(r'(?m)^\s*(?:source|\.)\s+([\w./-]+\.(?:sh|bash))', raw_content):
+                mod = m.group(1)
+                if mod.startswith('.'):
+                    _add((pp.parent / mod).as_posix(), f"shell include ({mod})")
+
+        elif suffix in {".yaml", ".yml", ".toml", ".json"}:
+            for ext in [".example", ".sample", ".template"]:
+                _add((pp.with_suffix(pp.suffix + ext)).as_posix(), f"config companion ({ext})")
+                _add((pp.parent / (pp.name + ext)).as_posix(), f"config companion ({ext})")
+            if name == 'package.json':
+                for candidate in ['src', 'lib', 'tests', 'test', '__tests__']:
+                    _add((pp.parent / candidate).as_posix(), f"package.json companion ({candidate})")
+
+        elif suffix == ".md":
+            for m in _re.finditer(r'\[[^\]]*\]\((\./[^)]+)\)', raw_content):
+                mod = m.group(1)
+                _add((pp.parent / mod).as_posix(), f"markdown link ({mod})")
+
+    if suffix == '.py' and pp.name != '__init__.py':
+        stem = pp.stem
+        parent = pp.parent
+        for pattern in [f'test_{stem}.py', f'{stem}_test.py']:
+            _add((parent / pattern).as_posix(), f'test companion ({pattern})')
+            _add(f'tests/{pattern}', f'test companion (tests/{pattern})')
+            _add(f'tests/{parent}/{pattern}', f'test companion (tests/{parent}/{pattern})')
+        _add((pp.parent / '__init__.py').as_posix(), 'package initializer')
+
+    # Generic companions for config files and other assets.
+    if suffix in {".yaml", ".yml", ".toml", ".json"}:
+        stem = pp.stem
+        for ext in [".example", ".sample", ".template"]:
+            _add((pp.parent / (pp.name + ext)).as_posix(), f"config companion ({ext})")
+            _add((pp.parent / (stem + ext)).as_posix(), f"config companion ({ext})")
+    if suffix == '.go' and name != '_test.go':
+        _add((pp.parent / f'{pp.stem}_test.go').as_posix(), 'test companion (*_test.go)')
+    if suffix == '.rs':
+        _add((pp.parent / 'tests' / f'{pp.stem}.rs').as_posix(), 'test companion (tests/*.rs)')
+    if suffix in {".sh", ".bash"}:
+        for candidate in [f'{pp.stem}.sh', f'{pp.stem}.bash']:
+            _add((pp.parent / candidate).as_posix(), f'shell companion ({candidate})')
+
+    return results[:5]
 
 
 def get_read_files_summary(task_id: str = "default") -> list:
@@ -654,7 +825,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                preview_lines: int = 0, task_id: str = "default") -> str:
     """Search for content or files."""
     try:
         # Track searches to detect *consecutive* repeated search loops.
@@ -668,6 +839,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             file_glob or "",
             limit,
             offset,
+            preview_lines,
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -694,13 +866,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            limit=limit, offset=offset, output_mode=output_mode, context=context,
+            preview_lines=preview_lines
         )
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content)
+                if hasattr(m, 'preview') and m.preview:
+                    m.preview = redact_sensitive_text(m.preview)
         result_dict = result.to_dict()
+
+        if preview_lines > 0 and hasattr(result, 'matches'):
+            previews_attached = sum(1 for m in result.matches if getattr(m, 'preview', None))
+            logger.debug("search_files preview_lines=%d: %d/%d previews attached",
+                         preview_lines, previews_attached, len(result.matches))
 
         if count >= 3:
             result_dict["_warning"] = (
@@ -795,7 +975,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "preview_lines": {"type": "integer", "description": "Number of context lines to preview around each content match (default: 0 = disabled). Set to 2 for a compact snippet (5 lines) that often eliminates the need for a follow-up read_file call.", "default": 0, "minimum": 0}
         },
         "required": ["pattern"]
     }
@@ -828,7 +1009,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        preview_lines=args.get("preview_lines", 0), task_id=tid)
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=float('inf'))


### PR DESCRIPTION
## Summary

Three complementary improvements that reduce tool-call round trips and preserve state during context compression:

### 1. Enhanced `search_files` with `preview_lines` (opt-in)

Optional `preview_lines` parameter inlines a numbered snippet around each content match, collapsing the common `search_files` → `read_file` round trip.

- Data: 60.5% of content searches immediately followed by read_file (26,309 real tool calls)
- Preview is redacted for secrets, capped at 20 context lines
- **Default=0** — zero cost when not used, agent activates explicitly when useful
- Backward-compatible

### 2. `read_file` path-only hints (`_related_paths`) — multi-language

When reading a file, the result now includes `_related_paths` with up to 5 related files and reasons. Supports 8 languages:

- **Python**: imports (relative + absolute), test companions (`test_*.py`), `__init__.py`
- **JavaScript/TypeScript**: `import`/`require()`/`export`, test companions (`*.test.js`, `*.spec.ts`)
- **Go**: import blocks, `_test.go` companions
- **Rust**: `use`/`mod`, `tests/*.rs` companions
- **Shell**: `source`/`.` includes
- **Markdown**: relative file links `[text](./file.md)`
- **YAML/TOML/JSON**: config companions (`.example`, `.sample`, package.json directory hints)

Deterministic, no learning, filesystem-verified, only existing files.

### 3. Structured TaskCheckpoint in context compression

Compact JSON checkpoint (<500 chars) injected as a **separate system message** with `RESUME STATE` prefix during context compression. Preserves:
- Pending tool calls
- Recently modified files
- Current plan step
- Last tool batch results

System message injection increases model adherence vs embedded text.

## Test Plan

```
172 passed (141 regression + 31 adversarial new tests)
```

- `tests/tools/test_file_tools.py` — 24 passed
- `tests/tools/test_file_tools_live.py` — 51 passed
- `tests/agent/test_context_compressor.py` — 39 passed
- `tests/run_agent/test_compression_boundary.py` — 6 passed
- `tests/run_agent/test_compression_feasibility.py` — 15 passed
- `tests/run_agent/test_compression_persistence.py` — 6 passed
- `tests/test_context_enrichment_adversarial.py` — **31 passed** (new)
  - `TestSearchPreviewLines` — 10 tests (preview opt-in, secret redaction, edge cases, caching)
  - `TestRelatedPaths` — 9 tests (imports, companions, init, self-reference, cap)
  - `TestRelatedPathsMultiLanguage` — 4 tests (JS/TS, Go, Rust, shell/markdown/config)
  - `TestTaskCheckpointAdversarial` — 8 tests (pending calls, modified files, max chars, system message injection, JSON parseable)