### PR TITLE
feat: streamline Xiaomi MiMo setup with Token Plan routing

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -165,6 +165,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "google": "google",
     "xai": "xai",
     "xiaomi": "xiaomi",
+    "xiaomi-token-plan": "xiaomi",
     "nvidia": "nvidia",
     "groq": "groq",
     "mistral": "mistral",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -266,6 +266,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "xiaomi-token-plan": ProviderConfig(
+        id="xiaomi-token-plan",
+        name="Xiaomi MiMo (Token Plan)",
+        auth_type="api_key",
+        inference_base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        api_key_env_vars=("XIAOMI_TOKEN_PLAN_API_KEY",),
+        base_url_env_var="XIAOMI_TOKEN_PLAN_BASE_URL",
+    ),
 }
 
 
@@ -910,6 +918,8 @@ def resolve_provider(
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
+        "xiaomi-token": "xiaomi-token-plan", "mimo-token-plan": "xiaomi-token-plan",
+        "xiaomi-sgp": "xiaomi-token-plan",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         # Local server aliases — route through the generic custom provider

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -955,6 +955,21 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "XIAOMI_TOKEN_PLAN_API_KEY": {
+        "description": "Xiaomi MiMo Token Plan API key for the token-plan-sgp endpoint",
+        "prompt": "Xiaomi MiMo Token Plan API Key",
+        "url": "https://platform.xiaomimimo.com",
+        "password": True,
+        "category": "provider",
+    },
+    "XIAOMI_TOKEN_PLAN_BASE_URL": {
+        "description": "Xiaomi MiMo Token Plan base URL override (default: https://token-plan-sgp.xiaomimimo.com/v1)",
+        "prompt": "Xiaomi Token Plan base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
 
     # ── Tool API keys ──
     "EXA_API_KEY": {

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -52,6 +52,7 @@ _PROVIDER_ENV_HINTS = (
     "OPENCODE_ZEN_API_KEY",
     "OPENCODE_GO_API_KEY",
     "XIAOMI_API_KEY",
+    "XIAOMI_TOKEN_PLAN_API_KEY",
 )
 
 
@@ -728,6 +729,8 @@ def run_doctor(args):
         # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
         ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        ("Xiaomi MiMo",      ("XIAOMI_API_KEY",),                             "https://api.xiaomimimo.com/v1/models", "XIAOMI_BASE_URL", True),
+        ("Xiaomi Token Plan", ("XIAOMI_TOKEN_PLAN_API_KEY",),                 "https://token-plan-sgp.xiaomimimo.com/v1/models", "XIAOMI_TOKEN_PLAN_BASE_URL", True),
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1037,7 +1037,8 @@ def select_provider_and_model(args=None):
     from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
 
     provider_labels = dict(_PROVIDER_LABELS)  # derive from canonical list
-    active_label = provider_labels.get(active, active) if active else "none"
+    picker_active = "xiaomi" if active == "xiaomi-token-plan" else active
+    active_label = provider_labels.get(picker_active, picker_active) if picker_active else "none"
 
     print()
     print(f"  Current model:    {current_model}")
@@ -1047,7 +1048,7 @@ def select_provider_and_model(args=None):
     # Step 1: Provider selection — top providers shown first, rest behind "More..."
     # Derived from CANONICAL_PROVIDERS (single source of truth)
     top_providers = [(p.slug, p.tui_desc) for p in CANONICAL_PROVIDERS if p.tier == "top"]
-    extended_providers = [(p.slug, p.tui_desc) for p in CANONICAL_PROVIDERS if p.tier == "extended"]
+    extended_providers = [(p.slug, p.tui_desc) for p in CANONICAL_PROVIDERS if p.tier == "extended" and p.slug != "xiaomi-token-plan"]
 
     def _named_custom_provider_map(cfg) -> dict[str, dict[str, str]]:
         custom_provider_map = {}
@@ -1090,17 +1091,17 @@ def select_provider_and_model(args=None):
     extended_keys = {k for k, _ in extended_providers}
 
     # If the active provider is in the extended list, promote it into top
-    if active and active in extended_keys:
-        promoted = [(k, l) for k, l in extended_providers if k == active]
-        extended_providers = [(k, l) for k, l in extended_providers if k != active]
+    if picker_active and picker_active in extended_keys:
+        promoted = [(k, l) for k, l in extended_providers if k == picker_active]
+        extended_providers = [(k, l) for k, l in extended_providers if k != picker_active]
         top_providers = promoted + top_providers
-        top_keys.add(active)
+        top_keys.add(picker_active)
 
     # Build the primary menu
     ordered = []
     default_idx = 0
     for key, label in top_providers:
-        if active and key == active:
+        if picker_active and key == picker_active:
             ordered.append((key, f"{label}  ← currently active"))
             default_idx = len(ordered) - 1
         else:
@@ -2436,11 +2437,71 @@ def _model_flow_kimi(config, current_model=""):
         print("No change.")
 
 
+def _is_xiaomi_token_plan_key(api_key: str) -> bool:
+    return (api_key or "").strip().lower().startswith("tp-")
+
+
+
+def _prompt_xiaomi_endpoint_choice(api_key: str, current_base: str) -> tuple[str, str | None]:
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    standard_base = PROVIDER_REGISTRY["xiaomi"].inference_base_url.rstrip("/")
+    token_plan_base = PROVIDER_REGISTRY["xiaomi-token-plan"].inference_base_url.rstrip("/")
+    current_base = (current_base or "").strip().rstrip("/")
+
+    if current_base and current_base not in {standard_base, token_plan_base}:
+        default_idx = 2
+    elif current_base == token_plan_base:
+        default_idx = 1
+    elif current_base == standard_base:
+        default_idx = 0
+    elif _is_xiaomi_token_plan_key(api_key):
+        default_idx = 1
+    else:
+        default_idx = 0
+
+    choices = [
+        f"Xiaomi MiMo API ({standard_base})",
+        f"Xiaomi Token Plan API ({token_plan_base})",
+        "Custom Xiaomi-compatible URL",
+    ]
+    choice_idx = _prompt_provider_choice(choices, default=default_idx)
+    if choice_idx is None:
+        fallback = token_plan_base if default_idx == 1 else standard_base
+        return current_base or fallback, None
+
+    if choice_idx == 0:
+        env_update = "" if current_base and current_base != standard_base else None
+        return standard_base, env_update
+
+    if choice_idx == 1:
+        env_update = token_plan_base if current_base != token_plan_base else None
+        return token_plan_base, env_update
+
+    default_custom = current_base if current_base and current_base not in {standard_base, token_plan_base} else (
+        token_plan_base if default_idx == 1 else standard_base
+    )
+    try:
+        custom_url = input(f"Custom Xiaomi base URL [{default_custom}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return default_custom, None
+
+    effective_base = (custom_url or default_custom).rstrip("/")
+    if not effective_base.startswith(("http://", "https://")):
+        print("  Invalid URL — must start with http:// or https://. Keeping current value.")
+        return current_base or default_custom, None
+
+    env_update = effective_base if effective_base != current_base else None
+    return effective_base, env_update
+
+
+
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
     """Generic flow for API-key providers (z.ai, MiniMax, OpenCode, etc.)."""
     from hermes_cli.auth import (
         PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
-        deactivate_provider,
+        deactivate_provider, has_usable_secret,
     )
     from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
     from hermes_cli.models import fetch_api_models, opencode_model_api_mode, normalize_opencode_model_id
@@ -2452,8 +2513,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     # Check / prompt for API key
     existing_key = ""
     for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
+        candidate = (get_env_value(ev) or os.getenv(ev, "") or "").strip()
+        if has_usable_secret(candidate):
+            existing_key = candidate
             break
 
     if not existing_key:
@@ -2469,6 +2531,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
                 print("Cancelled.")
                 return
             save_env_value(key_env, new_key)
+            existing_key = new_key
             print("API key saved.")
             print()
     else:
@@ -2481,17 +2544,22 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
     effective_base = current_base or pconfig.inference_base_url
 
-    try:
-        override = input(f"Base URL [{effective_base}]: ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        override = ""
-    if override and base_url_env:
-        if not override.startswith(("http://", "https://")):
-            print("  Invalid URL — must start with http:// or https://. Keeping current value.")
-        else:
-            save_env_value(base_url_env, override)
-            effective_base = override
+    if provider_id == "xiaomi":
+        effective_base, env_update = _prompt_xiaomi_endpoint_choice(existing_key, current_base)
+        if env_update is not None and base_url_env:
+            save_env_value(base_url_env, env_update)
+    else:
+        try:
+            override = input(f"Base URL [{effective_base}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            override = ""
+        if override and base_url_env:
+            if not override.startswith(("http://", "https://")):
+                print("  Invalid URL — must start with http:// or https://. Keeping current value.")
+            else:
+                save_env_value(base_url_env, override)
+                effective_base = override.rstrip("/")
 
     # Model selection — resolution order:
     #   1. models.dev registry (cached, filtered for agentic/tool-capable models)
@@ -4586,7 +4654,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "xiaomi-token-plan"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -94,6 +94,7 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "alibaba",
     "qwen-oauth",
     "xiaomi",
+    "xiaomi-token-plan",
     "custom",
 })
 
@@ -204,7 +205,10 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
 
     normalized_prefix = _normalize_provider_alias(prefix)
     normalized_target = _normalize_provider_alias(target_provider)
-    if normalized_prefix and normalized_prefix == normalized_target:
+    if normalized_prefix and (
+        normalized_prefix == normalized_target
+        or normalized_target.startswith(normalized_prefix + "-")
+    ):
         return remainder.strip()
     return model_name
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -200,6 +200,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "mimo-v2-omni",
         "mimo-v2-flash",
     ],
+    "xiaomi-token-plan": [
+        "mimo-v2-pro",
+        "mimo-v2-omni",
+        "mimo-v2-flash",
+    ],
     "opencode-zen": [
         "gpt-5.4-pro",
         "gpt-5.4",
@@ -529,6 +534,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ai-gateway",     "AI Gateway",               "extended", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
     ProviderEntry("alibaba",        "Alibaba Cloud (DashScope)","extended", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "extended", "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
+    ProviderEntry("xiaomi-token-plan", "Xiaomi MiMo (Token Plan)", "extended", "Xiaomi MiMo Token Plan (token-plan-sgp endpoint)"),
 ]
 
 # Derived dicts — used throughout the codebase
@@ -578,6 +584,9 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
+    "xiaomi-token": "xiaomi-token-plan",
+    "mimo-token-plan": "xiaomi-token-plan",
+    "xiaomi-sgp": "xiaomi-token-plan",
     "grok": "xai",
     "x-ai": "xai",
     "x.ai": "xai",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -136,6 +136,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "xiaomi-token-plan": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("XIAOMI_TOKEN_PLAN_API_KEY",),
+        base_url_override="https://token-plan-sgp.xiaomimimo.com/v1",
+        base_url_env_var="XIAOMI_TOKEN_PLAN_BASE_URL",
+    ),
 }
 
 
@@ -230,6 +236,9 @@ ALIASES: Dict[str, str] = {
     # xiaomi
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
+    "xiaomi-token": "xiaomi-token-plan",
+    "mimo-token-plan": "xiaomi-token-plan",
+    "xiaomi-sgp": "xiaomi-token-plan",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
@@ -252,6 +261,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "xiaomi": "Xiaomi MiMo",
+    "xiaomi-token-plan": "Xiaomi MiMo (Token Plan)",
     "local": "Local endpoint",
 }
 
@@ -306,8 +316,16 @@ def get_provider(name: str) -> Optional[ProviderDef]:
         base_url_env = overlay.base_url_env_var if overlay else ""
         base_url_override = overlay.base_url_override if overlay else ""
 
-        # Combine env vars: models.dev env + hermes extra
+        # Prefer auth.py PROVIDER_REGISTRY for env vars — it's Hermes' source of
+        # truth for variant providers that share a models.dev catalog entry.
         env_vars = list(mdev_info.env)
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY as _AUTH_PROVIDER_REGISTRY
+            pconfig = _AUTH_PROVIDER_REGISTRY.get(canonical)
+            if pconfig and pconfig.api_key_env_vars:
+                env_vars = list(pconfig.api_key_env_vars)
+        except Exception:
+            pass
         if overlay and overlay.extra_env_vars:
             for ev in overlay.extra_env_vars:
                 if ev not in env_vars:
@@ -315,7 +333,7 @@ def get_provider(name: str) -> Optional[ProviderDef]:
 
         return ProviderDef(
             id=canonical,
-            name=mdev_info.name,
+            name=_LABEL_OVERRIDES.get(canonical, mdev_info.name),
             transport=transport,
             api_key_env_vars=tuple(env_vars),
             base_url=base_url_override or mdev_info.api,

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -124,6 +124,8 @@ def show_status(args):
         "Kimi": "KIMI_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
+        "Xiaomi": "XIAOMI_API_KEY",
+        "Xiaomi-TP": "XIAOMI_TOKEN_PLAN_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
         "Tavily": "TAVILY_API_KEY",
         "Browser Use": "BROWSER_USE_API_KEY",  # Optional — local browser works without this
@@ -242,6 +244,8 @@ def show_status(args):
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "MiniMax":          ("MINIMAX_API_KEY",),
         "MiniMax (China)":  ("MINIMAX_CN_API_KEY",),
+        "Xiaomi MiMo":      ("XIAOMI_API_KEY",),
+        "Xiaomi Token Plan": ("XIAOMI_TOKEN_PLAN_API_KEY",),
     }
     for pname, env_vars in apikey_providers.items():
         key_val = ""

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -641,3 +641,219 @@ def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
         "ca_bundle": "/tmp/local-ca.pem",
         "insecure": True,
     }
+
+
+def test_select_provider_and_model_hides_separate_xiaomi_token_plan_entry(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "claude-sonnet-4.6", "provider": "anthropic"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "anthropic")
+
+    prompt_calls = []
+
+    def _prompt_choice(choices, *, default=0):
+        prompt_calls.append((list(choices), default))
+        if len(prompt_calls) == 1:
+            return len(choices) - 2  # More providers...
+        return len(choices) - 1  # Cancel
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _prompt_choice)
+
+    hermes_main.select_provider_and_model()
+
+    assert len(prompt_calls) == 2
+    extended_choices = prompt_calls[1][0]
+    assert any("Xiaomi MiMo (MiMo-V2 models" in choice for choice in extended_choices)
+    assert not any("Token Plan" in choice for choice in extended_choices)
+
+
+def test_select_provider_and_model_collapses_active_xiaomi_token_plan_into_xiaomi(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "mimo-v2-pro", "provider": "xiaomi-token-plan"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "xiaomi-token-plan")
+
+    prompt_calls = []
+
+    def _prompt_choice(choices, *, default=0):
+        prompt_calls.append((list(choices), default))
+        return len(choices) - 1  # Cancel from top menu
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _prompt_choice)
+
+    hermes_main.select_provider_and_model()
+
+    top_choices, default_idx = prompt_calls[0]
+    assert any("Xiaomi MiMo" in choice and "currently active" in choice for choice in top_choices)
+    assert not any("Token Plan" in choice for choice in top_choices)
+    assert "Xiaomi MiMo" in top_choices[default_idx]
+
+
+def _configure_xiaomi_flow_test(monkeypatch):
+    for key in (
+        "XIAOMI_API_KEY",
+        "XIAOMI_BASE_URL",
+        "XIAOMI_TOKEN_PLAN_API_KEY",
+        "XIAOMI_TOKEN_PLAN_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    saved_env = {}
+    saved_config = {}
+    chosen_models = []
+    deactivated = []
+    prompts = []
+
+    def _get_env_value(key):
+        return saved_env.get(key, "")
+
+    def _save_env_value(key, value):
+        saved_env[key] = value
+
+    def _save_config(cfg):
+        saved_config.clear()
+        saved_config.update(cfg)
+
+    monkeypatch.setattr("hermes_cli.config.get_env_value", _get_env_value)
+    monkeypatch.setattr("hermes_cli.config.save_env_value", _save_env_value)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "", "provider": "xiaomi", "base_url": ""}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", _save_config)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: chosen_models.append(model))
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: deactivated.append(True))
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda models, current_model="", pricing=None: models[0] if models else None,
+    )
+    monkeypatch.setattr(
+        "agent.models_dev.list_agentic_models",
+        lambda provider_id: ["mimo-v2-pro", "mimo-v2-omni"],
+    )
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda api_key, base_url: ["mimo-v2-pro"])
+
+    def _prompt_choice(choices, *, default=0):
+        prompts.append((list(choices), default))
+        return default
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _prompt_choice)
+
+    return saved_env, saved_config, chosen_models, deactivated, prompts
+
+
+def test_model_flow_xiaomi_ignores_redacted_placeholder_key(monkeypatch):
+    saved_env, saved_config, chosen_models, deactivated, prompts = _configure_xiaomi_flow_test(monkeypatch)
+    saved_env["XIAOMI_API_KEY"] = "***"
+
+    answers = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "tp-live-key")
+
+    hermes_main._model_flow_api_key_provider({}, "xiaomi")
+
+    assert saved_env["XIAOMI_API_KEY"] == "tp-live-key"
+    assert saved_env["XIAOMI_BASE_URL"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert saved_config["model"]["provider"] == "xiaomi"
+    assert saved_config["model"]["base_url"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert chosen_models == ["mimo-v2-pro"]
+    assert deactivated == [True]
+    assert prompts == [(
+        [
+            "Xiaomi MiMo API (https://api.xiaomimimo.com/v1)",
+            "Xiaomi Token Plan API (https://token-plan-sgp.xiaomimimo.com/v1)",
+            "Custom Xiaomi-compatible URL",
+        ],
+        1,
+    )]
+
+
+
+def test_model_flow_xiaomi_tp_key_defaults_to_token_plan_endpoint(monkeypatch):
+    saved_env, saved_config, chosen_models, deactivated, prompts = _configure_xiaomi_flow_test(monkeypatch)
+
+    answers = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "tp-live-key")
+
+    hermes_main._model_flow_api_key_provider({}, "xiaomi")
+
+    assert saved_env["XIAOMI_API_KEY"] == "tp-live-key"
+    assert saved_env["XIAOMI_BASE_URL"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert saved_config["model"]["provider"] == "xiaomi"
+    assert saved_config["model"]["base_url"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert chosen_models == ["mimo-v2-pro"]
+    assert deactivated == [True]
+    assert prompts == [(
+        [
+            "Xiaomi MiMo API (https://api.xiaomimimo.com/v1)",
+            "Xiaomi Token Plan API (https://token-plan-sgp.xiaomimimo.com/v1)",
+            "Custom Xiaomi-compatible URL",
+        ],
+        1,
+    )]
+
+
+def test_model_flow_xiaomi_non_tp_key_defaults_to_standard_endpoint(monkeypatch):
+    saved_env, saved_config, chosen_models, deactivated, prompts = _configure_xiaomi_flow_test(monkeypatch)
+
+    answers = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "user-generated-key")
+
+    hermes_main._model_flow_api_key_provider({}, "xiaomi")
+
+    assert saved_env["XIAOMI_API_KEY"] == "user-generated-key"
+    assert "XIAOMI_BASE_URL" not in saved_env
+    assert saved_config["model"]["provider"] == "xiaomi"
+    assert saved_config["model"]["base_url"] == "https://api.xiaomimimo.com/v1"
+    assert chosen_models == ["mimo-v2-pro"]
+    assert deactivated == [True]
+    assert prompts == [(
+        [
+            "Xiaomi MiMo API (https://api.xiaomimimo.com/v1)",
+            "Xiaomi Token Plan API (https://token-plan-sgp.xiaomimimo.com/v1)",
+            "Custom Xiaomi-compatible URL",
+        ],
+        0,
+    )]
+
+
+def test_model_flow_xiaomi_custom_endpoint_prompts_for_manual_url(monkeypatch):
+    saved_env, saved_config, chosen_models, deactivated, _ = _configure_xiaomi_flow_test(monkeypatch)
+
+    answers = iter(["https://token-plan-ams.xiaomimimo.com/v1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "tp-live-key")
+
+    prompts = []
+
+    def _prompt_choice(choices, *, default=0):
+        prompts.append((list(choices), default))
+        return 2
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _prompt_choice)
+
+    hermes_main._model_flow_api_key_provider({}, "xiaomi")
+
+    assert saved_env["XIAOMI_API_KEY"] == "tp-live-key"
+    assert saved_env["XIAOMI_BASE_URL"] == "https://token-plan-ams.xiaomimimo.com/v1"
+    assert saved_config["model"]["base_url"] == "https://token-plan-ams.xiaomimimo.com/v1"
+    assert chosen_models == ["mimo-v2-pro"]
+    assert deactivated == [True]
+    assert prompts == [(
+        [
+            "Xiaomi MiMo API (https://api.xiaomimimo.com/v1)",
+            "Xiaomi Token Plan API (https://token-plan-sgp.xiaomimimo.com/v1)",
+            "Custom Xiaomi-compatible URL",
+        ],
+        1,
+    )]

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -88,11 +88,13 @@ class TestXiaomiAutoDetection:
     def test_auto_detect(self, monkeypatch):
         # Clear all other provider env vars
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                     "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
                      "DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
                      "DASHSCOPE_API_KEY", "XAI_API_KEY", "KIMI_API_KEY",
                      "MINIMAX_API_KEY", "AI_GATEWAY_API_KEY", "KILOCODE_API_KEY",
                      "HF_TOKEN", "GLM_API_KEY", "COPILOT_GITHUB_TOKEN",
-                     "GH_TOKEN", "GITHUB_TOKEN", "MINIMAX_CN_API_KEY"):
+                     "GH_TOKEN", "GITHUB_TOKEN", "MINIMAX_CN_API_KEY",
+                     "XIAOMI_TOKEN_PLAN_API_KEY"):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("XIAOMI_API_KEY", "sk-xiaomi-test-12345678")
         provider = resolve_provider("auto")

--- a/tests/hermes_cli/test_xiaomi_token_plan_provider.py
+++ b/tests/hermes_cli/test_xiaomi_token_plan_provider.py
@@ -1,0 +1,181 @@
+"""Tests for Xiaomi MiMo Token Plan provider support."""
+
+import sys
+import types
+
+import pytest
+
+# Ensure dotenv doesn't interfere
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.runtime_provider import resolve_runtime_provider
+
+
+class TestXiaomiTokenPlanProviderRegistry:
+    def test_registered(self):
+        assert "xiaomi-token-plan" in PROVIDER_REGISTRY
+
+    def test_name(self):
+        assert PROVIDER_REGISTRY["xiaomi-token-plan"].name == "Xiaomi MiMo (Token Plan)"
+
+    def test_auth_type(self):
+        assert PROVIDER_REGISTRY["xiaomi-token-plan"].auth_type == "api_key"
+
+    def test_inference_base_url(self):
+        assert (
+            PROVIDER_REGISTRY["xiaomi-token-plan"].inference_base_url
+            == "https://token-plan-sgp.xiaomimimo.com/v1"
+        )
+
+    def test_api_key_env_vars(self):
+        assert PROVIDER_REGISTRY["xiaomi-token-plan"].api_key_env_vars == (
+            "XIAOMI_TOKEN_PLAN_API_KEY",
+        )
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["xiaomi-token-plan"].base_url_env_var == (
+            "XIAOMI_TOKEN_PLAN_BASE_URL"
+        )
+
+
+class TestXiaomiTokenPlanAliases:
+    @pytest.mark.parametrize(
+        "alias",
+        ["xiaomi-token-plan", "xiaomi-token", "mimo-token-plan", "xiaomi-sgp"],
+    )
+    def test_alias_resolves(self, alias, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+        assert resolve_provider(alias) == "xiaomi-token-plan"
+
+    def test_normalize_provider_models_py(self):
+        from hermes_cli.models import normalize_provider
+
+        assert normalize_provider("xiaomi-token") == "xiaomi-token-plan"
+        assert normalize_provider("mimo-token-plan") == "xiaomi-token-plan"
+        assert normalize_provider("xiaomi-sgp") == "xiaomi-token-plan"
+
+    def test_normalize_provider_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+
+        assert normalize_provider("xiaomi-token") == "xiaomi-token-plan"
+        assert normalize_provider("mimo-token-plan") == "xiaomi-token-plan"
+        assert normalize_provider("xiaomi-sgp") == "xiaomi-token-plan"
+
+
+class TestXiaomiTokenPlanAutoDetection:
+    def test_auto_detect_prefers_token_plan_when_only_token_plan_key_is_set(self, monkeypatch):
+        for var in (
+            "OPENROUTER_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "DEEPSEEK_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "DASHSCOPE_API_KEY",
+            "XAI_API_KEY",
+            "KIMI_API_KEY",
+            "MINIMAX_API_KEY",
+            "AI_GATEWAY_API_KEY",
+            "KILOCODE_API_KEY",
+            "HF_TOKEN",
+            "GLM_API_KEY",
+            "COPILOT_GITHUB_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "MINIMAX_CN_API_KEY",
+            "XIAOMI_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        assert resolve_provider("auto") == "xiaomi-token-plan"
+
+
+class TestXiaomiTokenPlanCredentials:
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        status = get_api_key_provider_status("xiaomi-token-plan")
+        assert status["configured"]
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        monkeypatch.delenv("XIAOMI_TOKEN_PLAN_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("xiaomi-token-plan")
+        assert creds["api_key"] == "tp-test-key"
+        assert creds["base_url"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        monkeypatch.setenv(
+            "XIAOMI_TOKEN_PLAN_BASE_URL", "https://token-plan-ams.xiaomimimo.com/v1"
+        )
+        creds = resolve_api_key_provider_credentials("xiaomi-token-plan")
+        assert creds["base_url"] == "https://token-plan-ams.xiaomimimo.com/v1"
+
+
+class TestXiaomiTokenPlanModelsAndListing:
+    def test_static_model_list_exists(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        assert "xiaomi-token-plan" in _PROVIDER_MODELS
+        models = _PROVIDER_MODELS["xiaomi-token-plan"]
+        assert "mimo-v2-pro" in models
+        assert "mimo-v2-omni" in models
+        assert "mimo-v2-flash" in models
+
+    def test_normalize_strips_provider_prefix(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert (
+            normalize_model_for_provider("xiaomi/mimo-v2-pro", "xiaomi-token-plan")
+            == "mimo-v2-pro"
+        )
+
+    def test_authenticated_provider_listing_includes_token_plan(self, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "***")
+        monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+        providers = list_authenticated_providers(current_provider="xiaomi-token-plan")
+        slugs = [p["slug"] for p in providers]
+        assert "xiaomi-token-plan" in slugs
+        entry = next(p for p in providers if p["slug"] == "xiaomi-token-plan")
+        assert entry["is_current"] is True
+        assert entry["models"][:3] == ["mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"]
+
+
+class TestXiaomiTokenPlanRuntimeResolution:
+    def test_runtime_provider_uses_token_plan_base_url(self, monkeypatch):
+        monkeypatch.setenv("XIAOMI_TOKEN_PLAN_API_KEY", "tp-test-key")
+        monkeypatch.delenv("XIAOMI_TOKEN_PLAN_BASE_URL", raising=False)
+        runtime = resolve_runtime_provider(requested="xiaomi-token-plan")
+        assert runtime["provider"] == "xiaomi-token-plan"
+        assert runtime["base_url"] == "https://token-plan-sgp.xiaomimimo.com/v1"
+        assert runtime["api_mode"] == "chat_completions"
+
+
+class TestXiaomiTokenPlanConfigAndDoctor:
+    def test_optional_env_vars_registered(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        assert "XIAOMI_TOKEN_PLAN_API_KEY" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["XIAOMI_TOKEN_PLAN_API_KEY"]["category"] == "provider"
+        assert OPTIONAL_ENV_VARS["XIAOMI_TOKEN_PLAN_API_KEY"]["password"] is True
+        assert "XIAOMI_TOKEN_PLAN_BASE_URL" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["XIAOMI_TOKEN_PLAN_BASE_URL"]["category"] == "provider"
+        assert OPTIONAL_ENV_VARS["XIAOMI_TOKEN_PLAN_BASE_URL"]["advanced"] is True
+
+    def test_provider_env_hints(self):
+        from hermes_cli.doctor import _PROVIDER_ENV_HINTS
+
+        assert "XIAOMI_TOKEN_PLAN_API_KEY" in _PROVIDER_ENV_HINTS


### PR DESCRIPTION
## Summary

- add a dedicated `xiaomi-token-plan` provider variant for Xiaomi MiMo Token Plan credentials and routing
- preserve a single visible Xiaomi MiMo entry in the interactive model/setup picker
- add a Xiaomi endpoint-family selector that defaults to Token Plan for `tp-` keys and standard Xiaomi otherwise

## Motivation

`main` already supports Xiaomi MiMo as a direct provider.

This branch adds support for Xiaomi's Token Plan endpoint and credentials without turning the interactive setup flow into two separate visible Xiaomi providers. The goal is:
- one visible Xiaomi family entry in the picker
- separate internal runtime/config handling for standard Xiaomi vs Token Plan

## Changes

- register `xiaomi-token-plan` in provider/auth/runtime plumbing
- add dedicated env vars:
  - `XIAOMI_TOKEN_PLAN_API_KEY`
  - `XIAOMI_TOKEN_PLAN_BASE_URL`
- map `xiaomi-token-plan` to Xiaomi metadata/models.dev data where appropriate
- add Xiaomi Token Plan aliases and model-normalization support
- add Xiaomi Token Plan visibility to config/doctor/status/provider metadata surfaces
- keep the interactive picker singular by hiding `xiaomi-token-plan` as a separate visible Xiaomi row
- collapse an active `xiaomi-token-plan` config into a single visible Xiaomi picker entry
- add a Xiaomi-specific endpoint selector in setup:
  - Xiaomi MiMo API
  - Xiaomi Token Plan API
  - Custom Xiaomi-compatible URL
- default that selector to Token Plan when the entered key starts with `tp-`
- otherwise default it to the standard Xiaomi API
- treat placeholder/redacted secret values as unset during setup credential detection so stale values like `***` do not suppress the API key prompt

## Test Plan

- [x] `pytest tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_xiaomi_provider.py tests/hermes_cli/test_xiaomi_token_plan_provider.py tests/test_model_picker_scroll.py -q`
- [x] same 91-test slice re-run against the published branch
- [x] branch published to a contributor fork and PR opened successfully

## Notes for Reviewers

- `main.py` stays on the existing `CANONICAL_PROVIDERS` / `_PROVIDER_LABELS` framework; the Xiaomi picker behavior is implemented with minimal targeted changes on top of that structure
- the internal provider split (`xiaomi` vs `xiaomi-token-plan`) is intentional
- the user-facing setup flow remains a single Xiaomi family entry by design
