### PR TITLE
fix: stabilize cli config and gateway update flows

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -134,6 +134,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek-ai/DeepSeek-V3.2": 65536,
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
+    "MiniMaxAI/MiniMax-M2.5": 1048576,
     "minimaxai/minimax-m2.5": 1048576,
     "XiaomiMiMo/MiMo-V2-Flash": 32768,
     "mimo-v2-pro": 1048576,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -390,6 +390,25 @@ def _sanitize_telegram_name(raw: str) -> str:
     return name.strip("_")
 
 
+def _clamp_name(name: str, used: set[str]) -> str | None:
+    """Return a unique <=32-char command name or ``None`` if no slot is free."""
+    if len(name) > _CMD_NAME_LIMIT:
+        candidate = name[:_CMD_NAME_LIMIT]
+        if candidate in used:
+            prefix = name[:_CMD_NAME_LIMIT - 1]
+            for digit in range(10):
+                candidate = f"{prefix}{digit}"
+                if candidate not in used:
+                    break
+            else:
+                return None
+        name = candidate
+    if name in used:
+        return None
+    used.add(name)
+    return name
+
+
 def _clamp_command_names(
     entries: list[tuple[str, str]],
     reserved: set[str],
@@ -405,22 +424,25 @@ def _clamp_command_names(
     used: set[str] = set(reserved)
     result: list[tuple[str, str]] = []
     for name, desc in entries:
-        if len(name) > _CMD_NAME_LIMIT:
-            candidate = name[:_CMD_NAME_LIMIT]
-            if candidate in used:
-                prefix = name[:_CMD_NAME_LIMIT - 1]
-                for digit in range(10):
-                    candidate = f"{prefix}{digit}"
-                    if candidate not in used:
-                        break
-                else:
-                    # All 10 digit slots exhausted — skip entry
-                    continue
-            name = candidate
-        if name in used:
+        clamped = _clamp_name(name, used)
+        if clamped is None:
             continue
-        used.add(name)
-        result.append((name, desc))
+        result.append((clamped, desc))
+    return result
+
+
+def _clamp_command_triples(
+    entries: list[tuple[str, str, str]],
+    reserved: set[str],
+) -> list[tuple[str, str, str]]:
+    """Clamp ``(name, desc, cmd_key)`` entries while preserving cmd_key mapping."""
+    used: set[str] = set(reserved)
+    result: list[tuple[str, str, str]] = []
+    for name, desc, cmd_key in entries:
+        clamped = _clamp_name(name, used)
+        if clamped is None:
+            continue
+        result.append((clamped, desc, cmd_key))
     return result
 
 
@@ -528,17 +550,12 @@ def _collect_gateway_skill_entries(
     except Exception:
         pass
 
-    # Clamp names; _clamp_command_names works on (name, desc) pairs so we
-    # need to zip/unzip.
-    skill_pairs = [(n, d) for n, d, _ in skill_triples]
-    key_by_pair = {(n, d): k for n, d, k in skill_triples}
-    skill_pairs = _clamp_command_names(skill_pairs, reserved_names)
+    skill_triples = _clamp_command_triples(skill_triples, reserved_names)
 
     # Skills fill remaining slots — only tier that gets trimmed
     remaining = max(0, max_slots - len(all_entries))
-    hidden_count = max(0, len(skill_pairs) - remaining)
-    for n, d in skill_pairs[:remaining]:
-        all_entries.append((n, d, key_by_pair.get((n, d), "")))
+    hidden_count = max(0, len(skill_triples) - remaining)
+    all_entries.extend(skill_triples[:remaining])
 
     return all_entries[:max_slots], hidden_count
 
@@ -576,8 +593,12 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
         desc_limit=40,
         sanitize_name=_sanitize_telegram_name,
     )
+    valid_entries = [(n, d, k) for n, d, k in entries if len(n) <= 32]
+    invalid_hidden = len(entries) - len(valid_entries)
+    hidden_count += invalid_hidden
+
     # Drop the cmd_key — Telegram only needs (name, desc) pairs.
-    all_commands.extend((n, d) for n, d, _k in entries)
+    all_commands.extend((n, d) for n, d, _k in valid_entries)
     return all_commands[:max_commands], hidden_count
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -5,14 +5,36 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+
+def _parse_env_file(path: Path, *, encoding: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding=encoding).splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("\"'")
+        if key:
+            values[key] = value
+    return values
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    """Load env vars from *path* even when ``PYTHON_DOTENV_DISABLED=1`` is set.
+
+    ``load_dotenv()`` respects ``PYTHON_DOTENV_DISABLED`` and becomes a no-op.
+    Hermes uses ``.env`` files as explicit user configuration, so this helper
+    parses the file directly and applies precedence itself.
+    """
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        values = _parse_env_file(path, encoding="utf-8")
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        values = _parse_env_file(path, encoding="latin-1")
+
+    for key, value in values.items():
+        if override or key not in os.environ:
+            os.environ[key] = value
 
 
 def load_hermes_dotenv(

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1310,6 +1310,11 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     if config is None:
         config = load_config()
     enabled_platforms = _get_enabled_platforms()
+    if first_install:
+        # Fresh-install flow is intentionally CLI-only. Messaging platforms may
+        # already have tokens in the environment on a developer machine, but the
+        # setup wizard should not fan out into Telegram/Discord/Slack prompts.
+        enabled_platforms = ["cli"]
 
     print()
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -632,6 +632,7 @@ class TestHasAnyProviderConfigured:
         hermes_home.mkdir()
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         # Clear all provider env vars so earlier checks don't short-circuit
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
                      "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"):
@@ -718,6 +719,7 @@ class TestHasAnyProviderConfigured:
         }))
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
                      "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -989,3 +989,64 @@ class TestDiscordSkillCommands:
             assert len(name) <= _CMD_NAME_LIMIT, (
                 f"Name '{name}' is {len(name)} chars (limit {_CMD_NAME_LIMIT})"
             )
