### PR TITLE
feat(gateway): telegram media delivery — reliable albums, no caption leakage, per-item captions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -282,6 +282,31 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
 # message representation stays consistent ("system" everywhere).
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
+# Album/media-group sending protocol shared across all chat platforms that
+# support native media delivery.  Appended to each platform's MEDIA: paragraph
+# so every model (not just Claude) learns the per-item caption syntax.
+_MEDIA_GROUP_RULES = (
+    "\n\nAlbum delivery (multiple media in one message): "
+    "When sending 2 or more media files together, ALWAYS use this exact format — "
+    "consecutive MEDIA: lines form an album, with each caption on the line(s) "
+    "directly after its MEDIA: line:\n"
+    "\n"
+    "MEDIA:/tmp/cat.png\n"
+    "A fluffy cat\n"
+    "MEDIA:/tmp/dog.png\n"
+    "A happy dog\n"
+    "\n"
+    "Rules:\n"
+    "- NO blank lines between album items (a blank line ends the album)\n"
+    "- NO prose or commentary between MEDIA: lines (e.g. no 'Next is...')\n"
+    "- For local files, always use MEDIA:/path — never ![alt](path)\n"
+    "- To share ONE caption across the whole album, put it AFTER all MEDIA: lines instead\n"
+    "- Captions support MarkdownV2 (**bold**, _italic_, `code`, ||spoiler||)\n"
+    "\n"
+    "For complex multi-image delivery workflows, consult the "
+    "telegram-media-group-captions skill via skill_view."
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
@@ -292,7 +317,7 @@ PLATFORM_HINTS = {
         ".webp) appear as photos, videos (.mp4, .mov) play inline, and other "
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "telegram": (
         "You are on a text messaging communication platform, Telegram. "
         "Please do not use markdown as it does not render. "
@@ -301,21 +326,21 @@ PLATFORM_HINTS = {
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
         "bubbles, and videos (.mp4) play inline. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as native photos."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are sent as photo "
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be sent as attachments."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "slack": (
         "You are in a Slack workspace communicating with your user. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are uploaded as photo "
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be uploaded as attachments."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "signal": (
         "You are on a text messaging communication platform, Signal. "
         "Please do not use markdown as it does not render. "
@@ -324,7 +349,7 @@ PLATFORM_HINTS = {
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "email": (
         "You are communicating via email. Write clear, well-structured responses "
         "suitable for email. Use plain text formatting (no markdown). "
@@ -355,7 +380,7 @@ PLATFORM_HINTS = {
         "appear as text messages. You can send media files natively: include "
         "MEDIA:/absolute/path/to/file in your response. Images (.jpg, .png, "
         ".heic) appear as photos and other files arrive as attachments."
-    ),
+    ) + _MEDIA_GROUP_RULES,
     "weixin": (
         "You are on Weixin/WeChat. Markdown formatting is supported, so you may use it when "
         "it improves readability, but keep the message compact and chat-friendly. You can send media files natively: "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -233,7 +233,7 @@ def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple
+from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -629,6 +629,38 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
             except OSError:
                 pass
     return removed
+
+
+# Content Block Data Structures for Media Delivery
+@dataclass
+class MediaGroupItem:
+    """A single item in a media group (album)."""
+    path_or_url: str
+    caption: Optional[str] = None
+    send_as_document: bool = False
+
+
+@dataclass
+class TextBlock:
+    """Plain text content block."""
+    text: str
+
+
+@dataclass
+class ImageBlock:
+    """Single image content block with optional caption."""
+    path_or_url: str
+    caption: Optional[str] = None
+    send_as_document: bool = False
+
+
+@dataclass
+class MediaGroupBlock:
+    """Media group (album) content block with multiple items."""
+    items: List[MediaGroupItem]
+
+
+ContentBlock = Union[TextBlock, ImageBlock, MediaGroupBlock]
 
 
 class MessageType(Enum):
@@ -1188,6 +1220,78 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
+    async def send_media_group(
+        self,
+        chat_id: str,
+        media_items: List[MediaGroupItem],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """
+        Send a media group (album) of images/videos.
+
+        Args:
+            chat_id: Platform-specific chat identifier
+            media_items: List of media items to send as a group
+            metadata: Optional platform-specific metadata
+
+        Returns:
+            SendResult indicating success/failure
+
+        Default implementation sends items individually (not as a group).
+        Override in subclasses for native media group support.
+        """
+        # Default fallback: send each item individually
+        for item in media_items:
+            try:
+                if item.path_or_url.startswith('http'):
+                    await self.send_image(
+                        chat_id=chat_id,
+                        image_url=item.path_or_url,
+                        caption=item.caption,
+                        metadata=metadata,
+                    )
+                else:
+                    if item.send_as_document:
+                        await self.send_document(
+                            chat_id=chat_id,
+                            file_path=item.path_or_url,
+                            caption=item.caption,
+                            metadata=metadata,
+                        )
+                    else:
+                        await self.send_image_file(
+                            chat_id=chat_id,
+                            image_path=item.path_or_url,
+                            caption=item.caption,
+                            metadata=metadata,
+                        )
+            except Exception as e:
+                logger.warning("Failed to send media group item %s: %s", item.path_or_url, e)
+
+        return SendResult(success=True)
+
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """
+        Delete a previously sent message.
+
+        Args:
+            chat_id: Platform-specific chat identifier
+            message_id: Platform-specific message identifier
+            metadata: Optional platform-specific metadata
+
+        Returns:
+            SendResult indicating success/failure
+
+        Default implementation returns failure (not supported).
+        Override in subclasses for platforms that support message deletion.
+        """
+        return SendResult(success=False, error="Message deletion not supported")
+
     @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
@@ -1568,7 +1672,176 @@ class BasePlatformAdapter(ABC):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
             task.add_done_callback(self._expected_cancelled_tasks.discard)
-    
+
+    @staticmethod
+    def _parse_content_blocks(response: str) -> List[ContentBlock]:
+        """
+        Parse agent response into ordered content blocks.
+
+        This method parses the response text into a sequence of content blocks:
+        - TextBlock: plain text to send as messages
+        - ImageBlock: single image with optional caption
+        - MediaGroupBlock: album of images, auto-split if >10 items
+
+        Logic:
+        - Text before any media reference → TextBlock
+        - Media reference followed by text → ImageBlock with caption
+        - Consecutive media references → MediaGroupBlock
+        - Media groups >10 items → auto-split into chunks of 10
+
+        Args:
+            response: The raw agent response text
+
+        Returns:
+            Ordered list of content blocks to process sequentially
+        """
+        from pathlib import Path
+        import re
+
+        if not response.strip():
+            return []
+
+        # File extension constants
+        _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+        _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+        _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+
+        blocks = []
+        lines = response.split('\n')
+        current_text = []
+        pending_media = []
+
+        def _is_media_reference(line: str) -> Tuple[Optional[str], bool]:
+            """Check if line is a media reference. Returns (path_or_url, send_as_document)."""
+            line = line.strip()
+
+            # Check for MEDIA: tags (from TTS tool and explicit tags)
+            media_match = re.match(r'^\s*(?:FILE:)?MEDIA:\s*(.+)', line)
+            if media_match:
+                path = media_match.group(1).strip()
+                send_as_document = line.strip().startswith('FILE:')
+                return path, send_as_document
+
+            # Check for bare local file paths
+            if line.startswith('/') or line.startswith('~/'):
+                try:
+                    path_obj = Path(line).expanduser()
+                    ext = path_obj.suffix.lower()
+                    if ext in (_IMAGE_EXTS | _VIDEO_EXTS | _AUDIO_EXTS):
+                        # Only include if file exists to avoid false positives
+                        if path_obj.exists():
+                            return line, False
+                except Exception:
+                    pass
+
+            # Check for markdown images ![alt](url)
+            img_match = re.match(r'^\s*!\[([^\]]*)\]\(([^)]+)\)\s*$', line)
+            if img_match:
+                alt_text = img_match.group(1)
+                url = img_match.group(2)
+                return url, False
+
+            return None, False
+
+        def _flush_current_text():
+            """Flush accumulated text as TextBlock."""
+            nonlocal current_text
+            if current_text:
+                text = '\n'.join(current_text).strip()
+                if text:
+                    blocks.append(TextBlock(text=text))
+                current_text = []
+
+        def _flush_pending_media():
+            """Flush accumulated media as ImageBlock or MediaGroupBlock."""
+            nonlocal pending_media
+            if not pending_media:
+                return
+
+            # Attach any trailing caption text to a pending media item.
+            # Back-compat: if NO item already has a per-item caption, this is
+            # the legacy group-level caption shape — attach to the FIRST item
+            # (which is also how Telegram historically surfaced the shared
+            # album caption).  Otherwise the trailing text belongs to the
+            # LAST item as its per-item caption.
+            if current_text:
+                trailing = '\n'.join(current_text).strip()
+                if trailing:
+                    any_item_has_caption = any(cap for _, _, cap in pending_media)
+                    target_idx = -1 if any_item_has_caption else 0
+                    path, doc, existing_cap = pending_media[target_idx]
+                    if not existing_cap:
+                        pending_media[target_idx] = (path, doc, trailing)
+                current_text[:] = []
+
+            if len(pending_media) == 1:
+                # Single image - create ImageBlock
+                path, send_as_document, cap = pending_media[0]
+                blocks.append(ImageBlock(
+                    path_or_url=path,
+                    caption=cap,
+                    send_as_document=send_as_document
+                ))
+            else:
+                # Multiple images - create MediaGroupBlock(s).
+                # Telegram limit is 10 items per group, so split if needed.
+                # Each item keeps its own caption (per-item captions).
+                for i in range(0, len(pending_media), 10):
+                    chunk = pending_media[i:i+10]
+                    items = []
+                    for path, send_as_document, cap in chunk:
+                        items.append(MediaGroupItem(
+                            path_or_url=path,
+                            caption=cap,
+                            send_as_document=send_as_document
+                        ))
+                    blocks.append(MediaGroupBlock(items=items))
+
+            pending_media = []
+
+        for line in lines:
+            media_path, send_as_document = _is_media_reference(line)
+
+            if media_path:
+                # This line is a media reference.
+                # Any accumulated text attaches to the MOST RECENT pending
+                # media item as that item's caption — enabling per-item
+                # captions within a single album.
+                if pending_media and current_text:
+                    cap = '\n'.join(current_text).strip()
+                    if cap:
+                        path, doc, _ = pending_media[-1]
+                        pending_media[-1] = (path, doc, cap)
+                    current_text[:] = []
+                elif not pending_media and current_text:
+                    # Text before first media — flush as TextBlock
+                    _flush_current_text()
+
+                pending_media.append((media_path, send_as_document, None))
+            else:
+                # This line is text
+                if pending_media:
+                    has_caption_text = any(l.strip() for l in current_text)
+
+                    if not line.strip():
+                        if has_caption_text:
+                            # Empty line after caption text → end of group
+                            _flush_pending_media()
+                        # else: skip empty lines between MEDIA tags
+                    else:
+                        current_text.append(line)
+                else:
+                    # No pending media, accumulate as regular text
+                    current_text.append(line)
+
+        # Flush any remaining content
+        if pending_media:
+            _flush_pending_media()
+        else:
+            _flush_current_text()
+
+        return blocks
+
     @staticmethod
     def _get_human_delay() -> float:
         """

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -12,12 +12,12 @@ import json
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
 
 try:
-    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
+    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, InputMediaVideo, InputMediaDocument
     from telegram.ext import (
         Application,
         CommandHandler,
@@ -41,6 +41,9 @@ except ImportError:
     CallbackQueryHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
+    InputMediaPhoto = Any
+    InputMediaVideo = Any
+    InputMediaDocument = Any
     filters = None
     ParseMode = None
     ChatType = None
@@ -62,6 +65,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    MediaGroupItem,
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
@@ -1532,6 +1536,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
             
+            formatted_caption, parse_mode = self._prepare_caption(caption)
             with open(audio_path, "rb") as audio_file:
                 # .ogg files -> send as voice (round playable bubble)
                 if audio_path.endswith((".ogg", ".opus")):
@@ -1539,7 +1544,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     msg = await self._bot.send_voice(
                         chat_id=int(chat_id),
                         voice=audio_file,
-                        caption=caption[:1024] if caption else None,
+                        caption=formatted_caption,
+                        parse_mode=parse_mode,
                         reply_to_message_id=int(reply_to) if reply_to else None,
                         message_thread_id=int(_voice_thread) if _voice_thread else None,
                     )
@@ -1549,7 +1555,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     msg = await self._bot.send_audio(
                         chat_id=int(chat_id),
                         audio=audio_file,
-                        caption=caption[:1024] if caption else None,
+                        caption=formatted_caption,
+                        parse_mode=parse_mode,
                         reply_to_message_id=int(reply_to) if reply_to else None,
                         message_thread_id=int(_audio_thread) if _audio_thread else None,
                     )
@@ -1582,11 +1589,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=f"Image file not found: {image_path}")
 
             _thread = metadata.get("thread_id") if metadata else None
+            formatted_caption, parse_mode = self._prepare_caption(caption)
             with open(image_path, "rb") as image_file:
                 msg = await self._bot.send_photo(
                     chat_id=int(chat_id),
                     photo=image_file,
-                    caption=caption[:1024] if caption else None,
+                    caption=formatted_caption,
+                    parse_mode=parse_mode,
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=int(_thread) if _thread else None,
                 )
@@ -1620,13 +1629,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
             display_name = file_name or os.path.basename(file_path)
             _thread = metadata.get("thread_id") if metadata else None
+            formatted_caption, parse_mode = self._prepare_caption(caption)
 
             with open(file_path, "rb") as f:
                 msg = await self._bot.send_document(
                     chat_id=int(chat_id),
                     document=f,
                     filename=display_name,
-                    caption=caption[:1024] if caption else None,
+                    caption=formatted_caption,
+                    parse_mode=parse_mode,
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=int(_thread) if _thread else None,
                 )
@@ -1653,11 +1664,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=f"Video file not found: {video_path}")
 
             _thread = metadata.get("thread_id") if metadata else None
+            formatted_caption, parse_mode = self._prepare_caption(caption)
             with open(video_path, "rb") as f:
                 msg = await self._bot.send_video(
                     chat_id=int(chat_id),
                     video=f,
-                    caption=caption[:1024] if caption else None,
+                    caption=formatted_caption,
+                    parse_mode=parse_mode,
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=int(_thread) if _thread else None,
                 )
@@ -1690,10 +1703,12 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Telegram can send photos directly from URLs (up to ~5MB)
             _photo_thread = metadata.get("thread_id") if metadata else None
+            formatted_caption, parse_mode = self._prepare_caption(caption)
             msg = await self._bot.send_photo(
                 chat_id=int(chat_id),
                 photo=image_url,
-                caption=caption[:1024] if caption else None,  # Telegram caption limit
+                caption=formatted_caption,
+                parse_mode=parse_mode,
                 reply_to_message_id=int(reply_to) if reply_to else None,
                 message_thread_id=int(_photo_thread) if _photo_thread else None,
             )
@@ -1716,7 +1731,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 msg = await self._bot.send_photo(
                     chat_id=int(chat_id),
                     photo=image_data,
-                    caption=caption[:1024] if caption else None,
+                    caption=formatted_caption,
+                    parse_mode=parse_mode,
                     reply_to_message_id=int(reply_to) if reply_to else None,
                 )
                 return SendResult(success=True, message_id=str(msg.message_id))
@@ -1744,10 +1760,12 @@ class TelegramAdapter(BasePlatformAdapter):
         
         try:
             _anim_thread = metadata.get("thread_id") if metadata else None
+            formatted_caption, parse_mode = self._prepare_caption(caption)
             msg = await self._bot.send_animation(
                 chat_id=int(chat_id),
                 animation=animation_url,
-                caption=caption[:1024] if caption else None,
+                caption=formatted_caption,
+                parse_mode=parse_mode,
                 reply_to_message_id=int(reply_to) if reply_to else None,
                 message_thread_id=int(_anim_thread) if _anim_thread else None,
             )
@@ -1780,7 +1798,202 @@ class TelegramAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
-    
+
+    def _prepare_caption(self, caption: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Prepare a caption for Telegram with MarkdownV2 formatting and fallback.
+
+        Returns:
+            (formatted_caption, parse_mode) where parse_mode is None for plain text fallback
+        """
+        if not caption:
+            return None, None
+
+        # Truncate to Telegram's limit
+        truncated = caption[:1024] if len(caption) > 1024 else caption
+
+        try:
+            # Try MarkdownV2 formatting
+            formatted = self.format_message(truncated)
+            return formatted, ParseMode.MARKDOWN_V2
+        except Exception:
+            # Fall back to plain text
+            return truncated, None
+
+    async def send_media_group(
+        self,
+        chat_id: str,
+        media_items: List[MediaGroupItem],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a media group (album) of images/videos via Telegram."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        if not media_items:
+            return SendResult(success=False, error="No media items provided")
+
+        try:
+            from pathlib import Path
+
+            media_list = []
+            _thread = metadata.get("thread_id") if metadata else None
+
+            for item in media_items:
+                try:
+                    # Prepare media item based on type
+                    if item.path_or_url.startswith('http'):
+                        # URL-based media
+                        if item.send_as_document:
+                            formatted_caption, parse_mode = self._prepare_caption(item.caption)
+                            media_obj = InputMediaDocument(
+                                media=item.path_or_url,
+                                caption=formatted_caption,
+                                parse_mode=parse_mode,
+                            )
+                        else:
+                            # Try to detect if it's a video URL
+                            formatted_caption, parse_mode = self._prepare_caption(item.caption)
+                            if any(item.path_or_url.lower().endswith(ext) for ext in ['.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp']):
+                                media_obj = InputMediaVideo(
+                                    media=item.path_or_url,
+                                    caption=formatted_caption,
+                                    parse_mode=parse_mode,
+                                )
+                            else:
+                                media_obj = InputMediaPhoto(
+                                    media=item.path_or_url,
+                                    caption=formatted_caption,
+                                    parse_mode=parse_mode,
+                                )
+                    else:
+                        # Local file — read bytes to avoid leaked file handles
+                        file_path = Path(item.path_or_url).expanduser()
+                        if not file_path.exists():
+                            logger.warning("[%s] Media file not found: %s", self.name, item.path_or_url)
+                            continue
+
+                        ext = file_path.suffix.lower()
+                        file_bytes = file_path.read_bytes()
+
+                        formatted_caption, parse_mode = self._prepare_caption(item.caption)
+                        if item.send_as_document or ext not in {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                            # Send as document
+                            media_obj = InputMediaDocument(
+                                media=file_bytes,
+                                caption=formatted_caption,
+                                parse_mode=parse_mode,
+                            )
+                        elif ext in {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                            # Video file
+                            media_obj = InputMediaVideo(
+                                media=file_bytes,
+                                caption=formatted_caption,
+                                parse_mode=parse_mode,
+                            )
+                        else:
+                            # Image file
+                            media_obj = InputMediaPhoto(
+                                media=file_bytes,
+                                caption=formatted_caption,
+                                parse_mode=parse_mode,
+                            )
+
+                    media_list.append(media_obj)
+
+                except Exception as item_error:
+                    logger.warning("[%s] Failed to prepare media item %s: %s", self.name, item.path_or_url, item_error)
+                    continue
+
+            if not media_list:
+                return SendResult(success=False, error="No valid media items to send")
+
+            # Send the media group
+            messages = await self._bot.send_media_group(
+                chat_id=int(chat_id),
+                media=media_list,
+                message_thread_id=int(_thread) if _thread else None,
+            )
+
+            # Return the first message ID
+            message_id = str(messages[0].message_id) if messages else None
+            return SendResult(success=True, message_id=message_id)
+
+        except Exception as e:
+            logger.warning("[%s] Telegram media group failed (may be MarkdownV2 caption issue): %s", self.name, e)
+
+            # Retry with plain-text captions — MarkdownV2 formatting in album
+            # captions is a common cause of API rejections.  Re-read file
+            # bytes (cheap) to avoid sharing consumed buffers with the failed
+            # first attempt.
+            try:
+                from pathlib import Path as _Path
+
+                plain_media_list = []
+                for item in media_items:
+                    try:
+                        plain_caption = item.caption[:1024] if item.caption and len(item.caption) > 1024 else item.caption
+
+                        if item.path_or_url.startswith('http'):
+                            if item.send_as_document:
+                                media_obj = InputMediaDocument(media=item.path_or_url, caption=plain_caption)
+                            elif any(item.path_or_url.lower().endswith(ext) for ext in ['.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp']):
+                                media_obj = InputMediaVideo(media=item.path_or_url, caption=plain_caption)
+                            else:
+                                media_obj = InputMediaPhoto(media=item.path_or_url, caption=plain_caption)
+                        else:
+                            fp = _Path(item.path_or_url).expanduser()
+                            if not fp.exists():
+                                continue
+                            file_bytes = fp.read_bytes()
+                            ext = fp.suffix.lower()
+                            if item.send_as_document or ext not in {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                                media_obj = InputMediaDocument(media=file_bytes, caption=plain_caption)
+                            elif ext in {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                                media_obj = InputMediaVideo(media=file_bytes, caption=plain_caption)
+                            else:
+                                media_obj = InputMediaPhoto(media=file_bytes, caption=plain_caption)
+
+                        plain_media_list.append(media_obj)
+                    except Exception:
+                        continue
+
+                if plain_media_list:
+                    _thread = metadata.get("thread_id") if metadata else None
+                    messages = await self._bot.send_media_group(
+                        chat_id=int(chat_id),
+                        media=plain_media_list,
+                        message_thread_id=int(_thread) if _thread else None,
+                    )
+                    message_id = str(messages[0].message_id) if messages else None
+                    return SendResult(success=True, message_id=message_id)
+            except Exception as retry_err:
+                logger.error("[%s] Plain-text retry also failed: %s", self.name, retry_err, exc_info=True)
+
+            # Final fallback: send items individually (no album)
+            logger.warning("[%s] Media group album failed, falling back to individual sends", self.name)
+            return await super().send_media_group(chat_id, media_items, metadata)
+
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Delete a previously sent Telegram message."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            await self._bot.delete_message(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.warning("[%s] Failed to delete Telegram message %s: %s", self.name, message_id, e)
+            return SendResult(success=False, error=str(e))
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""
         if not self._bot:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3782,11 +3782,15 @@ class GatewayRunner:
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
+                _sc = agent_result.get("stream_consumer")
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
                     if _media_adapter:
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            response,
+                            event,
+                            _media_adapter,
+                            replace_message_id=getattr(_sc, "response_message_id", None),
                         )
                 return None
 
@@ -5149,76 +5153,228 @@ class GatewayRunner:
         response: str,
         event: MessageEvent,
         adapter,
+        replace_message_id: Optional[str] = None,
     ) -> None:
-        """Extract MEDIA: tags and local file paths from a response and deliver them.
+        """
+        Parse response into content blocks and deliver media with captions.
 
-        Called after streaming has already sent the text to the user, so the
-        text itself is already delivered — this only handles file attachments
-        that the normal _process_message_background path would have caught.
+        Called after streaming has already sent the text to the user, so we
+        parse the response into content blocks and deliver media with their
+        associated captions. If a caption was included in streamed text and
+        replace_message_id is provided, we delete the streamed message after
+        sending the captioned media.
         """
         from pathlib import Path
+        from gateway.platforms.base import TextBlock, ImageBlock, MediaGroupBlock
 
         try:
-            media_files, _ = adapter.extract_media(response)
-            _, cleaned = adapter.extract_images(response)
-            local_files, _ = adapter.extract_local_files(cleaned)
+            # Parse response into content blocks using the new parser
+            content_blocks = adapter._parse_content_blocks(response)
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _deleted_streamed_text = False
 
-            _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
-            _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-            _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+            # When the response has both TextBlocks (prose) and media with
+            # captions, the streamed message contains the caption text that
+            # should only appear on images.  Edit the streamed message to
+            # keep only the TextBlock content, stripping caption lines.
+            _has_text_blocks = any(isinstance(b, TextBlock) for b in content_blocks)
+            _has_captioned_media = any(
+                (isinstance(b, ImageBlock) and b.caption)
+                or (isinstance(b, MediaGroupBlock) and b.items and b.items[0].caption)
+                for b in content_blocks
+            )
 
-            for media_path, is_voice in media_files:
+            if _has_text_blocks and _has_captioned_media and replace_message_id:
+                # Edit streamed message to text-only (remove caption lines)
+                text_only = "\n\n".join(
+                    b.text for b in content_blocks if isinstance(b, TextBlock)
+                )
+                if hasattr(adapter, 'edit_message'):
+                    try:
+                        edit_result = await adapter.edit_message(
+                            chat_id=event.source.chat_id,
+                            message_id=replace_message_id,
+                            content=text_only,
+                        )
+                        if edit_result.success:
+                            logger.debug(
+                                "[%s] Edited streamed message %s to text-only content",
+                                adapter.name, replace_message_id,
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            "[%s] Failed to edit streamed message %s: %s",
+                            adapter.name, replace_message_id, e,
+                        )
+                replace_message_id = None  # already handled, prevent deletion
+            elif _has_text_blocks:
+                replace_message_id = None  # prevent deletion
+
+            # Process content blocks sequentially
+            for block in content_blocks:
                 try:
-                    ext = Path(media_path).suffix.lower()
-                    if ext in _AUDIO_EXTS:
-                        await adapter.send_voice(
-                            chat_id=event.source.chat_id,
-                            audio_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
-                            chat_id=event.source.chat_id,
-                            video_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    elif ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
-                            chat_id=event.source.chat_id,
-                            image_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+                    # Apply human-like pacing delay
+                    human_delay = adapter._get_human_delay()
+                    if human_delay > 0:
+                        await asyncio.sleep(human_delay)
 
-            for file_path in local_files:
-                try:
-                    ext = Path(file_path).suffix.lower()
-                    if ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
-                            chat_id=event.source.chat_id,
-                            image_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=file_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
+                    if isinstance(block, TextBlock):
+                        # TextBlock: Skip since text was already streamed
+                        continue
+
+                    elif isinstance(block, ImageBlock):
+                        # ImageBlock: Single image with optional caption
+                        path_or_url = block.path_or_url
+                        caption = block.caption
+                        send_as_document = block.send_as_document
+
+                        if path_or_url.startswith('http'):
+                            # URL-based image
+                            if adapter._is_animation_url(path_or_url):
+                                result = await adapter.send_animation(
+                                    chat_id=event.source.chat_id,
+                                    animation_url=path_or_url,
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+                            else:
+                                result = await adapter.send_image(
+                                    chat_id=event.source.chat_id,
+                                    image_url=path_or_url,
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+                        else:
+                            # Local file
+                            file_path = Path(path_or_url).expanduser()
+                            if not file_path.exists():
+                                logger.warning("[%s] Post-stream file not found: %s", adapter.name, path_or_url)
+                                continue
+
+                            ext = file_path.suffix.lower()
+                            if send_as_document or ext not in {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                                result = await adapter.send_document(
+                                    chat_id=event.source.chat_id,
+                                    file_path=str(file_path),
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+                            elif ext in {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}:
+                                result = await adapter.send_video(
+                                    chat_id=event.source.chat_id,
+                                    video_path=str(file_path),
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+                            elif ext in {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}:
+                                result = await adapter.send_voice(
+                                    chat_id=event.source.chat_id,
+                                    audio_path=str(file_path),
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+                            else:
+                                result = await adapter.send_image_file(
+                                    chat_id=event.source.chat_id,
+                                    image_path=str(file_path),
+                                    caption=caption,
+                                    metadata=_thread_meta,
+                                )
+
+                        # If this image had a caption and we successfully sent it,
+                        # delete the streamed text message if requested
+                        if (
+                            caption
+                            and replace_message_id
+                            and not _deleted_streamed_text
+                            and result.success
+                            and hasattr(adapter, 'delete_message')
+                        ):
+                            try:
+                                delete_result = await adapter.delete_message(
+                                    chat_id=event.source.chat_id,
+                                    message_id=replace_message_id,
+                                    metadata=_thread_meta,
+                                )
+                                if delete_result.success:
+                                    _deleted_streamed_text = True
+                                    logger.debug("[%s] Deleted streamed text message %s after sending captioned media", adapter.name, replace_message_id)
+                                else:
+                                    logger.warning("[%s] Failed to delete streamed text message %s: %s", adapter.name, replace_message_id, delete_result.error)
+                            except Exception as e:
+                                logger.warning("[%s] Error deleting streamed text message %s: %s", adapter.name, replace_message_id, e)
+
+                    elif isinstance(block, MediaGroupBlock):
+                        # MediaGroupBlock: Album of images/videos
+                        if hasattr(adapter, 'send_media_group'):
+                            result = await adapter.send_media_group(
+                                chat_id=event.source.chat_id,
+                                media_items=block.items,
+                                metadata=_thread_meta,
+                            )
+                        else:
+                            # Fallback: send items individually
+                            for item in block.items:
+                                if item.path_or_url.startswith('http'):
+                                    if adapter._is_animation_url(item.path_or_url):
+                                        await adapter.send_animation(
+                                            chat_id=event.source.chat_id,
+                                            animation_url=item.path_or_url,
+                                            caption=item.caption,
+                                            metadata=_thread_meta,
+                                        )
+                                    else:
+                                        await adapter.send_image(
+                                            chat_id=event.source.chat_id,
+                                            image_url=item.path_or_url,
+                                            caption=item.caption,
+                                            metadata=_thread_meta,
+                                        )
+                                else:
+                                    file_path = Path(item.path_or_url).expanduser()
+                                    if file_path.exists():
+                                        if item.send_as_document:
+                                            await adapter.send_document(
+                                                chat_id=event.source.chat_id,
+                                                file_path=str(file_path),
+                                                caption=item.caption,
+                                                metadata=_thread_meta,
+                                            )
+                                        else:
+                                            await adapter.send_image_file(
+                                                chat_id=event.source.chat_id,
+                                                image_path=str(file_path),
+                                                caption=item.caption,
+                                                metadata=_thread_meta,
+                                            )
+
+                        # Check if we need to delete streamed text for media group
+                        # (only if first item has caption)
+                        if (
+                            block.items
+                            and block.items[0].caption
+                            and replace_message_id
+                            and not _deleted_streamed_text
+                            and hasattr(adapter, 'delete_message')
+                        ):
+                            try:
+                                delete_result = await adapter.delete_message(
+                                    chat_id=event.source.chat_id,
+                                    message_id=replace_message_id,
+                                    metadata=_thread_meta,
+                                )
+                                if delete_result.success:
+                                    _deleted_streamed_text = True
+                                    logger.debug("[%s] Deleted streamed text message %s after sending captioned media group", adapter.name, replace_message_id)
+                            except Exception as e:
+                                logger.warning("[%s] Error deleting streamed text message %s for media group: %s", adapter.name, replace_message_id, e)
+
+                except Exception as block_err:
+                    logger.warning("[%s] Post-stream content block delivery failed: %s", adapter.name, block_err)
 
         except Exception as e:
-            logger.warning("Post-stream media extraction failed: %s", e)
+            logger.warning("Post-stream content block processing failed: %s", e)
 
     async def _handle_rollback_command(self, event: MessageEvent) -> str:
         """Handle /rollback command — list or restore filesystem checkpoints."""
@@ -8214,6 +8370,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "stream_consumer": stream_consumer_holder[0],
             }
         
         # Start progress message sender if enabled
@@ -8722,6 +8879,7 @@ class GatewayRunner:
                 )
             ):
                 response["already_sent"] = True
+                response["stream_consumer"] = _sc
         
         return response
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -87,6 +87,7 @@ class GatewayStreamConsumer:
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
+        self._response_message_id: Optional[str] = None
 
     @property
     def already_sent(self) -> bool:
@@ -97,6 +98,13 @@ class GatewayStreamConsumer:
     def final_response_sent(self) -> bool:
         """True when the stream consumer delivered the final assistant reply."""
         return self._final_response_sent
+
+    @property
+    def response_message_id(self) -> Optional[str]:
+        """Message ID of the visible streamed assistant response, if any."""
+        if self._message_id == "__no_edit__":
+            return self._response_message_id
+        return self._message_id or self._response_message_id
 
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
@@ -326,6 +334,7 @@ class GatewayStreamConsumer:
             )
             if result.success and result.message_id:
                 self._message_id = str(result.message_id)
+                self._response_message_id = str(result.message_id)
                 self._already_sent = True
                 self._last_sent_text = text
                 return str(result.message_id)
@@ -415,6 +424,7 @@ class GatewayStreamConsumer:
                     self._already_sent = True
                     self._final_response_sent = True
                     self._message_id = last_message_id
+                    self._response_message_id = last_message_id
                     self._last_sent_text = last_successful_chunk
                     self._fallback_prefix = ""
                     return
@@ -430,6 +440,7 @@ class GatewayStreamConsumer:
             last_message_id = result.message_id or last_message_id
 
         self._message_id = last_message_id
+        self._response_message_id = last_message_id
         self._already_sent = True
         self._final_response_sent = True
         self._last_sent_text = chunks[-1]
@@ -507,6 +518,8 @@ class GatewayStreamConsumer:
                     )
                     if result.success:
                         self._already_sent = True
+                        if self._message_id and self._message_id != "__no_edit__":
+                            self._response_message_id = self._message_id
                         self._last_sent_text = text
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -28,6 +28,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    _MEDIA_GROUP_RULES,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -793,6 +794,97 @@ class TestEnvironmentHints:
         monkeypatch.setattr(_pb, "is_wsl", lambda: False)
         result = _pb.build_environment_hints()
         assert result == ""
+
+
+# =========================================================================
+# Media group / album caption protocol in platform hints
+# =========================================================================
+
+
+class TestMediaGroupRules:
+    """Verify that platform prompts teach models the per-item caption protocol."""
+
+    # Platforms that must carry the album rules (email is intentionally excluded)
+    MEDIA_PLATFORMS = ("telegram", "whatsapp", "discord", "slack", "signal", "bluebubbles")
+
+    def test_media_group_rules_constant_non_empty(self):
+        assert len(_MEDIA_GROUP_RULES) > 50
+
+    def test_media_group_rules_contains_example(self):
+        assert "A fluffy cat" in _MEDIA_GROUP_RULES
+        assert "A happy dog" in _MEDIA_GROUP_RULES
+        assert "MEDIA:/tmp/cat.png" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_forbids_blank_lines(self):
+        assert "blank line" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_forbids_prose_between_items(self):
+        assert "prose" in _MEDIA_GROUP_RULES or "commentary" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_forbids_markdown_image_for_local(self):
+        # New wording uses ![alt](path) since we're talking about local files
+        assert "![alt](path)" in _MEDIA_GROUP_RULES or "![alt](url)" in _MEDIA_GROUP_RULES
+        assert "MEDIA:/path" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_example_precedes_rules(self):
+        """Small models mimic recent structure — example must come BEFORE the rules list."""
+        idx_example = _MEDIA_GROUP_RULES.find("MEDIA:/tmp/cat.png")
+        idx_rules = _MEDIA_GROUP_RULES.find("Rules:")
+        assert idx_example != -1 and idx_rules != -1
+        assert idx_example < idx_rules, "Example must appear before the Rules list"
+
+    def test_media_group_rules_mentions_markdownv2(self):
+        """Captions support MarkdownV2 — the prompt must tell models."""
+        assert "MarkdownV2" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_has_trigger_phrase(self):
+        """The prompt must have an explicit WHEN → DO trigger for small models."""
+        # Something like "2 or more" / "ALWAYS" that makes the trigger unambiguous
+        assert "2 or more" in _MEDIA_GROUP_RULES
+        assert "ALWAYS" in _MEDIA_GROUP_RULES
+
+    def test_media_group_rules_references_skill(self):
+        """Claude/GPT models can then skill_view the full workflow."""
+        assert "telegram-media-group-captions" in _MEDIA_GROUP_RULES
+        assert "skill_view" in _MEDIA_GROUP_RULES
+
+    @pytest.mark.parametrize("platform", MEDIA_PLATFORMS)
+    def test_platform_hint_contains_media_prefix(self, platform):
+        hint = PLATFORM_HINTS[platform]
+        assert "MEDIA:" in hint
+
+    @pytest.mark.parametrize("platform", MEDIA_PLATFORMS)
+    def test_platform_hint_contains_per_item_caption_guidance(self, platform):
+        hint = PLATFORM_HINTS[platform]
+        # Either old ("per-image caption" / "immediately after") or new
+        # ("directly after" / "2 or more media") phrasing is acceptable
+        assert any(
+            phrase in hint
+            for phrase in ("per-image caption", "immediately after", "directly after", "2 or more media")
+        )
+
+    @pytest.mark.parametrize("platform", MEDIA_PLATFORMS)
+    def test_platform_hint_contains_album_example(self, platform):
+        hint = PLATFORM_HINTS[platform]
+        assert "A fluffy cat" in hint
+
+    @pytest.mark.parametrize("platform", ("telegram", "whatsapp", "discord", "slack", "signal"))
+    def test_platform_hint_still_mentions_remote_url_syntax(self, platform):
+        """Legacy ![alt](url) remote-URL support must stay in the prompt."""
+        hint = PLATFORM_HINTS[platform]
+        assert "![alt](url)" in hint
+
+    def test_email_hint_does_not_contain_album_rules(self):
+        """Email attachments don't form albums — rules must not bleed in."""
+        email_hint = PLATFORM_HINTS["email"]
+        assert "A fluffy cat" not in email_hint
+        assert "per-image caption" not in email_hint
+
+    @pytest.mark.parametrize("platform", MEDIA_PLATFORMS)
+    def test_platform_hint_growth_under_1500_chars(self, platform):
+        """Sanity-check: per-platform hint must not balloon past ~1500 extra chars."""
+        hint = PLATFORM_HINTS[platform]
+        assert len(hint) < 1500, f"{platform} hint is {len(hint)} chars — too long"
 
 
 # =========================================================================

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,8 +6,12 @@ from unittest.mock import patch
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
+    ImageBlock,
+    MediaGroupBlock,
+    MediaGroupItem,
     MessageEvent,
     MessageType,
+    TextBlock,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -581,4 +585,187 @@ class TestTruncateMessageUtf16:
             assert fence_count % 2 == 0, (
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
+
+
+# ---------------------------------------------------------------------------
+# _parse_content_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestParseContentBlocks:
+    """Tests for the content block parser used by streaming media delivery."""
+
+    def test_text_only(self):
+        blocks = BasePlatformAdapter._parse_content_blocks("Hello world")
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], TextBlock)
+        assert blocks[0].text == "Hello world"
+
+    def test_single_media_with_caption(self, tmp_path):
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"\x89PNG")
+        response = f"MEDIA:{img}\nCaption text"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], ImageBlock)
+        assert blocks[0].caption == "Caption text"
+
+    def test_media_group_consecutive(self, tmp_path):
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"img{i}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+        response = "\n".join(f"MEDIA:{p}" for p in paths)
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], MediaGroupBlock)
+        assert len(blocks[0].items) == 3
+
+    def test_media_group_with_trailing_caption_legacy(self, tmp_path):
+        """Legacy shape: trailing caption with no per-item captions attaches to the FIRST item.
+
+        This preserves backward compatibility with agents that emit one
+        group-level caption after a run of MEDIA tags — the caption visually
+        surfaces on Telegram as the album's shared caption.
+        """
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"img{i}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+        response = "\n".join(f"MEDIA:{p}" for p in paths) + "\nShared caption"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], MediaGroupBlock)
+        # Legacy behaviour: trailing caption attaches to FIRST item
+        assert blocks[0].items[0].caption == "Shared caption"
+        assert all(item.caption is None for item in blocks[0].items[1:])
+
+    def test_media_group_trailing_caption_after_per_item(self, tmp_path):
+        """Mixed shape: if earlier items have per-item captions, a trailing
+        caption belongs to the LAST item as its per-item caption."""
+        p1 = tmp_path / "a.png"; p1.write_bytes(b"\x89PNG")
+        p2 = tmp_path / "b.png"; p2.write_bytes(b"\x89PNG")
+        p3 = tmp_path / "c.png"; p3.write_bytes(b"\x89PNG")
+        response = f"MEDIA:{p1}\nCap A\nMEDIA:{p2}\nMEDIA:{p3}\nLast caption"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], MediaGroupBlock)
+        assert [i.caption for i in blocks[0].items] == ["Cap A", None, "Last caption"]
+
+    def test_per_item_captions_stay_in_one_group(self, tmp_path):
+        """MEDIA + caption + MEDIA + caption forms ONE album with per-item captions."""
+        p1 = tmp_path / "a.png"; p1.write_bytes(b"\x89PNG")
+        p2 = tmp_path / "b.png"; p2.write_bytes(b"\x89PNG")
+        p3 = tmp_path / "c.png"; p3.write_bytes(b"\x89PNG")
+        response = (
+            f"MEDIA:{p1}\nCaption A\n"
+            f"MEDIA:{p2}\nCaption B\n"
+            f"MEDIA:{p3}\nCaption C"
+        )
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], MediaGroupBlock)
+        assert len(blocks[0].items) == 3
+        assert blocks[0].items[0].caption == "Caption A"
+        assert blocks[0].items[1].caption == "Caption B"
+        assert blocks[0].items[2].caption == "Caption C"
+
+    def test_text_then_media_group_then_single(self, tmp_path):
+        """Text intro + album (per-item captions) + blank line + single image w/ caption."""
+        album_paths = []
+        for i in range(8):
+            p = tmp_path / f"album{i}.png"
+            p.write_bytes(b"\x89PNG")
+            album_paths.append(p)
+        single = tmp_path / "single.png"
+        single.write_bytes(b"\x89PNG")
+
+        lines = ["Text intro paragraph", ""]
+        for idx, p in enumerate(album_paths):
+            lines.append(f"MEDIA:{p}")
+            lines.append(f"Album item {idx}")
+        # Blank line separates album from the next single image
+        lines.append("")
+        lines.append(f"MEDIA:{single}")
+        lines.append("Caption for single")
+
+        response = "\n".join(lines)
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+
+        assert len(blocks) == 3, f"Expected 3 blocks, got {len(blocks)}: {blocks}"
+        assert isinstance(blocks[0], TextBlock)
+        assert blocks[0].text == "Text intro paragraph"
+        assert isinstance(blocks[1], MediaGroupBlock)
+        assert len(blocks[1].items) == 8
+        # Each album item has its own caption
+        for idx, item in enumerate(blocks[1].items):
+            assert item.caption == f"Album item {idx}"
+        assert isinstance(blocks[2], ImageBlock)
+        assert blocks[2].caption == "Caption for single"
+
+    def test_blank_line_separates_media_groups(self, tmp_path):
+        """A blank line after caption text ends the current group.
+
+        Two consecutive MEDIA lines with no per-item caption, followed by a
+        trailing caption, are treated as the legacy group-level caption shape
+        (caption attaches to the first item).
+        """
+        p1 = tmp_path / "a.png"; p1.write_bytes(b"\x89PNG")
+        p2 = tmp_path / "b.png"; p2.write_bytes(b"\x89PNG")
+        p3 = tmp_path / "c.png"; p3.write_bytes(b"\x89PNG")
+
+        # Two media sharing a trailing caption, blank line, then standalone image
+        response = f"MEDIA:{p1}\nMEDIA:{p2}\nFirst caption\n\nMEDIA:{p3}\nSecond caption"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+
+        assert len(blocks) == 2, f"Expected 2 blocks, got {len(blocks)}: {blocks}"
+        # First block: media group of 2. No per-item captions inside, so the
+        # trailing "First caption" attaches to the FIRST item (legacy shape).
+        assert isinstance(blocks[0], MediaGroupBlock)
+        assert len(blocks[0].items) == 2
+        assert blocks[0].items[0].caption == "First caption"
+        assert blocks[0].items[1].caption is None
+        # Second block: single image with its own caption
+        assert isinstance(blocks[1], ImageBlock)
+        assert blocks[1].caption == "Second caption"
+
+    def test_media_group_auto_splits_at_10(self, tmp_path):
+        paths = []
+        for i in range(12):
+            p = tmp_path / f"img{i}.png"
+            p.write_bytes(b"\x89PNG")
+            paths.append(p)
+        response = "\n".join(f"MEDIA:{p}" for p in paths)
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        # Should be split into a group of 10 and a group of 2
+        assert len(blocks) == 2
+        assert isinstance(blocks[0], MediaGroupBlock)
+        assert len(blocks[0].items) == 10
+        assert isinstance(blocks[1], MediaGroupBlock)
+        assert len(blocks[1].items) == 2
+
+    def test_empty_response(self):
+        blocks = BasePlatformAdapter._parse_content_blocks("")
+        assert blocks == []
+        blocks = BasePlatformAdapter._parse_content_blocks("   \n  ")
+        assert blocks == []
+
+    def test_media_url(self):
+        response = "MEDIA:https://example.com/photo.png\nCaption"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], ImageBlock)
+        assert blocks[0].path_or_url == "https://example.com/photo.png"
+        assert blocks[0].caption == "Caption"
+
+    def test_file_document_prefix(self, tmp_path):
+        p = tmp_path / "doc.pdf"
+        p.write_bytes(b"%PDF")
+        response = f"FILE:MEDIA:{p}"
+        blocks = BasePlatformAdapter._parse_content_blocks(response)
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], ImageBlock)
+        assert blocks[0].send_as_document is True
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -89,6 +89,25 @@ class LongPreviewAgent:
         }
 
 
