### PR TITLE
fix: include telegram dependency in termux bundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ termux = [
   # Tested Android / Termux path: keeps the core CLI feature-rich while
   # avoiding extras that currently depend on non-Android wheels (notably
   # faster-whisper -> ctranslate2 via the voice extra).
+  "python-telegram-bot[webhooks]>=22.6,<23",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[pty]",

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -16,6 +16,7 @@ The tested Termux bundle installs:
 - the Hermes CLI
 - cron support
 - PTY/background terminal support
+- Telegram gateway support (manual / best-effort background runs)
 - MCP support
 - Honcho memory support
 - ACP support
@@ -34,6 +35,7 @@ A few features still need desktop/server-style dependencies that are not publish
 - the `voice` extra is blocked by `faster-whisper -> ctranslate2`, and `ctranslate2` does not publish Android wheels
 - automatic browser / Playwright bootstrap is skipped in the Termux installer
 - Docker-based terminal isolation is not available inside Termux
+- Android may still suspend Termux background jobs, so gateway persistence is best-effort rather than a normal managed service
 
 That does not stop Hermes from working well as a phone-native CLI agent — it just means the recommended mobile install is intentionally narrower than the desktop/server install.
 


### PR DESCRIPTION
## What does this PR do?
Adds the Telegram adapter dependency to the tested Termux bundle so Hermes gateway can actually import the Telegram platform on Android installs that use .[termux].

## Related Issue
A user reported that Telegram gateway on Android / Termux would not start after install, and the missing piece was manually installing python-telegram-bot into the Hermes venv.

## Type of Change
- [x] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

## Changes Made
- add python-telegram-bot[webhooks] to the termux optional dependency bundle
- update the Termux guide to mention Telegram gateway support is included in the tested bundle
- clarify in the Termux guide that Android background gateway persistence is still best-effort, not a normal managed service

## How to Test
1. Inspect pyproject.toml and confirm the termux extra now includes python-telegram-bot[webhooks].
2. Open the Termux guide and confirm it mentions Telegram gateway support plus the best-effort backgrounding limitation.
3. On Android / Termux, run the tested install path and confirm Telegram gateway imports without needing a manual pip install of python-telegram-bot.

## Checklist
- [x] I kept the fix scoped to the Android / Termux packaging gap
- [x] I updated the user-facing docs to match the packaging change
- [ ] I ran the full test suite (not practical for this Android-specific packaging change in the current environment)

## Screenshots / Logs
Not applicable.
