### PR TITLE
feat: platform-specific SOUL files and per-app persona mapping

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -882,8 +882,13 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
-def load_soul_md() -> Optional[str]:
+def load_soul_md(platform: Optional[str] = None) -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
+
+    If *platform* is provided (e.g. ``"telegram"``, ``"wecom"``), first try
+    loading ``SOUL_{platform}.md``.  This lets users define distinct agent
+    identities per messaging platform while keeping ``SOUL.md`` as the
+    universal fallback.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
     returns content, ``build_context_files_prompt`` should be called with
@@ -895,7 +900,22 @@ def load_soul_md() -> Optional[str]:
     except Exception as e:
         logger.debug("Could not ensure HERMES_HOME before loading SOUL.md: %s", e)
 
-    soul_path = get_hermes_home() / "SOUL.md"
+    home = get_hermes_home()
+
+    # 1. Platform-specific soul file (e.g. SOUL_telegram.md)
+    if platform:
+        platform_soul_path = home / f"SOUL_{platform}.md"
+        if platform_soul_path.exists():
+            try:
+                content = platform_soul_path.read_text(encoding="utf-8").strip()
+                if content:
+                    content = _scan_context_content(content, f"SOUL_{platform}.md")
+                    return _truncate_content(content, f"SOUL_{platform}.md")
+            except Exception as e:
+                logger.debug("Could not read %s: %s", platform_soul_path, e)
+
+    # 2. Default SOUL.md fallback
+    soul_path = home / "SOUL.md"
     if not soul_path.exists():
         return None
     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1104,11 +1104,16 @@ class GatewayRunner:
             return []
 
     @staticmethod