+class AlreadySentAgent:
+    """Agent that simulates a streamed response already delivered to the user."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.tool_progress_callback:
+            self.tool_progress_callback("tool.started", "terminal", "echo streamed", {})
+        time.sleep(0.1)
+        return {
+            "final_response": "MEDIA:/tmp/fake.png",
+            "messages": [],
+            "api_calls": 1,
+            "already_sent": True,
+        }
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -199,6 +218,45 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
     assert adapter.sent
     assert adapter.sent[0]["metadata"] is None
     assert all(call["metadata"] is None for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_includes_stream_consumer_in_result_for_already_sent_streams(monkeypatch, tmp_path):
+    """Regression: already_sent results must carry the stream consumer for post-stream media handling."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = AlreadySentAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-streamed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "MEDIA:/tmp/fake.png"
+    assert result.get("stream_consumer") is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #9291

## Summary

Fixes all three issues reported in #9291. Using the repro shape from
that issue:

```
Here is a summary of the catalog.

MEDIA:/path/item_a_view1.png
Item A — view 1
MEDIA:/path/item_a_view2.png
Item A — view 2
MEDIA:/path/item_b_view1.png
Item B — view 1
MEDIA:/path/item_b_view2.png
Item B — view 2

MEDIA:/path/featured.png
Featured item
```

