### PR TITLE
fix: stop leaking placeholder text to users and cron targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -828,6 +828,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         final_response = result.get("final_response", "") or ""
+        # Strip leaked placeholder text that upstream may inject on empty completions.
+        if final_response.strip() == "(No response generated)":
+            final_response = ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8119,7 +8119,7 @@ class GatewayRunner:
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
-                error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
+                error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
                     "final_response": error_msg,
                     "messages": result.get("messages", []),


### PR DESCRIPTION
## Summary

When the LLM returns an empty completion (e.g. reasoning-only / think-only), `gateway/run.py` replaces `final_response` with the literal string `"(No response generated)"`. This defeats `cron/scheduler.py`'s empty-response skip guard, causing the placeholder to be delivered to home channels as a real message.

## Changes

1. **gateway/run.py:8122** — Return empty string instead of placeholder when there is no error and no response content. This keeps `final_response` falsy so downstream callers can properly detect empty completions.

2. **cron/scheduler.py:830** — Defensively strip the placeholder text in case any other upstream code path still produces it, before the delivery decision is made.

## Testing

- Verified that cron jobs with empty LLM responses now correctly skip delivery (the `bool(deliver_content)` guard fires as intended)
- Direct DM empty-response paths in `gateway/run.py` (lines 5405, 5433, 5571, 5587) are **not changed** — those are user-facing adapter sends where the placeholder is appropriate UI feedback

Fixes #9270
