### PR TITLE
feat(xai): add Grok execution guidance for anti-narration

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -275,6 +275,51 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "Don't stop with a plan — execute it.\n"
 )
 
+# xAI Grok-specific execution discipline.  Injected alongside
+# TOOL_USE_ENFORCEMENT_GUIDANCE when the model name contains "grok".
+#
+# Addresses a failure mode specific to Grok's reasoning architecture: because
+# reasoning is internal and the final response is a separate pass, Grok tends
+# to output intent phrases ("I will check X", "Let me verify Y") describing
+# planned actions without actually calling the corresponding tools.
+GROK_EXECUTION_GUIDANCE = """# Execution discipline (Grok-specific)
+<no_intent_phrases>
+NEVER write phrases that describe an action you are about to take:
+- 'I will check / fetch / run / install / fix / look / investigate...'
+- 'Let me first / next / now...'
+- 'I am going to / I am about to / I am now...'
+
+If you need to take an action, call the tool NOW in this turn. Do NOT
+announce the action in text. Do NOT narrate your plan before executing.
+The user cannot execute on your behalf. Only tool calls make things happen.
+</no_intent_phrases>
+
+<execute_first>
+For any request implying work (audit, debug, check, investigate, fix,
+install, ssh, read_file, grep, count, analyse, etc.):
+1. Your FIRST response MUST contain a tool call if information is needed.
+2. Only produce text when you have a concrete result to report or a
+   blocking question to ask that the tools cannot answer.
+3. 'I am going to verify X' without calling the verify tool is a failure.
+   Call the tool first, narrate the result after.
+4. Chain multiple tool calls in the same turn without intermediate prose.
+   Only speak when there is something concrete to show.
+</execute_first>
+
+<no_analysis_hallucination>
+Do NOT produce analyses, diagnoses, lists of 'possible causes', or
+structured recommendations from pure reasoning. If you have not called
+a tool to gather evidence, you cannot have a grounded analysis to report.
+Internal reasoning is not grounding.
+
+When asked 'why does X fail' or 'what's wrong with Y':
+- Your FIRST response must be a tool call that inspects X or Y directly.
+- NOT a structured list of 'possible causes' from memory.
+- NOT a plan of what you 'would check'.
+- An actual tool call that reads, greps, or inspects the target.
+Only after receiving the tool result may you produce an analysis.
+</no_analysis_hallucination>"""
+
 # Model name substrings that should use the 'developer' role instead of
 # 'system' for the system prompt.  OpenAI's newer models (GPT-5, Codex)
 # give stronger instruction-following weight to the 'developer' role.

--- a/run_agent.py
+++ b/run_agent.py
@@ -94,7 +94,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, GROK_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -3193,6 +3193,10 @@ class AIAgent:
                 # prerequisite checks, verification, anti-hallucination).
                 if "gpt" in _model_lower or "codex" in _model_lower:
                     prompt_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                # xAI Grok execution discipline (anti-narration, execute-first,
+                # no-analysis-hallucination).
+                if "grok" in _model_lower:
+                    prompt_parts.append(GROK_EXECUTION_GUIDANCE)
 
         # so it can refer the user to them rather than reinventing answers.
 

--- a/tests/agent/test_grok_execution_guidance.py
+++ b/tests/agent/test_grok_execution_guidance.py
@@ -1,0 +1,29 @@
+"""Tests for Grok-specific execution guidance injection."""
+
+import pytest
+from agent.prompt_builder import GROK_EXECUTION_GUIDANCE
+
+
+class TestGrokExecutionGuidance:
+    """Verify GROK_EXECUTION_GUIDANCE constant structure and content."""
+
+    def test_is_nonempty_string(self):
+        assert isinstance(GROK_EXECUTION_GUIDANCE, str)
+        assert len(GROK_EXECUTION_GUIDANCE) > 100
+
+    def test_contains_no_intent_phrases_block(self):
+        assert "<no_intent_phrases>" in GROK_EXECUTION_GUIDANCE
+        assert "</no_intent_phrases>" in GROK_EXECUTION_GUIDANCE
+
+    def test_contains_execute_first_block(self):
+        assert "<execute_first>" in GROK_EXECUTION_GUIDANCE
+        assert "</execute_first>" in GROK_EXECUTION_GUIDANCE
+
+    def test_contains_no_analysis_hallucination_block(self):
+        assert "<no_analysis_hallucination>" in GROK_EXECUTION_GUIDANCE
+        assert "</no_analysis_hallucination>" in GROK_EXECUTION_GUIDANCE
+
+    def test_prohibits_intent_phrases(self):
+        text = GROK_EXECUTION_GUIDANCE.lower()
+        assert "i will" in text or "let me" in text  # mentions phrases to avoid
+        assert "tool" in text  # mentions calling tools instead


### PR DESCRIPTION
## Summary

Adds model-specific execution guidance for xAI Grok models, following the same pattern already used for Google (GOOGLE_MODEL_OPERATIONAL_GUIDANCE) and OpenAI (OPENAI_MODEL_EXECUTION_GUIDANCE).

## Problem

Grok models exhibit a specific failure mode in agentic contexts: because reasoning is internal and the final response is a separate pass, Grok tends to output intent phrases ("I will check X", "Let me verify Y") describing planned actions **without actually calling the corresponding tools**. This leads to the agent narrating a plan instead of executing it.

## Solution

Three structured XML guidance blocks injected when the model name contains `grok`:

- **`<no_intent_phrases>`** — Prohibits announcing actions without calling tools
- **`<execute_first>`** — Requires tool calls before any text output when work is implied
- **`<no_analysis_hallucination>`** — Prevents producing analyses from pure reasoning without tool-gathered evidence

## Changes

- **`agent/prompt_builder.py`** — New `GROK_EXECUTION_GUIDANCE` constant (+45 lines)
- **`run_agent.py`** — Inject guidance when `"grok" in model_name.lower()`, matching existing Google/OpenAI pattern

## Testing

- Tested with grok-4.20-0309-reasoning in production for multi-day dogfooding
- Confirmed elimination of narration-without-execution pattern
- No regressions on other providers (guidance only injected for Grok models)

2 files changed, 50 insertions, 1 deletion