### PR TITLE
fix(gateway): strip think blocks from assistant message content

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6433,9 +6433,14 @@ class AIAgent:
                 except Exception:
                     pass
 
+        # Strip <think> blocks from stored content so they never leak to
+        # messaging platforms via session transcript (#8878).  The reasoning
+        # text is already captured separately above.
+        clean_content = self._strip_think_blocks(assistant_message.content or "").strip()
+
         msg = {
             "role": "assistant",
-            "content": assistant_message.content or "",
+            "content": clean_content,
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1036,6 +1036,25 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "tool_calls")
         assert "extra_content" not in result["tool_calls"][0]
 
+    def test_think_blocks_stripped_from_content(self, agent):
+        """Think blocks must be stripped from stored content so they don't
+        leak to messaging platforms via session transcript (#8878)."""
+        msg = _mock_assistant_msg(
+            content="<think>internal reasoning</think>The actual answer."
+        )
+        result = agent._build_assistant_message(msg, "stop")
+        assert "<think>" not in result["content"]
+        assert "internal reasoning" not in result["content"]
+        assert "The actual answer." in result["content"]
+        # The reasoning should be captured separately
+        assert result["reasoning"] == "internal reasoning"
+
+    def test_think_blocks_stripped_preserves_normal_content(self, agent):
+        """Content without think blocks should pass through unchanged."""
+        msg = _mock_assistant_msg(content="No thinking here.")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "No thinking here."
+
 
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):


### PR DESCRIPTION
## What
Think/reasoning tags (`<think>...</think>`) are now stripped from assistant message content before storage.

## Why
Think blocks were visible to users on messaging platforms (Telegram, Discord, etc.) because `_build_assistant_message` stored the raw content with tags intact. The reasoning text was already extracted into a separate `reasoning` field, but the tags remained in the `content` that gets persisted to session transcripts and sent to platforms.

## How
- Call the existing `_strip_think_blocks()` method on message content before storing it in the message dict.
- 2 regression tests: one verifying stripping with reasoning extraction, one verifying normal content passes through unchanged.

## Test plan
- [x] `pytest tests/run_agent/test_run_agent.py::TestBuildAssistantMessage -v` — all 9 tests pass (2 new + 7 existing)

## Platform
All platforms (primarily affects gateway/messaging platforms)

Closes #8878