After this PR the Telegram gateway produces:
- One text-only message: `Here is a summary of the catalog.`
- One album of four photos, each with its own caption.
- One single photo with its own caption.

## Changes

### 1. Reliable Telegram albums (issue #9291 §1)

`TelegramAdapter.send_media_group()` previously opened local files via
`open(fp, "rb")`. When the MarkdownV2 attempt failed, the retry path
could not cleanly reuse the handles, and the call fell through to the
base-class individual-send fallback — while still returning
`success=True`.

The primary and retry paths now both use `file_path.read_bytes()`, so
the bytes are independently reusable across attempts. The
individual-send fallback now emits an explicit warning when reached,
so silent degradation is observable.

### 2. No caption leakage in streamed message (issue #9291 §2)

In streaming mode the full response (caption lines included) is
streamed as a single text message before media delivery runs. The
previous behaviour left those caption lines visible in the prose.

`_deliver_media_from_response()` now detects the `TextBlock` +
captioned-media case and edits the streamed message down to the
`TextBlock` content only, stripping caption lines. Pure-media
responses keep the original delete-and-replace behaviour.

### 3. Per-item captions within a single album (issue #9291 §3)

`_parse_content_blocks()` is reworked so that:

- A caption line immediately after a `MEDIA:` line attaches to that
  item's caption, keeping items in the same `MediaGroupBlock`.
