### PR TITLE
fix: refresh cached agent activity after inactivity timeout

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7399,6 +7399,40 @@ class GatewayRunner:
             with _lock:
                 self._agent_cache.pop(session_key, None)
 
+    @staticmethod
+    def _refresh_cached_agent_activity(agent: Any) -> None:
+        """Reset per-turn activity state on a reused cached agent.
+
+        Cache reuse is desirable for prompt/session stability, but the prior
+        turn's heartbeat must not leak into the next turn. Refresh activity
+        before the watchdog can inspect the reused agent.
+        """
+        if agent is None:
+            return
+        try:
+            if hasattr(agent, "_current_tool"):
+                agent._current_tool = None
+            if hasattr(agent, "_touch_activity"):
+                agent._touch_activity("starting conversation turn")
+        except Exception:
+            pass
+
+    @staticmethod
+    def _should_evict_cached_agent_after_run(
+        result: Optional[Dict[str, Any]],
+        *,
+        inactivity_timeout: bool = False,
+    ) -> bool:
+        """Return True when a cached agent should be evicted after a run.
+
+        Ordinary failed runs keep the cached agent to avoid fallback/MCP loops
+        (#7130). Inactivity timeouts are different: they indicate a poisoned or
+        stale cached agent state, so the next turn should start fresh.
+        """
+        if inactivity_timeout:
+            return True
+        return not bool(result.get("failed") if result else False)
+
     async def _run_agent(
         self,
         message: str,
@@ -7880,6 +7914,7 @@ class GatewayRunner:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
                         agent = cached[0]
+                        self._refresh_cached_agent_activity(agent)
                         logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
@@ -8534,10 +8569,15 @@ class GatewayRunner:
             # MCP reinit → same 400 → loop, burning 91% CPU for hours.
             _agent = agent_holder[0]
             _result_for_fb = result_holder[0]
-            _run_failed = _result_for_fb.get("failed") if _result_for_fb else False
-            if _agent is not None and hasattr(_agent, 'model') and not _run_failed:
+            _should_evict_after_run = self._should_evict_cached_agent_after_run(
+                _result_for_fb,
+                inactivity_timeout=_inactivity_timeout,
+            )
+            if _agent is not None and hasattr(_agent, 'model') and _should_evict_after_run:
                 _cfg_model = _resolve_gateway_model()
-                if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
+                if _inactivity_timeout:
+                    self._evict_cached_agent(session_key)
+                elif _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.
                     self._evict_cached_agent(session_key)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -258,3 +258,27 @@ class TestAgentCacheLifecycle:
         cb3 = lambda *a: None
         agent.tool_progress_callback = cb3
         assert agent.tool_progress_callback is cb3
+
+    def test_cached_agent_activity_is_refreshed_for_new_turn(self):
+        """Reused cached agents must not carry stale idle timestamps into a fresh turn."""
+        from run_agent import AIAgent
+
+        runner = _make_runner()
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4", api_key="test",
+            base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            max_iterations=5, quiet_mode=True, skip_context_files=True,
+            skip_memory=True,
+        )
+
+        # Simulate a poisoned cached agent from a prior turn.
+        agent._last_activity_ts = 1.0
+        agent._last_activity_desc = "API call #39 completed"
+        agent._current_tool = "terminal"
+
+        runner._refresh_cached_agent_activity(agent)
+
+        summary = agent.get_activity_summary()
+        assert summary["seconds_since_activity"] < 5
+        assert summary["last_activity_desc"] == "starting conversation turn"
+        assert summary["current_tool"] is None

--- a/tests/gateway/test_fallback_eviction.py
+++ b/tests/gateway/test_fallback_eviction.py
@@ -42,3 +42,27 @@ class TestFallbackEvictionGating:
         result = {"completed": True, "final_response": "Hello!"}
         _run_failed = result.get("failed") if result else False
         assert not _run_failed, "Missing 'failed' key should be falsy"
+
+    def test_inactivity_timeout_failure_evicts_cached_agent(self):
+        """Inactivity timeouts are poisoned cached-agent failures and must be evicted."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        result = {"failed": True, "final_response": None, "error": "timeout"}
+
+        assert runner._should_evict_cached_agent_after_run(
+            result,
+            inactivity_timeout=True,
+        ) is True
+
+    def test_non_timeout_failure_does_not_evict_cached_agent(self):
+        """Ordinary failed runs still keep the cached agent to avoid fallback loops."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        result = {"failed": True, "final_response": None, "error": "400 invalid model"}
+
+        assert runner._should_evict_cached_agent_after_run(
+            result,
+            inactivity_timeout=False,
+        ) is False


### PR DESCRIPTION
## Summary
- refresh cached agent activity state before a reused agent starts a new turn
- evict cached agents after inactivity-timeout failures so the next message starts fresh
- preserve existing non-timeout failed-run cache behavior to avoid fallback loops

## Tests
- python -m pytest tests/gateway/test_agent_cache.py tests/gateway/test_fallback_eviction.py tests/gateway/test_gateway_inactivity_timeout.py -q