### PR TITLE
fix(gateway): disable streaming for webhook sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7800,6 +7800,11 @@ class GatewayRunner:
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            # Disable streaming for webhooks — the webhook adapter routes
+            # sends to the target platform (e.g. Telegram) and cannot edit
+            # messages, so each streamed chunk becomes a separate message.
+            if source.platform == Platform.WEBHOOK:
+                _streaming_enabled = False
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages


### PR DESCRIPTION
## What does this PR do?

Disables token streaming for webhook sessions. The webhook adapter routes responses via `_deliver_cross_platform` to a target platform (e.g. Telegram). The `GatewayStreamConsumer` sends progressive edits, but the webhook adapter cannot track message IDs for editing on the target platform, so each streamed chunk becomes a separate message — resulting in fragmented multi-message delivery of what should be a single final response.

`tool_progress` and `interim_assistant_messages` were already explicitly disabled for `Platform.WEBHOOK` but streaming was not, so this adds the same guard.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added `Platform.WEBHOOK` guard to disable `_streaming_enabled` for webhook sessions, matching the existing pattern used for `tool_progress_enabled` (line 7454) and `interim_assistant_messages_enabled` (line 7459).

## How to Test

1. Configure a webhook subscription with `deliver: telegram` (or any cross-platform target)
2. Fire an alert that triggers the webhook
3. Before fix: multiple fragmented messages appear on the target platform (streaming chunks + final response)
4. After fix: a single clean message is delivered

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (117 webhook tests pass, 106 pre-existing failures in unrelated modules)
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A for all documentation items