### PR TITLE
fix(weixin): align send_image_file with image_path keyword

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -464,21 +464,6 @@ class TestWeixinStreamingCursorSuppression:
         assert adapter.SUPPORTS_MESSAGE_EDITING is False
 
 
-class TestWeixinImageSend:
-    def test_send_image_file_accepts_image_path_keyword(self):
-        adapter = _make_adapter()
-        adapter.send_document = AsyncMock(return_value="sent")
-
-        result = asyncio.run(
-            adapter.send_image_file(chat_id="wxid_test123", image_path="/tmp/demo.png", metadata={"k": "v"})
-        )
-
-        assert result == "sent"
-        adapter.send_document.assert_awaited_once_with(
-            "wxid_test123", file_path="/tmp/demo.png", caption="", metadata={"k": "v"}
-        )
-
-
 class TestWeixinMediaBuilder:
     """Media builder uses base64(hex_key), not base64(raw_bytes) for aes_key."""
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -464,6 +464,21 @@ class TestWeixinStreamingCursorSuppression:
         assert adapter.SUPPORTS_MESSAGE_EDITING is False
 
 
+class TestWeixinImageSend:
+    def test_send_image_file_accepts_image_path_keyword(self):
+        adapter = _make_adapter()
+        adapter.send_document = AsyncMock(return_value="sent")
+
+        result = asyncio.run(
+            adapter.send_image_file(chat_id="wxid_test123", image_path="/tmp/demo.png", metadata={"k": "v"})
+        )
+
+        assert result == "sent"
+        adapter.send_document.assert_awaited_once_with(
+            "wxid_test123", file_path="/tmp/demo.png", caption="", metadata={"k": "v"}
+        )
+
+
 class TestWeixinMediaBuilder:
     """Media builder uses base64(hex_key), not base64(raw_bytes) for aes_key."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Weixin adapter method signature so `send_image_file` accepts the `image_path` keyword used by the messaging pipeline. Without this change, Weixin image sends can fail because the adapter parameter name does not match the call site.

## Related Issue

Fixes #8783

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/weixin.py` so `send_image_file` takes `image_path` instead of `path`
- Forwarded the `image_path` value to `send_document(file_path=...)` so Weixin image delivery uses the expected keyword path

## How to Test

1. Configure a Weixin gateway account.
2. Trigger any flow that sends an image through the Weixin adapter.
3. Confirm the image send completes successfully without a keyword-argument mismatch.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
