### PR TITLE
Add instance-scoped Hermes homes for embedded agents

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,7 +5,37 @@ without risk of circular imports.
 """
 
 import os
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
 from pathlib import Path
+
+_runtime_hermes_home: ContextVar[Path | None] = ContextVar("runtime_hermes_home", default=None)
+
+
+def set_runtime_hermes_home(path: str | Path | None) -> Token:
+    """Override Hermes home for the current runtime context.
+
+    This is primarily used by embedded/library callers that need multiple
+    concurrent AIAgent instances in one Python process, each with its own
+    profile root.
+    """
+    resolved = None if path is None else Path(path).expanduser().resolve()
+    return _runtime_hermes_home.set(resolved)
+
+
+def reset_runtime_hermes_home(token: Token) -> None:
+    """Reset a runtime-local Hermes home override."""
+    _runtime_hermes_home.reset(token)
+
+
+@contextmanager
+def hermes_home_context(path: str | Path | None):
+    """Context manager for a runtime-local Hermes home override."""
+    token = set_runtime_hermes_home(path)
+    try:
+        yield
+    finally:
+        reset_runtime_hermes_home(token)
 
 
 def get_hermes_home() -> Path:
@@ -14,6 +44,9 @@ def get_hermes_home() -> Path:
     Reads HERMES_HOME env var, falls back to ~/.hermes.
     This is the single source of truth — all other copies should import this.
     """
+    runtime_home = _runtime_hermes_home.get()
+    if runtime_home is not None:
+        return runtime_home
     return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 
 
@@ -35,9 +68,14 @@ def get_default_hermes_root() -> Path:
     """
     native_home = Path.home() / ".hermes"
     env_home = os.environ.get("HERMES_HOME", "")
+    current_home = get_hermes_home()
     if not env_home:
-        return native_home
-    env_path = Path(env_home)
+        if current_home == native_home:
+            return native_home
+        if current_home.parent.name == "profiles":
+            return current_home.parent.parent
+        return current_home
+    env_path = current_home
     try:
         env_path.resolve().relative_to(native_home.resolve())
         # HERMES_HOME is under ~/.hermes (normal or profile mode)
@@ -128,10 +166,8 @@ def get_subprocess_home() -> str | None:
     Activation is directory-based: if the ``home/`` subdirectory doesn't
     exist, returns ``None`` and behavior is unchanged.
     """
-    hermes_home = os.getenv("HERMES_HOME")
-    if not hermes_home:
-        return None
-    profile_home = os.path.join(hermes_home, "home")
+    hermes_home = get_hermes_home()
+    profile_home = os.path.join(str(hermes_home), "home")
     if os.path.isdir(profile_home):
         return profile_home
     return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -43,7 +43,7 @@ import fire
 from datetime import datetime
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, set_runtime_hermes_home
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -552,6 +552,7 @@ class AIAgent:
         base_url: str = None,
         api_key: str = None,
         provider: str = None,
+        hermes_home: str | Path | None = None,
         api_mode: str = None,
         acp_command: str = None,
         acp_args: list[str] | None = None,
@@ -645,6 +646,10 @@ class AIAgent:
                 polluting trajectories with user-specific persona or project instructions.
         """
         _install_safe_stdio()
+
+        self.hermes_home = (
+            Path(hermes_home).expanduser().resolve() if hermes_home is not None else get_hermes_home().resolve()
+        )
 
         self.model = model
         self.max_iterations = max_iterations
@@ -822,7 +827,7 @@ class AIAgent:
         # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
         # (which creates a new AIAgent per message) won't duplicate handlers.
         from hermes_logging import setup_logging, setup_verbose_logging
-        setup_logging(hermes_home=_hermes_home)
+        setup_logging(hermes_home=self.hermes_home)
 
         if self.verbose_logging:
             setup_verbose_logging()
@@ -1071,8 +1076,7 @@ class AIAgent:
             self.session_id = f"{timestamp_str}_{short_uuid}"
         
         # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
-        hermes_home = get_hermes_home()
-        self.logs_dir = hermes_home / "sessions"
+        self.logs_dir = self.hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
         
@@ -1196,11 +1200,10 @@ class AIAgent:
                     if _mp and _mp.is_available():
                         self._memory_manager.add_provider(_mp)
                     if self._memory_manager.providers:
-                        from hermes_constants import get_hermes_home as _ghh
                         _init_kwargs = {
                             "session_id": self.session_id,
                             "platform": platform or "cli",
-                            "hermes_home": str(_ghh()),
+                            "hermes_home": str(self.hermes_home),
                             "agent_context": "primary",
                         }
                         # Thread gateway user identity for per-user memory scoping
@@ -1403,7 +1406,7 @@ class AIAgent:
             try:
                 self.context_compressor.on_session_start(
                     self.session_id,
-                    hermes_home=str(get_hermes_home()),
+                    hermes_home=str(self.hermes_home),
                     platform=self.platform or "cli",
                     model=self.model,
                     context_length=getattr(self.context_compressor, "context_length", 0),
@@ -2202,6 +2205,7 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        hermes_home=self.hermes_home,
                     )
                     review_agent._memory_store = self._memory_store
                     review_agent._memory_enabled = self._memory_enabled
@@ -7728,6 +7732,8 @@ class AIAgent:
         Returns:
             Dict: Complete conversation result with final response and message history
         """
