### PR TITLE
fix(config): include model in custom_providers dedup key

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1656,7 +1656,8 @@ def get_compatible_custom_providers(
         provider_key = str(entry.get("provider_key", "") or "").strip().lower()
         name = str(entry.get("name", "") or "").strip().lower()
         base_url = str(entry.get("base_url", "") or "").strip().rstrip("/").lower()
-        pair = (name, base_url)
+        model = str(entry.get("model", "") or "").strip().lower()
+        pair = (name, base_url, model)
 
         if provider_key and provider_key in seen_provider_keys:
             return


### PR DESCRIPTION
## Summary

- `get_compatible_custom_providers()` deduplicates entries by `(name, base_url)`, which collapses multiple models under the same provider into a single entry
- For example, 7 Ollama Cloud entries with different models (minimax-m2.7, kimi-k2.5, glm-5.1, etc.) all sharing the same name + URL become 1 entry
- The `/model` picker then shows "Ollama Cloud (1)" instead of "Ollama Cloud (7)"

## Fix

Add `model` to the dedup tuple: `(name, base_url, model)`. Entries with the same provider name and URL but different models are now preserved.

## Test plan

- [x] Verified with config containing 7 Ollama Cloud entries — all 7 now returned by `get_compatible_custom_providers()`
- [x] `/model` picker shows correct count
- [x] Azure PTG (single entry) unaffected
- [x] No duplicate entries when model field is the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)