### PR TITLE
chore(docker): auto-activate venv in interactive bash sessions via /etc/bash.bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,9 @@ USER root
 RUN chmod +x /opt/hermes/docker/entrypoint.sh
 
 ENV HERMES_HOME=/opt/data
+
+# Activate the virtualenv for all interactive bash sessions (docker exec -it hermes bash)
+RUN echo 'source /opt/hermes/.venv/bin/activate' >> /etc/bash.bashrc
+
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]


### PR DESCRIPTION
## What does this PR do?

This PR ensures the virtualenv is automatically activated for interactive bash sessions inside the Hermes Docker container.

When developers or operators use `docker exec -it hermes bash` to shell into a running container, the virtualenv at `/opt/hermes/.venv` was not activated by default. This meant `python`, `pip`, and all Hermes CLI entry points were not on `PATH`, requiring a manual `source /opt/hermes/.venv/bin/activate` every time.

The fix appends the activation line to `/etc/bash.bashrc`, which Bash sources for every interactive non-login shell. This keeps the change minimal and non-intrusive — it has no effect on the container's normal startup via `entrypoint.sh` (which activates the venv explicitly), and only improves the interactive debug/maintenance experience.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a `RUN echo 'source /opt/hermes/.venv/bin/activate' >> /etc/bash.bashrc` step in `Dockerfile` so the virtualenv is active in all interactive bash sessions (`docker exec -it hermes bash`).

## How to Test

1. Build the Docker image:
   `docker build -t hermes-agent:test .`
2. Shell into the container:
   `docker exec -it hermes bash`
3. Verify the virtualenv is active automatically:
   `which python`
   Expected output: `/opt/hermes/.venv/bin/python`
4. Confirm normal container startup is unaffected:
   `docker run --rm hermes-agent:test python -c "import hermes_cli; print('ok')"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Docker/Linux only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs

Before fix (inside container):
```text
$ docker exec -it hermes bash
root@container:/# which python
/usr/bin/python   # system python, venv not active
```

After fix:
```text
$ docker exec -it hermes bash
(.venv) root@container:/# which python
/opt/hermes/.venv/bin/python   # venv active automatically
```


