### PR TITLE
feat(memory): per-job Honcho peers for cron-triggered agents

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import contextvars
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 
@@ -730,6 +731,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     return "\n".join(parts)
 
 
+def _slug(raw: str) -> str:
+    """Lowercase, strip non-[a-z0-9-], collapse runs of hyphens."""
+    return re.sub(r'-+', '-', re.sub(r'[^a-z0-9-]', '-', raw.lower())).strip('-')
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -921,7 +927,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             skip_context_files=True,  # Don't inject SOUL.md/AGENTS.md from scheduler cwd
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            # Each cron job gets its own Honcho peer (cron-{name}) so Honcho builds a
+            # coherent representation of what each scheduled behavior does over time. The
+            # assistant's own responses still attribute to the aiPeer, so the agent's
+            # self-model accumulates cron actions as its own.
+            user_id=f"cron-{_slug(job.get('name') or job['id'][:8])}",
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
@@ -1059,7 +1069,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
-        # Clean up ContextVar session/delivery state for this job.
+        # Flush memory providers so the last sync_turn / aretain_batch aren't
+        # dropped when the thread pool shuts down.
+        try:
+            agent.shutdown_memory_provider()
+        except Exception as e:
+            logger.debug("Job '%s': memory provider shutdown failed: %s", job_id, e)
+        # Clean up ContextVar session/delivery state for this job. Upstream
+        # consolidated the manual env-var unset into clear_session_vars().
         clear_session_vars(_ctx_tokens)
         if _session_db:
             try:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -225,8 +225,6 @@ class HonchoMemoryProvider(MemoryProvider):
         self._lazy_init_kwargs: Optional[dict] = None
         self._lazy_init_session_id: Optional[str] = None
 
-        # Port #4053: cron guard — when True, plugin is fully inactive
-        self._cron_skipped = False
 
     @property
     def name(self) -> str:
@@ -271,20 +269,11 @@ class HonchoMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Honcho session manager.
 
-        Handles: cron guard, recall_mode, session name resolution,
+        Handles: recall_mode, session name resolution,
         peer memory mode, SOUL.md ai_peer sync, memory file migration,
         and pre-warming context at init.
         """
         try:
-            # ----- Port #4053: cron guard -----
-            agent_context = kwargs.get("agent_context", "")
-            platform = kwargs.get("platform", "cli")
-            if agent_context in ("cron", "flush") or platform == "cron":
-                logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
-                             agent_context, platform)
-                self._cron_skipped = True
-                return
-
             from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
             from plugins.memory.honcho.session import HonchoSessionManager
 
@@ -292,6 +281,16 @@ class HonchoMemoryProvider(MemoryProvider):
             if not cfg.enabled or not (cfg.api_key or cfg.base_url):
                 logger.debug("Honcho not configured — plugin inactive")
                 return
+
+            # Override peer_name with the caller-supplied user_id so each caller
+            # gets their own Honcho peer.  For owner sessions the gateway will
+            # stop passing user_id once user-unify ships — until then, owner
+            # messages fragment across transport-level peers (pre-#6995 behavior,
+            # preferable to the active stranger/cron pollution #6995 introduced).
+            _gw_user_id = kwargs.get("user_id")
+            if _gw_user_id:
+                cfg.peer_name = _gw_user_id
+
 
             self._config = cfg
 
@@ -442,8 +441,6 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._manager and self._session_initialized:
             return True
-        if self._cron_skipped:
-            return False
         if not self._config or not self._lazy_init_kwargs:
             return False
 
@@ -497,8 +494,6 @@ class HonchoMemoryProvider(MemoryProvider):
         that doesn't change between turns (prompt-cache friendly).
         Live context (representation, card) is injected via prefetch().
         """
-        if self._cron_skipped:
-            return ""
         if not self._manager or not self._session_key:
             # tools-only mode without session yet still returns a minimal block
             if self._recall_mode == "tools" and self._config:
@@ -551,9 +546,6 @@ class HonchoMemoryProvider(MemoryProvider):
         B5: Respects injection_frequency — "first-turn" returns cached/empty after turn 0.
         Port #3265: Truncates to context_tokens budget.
         """
-        if self._cron_skipped:
-            return ""
-
         # B1: tools-only mode — no auto-injection
         if self._recall_mode == "tools":
             return ""
@@ -702,8 +694,6 @@ class HonchoMemoryProvider(MemoryProvider):
         Context refresh updates the base layer (representation + card).
         Dialectic fires the LLM reasoning supplement.
         """