+        set_runtime_hermes_home(self.hermes_home)
+
         # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
         # Installed once, transparent when streams are healthy, prevents crash on write.
         _install_safe_stdio()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -93,7 +93,6 @@ def test_aiagent_reuses_existing_errors_log_handler():
     try:
         for handler in list(root_logger.handlers):
             root_logger.removeHandler(handler)
-
         error_log_path.parent.mkdir(parents=True, exist_ok=True)
         preexisting_handler = RotatingFileHandler(
             error_log_path,
@@ -136,6 +135,56 @@ def test_aiagent_reuses_existing_errors_log_handler():
                 handler.close()
         for handler in original_handlers:
             root_logger.addHandler(handler)
+
+
+def test_aiagent_accepts_explicit_hermes_home(tmp_path):
+    custom_home = tmp_path / "agent-a" / ".hermes"
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            hermes_home=custom_home,
+        )
+
+    assert agent.hermes_home == custom_home.resolve()
+    assert agent.logs_dir == custom_home.resolve() / "sessions"
+    assert agent.logs_dir.is_dir()
+
+
+def test_aiagent_instances_keep_distinct_hermes_homes(tmp_path):
+    home_a = tmp_path / "agent-a" / ".hermes"
+    home_b = tmp_path / "agent-b" / ".hermes"
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent_a = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            hermes_home=home_a,
+        )
+        agent_b = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            hermes_home=home_b,
+        )
+
+    assert agent_a.hermes_home == home_a.resolve()
+    assert agent_b.hermes_home == home_b.resolve()
+    assert agent_a.logs_dir != agent_b.logs_dir
 
 
 class TestProviderModelNormalization:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -2,12 +2,14 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import (
+    get_default_hermes_root,
+    get_hermes_home,
+    hermes_home_context,
+    is_container,
+)
 
 
 class TestGetDefaultHermesRoot:
@@ -61,6 +63,25 @@ class TestGetDefaultHermesRoot:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_default_hermes_root() == docker_root
+
+    def test_runtime_override_becomes_root_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "native-home")
+        runtime_home = tmp_path / "agents" / "123" / ".hermes"
+
+        with hermes_home_context(runtime_home):
+            assert get_hermes_home() == runtime_home.resolve()
+            assert get_default_hermes_root() == runtime_home.resolve()
+
+    def test_runtime_override_is_context_local(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "native-home")
+        runtime_home = tmp_path / "agents" / "123" / ".hermes"
+
+        before = get_hermes_home()
+        with hermes_home_context(runtime_home):
+            assert get_hermes_home() == runtime_home.resolve()
+        assert get_hermes_home() == before
 
 
 class TestIsContainer:


### PR DESCRIPTION
## Summary
- add a runtime-local Hermes home override for embedded/library usage
- allow `AIAgent(..., hermes_home=...)` so multiple agents can run concurrently in one Python process with distinct profile roots
- switch agent runtime paths that previously depended on global `get_hermes_home()` to use the instance-specific home

## Why
Embedded consumers can host multiple `AIAgent` instances concurrently in one runtime. Today Hermes home resolution is process-global, which makes per-agent profile isolation difficult and can lead to writes to unexpected locations like `/.hermes` when ambient home state is not suitable.

This keeps CLI behavior unchanged while giving library callers an explicit instance-scoped override.

## Testing
- `uv run --extra dev pytest -q tests/test_hermes_constants.py tests/test_subprocess_home_isolation.py tests/run_agent/test_run_agent.py -k "hermes_home or subprocess_home or aiagent"`
