### PR TITLE
fix(whatsapp): log bridge allowlist drops

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -26,7 +26,7 @@ import path from 'path';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { expandWhatsAppIdentifiers, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -229,6 +229,15 @@ async function startSocket() {
 
       // Check allowlist for messages from others (resolve LID ↔ phone aliases)
       if (!msg.key.fromMe && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        try {
+          console.log(JSON.stringify({
+            event: 'ignored',
+            reason: 'allowlist_mismatch',
+            chatId,
+            senderId,
+            senderAliases: Array.from(expandWhatsAppIdentifiers(senderId, SESSION_DIR)),
+          }));
+        } catch {}
         continue;
       }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds one small debugging improvement to the WhatsApp bridge: when an inbound message is dropped by the allowlist check, the bridge now logs an explicit `ignored` event instead of silently continuing.

This is useful because the current bridge logs the inbound `upsert` before the allowlist check, then drops on mismatch without saying why. In practice that makes LID-vs-phone allowlist mismatches look like Hermes never received the message at all.

This PR does not change authorization behavior or startup behavior. It only makes an existing silent drop visible in `bridge.log`.

## Related Issue

https://discord.com/channels/1053877538025386074/1493272145021632717/1493272145021632717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `scripts/whatsapp-bridge/bridge.js`
- Added an explicit JSON log event when the bridge drops an inbound message on the allowlist check
- Included `chatId`, `senderId`, and `senderAliases` in that ignored-event log so LID/phone mismatches are easier to diagnose
- Kept the fix intentionally minimal: no startup logging changes and no authorization logic changes

## How to Test

1. Run `node --check scripts/whatsapp-bridge/bridge.js`
2. Run `node --test scripts/whatsapp-bridge/allowlist.test.mjs`
3. Reproduce a WhatsApp allowlist mismatch and confirm `~/.hermes/whatsapp/bridge.log` now shows an explicit `ignored` event instead of only an inbound `upsert`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

Note: `venv/bin/python -m pytest tests/ -v -n 3` is currently red on `main` in this repo both before and after this change (`56 failed, 11265 passed, 33 skipped` on the rerun for this PR branch), so I am not checking the full-pytest-pass box.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Example of the new bridge-side signal this adds:

```json
{"event":"ignored","reason":"allowlist_mismatch","chatId":"...","senderId":"...","senderAliases":["..."]}
```
