### PR TITLE
fix(cli): make /tools slash commands ANSI-safe and idempotent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3833,7 +3833,8 @@ class HermesCLI:
 
         if subcommand == "list":
             tools_disable_enable_command(
-                Namespace(tools_action="list", platform="cli"))
+                Namespace(tools_action="list", platform="cli"),
+                line_printer=_cprint)
             return
 
         names = parts[2:]
@@ -3850,15 +3851,19 @@ class HermesCLI:
         label = ", ".join(names)
         _cprint(f"{_ACCENT}{verb} {label}...{_RST}")
 
-        tools_disable_enable_command(
-            Namespace(tools_action=subcommand, names=names, platform="cli"))
+        result = tools_disable_enable_command(
+            Namespace(tools_action=subcommand, names=names, platform="cli"),
+            line_printer=_cprint)
 
-        # Reset session so the new tool config is picked up from a clean state
-        from hermes_cli.tools_config import _get_platform_tools
-        from hermes_cli.config import load_config
-        self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
-        self.new_session()
-        _cprint(f"{_DIM}Session reset. New tool configuration is active.{_RST}")
+        if result and result.get("changed"):
+            # Reset session so the new tool config is picked up from a clean state
+            from hermes_cli.tools_config import _get_platform_tools
+            from hermes_cli.config import load_config
+            self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
+            self.new_session()
+            _cprint(f"{_DIM}Session reset. New tool configuration is active.{_RST}")
+        else:
+            _cprint(f"{_DIM}No session reset needed.{_RST}")
 
     def show_toolsets(self):
         """Display available toolsets with kawaii ASCII art."""

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -13,7 +13,7 @@ import json as _json
 import logging
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
@@ -1575,22 +1575,37 @@ def _configure_mcp_tools_interactive(config: dict):
 # ─── Non-interactive disable/enable ──────────────────────────────────────────
 
 
-def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
-    """Add or remove built-in toolsets for a platform."""
+def _apply_toolset_change(
+    config: dict,
+    platform: str,
+    toolset_names: List[str],
+    action: str,
+) -> tuple[List[str], List[str]]:
+    """Add or remove built-in toolsets for a platform.
+
+    Returns ``(changed, unchanged)`` in request order.
+    """
     enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
     if action == "disable":
+        changed = [name for name in toolset_names if name in enabled]
+        unchanged = [name for name in toolset_names if name not in enabled]
         updated = enabled - set(toolset_names)
     else:
+        changed = [name for name in toolset_names if name not in enabled]
+        unchanged = [name for name in toolset_names if name in enabled]
         updated = enabled | set(toolset_names)
     _save_platform_tools(config, platform, updated)
+    return changed, unchanged
 
 
-def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
+def _apply_mcp_change(config: dict, targets: List[str], action: str) -> tuple[Set[str], List[str], List[str]]:
     """Add or remove specific MCP tools from a server's exclude list.
 
-    Returns the set of server names that were not found in config.
+    Returns ``(failed_servers, changed, unchanged)`` in request order.
     """
     failed_servers: Set[str] = set()
+    changed: List[str] = []
+    unchanged: List[str] = []
     mcp_servers = config.get("mcp_servers") or {}
 
     for target in targets:
@@ -1603,52 +1618,69 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
         if action == "disable":
             if tool_name not in exclude:
                 exclude.append(tool_name)
+                changed.append(target)
+            else:
+                unchanged.append(target)
         else:
-            exclude = [t for t in exclude if t != tool_name]
+            if tool_name in exclude:
+                exclude = [t for t in exclude if t != tool_name]
+                changed.append(target)
+            else:
+                unchanged.append(target)
         tools_cfg["exclude"] = exclude
 
-    return failed_servers
+    return failed_servers, changed, unchanged
 
 
-def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
-    """Print a summary of enabled/disabled toolsets and MCP tool filters."""
+def _print_tools_list(
+    enabled_toolsets: set,
+    mcp_servers: dict,
+    platform: str = "cli",
+    line_printer: Optional[Callable[[str], None]] = None,
+):
+    """Print a summary of enabled/disabled toolsets and MCP tool filters.
+
+    ``line_printer`` lets the interactive TUI route ANSI strings through
+    prompt_toolkit's renderer instead of raw stdout.
+    """
+    emit = line_printer or print
     effective = _get_effective_configurable_toolsets()
     builtin_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
 
-    print(f"Built-in toolsets ({platform}):")
+    emit(f"Built-in toolsets ({platform}):")
     for ts_key, label, _ in effective:
         if ts_key not in builtin_keys:
             continue
         status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                   else color("✗ disabled", Colors.RED))
