### PR TITLE
fix(context_compressor): prevent HEAD fossilization and ghost responses after compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -657,6 +657,23 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Align to avoid splitting tool groups
         cut_idx = self._align_boundary_backward(messages, cut_idx)
 
+        # ------------------------------------------------------------------
+        # HOTFIX: Ensure the last user message is always in the TAIL.
+        #
+        # The token-budget walk can land the cut AFTER the last user turn
+        # if tool results are small (few tokens, many fit under budget).
+        # That puts the user's question in MIDDLE → summarized → ghost.
+        # Search from the TRUE end of the message list to find the last
+        # user, then ensure the cut includes it regardless of alignment.
+        # ------------------------------------------------------------------
+        last_user_idx = None
+        for i in range(n - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+        if last_user_idx is not None and cut_idx > last_user_idx:
+            cut_idx = last_user_idx
+
         return max(cut_idx, head_end + 1)
 
     # ------------------------------------------------------------------
@@ -704,7 +721,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             logger.info("Pre-compression: pruned %d old tool result(s)", pruned_count)
 
         # Phase 2: Determine boundaries
-        compress_start = self.protect_first_n
+        # ------------------------------------------------------------------
+        # HOTFIX 2: Only fossilize HEAD when the session starts with a system
+        # message.  The intent of protect_first_n is to preserve the system
+        # prompt + first exchange.  If the session has NO system message it
+        # starts cold with a plain user message; copying that into every child
+        # session after compression causes the model to re-process it on every
+        # compaction cycle ("HEAD fossilization" bug).
+        # Fix: set compress_start = 0 when messages[0] is not a system message.
+        # ------------------------------------------------------------------
+        if messages and messages[0].get("role") == "system":
+            compress_start = self.protect_first_n
+        else:
+            compress_start = 0
         compress_start = self._align_boundary_forward(messages, compress_start)
 
         # Use token-budget tail protection instead of fixed message count

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -597,6 +597,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             idx = check
         return idx
 
+    def _compute_compress_start(self, messages):
+        """Return the first message index eligible for compression (HEAD boundary).
+
+        The HEAD is only meaningful when the session begins with a system
+        prompt.  If the first message is not a system message the session
+        started cold -- there is no privileged opening exchange to protect,
+        so compress_start is 0.  Centralising this logic here prevents the
+        compress() path and any preview paths (e.g. gateway /compress) from
+        drifting independently.
+        """
+        raw = self.protect_first_n if (messages and messages[0].get("role") == "system") else 0
+        return self._align_boundary_forward(messages, raw)
+
     # ------------------------------------------------------------------
     # Tail protection by token budget
     # ------------------------------------------------------------------
@@ -700,8 +713,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 everything else.  Inspired by Claude Code's ``/compact``.
         """
         n_messages = len(messages)
-        # Only need head + 3 tail messages minimum (token budget decides the real tail size)
-        _min_for_compress = self.protect_first_n + 3 + 1
+        # Use the actual effective head size (0 when no system message) so the
+        # minimum-messages guard is not too conservative for cold-start sessions.
+        _effective_head = self.protect_first_n if (messages and messages[0].get("role") == "system") else 0
+        _min_for_compress = _effective_head + 3 + 1
         if n_messages <= _min_for_compress:
             if not self.quiet_mode:
                 logger.warning(
@@ -721,20 +736,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             logger.info("Pre-compression: pruned %d old tool result(s)", pruned_count)
 
         # Phase 2: Determine boundaries
-        # ------------------------------------------------------------------
-        # HOTFIX 2: Only fossilize HEAD when the session starts with a system
-        # message.  The intent of protect_first_n is to preserve the system
-        # prompt + first exchange.  If the session has NO system message it
-        # starts cold with a plain user message; copying that into every child
-        # session after compression causes the model to re-process it on every
-        # compaction cycle ("HEAD fossilization" bug).
-        # Fix: set compress_start = 0 when messages[0] is not a system message.
-        # ------------------------------------------------------------------
-        if messages and messages[0].get("role") == "system":
-            compress_start = self.protect_first_n
-        else:
-            compress_start = 0
-        compress_start = self._align_boundary_forward(messages, compress_start)
+        compress_start = self._compute_compress_start(messages)
 
         # Use token-budget tail protection instead of fixed message count
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5898,8 +5898,7 @@ class GatewayRunner:
             tmp_agent._print_fn = lambda *a, **kw: None
 
             compressor = tmp_agent.context_compressor
-            compress_start = compressor.protect_first_n
-            compress_start = compressor._align_boundary_forward(msgs, compress_start)
+            compress_start = compressor._compute_compress_start(msgs)
             compress_end = compressor._find_tail_cut_by_tokens(msgs, compress_start)
             if compress_start >= compress_end:
                 return "Nothing to compress yet (the transcript is still all protected context)."

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -328,13 +328,14 @@ class TestCompressWithClient:
         mock_client.chat.completions.create.return_value = mock_response
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=2)
 
-        # Last head message (index 1) is "assistant" → summary should be "user".
-        # With min_tail=3, tail = last 3 messages (indices 5-7).
-        # head_last=assistant, tail_first=assistant → summary_role="user", no collision.
-        # Need 8 messages: min_for_compress = 2+3+1 = 6, must have > 6.
+        # System message is required so HEAD protection activates (protect_first_n=3).
+        # HEAD = [system, user, assistant] → last head = "assistant" → summary_role="user".
+        # With min_tail=3, tail = last 3 messages.
+        # Need 9 messages: min_for_compress = 3+3+1 = 7, must have > 7.
         msgs = [
+            {"role": "system", "content": "system prompt"},
             {"role": "user", "content": "msg 0"},
             {"role": "assistant", "content": "msg 1"},
             {"role": "user", "content": "msg 2"},
@@ -508,12 +509,14 @@ class TestCompressWithClient:
         mock_response.choices[0].message.content = "summary text"
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
-            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=2)
 
-        # Head=assistant, Tail=assistant → summary_role="user", no collision.
-        # With min_tail=3, tail = last 3 messages (indices 5-7).
-        # Need 8 messages: min_for_compress = 2+3+1 = 6, must have > 6.
+        # System message is required so HEAD protection activates (protect_first_n=3).
+        # HEAD = [system, user, assistant] → last head = "assistant" → summary_role="user".
+        # With min_tail=3, tail = last 3 messages.
+        # Need 9 messages: min_for_compress = 3+3+1 = 7, must have > 7.
         msgs = [
+            {"role": "system", "content": "system prompt"},
             {"role": "user", "content": "msg 0"},
             {"role": "assistant", "content": "msg 1"},
             {"role": "user", "content": "msg 2"},
@@ -781,3 +784,151 @@ class TestTokenBudgetTailProtection:
         # Tool at index 2 is outside the protected tail (last 3 = indices 2,3,4)
         # so it might or might not be pruned depending on boundary
         assert isinstance(pruned, int)
+
+
+class TestHotfixRegressions:
+    """Regression tests for the two production bugs fixed in PR#9199.
+
+    Bug 1 (Hotfix 1): last user message landing in MIDDLE when the transcript
+    ends with many small tool results, causing ghost responses after compression.
+
+    Bug 2 (Hotfix 2 / HEAD fossilization): a session that starts with a plain
+    user message (no system prompt) fossilizes that message as the HEAD and
+    re-injects it into every child session born from compression.
+    """
+
+    @pytest.fixture()
+    def fresh_compressor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.50,
+                protect_first_n=3,
+                protect_last_n=5,
+                summary_target_ratio=0.20,
+                quiet_mode=True,
+            )
+            return c
+
+    # ------------------------------------------------------------------
+    # Hotfix 1: last user message always in TAIL
+    # ------------------------------------------------------------------
+
+    def test_last_user_msg_stays_in_tail_with_many_small_tool_results(self, fresh_compressor):
+        """When the transcript ends with many small tool results, the token-budget
+        walk must not push the cut past the last user message.
+
+        Regression: before the fix, cut_idx would land at fallback_cut (head_end+3)
+        which was > last_user_idx, leaving the user's question in MIDDLE and causing
+        ghost responses after compression.
+
+        Concrete setup (protect_first_n=3):
+          head_end = 3
+          last_user_idx = 5  (one past the head, followed only by small tool results)
+          fallback_cut = 6   (head_end + min(3, n-head_end))
+          Without HOTFIX: cut=6 > last_user_idx=5 → last user IN MIDDLE (ghost)
+          With    HOTFIX: cut clamped to 5 = last_user_idx → last user in TAIL
+        """
+        c = fresh_compressor  # protect_first_n=3
+        # Large budget so all messages above head_end fit — this triggers the fallback
+        # path where cut_idx is forced to fallback_cut (head_end+3=6), past last_user.
+        c.tail_token_budget = 50_000
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},  # 0 HEAD
+            {"role": "user", "content": "Hello."},                           # 1 HEAD
+            {"role": "assistant", "content": "Hi there."},                   # 2 HEAD
+            # head_end = 3 — protection stops here
+            {"role": "user", "content": "Let's work on the project."},      # 3
+            {"role": "assistant", "content": "Starting now."},               # 4
+            # This is the LAST user message — must end up in TAIL, not MIDDLE.
+            {"role": "user", "content": "What is the build status?"},        # 5 = last_user_idx
+        ]
+        # Append 20 pairs of tiny assistant/tool messages after the last user msg.
+        # Each is ~5 tokens; 40 * 5 = 200 tokens << 50K budget, so the backward
+        # walk never hits the budget ceiling and cut_idx lands at head_end.
+        for i in range(20):
+            msgs.append({
+                "role": "assistant", "content": None,
+                "tool_calls": [{"id": f"c{i}", "type": "function",
+                                 "function": {"name": "check", "arguments": "{}"}}],
+            })
+            msgs.append({"role": "tool", "tool_call_id": f"c{i}", "content": f"ok {i}"})
+
+        head_end = c._compute_compress_start(msgs)  # = 3 (system present)
+        cut = c._find_tail_cut_by_tokens(msgs, head_end)
+        last_user_idx = max(i for i, m in enumerate(msgs) if m.get("role") == "user")  # = 5
+
+        assert cut <= last_user_idx, (
+            f"cut_idx={cut} is AFTER last_user_idx={last_user_idx} — "
+            "last user message would be summarized (ghost response bug)"
+        )
+
+    # ------------------------------------------------------------------
+    # Hotfix 2: no HEAD fossilization without a system message
+    # ------------------------------------------------------------------
+
+    def test_compress_start_is_zero_when_no_system_message(self, fresh_compressor):
+        """_compute_compress_start must return 0 for cold-start sessions (no system message).
+
+        Regression: before the fix, compress_start was always protect_first_n,
+        which fossilized a random user message as HEAD and re-injected it into
+        every child session.
+        """
+        c = fresh_compressor
+        msgs = [
+            {"role": "user", "content": "The lunch table formatting is terrible."},
+            {"role": "assistant", "content": "I will fix it."},
+            {"role": "user", "content": "Great, thanks."},
+        ]
+        start = c._compute_compress_start(msgs)
+        assert start == 0, (
+            f"compress_start={start} for a cold-start session — "
+            "first user message would be fossilized as HEAD"
+        )
+
+    def test_compress_start_respects_protect_first_n_when_system_present(self, fresh_compressor):
+        """_compute_compress_start must still return protect_first_n when a
+        system message is present — the happy path must not regress."""
+        c = fresh_compressor
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello."},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "Do something."},
+        ]
+        start = c._compute_compress_start(msgs)
+        assert start == c.protect_first_n, (
+            f"compress_start={start} but expected {c.protect_first_n} "
+            "for a session that starts with a system message"
+        )
+
+    def test_first_user_message_not_in_compressed_output(self, fresh_compressor):
+        """After compression, the first user message of a cold-start session
+        must NOT appear verbatim in the compressed output.
+
+        Regression: HEAD fossilization caused it to be copied into every child
+        session, where the model would act on it again.
+        """
+        c = fresh_compressor
+        fossilized_content = "The lunch table formatting is terrible."
+        msgs = [{"role": "user", "content": fossilized_content}]
+        # Build a long enough conversation to trigger compression
+        for i in range(20):
+            msgs.append({"role": "assistant", "content": f"Working on step {i}."})
+            msgs.append({"role": "user", "content": f"Continue with step {i}."})
+
+        mock_response = __import__('unittest.mock', fromlist=['MagicMock']).MagicMock()
+        mock_response.choices = [mock_response]
+        mock_response.choices[0].message.content = "Summary of work done."
+
+        with __import__('unittest.mock', fromlist=['patch']).patch(
+            "agent.context_compressor.call_llm", return_value=mock_response
+        ):
+            result = c.compress(msgs, current_tokens=150_000)
+
+        first_messages = [m for m in result if fossilized_content in (m.get("content") or "")]
+        assert len(first_messages) == 0, (
+            "The original first user message survived compression verbatim — "
+            "HEAD fossilization bug is present"
+        )


### PR DESCRIPTION
Fixes two related bugs in the compression boundary algorithm, both confirmed against real production sessions. Closes #7133.

## Bug 1: Last user message summarized into MIDDLE (ghost response)

`_find_tail_cut_by_tokens()` walks backward accumulating tokens until the budget is exhausted. When tool results are small (30–100 tokens each), many fit under the budget ceiling, pushing the cut far back and leaving the **last user message in the MIDDLE region**. On the next API call the model sees the summary and "continues" from it — producing a response about past history with no new user input.

**Fix:** after `_align_boundary_backward`, scan backward for the last user message and clamp `cut_idx` to include it unconditionally.

## Bug 2: HEAD fossilization — random user message replayed after every compression

`compress()` always sets `compress_start = protect_first_n` (default 3), copying the first N messages verbatim as HEAD into every child session born from compression. This is correct when `messages[0]` is a system prompt. But when a session starts cold (no system message), a **plain user message becomes the permanent HEAD** and is re-injected into every subsequent compressed session. The model sees it as an open unanswered turn and acts on it every cycle.

**Observed in production:** a single user message from 07:14 AM was replayed as `message[0]` across 6 consecutive compression-spawned sessions throughout the day, causing the agent to repeatedly act on a stale request in the middle of unrelated work.

**Fix:** only apply `protect_first_n` when `messages[0].role == "system"`. Otherwise `compress_start = 0` — no HEAD fossilization, the tail budget handles recency.

## Testing

Both fixes verified via dry-run on production sessions before deployment. The HEAD fossilization fix was confirmed by inspecting the session chain: all 6 child sessions created today started with the same user message at index 0.