### PR TITLE
fix(bluebubbles): repair same-host webhook flow and iMessage sanitization

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -60,6 +60,21 @@ _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
+# Characters that render as tofu boxes on iMessage because Apple Color Emoji
+# has no glyphs for them.  Strips:
+#   * Block Elements (U+2580..U+259F) — streaming-cursor artifacts like ▉ that
+#     the agent's stream renderer can leak into the final message.
+#   * Private Use Area (U+E000..U+F8FF) — Slack custom workspace emoji live
+#     here and get carried through when Slack history ends up in model context.
+#   * Supplementary Private Use Areas (U+F0000..U+FFFFD, U+100000..U+10FFFD).
+_IMSG_TOFU_RE = re.compile(
+    "[\u2580-\u259F\ue000-\uf8ff\U000f0000-\U000ffffd\U00100000-\U0010fffd]"
+)
+
+
+def _sanitize_for_imessage(text: str) -> str:
+    return _IMSG_TOFU_RE.sub("", text or "").rstrip()
+
 
 def _redact(text: str) -> str:
     """Redact phone numbers and emails from log output."""
@@ -220,9 +235,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
-        return f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        # Use 127.0.0.1 literal rather than "localhost": on macOS with modern
+        # Node.js the BlueBubbles Server resolves "localhost" to ::1 (IPv6
+        # first), but the aiohttp TCPSite binds 127.0.0.1 only, so webhook
+        # dispatches fail with ECONNREFUSED on same-host installs.
+        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::", "::1"):
+            host = "127.0.0.1"
+        base = f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        if self.password:
+            return f"{base}?password={quote(self.password, safe='')}"
+        return base
 
     async def _find_registered_webhooks(self, url: str) -> list:
         """Return list of BB webhook entries matching *url*."""
@@ -257,7 +279,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:
@@ -383,7 +405,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        text = strip_markdown(content or "")
+        text = _sanitize_for_imessage(strip_markdown(content or ""))
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
         chunks = self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
@@ -669,7 +691,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return info
 
     def format_message(self, content: str) -> str:
-        return strip_markdown(content)
+        return _sanitize_for_imessage(strip_markdown(content))
 
     # ------------------------------------------------------------------
     # Inbound attachment downloading (from #4588)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -68,6 +68,22 @@ def _redact(text: str) -> str:
     return text
 
 
+# Characters that render as tofu boxes on iMessage because Apple Color Emoji
+# has no glyphs for them.  Strips:
+#   * Block Elements (U+2580..U+259F) — streaming-cursor artifacts like ▉ that
+#     the agent's stream renderer can leak into the final message.
+#   * Private Use Area (U+E000..U+F8FF) — Slack custom workspace emoji live
+#     here and get carried through when Slack history ends up in model context.
+#   * Supplementary Private Use Areas (U+F0000..U+FFFFD, U+100000..U+10FFFD).
+_IMSG_TOFU_RE = re.compile(
+    "[\u2580-\u259f\ue000-\uf8ff\U000f0000-\U000ffffd\U00100000-\U0010fffd]"
+)
+
+
+def _sanitize_for_imessage(text: str) -> str:
+    return _IMSG_TOFU_RE.sub("", text or "").rstrip()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -223,8 +239,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
+        # Use 127.0.0.1 literal rather than "localhost": on macOS with modern
+        # Node.js the BlueBubbles Server resolves "localhost" to ::1 (IPv6
+        # first), but the aiohttp TCPSite binds 127.0.0.1 only, so webhook
+        # dispatches fail with ECONNREFUSED on same-host installs.
+        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::", "::1"):
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property
@@ -674,7 +694,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return info
 
     def format_message(self, content: str) -> str:
-        return strip_markdown(content)
+        return _sanitize_for_imessage(strip_markdown(content))
 
     # ------------------------------------------------------------------
     # Inbound attachment downloading (from #4588)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -109,6 +109,50 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch)
         assert adapter.format_message("[click here](http://example.com)") == "click here"
 
+
+class TestBlueBubblesIMessageSanitization:
+    """format_message strips iMessage-tofu characters (Block Elements, PUAs)
+    while preserving ordinary emoji and leading/trailing whitespace layout."""
+
+    def test_strips_block_elements(self, monkeypatch):
+        """Block Elements (U+2580..U+259F) like the ▉ cursor artifact are removed."""
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.format_message("hello▉ world") == "hello world"
+
+    def test_strips_bmp_pua(self, monkeypatch):
+        """BMP Private Use Area (U+E000..U+F8FF) — Slack custom-emoji chars."""
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.format_message("hi \ue028 there") == "hi  there"
+
+    def test_strips_supplementary_pua(self, monkeypatch):
+        """Supplementary Private Use Areas (U+F0000..U+FFFFD, U+100000..U+10FFFD)."""
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.format_message("a\U000f1234b") == "ab"
+        assert adapter.format_message("a\U0010cdefb") == "ab"
+
+    def test_preserves_ordinary_emoji(self, monkeypatch):
+        """Everyday emoji must survive sanitization untouched."""
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.format_message("hey 😀") == "hey 😀"
+        assert adapter.format_message("love ❤️") == "love ❤️"
+
+    def test_rstrips_trailing_whitespace(self, monkeypatch):
+        """Trailing whitespace left after stripping tofu chars is cleaned up."""
+        adapter = _make_adapter(monkeypatch)
+        # tofu char at the very end leaves trailing whitespace that must be removed
+        assert adapter.format_message("done▉ ") == "done"
+        assert adapter.format_message("done \uE028 ") == "done"
+
+    def test_sanitize_helper_direct(self):
+        """_sanitize_for_imessage strips the tofu ranges and rstrips."""
+        from gateway.platforms.bluebubbles import _sanitize_for_imessage
+
+        assert _sanitize_for_imessage("▉block▉") == "block"
+        assert _sanitize_for_imessage("\ue000pua\uf8ff") == "pua"
+        assert _sanitize_for_imessage("\U000f0000sup\U0010fffd") == "sup"
+        assert _sanitize_for_imessage("ok 😀  ") == "ok 😀"
+        assert _sanitize_for_imessage(None) == ""
+
     def test_init_normalizes_webhook_path(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_path="bluebubbles-webhook")
         assert adapter.webhook_path == "/bluebubbles-webhook"
