### PR TITLE
feat(xai): add xAI/Grok provider metadata

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -104,6 +104,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "xai": "grok-4-1-fast-non-reasoning",
 }
 
 # Vision-specific model overrides for direct providers.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -36,6 +36,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
     "mimo", "xiaomi-mimo",
     "arcee-ai", "arceeai",
+    "xai", "x-ai", "x.ai", "grok",
     "qwen-portal",
 })
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -111,6 +111,11 @@ _DEFAULT_PROVIDER_MODELS = {
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",
         "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.5",
     ],
+    "xai": [
+        "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning",
+        "grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning",
+        "grok-code-fast-1",
+    ],
 }
 
 


### PR DESCRIPTION
## Summary

Registers xAI as a first-class provider in Hermes so that `hermes setup`, model selection, and auxiliary client resolution all recognize Grok models natively.

## Changes

- **`agent/model_metadata.py`** — Add `xai`, `x-ai`, `x.ai`, `grok` to `_PROVIDER_PREFIXES` so prefix-stripping works correctly for context length lookups
- **`agent/auxiliary_client.py`** — Map `xai` provider to `grok-4-1-fast-non-reasoning` for auxiliary calls (summarization, vision fallback)
- **`hermes_cli/setup.py`** — Add default xAI model list (grok-4.20 reasoning/non-reasoning, grok-4-1-fast, grok-code-fast-1)

## Testing

- Verified `strip_provider_prefix("xai/grok-4.20-0309-reasoning")` → `"grok-4.20-0309-reasoning"`
- Verified xAI models appear in `hermes setup` model selection

3 files changed, 7 insertions