### PR TITLE
fix: reattach Camofox sessions after local cleanup drops tab state

### DIFF
--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -95,6 +95,29 @@ class TestEphemeralMode:
         s2 = _get_session("task-1")
         assert s1 is s2
 
+    def test_auto_reattach_uses_existing_server_tab(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+
+        tab_list_resp = _mock_response(
+            json_data={
+                "running": True,
+                "tabs": [
+                    {
+                        "tabId": "tab-existing",
+                        "url": "https://cloud.vast.ai/login/",
+                    }
+                ],
+            }
+        )
+
+        with patch("tools.browser_camofox.requests.get", return_value=tab_list_resp) as mock_get:
+            session = _get_session("task-1")
+
+        assert session["tab_id"] == "tab-existing"
+        mock_get.assert_called_once()
+        assert mock_get.call_args.kwargs["params"]["userId"] == session["user_id"]
+
 
 class TestManagedPersistenceMode:
     """With managed_persistence: stable userId derived from Hermes profile."""

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -142,7 +142,36 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "managed": False,
             }
         _sessions[task_id] = session
-        return session
+
+    # Auto-reattach: if tab_id is None, check server for existing tabs.
+    # This handles cases where a previous task's cleanup dropped the local
+    # Python-side session while the server-side shared-context tab is still
+    # alive (e.g. human takeover/noVNC handoff). Without this, snapshot/click
+    # would fail with "No browser session" even though the live tab still
+    # exists on the Camofox server.
+    session = _sessions[task_id]
+    if not session["tab_id"]:
+        try:
+            base = get_camofox_url()
+            resp = requests.get(
+                f"{base}/tabs",
+                params={"userId": session["user_id"]},
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                tabs = resp.json().get("tabs", [])
+                if tabs:
+                    reused_tab = tabs[-1]
+                    session["tab_id"] = reused_tab.get("tabId") or reused_tab.get("targetId")
+                    logger.info(
+                        "Auto-reattached to existing tab %s (url: %s)",
+                        session["tab_id"],
+                        reused_tab.get("url", "?"),
+                    )
+        except Exception as exc:
+            logger.debug("Auto-reattach check failed: %s", exc)
+
+    return session
 
 
 def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- auto-reattach to an existing Camofox tab when local in-memory session state has lost `tab_id`
- add a persistence test covering reuse of an already-live backend tab

## Why
This preserves working browser sessions when the backend still has a live tab but Hermes local bookkeeping has been cleaned up. In my current setup this was required to make human takeover handoff work reliably, but the patch itself is useful any time local client state and backend tab state drift apart.

## Notes
This is the current working version used in production for takeover/session recovery. It is intentionally a bit "dirty"/pragmatic so the exact working behavior is saved upstream-facing first. I plan to follow up with a cleaned-up version/PR once I've had more time to trim the framing and test it further.

## Test Plan
- [x] targeted pytest: `tests/tools/test_browser_camofox_persistence.py`
- [x] manual validation against a live Camofox backend with session handoff / reattach behavior
