### PR TITLE
fix: preserve named auxiliary providers with base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -96,7 +96,7 @@ def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
-    "zai": "glm-4.5-flash",
+    "zai": "glm-5",
     "kimi-coding": "kimi-k2-turbo-preview",
     "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",
@@ -1463,10 +1463,28 @@ def resolve_provider_client(
     # ── Named custom providers (config.yaml custom_providers list) ───
     try:
         from hermes_cli.runtime_provider import _get_named_custom_provider
+        from hermes_cli.auth import resolve_api_key_provider_credentials
         custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = custom_entry.get("base_url", "").strip()
-            custom_key = custom_entry.get("api_key", "").strip() or "no-key-required"
+            custom_key = custom_entry.get("api_key", "").strip()
+
+            # If this named custom provider also resolves via the standard
+            # provider credential path (e.g. zeabur), prefer that live auth.
+            # Pure custom providers like beans/local will raise or return no key,
+            # in which case we preserve the original custom_provider behavior.
+            try:
+                creds = resolve_api_key_provider_credentials(provider)
+            except Exception:
+                creds = {}
+            provider_api_key = str(creds.get("api_key", "") or "").strip()
+            provider_base_url = str(creds.get("base_url", "") or "").strip()
+            if provider_api_key:
+                custom_key = provider_api_key
+            if provider_base_url:
+                custom_base = provider_base_url.rstrip("/")
+
+            custom_key = custom_key or "no-key-required"
             if custom_base:
                 final_model = _normalize_resolved_model(
                     model or _read_main_model() or "gpt-4o-mini",
@@ -1708,16 +1726,18 @@ def resolve_vision_provider_client(
         return resolved_provider, sync_client, final_model
 
     if resolved_base_url:
+        endpoint_provider = requested if requested and requested != "auto" else "custom"
         client, final_model = resolve_provider_client(
-            "custom",
+            endpoint_provider,
             model=resolved_model,
             async_mode=async_mode,
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
         )
         if client is None:
-            return "custom", None, None
-        return "custom", client, final_model
+            return endpoint_provider, None, None
+        return endpoint_provider, client, final_model
 
     if requested == "auto":
         # Vision auto-detection order:
@@ -1918,6 +1938,34 @@ def _is_openrouter_client(client: Any) -> bool:
     return False
 
 
+def _should_try_auxiliary_fallback(error: Exception, *, explicit_provider: str) -> tuple[bool, Optional[str]]:
+    """Return whether auxiliary call_llm should try provider fallback for this error.
+
+    Auto provider always gets best-effort fallback for payment/auth/model/connection
+    failures. Explicit providers remain hard constraints except for direct custom
+    endpoints (explicit base_url / custom), where invalid auth or unsupported model
+    should degrade to the auto chain instead of breaking compression/search flows.
+    """
+    is_auto = explicit_provider in ("auto", "", None)
+    if _is_payment_error(error):
+        return is_auto, "payment error"
+    if _is_connection_error(error):
+        return is_auto, "connection error"
+
+    try:
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        classified = classify_api_error(error)
+        if classified.reason == FailoverReason.auth and explicit_provider in ("custom",):
+            return True, "auth error"
+        if classified.reason == FailoverReason.model_not_found and explicit_provider in ("custom",):
+            return True, "unsupported model"
+    except Exception:
+        pass
+
+    return False, None
+
+
 def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
     """Drop OpenRouter-format model slugs (with '/') for non-OpenRouter clients.
 
@@ -2016,9 +2064,10 @@ def _resolve_task_provider_model(
       4. "auto" (full auto-detection chain)
 
     Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
-    to "custom" and the task uses that direct endpoint. api_mode is one of
-    "chat_completions", "codex_responses", or None (auto-detect).
+    be None (use provider default). When a base_url is set without an explicit
+    non-auto provider, provider is forced to "custom" and the task uses that
+    direct endpoint. api_mode is one of "chat_completions", "codex_responses",
+    or None (auto-detect).
     """
     config = {}
     cfg_provider = None
@@ -2062,14 +2111,20 @@ def _resolve_task_provider_model(
     resolved_api_mode = cfg_api_mode or env_api_mode
 
     if base_url:
-        return "custom", resolved_model, base_url, api_key, resolved_api_mode
+        chosen_provider = provider if provider and provider != "auto" else "custom"
+        return chosen_provider, resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
         if cfg_base_url:
-            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+            # Preserve an explicitly configured named provider (e.g. zeabur)
+            # when a task also pins a base_url. Downgrading named providers to
+            # "custom" breaks provider-specific auth resolution and can make
+            # compression summarization fail even though the main provider works.
+            chosen_provider = cfg_provider if cfg_provider and cfg_provider != "auto" else "custom"
+            return chosen_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode
 
@@ -2403,23 +2458,18 @@ def call_llm(
         # common case where a user runs out of OpenRouter credits but has
         # Codex OAuth or another provider available.
         #
-        # ── Connection error fallback ────────────────────────────────
-        # When a provider endpoint is unreachable (DNS failure, connection
-        # refused, timeout), try alternative providers.  This handles stale
-        # Codex/OAuth tokens that authenticate but whose endpoint is down,
-        # and providers the user never configured that got picked up by
-        # the auto-detection chain.
-        should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        # Only try alternative providers when the user didn't explicitly
-        # configure this task's provider.  Explicit provider = hard constraint;
-        # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in ("auto", "", None)
-        if should_fallback and is_auto:
-            reason = "payment error" if _is_payment_error(first_err) else "connection error"
+        # ── Connection / auth / model fallback ───────────────────────
+        # Auto mode is always best-effort. For explicit custom endpoints,
+        # auth / invalid-model failures should also degrade to the auto chain
+        # so auxiliary tasks like compression don't hard-fail on a broken
+        # sidecar endpoint.
+        should_fallback, reason = _should_try_auxiliary_fallback(
+            first_err, explicit_provider=resolved_provider)
+        if should_fallback:
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
             fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+                resolved_provider, task, reason=reason or "error")
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
@@ -2589,15 +2639,14 @@ async def async_call_llm(
                     raise
                 first_err = retry_err
 
-        # ── Payment / connection fallback (mirrors sync call_llm) ─────
-        should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        is_auto = resolved_provider in ("auto", "", None)
-        if should_fallback and is_auto:
-            reason = "payment error" if _is_payment_error(first_err) else "connection error"
+        # ── Payment / connection / auth / model fallback (mirrors sync call_llm) ─────
+        should_fallback, reason = _should_try_auxiliary_fallback(
+            first_err, explicit_provider=resolved_provider)
+        if should_fallback:
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
             fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+                resolved_provider, task, reason=reason or "error")
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -96,7 +96,7 @@ def _normalize_aux_provider(provider: Optional[str], *, for_vision: bool = False
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
-    "zai": "glm-5",
+    "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
     "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -437,6 +437,19 @@ class TestExpiredCodexFallback:
             adapter = client.chat.completions
             assert adapter._is_oauth is True
 
+    def test_non_prefixed_oauth_like_token_sets_flag(self, monkeypatch):
+        """Legacy/setup tokens without sk-ant-/JWT prefixes still need bearer auth."""
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="hermes-oauth-jwt-token"), \
+             patch("agent.anthropic_adapter.build_anthropic_client") as mock_build, \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            mock_build.return_value = MagicMock()
+            from agent.auxiliary_client import _try_anthropic
+            client, model = _try_anthropic()
+            assert client is not None
+            assert client.chat.completions._is_oauth is True
+
 
 class TestExplicitProviderRouting:
     """Test explicit provider selection bypasses auto chain correctly."""
@@ -816,8 +829,9 @@ class TestAuxiliaryPoolAwareness:
             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="***"),
         ):
-            client, model = get_vision_auxiliary_client()
+            provider, client, model = resolve_vision_provider_client()
 
+        assert provider == "anthropic"
         assert client is not None
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
 
@@ -1057,6 +1071,29 @@ model:
             client, model = get_text_auxiliary_client("compression")
         assert model == "glm-4.7"
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+    def test_resolve_task_provider_model_preserves_named_provider_with_base_url(self, monkeypatch, tmp_path):
+        """Named providers like zeabur should not be downgraded to custom when base_url is configured."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """compression:
+  summary_provider: zeabur
+  summary_model: gpt-5.4
+  summary_base_url: https://claude-codex.zeabur.app/v1
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("compression")
+
+        assert provider == "zeabur"
+        assert model == "gpt-5.4"
+        assert base_url == "https://claude-codex.zeabur.app/v1"
+        assert api_key is None
+        assert api_mode is None
 
 
 class TestAuxiliaryMaxTokensParam:
@@ -1307,6 +1344,56 @@ class TestCallLlmPaymentFallback:
                     messages=[{"role": "user", "content": "hello"}],
                 )
 
+    def test_401_triggers_fallback_for_explicit_custom_provider(self, monkeypatch):
+        """Explicit custom endpoints should degrade to auto fallback on auth failures."""
+        primary_client = MagicMock()
+        auth_err = Exception("Unauthorized: invalid api key")
+        auth_err.status_code = 401
+        primary_client.chat.completions.create.side_effect = auth_err
+
+        fallback_client = MagicMock()
+        fallback_response = MagicMock()
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "broken-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("custom", "broken-model", "https://broken.example/v1", "bad-key", None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "glm-5", "zai")) as mock_fb:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is fallback_response
+        mock_fb.assert_called_once_with("custom", "compression", reason="auth error")
+
+    def test_unsupported_model_triggers_fallback_for_explicit_custom_provider(self, monkeypatch):
+        """Explicit custom endpoints should degrade to auto fallback on unsupported model."""
+        primary_client = MagicMock()
+        model_err = Exception("Bad Request: unsupported model")
+        model_err.status_code = 400
+        primary_client.chat.completions.create.side_effect = model_err
+
+        fallback_client = MagicMock()
+        fallback_response = MagicMock()
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "broken-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("custom", "broken-model", "https://broken.example/v1", "bad-key", None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "glm-5", "zai")) as mock_fb:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is fallback_response
+        mock_fb.assert_called_once_with("custom", "compression", reason="unsupported model")
+
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
@@ -1457,6 +1544,16 @@ class TestAsyncCallLlmFallback:
         exc.status_code = 402
         return exc
 
+    def _make_401_error(self, msg="Unauthorized: invalid api key"):
+        exc = Exception(msg)
+        exc.status_code = 401
+        return exc
+
+    def _make_400_model_error(self, msg="Bad Request: unsupported model"):
+        exc = Exception(msg)
+        exc.status_code = 400
+        return exc
+
     @pytest.mark.asyncio
     async def test_402_triggers_async_fallback_when_auto(self, monkeypatch):
         """When provider is auto and returns 402, async_call_llm tries fallback."""
@@ -1541,6 +1638,62 @@ class TestAsyncCallLlmFallback:
 
         assert result is fb_response
         mock_fb.assert_called_once_with("auto", "compression", reason="connection error")
+
+    @pytest.mark.asyncio
+    async def test_401_triggers_async_fallback_for_explicit_custom_provider(self, monkeypatch):
+        """Explicit custom endpoints should async-fallback on auth failures."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_401_error())
+
+        fb_sync_client = MagicMock()
+        fb_async_client = MagicMock()
+        fb_response = MagicMock()
+        fb_async_client.chat.completions.create = AsyncMock(return_value=fb_response)
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "broken-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("custom", "broken-model", "https://broken.example/v1", "bad-key", None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fb_sync_client, "glm-5", "zai")) as mock_fb, \
+             patch("agent.auxiliary_client._to_async_client",
+                    return_value=(fb_async_client, "glm-5")):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is fb_response
+        mock_fb.assert_called_once_with("custom", "compression", reason="auth error")
+
+    @pytest.mark.asyncio
+    async def test_unsupported_model_triggers_async_fallback_for_explicit_custom_provider(self, monkeypatch):
+        """Explicit custom endpoints should async-fallback on unsupported model."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_400_model_error())
+
+        fb_sync_client = MagicMock()
+        fb_async_client = MagicMock()
+        fb_response = MagicMock()
+        fb_async_client.chat.completions.create = AsyncMock(return_value=fb_response)
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "broken-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("custom", "broken-model", "https://broken.example/v1", "bad-key", None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fb_sync_client, "glm-5", "zai")) as mock_fb, \
+             patch("agent.auxiliary_client._to_async_client",
+                    return_value=(fb_async_client, "glm-5")):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is fb_response
+        mock_fb.assert_called_once_with("custom", "compression", reason="unsupported model")
 class TestStaleBaseUrlWarning:
     """_resolve_auto() warns when OPENAI_BASE_URL conflicts with config provider (#5161)."""
 

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -161,6 +161,30 @@ class TestResolveProviderClientNamedCustom:
         client, model = resolve_provider_client("coffee", "test")
         assert client is None
 
+    def test_named_custom_provider_prefers_provider_credentials_over_entry_api_key(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "zeabur"},
+            "custom_providers": [
+                {"name": "zeabur", "base_url": "https://claude-codex.zeabur.app/v1"},
+            ],
+        })
+        with (
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
+                "api_key": "zeabur-live-key",
+                "base_url": "https://claude-codex.zeabur.app/v1",
+            }),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("zeabur", "gpt-5.4")
+
+        assert client is not None
+        assert model == "gpt-5.4"
+        assert mock_openai.call_args.kwargs["api_key"] == "zeabur-live-key"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://claude-codex.zeabur.app/v1"
+
 
 class TestResolveProviderClientModelNormalization:
     """Direct-provider auxiliary routing should normalize models like main runtime."""


### PR DESCRIPTION
## Summary\n- preserve named auxiliary providers when an auxiliary task also pins base_url\n- prefer resolved provider credentials for named custom providers like zeabur\n- allow explicit custom auxiliary endpoints to fall back on auth/model errors\n- restore the previous zai auxiliary default model\n\n## Test Plan\n- added targeted auxiliary client regression tests\n