### PR TITLE
fix(copilot-acp): keep ACP runtime on chat completions

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1223,8 +1223,12 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
-    if sync_client.__class__.__name__ == "CopilotACPClient":
-        return sync_client, model
+    try:
+        from agent.copilot_acp_client import CopilotACPClient
+        if isinstance(sync_client, CopilotACPClient):
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1223,6 +1223,8 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
+    if sync_client.__class__.__name__ == "CopilotACPClient":
+        return sync_client, model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -1467,7 +1469,11 @@ def resolve_provider_client(
 
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
     try:
-        from hermes_cli.auth import PROVIDER_REGISTRY, resolve_api_key_provider_credentials
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            resolve_api_key_provider_credentials,
+            resolve_external_process_provider_credentials,
+        )
     except ImportError:
         logger.debug("hermes_cli.auth not available for provider %s", provider)
         return None, None
@@ -1540,6 +1546,41 @@ def resolve_provider_client(
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
+
+    if pconfig.auth_type == "external_process":
+        creds = resolve_external_process_provider_credentials(provider)
+        final_model = _normalize_resolved_model(model or _read_main_model(), provider)
+        if provider == "copilot-acp":
+            api_key = str(creds.get("api_key", "")).strip()
+            base_url = str(creds.get("base_url", "")).strip()
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: copilot-acp requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            if not api_key or not base_url:
+                logger.warning(
+                    "resolve_provider_client: copilot-acp requested but external "
+                    "process credentials are incomplete"
+                )
+                return None, None
+            from agent.copilot_acp_client import CopilotACPClient
+
+            client = CopilotACPClient(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model) if async_mode
+                    else (client, final_model))
+        logger.warning("resolve_provider_client: external-process provider %s not "
+                       "directly supported", provider)
+        return None, None
 
     elif pconfig.auth_type in ("oauth_device_code", "oauth_external"):
         # OAuth providers — route through their specific try functions

--- a/run_agent.py
+++ b/run_agent.py
@@ -705,10 +705,12 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models often require the Responses API path — they are
-        # rejected on /v1/chat/completions by both OpenAI and OpenRouter.
-        # Also auto-upgrade for direct OpenAI URLs (api.openai.com) since
+        # GPT-5.x models require the Responses API path — they are rejected
+        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
+        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
         # newer tool-calling models prefer Responses there.
+        # ACP runtimes are excluded: CopilotACPClient handles its own
+        # routing and does not implement the Responses API surface.
         if (
             self.api_mode == "chat_completions"
             and self.provider != "copilot-acp"

--- a/run_agent.py
+++ b/run_agent.py
@@ -705,13 +705,19 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
+        # GPT-5.x models often require the Responses API path — they are
+        # rejected on /v1/chat/completions by both OpenAI and OpenRouter.
+        # Also auto-upgrade for direct OpenAI URLs (api.openai.com) since
         # newer tool-calling models prefer Responses there.
-        if self.api_mode == "chat_completions" and (
-            self._is_direct_openai_url()
-            or self._model_requires_responses_api(self.model)
+        if (
+            self.api_mode == "chat_completions"
+            and self.provider != "copilot-acp"
+            and not str(self.base_url or "").lower().startswith("acp://copilot")
+            and not str(self.base_url or "").lower().startswith("acp+tcp://")
+            and (
+                self._is_direct_openai_url()
+                or self._model_requires_responses_api(self.model)
+            )
         ):
             self.api_mode = "codex_responses"
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -944,6 +944,46 @@ model:
         }
 
 
+def test_resolve_provider_client_supports_copilot_acp_external_process():
+    fake_client = MagicMock()
+
+    with patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4-mini"), \
+         patch("agent.auxiliary_client.CodexAuxiliaryClient", MagicMock()), \
+         patch("agent.copilot_acp_client.CopilotACPClient", return_value=fake_client) as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is fake_client
+    assert model == "gpt-5.4-mini"
+    assert mock_acp.call_args.kwargs["api_key"] == "copilot-acp"
+    assert mock_acp.call_args.kwargs["base_url"] == "acp://copilot"
+    assert mock_acp.call_args.kwargs["command"] == "/usr/bin/copilot"
+    assert mock_acp.call_args.kwargs["args"] == ["--acp", "--stdio"]
+
+
+def test_resolve_provider_client_copilot_acp_requires_explicit_or_configured_model():
+    with patch("agent.auxiliary_client._read_main_model", return_value=""), \
+         patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "copilot-acp",
+             "api_key": "copilot-acp",
+             "base_url": "acp://copilot",
+             "command": "/usr/bin/copilot",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("copilot-acp")
+
+    assert client is None
+    assert model is None
+    mock_acp.assert_not_called()
+
+
 class TestAuxiliaryMaxTokensParam:
     def test_codex_fallback_uses_max_tokens(self, monkeypatch):
         """Codex adapter translates max_tokens internally, so we return max_tokens."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -243,6 +243,22 @@ def test_api_mode_respects_explicit_openrouter_provider_over_codex_url(monkeypat
     assert agent.provider == "openrouter"
 
 
+def test_copilot_acp_stays_on_chat_completions_for_gpt_5_models(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5.4-mini",
+        base_url="acp://copilot",
+        provider="copilot-acp",
+        api_key="copilot-acp",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "copilot-acp"
+    assert agent.api_mode == "chat_completions"
+
+
 def test_build_api_kwargs_codex(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = agent._build_api_kwargs(


### PR DESCRIPTION
## Summary

Salvage of #8709 by @helix4u. Cherry-picked onto current main with follow-up improvements.

Fixes two bugs affecting copilot-acp users running GPT-5 family models:

**Bug 1 — Responses API auto-upgrade breaks ACP:** The agent auto-upgrades `chat_completions` to `codex_responses` when it detects a GPT-5 model, but `CopilotACPClient` doesn't implement `.responses`, causing `'CopilotACPClient' object has no attribute 'responses'`.

**Bug 2 — Auxiliary client ignores external_process auth:** `resolve_provider_client()` had no branch for `auth_type == "external_process"`, so copilot-acp fell through to the catch-all warning and auxiliary tasks (compression, vision, etc.) failed silently.

## Changes

- **run_agent.py**: Exclude copilot-acp provider and ACP-style URLs (`acp://`, `acp+tcp://`) from the GPT-5 Responses API auto-upgrade
- **agent/auxiliary_client.py**: Add `external_process` auth_type branch that builds a `CopilotACPClient` for copilot-acp auxiliary resolution; add `isinstance()` check in `_to_async_client()` to return ACP clients as-is
- **Tests**: 3 new tests covering both fixes + no-model edge case

## Follow-up improvements (on top of cherry-pick)

- Replaced fragile `__class__.__name__ == "CopilotACPClient"` string check with proper `isinstance()` via try/except import (matches existing pattern for CodexAuxiliaryClient and AnthropicAuxiliaryClient)
- Restored accurate comment: GPT-5.x models *require* the Responses API on OpenAI/OpenRouter — the fix is about ACP being exempt, not about the requirement being soft

## Test results

- All 8 copilot/ACP tests pass
- Full `test_run_agent_codex_responses.py` (41 tests) pass
- E2E verified with real imports: auto-upgrade exclusion, aux client resolution, async client passthrough
- 7 pre-existing failures in test_auxiliary_client.py (unrelated `get_vision_auxiliary_client` NameError)