### PR TITLE
fix(telegram): guard Updater.start_polling with a bootstrap timeout

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -193,6 +193,37 @@ class TelegramAdapter(BasePlatformAdapter):
             pass
         return isinstance(error, OSError)
 
+    # Bootstrap guard for Updater.start_polling. The initial getUpdates
+    # handshake can hang indefinitely if Telegram is slow to respond
+    # (observed on gateway startup after a previous crash and on flaky
+    # links). Wrapping the call in asyncio.wait_for turns the hang into
+    # a TimeoutError the caller can surface or retry.
+    _POLLING_START_TIMEOUT = 30  # seconds
+
+    async def _start_polling_with_timeout(
+        self,
+        *,
+        drop_pending_updates: bool,
+        error_callback,
+    ) -> None:
+        """Start Telegram long-polling with a bootstrap timeout guard.
+
+        python-telegram-bot's ``Updater.start_polling`` performs an initial
+        ``getUpdates`` handshake before returning. In rare cases this call
+        hangs indefinitely (network slow path, Telegram backend lag, DNS
+        fallback). Wrapping it in ``asyncio.wait_for`` converts the hang
+        into a ``TimeoutError`` so callers fail fast and either retry or
+        propagate to the supervisor.
+        """
+        await asyncio.wait_for(
+            self._app.updater.start_polling(
+                allowed_updates=Update.ALL_TYPES,
+                drop_pending_updates=drop_pending_updates,
+                error_callback=error_callback,
+            ),
+            timeout=self._POLLING_START_TIMEOUT,
+        )
+
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
 
@@ -239,8 +270,7 @@ class TelegramAdapter(BasePlatformAdapter):
             pass
 
         try:
-            await self._app.updater.start_polling(
-                allowed_updates=Update.ALL_TYPES,
+            await self._start_polling_with_timeout(
                 drop_pending_updates=False,
                 error_callback=self._polling_error_callback_ref,
             )
@@ -251,8 +281,9 @@ class TelegramAdapter(BasePlatformAdapter):
             self._polling_network_error_count = 0
         except Exception as retry_err:
             logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
-            # start_polling failed — polling is dead and no further error
-            # callbacks will fire, so schedule the next retry ourselves.
+            # start_polling failed or timed out — polling is dead and no
+            # further error callbacks will fire, so schedule the next retry
+            # ourselves. TimeoutError from the bootstrap guard lands here too.
             if not self.has_fatal_error:
                 task = asyncio.ensure_future(
                     self._handle_polling_network_error(retry_err)
@@ -286,8 +317,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 pass
             await asyncio.sleep(RETRY_DELAY)
             try:
-                await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                await self._start_polling_with_timeout(
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
                 )
@@ -298,6 +328,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Telegram polling retry failed: %s", self.name, retry_err)
                 # Don't fall through to fatal yet — wait for the next conflict
                 # to trigger another retry attempt (up to MAX_CONFLICT_RETRIES).
+                # TimeoutError from the bootstrap guard is treated the same way.
                 return
 
         # Exhausted retries — fatal
@@ -674,8 +705,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback
 
-                await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                await self._start_polling_with_timeout(
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )


### PR DESCRIPTION
## Summary

`Updater.start_polling` in python-telegram-bot can hang indefinitely during its initial `getUpdates` handshake when Telegram is slow to respond. This leaves the Hermes gateway stuck mid-bootstrap — systemd eventually kills it with a timeout and the failure surfaces as:

```
Last shutdown reason: telegram: Telegram startup failed: Timed out
```

We've seen this in production after a previous crash left a stale long-poll session on Telegram's side, and also on flaky network paths at reconnect time.

Currently `start_polling` is called from three places in `TelegramAdapter`, each with different (or no) timeout handling:

1. **Initial connect** (`connect` method) — no guard, hangs forever
2. **Network-error reconnect** (`_handle_polling_network_error`) — no guard
3. **Conflict retry** (`_handle_polling_conflict`) — no guard

## Fix

Adds a private `_start_polling_with_timeout` helper that wraps `start_polling` in `asyncio.wait_for` with a 30s bootstrap guard (`_POLLING_START_TIMEOUT`), and routes all three call sites through it.

- Initial startup: `TimeoutError` propagates to the outer `except Exception` and fails the adapter cleanly, letting the supervisor restart the gateway instead of hanging it.
- Network-error reconnect: `TimeoutError` is caught by the existing generic retry handler, which schedules the next exponential back-off attempt (5s → 10s → 20s → 40s → 60s cap, up to `MAX_NETWORK_RETRIES = 10`).
- Conflict retry: same treatment — retry counter preserved up to `MAX_CONFLICT_RETRIES = 3`, then escalates to fatal.

Centralising behind one helper also leaves future tweaks (timeout value, retry policy) in a single place.

## Why 30 seconds?

Long enough to accommodate Telegram backend lag plus DNS fallback IP discovery (the adapter already auto-discovers Telegram fallback IPs during network issues), short enough to fail before systemd's service start timeout kicks in.

## Testing

Patched version running on a production Hermes MSI instance (trading bot) since the fix was applied — initial polling connects in ~1–2 seconds on the happy path, so the 30s guard is invisible during normal operation. Previously hit the hang roughly once per week on gateway restart.

## Notes

- Backward compatible — no behavior change on the happy path.
- No new dependencies.
- The three call sites kept their own error handling semantics (network-error schedules back-off retry, conflict retry tracks counter, startup surfaces failure). Only the "hung call" failure mode is newly handled.