### PR TITLE
feat(xai): add xAI TTS backend with Grok voices

### DIFF
--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -1,6 +1,7 @@
 """Tests for the Mistral (Voxtral) TTS provider in tools/tts_tool.py."""
 
 import base64
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -216,7 +217,8 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
-             patch("tools.tts_tool._check_neutts_available", return_value=False):
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch.dict(os.environ, {"MINIMAX_API_KEY": "", "XAI_API_KEY": ""}, clear=False):
             assert check_tts_requirements() is False
 
 

--- a/tests/tools/test_tts_xai.py
+++ b/tests/tools/test_tts_xai.py
@@ -1,0 +1,126 @@
+"""Tests for the xAI TTS provider in tools/tts_tool.py."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+
+
+class TestGenerateXaiTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_xai_tts
+
+        output_path = str(tmp_path / "test.mp3")
+        with pytest.raises(ValueError, match="XAI_API_KEY"):
+            _generate_xai_tts("Hello", output_path, {})
+
+    def test_successful_mp3_generation(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        fake_audio = b"fake-mp3-audio-data"
+        mock_response = MagicMock()
+        mock_response.content = fake_audio
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / "test.mp3")
+            result = _generate_xai_tts("Hello world", output_path, {})
+
+        assert result == output_path
+        assert (tmp_path / "test.mp3").read_bytes() == fake_audio
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"]
+        assert payload["text"] == "Hello world"
+        assert payload["voice_id"] == "sal"  # default voice
+        assert payload["codec"] == "mp3"
+
+    def test_wav_codec_selection(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.content = b"fake-wav"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / "test.wav")
+            _generate_xai_tts("Hello", output_path, {})
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["codec"] == "wav"
+
+    def test_ogg_generates_mp3_then_converts(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.content = b"fake-mp3-for-opus"
+        mock_response.raise_for_status = MagicMock()
+
+        opus_path = str(tmp_path / "test.ogg")
+
+        with patch("requests.post", return_value=mock_response), \
+             patch("tools.tts_tool._convert_to_opus", return_value=opus_path) as mock_convert:
+            result = _generate_xai_tts("Hello", str(tmp_path / "test.ogg"), {})
+
+        # Should have called convert_to_opus with the intermediate mp3
+        mock_convert.assert_called_once()
+        mp3_arg = mock_convert.call_args[0][0]
+        assert mp3_arg.endswith(".mp3")
+
+    def test_custom_voice_from_config(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.content = b"audio"
+        mock_response.raise_for_status = MagicMock()
+
+        config = {"xai": {"voice": "eve", "language": "fr"}}
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            _generate_xai_tts("Bonjour", str(tmp_path / "out.mp3"), config)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voice_id"] == "eve"
+        assert payload["language"] == "fr"
+
+    def test_text_truncation_at_15k(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts, XAI_MAX_TEXT_LENGTH
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.content = b"audio"
+        mock_response.raise_for_status = MagicMock()
+
+        long_text = "x" * 20000
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            _generate_xai_tts(long_text, str(tmp_path / "out.mp3"), {})
+
+        payload = mock_post.call_args[1]["json"]
+        assert len(payload["text"]) == XAI_MAX_TEXT_LENGTH
+
+    def test_empty_audio_raises_runtime_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_xai_tts
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.content = b""
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            with pytest.raises(RuntimeError, match="empty audio"):
+                _generate_xai_tts("Hello", str(tmp_path / "out.mp3"), {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -100,6 +100,7 @@ def _get_default_output_dir() -> str:
 
 DEFAULT_OUTPUT_DIR = _get_default_output_dir()
 MAX_TEXT_LENGTH = 4000
+XAI_MAX_TEXT_LENGTH = 15000  # xAI API hard limit per request
 
 
 # ===========================================================================
@@ -455,6 +456,14 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     base_url = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
     if not api_key:
         raise ValueError("XAI_API_KEY not set. Get one at https://console.x.ai/")
+
+    # Enforce xAI 15k character limit.
+    if len(text) > XAI_MAX_TEXT_LENGTH:
+        logger.warning(
+            "xAI TTS text too long (%d chars), truncating to %d",
+            len(text), XAI_MAX_TEXT_LENGTH,
+        )
+        text = text[:XAI_MAX_TEXT_LENGTH]
 
     xai_config = tts_config.get("xai", {})
     voice = xai_config.get("voice", DEFAULT_XAI_TTS_VOICE)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -8,6 +8,7 @@ Supports six TTS providers:
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
+- xAI TTS: 6 multilingual Grok voices (ara/eve/leo/rex/sal/una), needs XAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
 
 Output formats:
@@ -91,6 +92,7 @@ DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
+DEFAULT_XAI_TTS_VOICE = "sal"  # Sal - multilingual
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -434,6 +436,84 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
 
 # ===========================================================================
+# Provider: xAI TTS (Grok voices)
+# ===========================================================================
+def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using xAI's TTS API.
+
+    xAI TTS supports 6 multilingual voices: ara, eve, leo, rex, sal, una.
+    Max 15,000 characters per request.  Supported codecs: mp3, wav, pcm,
+    mulaw, alaw.  Pricing: $4.20 per 1M characters.
+    Speech tags: [pause], [laugh], [whisper], etc.
+
+    Docs: https://docs.x.ai/developers/model-capabilities/voice/tts
+    """
+    import requests
+
+    # Resolve credentials.
+    api_key = os.getenv("XAI_API_KEY", "")
+    base_url = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
+    if not api_key:
+        raise ValueError("XAI_API_KEY not set. Get one at https://console.x.ai/")
+
+    xai_config = tts_config.get("xai", {})
+    voice = xai_config.get("voice", DEFAULT_XAI_TTS_VOICE)
+    language = xai_config.get("language", "auto")
+
+    # Determine codec from output extension.
+    if output_path.endswith(".wav"):
+        codec = "wav"
+    elif output_path.endswith(".ogg"):
+        # xAI doesn't support Opus natively — generate mp3, convert later.
+        codec = "mp3"
+    else:
+        codec = "mp3"
+
+    payload = {
+        "text": text,
+        "voice_id": voice,
+        "language": language,
+        "codec": codec,
+    }
+    # Optional sample_rate override.
+    sample_rate = xai_config.get("sample_rate")
+    if sample_rate:
+        payload["sample_rate"] = int(sample_rate)
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    response = requests.post(
+        f"{base_url}/tts", json=payload, headers=headers, timeout=60,
+    )
+    response.raise_for_status()
+
+    # xAI returns raw audio bytes in the response body.
+    audio_data = response.content
+    if not audio_data:
+        raise RuntimeError("xAI TTS returned empty audio data")
+
+    # If the caller wants .ogg but we got mp3, write mp3 first then convert.
+    if output_path.endswith(".ogg"):
+        mp3_path = output_path.rsplit(".", 1)[0] + ".mp3"
+        with open(mp3_path, "wb") as f:
+            f.write(audio_data)
+        opus_path = _convert_to_opus(mp3_path)
+        if opus_path:
+            os.remove(mp3_path)
+            return opus_path
+        # Conversion failed — rename mp3 to output_path as fallback.
+        os.rename(mp3_path, output_path)
+    else:
+        with open(output_path, "wb") as f:
+            f.write(audio_data)
+
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -610,6 +690,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with Mistral Voxtral TTS...")
             _generate_mistral_tts(text, file_str, tts_config)
 