+
+    def test_long_names_keep_cmd_key_after_clamping(self, tmp_path, monkeypatch):
+        """Clamped Discord names must still keep the original cmd_key."""
+        from unittest.mock import patch
+
+        fake_skills_dir = str(tmp_path / "skills")
+        long_name = "a" * 50
+        fake_cmds = {
+            f"/{long_name}": {
+                "name": long_name,
+                "description": "Long name skill",
+                "skill_md_path": f"{fake_skills_dir}/{long_name}/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/{long_name}",
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "skills").mkdir(exist_ok=True)
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            entries, _ = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        assert len(entries) == 1
+        assert entries[0][2] == f"/{long_name}"
+
+    def test_colliding_long_names_keep_distinct_cmd_keys(self, tmp_path, monkeypatch):
+        """Collision suffixing should preserve each original cmd_key."""
+        from unittest.mock import patch
+
+        fake_skills_dir = str(tmp_path / "skills")
+        long_a = "a" * 40 + "x"
+        long_b = "a" * 40 + "y"
+        fake_cmds = {
+            f"/{long_a}": {
+                "name": long_a,
+                "description": "Long collision skill A",
+                "skill_md_path": f"{fake_skills_dir}/{long_a}/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/{long_a}",
+            },
+            f"/{long_b}": {
+                "name": long_b,
+                "description": "Long collision skill B",
+                "skill_md_path": f"{fake_skills_dir}/{long_b}/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/{long_b}",
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "skills").mkdir(exist_ok=True)
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            entries, _ = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        returned = {cmd_key for _name, _desc, cmd_key in entries}
+        assert returned == {f"/{long_a}", f"/{long_b}"}

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -39,7 +39,10 @@ def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
     user_env = home / ".env"
     project_env = tmp_path / ".env"
     user_env.write_text("OPENAI_BASE_URL=https://user.example/v1\n", encoding="utf-8")
-    project_env.write_text("OPENAI_BASE_URL=https://project.example/v1\nOPENAI_API_KEY=project-key\n", encoding="utf-8")
+    project_env.write_text(
+        "OPENAI_BASE_URL=https://project.example/v1\nOPENAI_API_KEY=project-key\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.setenv("OPENAI_BASE_URL", "https://old.example/v1")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -368,6 +368,9 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(
             gateway_cli, "is_macos", lambda: False,
         )
+        monkeypatch.setattr(
+            gateway_cli, "is_linux", lambda: True,
+        )
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",


### PR DESCRIPTION
## Summary
- preserve Discord/Telegram skill command mappings after 32-char clamp and add regression tests
- make Hermes .env loading override stale shell env even when `PYTHON_DOTENV_DISABLED=1`
- keep first-install tools flow CLI-only and fix gateway/systemd + provider-config regression coverage
- add missing Hugging Face model metadata entry and harden related tests against ambient Copilot auth

## Verification
- `source venv/bin/activate && python -m pytest tests/hermes_cli/ -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py tests/cli/test_cli_init.py tests/test_model_tools.py -q`
