### PR TITLE
feat(gateway): Add gateway startup auto-resume from recent session history

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -257,6 +257,10 @@ class GatewayConfig:
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
+    # Startup recovery
+    auto_resume_last_session: bool = False
+    auto_resume_message_limit: int = 40
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -353,6 +357,8 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "auto_resume_last_session": self.auto_resume_last_session,
+            "auto_resume_message_limit": self.auto_resume_message_limit,
         }
     
     @classmethod
@@ -399,6 +405,11 @@ class GatewayConfig:
             data.get("unauthorized_dm_behavior"),
             "pair",
         )
+        auto_resume_message_limit = data.get("auto_resume_message_limit", 40)
+        try:
+            auto_resume_message_limit = int(auto_resume_message_limit)
+        except (TypeError, ValueError):
+            auto_resume_message_limit = 40
 
         return cls(
             platforms=platforms,
@@ -414,6 +425,11 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            auto_resume_last_session=_coerce_bool(
+                data.get("auto_resume_last_session"),
+                False,
+            ),
+            auto_resume_message_limit=max(1, min(auto_resume_message_limit, 100)),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -505,6 +521,13 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            gateway_cfg = yaml_cfg.get("gateway")
+            if isinstance(gateway_cfg, dict):
+                if "auto_resume_last_session" in gateway_cfg:
+                    gw_data["auto_resume_last_session"] = gateway_cfg["auto_resume_last_session"]
+                if "auto_resume_message_limit" in gateway_cfg:
+                    gw_data["auto_resume_message_limit"] = gateway_cfg["auto_resume_message_limit"]
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.
@@ -690,6 +713,13 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
             policy.idle_minutes,
         )
         policy.idle_minutes = 1440
