### PR TITLE
fix(compaction): protect latest user message from being summarized away

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -619,6 +619,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         the cut is placed right after the head so compression still runs.
 
         Never cuts inside a tool_call/result group.
+
+        **User-message protection**: The most recent user message and every
+        message after it are always kept in the tail regardless of the
+        token budget.  This prevents the current user request from being
+        summarised away, which causes the model to respond to stale context
+        instead of the user's latest message.  (#7133)
         """
         if token_budget is None:
             token_budget = self.tail_token_budget
@@ -629,6 +635,20 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
+        # ── User-message anchor ──────────────────────────────────────
+        # Find the most recent user message.  Everything from that index
+        # onward MUST remain in the tail so the model never loses the
+        # current user request.  The token-budget walk below is capped
+        # at this boundary — it can include more messages (if budget
+        # allows) but never fewer.
+        last_user_idx = n  # default: no anchor (shouldn't happen)
+        for i in range(n - 1, head_end - 1, -1):
+            if messages[i].get("role") == "user":
+                last_user_idx = i
+                break
+        # The anchor is the *furthest-back* index that the tail must cover.
+        user_anchor = min(last_user_idx, n - min_tail) if min_tail > 0 else last_user_idx
+
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             content = msg.get("content") or ""
@@ -638,8 +658,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
                     msg_tokens += len(args) // _CHARS_PER_TOKEN
-            # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
-            if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
+            # Stop once we exceed the soft ceiling (unless we haven't
+            # reached either the min_tail or the user-message anchor)
+            must_include = (n - i) < min_tail or i >= user_anchor
+            if accumulated + msg_tokens > soft_ceiling and not must_include:
                 break
             accumulated += msg_tokens
             cut_idx = i
@@ -648,6 +670,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         fallback_cut = n - min_tail
         if cut_idx > fallback_cut:
             cut_idx = fallback_cut
+
+        # Ensure the user-message anchor is always in the tail
+        if cut_idx > user_anchor:
+            cut_idx = user_anchor
 
         # If the token budget would protect everything (small conversations),
         # force a cut after the head so compression can still remove middle turns.


### PR DESCRIPTION
## Problem

After context compression, the model can respond to stale context instead of the user's latest message. This happens when large tool outputs consume the entire tail token budget in `_find_tail_cut_by_tokens()`.

### Root Cause

`_find_tail_cut_by_tokens()` uses a pure token-budget walk with a hard minimum of 3 messages. When the assistant executes multiple tool calls with large outputs (e.g., git log, git diff, file reads), the min_tail of 3 may only protect `[tool, assistant, tool]` — the user's actual request message gets pushed into the summarized region and disappears.

### Real-World Scenario

1. User sends: *"analyze commits after 10b0633"*
2. Assistant runs 3 tool calls (git log, git diff, notion read) — each ~40KB output
3. Compaction triggers → tail budget consumed by tool outputs
4. **Before fix**: min_tail=3 protects only tool results → user message summarized away → model responds about stale Notion content from earlier context
5. **After fix**: user-message anchor ensures the user's request stays in the tail → model responds correctly

This was observed on a Discord gateway session running `claude-opus-4-6` via ccapi with `threshold=0.5` and `gemini-3-flash-preview` as summary model.

## Fix

Adds a **user-message anchor** to `_find_tail_cut_by_tokens()`:

1. Find the index of the most recent `role=user` message
2. Use it as a floor for the tail boundary — the token-budget walk can include more messages (if budget allows) but never fewer than everything from the last user message onward
3. After the walk, enforce `cut_idx <= user_anchor`

The change is minimal (28 lines added, 2 modified) and backward-compatible — it only makes the tail boundary more conservative, never less.

## Testing

Tested with the exact scenario from the bug report:

```
=== Without user anchor (old behavior) ===
Old tail starts at: 11 (3 msgs)
  [11] tool: xxxx...
  [12] assistant: [+1 tool_calls]
  [13] tool: xxxx...
  User msg protected: False ❌

=== With user anchor (new behavior) ===
Tail starts at: 7 (7 msgs)
  [7] user: LATEST: analyze commits after 10b0633
  [8] assistant: [+1 tool_calls]
  [9] tool: xxxx...
  [10] assistant: [+1 tool_calls]
  [11] tool: xxxx...
  [12] assistant: [+1 tool_calls]
  [13] tool: xxxx...
  User msg protected: True ✅
```

## Relationship to Existing Fixes

This complements #8107 (v0.9.0) which addressed the model interpreting summaries as active instructions via SUMMARY_PREFIX rewrite. Together, they fix the two root causes of post-compaction incoherent responses reported in #7133:

1. **#8107**: Summary content no longer reads as instructions → model doesn't chase stale "Next Steps"
2. **This PR**: Latest user message never gets summarized away → model always sees the current request

Refs: #7133, #8107
