### PR TITLE
fix(model_switch): group custom_providers by endpoint in /model picker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4332,6 +4332,7 @@ class GatewayRunner:
                 try:
                     providers = list_authenticated_providers(
                         current_provider=current_provider,
+                        current_base_url=current_base_url,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
@@ -4443,6 +4444,7 @@ class GatewayRunner:
             try:
                 providers = list_authenticated_providers(
                     current_provider=current_provider,
+                    current_base_url=current_base_url,
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=5,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -752,6 +752,7 @@ def switch_model(
 
 def list_authenticated_providers(
     current_provider: str = "",
+    current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
     max_models: int = 8,
@@ -969,41 +970,62 @@ def list_authenticated_providers(
             })
 
     # --- 4. Saved custom providers from config ---
+    # Entries are grouped by (base_url, api_key) so a single Ollama host
+    # with several models appears as one provider group in the picker.
+    # When the entry's base_url matches the currently active endpoint the
+    # slug is set to current_provider so that switching via the picker
+    # resolves credentials correctly through the existing runtime provider
+    # logic (no extra credential lookup needed).
     if custom_providers and isinstance(custom_providers, list):
-        for entry in custom_providers:
+        from collections import OrderedDict
+        groups: dict = OrderedDict()
+        for i, entry in enumerate(custom_providers):
             if not isinstance(entry, dict):
                 continue
-
-            display_name = (entry.get("name") or "").strip()
-            api_url = (
-                entry.get("base_url", "")
-                or entry.get("url", "")
-                or entry.get("api", "")
-                or ""
-            ).strip()
-            if not display_name or not api_url:
+            b_url = (
+                entry.get("base_url") or entry.get("url") or entry.get("api") or ""
+            ).rstrip("/")
+            a_key = entry.get("api_key") or ""
+            model_id = (entry.get("model") or "").strip()
+            if not b_url:
                 continue
-
-            slug = custom_provider_slug(display_name)
-            if slug in seen_slugs:
-                continue
-
-            models_list = []
-            default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
-
-            results.append({
-                "slug": slug,
-                "name": display_name,
-                "is_current": slug == current_provider,
-                "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list),
-                "source": "user-config",
-                "api_url": api_url,
-            })
-            seen_slugs.add(slug)
+            if current_base_url and b_url == current_base_url.rstrip("/"):
+                slug = current_provider or "custom"
+            else:
+                slug = custom_provider_slug(entry.get("name") or b_url)
+            group_key = (b_url, a_key)
+            if group_key not in groups:
+                raw_name = (entry.get("name") or "").strip()
+                # Strip per-model suffix ("Ollama — GLM 5.1" -> "Ollama")
+                display_name = raw_name.split("—")[0].strip() if "—" in raw_name else raw_name
+                if not display_name:
+                    display_name = b_url
+                groups[group_key] = {
+                    "slug": slug,
+                    "name": display_name,
+                    "is_current": slug == current_provider,
+                    "is_user_defined": True,
+                    "models": [],
+                    "source": "custom_providers",
+                    "api_url": b_url,
+                }
+            if model_id and model_id not in groups[group_key]["models"]:
+                groups[group_key]["models"].append(model_id)
+        for g in groups.values():
+            g["total_models"] = len(g["models"])
+            g["models"] = g["models"][:max_models]
+            if g["slug"] not in seen_slugs:
+                results.append(g)
+                seen_slugs.add(g["slug"])
+            else:
+                # Merge models into existing entry (user-config + custom_providers overlap)
+                for existing in results:
+                    if existing["slug"] == g["slug"]:
+                        for m in g["models"]:
+                            if m not in existing["models"]:
+                                existing["models"].append(m)
+                        existing["total_models"] = len(existing["models"])
+                        break
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -770,7 +770,8 @@ def list_authenticated_providers(
       - is_user_defined: bool
       - models: list[str] — curated model IDs (up to max_models)
       - total_models: int — total curated count
-      - source: str — "built-in", "models.dev", "user-config"
+      - source: str — "built-in", "models.dev", "user-config" (custom_providers
+        entries also use "user-config" to stay consistent with the existing taxonomy)
 
     Only includes providers that have API keys set or are user-defined endpoints.
     """
@@ -979,7 +980,7 @@ def list_authenticated_providers(
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
         groups: dict = OrderedDict()
-        for i, entry in enumerate(custom_providers):
+        for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
             b_url = (
@@ -1006,7 +1007,7 @@ def list_authenticated_providers(
                     "is_current": slug == current_provider,
                     "is_user_defined": True,
                     "models": [],
-                    "source": "custom_providers",
+                    "source": "user-config",
                     "api_url": b_url,
                 }
             if model_id and model_id not in groups[group_key]["models"]:
@@ -1018,13 +1019,16 @@ def list_authenticated_providers(
                 results.append(g)
                 seen_slugs.add(g["slug"])
             else:
-                # Merge models into existing entry (user-config + custom_providers overlap)
+                # Merge models into existing entry (user-config + custom_providers overlap).
+                # total_models tracks the full deduplicated count; models is capped at
+                # max_models so the picker list stays within bounds.
                 for existing in results:
                     if existing["slug"] == g["slug"]:
-                        for m in g["models"]:
-                            if m not in existing["models"]:
-                                existing["models"].append(m)
-                        existing["total_models"] = len(existing["models"])
+                        merged = existing["models"] + [
+                            m for m in g["models"] if m not in existing["models"]
+                        ]
+                        existing["total_models"] = len(merged)
+                        existing["models"] = merged[:max_models]
                         break
 
     # Sort: current provider first, then by model count descending

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -102,3 +102,87 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
+    """Multiple custom_providers entries sharing a base_url must be returned
+    as a single provider group with all their models merged."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://localhost:11434/v1",
+        user_providers={},
+        custom_providers=[
+            {"name": "Ollama — MiniMax M2.7", "base_url": "http://localhost:11434/v1",
+             "api_key": "key123", "model": "minimax-m2.7:cloud"},
+            {"name": "Ollama — GLM 5.1",      "base_url": "http://localhost:11434/v1",
+             "api_key": "key123", "model": "glm-5.1:cloud"},
+            {"name": "Ollama — Qwen 3.5",     "base_url": "http://localhost:11434/v1",
+             "api_key": "key123", "model": "qwen3.5:cloud"},
+        ],
+        max_models=50,
+    )
+
+    # All three entries share the same endpoint → exactly one group
+    custom_groups = [p for p in providers if p.get("is_user_defined")]
+    assert len(custom_groups) == 1, (
+        f"Expected 1 group for shared endpoint, got {len(custom_groups)}: "
+        + str([p["slug"] for p in custom_groups])
+    )
+    group = custom_groups[0]
+    assert set(group["models"]) == {"minimax-m2.7:cloud", "glm-5.1:cloud", "qwen3.5:cloud"}
+    assert group["total_models"] == 3
+
+
+def test_list_authenticated_providers_current_endpoint_slug_and_is_current(monkeypatch):
+    """When current_base_url matches a custom_providers entry, the group slug
+    must equal current_provider and is_current must be True."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://localhost:11434/v1",
+        user_providers={},
+        custom_providers=[
+            {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
+             "api_key": "key123", "model": "glm-5.1:cloud"},
+        ],
+        max_models=50,
+    )
+
+    matches = [p for p in providers if p.get("is_user_defined")]
+    assert len(matches) == 1
+    group = matches[0]
+    assert group["slug"] == "custom", (
+        f"Slug should equal current_provider ('custom'), got '{group['slug']}'"
+    )
+    assert group["is_current"] is True, "is_current should be True for active endpoint"
+
+
+def test_list_authenticated_providers_max_models_cap_after_merge(monkeypatch):
+    """After merging two custom_providers entries into one group, the models
+    list must not exceed max_models, while total_models reflects the full count."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    entries = [
+        {"name": f"Ollama — Model {i}", "base_url": "http://localhost:11434/v1",
+         "api_key": "k", "model": f"model-{i}:cloud"}
+        for i in range(6)
+    ]
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://localhost:11434/v1",
+        user_providers={},
+        custom_providers=entries,
+        max_models=4,
+    )
+
+    groups = [p for p in providers if p.get("is_user_defined")]
+    assert len(groups) == 1
+    group = groups[0]
+    assert len(group["models"]) <= 4, "models list must be capped at max_models"
+    assert group["total_models"] == 6, "total_models must reflect the full count"


### PR DESCRIPTION
Fixes the `/model` command producing no output (or no picker) when the active configuration uses `custom_providers` with an Ollama or other OpenAI-compatible endpoint.

## Root cause

`list_authenticated_providers()` had two problems in section 4 (custom_providers handling):

**1. Missing `current_base_url` parameter**
The function had no way to tell which custom entry corresponds to the active endpoint. As a result `is_current` was always `False` and the slug was a name-derived hash (e.g. `ollama-glm-5-1`) that did not match the config `model.provider` value (`custom`). Switching via the picker therefore sent the wrong provider slug to `switch_model`, causing credential resolution to fail.

**2. One picker entry per config entry instead of grouping by endpoint**
A single Ollama host with 4 model entries appeared as 4 separate single-model providers in the picker instead of one group with 4 models to choose from.

**3. Silent TypeError at call site (same symptom on older gateway builds)**
Both call sites in `gateway/run.py` already passed `custom_providers=...` as a keyword arg, but the old signature did not declare that parameter — resulting in a `TypeError` that was silently swallowed by the surrounding `try/except`, leaving `providers = []` and the picker never opening.

## Fix

- Add `current_base_url: str = ` parameter.
- Replace section 4 with a grouping pass: entries are bucketed by `(base_url, api_key)`. When a bucket matches the active endpoint (`base_url == current_base_url`) the slug is set to `current_provider` so that credential resolution in the existing `switch_model` pipeline works without any extra lookup.
- Display name is derived from the first entry in the group, stripping per-model suffixes (`Ollama — GLM 5.1` → `Ollama`). All model names from matching entries are merged into a single list.
- Pass `current_base_url` through both `list_authenticated_providers` call sites in `gateway/run.py`.

## Result

Before: 0 providers shown, picker never opened (TypeError swallowed).
After: 1 provider group Ollama with all 4 models, correctly marked as current, inline keyboard picker opens and model switching works.