### PR TITLE
fix(cli): remove c-j binding that breaks Enter on Ghostty/WSL terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8421,10 +8421,13 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
-        @kb.add('c-j')
-        def handle_ctrl_enter(event):
-            """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
-            event.current_buffer.insert_text('\n')
+        # NOTE: Do NOT bind 'c-j' here.  prompt_toolkit's built-in c-j handler
+        # (basic.py) re-feeds '\n' as '\r' (Enter/ControlM) because some
+        # terminals — Ghostty, WSL, and others — send '\n' instead of '\r'
+        # when the Enter key is pressed.  Overriding c-j with "insert newline"
+        # breaks submission for those terminals.  Alt+Enter (above) is the
+        # correct way to insert a newline in multi-line input.
+        # See: https://github.com/NousResearch/hermes-agent/issues/9299
 
         @kb.add('tab', eager=True)
         def handle_tab(event):


### PR DESCRIPTION
## Summary

Remove the custom `@kb.add('c-j')` key binding that shadows prompt_toolkit's built-in `c-j → c-m` remapping safety net.

## Problem

Some terminals — Ghostty, WSL, and others — send `\n` (0x0a / `c-j`) instead of `\r` (0x0d / `c-m` / Enter) when the Enter key is pressed. prompt_toolkit has a built-in handler for exactly this case ([`basic.py:195-202`](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/src/prompt_toolkit/key_binding/bindings/basic.py#L195-L202)):

```python
@handle("c-j")
def _newline2(event):
    """
    By default, handle \n as if it were a \r (enter).
    (It appears that some terminals send \n instead of \r when pressing
    enter. - at least the Linux subsystem for Windows.)
    """
    event.key_processor.feed(KeyPress(Keys.ControlM, "\r"), first=True)
```

The Hermes CLI overrides this with a custom `c-j` handler that inserts a newline. This means on affected terminals, pressing Enter inserts a newline in the input area instead of submitting the message. The user has to press Ctrl+D to exit.

## Fix

Delete the `c-j` binding. Alt+Enter (`escape`, `enter`) already provides multi-line input, so no functionality is lost. The built-in prompt_toolkit handler correctly remaps `\n` → `\r`, restoring Enter functionality on all terminals.

## Testing

- Verified 2941 tests pass (all failures are pre-existing and unrelated — codex auth, reasoning command tests)
- No tests reference the removed `c-j` binding

Fixes #9299