### PR TITLE
fix(gemini): use x-goog-api-key header instead of Bearer token

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -910,6 +910,12 @@ class AIAgent:
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
+                elif "generativelanguage.googleapis.com" in effective_base.lower():
+                    # Gemini uses x-goog-api-key; suppress the OpenAI SDK's
+                    # automatic Authorization: Bearer header to avoid HTTP 400
+                    # "Multiple authentication credentials received".
+                    client_kwargs["default_headers"] = {"x-goog-api-key": api_key}
+                    client_kwargs["api_key"] = "PLACEHOLDER"
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -4612,6 +4618,11 @@ class AIAgent:
             self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
+        elif "generativelanguage.googleapis.com" in normalized:
+            self._client_kwargs["default_headers"] = {
+                "x-goog-api-key": self._client_kwargs.get("api_key", ""),
+            }
+            self._client_kwargs["api_key"] = "PLACEHOLDER"
         else:
             self._client_kwargs.pop("default_headers", None)
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -211,6 +211,51 @@ class TestGeminiAgentInit:
             assert agent.api_mode == "chat_completions"
             assert agent.provider == "gemini"
 
+    def test_gemini_uses_x_goog_api_key_not_bearer(self, monkeypatch):
+        """Gemini must use x-goog-api-key header, not Authorization: Bearer.
+
+        Regression test for #7893: Google's API returns HTTP 400
+        'Multiple authentication credentials received' when both
+        x-goog-api-key and Authorization: Bearer are present.
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        with patch("run_agent.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from run_agent import AIAgent
+            AIAgent(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                api_key="test-google-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+            call_kwargs = mock_openai.call_args[1]
+            headers = call_kwargs.get("default_headers", {})
+            assert headers.get("x-goog-api-key") == "test-google-key"
+            # api_key must not be the real key (would cause Bearer header)
+            assert call_kwargs.get("api_key") != "test-google-key"
+
+    def test_apply_headers_sets_gemini_header_on_model_switch(self, monkeypatch):
+        """_apply_client_headers_for_base_url must also set x-goog-api-key.
+
+        This path is used when switching models mid-session.
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        with patch("run_agent.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from run_agent import AIAgent
+            agent = AIAgent(
+                model="gemini-2.5-flash",
+                provider="gemini",
+                api_key="test-google-key",
+                base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            )
+            # Simulate the model-switch header update path
+            agent._client_kwargs = {"api_key": "test-google-key", "base_url": "https://generativelanguage.googleapis.com/v1beta/openai"}
+            agent._apply_client_headers_for_base_url("https://generativelanguage.googleapis.com/v1beta/openai")
+            headers = agent._client_kwargs.get("default_headers", {})
+            assert headers.get("x-goog-api-key") == "test-google-key"
+            assert agent._client_kwargs.get("api_key") != "test-google-key"
+
 
 # ── models.dev Integration ──
 


### PR DESCRIPTION
## What
Routes the Gemini API key through the `x-goog-api-key` header and sets a placeholder `api_key` to suppress the OpenAI SDK's automatic `Authorization: Bearer` header.

## Why
Google's Gemini API rejects requests with HTTP 400 "Multiple authentication credentials received" when both `Authorization: Bearer` and `x-goog-api-key` headers are present. The OpenAI SDK automatically injects the Bearer header when `api_key` is set.

## How
- Added Gemini-specific header handling in both the init path and `_apply_client_headers_for_base_url` (used during model switches), matching the existing pattern for Copilot, Kimi, and Qwen providers.
- 2 regression tests covering both code paths.

## Test plan
- [x] `pytest tests/hermes_cli/test_gemini_provider.py -v` — all 44 tests pass

## Platform
All platforms

Closes #7893