### PR TITLE
fix(discord): register native /restart slash command

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1698,6 +1698,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
+        @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
+        async def slash_restart(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/restart", "Restart requested~")
+
         @tree.command(name="approve", description="Approve a pending dangerous command")
         @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
         async def slash_approve(interaction: discord.Interaction, scope: str = ""):

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -87,6 +87,23 @@ async def test_registers_native_thread_slash_command(adapter):
     adapter._handle_thread_create_slash.assert_awaited_once_with(interaction, "Planning", "", 1440)
 
 
+@pytest.mark.asyncio
+async def test_registers_native_restart_slash_command(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    assert "restart" in adapter._client.tree.commands
+
+    interaction = SimpleNamespace()
+    await adapter._client.tree.commands["restart"](interaction)
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction,
+        "/restart",
+        "Restart requested~",
+    )
+
+
 # ------------------------------------------------------------------
 # _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

  Fixes a Discord-only regression where `/restart` was implemented and documented, but not registered in Discord’s
  native slash-command tree.

  Hermes already exposed `/restart` through the messaging command registry and `gateway/run.py` handled it correctly.
  The missing piece was `gateway/platforms/discord.py`, which manually registers native Discord slash commands and had
  omitted `/restart`. As a result, Discord users could not discover or invoke `/restart` from the native slash menu
  even though the command already existed.

  This PR adds `/restart` to Discord’s native slash-command registration and routes it through the existing
  `_run_simple_slash(...)` path.

  ## Related Issue

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added native Discord `/restart` registration in `gateway/platforms/discord.py`
  - Routed `/restart` through `_run_simple_slash(interaction, "/restart", "Restart requested~")`
  - Added a regression test in `tests/gateway/test_discord_slash_commands.py`
  - Verified the existing command path already exists in `hermes_cli/commands.py`, `website/docs/reference/slash-
  commands.md`, and `gateway/run.py`

  ## How to Test

  1. Start Hermes with the Discord gateway enabled.
  2. Confirm `/restart` appears in Discord slash-command autocomplete/menu.
  3. Invoke `/restart` and confirm it routes through the normal gateway restart flow.

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`,
  `feat(scope):`, etc.)
  - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a
  duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/
  NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Local validation notes:

  - `pytest -q tests/gateway/test_discord_slash_commands.py` could not run as-is because repo `addopts` expects
  `pytest-xdist` (`-n auto`) and that plugin was not installed in the local environment
  - rerunning without repo `addopts` still could not execute the async test file because `pytest-asyncio` was not
  installed in the local environment
  - direct lightweight verification succeeded by importing `DiscordAdapter` with mocked Discord objects, calling
  `_register_slash_commands()`, confirming `"restart"` was registered, and invoking the registered handler to verify
  it dispatched through `_run_simple_slash(..., "/restart", "Restart requested~")`
