### PR TITLE
fix: explicit api_key should override pool credential for custom providers (#9315)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -390,6 +390,10 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        # Allow explicit_api_key to override the pool credential (#9315).
+        if has_usable_secret(explicit_api_key):
+            pool_result["api_key"] = explicit_api_key
+            pool_result["source"] = pool_result.get("source", "") + ":explicit_api_key_override"
         return pool_result
 
     api_key_candidates = [
@@ -498,6 +502,15 @@ def _resolve_openrouter_runtime(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
         )
         if pool_result:
+            # Allow explicit_api_key or cfg_api_key to override pool credential (#9315).
+            override_key = ""
+            if has_usable_secret(explicit_api_key):
+                override_key = explicit_api_key
+            elif use_config_base_url and has_usable_secret(cfg_api_key):
+                override_key = cfg_api_key
+            if override_key:
+                pool_result["api_key"] = override_key
+                pool_result["source"] = pool_result.get("source", "") + ":explicit_api_key_override"
             return pool_result
 
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1412,3 +1412,144 @@ def test_named_custom_runtime_no_model_when_absent(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert "model" not in resolved
+
+
+# ------------------------------------------------------------------
+# fix #9315 — explicit api_key must override pool credential
+# ------------------------------------------------------------------
+
+
+def test_named_custom_runtime_explicit_key_overrides_pool(monkeypatch):
+    """When a named custom provider matches a pool AND explicit_api_key is set,
+    the explicit key should win over the pool credential."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-server",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "cfg-key",
+            "model": "test-model",
+        },
+    )
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom:my-server",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="my-server",
+        explicit_api_key="explicit-override-key",
+    )
+
+    assert resolved["api_key"] == "explicit-override-key", (
+        "explicit_api_key must override pool credential"
+    )
+    assert ":explicit_api_key_override" in resolved["source"]
+    assert resolved["model"] == "test-model"
+
+
+def test_named_custom_runtime_pool_used_when_no_explicit_key(monkeypatch):
+    """When no explicit_api_key is provided, pool credential should be used as-is."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-server",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "cfg-key",
+        },
+    )
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom:my-server",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="my-server")
+
+    assert resolved["api_key"] == "pool-key", (
+        "pool credential should be used when no explicit key"
+    )
+    assert ":explicit_api_key_override" not in resolved["source"]
+
+
+def test_openrouter_custom_explicit_key_overrides_pool(monkeypatch):
+    """OpenRouter custom path: explicit_api_key overrides pool credential."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://my-api.example.com/v1",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://my-api.example.com/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_api_key="explicit-override-key",
+    )
+
+    assert resolved["api_key"] == "explicit-override-key", (
+        "explicit_api_key must override pool credential in openrouter path"
+    )
+    assert ":explicit_api_key_override" in resolved["source"]
+
+
+def test_openrouter_custom_cfg_key_overrides_pool_when_config_base_url(monkeypatch):
+    """OpenRouter custom path: cfg_api_key overrides pool when use_config_base_url is true."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://my-api.example.com/v1",
+            "api_key": "cfg-api-key",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://my-api.example.com/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["api_key"] == "cfg-api-key", (
+        "cfg_api_key must override pool credential when use_config_base_url is true"
+    )
+    assert ":explicit_api_key_override" in resolved["source"]


### PR DESCRIPTION
## Summary

When two `custom_providers` entries share the same `base_url` but have different `api_key` values, Hermes ignores the explicit `model.api_key` and uses the first provider's key from the credential pool.

Fixes #9315.

## Root Cause

Two code paths had this bug:

1. **`_resolve_named_custom_runtime()`**: When `pool_result` is found via `_try_resolve_from_custom_pool(base_url, ...)`, it immediately returned without checking if `explicit_api_key` was provided.

2. **`_resolve_openrouter_runtime()`**: Same issue — pool result takes precedence over `explicit_api_key` and `cfg_api_key`.

## Fix

In both functions, when an `explicit_api_key` is provided AND is usable (checked with `has_usable_secret()`), it now overrides the pool credential's `api_key`. The pool result is still used for `base_url` and `api_mode` — only the `api_key` is overridden.

For `_resolve_openrouter_runtime()`, `cfg_api_key` is also checked as a fallback when `use_config_base_url` is true.

The `source` field is updated with `:explicit_api_key_override` suffix to make the override observable in logs/debugging.

## Test Plan

Added 4 regression tests in `tests/hermes_cli/test_runtime_provider_resolution.py`:
- `test_named_custom_runtime_explicit_key_overrides_pool` — explicit api_key overrides pool credential in named custom provider path
- `test_named_custom_runtime_pool_used_when_no_explicit_key` — pool credential used when no explicit key (no regression)
- `test_openrouter_custom_explicit_key_overrides_pool` — explicit_api_key overrides pool in openrouter custom path
- `test_openrouter_custom_cfg_key_overrides_pool_when_config_base_url` — cfg_api_key overrides pool when use_config_base_url is true

All existing tests pass (70/71 in runtime_provider, 26/27 in credential_pool — the 2 failures are pre-existing on main).