-        print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+        emit(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     # Plugin toolsets
     plugin_entries = [(k, l) for k, l, _ in effective if k not in builtin_keys]
     if plugin_entries:
-        print()
-        print(f"Plugin toolsets ({platform}):")
+        emit("")
+        emit(f"Plugin toolsets ({platform}):")
         for ts_key, label in plugin_entries:
             status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                       else color("✗ disabled", Colors.RED))
-            print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+            emit(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     if mcp_servers:
-        print()
-        print("MCP servers:")
+        emit("")
+        emit("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []
             include = tools_cfg.get("include") or []
             if include:
-                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+                emit(color(f"  {srv_name}  [include only: {', '.join(include)}]", Colors.DIM))
             elif exclude:
-                _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
+                emit(color(f"  {srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]", Colors.DIM))
             else:
-                _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
+                emit(color(f"  {srv_name}  {color('all tools enabled', Colors.DIM)}", Colors.DIM))
 
 
-def tools_disable_enable_command(args):
+def tools_disable_enable_command(args, line_printer: Optional[Callable[[str], None]] = None):
     """Enable, disable, or list tools for a platform.
 
     Built-in toolsets use plain names (e.g. ``web``, ``memory``).
@@ -1657,15 +1689,34 @@ def tools_disable_enable_command(args):
     action = args.tools_action
     platform = getattr(args, "platform", "cli")
     config = load_config()
+    emit = line_printer or print
+
+    def emit_error(text: str) -> None:
+        if line_printer:
+            emit(color(f"✗ {text}", Colors.RED))
+        else:
+            _print_error(text)
+
+    def emit_success(text: str) -> None:
+        if line_printer:
+            emit(color(f"✓ {text}", Colors.GREEN))
+        else:
+            _print_success(text)
+
+    def emit_info(text: str) -> None:
+        if line_printer:
+            emit(color(text, Colors.DIM))
+        else:
+            _print_info(text)
 
     if platform not in PLATFORMS:
-        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
-        return
+        emit_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        return {"changed": False, "changed_targets": [], "unchanged_targets": []}
 
     if action == "list":
         _print_tools_list(_get_platform_tools(config, platform, include_default_mcp_servers=False),
-                          config.get("mcp_servers") or {}, platform)
-        return
+                          config.get("mcp_servers") or {}, platform, line_printer=line_printer)
+        return {"changed": False, "changed_targets": [], "unchanged_targets": []}
 
     targets: List[str] = args.names
     toolset_targets = [t for t in targets if ":" not in t]
@@ -1675,24 +1726,39 @@ def tools_disable_enable_command(args):
     unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
     if unknown_toolsets:
         for name in unknown_toolsets:
-            _print_error(f"Unknown toolset '{name}'")
+            emit_error(f"Unknown toolset '{name}'")
         toolset_targets = [t for t in toolset_targets if t in valid_toolsets]
 
+    changed_targets: List[str] = []
+    unchanged_targets: List[str] = []
     if toolset_targets:
-        _apply_toolset_change(config, platform, toolset_targets, action)
+        builtin_changed, builtin_unchanged = _apply_toolset_change(config, platform, toolset_targets, action)
+        changed_targets.extend(builtin_changed)
+        unchanged_targets.extend(builtin_unchanged)
 
     failed_servers: Set[str] = set()
     if mcp_targets:
-        failed_servers = _apply_mcp_change(config, mcp_targets, action)
+        failed_servers, mcp_changed, mcp_unchanged = _apply_mcp_change(config, mcp_targets, action)
+        changed_targets.extend(mcp_changed)
+        unchanged_targets.extend(mcp_unchanged)
         for srv in failed_servers:
-            _print_error(f"MCP server '{srv}' not found in config")
+            emit_error(f"MCP server '{srv}' not found in config")
 
     save_config(config)
 
-    successful = [
-        t for t in targets
-        if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
-    ]
-    if successful:
+    ordered_changed = [t for t in targets if t in changed_targets]
+    ordered_unchanged = [t for t in targets if t in unchanged_targets]
+
+    if ordered_changed:
         verb = "Disabled" if action == "disable" else "Enabled"
-        _print_success(f"{verb}: {', '.join(successful)}")
+        emit_success(f"{verb}: {', '.join(ordered_changed)}")
+
+    if ordered_unchanged:
+        state = "already disabled" if action == "disable" else "already enabled"
+        emit_info(f"No changes ({state}): {', '.join(ordered_unchanged)}")
+
+    return {
+        "changed": bool(ordered_changed),
+        "changed_targets": ordered_changed,
+        "unchanged_targets": ordered_unchanged,
+    }

--- a/tests/cli/test_cli_tools_command.py
+++ b/tests/cli/test_cli_tools_command.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch, call
 
+import pytest
+
 from cli import HermesCLI
 
 
@@ -12,6 +14,13 @@ def _make_cli(enabled_toolsets=None):
     cli_obj._command_running = False
     cli_obj.console = MagicMock()
     return cli_obj
+
+
+@pytest.fixture(autouse=True)
+def _patch_cprint_for_tests():
+    """Route prompt_toolkit output through plain print during unit tests."""
+    with patch("cli._cprint", side_effect=print):
+        yield
 
 
 # ── /tools (no subcommand) ──────────────────────────────────────────────────
@@ -66,7 +75,8 @@ class TestToolsSlashDisableWithReset:
         with patch("hermes_cli.tools_config.load_config",
                    return_value={"platform_toolsets": {"cli": ["web", "memory"]}}), \
              patch("hermes_cli.tools_config.save_config"), \
-             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.tools_config._get_platform_tools",
+                   side_effect=[{"web", "memory"}, {"memory"}]), \
              patch("hermes_cli.config.load_config", return_value={}), \
              patch.object(cli_obj, "new_session") as mock_reset:
             cli_obj._handle_tools_command("/tools disable web")
@@ -86,17 +96,26 @@ class TestToolsSlashDisableWithReset:
             cli_obj._handle_tools_command("/tools disable web")
         mock_input.assert_not_called()
 
-    def test_disable_always_resets_session(self):
-        """Even without a confirmation prompt, disable always resets the session."""
+    def test_disable_resets_session_when_changed(self):
+        """Disable resets the session only when the tool config actually changes."""
         cli_obj = _make_cli(["web", "memory"])
         with patch("hermes_cli.tools_config.load_config",
                    return_value={"platform_toolsets": {"cli": ["web", "memory"]}}), \
              patch("hermes_cli.tools_config.save_config"), \
-             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory"}), \
+             patch("hermes_cli.tools_config._get_platform_tools",
+                   side_effect=[{"web", "memory"}, {"memory"}]), \
              patch("hermes_cli.config.load_config", return_value={}), \
              patch.object(cli_obj, "new_session") as mock_reset:
             cli_obj._handle_tools_command("/tools disable web")
         mock_reset.assert_called_once()
+
+    def test_disable_noop_does_not_reset_session(self):
+        cli_obj = _make_cli(["memory"])
+        with patch("hermes_cli.tools_config.tools_disable_enable_command",
+                   return_value={"changed": False, "changed_targets": [], "unchanged_targets": ["web"]}), \
+             patch.object(cli_obj, "new_session") as mock_reset:
+            cli_obj._handle_tools_command("/tools disable web")
+        mock_reset.assert_not_called()
 
     def test_disable_missing_name_prints_usage(self, capsys):
         cli_obj = _make_cli()
@@ -116,12 +135,21 @@ class TestToolsSlashEnableWithReset:
         with patch("hermes_cli.tools_config.load_config",
                    return_value={"platform_toolsets": {"cli": ["memory"]}}), \
              patch("hermes_cli.tools_config.save_config"), \
-             patch("hermes_cli.tools_config._get_platform_tools", return_value={"memory", "web"}), \
+             patch("hermes_cli.tools_config._get_platform_tools",
+                   side_effect=[{"memory"}, {"memory", "web"}]), \
              patch("hermes_cli.config.load_config", return_value={}), \
              patch.object(cli_obj, "new_session") as mock_reset:
             cli_obj._handle_tools_command("/tools enable web")
         mock_reset.assert_called_once()
         assert "web" in cli_obj.enabled_toolsets
+
+    def test_enable_noop_does_not_reset_session(self):
+        cli_obj = _make_cli(["web", "memory"])
+        with patch("hermes_cli.tools_config.tools_disable_enable_command",
+                   return_value={"changed": False, "changed_targets": [], "unchanged_targets": ["web"]}), \
+             patch.object(cli_obj, "new_session") as mock_reset:
+            cli_obj._handle_tools_command("/tools enable web")
+        mock_reset.assert_not_called()
 
     def test_enable_missing_name_prints_usage(self, capsys):
         cli_obj = _make_cli()

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -33,9 +33,13 @@ class TestToolsDisableBuiltin:
         config = {"platform_toolsets": {"cli": ["memory"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \
              patch("hermes_cli.tools_config.save_config") as mock_save:
-            tools_disable_enable_command(Namespace(tools_action="disable", names=["web"], platform="cli"))
+            result = tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web"], platform="cli")
+            )
         saved = mock_save.call_args[0][0]
         assert "web" not in saved["platform_toolsets"]["cli"]
+        assert result["changed"] is False
+        assert result["unchanged_targets"] == ["web"]
 
 
 # ── Built-in toolset enable ─────────────────────────────────────────────────
@@ -55,9 +59,13 @@ class TestToolsEnableBuiltin:
         config = {"platform_toolsets": {"cli": ["web"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \
              patch("hermes_cli.tools_config.save_config") as mock_save:
-            tools_disable_enable_command(Namespace(tools_action="enable", names=["web"], platform="cli"))
+            result = tools_disable_enable_command(
+                Namespace(tools_action="enable", names=["web"], platform="cli")
+            )
         saved = mock_save.call_args[0][0]
         assert saved["platform_toolsets"]["cli"].count("web") == 1
+        assert result["changed"] is False
+        assert result["unchanged_targets"] == ["web"]
 
 
 # ── MCP tool disable ────────────────────────────────────────────────────────
@@ -222,3 +230,13 @@ class TestToolsValidation:
         saved = mock_save.call_args[0][0]
         assert "web" not in saved["platform_toolsets"]["cli"]
         assert "memory" in saved["platform_toolsets"]["cli"]
+
+    def test_disable_noop_prints_no_changes(self, capsys):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config"):
+            tools_disable_enable_command(
+                Namespace(tools_action="disable", names=["web"], platform="cli")
+            )
+        out = capsys.readouterr().out
+        assert "No changes (already disabled): web" in out


### PR DESCRIPTION
## What does this PR do?

Fixes two related interactive `/tools` slash-command bugs in the prompt_toolkit TUI:

1. `/tools list`, `/tools enable`, and `/tools disable` could print raw ANSI fragments like `?[32m` instead of rendered colors because the interactive path was not consistently routing output through the prompt_toolkit renderer.
2. Repeating `/tools enable <tool>` or `/tools disable <tool>` reported a false success and reset the session even when the tool was already in the requested state.

I searched existing open PRs before sending this. PRs #8630 and #9091 already cover the garbled ANSI subset, but this change also fixes the repeated no-op success/session-reset behavior for `/tools enable` and `/tools disable`.

## Related Issue

Fixes #9017

No separate issue was filed for the repeated no-op reset path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - route interactive `/tools list` output through `_cprint`
  - route interactive `/tools enable|disable` result lines through `_cprint`
  - only reset the session when the backend reports that tool state actually changed
  - show `No session reset needed.` for no-op repeated toggles
- `hermes_cli/tools_config.py`
  - add `line_printer` plumbing so interactive TUI callers can render ANSI correctly without changing standalone CLI behavior
  - track which requested targets actually changed vs. were already enabled/disabled
  - return structured change metadata to the slash-command handler
  - emit `No changes (already enabled/disabled): ...` for repeated no-op operations
- `tests/cli/test_cli_tools_command.py`
  - cover no-op slash-command behavior and ensure no session reset happens on repeated toggles
  - patch `_cprint` in unit tests so prompt_toolkit output is exercised safely on Windows test runners
- `tests/hermes_cli/test_tools_disable_enable.py`
  - cover backend change metadata and the new `No changes (...)` output for idempotent calls

## How to Test

1. Start Hermes in the interactive CLI on Windows / PowerShell.
2. Run `/tools list` and verify the output is clean text with rendered status markers, not raw ANSI fragments like `?[32m`.
3. Run `/tools disable code_execution` twice and verify the second run says `No changes (already disabled): code_execution` and does not start a new session.
4. Run `/tools enable code_execution` twice and verify the second run says `No changes (already enabled): code_execution` and does not start a new session.
5. Run `hermes tools list --platform cli` and verify the standalone CLI path still prints correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 + PowerShell 7

Notes on validation:
- `python -m py_compile cli.py hermes_cli/tools_config.py tests/cli/test_cli_tools_command.py tests/hermes_cli/test_tools_disable_enable.py`
- `pytest tests/cli/test_cli_tools_command.py tests/hermes_cli/test_tools_disable_enable.py -q`
- Attempted full-suite runs with `pytest tests/ -q` and `pytest tests/ -q -n 1`, but both were terminated by the OS with exit code `137` on this Windows machine before completion.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — yes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Interactive Windows CLI after the fix:

```text
⚙️  /tools disable code_execution
Disabling code_execution...
✓ Disabled: code_execution
Session reset. New tool configuration is active.
(^_^)v New session started!

⚙️  /tools disable code_execution
Disabling code_execution...
No changes (already disabled): code_execution
No session reset needed.

⚙️  /tools enable code_execution
Enabling code_execution...
✓ Enabled: code_execution
Session reset. New tool configuration is active.
(^_^)v New session started!

⚙️  /tools enable code_execution
Enabling code_execution...
No changes (already enabled): code_execution
No session reset needed.
```
