### PR TITLE
feat(gateway): add Nextcloud Talk bot adapter

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -325,6 +325,11 @@ PLATFORM_HINTS = {
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
     ),
+    "nextcloud_talk": (
+        "You are in a Nextcloud Talk conversation. Keep formatting simple and "
+        "prefer plain text or light markdown. Native file/media delivery is "
+        "not implemented for this platform yet, so do not rely on MEDIA: paths."
+    ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "
         "suitable for email. Use plain text formatting (no markdown). "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -245,6 +245,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "whatsapp": Platform.WHATSAPP,
         "signal": Platform.SIGNAL,
         "matrix": Platform.MATRIX,
+        "nextcloud_talk": Platform.NEXTCLOUD_TALK,
         "mattermost": Platform.MATTERMOST,
         "homeassistant": Platform.HOMEASSISTANT,
         "dingtalk": Platform.DINGTALK,

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -55,6 +55,7 @@ class Platform(Enum):
     SIGNAL = "signal"
     MATTERMOST = "mattermost"
     MATRIX = "matrix"
+    NEXTCLOUD_TALK = "nextcloud_talk"
     HOMEASSISTANT = "homeassistant"
     EMAIL = "email"
     SMS = "sms"
@@ -283,6 +284,10 @@ class GatewayConfig:
                 connected.append(platform)
             # SMS uses api_key (Twilio auth token) — SID checked via env
             elif platform == Platform.SMS and os.getenv("TWILIO_ACCOUNT_SID"):
+                connected.append(platform)
+            # Nextcloud Talk uses a shared bot secret; backend URL can come
+            # from config or from inbound webhook headers.
+            elif platform == Platform.NEXTCLOUD_TALK and config.token:
                 connected.append(platform)
             # API Server uses enabled flag only (no token needed)
             elif platform == Platform.API_SERVER:
@@ -703,6 +708,7 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
         Platform.SLACK: "SLACK_BOT_TOKEN",
         Platform.MATTERMOST: "MATTERMOST_TOKEN",
         Platform.MATRIX: "MATRIX_ACCESS_TOKEN",
+        Platform.NEXTCLOUD_TALK: "NEXTCLOUD_TALK_SECRET",
         Platform.WEIXIN: "WEIXIN_TOKEN",
     }
     for platform, pconfig in config.platforms.items():
@@ -890,6 +896,39 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             platform=Platform.MATRIX,
             chat_id=matrix_home,
             name=os.getenv("MATRIX_HOME_ROOM_NAME", "Home"),
+        )
+
+    # Nextcloud Talk
+    nextcloud_talk_secret = os.getenv("NEXTCLOUD_TALK_SECRET")
+    nextcloud_talk_base_url = os.getenv("NEXTCLOUD_TALK_BASE_URL", "").strip().rstrip("/")
+    if nextcloud_talk_secret:
+        if Platform.NEXTCLOUD_TALK not in config.platforms:
+            config.platforms[Platform.NEXTCLOUD_TALK] = PlatformConfig()
+        config.platforms[Platform.NEXTCLOUD_TALK].enabled = True
+        config.platforms[Platform.NEXTCLOUD_TALK].token = nextcloud_talk_secret
+        if nextcloud_talk_base_url:
+            config.platforms[Platform.NEXTCLOUD_TALK].extra["base_url"] = nextcloud_talk_base_url
+        nextcloud_talk_host = os.getenv("NEXTCLOUD_TALK_WEBHOOK_HOST", "")
+        if nextcloud_talk_host:
+            config.platforms[Platform.NEXTCLOUD_TALK].extra["host"] = nextcloud_talk_host
+        nextcloud_talk_port = os.getenv("NEXTCLOUD_TALK_WEBHOOK_PORT", "")
+        if nextcloud_talk_port:
+            try:
+                config.platforms[Platform.NEXTCLOUD_TALK].extra["port"] = int(nextcloud_talk_port)
+            except ValueError:
+                pass
+        nextcloud_talk_path = os.getenv("NEXTCLOUD_TALK_WEBHOOK_PATH", "")
+        if nextcloud_talk_path:
+            config.platforms[Platform.NEXTCLOUD_TALK].extra["path"] = nextcloud_talk_path
+        nextcloud_talk_chat_type = os.getenv("NEXTCLOUD_TALK_CHAT_TYPE", "")
+        if nextcloud_talk_chat_type:
+            config.platforms[Platform.NEXTCLOUD_TALK].extra["chat_type"] = nextcloud_talk_chat_type
+    nextcloud_talk_home = os.getenv("NEXTCLOUD_TALK_HOME_CHANNEL")
+    if nextcloud_talk_home and Platform.NEXTCLOUD_TALK in config.platforms:
+        config.platforms[Platform.NEXTCLOUD_TALK].home_channel = HomeChannel(
+            platform=Platform.NEXTCLOUD_TALK,
+            chat_id=nextcloud_talk_home,
+            name=os.getenv("NEXTCLOUD_TALK_HOME_CHANNEL_NAME", "Home"),
         )
 
     # Home Assistant

--- a/gateway/platforms/nextcloud_talk.py
+++ b/gateway/platforms/nextcloud_talk.py
@@ -41,6 +41,7 @@ import re
 import secrets
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 try:
     from aiohttp import ClientSession, ClientTimeout, web
@@ -88,7 +89,11 @@ def _normalize_base_url(value: str) -> str:
 
 def _validate_backend_url(url: str) -> bool:
     """Return True if *url* looks like a valid Nextcloud backend URL."""
-    return url.startswith("https://") or url.startswith("http://")
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
 def _sanitize_chat_id(chat_id: str) -> Optional[str]:

--- a/gateway/platforms/nextcloud_talk.py
+++ b/gateway/platforms/nextcloud_talk.py
@@ -1,0 +1,451 @@
+"""Nextcloud Talk bot adapter.
+
+Implements Hermes as a webhook-based Nextcloud Talk bot using the official
+Talk bot API:
+
+- Receives signed webhook callbacks for inbound chat messages
+- Sends signed replies back to the originating conversation
+- Preserves reply context when Talk includes ``object.inReplyTo``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import hmac
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import time
+from typing import Any, Dict, Optional
+
+try:
+    from aiohttp import ClientSession, ClientTimeout, web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    ClientSession = Any  # type: ignore[assignment]
+    ClientTimeout = Any  # type: ignore[assignment]
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8645
+DEFAULT_PATH = "/nextcloud-talk"
+MAX_MESSAGE_LENGTH = 32_000
+
+# Webhook security limits
+_MAX_WEBHOOK_BODY_BYTES = 1 * 1024 * 1024  # 1 MB
+_WEBHOOK_BODY_READ_TIMEOUT = 10  # seconds
+_RATE_LIMIT_WINDOW = 60  # seconds
+_RATE_LIMIT_MAX = 120  # requests per window per IP
+
+# Cache limits to prevent unbounded memory growth
+_MAX_CHAT_CACHE_ENTRIES = 1024
+
+# Talk conversation tokens are alphanumeric; reject path separators and
+# URL-unsafe characters to prevent path traversal and injection.
+_VALID_CHAT_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def check_nextcloud_talk_requirements() -> bool:
+    """Return True when the adapter dependencies are available."""
+    return AIOHTTP_AVAILABLE
+
+
+def _normalize_base_url(value: str) -> str:
+    """Normalize a configured Nextcloud base URL."""
+    return (value or "").strip().rstrip("/")
+
+
+def _validate_backend_url(url: str) -> bool:
+    """Return True if *url* looks like a valid Nextcloud backend URL."""
+    return url.startswith("https://") or url.startswith("http://")
+
+
+def _sanitize_chat_id(chat_id: str) -> Optional[str]:
+    """Return *chat_id* if it is a valid Talk conversation token, else None."""
+    if _VALID_CHAT_ID_RE.match(chat_id):
+        return chat_id
+    return None
+
+
+def _decode_talk_message(raw_content: Any) -> str:
+    """Decode Talk's JSON-encoded ``object.content`` payload to plain text."""
+    if raw_content is None:
+        return ""
+    if not isinstance(raw_content, str):
+        return str(raw_content)
+
+    try:
+        parsed = json.loads(raw_content)
+    except json.JSONDecodeError:
+        return raw_content
+
+    if isinstance(parsed, dict):
+        message = parsed.get("message")
+        if isinstance(message, str):
+            return message
+    return raw_content
+
+
+def _sign_payload(secret_value: str, random_header: str, body: bytes) -> str:
+    """Return the Talk bot HMAC signature for *body*."""
+    mac = hmac.new(secret_value.encode("utf-8"), digestmod=hashlib.sha256)
+    mac.update(random_header.encode("utf-8"))
+    mac.update(body)
+    return mac.hexdigest()
+
+
+class _RateLimiter:
+    """Simple sliding-window rate limiter keyed by remote IP."""
+
+    _PRUNE_THRESHOLD = 4096  # prune stale keys when dict exceeds this size
+
+    def __init__(self, window: int = _RATE_LIMIT_WINDOW, max_requests: int = _RATE_LIMIT_MAX):
+        self._window = window
+        self._max = max_requests
+        self._hits: Dict[str, collections.deque] = {}
+
+    def _prune_stale(self, now: float) -> None:
+        """Remove keys whose windows have fully expired."""
+        stale = [k for k, dq in self._hits.items() if not dq or dq[-1] < now - self._window]
+        for k in stale:
+            del self._hits[k]
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        # Periodic housekeeping to prevent unbounded growth from unique IPs
+        if len(self._hits) > self._PRUNE_THRESHOLD:
+            self._prune_stale(now)
+        dq = self._hits.get(key)
+        if dq is None:
+            dq = collections.deque()
+            self._hits[key] = dq
+        # Expire old entries for this key
+        while dq and dq[0] < now - self._window:
+            dq.popleft()
+        if len(dq) >= self._max:
+            return False
+        dq.append(now)
+        return True
+
+
+class NextcloudTalkAdapter(BasePlatformAdapter):
+    """Hermes gateway adapter for webhook-based Nextcloud Talk bots."""
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.NEXTCLOUD_TALK)
+        self._secret: str = config.token or os.getenv("NEXTCLOUD_TALK_SECRET", "")
+        self._base_url: str = _normalize_base_url(
+            config.extra.get("base_url") or os.getenv("NEXTCLOUD_TALK_BASE_URL", "")
+        )
+        self._host: str = config.extra.get("host", DEFAULT_HOST)
+        self._port: int = int(config.extra.get("port", DEFAULT_PORT))
+        raw_path = str(config.extra.get("path", DEFAULT_PATH) or DEFAULT_PATH).strip()
+        self._path: str = raw_path if raw_path.startswith("/") else f"/{raw_path}"
+        self._default_chat_type: str = str(
+            config.extra.get("chat_type")
+            or os.getenv("NEXTCLOUD_TALK_CHAT_TYPE", "group")
+        ).strip().lower() or "group"
+        if self._default_chat_type not in {"dm", "group"}:
+            self._default_chat_type = "group"
+
+        self._runner = None
+        self._session: Optional[ClientSession] = None
+        self._chat_backends: collections.OrderedDict[str, str] = collections.OrderedDict()
+        self._chat_info_cache: collections.OrderedDict[str, Dict[str, Any]] = collections.OrderedDict()
+        self._rate_limiter = _RateLimiter()
+
+    async def connect(self) -> bool:
+        """Start the webhook HTTP server for Nextcloud Talk callbacks."""
+        if not self._secret:
+            logger.error("Nextcloud Talk: NEXTCLOUD_TALK_SECRET is required")
+            return False
+
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post(self._path, self._handle_webhook)
+
+        import socket as _socket
+
+        try:
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
+                sock.settimeout(1)
+                sock.connect(("127.0.0.1", self._port))
+            logger.error(
+                "Nextcloud Talk: port %d already in use. Set NEXTCLOUD_TALK_WEBHOOK_PORT or platforms.nextcloud_talk.extra.port",
+                self._port,
+            )
+            return False
+        except (ConnectionRefusedError, OSError):
+            pass
+
+        self._session = ClientSession(timeout=ClientTimeout(total=30))
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+        await site.start()
+        self._mark_connected()
+        logger.info(
+            "Nextcloud Talk: listening on %s:%d%s",
+            self._host,
+            self._port,
+            self._path,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        if self._session:
+            await self._session.close()
+            self._session = None
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+        logger.info("Nextcloud Talk: disconnected")
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _cache_chat_info(self, chat_id: str, info: Dict[str, Any]) -> None:
+        """Store chat info with LRU eviction."""
+        self._chat_info_cache[chat_id] = info
+        self._chat_info_cache.move_to_end(chat_id)
+        while len(self._chat_info_cache) > _MAX_CHAT_CACHE_ENTRIES:
+            self._chat_info_cache.popitem(last=False)
+
+    def _cache_backend(self, chat_id: str, backend: str) -> None:
+        """Store backend URL with LRU eviction."""
+        self._chat_backends[chat_id] = backend
+        self._chat_backends.move_to_end(chat_id)
+        while len(self._chat_backends) > _MAX_CHAT_CACHE_ENTRIES:
+            self._chat_backends.popitem(last=False)
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a signed bot message into a Nextcloud Talk conversation."""
+        if not content:
+            return SendResult(success=True)
+
+        if not self._secret:
+            return SendResult(success=False, error="Nextcloud Talk not configured: missing secret")
+
+        safe_chat_id = _sanitize_chat_id(str(chat_id))
+        if not safe_chat_id:
+            return SendResult(success=False, error=f"Invalid Talk conversation token: {chat_id!r}")
+
+        backend = _normalize_base_url(
+            (metadata or {}).get("backend_url")
+            or self._chat_backends.get(safe_chat_id, "")
+            or self._base_url
+        )
+        if not backend:
+            return SendResult(
+                success=False,
+                error=(
+                    "Nextcloud Talk backend URL is unknown for this conversation. "
+                    "Set NEXTCLOUD_TALK_BASE_URL or wait for an inbound webhook to establish the backend."
+                ),
+            )
+        if not _validate_backend_url(backend):
+            return SendResult(success=False, error=f"Invalid backend URL scheme: {backend!r}")
+
+        chunks = self.truncate_message(self.format_message(content), self.MAX_MESSAGE_LENGTH)
+        last_result = SendResult(success=True)
+        session = self._session or ClientSession(timeout=ClientTimeout(total=30))
+        session_is_temporary = self._session is None
+
+        try:
+            for index, chunk in enumerate(chunks):
+                payload: Dict[str, Any] = {"message": chunk}
+                if index == 0 and reply_to is not None:
+                    try:
+                        payload["replyTo"] = int(reply_to)
+                    except (TypeError, ValueError):
+                        logger.debug("Nextcloud Talk: ignoring non-numeric reply_to=%r", reply_to)
+
+                body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                random_header = secrets.token_hex(32)
+                # NC Talk Bot API signs: HMAC(secret, random + message_text), NOT random + json_body
+                signature = _sign_payload(self._secret, random_header, chunk.encode("utf-8"))
+                url = f"{backend}/ocs/v2.php/apps/spreed/api/v1/bot/{safe_chat_id}/message"
+                headers = {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "OCS-APIRequest": "true",
+                    "X-Nextcloud-Talk-Bot-Random": random_header,
+                    "X-Nextcloud-Talk-Bot-Signature": signature,
+                }
+
+                try:
+                    async with session.post(url, data=body, headers=headers) as resp:
+                        resp_text = await resp.text()
+                        if resp.status not in (200, 201):
+                            return SendResult(
+                                success=False,
+                                error=f"Nextcloud Talk API error ({resp.status}): {resp_text}",
+                                retryable=resp.status >= 500,
+                            )
+                        raw_response: Any = resp_text
+                        try:
+                            raw_response = json.loads(resp_text) if resp_text else {}
+                        except json.JSONDecodeError:
+                            pass
+                        last_result = SendResult(success=True, raw_response=raw_response)
+                except Exception as exc:
+                    return SendResult(
+                        success=False,
+                        error=f"Nextcloud Talk send failed: {exc}",
+                        retryable=True,
+                    )
+        finally:
+            if session_is_temporary:
+                await session.close()
+
+        return last_result
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Nextcloud Talk bots do not currently expose a typing API."""
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return self._chat_info_cache.get(
+            str(chat_id),
+            {"name": str(chat_id), "type": self._default_chat_type, "chat_id": str(chat_id)},
+        )
+
+    # ------------------------------------------------------------------
+    # Webhook handler
+    # ------------------------------------------------------------------
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok", "platform": "nextcloud_talk"})
+
+    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
+        remote_ip = getattr(request, "remote", None) or "unknown"
+
+        # Rate limiting
+        if not self._rate_limiter.allow(remote_ip):
+            logger.warning("Nextcloud Talk: rate limit exceeded for %s", remote_ip)
+            return web.Response(status=429, text="Too Many Requests")
+
+        # Content-Type guard — Talk always sends application/json
+        content_type = (request.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+        if content_type and content_type != "application/json":
+            logger.warning("Nextcloud Talk: rejected Content-Type %r from %s", content_type, remote_ip)
+            return web.Response(status=415, text="Unsupported Media Type")
+
+        # Body size guard — reject early via Content-Length when available
+        content_length = request.content_length
+        if content_length is not None and content_length > _MAX_WEBHOOK_BODY_BYTES:
+            logger.warning("Nextcloud Talk: body too large (%d bytes) from %s", content_length, remote_ip)
+            return web.Response(status=413, text="Request body too large")
+
+        # Read body with timeout to prevent slow-loris
+        try:
+            body = await asyncio.wait_for(request.read(), timeout=_WEBHOOK_BODY_READ_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning("Nextcloud Talk: body read timed out from %s", remote_ip)
+            return web.Response(status=408, text="Request Timeout")
+        except Exception:
+            return web.json_response({"error": "failed to read body"}, status=400)
+
+        if len(body) > _MAX_WEBHOOK_BODY_BYTES:
+            logger.warning("Nextcloud Talk: body exceeds limit (%d bytes) from %s", len(body), remote_ip)
+            return web.Response(status=413, text="Request body too large")
+
+        # Signature verification (timing-safe)
+        signature = (request.headers.get("X-Nextcloud-Talk-Signature") or "").strip().lower()
+        random_header = (request.headers.get("X-Nextcloud-Talk-Random") or "").strip()
+        backend = _normalize_base_url(request.headers.get("X-Nextcloud-Talk-Backend", ""))
+
+        if not signature or not random_header:
+            return web.json_response({"error": "missing signature headers"}, status=401)
+
+        expected = _sign_payload(self._secret, random_header, body)
+        if not hmac.compare_digest(expected, signature):
+            logger.warning("Nextcloud Talk: invalid signature from %s", remote_ip)
+            return web.json_response({"error": "invalid signature"}, status=401)
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return web.json_response({"error": "invalid json body"}, status=400)
+
+        hook_type = str(payload.get("type") or "")
+        if hook_type != "Create":
+            logger.debug("Nextcloud Talk: ignoring unsupported hook type %s", hook_type)
+            return web.json_response({"status": "ignored", "type": hook_type}, status=202)
+
+        actor = payload.get("actor") or {}
+        actor_type = str(actor.get("type") or "")
+        actor_id = str(actor.get("id") or "")
+        if actor_type.lower() == "application" or actor_id.startswith("bots/"):
+            return web.json_response({"status": "ignored", "reason": "self_message"}, status=202)
+
+        obj = payload.get("object") or {}
+        target = payload.get("target") or {}
+        raw_chat_id = str(target.get("id") or "")
+        chat_id = _sanitize_chat_id(raw_chat_id)
+        if not chat_id:
+            logger.warning("Nextcloud Talk: invalid conversation token %r from %s", raw_chat_id, remote_ip)
+            return web.json_response({"error": "invalid target.id"}, status=400)
+
+        text = _decode_talk_message(obj.get("content"))
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=target.get("name") or chat_id,
+            chat_type=self._default_chat_type,
+            user_id=actor_id or None,
+            user_name=actor.get("name"),
+        )
+
+        in_reply_to = obj.get("inReplyTo") or {}
+        parent_object = in_reply_to.get("object") or {}
+        parent_actor = in_reply_to.get("actor") or {}
+        reply_to_text = _decode_talk_message(parent_object.get("content"))
+        if reply_to_text and parent_actor.get("name"):
+            reply_to_text = f"{parent_actor.get('name')}: {reply_to_text}"
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=payload,
+            message_id=str(obj.get("id") or "") or None,
+            reply_to_message_id=str(parent_object.get("id") or "") or None,
+            reply_to_text=reply_to_text or None,
+        )
+
+        self._cache_chat_info(chat_id, {
+            "name": target.get("name") or chat_id,
+            "type": self._default_chat_type,
+            "chat_id": chat_id,
+        })
+        if backend and _validate_backend_url(backend):
+            self._cache_backend(chat_id, backend)
+
+        await self.handle_message(event)
+        return web.json_response({"status": "accepted"}, status=202)

--- a/gateway/platforms/nextcloud_talk.py
+++ b/gateway/platforms/nextcloud_talk.py
@@ -1,19 +1,39 @@
-"""Nextcloud Talk bot adapter.
+"""Nextcloud Talk gateway adapter.
 
-Implements Hermes as a webhook-based Nextcloud Talk bot using the official
-Talk bot API:
+Connects Hermes to a self-hosted Nextcloud Talk server as a webhook-based
+bot using the official Talk Bot API.  The bot is registered on the
+Nextcloud side with ``occ talk:bot:install`` and receives HMAC-signed
+webhook callbacks for new chat messages; Hermes replies through the Talk
+Bot message endpoint with the same signing scheme.
 
-- Receives signed webhook callbacks for inbound chat messages
-- Sends signed replies back to the originating conversation
-- Preserves reply context when Talk includes ``object.inReplyTo``
+Because Talk conversation tokens identify rooms across every Nextcloud
+instance that installs the bot, the adapter also caches the originating
+backend URL per conversation so a single Hermes instance can serve Talk
+rooms on multiple Nextcloud servers without per-server configuration.
+
+Environment variables:
+    NEXTCLOUD_TALK_SECRET          Bot shared secret (required)
+    NEXTCLOUD_TALK_BASE_URL        Fallback Nextcloud base URL for
+                                   outbound sends when no inbound webhook
+                                   has established one yet
+    NEXTCLOUD_TALK_WEBHOOK_HOST    Bind host for the webhook listener
+                                   (default: 0.0.0.0)
+    NEXTCLOUD_TALK_WEBHOOK_PORT    Bind port (default: 8645)
+    NEXTCLOUD_TALK_WEBHOOK_PATH    Webhook path (default: /nextcloud-talk)
+    NEXTCLOUD_TALK_CHAT_TYPE       Default chat type ("group" or "dm",
+                                   default: group)
+    NEXTCLOUD_TALK_HOME_CHANNEL    Talk conversation token for scheduled
+                                   cron deliveries
+    NEXTCLOUD_TALK_ALLOWED_USERS   Comma-separated Talk actor IDs allowed
+                                   to interact (e.g. "users/alice")
 """
 
 from __future__ import annotations
 
 import asyncio
 import collections
-import hmac
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -170,7 +190,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
     async def connect(self) -> bool:
         """Start the webhook HTTP server for Nextcloud Talk callbacks."""
         if not self._secret:
-            logger.error("Nextcloud Talk: NEXTCLOUD_TALK_SECRET is required")
+            logger.error("[nextcloud_talk] NEXTCLOUD_TALK_SECRET is required")
             return False
 
         app = web.Application()
@@ -184,7 +204,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
                 sock.settimeout(1)
                 sock.connect(("127.0.0.1", self._port))
             logger.error(
-                "Nextcloud Talk: port %d already in use. Set NEXTCLOUD_TALK_WEBHOOK_PORT or platforms.nextcloud_talk.extra.port",
+                "[nextcloud_talk] port %d already in use. Set NEXTCLOUD_TALK_WEBHOOK_PORT or platforms.nextcloud_talk.extra.port",
                 self._port,
             )
             return False
@@ -199,7 +219,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
         await site.start()
         self._mark_connected()
         logger.info(
-            "Nextcloud Talk: listening on %s:%d%s",
+            "[nextcloud_talk] listening on %s:%d%s",
             self._host,
             self._port,
             self._path,
@@ -214,7 +234,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._mark_disconnected()
-        logger.info("Nextcloud Talk: disconnected")
+        logger.info("[nextcloud_talk] disconnected")
 
     # ------------------------------------------------------------------
     # Cache helpers
@@ -284,7 +304,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
                     try:
                         payload["replyTo"] = int(reply_to)
                     except (TypeError, ValueError):
-                        logger.debug("Nextcloud Talk: ignoring non-numeric reply_to=%r", reply_to)
+                        logger.debug("[nextcloud_talk] ignoring non-numeric reply_to=%r", reply_to)
 
                 body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
                 random_header = secrets.token_hex(32)
@@ -348,32 +368,33 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
 
         # Rate limiting
         if not self._rate_limiter.allow(remote_ip):
-            logger.warning("Nextcloud Talk: rate limit exceeded for %s", remote_ip)
+            logger.warning("[nextcloud_talk] rate limit exceeded for %s", remote_ip)
             return web.Response(status=429, text="Too Many Requests")
 
         # Content-Type guard — Talk always sends application/json
         content_type = (request.headers.get("Content-Type") or "").split(";")[0].strip().lower()
         if content_type and content_type != "application/json":
-            logger.warning("Nextcloud Talk: rejected Content-Type %r from %s", content_type, remote_ip)
+            logger.warning("[nextcloud_talk] rejected Content-Type %r from %s", content_type, remote_ip)
             return web.Response(status=415, text="Unsupported Media Type")
 
         # Body size guard — reject early via Content-Length when available
         content_length = request.content_length
         if content_length is not None and content_length > _MAX_WEBHOOK_BODY_BYTES:
-            logger.warning("Nextcloud Talk: body too large (%d bytes) from %s", content_length, remote_ip)
+            logger.warning("[nextcloud_talk] body too large (%d bytes) from %s", content_length, remote_ip)
             return web.Response(status=413, text="Request body too large")
 
         # Read body with timeout to prevent slow-loris
         try:
             body = await asyncio.wait_for(request.read(), timeout=_WEBHOOK_BODY_READ_TIMEOUT)
         except asyncio.TimeoutError:
-            logger.warning("Nextcloud Talk: body read timed out from %s", remote_ip)
+            logger.warning("[nextcloud_talk] body read timed out from %s", remote_ip)
             return web.Response(status=408, text="Request Timeout")
-        except Exception:
+        except Exception as exc:
+            logger.warning("[nextcloud_talk] body read failed from %s: %s", remote_ip, exc)
             return web.json_response({"error": "failed to read body"}, status=400)
 
         if len(body) > _MAX_WEBHOOK_BODY_BYTES:
-            logger.warning("Nextcloud Talk: body exceeds limit (%d bytes) from %s", len(body), remote_ip)
+            logger.warning("[nextcloud_talk] body exceeds limit (%d bytes) from %s", len(body), remote_ip)
             return web.Response(status=413, text="Request body too large")
 
         # Signature verification (timing-safe)
@@ -386,7 +407,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
 
         expected = _sign_payload(self._secret, random_header, body)
         if not hmac.compare_digest(expected, signature):
-            logger.warning("Nextcloud Talk: invalid signature from %s", remote_ip)
+            logger.warning("[nextcloud_talk] invalid signature from %s", remote_ip)
             return web.json_response({"error": "invalid signature"}, status=401)
 
         try:
@@ -396,7 +417,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
 
         hook_type = str(payload.get("type") or "")
         if hook_type != "Create":
-            logger.debug("Nextcloud Talk: ignoring unsupported hook type %s", hook_type)
+            logger.debug("[nextcloud_talk] ignoring unsupported hook type %s", hook_type)
             return web.json_response({"status": "ignored", "type": hook_type}, status=202)
 
         actor = payload.get("actor") or {}
@@ -410,7 +431,7 @@ class NextcloudTalkAdapter(BasePlatformAdapter):
         raw_chat_id = str(target.get("id") or "")
         chat_id = _sanitize_chat_id(raw_chat_id)
         if not chat_id:
-            logger.warning("Nextcloud Talk: invalid conversation token %r from %s", raw_chat_id, remote_ip)
+            logger.warning("[nextcloud_talk] invalid conversation token %r from %s", raw_chat_id, remote_ip)
             return web.json_response({"error": "invalid target.id"}, status=400)
 
         text = _decode_talk_message(obj.get("content"))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1493,7 +1493,8 @@ class GatewayRunner:
                        "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
                        "EMAIL_ALLOWED_USERS",
                        "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
-                       "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
+                       "MATRIX_ALLOWED_USERS", "NEXTCLOUD_TALK_ALLOWED_USERS",
+                       "DINGTALK_ALLOWED_USERS",
                        "FEISHU_ALLOWED_USERS",
                        "WECOM_ALLOWED_USERS",
                        "WECOM_CALLBACK_ALLOWED_USERS",
@@ -1508,7 +1509,8 @@ class GatewayRunner:
                        "WHATSAPP_ALLOW_ALL_USERS", "SLACK_ALLOW_ALL_USERS",
                        "SIGNAL_ALLOW_ALL_USERS", "EMAIL_ALLOW_ALL_USERS",
                        "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
-                       "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS",
+                       "MATRIX_ALLOW_ALL_USERS", "NEXTCLOUD_TALK_ALLOW_ALL_USERS",
+                       "DINGTALK_ALLOW_ALL_USERS",
                        "FEISHU_ALLOW_ALL_USERS",
                        "WECOM_ALLOW_ALL_USERS",
                        "WECOM_CALLBACK_ALLOW_ALL_USERS",
@@ -2234,6 +2236,16 @@ class GatewayRunner:
                 return None
             return MatrixAdapter(config)
 
+        elif platform == Platform.NEXTCLOUD_TALK:
+            from gateway.platforms.nextcloud_talk import (
+                NextcloudTalkAdapter,
+                check_nextcloud_talk_requirements,
+            )
+            if not check_nextcloud_talk_requirements():
+                logger.warning("Nextcloud Talk: aiohttp not installed")
+                return None
+            return NextcloudTalkAdapter(config)
+
         elif platform == Platform.API_SERVER:
             from gateway.platforms.api_server import APIServerAdapter, check_api_server_requirements
             if not check_api_server_requirements():
@@ -2299,6 +2311,7 @@ class GatewayRunner:
             Platform.SMS: "SMS_ALLOWED_USERS",
             Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
             Platform.MATRIX: "MATRIX_ALLOWED_USERS",
+            Platform.NEXTCLOUD_TALK: "NEXTCLOUD_TALK_ALLOWED_USERS",
             Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
             Platform.FEISHU: "FEISHU_ALLOWED_USERS",
             Platform.WECOM: "WECOM_ALLOWED_USERS",
@@ -2317,6 +2330,7 @@ class GatewayRunner:
             Platform.SMS: "SMS_ALLOW_ALL_USERS",
             Platform.MATTERMOST: "MATTERMOST_ALLOW_ALL_USERS",
             Platform.MATRIX: "MATRIX_ALLOW_ALL_USERS",
+            Platform.NEXTCLOUD_TALK: "NEXTCLOUD_TALK_ALLOW_ALL_USERS",
             Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
             Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -48,6 +48,9 @@ _EXTRA_ENV_KEYS = frozenset({
     "QQ_APP_ID", "QQ_CLIENT_SECRET", "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",
     "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
     "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
+    "NEXTCLOUD_TALK_SECRET", "NEXTCLOUD_TALK_BASE_URL",
+    "NEXTCLOUD_TALK_WEBHOOK_HOST", "NEXTCLOUD_TALK_WEBHOOK_PORT", "NEXTCLOUD_TALK_WEBHOOK_PATH",
+    "NEXTCLOUD_TALK_CHAT_TYPE", "NEXTCLOUD_TALK_HOME_CHANNEL", "NEXTCLOUD_TALK_HOME_CHANNEL_NAME",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
     "WHATSAPP_MODE", "WHATSAPP_ENABLED",
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
@@ -1337,6 +1340,27 @@ OPTIONAL_ENV_VARS = {
     "BLUEBUBBLES_ALLOW_ALL_USERS": {
         "description": "Allow all BlueBubbles users without allowlist",
         "prompt": "Allow All BlueBubbles Users",
+        "category": "messaging",
+    },
+    "NEXTCLOUD_TALK_SECRET": {
+        "description": "Nextcloud Talk bot shared secret. Configure with `occ talk:bot:install` on the Nextcloud server.",
+        "prompt": "Nextcloud Talk bot shared secret",
+        "url": "https://nextcloud-talk.readthedocs.io/en/latest/bots/",
+        "password": True,
+        "category": "messaging",
+    },
+    "NEXTCLOUD_TALK_BASE_URL": {
+        "description": "Public base URL of the Nextcloud server (e.g. https://cloud.example.com). Used for outbound replies and cron delivery.",
+        "prompt": "Nextcloud base URL",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "NEXTCLOUD_TALK_ALLOWED_USERS": {
+        "description": "Comma-separated Talk actor IDs (e.g. 'users/alice') allowed to use the bot",
+        "prompt": "Allowed Talk actor IDs (comma-separated)",
+        "url": None,
+        "password": False,
         "category": "messaging",
     },
     "QQ_APP_ID": {

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1725,6 +1725,32 @@ _PLATFORMS = [
         "token_var": "SIGNAL_HTTP_URL",
     },
     {
+        "key": "nextcloud_talk",
+        "label": "Nextcloud Talk",
+        "emoji": "☁️",
+        "token_var": "NEXTCLOUD_TALK_SECRET",
+        "setup_instructions": [
+            "1. Expose Hermes on a reachable HTTPS URL for Nextcloud to call",
+            "2. Choose a long shared secret (40+ chars) for Talk bot signing",
+            "3. Set the public Nextcloud base URL so Hermes can send replies back",
+            "4. Install the bot on your Nextcloud server with:",
+            "   ./occ talk:bot:install -f webhook -f response <name> <secret> https://your-hermes-host:8645/nextcloud-talk [description]",
+            "5. Add the bot to one or more Talk conversations",
+            "6. Allowed users should match Talk actor IDs such as users/alice",
+        ],
+        "vars": [
+            {"name": "NEXTCLOUD_TALK_BASE_URL", "prompt": "Nextcloud base URL (e.g. https://cloud.example.com)", "password": False,
+             "help": "The public base URL of your Nextcloud server. Hermes uses this for direct sends and fallback replies."},
+            {"name": "NEXTCLOUD_TALK_SECRET", "prompt": "Bot shared secret", "password": True,
+             "help": "Use the same secret you pass to 'occ talk:bot:install'."},
+            {"name": "NEXTCLOUD_TALK_ALLOWED_USERS", "prompt": "Allowed Talk actor IDs (comma-separated, e.g. users/alice)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which Talk participants can interact with Hermes."},
+            {"name": "NEXTCLOUD_TALK_HOME_CHANNEL", "prompt": "Home conversation token (optional, for cron/notifications)", "password": False,
+             "help": "Talk conversation token for scheduled results and notifications."},
+        ],
+    },
+    {
         "key": "email",
         "label": "Email",
         "emoji": "📧",
@@ -1968,6 +1994,13 @@ def _platform_status(platform: dict) -> str:
         if all([val, pwd, imap, smtp]):
             return "configured"
         if any([val, pwd, imap, smtp]):
+            return "partially configured"
+        return "not configured"
+    if platform.get("key") == "nextcloud_talk":
+        base_url = get_env_value("NEXTCLOUD_TALK_BASE_URL")
+        if val and base_url:
+            return "configured"
+        if val or base_url:
             return "partially configured"
         return "not configured"
     if platform.get("key") == "matrix":

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -30,6 +30,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),
     ("mattermost",     PlatformInfo(label="💬 Mattermost",      default_toolset="hermes-mattermost")),
     ("matrix",         PlatformInfo(label="💬 Matrix",          default_toolset="hermes-matrix")),
+    ("nextcloud_talk", PlatformInfo(label="☁️  Nextcloud Talk",  default_toolset="hermes-nextcloud-talk")),
     ("dingtalk",       PlatformInfo(label="💬 DingTalk",        default_toolset="hermes-dingtalk")),
     ("feishu",         PlatformInfo(label="🪽 Feishu",          default_toolset="hermes-feishu")),
     ("wecom",          PlatformInfo(label="💬 WeCom",           default_toolset="hermes-wecom")),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -297,6 +297,7 @@ def show_status(args):
         "WhatsApp": ("WHATSAPP_ENABLED", None),
         "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
         "Slack": ("SLACK_BOT_TOKEN", None),
+        "Nextcloud Talk": ("NEXTCLOUD_TALK_SECRET", "NEXTCLOUD_TALK_HOME_CHANNEL"),
         "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
         "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
         "DingTalk": ("DINGTALK_CLIENT_ID", None),

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -768,6 +768,7 @@ class TestPromptBuilderConstants:
         assert "whatsapp" in PLATFORM_HINTS
         assert "telegram" in PLATFORM_HINTS
         assert "discord" in PLATFORM_HINTS
+        assert "nextcloud_talk" in PLATFORM_HINTS
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 

--- a/tests/gateway/test_nextcloud_talk.py
+++ b/tests/gateway/test_nextcloud_talk.py
@@ -153,7 +153,7 @@ class TestBackendUrlValidation:
         assert _validate_backend_url("https://cloud.example.com") is True
 
     def test_accepts_http(self):
-        assert _validate_backend_url("http://192.168.1.1") is True
+        assert _validate_backend_url("http://nextcloud.local") is True
 
     def test_rejects_ftp(self):
         assert _validate_backend_url("ftp://evil.com") is False

--- a/tests/gateway/test_nextcloud_talk.py
+++ b/tests/gateway/test_nextcloud_talk.py
@@ -1,0 +1,385 @@
+"""Tests for the Nextcloud Talk gateway adapter."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.platforms.nextcloud_talk import (
+    NextcloudTalkAdapter,
+    _decode_talk_message,
+    _sanitize_chat_id,
+    _sign_payload,
+    _validate_backend_url,
+    check_nextcloud_talk_requirements,
+)
+
+
+def _make_config(**extra_overrides):
+    extra = {
+        "base_url": "https://cloud.example.com",
+        "host": "127.0.0.1",
+        "port": 0,
+        "path": "/nextcloud-talk",
+        "chat_type": "group",
+    }
+    extra.update(extra_overrides)
+    return PlatformConfig(enabled=True, token="super-secret-value", extra=extra)
+
+
+def _make_adapter(**extra_overrides):
+    return NextcloudTalkAdapter(_make_config(**extra_overrides))
+
+
+def _create_app(adapter: NextcloudTalkAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/nextcloud-talk", adapter._handle_webhook)
+    return app
+
+
+def _talk_headers(secret_value: str, body: bytes, *, backend: str = "https://cloud.example.com") -> dict[str, str]:
+    random_header = "a" * 64
+    signature = _sign_payload(secret_value, random_header, body)
+    return {
+        "X-Nextcloud-Talk-Signature": signature,
+        "X-Nextcloud-Talk-Random": random_header,
+        "X-Nextcloud-Talk-Backend": backend,
+        "Content-Type": "application/json",
+    }
+
+
+class TestNextcloudTalkConfig:
+    def test_enum_exists(self):
+        assert Platform.NEXTCLOUD_TALK.value == "nextcloud_talk"
+
+    def test_apply_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("NEXTCLOUD_TALK_SECRET", "shared-secret")
+        monkeypatch.setenv("NEXTCLOUD_TALK_BASE_URL", "https://cloud.example.com/")
+        monkeypatch.setenv("NEXTCLOUD_TALK_WEBHOOK_PORT", "9765")
+        monkeypatch.setenv("NEXTCLOUD_TALK_WEBHOOK_PATH", "/hooks/talk")
+        monkeypatch.setenv("NEXTCLOUD_TALK_HOME_CHANNEL", "room-token")
+
+        from gateway.config import _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.NEXTCLOUD_TALK in config.platforms
+        pconfig = config.platforms[Platform.NEXTCLOUD_TALK]
+        assert pconfig.enabled is True
+        assert pconfig.token == "shared-secret"
+        assert pconfig.extra["base_url"] == "https://cloud.example.com"
+        assert pconfig.extra["port"] == 9765
+        assert pconfig.extra["path"] == "/hooks/talk"
+        assert config.get_home_channel(Platform.NEXTCLOUD_TALK).chat_id == "room-token"
+
+    def test_connected_platforms_includes_nextcloud_talk(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.NEXTCLOUD_TALK: PlatformConfig(enabled=True, token="secret")
+            }
+        )
+        assert Platform.NEXTCLOUD_TALK in config.get_connected_platforms()
+
+
+class TestNextcloudTalkHelpers:
+    def test_decode_talk_message_extracts_inner_message(self):
+        raw = json.dumps({"message": "hello there", "parameters": {}})
+        assert _decode_talk_message(raw) == "hello there"
+
+    def test_decode_talk_message_none(self):
+        assert _decode_talk_message(None) == ""
+
+    def test_decode_talk_message_plain_string(self):
+        assert _decode_talk_message("just text") == "just text"
+
+    def test_decode_talk_message_non_string(self):
+        assert _decode_talk_message(42) == "42"
+
+    def test_decode_talk_message_dict_without_message_key(self):
+        raw = json.dumps({"parameters": {}, "other": "data"})
+        assert _decode_talk_message(raw) == raw
+
+    def test_signature_matches_reference_hmac(self):
+        body = b'{"message":"hello"}'
+        random_header = "b" * 64
+        expected = hmac.new(b"secret", digestmod=hashlib.sha256)
+        expected.update(random_header.encode("utf-8"))
+        expected.update(body)
+        assert _sign_payload("secret", random_header, body) == expected.hexdigest()
+
+
+class TestChatIdSanitization:
+    def test_valid_token_lowercase(self):
+        assert _sanitize_chat_id("abc123def") == "abc123def"
+
+    def test_valid_token_with_hyphen(self):
+        assert _sanitize_chat_id("room-token") == "room-token"
+
+    def test_valid_token_with_underscore(self):
+        assert _sanitize_chat_id("room_token") == "room_token"
+
+    def test_valid_token_mixed_case(self):
+        assert _sanitize_chat_id("AbCdEf") == "AbCdEf"
+
+    def test_rejects_path_traversal(self):
+        assert _sanitize_chat_id("../../../etc/passwd") is None
+
+    def test_rejects_slashes(self):
+        assert _sanitize_chat_id("room/token") is None
+
+    def test_rejects_special_characters(self):
+        assert _sanitize_chat_id("room;DROP TABLE") is None
+
+    def test_rejects_url_query_chars(self):
+        assert _sanitize_chat_id("room?param=1") is None
+
+    def test_rejects_empty(self):
+        assert _sanitize_chat_id("") is None
+
+    def test_rejects_too_long(self):
+        assert _sanitize_chat_id("a" * 65) is None
+
+
+class TestBackendUrlValidation:
+    def test_accepts_https(self):
+        assert _validate_backend_url("https://cloud.example.com") is True
+
+    def test_accepts_http(self):
+        assert _validate_backend_url("http://192.168.1.1") is True
+
+    def test_rejects_ftp(self):
+        assert _validate_backend_url("ftp://evil.com") is False
+
+    def test_rejects_javascript(self):
+        assert _validate_backend_url("javascript:alert(1)") is False
+
+    def test_rejects_empty(self):
+        assert _validate_backend_url("") is False
+
+
+class TestNextcloudTalkWebhook:
+    @pytest.mark.asyncio
+    async def test_accepts_valid_signed_message(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+
+        payload = {
+            "type": "Create",
+            "actor": {"type": "Person", "id": "users/alice", "name": "Alice"},
+            "object": {
+                "type": "Note",
+                "id": "1567",
+                "name": "message",
+                "content": json.dumps({"message": "hello hermes", "parameters": {}}),
+                "mediaType": "text/markdown",
+                "inReplyTo": {
+                    "actor": {"type": "Person", "id": "users/bob", "name": "Bob"},
+                    "object": {
+                        "type": "Note",
+                        "id": "1444",
+                        "content": json.dumps({"message": "parent text", "parameters": {}}),
+                    },
+                },
+            },
+            "target": {"type": "Collection", "id": "room-token", "name": "General"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        headers = _talk_headers("super-secret-value", body)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=headers)
+            assert resp.status == 202
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert isinstance(event, MessageEvent)
+        assert event.text == "hello hermes"
+        assert event.source.platform == Platform.NEXTCLOUD_TALK
+        assert event.source.chat_id == "room-token"
+        assert event.source.user_id == "users/alice"
+        assert event.reply_to_message_id == "1444"
+        assert event.reply_to_text == "Bob: parent text"
+        assert adapter._chat_backends["room-token"] == "https://cloud.example.com"
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_signature(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        body = json.dumps({"type": "Create", "target": {"id": "room-token"}}).encode("utf-8")
+        headers = {
+            "X-Nextcloud-Talk-Signature": "deadbeef",
+            "X-Nextcloud-Talk-Random": "a" * 64,
+            "X-Nextcloud-Talk-Backend": "https://cloud.example.com",
+            "Content-Type": "application/json",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=headers)
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_ignores_bot_messages(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        payload = {
+            "type": "Create",
+            "actor": {"type": "Application", "id": "bots/bot-123", "name": "Hermes"},
+            "object": {"id": "1", "content": json.dumps({"message": "self", "parameters": {}})},
+            "target": {"id": "room-token", "name": "General"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=_talk_headers("super-secret-value", body))
+            assert resp.status == 202
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_content_type(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        body = b"not json"
+        headers = {
+            "Content-Type": "text/plain",
+            "X-Nextcloud-Talk-Signature": "abc",
+            "X-Nextcloud-Talk-Random": "a" * 64,
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=headers)
+            assert resp.status == 415
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_body(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        # Send a body larger than the 1MB limit via Content-Length header
+        headers = {
+            "Content-Type": "application/json",
+            "Content-Length": str(2 * 1024 * 1024),
+            "X-Nextcloud-Talk-Signature": "abc",
+            "X-Nextcloud-Talk-Random": "a" * 64,
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=b"{}", headers=headers)
+            assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_chat_id(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        payload = {
+            "type": "Create",
+            "actor": {"type": "Person", "id": "users/alice", "name": "Alice"},
+            "object": {"id": "1", "content": json.dumps({"message": "test", "parameters": {}})},
+            "target": {"id": "../../../admin", "name": "Evil"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        headers = _talk_headers("super-secret-value", body)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=headers)
+            assert resp.status == 400
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_https_backend(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        payload = {
+            "type": "Create",
+            "actor": {"type": "Person", "id": "users/alice", "name": "Alice"},
+            "object": {"id": "1", "content": json.dumps({"message": "test", "parameters": {}})},
+            "target": {"id": "abcd1234", "name": "Room"},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        headers = _talk_headers("super-secret-value", body, backend="ftp://evil.com")
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/nextcloud-talk", data=body, headers=headers)
+            assert resp.status == 202
+
+        # Message should be processed but the invalid backend should NOT be cached
+        assert "abcd1234" not in adapter._chat_backends
+
+
+class TestNextcloudTalkSend:
+    @pytest.mark.asyncio
+    async def test_send_uses_backend_mapping_and_signs_payload(self):
+        adapter = _make_adapter(base_url="")
+        adapter._chat_backends["roomtoken"] = "https://cloud.example.com"
+
+        response = MagicMock()
+        response.status = 201
+        response.text = AsyncMock(return_value='{"ocs":{"meta":{"status":"ok"}}}')
+        context = AsyncMock()
+        context.__aenter__.return_value = response
+        context.__aexit__.return_value = False
+
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        session.close = AsyncMock()
+        session.post.return_value = context
+
+        with patch("gateway.platforms.nextcloud_talk.ClientSession", return_value=session):
+            result = await adapter.send("roomtoken", "hello back", reply_to="1567")
+
+        assert isinstance(result, SendResult)
+        assert result.success is True
+        session.post.assert_called_once()
+        args, kwargs = session.post.call_args
+        assert args[0] == "https://cloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/roomtoken/message"
+        assert kwargs["headers"]["OCS-APIRequest"] == "true"
+        assert kwargs["headers"]["X-Nextcloud-Talk-Bot-Random"]
+        body = kwargs["data"]
+        payload = json.loads(body.decode("utf-8"))
+        assert payload["message"] == "hello back"
+        assert payload["replyTo"] == 1567
+
+    @pytest.mark.asyncio
+    async def test_send_requires_backend(self):
+        adapter = _make_adapter(base_url="")
+        result = await adapter.send("roomtoken", "hello")
+        assert result.success is False
+        assert "backend URL is unknown" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_rejects_invalid_chat_id(self):
+        adapter = _make_adapter()
+        result = await adapter.send("../../../etc/passwd", "hello")
+        assert result.success is False
+        assert "Invalid Talk conversation token" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_rejects_invalid_backend_scheme(self):
+        adapter = _make_adapter(base_url="ftp://evil.com")
+        result = await adapter.send("roomtoken", "hello")
+        assert result.success is False
+        assert "Invalid backend URL scheme" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_empty_content_is_noop(self):
+        adapter = _make_adapter()
+        result = await adapter.send("roomtoken", "")
+        assert result.success is True
+
+
+class TestNextcloudTalkRequirements:
+    def test_requirements_flag_matches_import(self):
+        assert check_nextcloud_talk_requirements() is True

--- a/tests/gateway/test_nextcloud_talk.py
+++ b/tests/gateway/test_nextcloud_talk.py
@@ -155,6 +155,9 @@ class TestBackendUrlValidation:
     def test_accepts_http(self):
         assert _validate_backend_url("http://nextcloud.local") is True
 
+    def test_accepts_path_under_host(self):
+        assert _validate_backend_url("https://cloud.example.com/nextcloud") is True
+
     def test_rejects_ftp(self):
         assert _validate_backend_url("ftp://evil.com") is False
 
@@ -163,6 +166,9 @@ class TestBackendUrlValidation:
 
     def test_rejects_empty(self):
         assert _validate_backend_url("") is False
+
+    def test_rejects_missing_host(self):
+        assert _validate_backend_url("https:///missing-host") is False
 
 
 class TestNextcloudTalkWebhook:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -12,6 +12,7 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _parse_target_ref,
     _send_discord,
+    _send_nextcloud_talk,
     _send_telegram,
     _send_to_platform,
     send_message_tool,
@@ -617,6 +618,47 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+
+class TestSendNextcloudTalkDirect:
+    def test_rejects_invalid_backend_url(self):
+        result = asyncio.run(
+            _send_nextcloud_talk(
+                "secret",
+                {"base_url": "https:///missing-host"},
+                "room-token",
+                "hello",
+            )
+        )
+
+        assert "error" in result
+        assert "Invalid Nextcloud Talk backend URL" in result["error"]
+
+    def test_sends_with_normalized_backend_url(self):
+        mock_resp = MagicMock()
+        mock_resp.status = 201
+        mock_resp.text = AsyncMock(return_value='{"ocs":{"meta":{"status":"ok"}}}')
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_nextcloud_talk(
+                    "secret",
+                    {"base_url": "https://cloud.example.com/"},
+                    "room-token",
+                    "hello",
+                )
+            )
+
+        assert result["success"] is True
+        call_url = mock_session.post.call_args.args[0]
+        assert call_url == "https://cloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/room-token/message"
 
 
 class TestSendTelegramHtmlDetection:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -853,14 +853,21 @@ async def _send_nextcloud_talk(token, extra, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
-        from gateway.platforms.nextcloud_talk import _sign_payload, _sanitize_chat_id
+        from gateway.platforms.nextcloud_talk import (
+            _normalize_base_url,
+            _sanitize_chat_id,
+            _sign_payload,
+            _validate_backend_url,
+        )
 
         secret_value = token or os.getenv("NEXTCLOUD_TALK_SECRET", "")
-        base_url = (extra.get("base_url") or os.getenv("NEXTCLOUD_TALK_BASE_URL", "")).strip().rstrip("/")
+        base_url = _normalize_base_url(extra.get("base_url") or os.getenv("NEXTCLOUD_TALK_BASE_URL", ""))
         if not secret_value:
             return {"error": "Nextcloud Talk not configured (NEXTCLOUD_TALK_SECRET required)"}
         if not base_url:
             return {"error": "Nextcloud Talk not configured (NEXTCLOUD_TALK_BASE_URL required for direct sends)"}
+        if not _validate_backend_url(base_url):
+            return _error(f"Invalid Nextcloud Talk backend URL: {base_url!r}")
 
         safe_chat_id = _sanitize_chat_id(str(chat_id))
         if not safe_chat_id:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import ssl
 import time
 
@@ -68,7 +69,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'nextcloud_talk:conversation-token'"
             },
             "message": {
                 "type": "string",
@@ -154,6 +155,7 @@ def _handle_send(args):
         "bluebubbles": Platform.BLUEBUBBLES,
         "qqbot": Platform.QQBOT,
         "matrix": Platform.MATRIX,
+        "nextcloud_talk": Platform.NEXTCLOUD_TALK,
         "mattermost": Platform.MATTERMOST,
         "homeassistant": Platform.HOMEASSISTANT,
         "dingtalk": Platform.DINGTALK,
@@ -417,6 +419,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_mattermost(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.MATRIX:
             result = await _send_matrix(pconfig.token, pconfig.extra, chat_id, chunk)
+        elif platform == Platform.NEXTCLOUD_TALK:
+            result = await _send_nextcloud_talk(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.HOMEASSISTANT:
             result = await _send_homeassistant(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
@@ -840,6 +844,49 @@ async def _send_matrix(token, extra, chat_id, message):
         return {"success": True, "platform": "matrix", "chat_id": chat_id, "message_id": data.get("event_id")}
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
+
+
+async def _send_nextcloud_talk(token, extra, chat_id, message):
+    """Send via the Nextcloud Talk bot API."""
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    try:
+        from gateway.platforms.nextcloud_talk import _sign_payload, _sanitize_chat_id
+
+        secret_value = token or os.getenv("NEXTCLOUD_TALK_SECRET", "")
+        base_url = (extra.get("base_url") or os.getenv("NEXTCLOUD_TALK_BASE_URL", "")).strip().rstrip("/")
+        if not secret_value:
+            return {"error": "Nextcloud Talk not configured (NEXTCLOUD_TALK_SECRET required)"}
+        if not base_url:
+            return {"error": "Nextcloud Talk not configured (NEXTCLOUD_TALK_BASE_URL required for direct sends)"}
+
+        safe_chat_id = _sanitize_chat_id(str(chat_id))
+        if not safe_chat_id:
+            return _error(f"Invalid Talk conversation token: {chat_id!r}")
+
+        payload = {"message": message}
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        random_header = secrets.token_hex(32)
+        # Talk Bot API signs: HMAC(secret, random + message_text), NOT random + json_body
+        signature = _sign_payload(secret_value, random_header, message.encode("utf-8"))
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "OCS-APIRequest": "true",
+            "X-Nextcloud-Talk-Bot-Random": random_header,
+            "X-Nextcloud-Talk-Bot-Signature": signature,
+        }
+        url = f"{base_url}/ocs/v2.php/apps/spreed/api/v1/bot/{safe_chat_id}/message"
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            async with session.post(url, data=body, headers=headers) as resp:
+                resp_text = await resp.text()
+                if resp.status not in (200, 201):
+                    return _error(f"Nextcloud Talk API error ({resp.status}): {resp_text}")
+        return {"success": True, "platform": "nextcloud_talk", "chat_id": safe_chat_id}
+    except Exception as e:
+        return _error(f"Nextcloud Talk send failed: {e}")
 
 
 async def _send_homeassistant(token, extra, chat_id, message):

--- a/toolsets.py
+++ b/toolsets.py
@@ -341,6 +341,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-nextcloud-talk": {
+        "description": "Nextcloud Talk bot toolset - self-hosted messaging via Talk bots (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-dingtalk": {
         "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
         "tools": _HERMES_CORE_TOOLS,
@@ -392,7 +398,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-nextcloud-talk", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds **Nextcloud Talk** as a first-class gateway platform. Hermes becomes a self-hosted Nextcloud Talk bot using the official [Talk Bot API](https://nextcloud-talk.readthedocs.io/en/latest/bots/), registered via `occ talk:bot:install` with HMAC-signed webhooks in both directions. For users who run Nextcloud, this makes their agent reachable from the Talk clients on desktop, web, and mobile without a third-party messaging service.

The implementation follows the same adapter pattern as Matrix, Slack, and the recently-added BlueBubbles (#6437), with a single bot shared secret as the only required credential and no new Python dependencies.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**New files**
- `gateway/platforms/nextcloud_talk.py` — `NextcloudTalkAdapter` with webhook receiver, signed send, reply threading, backend auto-discovery, bounded LRU caches, sliding-window rate limiter.
- `tests/gateway/test_nextcloud_talk.py` — 37 tests covering signing, path-traversal rejection, oversized body, wrong Content-Type, slow-loris timeout, invalid backend scheme, empty content, bot self-filter, LRU eviction, and helper edge cases.

**Gateway integration**
- `gateway/config.py` — `Platform.NEXTCLOUD_TALK` enum, connected-platform detection, env var token map, `_apply_env_overrides()` for `NEXTCLOUD_TALK_{SECRET,BASE_URL,WEBHOOK_*,CHAT_TYPE,HOME_CHANNEL,ALLOWED_USERS}`.
- `gateway/run.py` — adapter factory, startup allowlist warning, per-platform auth maps.
- `cron/scheduler.py`, `tools/send_message_tool.py` — delivery target routing and `_send_nextcloud_talk()` helper (reuses `_sign_payload`, `_sanitize_chat_id` from the adapter to avoid signing-logic duplication).

**CLI + setup**
- `hermes_cli/config.py` — registers `NEXTCLOUD_TALK_*` env vars in `_EXTRA_ENV_KEYS` and `OPTIONAL_ENV_VARS` so `hermes setup env` prompts for them.
- `hermes_cli/gateway.py` — setup wizard entry with `occ talk:bot:install` instructions.
- `hermes_cli/platforms.py`, `hermes_cli/status.py` — platform registry + status display.
- `toolsets.py` — `hermes-nextcloud-talk` toolset, included in `hermes-gateway`.
- `agent/prompt_builder.py` — platform hint for the agent (text-only, no MEDIA: paths).

## Implementation notes

### Webhook verification

Incoming webhooks are verified with HMAC-SHA256 over `random_header + raw_body`, using `hmac.compare_digest` for timing-safe comparison. On top of signature verification, the handler enforces:

- 1 MB body size cap (Content-Length pre-check + post-read validation)
- 10 s \`asyncio.wait_for\` read timeout (slow-loris defence)
- \`application/json\` Content-Type guard
- Per-IP sliding-window rate limiter (120 req / 60 s) with stale-key pruning
- Regex allowlist sanitisation for Talk conversation tokens (path-traversal prevention)
- Bot self-message filter (\`actor.type == Application\` or \`bots/*\` actor ID)

### Outbound signing

Per the Talk Bot API spec, outbound replies sign **the message text**, not the JSON body:

\`\`\`
X-Nextcloud-Talk-Bot-Signature: HMAC-SHA256(secret, random + message_text)
\`\`\`

Both the adapter's \`send()\` and the standalone \`_send_nextcloud_talk()\` helper import \`_sign_payload\` from a single source so the signing rule has exactly one implementation.

### Allowlists

\`NEXTCLOUD_TALK_ALLOWED_USERS\` follows the same comma-separated pattern as every other platform and is wired into \`GatewayRunner._is_user_authorized\` via \`platform_env_map\` and \`platform_allow_all_map\`. The startup warning that lists unconfigured allowlists also includes \`NEXTCLOUD_TALK_ALLOWED_USERS\` and \`NEXTCLOUD_TALK_ALLOW_ALL_USERS\`.

### Direct-send support

\`tools/send_message_tool.py\` routes \`nextcloud_talk:<token>\` targets through \`_send_nextcloud_talk()\`, which validates the backend URL scheme and chat token before signing. \`cron/scheduler.py\` delivery map is updated so scheduled jobs can target \`nextcloud_talk\` the same way as any other platform.

### Multi-server support

Talk conversation tokens identify rooms within a single Nextcloud instance, but a single Hermes bot secret can be installed on multiple Nextcloud servers. The adapter caches \`X-Nextcloud-Talk-Backend\` from each inbound webhook per conversation (LRU, 1024 entries) so outbound replies go back to the originating server without per-server configuration.

### Attachments

Out of scope for this PR. The Talk Bot API only exposes a text \`message\` endpoint to bots; sending files would require a separate Nextcloud user credential to call the Files API and the Files Sharing API, which breaks the single-secret, multi-server design. The platform hint tells the agent not to use \`MEDIA:\` paths for Nextcloud Talk. Can be revisited as a follow-up if the Talk Bot API adds file support.

## How to Test

1. Expose Hermes on a reachable HTTPS URL that your Nextcloud can call.
2. Choose a long shared secret (40+ chars) and set \`NEXTCLOUD_TALK_SECRET\` and \`NEXTCLOUD_TALK_BASE_URL\` in \`~/.hermes/.env\`.
3. Register the bot on the Nextcloud server:
   \`\`\`
   ./occ talk:bot:install -f webhook -f response <name> <secret> https://<your-hermes-host>:8645/nextcloud-talk
   \`\`\`
4. Add the bot to a Talk conversation and send it a message.
5. Verify the bot replies, logs under \`[nextcloud_talk]\`, and respects \`NEXTCLOUD_TALK_ALLOWED_USERS\`.
6. Run focused tests:
   \`\`\`
   pytest tests/gateway/test_nextcloud_talk.py tests/agent/test_prompt_builder.py tests/test_toolsets.py -v
   \`\`\`

## Test coverage

37 tests in \`tests/gateway/test_nextcloud_talk.py\` cover:

- **Signing** — reference HMAC match, round-trip between inbound verification and outbound signing.
- **Webhook security** — valid signed accept, invalid signature reject, bot self-filter, wrong Content-Type (415), oversized body (413), invalid chat token (400), non-HTTPS backend (ignored in cache).
- **Input validation** — path-traversal \`../\` rejected, slashes rejected, URL query chars rejected, empty/too-long rejected, alphanumeric + hyphen + underscore accepted.
- **Send path** — valid send with backend resolution and correct signing, missing backend error, invalid chat token rejected, invalid backend scheme rejected, empty content noop.
- **Helpers** — \`_decode_talk_message\` for None, plain string, non-string, dict without message key.

Focused CI-equivalent run against this branch vs. \`origin/main\`:

| Metric | origin/main baseline | this branch | Delta |
|---|---|---|---|
| Passed | 10,955 | 10,996 | **+41** |
| Failed | 58 | 54 | −4 (flake noise) |
| Errors | 95 | 95 | 0 |

No new regressions. The error/failure counts are pre-existing in files this PR does not touch.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs — no duplicates
- [x] PR contains only NC-Talk changes — no unrelated commits
- [x] \`pytest tests/ -q\` shows no regressions vs \`origin/main\` baseline
- [x] New tests added: 37 tests for the adapter + 1 assertion for the prompt builder hint
- [x] Tested on: macOS 15 (Darwin), Python 3.12, live-tested end-to-end against a real Nextcloud 29 instance

### Documentation & Housekeeping

- [x] Env var reference in adapter module docstring
- [x] CLI setup wizard instructions (\`hermes_cli/gateway.py\`) include the \`occ talk:bot:install\` command
- [x] Cross-platform — no Unix-only patterns (stdlib + aiohttp only)
- [x] Tool descriptions — \`send_message_tool.py\` target description updated