### PR TITLE
fix(cli): make Ctrl-D respect Unix EOF semantics

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9012,6 +9012,39 @@ class HermesCLI:
             ] if item is not None
         ]
 
+    def _handle_ctrl_d_keypress(self, app):
+        """Handle Ctrl+D like a normal Unix line editor.
+
+        Behavior:
+        - Non-empty buffer: delete the character under the cursor (or no-op at EOL)
+        - Empty buffer: exit the CLI (EOF)
+
+        This avoids treating Ctrl+D as unconditional process termination when the
+        user is editing an in-progress line.
+        """
+        buf = getattr(app, "current_buffer", None)
+        text = getattr(buf, "text", "") if buf is not None else ""
+
+        if buf is not None and text:
+            try:
+                buf.delete()
+            except Exception:
+                pass
+            try:
+                app.invalidate()
+            except Exception:
+                pass
+            return
+
+        self._should_exit = True
+        if getattr(app, "is_running", False):
+            app.exit()
+        else:
+            try:
+                app.exit()
+            except Exception:
+                pass
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         # Push the entire TUI to the bottom of the terminal so the banner,
@@ -9525,9 +9558,8 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Handle Ctrl+D - delete forward or exit on EOF."""
+            self._handle_ctrl_d_keypress(event.app)
 
         _modal_prompt_active = Condition(
             lambda: bool(self._secret_state or self._sudo_state)

--- a/tests/cli/test_ctrl_d_behavior.py
+++ b/tests/cli/test_ctrl_d_behavior.py
@@ -1,0 +1,70 @@
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text="", cursor_position=0):
+        self.text = text
+        self.cursor_position = cursor_position
+
+    def delete(self, count=1):
+        if count <= 0:
+            return ""
+        if self.cursor_position >= len(self.text):
+            return ""
+        deleted = self.text[self.cursor_position : self.cursor_position + count]
+        self.text = self.text[: self.cursor_position] + self.text[self.cursor_position + count :]
+        return deleted
+
+
+class _FakeApp:
+    def __init__(self, text="", cursor_position=0, is_running=True):
+        self.current_buffer = _FakeBuffer(text=text, cursor_position=cursor_position)
+        self.invalidated = False
+        self.exited = False
+        self.is_running = is_running
+
+    def invalidate(self):
+        self.invalidated = True
+
+    def exit(self):
+        self.exited = True
+
+
+def _make_cli_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._should_exit = False
+    return cli
+
+
+def test_ctrl_d_deletes_character_under_cursor_instead_of_exiting():
+    cli = _make_cli_stub()
+    app = _FakeApp(text="abc", cursor_position=1)
+
+    cli._handle_ctrl_d_keypress(app)
+
+    assert app.current_buffer.text == "ac"
+    assert app.invalidated is True
+    assert app.exited is False
+    assert cli._should_exit is False
+
+
+def test_ctrl_d_at_end_of_non_empty_line_does_not_exit():
+    cli = _make_cli_stub()
+    app = _FakeApp(text="abc", cursor_position=3)
+
+    cli._handle_ctrl_d_keypress(app)
+
+    assert app.current_buffer.text == "abc"
+    assert app.invalidated is True
+    assert app.exited is False
+    assert cli._should_exit is False
+
+
+def test_ctrl_d_on_empty_buffer_exits_like_eof():
+    cli = _make_cli_stub()
+    app = _FakeApp(text="", cursor_position=0)
+
+    cli._handle_ctrl_d_keypress(app)
+
+    assert app.exited is True
+    assert cli._should_exit is True


### PR DESCRIPTION
## Summary
- make `Ctrl+D` delete the character under the cursor when the input buffer is non-empty
- treat `Ctrl+D` as EOF only when the buffer is empty
- add regression coverage for mid-line delete, end-of-line no-op, and empty-buffer exit

## Problem
Hermes currently exits unconditionally on `Ctrl+D`, even while the user is editing a non-empty input line. That differs from normal Unix/readline behavior and can terminate a session unexpectedly.

## Behavior after this change
- non-empty buffer + cursor over a character: delete that character
- non-empty buffer + cursor at end-of-line: no-op
- empty buffer: exit the CLI as EOF

## Implementation notes
- factor the behavior into `_handle_ctrl_d_keypress()` for easier testing
- use `prompt_toolkit`'s `Buffer.delete()` so behavior matches the underlying line editor semantics

## Test plan
- `source venv/bin/activate && pytest -q tests/cli/test_ctrl_d_behavior.py`
- `source venv/bin/activate && pytest -q tests/cli/test_ctrl_d_behavior.py tests/cli/test_cli_secret_capture.py`

Fixes #8478
Also addresses #6448