### PR TITLE
test(gateway): guard every /stop path against session suspension

### DIFF
--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -323,6 +323,51 @@ async def test_stop_clears_pending_messages():
 
 
 # ------------------------------------------------------------------
+# Test 6d: /stop must NOT suspend the session (regression for #9224)
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_does_not_suspend_session():
+    """PR #9224 removed suspend_session() from /stop because it caused
+    users to lose their conversation history.  This test guards against
+    a revert: /stop must interrupt the agent and unlock the session
+    WITHOUT marking it suspended.
+
+    Covers all three code paths:
+      - sentinel set (agent still starting)
+      - real agent running
+      - no agent running (no-op path)
+    """
+    runner = _make_runner()
+    session_key = build_session_key(
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="u1",
+        )
+    )
+
+    # Path 1: /stop while sentinel is set (agent starting)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    stop_event = _make_event(text="/stop")
+    await runner._handle_message(stop_event)
+    runner.session_store.suspend_session.assert_not_called()
+
+    # Path 2: /stop while real agent is running
+    runner.session_store.reset_mock()
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+    await runner._handle_message(stop_event)
+    runner.session_store.suspend_session.assert_not_called()
+
+    # Path 3: /stop with no agent (no-op)
+    runner.session_store.reset_mock()
+    assert session_key not in runner._running_agents
+    await runner._handle_message(stop_event)
+    runner.session_store.suspend_session.assert_not_called()
+
+
+# ------------------------------------------------------------------
 # Test 7: Shutdown skips sentinel entries
 # ------------------------------------------------------------------
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -347,11 +347,15 @@ async def test_stop_does_not_suspend_session():
         )
     )
 
+    stop_event = _make_event(text="/stop")
+
     # Path 1: /stop while sentinel is set (agent starting)
     runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
-    stop_event = _make_event(text="/stop")
     await runner._handle_message(stop_event)
     runner.session_store.suspend_session.assert_not_called()
+    assert session_key not in runner._running_agents, (
+        "sentinel must be cleaned up after /stop"
+    )
 
     # Path 2: /stop while real agent is running
     runner.session_store.reset_mock()
@@ -359,10 +363,12 @@ async def test_stop_does_not_suspend_session():
     runner._running_agents[session_key] = fake_agent
     await runner._handle_message(stop_event)
     runner.session_store.suspend_session.assert_not_called()
+    assert session_key not in runner._running_agents, (
+        "agent must be removed after /stop"
+    )
 
     # Path 3: /stop with no agent (no-op)
     runner.session_store.reset_mock()
-    assert session_key not in runner._running_agents
     await runner._handle_message(stop_event)
     runner.session_store.suspend_session.assert_not_called()
 

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -437,6 +437,7 @@ async def test_stop_during_sentinel_force_cleans_session():
         assert session_key not in runner._running_agents, (
             "/stop must remove sentinel so the session is unlocked"
         )
+        runner.session_store.suspend_session.assert_not_called()
 
         # Should NOT be queued as pending
         adapter = runner.adapters[Platform.TELEGRAM]
@@ -487,6 +488,7 @@ async def test_stop_hard_kills_running_agent():
     # Must return a confirmation
     assert result is not None
     assert "stopped" in result.lower()
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------
@@ -518,6 +520,28 @@ async def test_stop_clears_pending_messages():
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
     adapter.get_pending_message.assert_called_once_with(session_key)
+    runner.session_store.suspend_session.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Test 6d: /stop with no active run preserves the session
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_stop_with_no_active_agent_does_not_suspend_session():
+    """The no-op /stop path must not hide the current conversation."""
+    runner = _make_runner()
+    stop_event = _make_event(text="/stop")
+    session_key = build_session_key(stop_event.source)
+    runner.session_store.get_or_create_session.return_value = MagicMock(
+        session_key=session_key,
+    )
+
+    result = await runner._handle_message(stop_event)
+
+    result_text = str(getattr(result, "text", result)).lower().replace(" ", "_")
+    assert "no_active" in result_text
+    runner.session_store.get_or_create_session.assert_called()
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -8,6 +8,8 @@ nothing and reply "no active task to stop".  Authorized users should be able to
 stop any run in the same thread.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
@@ -102,6 +104,7 @@ class _StoreEntry:
 class _FakeStore:
     def __init__(self, session_key):
         self._key = session_key
+        self.suspend_session = MagicMock()
 
     def get_or_create_session(self, source):
         return _StoreEntry(self._key)
@@ -131,6 +134,7 @@ async def test_stop_interrupts_sibling_thread_run_when_authorized(monkeypatch):
     assert interrupted == [(key_b, _INTERRUPT_REASON_STOP, "stop_command_thread_sibling")]
     # EphemeralReply or str — both carry the "stopped" message, not "no_active".
     assert "no active" not in str(getattr(result, "text", result)).lower()
+    runner.session_store.suspend_session.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -155,4 +159,6 @@ async def test_stop_does_not_interrupt_sibling_when_unauthorized(monkeypatch):
     result = await runner._handle_stop_command(event)
 
     assert interrupted == []
-    assert "no active" in str(getattr(result, "text", result)).lower()
+    result_text = str(getattr(result, "text", result)).lower().replace(" ", "_")
+    assert "no_active" in result_text
+    runner.session_store.suspend_session.assert_not_called()


### PR DESCRIPTION
## Summary

`/stop` intentionally interrupts work without suspending the conversation. This
rebases the regression guard onto current `main` and covers every current route:

- existing sentinel, active-agent, and pending-message tests now assert that
  `suspend_session()` was not called;
- a no-active-agent test enters through the production message dispatcher and
  checks that the current session remains visible;
- both authorized and unauthorized sibling-thread `/stop` paths assert session
  preservation.

The patch reuses the existing scenario setup instead of keeping the original
aggregate test. Related PR #9457 overlaps the three older assertions, but its
current head includes unrelated changes and does not cover the no-active or
sibling-thread paths requested in the maintainer review.

## Test plan

- `uv run pytest -q tests/gateway/test_session_race_guard.py tests/gateway/test_stop_thread_sibling.py` — 27 passed
- `uv run ruff check tests/gateway/test_session_race_guard.py tests/gateway/test_stop_thread_sibling.py`

Follow-up to #9241.
