### PR TITLE
fix(memory): refresh provider tool routing after init

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -83,6 +83,79 @@ class MemoryManager:
 
     # -- Registration --------------------------------------------------------
 
+    def _rebuild_tool_index(self, reason: str = "") -> None:
+        """Rebuild tool-name routing from providers' current schemas.
+
+        Providers are allowed to change their exposed tools during initialize()
+        after they connect to a backend or discover capabilities. Rebuilding,
+        rather than appending, keeps dispatch routing consistent with
+        get_all_tool_schemas() and prevents stale pre-initialize tools from
+        remaining callable.
+        """
+        previous = {
+            name: provider.name
+            for name, provider in self._tool_to_provider.items()
+        }
+        rebuilt: Dict[str, MemoryProvider] = {}
+
+        for provider in self._providers:
+            try:
+                schemas = provider.get_tool_schemas()
+            except Exception as e:
+                logger.warning(
+                    "Memory provider '%s' get_tool_schemas() failed while "
+                    "rebuilding tool routing: %s",
+                    provider.name,
+                    e,
+                )
+                continue
+
+            for schema in schemas:
+                tool_name = schema.get("name", "")
+                if not tool_name:
+                    continue
+                existing = rebuilt.get(tool_name)
+                if existing is not None:
+                    logger.warning(
+                        "Memory tool name conflict: '%s' already registered by %s, "
+                        "ignoring from %s",
+                        tool_name,
+                        existing.name,
+                        provider.name,
+                    )
+                    continue
+                rebuilt[tool_name] = provider
+
+        self._tool_to_provider = rebuilt
+
+        current = {
+            name: provider.name
+            for name, provider in self._tool_to_provider.items()
+        }
+        added = sorted(name for name in current if name not in previous)
+        removed = sorted(name for name in previous if name not in current)
+        moved = sorted(
+            name for name in current
+            if name in previous and current[name] != previous[name]
+        )
+        label = f" after {reason}" if reason else ""
+        if added or removed or moved:
+            logger.info(
+                "Memory provider tool routing refreshed%s: added=%s removed=%s "
+                "moved=%s active=%s",
+                label,
+                added,
+                removed,
+                moved,
+                sorted(current),
+            )
+        else:
+            logger.debug(
+                "Memory provider tool routing refreshed%s: unchanged (%d tools)",
+                label,
+                len(current),
+            )
+
     def add_provider(self, provider: MemoryProvider) -> None:
         """Register a memory provider.
 
@@ -110,18 +183,7 @@ class MemoryManager:
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
-            tool_name = schema.get("name", "")
-            if tool_name and tool_name not in self._tool_to_provider:
-                self._tool_to_provider[tool_name] = provider
-            elif tool_name in self._tool_to_provider:
-                logger.warning(
-                    "Memory tool name conflict: '%s' already registered by %s, "
-                    "ignoring from %s",
-                    tool_name,
-                    self._tool_to_provider[tool_name].name,
-                    provider.name,
-                )
+        self._rebuild_tool_index(reason=f"registering {provider.name}")
 
         logger.info(
             "Memory provider '%s' registered (%d tools)",
@@ -355,6 +417,7 @@ class MemoryManager:
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)
+                self._rebuild_tool_index(reason=f"initializing {provider.name}")
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,7 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+import logging
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -75,6 +76,34 @@ class FakeMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action, target, content):
         self.memory_writes.append((action, target, content))
+
+
+class DelayedToolProvider(FakeMemoryProvider):
+    """Provider whose tools are only available after initialize()."""
+
+    def __init__(self, name="delayed"):
+        super().__init__(name=name, tools=[])
+
+    def initialize(self, session_id, **kwargs):
+        super().initialize(session_id, **kwargs)
+        self._tools = [
+            {"name": "delayed_recall", "description": "Delayed recall", "parameters": {}}
+        ]
+
+
+class ReplacingToolProvider(FakeMemoryProvider):
+    """Provider that replaces its provisional tools during initialize()."""
+
+    def __init__(self, name="replacing"):
+        super().__init__(name=name, tools=[
+            {"name": "pre_init_tool", "description": "Temporary", "parameters": {}}
+        ])
+
+    def initialize(self, session_id, **kwargs):
+        super().initialize(session_id, **kwargs)
+        self._tools = [
+            {"name": "post_init_tool", "description": "Ready", "parameters": {}}
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +373,48 @@ class TestMemoryManager:
         assert p2.initialized
         assert p1._init_kwargs["session_id"] == "test-123"
         assert p1._init_kwargs["platform"] == "cli"
+
+    def test_initialize_all_indexes_tools_exposed_after_initialize(self):
+        """Providers may expose tools only after connecting during initialize()."""
+        mgr = MemoryManager()
+        provider = DelayedToolProvider()
+        mgr.add_provider(provider)
+
+        assert not mgr.has_tool("delayed_recall")
+
+        mgr.initialize_all(session_id="test-123", platform="cli")
+
+        assert mgr.has_tool("delayed_recall")
+        result = json.loads(mgr.handle_tool_call("delayed_recall", {"query": "hello"}))
+        assert result["handled"] == "delayed_recall"
+
+    def test_initialize_all_removes_stale_preinitialize_tools(self):
+        """Tool routing should match current schemas after initialize()."""
+        mgr = MemoryManager()
+        provider = ReplacingToolProvider()
+        mgr.add_provider(provider)
+
+        assert mgr.has_tool("pre_init_tool")
+        assert not mgr.has_tool("post_init_tool")
+
+        mgr.initialize_all(session_id="test-123", platform="cli")
+
+        assert not mgr.has_tool("pre_init_tool")
+        assert mgr.has_tool("post_init_tool")
+        assert mgr.get_all_tool_names() == {"post_init_tool"}
+
+    def test_initialize_all_logs_tool_routing_deltas(self, caplog):
+        """Refresh logging should show whether initialize changed routing."""
+        mgr = MemoryManager()
+        provider = DelayedToolProvider()
+        mgr.add_provider(provider)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="agent.memory_manager"):
+            mgr.initialize_all(session_id="test-123", platform="cli")
+
+        assert "Memory provider tool routing refreshed after initializing delayed" in caplog.text
+        assert "delayed_recall" in caplog.text
 
     # -- Error resilience ---------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Refreshes memory provider tool routing after each provider finishes `initialize()`.

Before this change, `MemoryManager.add_provider()` indexed provider tools only at registration time. Providers that discover or expose tool schemas during initialization could initialize correctly, but their tools would never be routable through `execute_tool()`. That made delayed provider setup look like a tool hallucination or missing-tool failure even when the provider itself was healthy.

This changes the routing refresh to rebuild from the current provider schemas after registration and after each provider initialization. Rebuilding instead of appending matters because it also removes stale provisional routes when a provider replaces its pre-init schemas with post-init schemas. It preserves existing first-provider-wins conflict behavior.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/memory_manager.py`
  - Adds a `_rebuild_tool_index()` helper that rebuilds tool routing from all providers' current `get_tool_schemas()` output.
  - Refreshes the tool index after provider registration and after each provider initialization.
  - Adds logging for routing deltas: added, removed, and moved tool routes at info level, unchanged refreshes at debug level.
- `tests/agent/test_memory_provider.py`
  - Adds regression coverage for tools that appear only after initialization.
  - Adds regression coverage for stale pre-initialization routes being removed when schemas change.
  - Adds observability coverage for routing delta logging.

## How to Test

1. Run the focused regression suite:

   ```bash
   python3 -m pytest -o addopts='' tests/agent/test_memory_provider.py -q
   ```

   Result locally:

   ```text
   49 passed, 1 warning in 0.15s
   ```

2. Run the broader non-integration suite:

   ```bash
   venv/bin/python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
   ```

   I ran this locally. It completed with unrelated failures outside this PR's changed area: credential/token test isolation, context compressor model stub drift, gateway bot-filter expectations, file-tool test environment pollution, transcription provider environment assumptions, Matrix mock awaiting, Feishu builder API drift, and code execution stub drift. The focused memory provider suite above passes.

3. Manual behavior covered by the new tests:
   - Register a provider that returns no tool schemas before `initialize()` and returns a schema after `initialize()`.
   - Call `initialize_all()`.
   - Verify `execute_tool()` can route to the newly exposed tool.
   - Register a provider that exposes a provisional schema before init and replaces it after init.
   - Verify the stale route is removed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Attempted broader local suite as described above, but it fails on unrelated existing/environmental issues outside this PR's files. The focused regression suite passes.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, code behavior and tests only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - N/A, no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, routing refresh only, no schema changes

## Screenshots / Logs

Focused regression test output:

```text
$ python3 -m pytest -o addopts='' tests/agent/test_memory_provider.py -q
49 passed, 1 warning in 0.15s
```