-        if self._cron_skipped:
-            return
         if not self._manager or not self._session_key or not query:
             return
 
@@ -1062,8 +1052,6 @@ class HonchoMemoryProvider(MemoryProvider):
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
         """
-        if self._cron_skipped:
-            return
         if not self._manager or not self._session_key:
             return
 
@@ -1091,8 +1079,6 @@ class HonchoMemoryProvider(MemoryProvider):
         """Mirror built-in user profile writes as Honcho conclusions."""
         if action != "add" or target != "user" or not content:
             return
-        if self._cron_skipped:
-            return
         if not self._manager or not self._session_key:
             return
 
@@ -1107,8 +1093,6 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
-        if self._cron_skipped:
-            return
         if not self._manager:
             return
         # Wait for pending sync
@@ -1124,16 +1108,12 @@ class HonchoMemoryProvider(MemoryProvider):
 
         B1: context-only mode hides all tools.
         """
-        if self._cron_skipped:
-            return []
         if self._recall_mode == "context":
             return []
         return list(ALL_TOOL_SCHEMAS)
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         """Handle a Honcho tool call, with lazy session init for tools-only mode."""
-        if self._cron_skipped:
-            return tool_error("Honcho is not active (cron context).")
 
         # Port #1957: ensure session is initialized for tools-only mode
         if not self._session_initialized:


### PR DESCRIPTION
## Summary

- Cron-triggered agents currently skip memory entirely (`skip_memory=True`), so scheduled behaviors like self-reflection and hub-discovery have zero persistence across runs
- Route each cron job to its own Honcho peer (`cron-{job_name}`) instead of the human owner's peer, giving each scheduled behavior a coherent representation while the assistant's unified self-model accumulates all cron actions
- Revert the #6995 `not cfg.peer_name` guard that silently blocked all `user_id` overrides on provisioned agents (where `peerName: "user"` is configured), fixing active stranger pollution and unblocking cron peer routing
- Add `skip_memory=True` to the hygiene compress agent, which was accidentally protected by the now-removed cron guard but should never write to memory providers
- Add `agent.shutdown_memory_provider()` to the cron teardown path so final `sync_turn`/`aretain_batch` writes aren't silently dropped

## Detail

### Why per-job peers (not one global cron peer)

Cron behaviors are semantically distinct — `self-reflection`, `hub-discovery`, `morning-brief`, etc. A single peer accumulating all of them would produce an incoherent representation. Each named job gets its own peer with a readable ID derived from the job name.

### Why revert #6995's peerName guard

The guard (`if _gw_user_id and not cfg.peer_name`) was intended to prevent raw transport IDs from overwriting an explicitly configured `peerName`. But on provisioned agents where `peerName: "user"` is set, it blocks **all** `user_id` overrides — including cron peer routing and stranger isolation. This causes two bugs:

1. **Cron pollution**: `user_id="cron-self-reflection"` is silently ignored → cron messages land on the owner's `user` peer
2. **Stranger pollution**: any stranger DMing the bot also lands on `user` instead of their own transport-level peer

The fix moves identity protection to the gateway layer (where caller context is available) rather than the plugin layer. Owner fragmentation temporarily returns to pre-#6995 behavior until the gateway-side owner detection ships as a follow-up.

### Hindsight

Hindsight has no cron guard — when `skip_memory=True` is removed, it activates automatically and begins retaining cron turns. Each run stores under its own `document_id` (the `cron_{job_id}_{timestamp}` session ID), so runs are naturally distinct. No hindsight-specific changes needed.

## Test plan

- [ ] Create two named cron jobs, let each fire 2-3 times, verify distinct `cron-{name}` peers appear in Honcho workspace with per-job representations
- [ ] Verify owner's peer representation is not polluted with cron content
- [ ] Verify stranger DMs attribute to transport-level peers (not `user`)
- [ ] Let self-reflection cron fire and confirm it can read prior self-reflections via Honcho
- [ ] Verify cron run documents appear in Hindsight with correct `document_id` pattern
- [ ] Confirm `shutdown_memory_provider()` runs cleanly in cron teardown (no dropped writes in logs)
- [ ] Trigger hygiene compression and verify `_hyg_agent` does not create Honcho peers or Hindsight documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)