### PR TITLE
fix(custom-providers): preserve multi-model entries and group by provider name

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1656,7 +1656,8 @@ def get_compatible_custom_providers(
         provider_key = str(entry.get("provider_key", "") or "").strip().lower()
         name = str(entry.get("name", "") or "").strip().lower()
         base_url = str(entry.get("base_url", "") or "").strip().rstrip("/").lower()
-        pair = (name, base_url)
+        model = str(entry.get("model", "") or "").strip().lower()
+        pair = (name, base_url, model)
 
         if provider_key and provider_key in seen_provider_keys:
             return

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1028,7 +1028,17 @@ def list_authenticated_providers(
             })
 
     # --- 4. Saved custom providers from config ---
+    # Each ``custom_providers`` entry represents one model under a named
+    # provider. Entries sharing the same provider name are grouped into a
+    # single picker row so that e.g. four Ollama Cloud entries
+    # (qwen3-coder, glm-5.1, kimi-k2, minimax-m2.7) appear as one
+    # "Ollama Cloud" row with four models inside instead of four
+    # duplicate "Ollama Cloud" rows. Entries with distinct provider names
+    # still produce separate rows (e.g. Ollama Cloud vs Moonshot).
     if custom_providers and isinstance(custom_providers, list):
+        from collections import OrderedDict
+
+        groups: "OrderedDict[str, dict]" = OrderedDict()
         for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
@@ -1044,23 +1054,28 @@ def list_authenticated_providers(
                 continue
 
             slug = custom_provider_slug(display_name)
+            if slug not in groups:
+                groups[slug] = {
+                    "name": display_name,
+                    "api_url": api_url,
+                    "models": [],
+                }
+            default_model = (entry.get("model") or "").strip()
+            if default_model and default_model not in groups[slug]["models"]:
+                groups[slug]["models"].append(default_model)
+
+        for slug, grp in groups.items():
             if slug in seen_slugs:
                 continue
-
-            models_list = []
-            default_model = (entry.get("model") or "").strip()
-            if default_model:
-                models_list.append(default_model)
-
             results.append({
                 "slug": slug,
-                "name": display_name,
+                "name": grp["name"],
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list),
+                "models": grp["models"],
+                "total_models": len(grp["models"]),
                 "source": "user-config",
-                "api_url": api_url,
+                "api_url": grp["api_url"],
             })
             seen_slugs.add(slug)
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -564,6 +564,30 @@ class TestCustomProviderCompatibility:
         # Legacy entry wins (read first)
         assert compatible[0]["api_key"] == "legacy-key"
 
+    def test_dedup_preserves_entries_with_different_models(self, tmp_path):
+        """Entries with same name+URL but different models must not be collapsed."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": [
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "qwen3-coder"},
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "glm-5.1"},
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "kimi-k2.5"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 3
+        models = [e.get("model") for e in compatible]
+        assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
+
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -102,3 +102,57 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+
+
+def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
+    """Multiple custom_providers entries sharing a name should produce one row
+    with all models collected, not N duplicate rows."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[
+            {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "qwen3-coder:480b-cloud"},
+            {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "glm-5.1:cloud"},
+            {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "kimi-k2.5"},
+            {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "minimax-m2.7:cloud"},
+            {"name": "Moonshot", "base_url": "https://api.moonshot.ai/v1", "model": "kimi-k2-thinking"},
+        ],
+        max_models=50,
+    )
+
+    ollama_rows = [p for p in providers if p["name"] == "Ollama Cloud"]
+    assert len(ollama_rows) == 1, f"Expected 1 Ollama Cloud row, got {len(ollama_rows)}"
+    assert ollama_rows[0]["models"] == [
+        "qwen3-coder:480b-cloud", "glm-5.1:cloud", "kimi-k2.5", "minimax-m2.7:cloud"
+    ]
+    assert ollama_rows[0]["total_models"] == 4
+
+    moonshot_rows = [p for p in providers if p["name"] == "Moonshot"]
+    assert len(moonshot_rows) == 1
+    assert moonshot_rows[0]["models"] == ["kimi-k2-thinking"]
+
+
+def test_list_deduplicates_same_model_in_group(monkeypatch):
+    """Duplicate model entries under the same provider name should not produce
+    duplicate entries in the models list."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[
+            {"name": "MyProvider", "base_url": "http://localhost:11434/v1", "model": "llama3"},
+            {"name": "MyProvider", "base_url": "http://localhost:11434/v1", "model": "llama3"},
+            {"name": "MyProvider", "base_url": "http://localhost:11434/v1", "model": "mistral"},
+        ],
+        max_models=50,
+    )
+
+    my_rows = [p for p in providers if p["name"] == "MyProvider"]
+    assert len(my_rows) == 1
+    assert my_rows[0]["models"] == ["llama3", "mistral"]
+    assert my_rows[0]["total_models"] == 2


### PR DESCRIPTION
## Summary

Salvages PRs #9233 and #8011 by @akhater (Tony365's feature request).

When a user configures multiple `custom_providers` entries sharing the same provider name (e.g. 4 Ollama Cloud entries for different models), two bugs prevented them from appearing correctly in the `/model` picker:

**Bug 1 (data layer):** `get_compatible_custom_providers()` deduplicates by `(name, base_url)`, collapsing entries with different models into one. Fix: include `model` in the dedup key.

**Bug 2 (display layer):** `list_authenticated_providers()` creates one row per entry, and the `seen_slugs` guard drops all entries after the first for each slug. Fix: two-pass grouping via OrderedDict — first collect all models per provider slug, then emit one grouped row per provider.

### Before
```
1. Ollama Cloud      qwen3-coder:480b-cloud
(other 3 entries silently dropped)
```

### After
```
1. Ollama Cloud      qwen3-coder:480b-cloud, glm-5.1:cloud, kimi-k2.5, minimax-m2.7:cloud
2. Moonshot          kimi-k2-thinking
```

## Changes
- `hermes_cli/config.py` — Add model to dedup tuple in `_append_if_new()` (+2/-1)
- `hermes_cli/model_switch.py` — Two-pass grouping in section 4 of `list_authenticated_providers()` (+25/-10)
- Tests: 3 new regression tests covering grouping, dedup, and multi-model preservation

## Test plan
- [x] Unit tests pass (10/10 in custom_providers + config tests)
- [x] E2E test with real config file, real imports, isolated HERMES_HOME

Closes #8011, closes #9233.