### PR TITLE
chore: fix spelling in display config and voice mode

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# Overrideable display settings and their global defaults
+# Overridable display settings and their global defaults
 # ---------------------------------------------------------------------------
 # These are the settings that can be configured per-platform.
 # Other display settings (compact, personality, skin, etc.) are CLI-only
@@ -97,8 +97,8 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
-# Canonical set of per-platform overrideable keys (for validation).
-OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+# Canonical set of per-platform overridable keys (for validation).
+OVERRIDABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
 def resolve_display_setting(

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -812,7 +812,7 @@ def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str
 
 
 # ============================================================================
-# Audio playback (interruptable)
+# Audio playback (interruptible)
 # ============================================================================
 
 # Global reference to the active playback process so it can be interrupted.
@@ -882,7 +882,7 @@ def play_audio_file(file_path: str) -> bool:
         except Exception as e:
             logger.debug("sounddevice playback failed: %s", e)
 
-    # Fall back to system audio players (using Popen for interruptability)
+    # Fall back to system audio players (using Popen for interruptibility)
     system = platform.system()
     players = []
 


### PR DESCRIPTION
## Summary
- rename the internal display-config constant to `OVERRIDABLE_KEYS`
- update nearby `overridable` spelling in comments
- fix `interruptible` spelling in voice mode comments

## Testing
- not run

Closes #9335
