### PR TITLE
fix(launchd): add ThrottleInterval for faster gateway restart after update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1299,7 +1299,15 @@ def generate_launchd_plist() -> str:
         <key>SuccessfulExit</key>
         <false/>
     </dict>
-    
+
+    <!-- Cap the restart delay so the gateway recovers quickly after
+         `hermes update` triggers a service restart (exit code {GATEWAY_SERVICE_RESTART_EXIT_CODE}).
+         Without this, launchd's default exponential back-off can delay
+         restarts by minutes when the process exits repeatedly in quick
+         succession (e.g. update → restart → brief crash → restart). -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -128,6 +128,25 @@ class TestLaunchdPlistReplace:
         assert replace_idx == run_idx + 1
 
 
+class TestLaunchdPlistThrottle:
+    """ThrottleInterval must be present so launchd restarts the gateway
+    quickly after ``hermes update`` triggers a service restart."""
+
+    def test_plist_contains_throttle_interval(self):
+        plist = gateway_cli.generate_launchd_plist()
+        assert "<key>ThrottleInterval</key>" in plist
+
+    def test_plist_throttle_interval_is_10_seconds(self):
+        plist = gateway_cli.generate_launchd_plist()
+        lines = [line.strip() for line in plist.splitlines()]
+        for i, line in enumerate(lines):
+            if line == "<key>ThrottleInterval</key>":
+                assert lines[i + 1] == "<integer>10</integer>"
+                break
+        else:
+            raise AssertionError("ThrottleInterval key not found in plist")
+
+
 class TestLaunchdPlistPath:
     def test_plist_contains_environment_variables(self):
         plist = gateway_cli.generate_launchd_plist()


### PR DESCRIPTION
## Summary

- Add `ThrottleInterval=10` to the generated launchd plist template in `generate_launchd_plist()`
- Add tests to verify the ThrottleInterval key and value are present in the generated plist

## Problem

When running `/update` from Telegram on macOS, `hermes update --gateway` triggers a gateway restart via `launchd_restart()`. The gateway exits with code 75 (`GATEWAY_SERVICE_RESTART_EXIT_CODE`), and launchd is expected to respawn it via `KeepAlive.SuccessfulExit=false`.

However, without `ThrottleInterval`, launchd uses its default exponential back-off for process restarts. If the gateway has restarted recently (e.g. during the update cycle), launchd delays the next restart by progressively longer intervals — observed delays of **1-2 hours** in practice, during which the bot is completely unresponsive.

The systemd unit already handles this correctly with `RestartSec=30` and `RestartForceExitStatus=75`, but the launchd plist was missing the equivalent setting.

## Fix

Add `<key>ThrottleInterval</key><integer>10</integer>` to the launchd plist template, capping the restart delay at 10 seconds. This matches the intent of the systemd `RestartSec=30` (slightly faster since launchd's mechanism is simpler).

## Test plan

- [x] Existing tests pass (`pytest tests/hermes_cli/test_update_gateway_restart.py` — 36 passed)
- [x] New tests verify ThrottleInterval presence and value
- [x] Verified on macOS (Darwin 24.6.0, launchd) — gateway restarts within 10s after `/update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)