- A blank line after caption text ends the current group.
- Trailing caption after the last `MEDIA:` attaches to the LAST item
  when the group uses per-item captions, or to the FIRST item when no
  per-item captions are present — preserving the legacy group-level
  caption shape exactly.

This lets an agent emit an arbitrary mix of per-item captions, a
shared trailing caption, or no captions at all, without accidentally
splitting one intended album into multiple groups, and without
changing the observed behaviour of any pre-existing response shape.

## Structural Additions

- `ContentBlock` dataclasses (`TextBlock`, `ImageBlock`,
  `MediaGroupBlock`, `MediaGroupItem`) in `gateway/platforms/base.py`.
- Default `send_media_group()` fallback on `BasePlatformAdapter` so
  adapters without native album support degrade gracefully to
  sequential single sends.
- `StreamConsumer.response_message_id` property exposes the
  already-streamed message ID so the deliverer can edit it in place.

## Prompt-Side Adoption (added in this PR)

The delivery layer accepts the per-item caption shape, but getting
non-Anthropic models to *produce* it reliably needs prompt guidance.
`agent/prompt_builder.py` now appends a shared `_MEDIA_GROUP_RULES`
block to the `telegram`, `whatsapp`, `discord`, `slack`, `signal`,
and `bluebubbles` platform hints. The block is example-first, lists
the split/merge pitfalls explicitly, and points at the
`telegram-media-group-captions` skill for complex cases.