+        elif provider == "xai":
+            logger.info("Generating speech with xAI TTS...")
+            _generate_xai_tts(text, file_str, tts_config)
+
         elif provider == "neutts":
             if not _check_neutts_available():
                 return json.dumps({
@@ -659,7 +743,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -731,6 +815,8 @@ def check_tts_requirements() -> bool:
     except ImportError:
         pass
     if os.getenv("MINIMAX_API_KEY"):
+        return True
+    if os.getenv("XAI_API_KEY"):
         return True
     try:
         _import_mistral_client()


### PR DESCRIPTION
## Summary

Adds xAI as a TTS provider in the existing `text_to_speech` tool, alongside Edge, ElevenLabs, OpenAI, MiniMax, Mistral, and NeuTTS.

## Features

- **6 multilingual Grok voices**: ara, eve, leo, rex, sal (default), una
- **Automatic language detection** (or explicit language parameter)
- **Speech tags support**: `[pause]`, `[laugh]`, `[whisper]`, etc.
- **Automatic Opus conversion** for Telegram voice bubble compatibility
- **Configurable via `config.yaml`**: voice, language, sample_rate under `tts.xai`

## Pricing

$4.20 per 1M characters. Max 15,000 characters per request.

## Implementation

- Uses xAI's `POST /v1/tts` endpoint directly via `requests` (no SDK — xAI TTS is not part of the OpenAI-compatible API surface)
- Generates mp3, then converts to Opus for Telegram when needed (xAI doesn't support Opus natively)
- Follows the same provider pattern as existing TTS backends (credential resolution, config structure, error handling)
- Added to Opus conversion list for Telegram compatibility

## Changes

- **`tools/tts_tool.py`** — New `_generate_xai_tts()` function, provider routing, availability check (+101 lines)
- **`tests/tools/test_tts_mistral.py`** — Fix `check_tts_requirements()` test to mock `XAI_API_KEY` (otherwise the test fails when run in an environment where the key is set)

## Testing

- Tested against live xAI API with French and English text
- Verified Opus conversion and native Telegram voice bubble delivery
- Verified all 6 voices produce output
- Existing TTS tests pass (`test_tts_mistral.py`: 17/17)

2 files changed, 103 insertions, 2 deletions