### PR TITLE
docs: add Slack files:read scope

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1176,7 +1176,7 @@ OPTIONAL_ENV_VARS = {
     "SLACK_BOT_TOKEN": {
         "description": "Slack bot token (xoxb-). Get from OAuth & Permissions after installing your app. "
                        "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
-                       "im:history, im:read, im:write, users:read, files:write",
+                       "im:history, im:read, im:write, users:read, files:read, files:write",
         "prompt": "Slack Bot Token (xoxb-...)",
         "url": "https://api.slack.com/apps",
         "password": True,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1634,7 +1634,7 @@ _PLATFORMS = [
             "   Create an App-Level Token with scope: connections:write → copy xapp-... token",
             "3. Add Bot Token Scopes: Features → OAuth & Permissions → Scopes",
             "   Required: chat:write, app_mentions:read, channels:history, channels:read,",
-            "   groups:history, im:history, im:read, im:write, users:read, files:write",
+            "   groups:history, im:history, im:read, im:write, users:read, files:read, files:write",
             "4. Subscribe to Events: Features → Event Subscriptions → Enable",
             "   Required events: message.im, message.channels, app_mention",
             "   Optional: message.groups (for private channels)",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1781,7 +1781,7 @@ def _setup_slack():
     print_info("   3. Add Bot Token Scopes: Features → OAuth & Permissions")
     print_info("      Required scopes: chat:write, app_mentions:read,")
     print_info("      channels:history, channels:read, im:history,")
-    print_info("      im:read, im:write, users:read, files:write")
+    print_info("      im:read, im:write, users:read, files:read, files:write")
     print_info("      Optional for private channels: groups:history")
     print_info("   4. Subscribe to Events: Features → Event Subscriptions → Enable")
     print_info("      Required events: message.im, message.channels, app_mention")

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -54,6 +54,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | `im:read` | View basic DM info |
 | `im:write` | Open and manage DMs |
 | `users:read` | Look up user information |
+| `files:read` | Read and download attached files, including voice notes/audio |
 | `files:write` | Upload files (images, audio, documents) |
 
 :::caution Missing scopes = missing features


### PR DESCRIPTION
## Summary
Salvage of PR #9258 by @helix4u — adds `files:read` to all Slack bot token scope lists.

The Slack adapter downloads file attachments via `url_private_download` (slack.py L1080), which requires the `files:read` scope. Without it, voice notes and private file attachments silently fail.

## Changes
- Cherry-picked helix4u's commit (3 files: gateway.py, setup.py, slack.md)
- Added missing 4th location: `hermes_cli/config.py` SLACK_BOT_TOKEN description

## Files changed
- `hermes_cli/gateway.py` — gateway setup instructions
- `hermes_cli/setup.py` — setup wizard instructions  
- `hermes_cli/config.py` — env var description
- `website/docs/user-guide/messaging/slack.md` — docs scope table

Closes #9258