### PR TITLE
fix(agent): resolve context_length for plugin context engines

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1331,6 +1331,22 @@ class AIAgent:
 
         if _selected_engine is not None:
             self.context_compressor = _selected_engine
+            # Resolve context_length for plugin engines — mirrors switch_model() path
+            from agent.model_metadata import get_model_context_length
+            _plugin_ctx_len = get_model_context_length(
+                self.model,
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                config_context_length=_config_context_length,
+                provider=self.provider,
+            )
+            self.context_compressor.update_model(
+                model=self.model,
+                context_length=_plugin_ctx_len,
+                base_url=self.base_url,
+                api_key=getattr(self, "api_key", ""),
+                provider=self.provider,
+            )
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)
         else:

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -1,0 +1,89 @@
+"""Tests that plugin context engines get update_model() called during init.
+
+Regression test for #9071 — plugin engines were never initialized with
+context_length, causing the CLI status bar to show 'ctx --'.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_engine import ContextEngine
+
+
+class _StubEngine(ContextEngine):
+    """Minimal concrete context engine for testing."""
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    def update_from_response(self, usage):
+        pass
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None):
+        return messages
+
+
+def test_plugin_engine_gets_context_length_on_init():
+    """Plugin context engine should have context_length set during AIAgent init."""
+    engine = _StubEngine()
+    assert engine.context_length == 0  # ABC default before fix
+
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor is engine
+    assert engine.context_length == 204_800
+    assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
+
+
+def test_plugin_engine_update_model_args():
+    """Verify update_model() receives model, context_length, base_url, api_key, provider."""
+    engine = _StubEngine()
+    engine.update_model = MagicMock()
+
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="openrouter/auto",
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    engine.update_model.assert_called_once()
+    kw = engine.update_model.call_args.kwargs
+    assert kw["context_length"] == 131_072
+    assert "model" in kw
+    assert "provider" in kw
+    # Should NOT pass api_mode — the ABC doesn't accept it
+    assert "api_mode" not in kw


### PR DESCRIPTION
## Summary
Salvage of PR #9218 by @stephenschoettler. Also addresses #9117 by @corazzione (duplicate fix, submitted first).

Plugin context engines (like LCM) were never initialized with `context_length` during agent startup. The built-in `ContextCompressor` resolves it in its `__init__`, but the plugin path just assigned the engine directly — leaving `context_length` at the ABC default of 0. This caused the CLI status bar to permanently show `ctx --` with an empty progress bar.

The fix calls `update_model()` on the plugin engine immediately after loading, mirroring what `switch_model()` already does.

## Changes
- `run_agent.py`: Call `get_model_context_length()` + `update_model()` after assigning plugin engine (cherry-picked from #9218)
- `tests/run_agent/test_plugin_context_engine_init.py`: Regression tests verifying plugin engines get correct `context_length` and `update_model()` args

## Test plan
```
python3 -m pytest tests/run_agent/test_plugin_context_engine_init.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_context_pressure.py -o 'addopts=' -q
```
49 passed.

Fixes #9071
Closes #9218
Closes #9117