-    def _load_ephemeral_system_prompt() -> str:
+    def _load_ephemeral_system_prompt(self, platform_key: str = "", bot_name: str = None) -> str:
         """Load ephemeral system prompt from config or env var.
         
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        Priority:
+        1. HERMES_EPHEMERAL_SYSTEM_PROMPT env var
+        2. platform_system_prompts[platform_key][bot_name] (if dict)
+        3. platform_system_prompts[platform_key]['default'] (if dict)
+        4. platform_system_prompts[platform_key] (if string)
+        5. Per-app persona via app_personas[bot_name] → personalities lookup
+        6. agent.system_prompt
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
@@ -1119,7 +1124,34 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                return (cfg.get("agent", {}).get("system_prompt", "") or "").strip()
+                agent_cfg = cfg.get("agent", {})
+                
+                # Check platform-specific prompts
+                plat_prompts = agent_cfg.get("platform_system_prompts", {})
+                if platform_key in plat_prompts:
+                    val = plat_prompts[platform_key]
+                    if isinstance(val, dict):
+                        if bot_name and bot_name in val:
+                            return (val[bot_name] or "").strip()
+                        if "default" in val:
+                            return (val["default"] or "").strip()
+                    elif isinstance(val, str):
+                        return val.strip()
+                
+                # Per-app persona mapping (e.g. WeCom bots → different personalities)
+                if bot_name:
+                    app_personas = agent_cfg.get("app_personas", {})
+                    if bot_name in app_personas:
+                        persona_name = app_personas[bot_name]
+                        if persona_name:
+                            personalities = agent_cfg.get("personalities", {})
+                            if persona_name in personalities:
+                                return (personalities[persona_name] or "").strip()
+                            # Treat as raw prompt if not a known personality name
+                            return persona_name.strip()
+                
+                # Fallback to global system prompt
+                return (agent_cfg.get("system_prompt", "") or "").strip()
         except Exception:
             pass
         return ""
@@ -7744,10 +7776,15 @@ class GatewayRunner:
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
-            # Combine platform context with user-configured ephemeral system prompt
+            # Resolve persona: per-platform/per-bot ephemeral prompt overrides global one
+            ephemeral_prompt = self._load_ephemeral_system_prompt(
+                platform_key=platform_key,
+                bot_name=source.app_name,
+            )
+            
             combined_ephemeral = context_prompt or ""
-            if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+            if ephemeral_prompt:
+                combined_ephemeral = (combined_ephemeral + "\n\n" + ephemeral_prompt).strip()
 
             # Re-read .env and config for fresh credentials (gateway is long-lived,
             # keys may change without restart).

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -82,6 +82,7 @@ class SessionSource:
     chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # Signal UUID (alternative to phone number)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
+    app_name: Optional[str] = None  # Per-platform app identifier (e.g. WeCom self-built app name)
     
     @property
     def description(self) -> str:
@@ -444,6 +445,8 @@ def build_session_key(
     DM rules:
       - DMs include chat_id when present, so each private conversation is isolated.
       - thread_id further differentiates threaded DMs within the same DM chat.
+      - app_name further differentiates multiple apps on the same platform
+        (e.g. WeCom self-built apps sharing a corp_id).
       - Without chat_id, thread_id is used as a best-effort fallback.
       - Without thread_id or chat_id, DMs share a single session.
 
@@ -461,14 +464,19 @@ def build_session_key(
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
     platform = source.platform.value
+    _app = source.app_name
     if source.chat_type == "dm":
         if source.chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{source.chat_id}"
+                base = f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
+                return f"{base}:{_app}" if _app else base
+            base = f"agent:main:{platform}:dm:{source.chat_id}"
+            return f"{base}:{_app}" if _app else base
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            base = f"agent:main:{platform}:dm:{source.thread_id}"
+            return f"{base}:{_app}" if _app else base
+        base = f"agent:main:{platform}:dm"
+        return f"{base}:{_app}" if _app else base
 
     participant_id = source.user_id_alt or source.user_id
     key_parts = ["agent:main", platform, source.chat_type]
@@ -487,6 +495,9 @@ def build_session_key(
 
     if isolate_user and participant_id:
         key_parts.append(str(participant_id))
+
+    if source.app_name:
+        key_parts.append(source.app_name)
 
     return ":".join(key_parts)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -663,6 +663,11 @@ DEFAULT_CONFIG = {
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
     "personalities": {},
 
+    # Per-app persona mapping — assign different personalities to platform apps
+    # Key: app name (e.g. WeCom self-built app name), Value: personality name or raw prompt
+    # Example: {"查询机器人": "tianmei", "金价": "technical", "MR": "concise"}
+    "app_personas": {},
+
     # Pre-exec security scanning via tirith
     "security": {
         "redact_secrets": True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3138,7 +3138,7 @@ class AIAgent:
         # Try SOUL.md as primary identity (unless context files are skipped)
         _soul_loaded = False
         if not self.skip_context_files:
-            _soul_content = load_soul_md()
+            _soul_content = load_soul_md(platform=self.platform)
             if _soul_content:
                 prompt_parts = [_soul_content]
                 _soul_loaded = True


### PR DESCRIPTION
## Summary

Two complementary mechanisms for customizing agent identity per context:

### 1. Platform-level persona via `SOUL_{platform}.md` files

Users can create `SOUL_telegram.md`, `SOUL_wecom.md`, etc. in `~/.hermes/` to define distinct agent identities per messaging platform. The `load_soul_md()` function tries the platform-specific file first, then falls back to `SOUL.md`.

**Example:**
```bash
# Telegram gets a playful assistant persona
echo '# Playful Assistant\n\nYou are a witty and fun AI assistant...' > ~/.hermes/SOUL_telegram.md

# WeCom gets a professional persona  
echo '# Professional Assistant\n\nYou are a formal, business-oriented AI...' > ~/.hermes/SOUL_wecom.md

# All other platforms use the default SOUL.md
```

### 2. Per-app persona mapping via `app_personas`

For platforms with multiple bots/apps (e.g. WeCom self-built apps), the new `app_personas` config key maps app names to personality names:

```yaml
agent:
  personalities:
    tianmei: 'You are a sweet junior assistant...'
    technical: 'You are a technical expert...'
  app_personas:
    查询机器人: tianmei
    金价助手: technical
```

### 3. Per-app session isolation

The `app_name` field in `SessionSource` ensures different apps on the same platform get separate conversation histories.

## Changes

| File | Change |
|------|--------|
| `agent/prompt_builder.py` | `load_soul_md(platform)` tries `SOUL_{platform}.md` first |
| `run_agent.py` | Pass `self.platform` to `load_soul_md()` |
| `gateway/run.py` | Enhanced `_load_ephemeral_system_prompt` with per-app persona resolution |
| `gateway/session.py` | `app_name` in `SessionSource` and `build_session_key` |
| `hermes_cli/config.py` | `app_personas` default config |

## Design notes

- **Non-breaking:** All changes are additive. Existing setups without `SOUL_{platform}.md` or `app_personas` work exactly as before.
- **SOUL file priority:** `SOUL_{platform}.md > SOUL.md > config.yaml system_prompt`
- **Real-time:** SOUL files are read from disk on each session build, no restart needed.
- **app_personas priority:** Resolved after `platform_system_prompts` but before global `system_prompt`.