### PR TITLE
fix: restore rasputin provider and direct setup CLI

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5377,13 +5377,18 @@ Examples:
         description=(
             "Set up and manage external memory provider plugins.\n\n"
             "Available providers: honcho, openviking, mem0, hindsight,\n"
-            "holographic, retaindb, byterover.\n\n"
+            "holographic, retaindb, byterover, rasputin.\n\n"
             "Only one external provider can be active at a time.\n"
             "Built-in memory (MEMORY.md/USER.md) is always active."
         ),
     )
     memory_sub = memory_parser.add_subparsers(dest="memory_command")
-    memory_sub.add_parser("setup", help="Interactive provider selection and configuration")
+    memory_setup_parser = memory_sub.add_parser("setup", help="Interactive provider selection and configuration")
+    memory_setup_parser.add_argument(
+        "provider_name",
+        nargs="?",
+        help="Optional provider name for direct setup (e.g. rasputin)",
+    )
     memory_sub.add_parser("status", help="Show current memory provider config")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -444,7 +444,11 @@ def memory_command(args) -> None:
     """Route memory subcommands."""
     sub = getattr(args, "memory_command", None)
     if sub == "setup":
-        cmd_setup(args)
+        provider_name = getattr(args, "provider_name", None)
+        if provider_name:
+            cmd_setup_provider(provider_name)
+        else:
+            cmd_setup(args)
     elif sub == "status":
         cmd_status(args)
     else:

