### PR TITLE
docs: add Slack files:read scope

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1634,7 +1634,7 @@ _PLATFORMS = [
             "   Create an App-Level Token with scope: connections:write → copy xapp-... token",
             "3. Add Bot Token Scopes: Features → OAuth & Permissions → Scopes",
             "   Required: chat:write, app_mentions:read, channels:history, channels:read,",
-            "   groups:history, im:history, im:read, im:write, users:read, files:write",
+            "   groups:history, im:history, im:read, im:write, users:read, files:read, files:write",
             "4. Subscribe to Events: Features → Event Subscriptions → Enable",
             "   Required events: message.im, message.channels, app_mention",
             "   Optional: message.groups (for private channels)",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1781,7 +1781,7 @@ def _setup_slack():
     print_info("   3. Add Bot Token Scopes: Features → OAuth & Permissions")
     print_info("      Required scopes: chat:write, app_mentions:read,")
     print_info("      channels:history, channels:read, im:history,")
-    print_info("      im:read, im:write, users:read, files:write")
+    print_info("      im:read, im:write, users:read, files:read, files:write")
     print_info("      Optional for private channels: groups:history")
     print_info("   4. Subscribe to Events: Features → Event Subscriptions → Enable")
     print_info("      Required events: message.im, message.channels, app_mention")

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -54,6 +54,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | `im:read` | View basic DM info |
 | `im:write` | Open and manage DMs |
 | `users:read` | Look up user information |
+| `files:read` | Read and download attached files, including voice notes/audio |
 | `files:write` | Upload files (images, audio, documents) |
 
 :::caution Missing scopes = missing features


### PR DESCRIPTION
## What does this PR do?
Adds files:read to the documented and interactive Slack setup scope lists so Slack voice notes and other private file attachments can be downloaded correctly.

## Related Issue
Slack audio attachments were being treated as empty until files:read was added to the Slack app permissions.

## Type of Change
- [x] Documentation update
- [x] Setup / UX text update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Changes Made
- add files:read to the Slack messaging docs scope table
- add files:read to the Slack setup text in hermes setup
- add files:read to the Slack setup instructions in hermes gateway setup

## How to Test
1. Open the Slack setup docs and confirm files:read is listed with the required bot token scopes.
2. Run hermes setup and inspect the Slack setup instructions.
3. Run hermes gateway setup and inspect the Slack setup instructions.

## Checklist
- [x] I kept the change scoped to the docs/setup text needed for this issue
- [x] I did not change runtime behavior
- [ ] I ran the full test suite (not applicable for this docs-only change)

## Screenshots / Logs
Not applicable for this docs/setup text change.
