### PR TITLE
fix(weixin): rename send_image_file param path→image_path to match base class

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,


### PR DESCRIPTION
## What does this PR do?

This PR fixes a `TypeError` crash that prevented image delivery on the Weixin (WeChat) channel.

`WeixinAdapter.send_image_file()` declared its second parameter as `path`, while every caller in `base.py` and `run.py` passes the value as the keyword argument `image_path` — matching the base class contract and all other adapters (Telegram, Discord, Slack). This mismatch caused every image send attempt via Weixin to fail with:

```
WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
```

The fix renames the parameter from `path` to `image_path` and updates the forwarding call to `send_document()` accordingly. The internal positional call at line 1817 is unaffected.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Renamed parameter `path` → `image_path` in `WeixinAdapter.send_image_file()` (`gateway/platforms/weixin.py:1545`) to match the `BasePlatformAdapter` contract.
- Updated the internal `send_document()` forwarding call to use `file_path=image_path`.

## How to Test

1. Configure a Weixin channel in Hermes gateway.
2. Ask the agent to generate or send an image via the Weixin channel.
3. Confirm the image is delivered without the `unexpected keyword argument 'image_path'` error in the logs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs

Before fix:
```
WARNING gateway.run: [Weixin] Post-stream media delivery failed: WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
WARNING gateway.platforms.base: [Weixin] Error sending media: WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
```

After fix: image delivered successfully with no errors.
