### PR TITLE
fix(security): validate snapshot_id and file paths in restore_quick_snapshot to prevent path traversal

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -574,7 +574,21 @@ def restore_quick_snapshot(
     """
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
+
+    # Security: reject snapshot_id values that contain path separators or
+    # traversal sequences so that `root / snapshot_id` stays inside root.
+    if not snapshot_id or "/" in snapshot_id or "\\" in snapshot_id or snapshot_id in (".", ".."):
+        logger.error("Invalid snapshot_id: %s", snapshot_id)
+        return False
+
     snap_dir = root / snapshot_id
+
+    # Confirm the resolved path is still inside root (handles symlinks etc.)
+    try:
+        snap_dir.resolve().relative_to(root.resolve())
+    except ValueError:
+        logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
+        return False
 
     if not snap_dir.is_dir():
         return False
@@ -588,11 +602,24 @@ def restore_quick_snapshot(
 
     restored = 0
     for rel in meta.get("files", {}):
+        # Security: reject absolute paths and traversals in manifest entries
         src = snap_dir / rel
-        if not src.exists():
+        try:
+            src.resolve().relative_to(snap_dir.resolve())
+        except ValueError:
+            logger.error("Manifest path traversal blocked: %s", rel)
             continue
 
         dst = home / rel
+        try:
+            dst.resolve().relative_to(home.resolve())
+        except ValueError:
+            logger.error("Manifest path traversal blocked: %s", rel)
+            continue
+
+        if not src.exists():
+            continue
+
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -632,7 +632,21 @@ def restore_quick_snapshot(
     """
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
+
+    # Security: reject snapshot_id values that contain path separators or
+    # traversal sequences so that `root / snapshot_id` stays inside root.
+    if not snapshot_id or "/" in snapshot_id or "\\" in snapshot_id or snapshot_id in (".", ".."):
+        logger.error("Invalid snapshot_id: %s", snapshot_id)
+        return False
+
     snap_dir = root / snapshot_id
+
+    # Confirm the resolved path is still inside root (handles symlinks etc.)
+    try:
+        snap_dir.resolve().relative_to(root.resolve())
+    except ValueError:
+        logger.error("Snapshot path traversal blocked for id: %s", snapshot_id)
+        return False
 
     if not snap_dir.is_dir():
         return False
@@ -646,11 +660,24 @@ def restore_quick_snapshot(
 
     restored = 0
     for rel in meta.get("files", {}):
+        # Security: reject absolute paths and traversals in manifest entries
         src = snap_dir / rel
-        if not src.exists():
+        try:
+            src.resolve().relative_to(snap_dir.resolve())
+        except ValueError:
+            logger.error("Manifest path traversal blocked: %s", rel)
             continue
 
         dst = home / rel
+        try:
+            dst.resolve().relative_to(home.resolve())
+        except ValueError:
+            logger.error("Manifest path traversal blocked: %s", rel)
+            continue
+
+        if not src.exists():
+            continue
+
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1302,6 +1302,79 @@ class TestQuickSnapshot:
 # Pre-update backup (hermes update safety net)
 # ---------------------------------------------------------------------------
 
+    # -- security: path traversal regression coverage -----------------------
+    # Per @egilewski audit on PR #9217: restore_quick_snapshot must reject
+    # malicious snapshot_id values (the directory selector) AND malicious
+    # rel paths inside the manifest (the per-file selector). Both surfaces
+    # need explicit regression tests because they validate independent
+    # traversal vectors.
+
+    def test_restore_rejects_snapshot_id_traversal(self, hermes_home):
+        """restore_quick_snapshot must reject snapshot_id values that
+        contain path separators, POSIX traversal entries, or are empty.
+        These are rejected on the input string before any filesystem
+        lookup, so the guard cannot be bypassed by arranging a directory
+        layout that would otherwise satisfy ``snap_dir.is_dir()``.
+
+        Regression for the path-traversal surface where ``root /
+        snapshot_id`` could resolve above the snapshots root."""
+        from hermes_cli.backup import restore_quick_snapshot
+
+        hostile_ids = [
+            "../../etc",                # parent traversal
+            "../outside",               # single parent
+            "..",                       # bare parent dir
+            ".",                        # bare current dir
+            "subdir/snap",              # forward slash
+            "subdir\\snap",           # backslash (Windows-style)
+            "",                         # empty string
+        ]
+        for hostile in hostile_ids:
+            assert restore_quick_snapshot(
+                hostile, hermes_home=hermes_home
+            ) is False, f"hostile snapshot_id was not rejected: {hostile!r}"
+
+    def test_restore_rejects_manifest_rel_traversal(self, hermes_home):
+        """A snapshot whose manifest.json contains a rel path that escapes
+        the snapshot directory (e.g. ``../../outside.txt``) must skip that
+        entry rather than restoring outside HERMES_HOME."""
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id is not None
+        snap_dir = hermes_home / "state-snapshots" / snap_id
+
+        # Inject a traversal entry into manifest.json AND seed the source
+        # file outside the snapshot directory so a vulnerable implementation
+        # would actually write something at the escaped destination.
+        manifest_path = snap_dir / "manifest.json"
+        with open(manifest_path) as f:
+            meta = json.load(f)
+        meta["files"]["../../outside.txt"] = 9
+        with open(manifest_path, "w") as f:
+            json.dump(meta, f)
+
+        # Source: ../../outside.txt resolves above the snapshot root.
+        # Place a payload there so we can detect a successful escape.
+        escape_src = snap_dir.parent.parent / "outside.txt"
+        escape_src.write_text("pwned-source")
+
+        # Pre-condition: the destination must not exist before restore.
+        escape_dst = hermes_home.parent.parent / "outside.txt"
+        assert not escape_dst.exists()
+
+        # Restore should succeed for legitimate files but skip the hostile
+        # entry. We don't assert on the return value (other legitimate
+        # entries may still restore); we assert on the file-system effect.
+        restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        assert not escape_dst.exists(), (
+            f"manifest rel traversal escaped HERMES_HOME: {escape_dst} exists"
+        )
+
+        # Cleanup the seeded escape source so the test is hermetic.
+        escape_src.unlink()
+
 class TestPreUpdateBackup:
     """Tests for create_pre_update_backup — the auto-backup ``hermes update``
     runs before touching anything."""


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/backup.py` had path traversal vulnerabilities in
`restore_quick_snapshot()` that were absent in the more hardened
`run_import()` function.

### 1. Unvalidated `snapshot_id` (line 577)

```python
# Before (vulnerable)
snap_dir = root / snapshot_id  # snapshot_id never validated
```

A crafted `snapshot_id` like `../../attacker_dir` would cause
`snap_dir` to escape the snapshots directory entirely.

**Fix:** Reject `snapshot_id` values containing `/`, `\`, `.`, `..`
or empty strings. Then verify `snap_dir.resolve().relative_to(root.resolve())`
to block symlink-based escapes.

### 2. Unvalidated manifest `rel` paths (lines 590-596)

```python
# Before (vulnerable)
for rel in meta.get("files", {}):
    src = snap_dir / rel
    dst = home / rel  # no relative_to() check on rel!
```

A malicious `manifest.json` with `"files": {"../../.bashrc": 1}`
would write arbitrary files outside `~/.hermes/`.

**Fix:** Applied the same `target.resolve().relative_to(hermes_root.resolve())`
pattern used in `run_import()` to both `src` and `dst` paths. Files
that fail the check are skipped and logged.

## Type of Change

- [x] 🔒 Security fix (path traversal — CRITICAL)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Mirrors the existing path traversal protection in `run_import()`
- [x] No behavior change for legitimate snapshot IDs and file paths