### PR TITLE
fix: make c-j binding submit instead of inserting newline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8422,9 +8422,19 @@ class HermesCLI:
             event.current_buffer.insert_text('\n')
 
         @kb.add('c-j')
-        def handle_ctrl_enter(event):
-            """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
-            event.current_buffer.insert_text('\n')
+        def handle_ctrl_j(event):
+            """Ctrl+J / \\n — treat as Enter (submit).
+
+            prompt_toolkit's built-in c-j handler re-feeds the keypress as
+            ControlM (Enter) to accommodate terminals that send \\n (0x0a)
+            instead of \\r (0x0d) for the Enter key (Ghostty, WSL, and others).
+            The previous binding here shadowed that safety net and broke Enter
+            on affected terminals.  Alt+Enter (escape enter) is the dedicated
+            binding for inserting newlines in multi-line input.
+
+            See: https://github.com/NousResearch/hermes-agent/issues/9299
+            """
+            handle_enter(event)
 
         @kb.add('tab', eager=True)
         def handle_tab(event):


### PR DESCRIPTION
## Summary

The `c-j` key binding in `cli.py` was overriding prompt_toolkit's built-in safety net that remaps `\n` (0x0a) to `\r` (0x0d) for terminals that send line feed instead of carriage return for the Enter key.

This broke Enter on Ghostty, WSL terminals, and any terminal where `stty icrnl` is disrupted — pressing Enter would insert a newline instead of submitting the message.

## Fix

Changed `handle_ctrl_enter` to delegate to `handle_enter(event)` instead of inserting a newline. Alt+Enter (`escape enter`) remains the dedicated binding for multi-line input.

## Before / After

| Byte received | prompt_toolkit Key | Before (broken) | After (fixed) |
|---|---|---|---|
| `\r` (0x0d) | `Keys.ControlM` / Enter | ✅ Submit | ✅ Submit |
| `\n` (0x0a) | `Keys.ControlJ` | ❌ Insert newline | ✅ Submit |

## Testing

- Verified the `c-j` binding now calls `handle_enter`
- Alt+Enter multiline input is unaffected
- No existing tests reference this binding (purely a keybinding routing change)

Fixes #9299