### PR TITLE
fix(local): recognize unqualified hostnames as local endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -436,6 +436,10 @@ def is_local_endpoint(base_url: str) -> bool:
     # Docker / Podman / Lima internal DNS names (e.g. host.docker.internal)
     if any(host.endswith(suffix) for suffix in _CONTAINER_LOCAL_SUFFIXES):
         return True
+    # Unqualified hostnames (no dots) are local by definition — Docker
+    # Compose service names, /etc/hosts entries, or mDNS names.
+    if host and "." not in host:
+        return True
     # RFC-1918 private ranges, link-local, and Tailscale CGNAT
     try:
         addr = ipaddress.ip_address(host)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -268,6 +268,10 @@ def is_local_endpoint(base_url: str) -> bool:
     # Docker / Podman / Lima internal DNS names (e.g. host.docker.internal)
     if any(host.endswith(suffix) for suffix in _CONTAINER_LOCAL_SUFFIXES):
         return True
+    # Unqualified hostnames (no dots) are local by definition — Docker
+    # Compose service names, /etc/hosts entries, or mDNS names.
+    if host and "." not in host:
+        return True
     # RFC-1918 private ranges and link-local
     import ipaddress
     try:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -99,6 +99,16 @@ class TestIsLocalEndpoint:
         assert is_local_endpoint(url) is True
 
     @pytest.mark.parametrize("url", [
+        "http://ollama:11434",
+        "http://litellm:4000/v1",
+        "http://hermes-litellm:8080",
+        "http://vllm:8000",
+    ])
+    def test_unqualified_docker_hostnames(self, url):
+        """Unqualified hostnames (no dots) are local — Docker Compose, /etc/hosts, etc."""
+        assert is_local_endpoint(url) is True
+
+    @pytest.mark.parametrize("url", [
         "https://api.openai.com",
         "https://openrouter.ai/api",
         "https://api.anthropic.com",


### PR DESCRIPTION
## What does this PR do?

Unqualified hostnames (no dots) are now recognized as local endpoints by `is_local_endpoint()`.

Docker Compose service names (e.g. `ollama`, `litellm`, `hermes-litellm`) are unqualified hostnames that resolve via Docker DNS, `/etc/hosts`, or mDNS. Without this fix, the stale stream timeout fires on local LLM proxies, causing infinite reconnect loops.

**Approach:** added a check after the existing container suffix matching — `if host and "." not in host: return True`.

## Related Issue

Closes #7905

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `is_local_endpoint()` (in agent local endpoint detection): added unqualified-hostname check after the existing container suffix matching
- 4 parametrized regression tests in `tests/agent/test_local_stream_timeout.py::TestIsLocalEndpoint` covering realistic Docker Compose service names

## How to Test

1. `pytest tests/agent/test_local_stream_timeout.py::TestIsLocalEndpoint -v` — all 20 tests pass (4 new + 16 existing)
2. Verify with Docker Compose service names: `ollama`, `litellm`, `hermes-litellm`

Platform: all platforms (primarily Docker/Podman environments).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/agent/test_local_stream_timeout.py::TestIsLocalEndpoint -v
20 passed (4 new + 16 existing)
```
