### PR TITLE
feat(cli): add word wrapping for streamed prose output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1637,6 +1637,7 @@ class HermesCLI:
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
         self._stream_started = False  # True once first delta arrives
         self._stream_box_opened = False  # True once the response box header is printed
+        self._stream_in_code_fence = False  # Preserve fenced code blocks verbatim while streaming
         self._reasoning_preview_buf = ""  # Coalesce tiny reasoning chunks for [thinking] output
         self._pending_edit_snapshots = {}
         
@@ -2577,7 +2578,37 @@ class HermesCLI:
         _tc = getattr(self, "_stream_text_ansi", "")
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
-            _cprint(f"{_tc}{line}{_RST}" if _tc else line)
+            for rendered in self._format_stream_line(line):
+                _cprint(f"{_tc}{rendered}{_RST}" if _tc else rendered)
+
+    def _format_stream_line(self, line: str) -> list[str]:
+        """Wrap plain prose lines while preserving fenced and preformatted text."""
+        if line == "":
+            return [""]
+
+        in_fence = getattr(self, "_stream_in_code_fence", False)
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            self._stream_in_code_fence = not in_fence
+            return [line]
+        if in_fence or line.startswith((" ", "\t")):
+            return [line]
+
+        try:
+            term_width = shutil.get_terminal_size().columns
+        except Exception:
+            term_width = 80
+
+        wrap_width = max(20, term_width - 2)
+        wrapped = textwrap.wrap(
+            line,
+            width=wrap_width,
+            break_long_words=False,
+            break_on_hyphens=False,
+            replace_whitespace=False,
+            drop_whitespace=False,
+        )
+        return wrapped or [line]
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -2594,7 +2625,8 @@ class HermesCLI:
 
         if self._stream_buf:
             _tc = getattr(self, "_stream_text_ansi", "")
-            _cprint(f"{_tc}{self._stream_buf}{_RST}" if _tc else self._stream_buf)
+            for rendered in self._format_stream_line(self._stream_buf):
+                _cprint(f"{_tc}{rendered}{_RST}" if _tc else rendered)
             self._stream_buf = ""
 
         # Close the response box
@@ -2608,6 +2640,7 @@ class HermesCLI:
         self._stream_started = False
         self._stream_box_opened = False
         self._stream_text_ansi = ""
+        self._stream_in_code_fence = False
         self._stream_prefilt = ""
         self._in_reasoning_block = False
         self._stream_last_was_newline = True

--- a/tests/cli/test_stream_output_wrap.py
+++ b/tests/cli/test_stream_output_wrap.py
@@ -1,0 +1,97 @@
+"""Tests for word wrapping in streamed CLI output."""
+
+import os
+import re
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _make_cli_stub():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.verbose = False
+    cli._stream_buf = ""
+    cli._stream_started = False
+    cli._stream_box_opened = False
+    cli._stream_prefilt = ""
+    cli._stream_text_ansi = ""
+    cli._stream_in_code_fence = False
+    cli._in_reasoning_block = False
+    cli._reasoning_box_opened = False
+    cli._reasoning_buf = ""
+    cli._reasoning_preview_buf = ""
+    cli._deferred_content = ""
+    cli._close_reasoning_box = lambda: None
+    return cli
+
+
+def _capture_output(mock_print):
+    lines = []
+    for call in mock_print.call_args_list:
+        text = call.args[0]
+        lines.append(ANSI_RE.sub("", text))
+    return lines
+
+
+def _patch_skin():
+    class _Skin:
+        def get_branding(self, key, default):
+            return default
+
+        def get_color(self, key, default):
+            return default
+
+    return patch("hermes_cli.skin_engine.get_active_skin", return_value=_Skin())
+
+
+class TestStreamOutputWrap:
+    def test_wraps_complete_prose_lines(self):
+        cli = _make_cli_stub()
+        prose = "This streamed prose sentence should wrap cleanly across multiple lines."
+
+        with patch("cli._cprint") as mock_print, patch("shutil.get_terminal_size", return_value=os.terminal_size((36, 24))), _patch_skin():
+            cli._emit_stream_text(prose + "\n")
+            cli._flush_stream()
+
+        lines = _capture_output(mock_print)
+        body = lines[1:-1]
+        assert len(body) >= 2
+        assert " ".join(part.strip() for part in body).startswith("This streamed prose sentence")
+        assert all(len(part) <= 36 for part in body)
+
+    def test_wraps_partial_line_on_flush(self):
+        cli = _make_cli_stub()
+        prose = "Partial streamed prose should also wrap when the buffer is flushed."
+
+        with patch("cli._cprint") as mock_print, patch("shutil.get_terminal_size", return_value=os.terminal_size((34, 24))), _patch_skin():
+            cli._emit_stream_text(prose)
+            cli._flush_stream()
+
+        lines = _capture_output(mock_print)
+        body = lines[1:-1]
+        assert len(body) >= 2
+        assert " ".join(part.strip() for part in body).startswith("Partial streamed prose")
+        assert all(len(part) <= 34 for part in body)
+
+    def test_preserves_fenced_and_indented_lines(self):
+        cli = _make_cli_stub()
+        with patch("cli._cprint") as mock_print, patch("shutil.get_terminal_size", return_value=os.terminal_size((28, 24))), _patch_skin():
+            cli._emit_stream_text("```python\n")
+            cli._emit_stream_text("print('this line should stay intact even though it is long')\n")
+            cli._emit_stream_text("```\n")
+            cli._emit_stream_text("    indented preformatted content that should stay intact\n")
+            cli._flush_stream()
+
+        lines = _capture_output(mock_print)
+        body = lines[1:-1]
+        assert "```python" in body
+        assert "print('this line should stay intact even though it is long')" in body
+        assert "```" in body
+        assert "    indented preformatted content that should stay intact" in body
+        assert not any("stay intact even though" in part and part != "print('this line should stay intact even though it is long')" for part in body)


### PR DESCRIPTION
## What does this PR do?

Adds word-boundary wrapping for streamed prose in the interactive CLI so long assistant sentences no longer wrap mid-word at terminal column boundaries.

## Related Issue

Fixes #9245

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- wrap streamed prose lines in `cli.py` before printing so word boundaries are preserved
- preserve fenced code blocks and indented/preformatted lines verbatim during streaming
- add `tests/cli/test_stream_output_wrap.py` to cover complete-line wrapping, flush-time wrapping, and non-wrapping cases

## How to Test

1. `source /ssd1/jianglidang/workspace/myenv-hermes-9245/bin/activate`
2. `pytest tests/cli/test_stream_output_wrap.py tests/cli/test_stream_delta_think_tag.py -n0 -q`
3. Optionally run the stream harness below to compare before/after terminal output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<details><summary>Before/After</summary>

### Before

```text

╭─⚕ Hermes─────────────────────────╮
This streamed prose sentence should wrap cleanly across multiple lines.
╰──────────────────────────────────╯
```

### After

```text

╭─⚕ Hermes─────────────────────────╮
This streamed prose sentence 
should wrap cleanly across 
multiple lines.
╰──────────────────────────────────╯

...........                                                              [100%]
=============================== warnings summary ===============================
tests/cli/test_stream_output_wrap.py::TestStreamOutputWrap::test_wraps_complete_prose_lines
  /ssd1/jianglidang/workspace/hermes-agent-wt-9245-stream-wrap/tests/conftest.py:91: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop_policy().get_event_loop()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
11 passed, 1 warning in 1.46s
```

</details>
