### PR TITLE
fix(auxiliary): omit temperature for auto-routed kimi calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2148,7 +2148,17 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
-    if temperature is not None:
+    normalized_base_url = str(base_url or "").strip().lower()
+    normalized_provider = _normalize_aux_provider(provider)
+    # Kimi only accepts temperature=1 on these auxiliary models. Omit the
+    # parameter so the API uses its default when auto mode resolves to Kimi.
+    omit_temperature = (
+        normalized_provider == "kimi-coding"
+        or "api.moonshot.ai" in normalized_base_url
+        or "api.kimi.com" in normalized_base_url
+    )
+
+    if temperature is not None and not omit_temperature:
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
@@ -2320,7 +2330,7 @@ def call_llm(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=str(getattr(client, "base_url", resolved_base_url) or resolved_base_url or ""))
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")
@@ -2374,7 +2384,8 @@ def call_llm(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
-                    extra_body=extra_body)
+                    extra_body=extra_body,
+                    base_url=str(getattr(fb_client, "base_url", "") or ""))
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
         raise
@@ -2513,7 +2524,7 @@ async def async_call_llm(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=str(getattr(client, "base_url", resolved_base_url) or resolved_base_url or ""))
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")
@@ -2552,7 +2563,8 @@ async def async_call_llm(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, timeout=effective_timeout,
-                    extra_body=extra_body)
+                    extra_body=extra_body,
+                    base_url=str(getattr(fb_client, "base_url", "") or ""))
                 # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(fb_client, fb_model or "")
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1193,6 +1193,85 @@ class TestCallLlmPaymentFallback:
                 )
 
 
+class TestKimiTemperatureOmission:
+    """Kimi-backed auxiliary calls must not forward non-default temperature."""
+
+    def test_auto_kimi_omits_temperature_for_sync_calls(self):
+        client = MagicMock()
+        client.base_url = "https://api.moonshot.ai/v1"
+
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "kimi-k2.5"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "kimi-k2.5", None, None, None),
+        ):
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0.1,
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "kimi-k2.5"
+        assert "temperature" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_auto_kimi_omits_temperature_for_async_calls(self):
+        client = MagicMock()
+        client.base_url = "https://api.moonshot.ai/v1"
+
+        response = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=response)
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "kimi-k2.5"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "kimi-k2.5", None, None, None),
+        ):
+            result = await async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0.1,
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "kimi-k2.5"
+        assert "temperature" not in kwargs
+
+    def test_non_kimi_providers_still_forward_temperature(self):
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "google/gemini-3-flash-preview"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "google/gemini-3-flash-preview", None, None, None),
+        ):
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0.1,
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.1
+
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #9125.

When auxiliary tasks are configured as `provider: auto` and the resolved backend is Kimi/Moonshot, Hermes was still forwarding `temperature=0.1`. Kimi auxiliary models only accept the default temperature, so those calls failed with `400 invalid temperature` and broke session summarization / vision-side auxiliary flows.

## Root cause

`call_llm()` / `async_call_llm()` passed the configured provider label into `_build_call_kwargs()`. For non-vision auto mode that label stays `auto`, even when the cached client is actually a Kimi endpoint, so a provider-only check is not sufficient.

## Changes

- Omit `temperature` when auxiliary requests target Kimi endpoints (`api.moonshot.ai` / `api.kimi.com`) or the normalized provider is `kimi-coding`
- Pass the concrete client `base_url` into `_build_call_kwargs()` for both primary and fallback sync/async paths so auto-resolved Kimi clients are detected correctly
- Add regression tests covering sync and async auto→Kimi routing, plus a non-Kimi control that still forwards temperature

## Validation

- `source venv/bin/activate && python -m pytest tests/agent/test_auxiliary_client.py -q -k 'KimiTemperatureOmission or CallLlmPaymentFallback or AsyncCallLlmFallback'` — 11 passed
- `source venv/bin/activate && python -m pytest tests/tools/test_session_search.py -q` — 28 passed
- `source venv/bin/activate && python -m pytest tests/test_model_tools_async_bridge.py -q` — 10 passed
- `source venv/bin/activate && python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` — passed
- `git diff --check` — passed
- `source /Users/magic/.config/superpowers/worktrees/hermes-agent/triage-main/venv/bin/activate && python -m pytest tests/agent/test_auxiliary_client.py -q` — 7 unrelated failures reproduced on fresh `origin/main` worktree at `b909a9ef` (`TestReadCodexAccessToken`, `TestGetTextAuxiliaryClient`, `TestExpiredCodexFallback`, `TestAuxiliaryPoolAwareness`), so they are pre-existing baseline and not introduced by this change

## Platform

Issue was reported on Ubuntu 24.04 / Python 3.11.15. Local validation here was on macOS / Python 3.11.15. The fix is in provider request construction only, so it is OS-agnostic.
