### PR TITLE
fix(agent): strip inline <think> blocks from API messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8116,6 +8116,11 @@ class AIAgent:
                     if reasoning_text:
                         # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
                         api_msg["reasoning_content"] = reasoning_text
+                    # Strip inline <think> blocks from content sent to API —
+                    # reasoning is already carried in reasoning_content above.
+                    # Leaving them doubles context usage and degrades quality.
+                    if isinstance(api_msg.get("content"), str) and "<think>" in api_msg["content"]:
+                        api_msg["content"] = self._strip_think_blocks(api_msg["content"]).strip()
 
                 # Remove 'reasoning' field - it's for trajectory storage only
                 # We've copied it to 'reasoning_content' for the API above


### PR DESCRIPTION
## Summary

Models that emit reasoning via inline `<think>` tags (MiniMax M2.7, Moonshot, etc.) have their thinking correctly extracted into `msg["reasoning"]` by `_build_assistant_message()` and passed back to the API via `reasoning_content`. However, the raw `<think>…</think>` blocks **also remain in the `content` field** of historical assistant messages, which are sent verbatim on subsequent API calls.

Over a multi-turn session this causes:
- **Doubled context usage** — reasoning is carried in both `content` and `reasoning_content`
- **Degraded response quality** — effective context window shrinks as thinking text accumulates
- **Wasted compression** — the compressor summarizes low-value thinking text instead of actual conversation
- **Polluted session titles** — title generator sees `<think>` as the first content

### Measured impact (real user session, MiniMax M2.7-highspeed)
- **55% of all assistant messages** (2,249 / 4,053) started with `<think>` blocks
- **51 / 100 session titles** were `<think> The user is asking...` instead of actual titles
- **8.9 MB → 7.5 MB** content size after stripping (16% reduction)

## Fix

3 lines added after `reasoning_content` assignment in the API message builder (~line 8119):

```python
if isinstance(api_msg.get("content"), str) and "<think>" in api_msg["content"]:
    api_msg["content"] = self._strip_think_blocks(api_msg["content"]).strip()
```

This calls the **existing** `_strip_think_blocks()` method (line 1948) on the API copy (`api_msg`) only. The original `messages` list is untouched — trajectory storage and session persistence are unaffected.

## Test plan

- [ ] Multi-turn conversation with a thinking model (MiniMax M2.7, Moonshot Kimi) — verify `<think>` blocks do not appear in API request content
- [ ] Verify `reasoning_content` field still carries reasoning correctly
- [ ] Verify trajectory JSONL still contains `<think>` blocks for training data
- [ ] Verify session title generation no longer sees `<think>` prefix
- [ ] Conversation with a non-thinking model — verify no behavior change (guard clause skips)