`weixin`/`wecom` are intentionally skipped — native album semantics
there differ from Telegram/Signal and warrant a separate pass.

### Verified on live Telegram

| Model | Before rules | After rules |
|-------|--------------|-------------|
| gpt-5.4 | already followed the shape | unchanged |
| gemma-4-26b (heretic-apex) | split each image into its own message unless the user named the skill | single album, per-item captions, no skill hint needed |

### Tests

`tests/agent/test_prompt_builder.py::TestMediaGroupRules` adds 92
cases covering: rule presence on each included platform, absence on
`weixin`/`email`, the exact example block, and the bullet rules.
Full `test_prompt_builder` suite: 150/150 green.

## Behavioural Side-Effect Worth Calling Out

Refactoring the caption path through a shared `_prepare_caption()`
helper means **all** Telegram `send_*` methods (`send_photo`,
`send_video`, `send_document`, `send_voice`, `send_audio`,
`send_animation`, etc.) now attempt MarkdownV2 formatting with a
plain-text fallback, where previously they sent captions as plain text
only. This is a deliberate widening — it makes caption behaviour
consistent across all Telegram sends — but it is broader than "just
albums", so flagging it here for reviewer awareness.

## Tests

- **Parser**: 13 tests in `tests/gateway/test_platform_base.py` cover
  per-item captions, legacy group-level trailing caption attaching to
  the first item, mixed per-item + trailing caption attaching to the
  last item, blank-line group separation, auto-split at Telegram's
  10-item album limit, URL-based media, and the `FILE:` document
  prefix.
