### PR TITLE
fix(bluebubbles): fix webhook registration, auth, and message editing

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -100,6 +100,7 @@ def _normalize_server_url(raw: str) -> str:
 class BlueBubblesAdapter(BasePlatformAdapter):
     platform = Platform.BLUEBUBBLES
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
@@ -219,10 +220,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     @property
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
+        from urllib.parse import quote
         host = self.webhook_host
         if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
             host = "localhost"
-        return f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        base = f"http://{host}:{self.webhook_port}{self.webhook_path}"
+        if self.password:
+            base += f"?password={quote(self.password, safe='')}"
+        return base
 
     async def _find_registered_webhooks(self, url: str) -> list:
         """Return list of BB webhook entries matching *url*."""
@@ -257,7 +262,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:


### PR DESCRIPTION
## Problem

The BlueBubbles adapter has three bugs that break inbound message handling:

1. **Invalid webhook event type causes 400 on registration** — `_register_webhook()` includes `"message"` in the events list, which BlueBubbles rejects with 400 Bad Request. Only `"new-message"` and `"updated-message"` are valid BB event types. Result: webhook never registers, gateway appears connected but never receives inbound messages.

2. **Webhook URL missing password causes 401 on dispatch** — `_webhook_url` builds the URL without `?password=` in the query string. BlueBubbles dispatches webhook events to the stored URL verbatim (no auth headers added). The gateway webhook handler requires the password parameter to authenticate requests. Result: BB dispatches succeed but gateway rejects them with 401 Unauthorized.

3. **Missing SUPPORTS_MESSAGE_EDITING flag causes split messages** — Without `SUPPORTS_MESSAGE_EDITING = False`, the stream consumer attempts progressive message edits. BlueBubbles has no message editing capability (AppleScript API), so each streaming chunk becomes a separate message. Result: responses arrive as 2-10 fragmented messages with rendering artifacts.

## Changes

- Remove invalid `"message"` event from webhook registration payload
- Append `?password=` to webhook URL so BB dispatches pass gateway auth
- Add `SUPPORTS_MESSAGE_EDITING = False` class attribute to BlueBubblesAdapter

## Testing

- Verified webhook registration succeeds (was returning 400, now returns 200)
- Verified BB webhook list contains URL with password parameter
- Verified inbound messages are received and processed by gateway
- Verified responses arrive as single messages (no fragmentation)