### PR TITLE
cron: skip model invocation when pre-run script produces no output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -482,8 +482,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script execution failed: {exc}"
 
 
-def _build_job_prompt(job: dict) -> str:
-    """Build the effective prompt for a cron job, optionally loading one or more skills first."""
+def _build_job_prompt(job: dict) -> Optional[str]:
+    """Build the effective prompt for a cron job, optionally loading one or more skills first.
+
+    Returns None when the job has a pre-run script that succeeded with empty
+    output — signaling the caller to skip the model invocation entirely. The
+    script's empty output is the job's way of saying "nothing to do."
+    """
     prompt = job.get("prompt", "")
     skills = job.get("skills")
 
@@ -501,10 +506,7 @@ def _build_job_prompt(job: dict) -> str:
                     f"{prompt}"
                 )
             else:
-                prompt = (
-                    "[Script ran successfully but produced no output.]\n\n"
-                    f"{prompt}"
-                )
+                return None
         else:
             prompt = (
                 "## Script Error\n"
@@ -593,6 +595,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     job_id = job["id"]
     job_name = job["name"]
     prompt = _build_job_prompt(job)
+    if prompt is None:
+        # Pre-run script succeeded with empty output → nothing to do.
+        # Skip model invocation entirely and report a silent success so
+        # the delivery/bookkeeping path treats this like any other no-op run.
+        logger.info("Job '%s': pre-run script produced no output — skipping model invocation", job_name)
+        output = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Schedule:** {job.get('schedule_display', 'N/A')}\n\n"
+            f"## Response\n\n{SILENT_MARKER} (script produced no output, model not invoked)\n"
+        )
+        return True, output, SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 


### PR DESCRIPTION
## What does this PR do?

When a cron job is configured with a pre-run `script`, the script collects data and its stdout is injected as context for the model. The script printing nothing is a deliberate convention for "nothing changed / nothing to do" — e.g. a poller that only emits output when it detects a real change.

Previously, empty script output didn't short-circuit: the scheduler still invoked the model with a `[Script ran successfully but produced no output.]` placeholder, which effectively forces the model to reply `[SILENT]`. The delivery path then suppressed delivery anyway, so the user never saw anything — but the full prompt (system prompt + tool schemas + cron hint) was still tokenized and sent to the provider. For a job firing every minute, this adds up to tens of thousands of cache-write tokens per hour for zero user-visible work.

This PR short-circuits that path: when the pre-run script succeeds with empty stdout, the scheduler now skips the model call entirely, writes a silent output doc, and returns success. The existing `[SILENT]` delivery suppression handles the rest.

The "error" and "non-empty output" branches of `_build_job_prompt` are unchanged, so jobs that legitimately want the model to run on every tick (no `script` configured) are also unaffected.

## Related Issue

N/A — internal optimization.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: `_build_job_prompt` return type changed to `Optional[str]`; returns `None` when a configured script succeeds with empty stdout.
- `cron/scheduler.py`: `run_job` now handles the `None` case by logging, writing a silent output doc, and returning `(True, output, "[SILENT]", None)` — matching the contract the delivery loop already uses to suppress delivery.

## How to Test

1. Configure a cron job with a `script` that `exit 0`s without printing anything (e.g. `true`). Fire it via `hermes cron run <id>`.
2. Verify in the logs that the scheduler logs `pre-run script produced no output — skipping model invocation` and no new session appears in `state.db` for that run.
3. Swap the script for one that prints a line. Fire again and confirm the model is invoked normally and the output appears.
4. Swap the script for one that `exit 1`s. Fire again and confirm the existing "Script Error" path still invokes the model with the error banner.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [ ] My commit messages follow Conventional Commits — the commit uses a `cron:` prefix rather than `fix(cron):`; happy to amend/squash on merge
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run \`pytest tests/ -q\` and all tests pass — not run locally; no tests touch this path
- [ ] I've added tests for my changes — not added; would appreciate guidance on the right fixture shape for the cron scheduler
- [x] I've tested on my platform: Ubuntu (Linux 6.8)

### Documentation & Housekeeping

- [x] Documentation — N/A (internal behavior change, no user-facing API)
- [x] \`cli-config.yaml.example\` — N/A (no new config keys)
- [x] \`CONTRIBUTING.md\` / \`AGENTS.md\` — N/A
- [x] Cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

From the production DB this was found on: 828 of 850 cron user prompts contained the `produced no output` placeholder — i.e. ~97% of model invocations on cron were pure no-ops. After this change, those invocations disappear entirely.