### PR TITLE
fix(claw): show conflict/error warning when nothing can be migrated

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -432,9 +432,18 @@ def _cmd_migrate(args):
     preview_summary = preview_report.get("summary", {})
     preview_count = preview_summary.get("migrated", 0)
 
+    conflict_count = preview_summary.get("conflict", 0)
+    error_count = preview_summary.get("error", 0)
     if preview_count == 0:
         print()
-        print_info("Nothing to migrate from OpenClaw.")
+        if conflict_count or error_count:
+            print_error(
+                f"Nothing can be migrated — "
+                f"{conflict_count} conflict(s) and {error_count} error(s) found. "
+                "Use --overwrite to force conflicting items."
+            )
+        else:
+            print_info("Nothing to migrate from OpenClaw.")
         _print_migration_report(preview_report, dry_run=True)
         return
 

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -475,6 +475,42 @@ class TestCmdMigrate:
         assert call_kwargs["migrate_secrets"] is True
 
 
+
+    def test_shows_warning_when_all_items_conflict(self, tmp_path, capsys):
+        """When migrated=0 but conflicts exist, show warning not 'Nothing to migrate'."""
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_path = tmp_path / "config.yaml"
+        fake_mod = ModuleType("openclaw_to_hermes")
+        fake_mod.resolve_selected_options = MagicMock(return_value=set())
+        fake_migrator = MagicMock()
+        fake_migrator.migrate.return_value = {
+            "summary": {"migrated": 0, "skipped": 0, "conflict": 3, "error": 1},
+            "items": [],
+        }
+        fake_mod.Migrator = MagicMock(return_value=fake_migrator)
+        args = Namespace(
+            source=str(openclaw_dir),
+            dry_run=False, preset="full", overwrite=False,
+            migrate_secrets=False, workspace_target=None,
+            skill_conflict="skip", yes=True,
+        )
+        with (
+            patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
+            patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
+            patch.object(claw_mod, "get_config_path", return_value=config_path),
+            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "load_config", return_value={}),
+            patch.object(claw_mod, "_warn_if_openclaw_running"),
+            patch.object(claw_mod, "_warn_if_gateway_running"),
+        ):
+            claw_mod._cmd_migrate(args)
+        captured = capsys.readouterr()
+        assert "Nothing can be migrated" in captured.out
+        assert "3 conflict(s)" in captured.out
+        assert "1 error(s)" in captured.out
+        assert "Nothing to migrate from OpenClaw" not in captured.out
+
 # ---------------------------------------------------------------------------
 # _cmd_cleanup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
When `hermes claw migrate` preview finds `migrated: 0` but there are conflicts or errors, it silently prints "Nothing to migrate from OpenClaw" and exits — hiding the real reason why nothing was imported.
Example: all items conflict because they already exist in the target. The user sees "Nothing to migrate" with no actionable guidance.
## Fix
When `migrated == 0` but `conflict > 0` or `error > 0`, show a clear error message instead:
```
Nothing can be migrated — 3 conflict(s) and 1 error(s) found.
Use --overwrite to force conflicting items.
```
The "Nothing to migrate from OpenClaw" message is only shown when there are genuinely no items to process.
## Testing
Added `test_shows_warning_when_all_items_conflict` — 48/48 pass.