### PR TITLE
fix(agent): resolve context_length for plugin context engines

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1331,6 +1331,22 @@ class AIAgent:
 
         if _selected_engine is not None:
             self.context_compressor = _selected_engine
+            # Resolve context_length for plugin engines — mirrors switch_model() path
+            from agent.model_metadata import get_model_context_length
+            _plugin_ctx_len = get_model_context_length(
+                self.model,
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                config_context_length=_config_context_length,
+                provider=self.provider,
+            )
+            self.context_compressor.update_model(
+                model=self.model,
+                context_length=_plugin_ctx_len,
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                provider=self.provider,
+            )
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)
         else:


### PR DESCRIPTION
## What

Plugin context engines loaded via `load_context_engine()` are never given `context_length`, causing the CLI status bar to show `ctx --` with an empty progress bar. This calls `update_model()` immediately after loading the plugin engine, mirroring what `switch_model()` already does (~line 1600).

## Why

The built-in `ContextCompressor` resolves `context_length` via `get_model_context_length()` in its init path. Plugin context engines skip this — `update_model()` is never called, so `context_length` stays at 0. The status bar calculation `context_tokens / context_length` produces `None` → `ctx --`.

## Change

`run_agent.py` ~line 1332: after assigning the plugin engine to `self.context_compressor`, resolve `context_length` and call `update_model()` with the same arguments that `switch_model()` uses.

## How to test

1. Install a plugin context engine (e.g. [hermes-lcm](https://github.com/stephenschoettler/hermes-lcm))
2. Set `context.engine: lcm` in `~/.hermes/config.yaml`
3. Start `hermes` — status bar should show actual context usage instead of `ctx --`

Tested on Linux (Python 3.11).

## References

- Reported by @strueman in #9071 and stephenschoettler/hermes-lcm#12