### PR TITLE
fix: show custom provider models in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -988,18 +988,32 @@ def list_authenticated_providers(
             if slug in seen_slugs:
                 continue
 
-            models_list = []
+            models_list: list[str] = []
+            seen_models: set[str] = set()
+
             default_model = (entry.get("model") or "").strip()
             if default_model:
                 models_list.append(default_model)
+                seen_models.add(default_model)
+
+            configured_models = entry.get("models")
+            if isinstance(configured_models, dict):
+                for model_id in configured_models.keys():
+                    normalized_model = str(model_id or "").strip()
+                    if not normalized_model or normalized_model in seen_models:
+                        continue
+                    models_list.append(normalized_model)
+                    seen_models.add(normalized_model)
+
+            total_models = len(models_list)
 
             results.append({
                 "slug": slug,
                 "name": display_name,
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list),
+                "models": models_list[:max_models],
+                "total_models": total_models,
                 "source": "user-config",
                 "api_url": api_url,
             })

--- a/tests/hermes_cli/test_custom_provider_model_picker.py
+++ b/tests/hermes_cli/test_custom_provider_model_picker.py
@@ -1,0 +1,82 @@
+"""Regression tests for named custom providers in /model picker.
+
+Root cause: list_authenticated_providers() only surfaced the singular
+custom_providers[].model field and ignored the optional custom_providers[].models
+mapping, so gateway /model menus showed only one model even when the config
+explicitly declared multiple models.
+"""
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_custom_provider_picker_merges_default_model_and_models_map():
+    """Custom provider entries should surface all configured models in picker data."""
+    providers = list_authenticated_providers(
+        current_provider="custom:local-(127.0.0.1:8317)",
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8317)",
+                "base_url": "http://127.0.0.1:8317/v1",
+                "model": "gpt-5.4",
+                "models": {
+                    "gpt-5.4": {},
+                    "gpt-5.3-codex": {},
+                },
+            }
+        ],
+        max_models=10,
+    )
+
+    local = next((p for p in providers if p["name"] == "Local (127.0.0.1:8317)"), None)
+    assert local is not None
+    assert local["models"] == ["gpt-5.4", "gpt-5.3-codex"]
+    assert local["total_models"] == 2
+    assert local["is_current"] is True
+
+
+def test_custom_provider_picker_avoids_duplicate_default_model_when_also_in_models_map():
+    """Default custom provider model should not be duplicated when already in models map."""
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8317)",
+                "base_url": "http://127.0.0.1:8317/v1",
+                "model": "gpt-5.4",
+                "models": {
+                    "gpt-5.4": {},
+                    "gpt-5.3-codex": {},
+                    "gpt-5.4-mini": {},
+                },
+            }
+        ],
+        max_models=2,
+    )
+
+    local = next((p for p in providers if p["name"] == "Local (127.0.0.1:8317)"), None)
+    assert local is not None
+    assert local["models"] == ["gpt-5.4", "gpt-5.3-codex"]
+    assert local["total_models"] == 3
+
+
+def test_custom_provider_picker_supports_models_map_without_default_model():
+    """Named custom providers should still expose configured models when only models map is present."""
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:8317)",
+                "base_url": "http://127.0.0.1:8317/v1",
+                "models": {
+                    "gpt-5.3-codex": {},
+                    "gpt-5.4": {},
+                },
+            }
+        ],
+        max_models=10,
+    )
+
+    local = next((p for p in providers if p["name"] == "Local (127.0.0.1:8317)"), None)
+    assert local is not None
+    assert local["models"] == ["gpt-5.3-codex", "gpt-5.4"]
+    assert local["total_models"] == 2


### PR DESCRIPTION
## Problem
Named custom providers defined in config.yaml only surfaced the singular custom_providers[].model field in the /model picker. When users declared multiple models under custom_providers[].models, the gateway (Telegram/Discord picker + text list) still showed a single model. The total_models count was also derived from that single entry, so the UI never indicated more models were available.

## Root Cause
list_authenticated_providers() (model_switch.py, Section 4: Saved custom providers) only appended entry["model"] and ignored entry["models"] entirely. total_models was computed from that one-item list.

## Fix
- Merge the default model (entry["model"]) with the keys from entry["models"]
- Deduplicate while preserving order (default model first, then configured models)
- Compute total_models from the full merged list while still truncating the visible list by max_models

## Tests
- pytest tests/hermes_cli/test_custom_provider_model_picker.py -q
- pytest tests/hermes_cli/test_custom_provider_model_picker.py tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_overlay_slug_resolution.py -q