@@ -418,19 +462,21 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises local hosts to '127.0.0.1'."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
+    @pytest.mark.parametrize(
+        "host", ["0.0.0.0", "127.0.0.1", "localhost", "::", "::1"]
+    )
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## Summary

- Makes the native BlueBubbles adapter actually work on a same-host install (BlueBubbles Server + Hermes on one Mac, the recommended topology).
- Fixes two independent failures that each block all inbound messages (#9263, #9265), plus a macOS IPv6 resolution footgun, plus outbound rendering tofu on iMessage.

## What's in this PR

All four fixes live in `gateway/platforms/bluebubbles.py`:

1. **Drop invalid `"message"` event from the webhook registration payload** (fixes #9263). BlueBubbles Server only accepts `new-message` / `updated-message` (among others) and 400s the entire `POST /api/v1/webhook` if `"message"` is in the list — so on stock main, no events get subscribed at all.

2. **Embed the password in `_webhook_url`** (fixes #9265). BlueBubbles `WebhookService.dispatchEvent()` has no auth-header configuration, so every dispatch was being rejected by `_handle_webhook`'s password check with 401 Unauthorized.

3. **Use the `127.0.0.1` literal in `_webhook_url` instead of rewriting loopback hosts to `"localhost"`.** On macOS with modern Node.js, BlueBubbles Server resolves `localhost` → `::1` (IPv6 first), but the adapter's `aiohttp.web.TCPSite` binds IPv4-only, so every same-host dispatch fails with `ECONNREFUSED ::1:8645`. Switching to the literal avoids the AAAA lookup entirely.

4. **Strip iMessage tofu characters in outbound sends.** Apple Color Emoji has no glyphs for two ranges that routinely leak through the pipeline:
   - Block Elements (U+2580..U+259F) — streaming-cursor artifacts like `▉` that the agent's stream renderer can leave in the final message.
   - Private Use Area (U+E000..U+F8FF plus the two supplementary PUAs) — Slack custom workspace emojis are stored here and get carried through whenever Slack history / SOUL / memory feeds back into model context.
   A new `_sanitize_for_imessage()` helper is called from `send()` and `format_message()` before the outbound REST call so the user sees clean text instead of boxes.

#1 and #2 each independently prevent any inbound message from reaching the agent, and #3 prevents anything if you run BB Server and Hermes on the same Mac (which is the documented recommended setup). In combination, the native BlueBubbles adapter has not worked out of the box for same-host installs since it was added. #4 is a quality-of-life fix that becomes visible as soon as the first three are in place.

## Test plan

- [x] With the `"message"` event removed, `_register_webhook` returns `status=200` against a real BlueBubbles Server 1.9.9 and `GET /api/v1/webhook` shows the new entry with `events: ["new-message", "updated-message"]`.
- [x] With the password embedded in `_webhook_url`, inbound iMessages from BlueBubbles dispatch to Hermes and hit `_handle_webhook` as 200 OK instead of 401; the agent actually runs and produces a reply.
- [x] With the host rewritten to `127.0.0.1`, `aiohttp.TCPSite` bind and BB dispatch target are both unambiguously IPv4; same-host dispatch succeeds where it previously returned `ECONNREFUSED ::1:8645` in `~/Library/Logs/bluebubbles-server/main.log`.
- [x] `_sanitize_for_imessage` unit-sanity tested against `"Hello ▉"`, `"Done ▉"`, strings with `\uE001\uE002` PUA chars, strings with legitimate `🙂 ✅` emoji (preserved), and mixed strings. Trailing-whitespace cleanup works as expected.
- [x] End-to-end: an iMessage sent from a real user handle to the BlueBubbles Mac reaches the Hermes agent, the agent replies via the adapter's outbound send path, and the reply appears in Messages without any tofu characters.

## Notes

- Each fix is small and localized to a single file, so they are bundled into one commit for easier review; I can split them if you'd prefer separate commits.
- I also filed #9270 about a related (but not co-located) issue where `gateway/run.py` substitutes the literal `"(No response generated)"` into empty agent results and it ends up being delivered to users (and to cron home channels). Not fixed in this PR since it lives in different files and touches the cron scheduler's empty-skip path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)