### PR TITLE
Fix: add missing os import in web_server.py

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12,6 +12,7 @@ Usage:
 import asyncio
 import json
 import logging
+import os
 import secrets
 import sys
 import threading


### PR DESCRIPTION
Fixes NameError on the /web keys page (Provider Logins OAuth).

Root cause: _anthropic_oauth_status() calls os.getenv() but the os module was never imported in web_server.py.

Fix: Add import os to the imports at the top of the file.

Affected endpoint: GET /api/providers/oauth