### PR TITLE
fix: force Copilot models to use chat completions

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1484,20 +1484,13 @@ def _github_reasoning_efforts_for_model_id(model_id: str) -> list[str]:
 
 
 def _should_use_copilot_responses_api(model_id: str) -> bool:
-    """Decide whether a Copilot model should use the Responses API.
+    """Compatibility shim for older code paths.
 
-    Replicates opencode's ``shouldUseCopilotResponsesApi`` logic:
-    GPT-5+ models use Responses API, except ``gpt-5-mini`` which uses
-    Chat Completions.  All non-GPT models (Claude, Gemini, etc.) use
-    Chat Completions.
+    Hermes policy is now chat-completions-only for Copilot-visible models,
+    so this always returns False. The helper remains for callers and tests
+    that still import it directly.
     """
-    import re
-
-    match = re.match(r"^gpt-(\d+)", model_id)
-    if not match:
-        return False
-    major = int(match.group(1))
-    return major >= 5 and not model_id.startswith("gpt-5-mini")
+    return False
 
 
 def copilot_model_api_mode(
@@ -1508,34 +1501,9 @@ def copilot_model_api_mode(
 ) -> str:
     """Determine the API mode for a Copilot model.
 
-    Uses the model ID pattern (matching opencode's approach) as the
-    primary signal.  Falls back to the catalog's ``supported_endpoints``
-    only for models not covered by the pattern check.
+    Hermes intentionally forces all Copilot-visible models through
+    Chat Completions to avoid silent model-dependent API switching.
     """
-    normalized = normalize_copilot_model_id(model_id, catalog=catalog, api_key=api_key)
-    if not normalized:
-        return "chat_completions"
-
-    # Primary: model ID pattern (matches opencode's shouldUseCopilotResponsesApi)
-    if _should_use_copilot_responses_api(normalized):
-        return "codex_responses"
-
-    # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
-    if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
-
-    if catalog:
-        catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
-        if isinstance(catalog_entry, dict):
-            supported_endpoints = {
-                str(endpoint).strip()
-                for endpoint in (catalog_entry.get("supported_endpoints") or [])
-                if str(endpoint).strip()
-            }
-            # For non-GPT-5 models, check if they only support messages API
-            if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
-                return "anthropic_messages"
-
     return "chat_completions"
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -705,11 +705,10 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
-        # newer tool-calling models prefer Responses there.
-        if self.api_mode == "chat_completions" and (
+        # Some providers require the Responses API path, but Copilot is now
+        # intentionally pinned to chat_completions to avoid silent model-based
+        # transport switching.  Only auto-upgrade providers that still need it.
+        if self.api_mode == "chat_completions" and self.provider != "copilot" and (
             self._is_direct_openai_url()
             or self._model_requires_responses_api(self.model)
         ):

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -557,7 +557,7 @@ class TestRuntimeProviderResolution:
         assert result["api_key"] == "gho_cli_secret"
         assert result["base_url"] == "https://api.githubcopilot.com"
 
-    def test_runtime_copilot_uses_responses_for_gpt_5_4(self, monkeypatch):
+    def test_runtime_copilot_uses_chat_for_gpt_5_4(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         monkeypatch.setattr(
             "hermes_cli.runtime_provider._get_model_config",
@@ -578,7 +578,7 @@ class TestRuntimeProviderResolution:
         result = resolve_runtime_provider(requested="copilot")
 
         assert result["provider"] == "copilot"
-        assert result["api_mode"] == "codex_responses"
+        assert result["api_mode"] == "chat_completions"
 
     def test_runtime_copilot_acp_uses_process_runtime(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -155,18 +155,18 @@ class TestCopilotDefaultHeaders:
 
 
 class TestApiModeSelection:
-    """API mode selection matching opencode's shouldUseCopilotResponsesApi."""
+    """Hermes forces Copilot-visible models to chat completions."""
 
-    def test_gpt5_uses_responses(self):
+    def test_gpt5_uses_chat(self):
         from hermes_cli.models import _should_use_copilot_responses_api
-        assert _should_use_copilot_responses_api("gpt-5.4") is True
-        assert _should_use_copilot_responses_api("gpt-5.4-mini") is True
-        assert _should_use_copilot_responses_api("gpt-5.3-codex") is True
-        assert _should_use_copilot_responses_api("gpt-5.2-codex") is True
-        assert _should_use_copilot_responses_api("gpt-5.2") is True
-        assert _should_use_copilot_responses_api("gpt-5.1-codex-max") is True
+        assert _should_use_copilot_responses_api("gpt-5.4") is False
+        assert _should_use_copilot_responses_api("gpt-5.4-mini") is False
+        assert _should_use_copilot_responses_api("gpt-5.3-codex") is False
+        assert _should_use_copilot_responses_api("gpt-5.2-codex") is False
+        assert _should_use_copilot_responses_api("gpt-5.2") is False
+        assert _should_use_copilot_responses_api("gpt-5.1-codex-max") is False
 
-    def test_gpt5_mini_excluded(self):
+    def test_gpt5_mini_uses_chat(self):
         from hermes_cli.models import _should_use_copilot_responses_api
         assert _should_use_copilot_responses_api("gpt-5-mini") is False
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -317,20 +317,17 @@ class TestCopilotNormalization:
         catalog = [{"id": "gpt-4.1"}, {"id": "gpt-5.4"}]
         assert normalize_copilot_model_id("openai/gpt-4.1-mini", catalog=catalog) == "gpt-4.1"
 
-    def test_copilot_api_mode_gpt5_uses_responses(self):
-        """GPT-5+ models should use Responses API (matching opencode)."""
-        assert copilot_model_api_mode("gpt-5.4") == "codex_responses"
-        assert copilot_model_api_mode("gpt-5.4-mini") == "codex_responses"
-        assert copilot_model_api_mode("gpt-5.3-codex") == "codex_responses"
-        assert copilot_model_api_mode("gpt-5.2-codex") == "codex_responses"
-        assert copilot_model_api_mode("gpt-5.2") == "codex_responses"
-
-    def test_copilot_api_mode_gpt5_mini_uses_chat(self):
-        """gpt-5-mini is the exception — uses Chat Completions."""
+    def test_copilot_api_mode_forces_chat_for_gpt5(self):
+        """Hermes forces Copilot-visible GPT-5 models to chat completions."""
+        assert copilot_model_api_mode("gpt-5.4") == "chat_completions"
+        assert copilot_model_api_mode("gpt-5.4-mini") == "chat_completions"
+        assert copilot_model_api_mode("gpt-5.3-codex") == "chat_completions"
+        assert copilot_model_api_mode("gpt-5.2-codex") == "chat_completions"
+        assert copilot_model_api_mode("gpt-5.2") == "chat_completions"
         assert copilot_model_api_mode("gpt-5-mini") == "chat_completions"
 
     def test_copilot_api_mode_non_gpt5_uses_chat(self):
-        """Non-GPT-5 models use Chat Completions."""
+        """Non-GPT models also stay on chat completions."""
         assert copilot_model_api_mode("gpt-4.1") == "chat_completions"
         assert copilot_model_api_mode("gpt-4o") == "chat_completions"
         assert copilot_model_api_mode("gpt-4o-mini") == "chat_completions"
@@ -338,22 +335,21 @@ class TestCopilotNormalization:
         assert copilot_model_api_mode("claude-opus-4.6") == "chat_completions"
         assert copilot_model_api_mode("gemini-2.5-pro") == "chat_completions"
 
-    def test_copilot_api_mode_with_catalog_both_endpoints(self):
-        """When catalog shows both endpoints, model ID pattern wins."""
+    def test_copilot_api_mode_ignores_catalog_endpoint_hints(self):
+        """Catalog endpoint hints do not override Hermes's chat-only policy."""
         catalog = [{
             "id": "gpt-5.4",
             "supported_endpoints": ["/chat/completions", "/responses"],
         }]
-        # GPT-5.4 should use responses even though chat/completions is listed
-        assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "codex_responses"
+        assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "chat_completions"
 
-    def test_copilot_api_mode_with_catalog_only_responses(self):
+    def test_copilot_api_mode_ignores_catalog_response_only_models(self):
         catalog = [{
             "id": "gpt-5.4",
             "supported_endpoints": ["/responses"],
             "capabilities": {"type": "chat"},
         }]
-        assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "codex_responses"
+        assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "chat_completions"
 
     def test_normalize_opencode_model_id_strips_provider_prefix(self):
         assert normalize_opencode_model_id("opencode-go", "opencode-go/kimi-k2.5") == "kimi-k2.5"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -55,7 +55,7 @@ def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):
     agent = run_agent.AIAgent(
         model=model,
         provider="copilot",
-        api_mode="codex_responses",
+        api_mode="chat_completions",
         base_url="https://api.githubcopilot.com",
         api_key="gh-token",
         quiet_mode=True,
@@ -271,17 +271,20 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
-def test_build_api_kwargs_copilot_responses_omits_openai_only_fields(monkeypatch):
+def test_build_api_kwargs_copilot_chat_omits_openai_only_fields(monkeypatch):
     agent = _build_copilot_agent(monkeypatch)
     kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
 
     assert kwargs["model"] == "gpt-5.4"
-    assert kwargs["store"] is False
-    assert kwargs["tool_choice"] == "auto"
-    assert kwargs["parallel_tool_calls"] is True
-    assert kwargs["reasoning"] == {"effort": "medium"}
+    assert kwargs["timeout"] == 1800.0
+    assert kwargs["tools"][0]["type"] == "function"
+    assert kwargs["tools"][0]["function"]["name"] == "terminal"
+    assert "store" not in kwargs
+    assert "tool_choice" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
     assert "prompt_cache_key" not in kwargs
     assert "include" not in kwargs
+    assert kwargs["extra_body"] == {"reasoning": {"effort": "medium"}}
 
 
 def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_model(monkeypatch):


### PR DESCRIPTION
## Summary

Prevent Hermes from auto-switching Copilot-visible GPT-5 models to Responses API
Force Copilot model routing to chat_completions for consistency
Update tests to reflect the new behavior

## Motivation

This avoids silent API-mode switching that made gpt-5-mini behavior confusing and hard to debug.

## Verification

pytest tests/hermes_cli/test_copilot_auth.py -q
pytest tests/cli/test_cli_provider_resolution.py tests/run_agent/test_strict_api_validation.py tests/run_agent/test_provider_parity.py -q

## Notes
This is a deliberate policy change in Hermes rather than a config-only fix.