--- a/plugins/memory/rasputin/__init__.py
+++ b/plugins/memory/rasputin/__init__.py
@@ -1,0 +1,255 @@
+"""Rasputin memory provider scaffold for Hermes.
+
+V1 scope from the planning docs:
+- Rasputin is a derived retrieval and enrichment sidecar
+- built-in Hermes memory plus Ryan Book/JSONL remain canonical
+- no model-facing Rasputin tools in v1
+- all failures must fail open so turns continue normally
+
+This module intentionally scaffolds the provider without attempting a full
+production implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+from .client import RasputinClient, RasputinClientConfig
+from .formatter import format_recall_block
+from .mappers import build_memory_write_commit, build_turn_commit
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class RasputinProviderConfig:
+    """Environment-backed provider config for the scaffold."""
+
+    enabled: bool = True
+    base_url: str = "http://127.0.0.1:7777"
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    source_namespace: str = "hermes"
+    prefetch_limit: int = 8
+    commit_importance_default: int = 60
+    fail_open: bool = True
+
+    @classmethod
+    def from_env(cls) -> "RasputinProviderConfig":
+        return cls(
+            enabled=_env_bool("RASPUTIN_ENABLED", True),
+            base_url=os.getenv("RASPUTIN_BASE_URL", cls.base_url).strip() or cls.base_url,
+            timeout_seconds=_env_float("RASPUTIN_TIMEOUT_SECONDS", cls.timeout_seconds),
+            commit_timeout_seconds=_env_float(
+                "RASPUTIN_COMMIT_TIMEOUT_SECONDS",
+                cls.commit_timeout_seconds,
+            ),
+            source_namespace=os.getenv("RASPUTIN_SOURCE_NAMESPACE", cls.source_namespace).strip() or cls.source_namespace,
+            prefetch_limit=max(1, _env_int("RASPUTIN_PREFETCH_LIMIT", cls.prefetch_limit)),
+            commit_importance_default=max(
+                1,
+                min(100, _env_int("RASPUTIN_COMMIT_IMPORTANCE_DEFAULT", cls.commit_importance_default)),
+            ),
+            fail_open=_env_bool("RASPUTIN_FAIL_OPEN", True),
+        )
+
+
+class RasputinMemoryProvider(MemoryProvider):
+    """Derived-memory Rasputin provider scaffold.
+
+    The implementation stays intentionally conservative: it wires up Hermes'
+    provider lifecycle, performs best-effort search and commit calls, and keeps
+    every path safe when Rasputin is unavailable.
+    """
+
+    def __init__(self) -> None:
+        self._config = RasputinProviderConfig.from_env()
+        self._client: Optional[RasputinClient] = None
+        self._session_id = ""
+        self._platform = "cli"
+        self._agent_context = "primary"
+        self._user_id = ""
+        self._healthy = False
+        self._prefetch_cache: Dict[str, List[Dict[str, Any]]] = {}
+        self._prefetch_lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "rasputin"
+
+    def is_available(self) -> bool:
+        """Return True when the scaffold is enabled by config.
+
+        Per the MemoryProvider contract, this does not make network calls.
+        Actual server reachability is checked in initialize().
+        """
+        self._config = RasputinProviderConfig.from_env()
+        return self._config.enabled and bool(self._config.base_url)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize the provider for a session and run a best-effort health check."""
+        self._config = RasputinProviderConfig.from_env()
+        self._session_id = session_id
+        self._platform = str(kwargs.get("platform") or "cli")
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        self._user_id = str(kwargs.get("user_id") or "")
+        self._client = RasputinClient(
+            RasputinClientConfig(
+                base_url=self._config.base_url,
+                timeout_seconds=self._config.timeout_seconds,
+                commit_timeout_seconds=self._config.commit_timeout_seconds,
+                fail_open=self._config.fail_open,
+            )
+        )
+
+        # Fail-open by design: provider readiness should never break canonical memory.
+        self._healthy = self._client.healthcheck()
+        if self._healthy:
+            logger.info("Rasputin provider initialized against %s", self._config.base_url)
+        else:
+            logger.warning(
+                "Rasputin health check failed for %s; continuing in fail-open mode",
+                self._config.base_url,
+            )
+
+    def system_prompt_block(self) -> str:
+        if not self._config.enabled:
+            return ""
+        return (
+            "# Rasputin Memory\n"
+            "Derived retrieval sidecar only. Canonical memory remains Hermes built-ins "
+            "plus Ryan Book/JSONL.\n"
+            "V1 exposes no Rasputin tools to the model; recall and mirrored writes are "
+            "best-effort and may be absent when Rasputin is unavailable."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return formatted recall, using cached results when available."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return ""
+
+        cache_key = session_id or self._session_id
+        with self._prefetch_lock:
+            cached = self._prefetch_cache.pop(cache_key, None)
+        if cached is not None:
+            return format_recall_block(cached, limit=self._config.prefetch_limit)
+
+        results = self._client.search(query, limit=self._config.prefetch_limit)
+        return format_recall_block(results, limit=self._config.prefetch_limit)
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Start a best-effort background search for the next turn."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return
+
+        cache_key = session_id or self._session_id
+
+        def _run() -> None:
+            try:
+                results = self._client.search(query, limit=self._config.prefetch_limit)
+                with self._prefetch_lock:
+                    self._prefetch_cache[cache_key] = results
+            except Exception:
+                logger.debug("Rasputin queue_prefetch failed", exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name="rasputin-prefetch").start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Mirror a completed turn into Rasputin without blocking the response path."""
+        if not self._client or self._agent_context != "primary":
+            return
+        if not (user_content or "").strip() and not (assistant_content or "").strip():
+            return
+
+        payload = build_turn_commit(
+            user_content,
+            assistant_content,
+            session_id=session_id or self._session_id,
+            platform=self._platform,
+            agent_context=self._agent_context,
+            user_id=self._user_id,
+            namespace=self._config.source_namespace,
+        )
+        self._commit_best_effort(payload, label="turn")
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes while preserving canonical ownership."""
+        if not self._client:
+            return
+        if action not in {"add", "replace"}:
+            return
+        if not (content or "").strip():
+            return
+
+        payload = build_memory_write_commit(
+            action,
+            target,
+            content,
+            namespace=self._config.source_namespace,
+            session_id=self._session_id,
+        )
+        self._commit_best_effort(payload, label="memory-write")
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """V1 is context-only; no model-facing Rasputin tools are exposed."""
+        return []
+
+    def _commit_best_effort(self, payload: Dict[str, Any], *, label: str) -> None:
+        """Fire a background commit and swallow failures.
+
+        TODO:
+        - add a bounded queue and flush on shutdown if reliability needs increase
+        - consider retries once real traffic patterns are known
+        """
+        if not self._client:
+            return
+
+        def _run() -> None:
+            try:
+                ok = self._client.commit(payload)
+                if not ok:
+                    logger.debug("Rasputin %s commit skipped/failed (fail-open)", label)
+            except Exception:
+                logger.debug("Rasputin %s commit failed", label, exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name=f"rasputin-{label}").start()
+
+
+def register(ctx) -> None:
+    """Register Rasputin as a Hermes memory provider plugin."""
+    ctx.register_memory_provider(RasputinMemoryProvider())

--- a/plugins/memory/rasputin/client.py
+++ b/plugins/memory/rasputin/client.py
@@ -1,0 +1,219 @@
+"""Thin Rasputin HTTP client for the Hermes memory provider scaffold.
+
+V1 intentionally stays small:
+- use only the public /health, /search, and /commit endpoints
+- fail open on transport or payload issues
+- avoid third-party dependencies so the plugin remains import-safe
+
+TODO:
+- add richer response schema validation once the provider graduates past scaffold
+- add retry/backoff and queue instrumentation if commit volume increases
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+from urllib import error, request
+
+_MAX_COMMIT_TEXT_CHARS = 8000
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RasputinClientConfig:
+    """Runtime config for talking to Rasputin over HTTP."""
+
+    base_url: str = "http://127.0.0.1:7777"
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    fail_open: bool = True
+
+
+class RasputinClient:
+    """Best-effort HTTP wrapper around Rasputin's public API."""
+
+    def __init__(self, config: RasputinClientConfig):
+        self._config = config
+        self._base_url = config.base_url.rstrip("/")
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def healthcheck(self) -> bool:
+        """Return True when Rasputin's health endpoint answers successfully."""
+        payload = self._request_json("/health", timeout=3.0, method="GET")
+        if payload is None:
+            return False
+        if isinstance(payload, dict):
+            status = str(payload.get("status", "")).strip().lower()
+            if status:
+                return status in {"ok", "healthy", "pass"}
+        return True
+
+    def search(self, query: str, *, limit: int = 8) -> List[Dict[str, Any]]:
+        """Search Rasputin and normalize the response into a list of hits.
+
+        Use POST /search so long prompts stay in the request body instead of the
+        query string. Rasputin supports both GET and POST search, and POST avoids
+        noisy HTTP 414 errors on large recall queries.
+        """
+        query = (query or "").strip()
+        if not query:
+            return []
+
+        started = time.monotonic()
+        payload = self._request_json(
+            "/search",
+            timeout=self._config.timeout_seconds,
+            method="POST",
+            payload={
+                "query": query,
+                "limit": max(int(limit or 1), 1),
+            },
+        )
+        hits = self._normalize_search_results(payload)
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        logger.debug(
+            "rasputin_search_ms=%s rasputin_search_hits=%s base_url=%s",
+            elapsed_ms,
+            len(hits),
+            self._base_url,
+        )
+        return hits
+
+    def commit(self, payload: Mapping[str, Any]) -> bool:
+        """POST a commit payload to Rasputin.
+
+        Returns False instead of raising on expected fail-open paths.
+        Oversized text is clamped client-side so derived-memory mirroring stays
+        quiet and fail-open instead of producing predictable HTTP 400 warnings.
+        """
+        if not payload:
+            return False
+
+        started = time.monotonic()
+        response = self._request_json(
+            "/commit",
+            timeout=self._config.commit_timeout_seconds,
+            method="POST",
+            payload=self._prepare_commit_payload(payload),
+        )
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        success = response is not None
+        if success:
+            logger.debug("rasputin_commit_ms=%s", elapsed_ms)
+        else:
+            logger.debug("rasputin_commit_ms=%s rasputin_commit_failures=1", elapsed_ms)
+        return success
+
+    def _request_json(
+        self,
+        path: str,
+        *,
+        timeout: float,
+        method: str,
+        payload: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Any]:
+        """Issue an HTTP request and decode JSON.
+
+        Returns None on failure when fail_open is enabled.
+        """
+        url = f"{self._base_url}{path}"
+        body = None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        req = request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with request.urlopen(req, timeout=timeout) as response:
+                raw = response.read().decode("utf-8", errors="replace").strip()
+        except error.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.read().decode("utf-8", errors="replace").strip()
+            except Exception:
+                detail = ""
+            logger.warning(
+                "Rasputin %s %s failed with HTTP %s%s",
+                method,
+                url,
+                exc.code,
+                f": {detail[:200]}" if detail else "",
+            )
+            if self._config.fail_open:
+                return None
+            raise
+        except (error.URLError, TimeoutError, OSError) as exc:
+            logger.warning("Rasputin %s %s failed: %s", method, url, exc)
+            if self._config.fail_open:
+                return None
+            raise
+
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Rasputin returned non-JSON payload for %s %s", method, url)
+            if self._config.fail_open:
+                return None
+            raise
+
+    @staticmethod
+    def _prepare_commit_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        clean: Dict[str, Any] = dict(payload)
+        text = clean.get("text")
+        if not isinstance(text, str) or len(text) <= _MAX_COMMIT_TEXT_CHARS:
+            return clean
+
+        metadata = clean.get("metadata")
+        if isinstance(metadata, Mapping):
+            metadata = dict(metadata)
+        else:
+            metadata = {}
+        metadata["rasputin_truncated"] = True
+        metadata["rasputin_original_text_length"] = len(text)
+
+        clean["metadata"] = metadata
+        clean["text"] = text[:_MAX_COMMIT_TEXT_CHARS]
+        return clean
+
+    @staticmethod
+    def _normalize_search_results(payload: Any) -> List[Dict[str, Any]]:
+        """Normalize several plausible search response envelopes.
+
+        The scaffold tolerates light schema drift because Rasputin is derived,
+        not canonical. Unknown shapes safely collapse to an empty result set.
+        """
+        items: Any = []
+        if isinstance(payload, list):
+            items = payload
+        elif isinstance(payload, dict):
+            for key in ("results", "hits", "items", "memories", "data"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    items = value
+                    break
+
+        normalized: List[Dict[str, Any]] = []
+        for index, item in enumerate(items or []):
+            if isinstance(item, dict):
+                normalized.append(item)
+                continue
+            if isinstance(item, str):
+                normalized.append(
+                    {
+                        "id": f"rasputin-hit-{index + 1}",
+                        "text": item,
+                        "metadata": {},
+                    }
+                )
+        return normalized

--- a/plugins/memory/rasputin/formatter.py
+++ b/plugins/memory/rasputin/formatter.py
@@ -1,0 +1,151 @@
+"""Formatting helpers for Rasputin recall blocks.
+
+The provider is context-only in V1, so the formatter's job is simply to turn
+raw search hits into a compact injected block with provenance. Canonical memory
+stays in Hermes built-ins and JSONL; Rasputin output is advisory context.
+
+TODO:
+- tighten formatting against the final Rasputin hit schema
+- add richer grouping for daily-log windows if they become noisy
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+import textwrap
+
+
+def format_recall_block(results: Iterable[Mapping[str, Any]], *, limit: int = 8) -> str:
+    """Render a compact recall block for prompt injection."""
+    hits = [dict(hit) for hit in list(results or [])[: max(int(limit or 1), 1)]]
+    if not hits:
+        return ""
+
+    facts: List[Dict[str, Any]] = []
+    windows: List[Dict[str, Any]] = []
+    other: List[Dict[str, Any]] = []
+
+    for hit in hits:
+        bucket = _bucket_for_hit(hit)
+        if bucket == "facts":
+            facts.append(hit)
+        elif bucket == "windows":
+            windows.append(hit)
+        else:
+            other.append(hit)
+
+    lines = ["# Rasputin Recall"]
+    mixed = sum(bool(group) for group in (facts, windows, other)) > 1
+
+    if facts:
+        if mixed:
+            lines.append("## Facts")
+        lines.extend(_format_group(facts))
+    if windows:
+        if mixed:
+            lines.append("## Windows")
+        lines.extend(_format_group(windows))
+    if other:
+        if mixed:
+            lines.append("## Other")
+        lines.extend(_format_group(other))
+
+    return "\n".join(lines)
+
+
+def _format_group(hits: Iterable[Mapping[str, Any]]) -> List[str]:
+    lines: List[str] = []
+    for hit in hits:
+        metadata = _metadata(hit)
+        identifier = (
+            str(metadata.get("canonical_id") or "").strip()
+            or str(hit.get("id") or "").strip()
+            or str(hit.get("source") or "").strip()
+            or "rasputin-hit"
+        )
+        score = _score_text(hit)
+        provenance = _provenance_text(hit, metadata)
+        text = _truncate(_extract_text(hit), width=220)
+
+        lines.append(f"- [score {score}] {identifier}")
+        if provenance:
+            lines.append(f"  {provenance}")
+        if text:
+            lines.append(f"  text: {text}")
+        lines.append("")
+    if lines:
+        lines.pop()
+    return lines
+
+
+def _bucket_for_hit(hit: Mapping[str, Any]) -> str:
+    metadata = _metadata(hit)
+    kind = str(metadata.get("kind") or "").lower()
+    source = str(hit.get("source") or metadata.get("source") or "").lower()
+    if kind in {"typed_memory", "memory_write"}:
+        return "facts"
+    if kind in {"conversation_window", "session_window", "daily_log_window"}:
+        return "windows"
+    if "window" in kind or "window" in source:
+        return "windows"
+    if metadata.get("canonical_id") or metadata.get("memory_type"):
+        return "facts"
+    return "other"
+
+
+def _metadata(hit: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata = hit.get("metadata")
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _score_text(hit: Mapping[str, Any]) -> str:
+    value = hit.get("score")
+    if value is None:
+        value = hit.get("similarity")
+    if value is None:
+        return "n/a"
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _provenance_text(hit: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    parts: List[str] = []
+
+    source = str(hit.get("source") or metadata.get("source") or "").strip()
+    if source:
+        parts.append(f"source: {source}")
+
+    fleet = str(metadata.get("fleet") or "").strip()
+    if fleet:
+        parts.append(f"fleet: {fleet}")
+
+    memory_type = str(metadata.get("memory_type") or metadata.get("type") or "").strip()
+    if memory_type:
+        parts.append(f"type: {memory_type}")
+
+    session_id = str(metadata.get("session_id") or "").strip()
+    if session_id:
+        parts.append(f"session: {session_id}")
+
+    kind = str(metadata.get("kind") or "").strip()
+    if kind and kind not in {"typed_memory", "conversation_window", "session_window", "daily_log_window", "memory_write"}:
+        parts.append(f"kind: {kind}")
+
+    return " | ".join(parts)
+
+
+def _extract_text(hit: Mapping[str, Any]) -> str:
+    for key in ("text", "content", "snippet", "summary"):
+        value = hit.get(key)
+        if isinstance(value, str) and value.strip():
+            return " ".join(value.split())
+    return ""
+
+
+def _truncate(text: str, *, width: int) -> str:
+    text = " ".join((text or "").split())
+    if not text:
+        return ""
+    return textwrap.shorten(text, width=width, placeholder=" …")

--- a/plugins/memory/rasputin/mappers.py
+++ b/plugins/memory/rasputin/mappers.py
@@ -1,0 +1,172 @@
+"""Payload mappers for Rasputin commit bodies.
+
+These helpers preserve the architectural rule from the planning docs:
+Rasputin is a derived retrieval plane, not the canonical memory store.
+Mappings therefore keep provenance metadata so Rasputin commits remain
+rebuildable from Hermes-native sources.
+
+TODO:
+- wire build_jsonl_fact_commit() into the separate backfill/import scripts
+- refine text rendering once real canonical JSONL samples are exercised
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+
+_TYPE_IMPORTANCE = {
+    "fact": 80,
+    "decision": 90,
+    "pattern": 70,
+    "gotcha": 85,
+    "incident": 90,
+    "preference": 85,
+}
+
+
+def build_turn_commit(
+    user_content: str,
+    assistant_content: str,
+    *,
+    session_id: str = "",
+    platform: str = "cli",
+    agent_context: str = "primary",
+    user_id: str = "",
+    namespace: str = "hermes",
+) -> Dict[str, Any]:
+    """Map one completed Hermes turn into a Rasputin window commit."""
+    return {
+        "text": _strip_join(
+            f"USER: {(user_content or '').strip()}",
+            f"ASSISTANT: {(assistant_content or '').strip()}",
+        ),
+        "source": "hermes-turn",
+        "importance": 55,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "conversation_window",
+            "session_id": session_id,
+            "platform": platform,
+            "agent_context": agent_context,
+            "user_id": user_id or None,
+        },
+    }
+
+
+def build_memory_write_commit(
+    action: str,
+    target: str,
+    content: str,
+    *,
+    namespace: str = "hermes",
+    session_id: str = "",
+) -> Dict[str, Any]:
+    """Map a built-in Hermes memory write into a Rasputin mirror commit."""
+    clean_action = (action or "").strip() or "add"
+    clean_target = (target or "").strip() or "memory"
+    clean_content = (content or "").strip()
+    return {
+        "text": f"MEMORY WRITE [target={clean_target} action={clean_action}]: {clean_content}",
+        "source": "hermes-memory-write",
+        "importance": 75,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "memory_write",
+            "session_id": session_id or None,
+            "target": clean_target,
+            "action": clean_action,
+        },
+    }
+
+
+def build_jsonl_fact_commit(
+    record: Mapping[str, Any],
+    *,
+    namespace: str = "ryan-book",
+    source_path: str = "",
+) -> Dict[str, Any]:
+    """Scaffold mapper for canonical JSONL typed memory backfill.
+
+    This is intentionally not wired into the live provider yet. It exists so the
+    backfill/import phase can reuse a single mapping definition later.
+    """
+    memory_type = str(record.get("type") or "fact").strip() or "fact"
+    pinned = bool(record.get("pinned"))
+    trust = _coerce_float(record.get("trust"))
+    importance = _importance_for_record(memory_type, pinned=pinned, trust=trust)
+    metadata = {
+        "namespace": namespace,
+        "kind": "typed_memory",
+        "canonical_id": record.get("id"),
+        "memory_type": memory_type,
+        "fleet": record.get("fleet"),
+        "tags": list(record.get("tags") or []),
+        "trust": trust,
+        "pinned": pinned,
+        "source_path": source_path or None,
+        "source_created_at": record.get("created_at"),
+    }
+    return {
+        "text": _render_typed_memory_text(record, memory_type),
+        "source": f"jsonl-{memory_type}",
+        "importance": importance,
+        "metadata": metadata,
+    }
+
+
+def _render_typed_memory_text(record: Mapping[str, Any], memory_type: str) -> str:
+    content = record.get("content")
+    pieces = [f"[{memory_type}]"]
+    if isinstance(content, Mapping):
+        for key, value in content.items():
+            rendered = _render_value(value)
+            if rendered:
+                pieces.append(f"{key}: {rendered}")
+    else:
+        rendered = _render_value(content)
+        if rendered:
+            pieces.append(rendered)
+    return "\n".join(pieces)
+
+
+def _importance_for_record(memory_type: str, *, pinned: bool, trust: float | None) -> int:
+    importance = _TYPE_IMPORTANCE.get(memory_type, 80)
+    if pinned:
+        importance = min(100, importance + 5)
+    if trust is not None and trust < 0.6:
+        importance = max(40, importance - 10)
+    return importance
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        parts = [part for part in (_render_value(item) for item in value) if part]
+        return ", ".join(parts)
+    if isinstance(value, Mapping):
+        parts = []
+        for key, item in value.items():
+            rendered = _render_value(item)
+            if rendered:
+                parts.append(f"{key}={rendered}")
+        return ", ".join(parts)
+    return str(value).strip()
+
+
+def _strip_join(*parts: str) -> str:
+    return "\n".join(part for part in parts if part and part.strip())
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/plugins/memory/rasputin/plugin.yaml
+++ b/plugins/memory/rasputin/plugin.yaml
@@ -1,0 +1,4 @@
+name: rasputin
+version: 0.1.0
+description: "Rasputin derived-memory provider scaffold for Hermes. V1 is context-only with mirrored writes and no model-facing tools."
+pip_dependencies: []