+
+    if config.auto_resume_message_limit <= 0:
+        logger.warning(
+            "Invalid auto_resume_message_limit=%s (must be positive). Using default 40.",
+            config.auto_resume_message_limit,
+        )
+        config.auto_resume_message_limit = 40
 
     # Warn about empty bot tokens — platforms that loaded an empty string
     # won't connect and the cause can be confusing without a log line.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -245,6 +245,7 @@ from gateway.config import (
 )
 from gateway.session import (
     SessionStore,
+    SessionEntry,
     SessionSource,
     SessionContext,
     build_session_context,
@@ -530,6 +531,9 @@ class GatewayRunner:
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    _startup_resume_messages: List[Dict[str, Any]] = []
+    _startup_resume_source_session_id: Optional[str] = None
+    _startup_resume_consumed: bool = False
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -567,6 +571,9 @@ class GatewayRunner:
         self._restart_detached = False
         self._restart_via_service = False
         self._stop_task: Optional[asyncio.Task] = None
+        self._startup_resume_messages = []
+        self._startup_resume_source_session_id = None
+        self._startup_resume_consumed = False
         
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
@@ -618,6 +625,7 @@ class GatewayRunner:
             self._session_db = SessionDB()
         except Exception as e:
             logger.debug("SQLite session store not available: %s", e)
+        self._startup_resume_messages = self._load_startup_resume_messages()
         
         # DM pairing store for code-based user authorization
         from gateway.pairing import PairingStore
@@ -637,6 +645,76 @@ class GatewayRunner:
 
 
     # -- Setup skill availability ----------------------------------------
+
+    def _load_startup_resume_messages(self) -> List[Dict[str, Any]]:
+        """Load one startup recovery seed from the most recent gateway session."""
+        if not self._session_db or not getattr(self.config, "auto_resume_last_session", False):
+            return []
+
+        exclude_sources = ["cli", "local", "cron", "api_server", "webhook", "acp"]
+        limit = max(
+            1,
+            min(int(getattr(self.config, "auto_resume_message_limit", 40) or 40), 100),
+        )
+        try:
+            candidate = self._session_db.get_latest_resume_candidate(
+                exclude_sources=exclude_sources,
+            )
+            if not candidate:
+                return []
+            messages = self._session_db.get_recent_conversation_tail(
+                candidate["id"],
+                limit=limit,
+            )
+            if not messages:
+                return []
+            self._startup_resume_source_session_id = candidate["id"]
+            logger.info(
+                "Loaded %d startup resume message(s) from session %s (%s)",
+                len(messages),
+                candidate["id"],
+                candidate.get("source", "unknown"),
+            )
+            return messages
+        except Exception as e:
+            logger.debug("Startup session recovery preload failed: %s", e)
+            return []
+
+    def _maybe_seed_startup_resume_history(
+        self,
+        session_entry: SessionEntry,
+        history: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Seed a brand-new empty session with one recovered transcript tail."""
+        if history:
+            return history
+        if self._startup_resume_consumed or not self._startup_resume_messages:
+            return history
+        if getattr(session_entry, "was_auto_reset", False):
+            return history
+        if session_entry.created_at != session_entry.updated_at:
+            return history
+
+        seed = [msg.copy() for msg in self._startup_resume_messages]
+        try:
+            self.session_store.rewrite_transcript(session_entry.session_id, seed)
+        except Exception as e:
+            logger.warning(
+                "Startup session recovery failed for %s: %s",
+                session_entry.session_id,
+                e,
+            )
+            return history
+
+        self._startup_resume_consumed = True
+        self._startup_resume_messages = []
+        logger.info(
+            "Seeded new session %s with %d recovered message(s) from %s",
+            session_entry.session_id,
+            len(seed),
+            self._startup_resume_source_session_id or "unknown session",
+        )
+        return seed
 
     def _has_setup_skill(self) -> bool:
         """Check if the hermes-agent-setup skill is installed."""
@@ -3238,6 +3316,8 @@ class GatewayRunner:
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
+        if _is_new_session:
+            history = self._maybe_seed_startup_resume_history(session_entry, history)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -342,6 +342,10 @@ DEFAULT_CONFIG = {
         # agent hasn't died during long tasks.  0 = disable notifications.
         "gateway_notify_interval": 600,
     },
+    "gateway": {
+        "auto_resume_last_session": False,
+        "auto_resume_message_limit": 40,
+    },
     
     "terminal": {
         "backend": "local",
@@ -700,7 +704,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -784,6 +784,95 @@ class SessionDB:
 
         return sessions
 
+    def get_latest_resume_candidate(
+        self,
+        *,
+        exclude_sources: List[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the most recent root session suitable for startup recovery."""
+        where_clauses = [
+            "s.parent_session_id IS NULL",
+            """EXISTS (
+                SELECT 1
+                FROM messages m
+                WHERE m.session_id = s.id
+                  AND m.role IN ('user', 'assistant')
+                  AND m.content IS NOT NULL
+                  AND TRIM(m.content) != ''
+            )""",
+        ]
+        params: list[Any] = []
+
+        if exclude_sources:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
+
+        query = f"""
+            SELECT s.*
+            FROM sessions s
+            WHERE {' AND '.join(where_clauses)}
+            ORDER BY COALESCE(
+                (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),
+                s.started_at
+            ) DESC
+            LIMIT 1
+        """
+        with self._lock:
+            row = self._conn.execute(query, params).fetchone()
+        return dict(row) if row else None
+
+    def get_recent_conversation_tail(
+        self,
+        session_id: str,
+        limit: int = 40,
+    ) -> List[Dict[str, Any]]:
+        """Return the last N user/assistant text messages in chronological order."""
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 40
+        limit = max(1, min(limit, 100))
+
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT role, content, reasoning, reasoning_details, codex_reasoning_items
+                FROM messages
+                WHERE session_id = ?
+                  AND role IN ('user', 'assistant')
+                  AND content IS NOT NULL
+                  AND TRIM(content) != ''
+                ORDER BY timestamp DESC, id DESC
+                LIMIT ?
+                """,
+                (session_id, limit),
+            ).fetchall()
+
+        messages: List[Dict[str, Any]] = []
+        for row in reversed(rows):
+            msg: Dict[str, Any] = {"role": row["role"], "content": row["content"]}
+            if row["role"] == "assistant":
+                if row["reasoning"]:
+                    msg["reasoning"] = row["reasoning"]
+                if row["reasoning_details"]:
+                    try:
+                        msg["reasoning_details"] = json.loads(row["reasoning_details"])
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            "Failed to deserialize reasoning_details in get_recent_conversation_tail"
+                        )
+                if row["codex_reasoning_items"]:
+                    try:
+                        msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            "Failed to deserialize codex_reasoning_items in get_recent_conversation_tail"
+                        )
+            messages.append(msg)
+
+        return messages
+
     # =========================================================================
     # Message storage
     # =========================================================================

--- a/tests/gateway/test_startup_resume.py
+++ b/tests/gateway/test_startup_resume.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionEntry
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        auto_resume_last_session=True,
+        auto_resume_message_limit=40,
+    )
+    runner.session_store = MagicMock()
+    runner._startup_resume_messages = [
+        {"role": "user", "content": "earlier question"},
+        {"role": "assistant", "content": "earlier answer"},
+    ]
+    runner._startup_resume_source_session_id = "old-session"
+    runner._startup_resume_consumed = False
+    return runner
+
+
+def test_seed_startup_resume_history_rewrites_empty_new_session():
+    runner = _make_runner()
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key="key-1",
+        session_id="new-session",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+    history = runner._maybe_seed_startup_resume_history(entry, [])
+
+    assert history == [
+        {"role": "user", "content": "earlier question"},
+        {"role": "assistant", "content": "earlier answer"},
+    ]
+    runner.session_store.rewrite_transcript.assert_called_once_with(
+        "new-session",
+        history,
+    )
+    assert runner._startup_resume_consumed is True
+    assert runner._startup_resume_messages == []
+
+
+def test_seed_startup_resume_history_skips_nonempty_history():
+    runner = _make_runner()
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key="key-1",
+        session_id="new-session",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    existing = [{"role": "user", "content": "already there"}]
+
+    history = runner._maybe_seed_startup_resume_history(entry, existing)
+
+    assert history == existing
+    runner.session_store.rewrite_transcript.assert_not_called()
+    assert runner._startup_resume_consumed is False
+
+
+def test_seed_startup_resume_history_skips_auto_reset_session():
+    runner = _make_runner()
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key="key-1",
+        session_id="new-session",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        was_auto_reset=True,
+    )
+
+    history = runner._maybe_seed_startup_resume_history(entry, [])
+
+    assert history == []
+    runner.session_store.rewrite_transcript.assert_not_called()
+    assert runner._startup_resume_consumed is False

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -263,6 +263,70 @@ class TestMessageStorage:
         assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
 
 
+class TestStartupResumeHelpers:
+    def test_get_latest_resume_candidate_excludes_sources_and_children(self, db):
+        db.create_session(session_id="cli_recent", source="cli")
+        db.append_message("cli_recent", role="user", content="local session")
+
+        db.create_session(session_id="cron_recent", source="cron")
+        db.append_message("cron_recent", role="user", content="cron session")
+
+        db.create_session(session_id="root_old", source="telegram")
+        db.append_message("root_old", role="user", content="old root")
+        time.sleep(0.01)
+
+        db.create_session(session_id="root_new", source="discord")
+        db.append_message("root_new", role="user", content="new root")
+        time.sleep(0.01)
+
+        db.create_session(
+            session_id="child_newer",
+            source="discord",
+            parent_session_id="root_new",
+        )
+        db.append_message("child_newer", role="user", content="child should be ignored")
+
+        latest = db.get_latest_resume_candidate(
+            exclude_sources=["cli", "cron"],
+        )
+
+        assert latest is not None
+        assert latest["id"] == "root_new"
+
+    def test_get_recent_conversation_tail_returns_last_text_turns_in_order(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message("s1", role="user", content="u1")
+        db.append_message("s1", role="assistant", content="a1", reasoning="r1")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="",
+            tool_calls=[{"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}}],
+        )
+        db.append_message("s1", role="tool", content="tool output", tool_call_id="call_1")
+        db.append_message("s1", role="user", content="u2")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="a2",
+            reasoning_details=[{"type": "reasoning.summary", "summary": "two"}],
+        )
+        db.append_message("s1", role="user", content="u3")
+
+        tail = db.get_recent_conversation_tail("s1", limit=4)
+
+        assert tail == [
+            {"role": "assistant", "content": "a1", "reasoning": "r1"},
+            {"role": "user", "content": "u2"},
+            {
+                "role": "assistant",
+                "content": "a2",
+                "reasoning_details": [{"type": "reasoning.summary", "summary": "two"}],
+            },
+            {"role": "user", "content": "u3"},
+        ]
+
+
 # =========================================================================
 # FTS5 search
 # =========================================================================


### PR DESCRIPTION
…story

## What does this PR do?

This PR adds startup session recovery for the messaging gateway so Hermes can resume recent conversational context after a restart.

Today, if the gateway restarts and a new session is created, the agent starts fresh even though recent context still exists in `state.db`. This breaks continuity and forces the user to restate context. This PR fixes that by loading the most recent resumable non-infrastructure session from `state.db`, extracting the last N user/assistant turns, and seeding that history into the first truly new empty gateway session after startup.

I implemented this by rewriting the new session transcript once at startup recovery time instead of using `prefill_messages`. That approach fits the existing `load_transcript() -> conversation_history` flow and avoids re-injecting the same history on every API call.

## Related Issue

Fixes #9286 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added startup recovery helpers in `hermes_state.py` to:
  - find the latest resumable root session
  - load the last N user/assistant text messages in chronological order
- Added gateway config support in `gateway/config.py` for:
  - `gateway.auto_resume_last_session`
  - `gateway.auto_resume_message_limit`
- Added default config entries in `hermes_cli/config.py`
- Added one-time startup recovery seeding in `gateway/run.py`
- Added tests in `tests/gateway/test_startup_resume.py`
- Extended DB coverage in `tests/test_hermes_state.py`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Add this to `~/.hermes/config.yaml`:
```yaml
gateway:
  auto_resume_last_session: true
  auto_resume_message_limit: 40
```

2. Start the gateway, send a few messages on a messaging platform, then stop and restart the gateway.

3. Send a message that creates a new session and confirm Hermes still has the recent prior context.

4. Confirm recovery only happens once and does not keep injecting old history into later fresh sessions.

5. Run targeted tests:
```bash
source venv/bin/activate
python -m pytest tests/test_hermes_state.py tests/gateway/test_startup_resume.py tests/gateway/test_status_command.py -q
```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

