### PR TITLE
feat: add bell_on_approval config option

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7370,6 +7370,12 @@ class HermesCLI:
 
             self._invalidate()
 
+            # Bell on approval prompt
+            from cli import CLI_CONFIG
+            if CLI_CONFIG.get("display", {}).get("bell_on_approval", False):
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+
             _last_countdown_refresh = _time.monotonic()
             while True:
                 try:

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -7,6 +7,7 @@ with the TUI.
 """
 
 import queue
+import sys
 import time as _time
 import getpass
 
@@ -218,6 +219,11 @@ def approval_callback(cli, command: str, description: str) -> str:
 
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()
+
+        # Bell on approval prompt
+        if CLI_CONFIG.get("display", {}).get("bell_on_approval", False):
+            sys.stdout.write("\a")
+            sys.stdout.flush()
 
         while True:
             try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -495,6 +495,7 @@ DEFAULT_CONFIG = {
         "resume_display": "full",
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
+        "bell_on_approval": False,
         "show_reasoning": False,
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
@@ -2919,6 +2920,7 @@ def show_config():
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Bell approval:{' on' if display.get('bell_on_approval', False) else ' off'}")
 
     # Terminal
     print()


### PR DESCRIPTION
Add a terminal bell sound when dangerous command approval prompts appear, parallel to the existing `bell_on_complete` setting.

## Changes

- Add `bell_on_approval` to `DEFAULT_CONFIG` (default: `False`)
- Play terminal bell (`\\a`) in `cli.py` `_approval_callback` when enabled
- Play terminal bell in `callbacks.py` `approval_callback` when enabled
- Show Bell approval status in `hermes config show` output

## Usage

```
hermes config set display.bell_on_approval true
```

## Tested

Verified that the bell sounds when dangerous commands trigger the approval prompt (e.g. `rm -rf`, `chmod 777`, `mkfs`).