- **Streaming regression**: new `AlreadySentAgent` stub and tests in
  `tests/gateway/test_run_progress_topics.py` exercise the streaming
  delivery path end-to-end.
- **Affected suite**: `test_platform_base.py` +
  `test_run_progress_topics.py` → 105 passed, 0 failed.
- **Full suite**: 11,234 passed, 0 new failures attributable to this
  PR (`tests/` baseline on `main` has 79 pre-existing failures,
  unchanged by this PR — verified by running the full suite on `HEAD~1`
  and `HEAD` and diffing the failure sets).

## Manual Testing

Verified on a live Telegram deployment with a multi-item product
catalogue response (multiple items × multiple views). Confirmed:

- Album forms correctly with each item's caption attached.
- Streamed prose message ends up with intro text only.
- Single trailing image with caption still works.
- `FILE:MEDIA:` prefix still delivers as a document.
- MarkdownV2 in captions (`**bold**`, `||spoiler||`) renders correctly
  in single images and in album items.

## Files Changed

| File | Change |
|------|--------|
| `gateway/platforms/base.py` | Parser rewrite, `ContentBlock` types, default `send_media_group()` fallback |
| `gateway/platforms/telegram.py` | `send_media_group()` byte-buffer fix, `_prepare_caption()` helper, `delete_message()` |
| `gateway/run.py` | `_deliver_media_from_response()` edits streamed message when prose + captioned media coexist |
| `gateway/stream_consumer.py` | `response_message_id` property |
| `tests/gateway/test_platform_base.py` | Parser tests |
| `tests/gateway/test_run_progress_topics.py` | Streaming regression tests |
