### PR TITLE
fix(gateway): use venv Python for systemd ExecStart instead of sys.executable (#9201)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -813,11 +813,19 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
 
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
-    python_path = get_python_path()
+    # Always prefer the project venv Python for ExecStart — sys.executable
+    # may point to a bare uv-managed interpreter with no site-packages.
+    venv = _detect_venv_dir()
+    if venv is not None:
+        python_path = str(venv / "Scripts" / "python.exe" if is_windows() else venv / "bin" / "python")
+    else:
+        # No venv found — default to PROJECT_ROOT/venv even if it doesn't exist
+        # yet, so the service file is always valid.  sys.executable is avoided
+        # because under uv it resolves to a standalone CPython with no packages.
+        python_path = str(PROJECT_ROOT / "venv" / "bin" / "python")
     working_dir = str(PROJECT_ROOT)
-    detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
-    venv_bin = str(detected_venv / "bin") if detected_venv else str(PROJECT_ROOT / "venv" / "bin")
+    venv_dir = str(venv) if venv else str(PROJECT_ROOT / "venv")
+    venv_bin = str(venv / "bin") if venv else str(PROJECT_ROOT / "venv" / "bin")
     node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
 
     path_entries = [venv_bin, node_bin]


### PR DESCRIPTION
## Problem
When running `hermes gateway install --system --run-as-user root`, the generated systemd service sets `ExecStart` to the uv-managed Python binary (`~/.local/share/uv/python/.../python3.11`) instead of the venv Python. This bare interpreter has no packages installed, so the service crashes with `ModuleNotFoundError: No module named 'yaml'`.

## Root Cause
`get_python_path()` falls back to `sys.executable` when no venv is detected. Under uv, `sys.executable` resolves to the standalone CPython at `~/.local/share/uv/python/...`, not the project venv.

## Fix
`generate_systemd_unit()` now always uses the project venv Python for ExecStart:
1. Detects the active venv via `_detect_venv_dir()`
2. Uses `venv/bin/python` if found
3. Falls back to `PROJECT_ROOT/venv/bin/python` (not `sys.executable`) if no venv detected

This ensures the systemd service always starts with the Python that has all dependencies installed.

Fixes #9201
