### PR TITLE
fix(nix): include fastapi and build web frontend for dashboard

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,6 +13,39 @@
           !(pkgs.lib.hasInfix "/index-cache/" path);
       };
 
+      # Build the Vite/React web dashboard frontend.
+      # Output lands in hermes_cli/web_dist which the FastAPI server serves
+      # as a static SPA (see hermes_cli/web_server.py:WEB_DIST).
+      hermesWeb = pkgs.buildNpmPackage {
+        pname = "hermes-web";
+        version = "0.0.0";
+        src = ../web;
+        npmDepsHash = "sha256-kBq8QpUBmvfinqjGXT81TatWslql/uZN6Fd7b/We4VI=";
+        # vite build writes to ../hermes_cli/web_dist relative to web/;
+        # redirect into $out instead.
+        postPatch = ''
+          substituteInPlace vite.config.ts \
+            --replace-warn '../hermes_cli/web_dist' "$out"
+        '';
+        installPhase = ''
+          runHook preInstall
+          npm run build
+          runHook postInstall
+        '';
+        dontNpmBuild = true;  # we run the build in installPhase after substituteInPlace
+      };
+
+      # The venv's hermes_cli is in the read-only Nix store and lacks web_dist.
+      # Create a thin overlay directory that shadows hermes_cli with web_dist
+      # present, then prepend it via PYTHONPATH so Python finds it first.
+      hermesSiteOverlay = pkgs.runCommand "hermes-site-overlay" { } ''
+        venvSite=$(echo ${hermesVenv}/lib/python3.*/site-packages)
+        mkdir -p $out/lib/hermes-overlay
+        cp -r $venvSite/hermes_cli $out/lib/hermes-overlay/hermes_cli
+        chmod -R u+w $out/lib/hermes-overlay/hermes_cli
+        ln -s ${hermesWeb} $out/lib/hermes-overlay/hermes_cli/web_dist
+      '';
+
       runtimeDeps = with pkgs; [
         nodejs_20 ripgrep git openssh ffmpeg tirith
       ];
@@ -36,7 +69,8 @@
           ${pkgs.lib.concatMapStringsSep "\n" (name: ''
             makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
               --suffix PATH : "${runtimePath}" \
-              --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills
+              --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
+              --prefix PYTHONPATH : "${hermesSiteOverlay}/lib/hermes-overlay"
           '') [ "hermes" "hermes-agent" "hermes-acp" ]}
 
           runHook postInstall

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -80,4 +80,5 @@ let
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
   hermes-agent = [ "all" ];
+  fastapi = [ ];  # Explicitly include — uv2nix silently drops it from [web] extra
 }


### PR DESCRIPTION
## Summary

Fixes two Nix packaging bugs that break `hermes dashboard`:

- **fastapi missing from venv**: uv2nix silently drops `fastapi` from the virtualenv even though the `[web]` extra requires it (its transitive deps like starlette/uvicorn are present, but fastapi itself is not). Fixed by explicitly adding `fastapi = [];` to the `mkVirtualEnv` dependency set in `nix/python.nix`.

- **web_dist not built**: The Vite/React frontend in `web/` was never built during the Nix package build. The FastAPI server looks for `web_dist` adjacent to `hermes_cli/web_server.py` via `Path(__file__).parent / "web_dist"`. Fixed by adding a `buildNpmPackage` derivation for the frontend, creating a site-packages overlay with `web_dist` symlinked into `hermes_cli`, and prepending it via `PYTHONPATH` in the wrapper scripts.

Fixes #9305

## Test plan

- [ ] `nix build` completes without errors
- [ ] `hermes dashboard` starts the FastAPI server successfully
- [ ] Web UI loads at http://127.0.0.1:9119 and serves the React SPA
- [ ] `python -c "import fastapi"` works inside the wrapped environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)