--- a/tests/hermes_cli/test_memory_setup_cli.py
+++ b/tests/hermes_cli/test_memory_setup_cli.py
@@ -1,0 +1,43 @@
+import argparse
+from unittest import mock
+
+import hermes_cli.main as cli_main
+import hermes_cli.memory_setup as memory_setup
+
+
+def test_main_accepts_memory_setup_provider_arg(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+
+    def fake_memory_command(args):
+        captured["memory_command"] = args.memory_command
+        captured["provider_name"] = getattr(args, "provider_name", None)
+
+    monkeypatch.setattr("hermes_cli.memory_setup.memory_command", fake_memory_command)
+
+    with mock.patch("sys.argv", ["hermes", "memory", "setup", "rasputin"]):
+        cli_main.main()
+
+    assert captured == {
+        "memory_command": "setup",
+        "provider_name": "rasputin",
+    }
+
+
+def test_memory_command_routes_direct_provider_setup(monkeypatch):
+    called = {}
+
+    def fake_cmd_setup_provider(provider_name):
+        called["provider_name"] = provider_name
+
+    def fake_cmd_setup(args):
+        called["interactive"] = True
+
+    monkeypatch.setattr(memory_setup, "cmd_setup_provider", fake_cmd_setup_provider)
+    monkeypatch.setattr(memory_setup, "cmd_setup", fake_cmd_setup)
+
+    args = argparse.Namespace(memory_command="setup", provider_name="rasputin")
+    memory_setup.memory_command(args)
+
+    assert called == {"provider_name": "rasputin"}

--- a/tests/plugins/memory/test_rasputin_provider.py
+++ b/tests/plugins/memory/test_rasputin_provider.py
@@ -1,0 +1,84 @@
+import json
+
+from plugins.memory.rasputin.client import (
+    RasputinClient,
+    RasputinClientConfig,
+    _MAX_COMMIT_TEXT_CHARS,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_search_uses_post_body(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"results": [{"id": "r1", "text": "match"}]})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    results = client.search("x" * 12000, limit=3)
+
+    assert results == [{"id": "r1", "text": "match"}]
+    assert captured["url"] == "http://127.0.0.1:7777/search"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"query": "x" * 12000, "limit": 3}
+    assert captured["headers"]["Content-type"] == "application/json"
+
+
+def test_prepare_commit_payload_truncates_oversized_text():
+    original = "x" * (_MAX_COMMIT_TEXT_CHARS + 250)
+
+    prepared = RasputinClient._prepare_commit_payload(
+        {
+            "text": original,
+            "source": "hermes-turn",
+            "metadata": {"kind": "conversation_window"},
+        }
+    )
+
+    assert len(prepared["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert prepared["text"] == original[:_MAX_COMMIT_TEXT_CHARS]
+    assert prepared["metadata"]["kind"] == "conversation_window"
+    assert prepared["metadata"]["rasputin_truncated"] is True
+    assert prepared["metadata"]["rasputin_original_text_length"] == len(original)
+
+
+def test_commit_sends_truncated_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    ok = client.commit({"text": "y" * (_MAX_COMMIT_TEXT_CHARS + 10), "source": "hermes-turn"})
+
+    assert ok is True
+    assert captured["url"] == "http://127.0.0.1:7777/commit"
+    assert captured["method"] == "POST"
+    assert len(captured["body"]["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert captured["body"]["metadata"]["rasputin_truncated"] is True


### PR DESCRIPTION
## Summary
- restore the Rasputin memory provider scaffold from PR 8989
- add direct CLI support for 
- add regression tests for provider-name parsing and routing

## Test Plan
- 
- 
  Memory provider: rasputin
  Activation saved to config.yaml
- 
┌─────────────────────────────────────────────────────────┐
│                 🩺 Hermes Doctor                        │
└─────────────────────────────────────────────────────────┘

◆ Python Environment
  ✓ Python 3.11.14
  ✓ Virtual environment active

◆ Required Packages
  ✓ OpenAI SDK
  ✓ Rich (terminal UI)
  ✓ python-dotenv
  ✓ PyYAML
  ✓ HTTPX
  ✓ Croniter (cron expressions) (optional)
  ✓ python-telegram-bot (optional)
  ✓ discord.py (optional)

◆ Configuration Files
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/.env file exists
  ⚠ No API key found in /Users/ashsokke/.hermes/profiles/generic-core/.env
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/config.yaml exists
  ✓ Config version up to date (v17)

◆ Auth Providers
  ⚠ Nous Portal auth (not logged in)
  ✓ OpenAI Codex auth (logged in)
  ✓ codex CLI

◆ Directory Structure
  ✓ /Users/ashsokke/.hermes/profiles/generic-core directory exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/cron/ exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/sessions/ exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/logs/ exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/skills/ exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/memories/ exists
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/SOUL.md exists (persona configured)
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/memories/ directory exists
  ✓ MEMORY.md exists (2108 chars)
  ✓ USER.md exists (1373 chars)
  ✓ /Users/ashsokke/.hermes/profiles/generic-core/state.db exists (176 sessions)

◆ External Tools
  ✓ git
  ✓ ripgrep (rg) (faster file search)
  ✓ docker (optional)
  ✓ Node.js
  ✓ agent-browser (Node.js) (browser automation)
  ✓ Browser tools (agent-browser) deps (no known vulnerabilities)

◆ API Connectivity
  ⚠ OpenRouter API (not configured)

◆ Submodules
  ⚠ tinker-atropos found but not installed (run: uv pip install -e ./tinker-atropos)

◆ Tool Availability
  ✓ terminal
  ✓ file
  ✓ vision
  ✓ skills
  ✓ browser
  ✓ cronjob
  ✓ tts
  ✓ todo
  ✓ memory
  ✓ session_search
  ✓ clarify
  ✓ code_execution
  ✓ delegation
  ✓ messaging
  ⚠ web (missing EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL)
  ⚠ moa (missing OPENROUTER_API_KEY)
  ⚠ image_gen (system dependency not met)
  ⚠ rl (missing TINKER_API_KEY, WANDB_API_KEY)
  ⚠ homeassistant (system dependency not met)

◆ Skills Hub
  ✓ Skills Hub directory exists
  ✓ Lock file OK (0 hub-installed skill(s))
  ⚠ No GITHUB_TOKEN (60 req/hr rate limit — set in /Users/ashsokke/.hermes/profiles/generic-core/.env for better rates)

◆ Memory Provider
  ✓ rasputin provider active

◆ Profiles
  ✓ 4 profile(s) found
  ✓   bharat-digital: gpt-5.4, no alias
  ✓   generic-core: gateway running, gpt-5.4, no alias
  ✓   rani-swivo: gpt-5.4, no alias
  ✓   thindi: gpt-5.4, no alias

────────────────────────────────────────────────────────────
  Found 3 issue(s) to address:

  1. Run 'hermes setup' to configure API keys
  2. Install tinker-atropos: uv pip install -e ./tinker-atropos
  3. Run 'hermes setup' to configure missing API keys for full tool access

  Tip: run 'hermes doctor --fix' to auto-fix what's possible.

🤖 This PR was created by an AI coding agent
🤖 This was written by an AI coding agent
