### PR TITLE
fix: correct GPT-5 family context lengths in fallback defaults

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -105,9 +105,15 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude-sonnet-4.6": 1000000,
     # Catch-all for older Claude models (must sort after specific entries)
     "claude": 200000,
-    # OpenAI
+    # OpenAI — GPT-5 family (most have 400k; specific overrides first)
+    # Source: https://developers.openai.com/api/docs/models
+    "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
+    "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
+    "gpt-5.4": 1050000,               # GPT-5.4, GPT-5.4 Pro (1.05M context)
+    "gpt-5.3-codex-spark": 128000,    # Spark variant has reduced 128k context
+    "gpt-5.1-chat": 128000,           # Chat variant has 128k context
+    "gpt-5": 400000,                  # GPT-5.x base, mini, codex variants (400k)
     "gpt-4.1": 1047576,
-    "gpt-5": 128000,
     "gpt-4": 128000,
     # Google
     "gemini": 1048576,


### PR DESCRIPTION
## Summary

Fixes incorrect context window reporting for GPT-5 Codex models (and the entire GPT-5 family). 

**Bug**: `/model gpt-5.3-codex` showed `Context: 128,000 tokens` — the actual context window is 400,000 tokens. The 128k value was the max *output* tokens, not the context window.

**Root cause**: `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py` had `"gpt-5": 128000` as a catch-all. This fired as the fallback when models.dev didn't have the exact model or was unavailable. The GPT-5 base model itself has 400k context, not 128k.

**Fix**: Updated the generic `gpt-5` catch-all from 128k → 400k, and added specific entries for GPT-5 variants with different context sizes:

| Model pattern | Context | Notes |
|--------------|---------|-------|
| `gpt-5.4` | 1,050,000 | GPT-5.4, GPT-5.4 Pro |
| `gpt-5.4-mini` | 400,000 | Not 1.05M like full 5.4 |
| `gpt-5.4-nano` | 400,000 | Not 1.05M like full 5.4 |
| `gpt-5.3-codex-spark` | 128,000 | Spark has reduced context |
| `gpt-5.1-chat` | 128,000 | Chat variant |
| `gpt-5` (catch-all) | 400,000 | All other GPT-5.x |

Sources: [OpenAI API docs](https://developers.openai.com/api/docs/models)

## Impact
This affects both the `/model` display and the agent runtime's context window calculations. Users on the `openai-codex` provider were getting incorrect context management because the agent thought it only had 128k to work with instead of 400k.

## Test plan
- All 80 model_metadata tests pass
- All 25 models_dev tests pass  
- All 26 model_switch tests pass
- Verified substring matching resolves correctly for all GPT-5 variants