### PR TITLE
fix(gateway): honor background_process_notifications=off for watch reinjection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11870,14 +11870,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # single consumer — so we leave them on the queue here.
             try:
                 from tools.process_registry import process_registry as _pr
-                _watch_events = _drain_gateway_watch_events(_pr.completion_queue)
-                for evt in _watch_events:
-                    synth_text = _format_gateway_process_notification(evt)
-                    if synth_text:
-                        try:
-                            await self._inject_watch_notification(synth_text, evt)
-                        except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                await self._drain_watch_notifications(_pr.completion_queue)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -15425,6 +15418,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
+
+    async def _drain_watch_notifications(self, completion_queue) -> None:
+        """Consume queued watch events and inject them when notifications are enabled."""
+        watch_events = _drain_gateway_watch_events(completion_queue)
+        if self._load_background_notifications_mode() == "off":
+            return
+
+        for evt in watch_events:
+            synth_text = _format_gateway_process_notification(evt)
+            if not synth_text:
+                continue
+            try:
+                await self._inject_watch_notification(synth_text, evt)
+            except Exception as exc:
+                logger.error("Watch notification injection error: %s", exc)
 
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
         """Inject a watch-pattern notification as a synthetic message event.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3658,21 +3658,7 @@ class GatewayRunner:
             # already handled by the per-process watcher task above, so we only
             # inject watch-type events here.
             try:
-                from tools.process_registry import process_registry as _pr
-                _watch_events = []
-                while not _pr.completion_queue.empty():
-                    evt = _pr.completion_queue.get_nowait()
-                    evt_type = evt.get("type", "completion")
-                    if evt_type in ("watch_match", "watch_disabled"):
-                        _watch_events.append(evt)
-                    # else: completion events are handled by the watcher task
-                for evt in _watch_events:
-                    synth_text = _format_gateway_process_notification(evt)
-                    if synth_text:
-                        try:
-                            await self._inject_watch_notification(synth_text, event)
-                        except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                await self._drain_watch_notifications(event)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -7171,6 +7157,32 @@ class GatewayRunner:
             await adapter.handle_message(synth_event)
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
+
+    async def _drain_watch_notifications(self, original_event, notify_mode: Optional[str] = None) -> None:
+        """Drain watch-related events and optionally reinject them into chat.
+
+        When notifications are disabled, we still empty the queue so watch
+        events do not accumulate, but we skip synthetic message reinjection.
+        """
+        if notify_mode is None:
+            notify_mode = self._load_background_notifications_mode()
+        try:
+            from tools.process_registry import process_registry as _pr
+            while not _pr.completion_queue.empty():
+                evt = _pr.completion_queue.get_nowait()
+                evt_type = evt.get("type", "completion")
+                if evt_type not in ("watch_match", "watch_disabled"):
+                    continue
+                if notify_mode == "off":
+                    continue
+                synth_text = _format_gateway_process_notification(evt)
+                if synth_text:
+                    try:
+                        await self._inject_watch_notification(synth_text, original_event)
+                    except Exception as e:
+                        logger.error("Watch notification injection error: %s", e)
+        except Exception as e:
+            logger.debug("Watch queue drain error: %s", e)
 
     async def _run_process_watcher(self, watcher: dict) -> None:
         """

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "lidangjiang@gmail.com": "Lidang-Jiang",  # PRs #9341/#9345 (gateway watch notification + progress edit recovery)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "135129512+ansel-f@users.noreply.github.com": "ansel-f",  # PR #62388 salvage (approval: allow exact verifier temp cleanup without broadening rm safety boundary)
     "robert@modern-minds.ai": "Hopfensaft",  # PR #31933 salvage (dashboard: align approvals.mode dropdown with canonical engine values)

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,6 +8,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+import queue
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -63,6 +64,17 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     if thread_id:
         d["thread_id"] = thread_id
     return d
+
+
+def _watch_event(session_id="proc_watch", thread_id="42"):
+    return {
+        "type": "watch_match",
+        "session_id": session_id,
+        "session_key": f"agent:main:telegram:dm:123:{thread_id}",
+        "pattern": "READY",
+        "command": "build",
+        "output": "READY\n",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +293,54 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "123"
     assert synth_event.source.user_name == "Emiliyan"
+
+
+@pytest.mark.asyncio
+async def test_post_turn_watch_drain_off_consumes_without_injecting(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path, "off")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    completion_queue = queue.Queue()
+    completion_queue.put(_watch_event("proc_one"))
+    completion_queue.put(_watch_event("proc_two"))
+    async_event = {"type": "async_delegation", "session_id": "delegate_one"}
+    completion_queue.put(async_event)
+
+    await runner._drain_watch_notifications(completion_queue)
+
+    adapter.handle_message.assert_not_awaited()
+    assert completion_queue.qsize() == 1
+    assert completion_queue.get_nowait() is async_event
+
+
+@pytest.mark.asyncio
+async def test_post_turn_watch_drain_all_injects_from_queued_event_origin(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:dm:123:42"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            thread_id="42",
+            user_id="proc_owner",
+            user_name="alice",
+        )
+    )
+    completion_queue = queue.Queue()
+    completion_queue.put(_watch_event())
+    async_event = {"type": "async_delegation", "session_id": "delegate_one"}
+    completion_queue.put(async_event)
+
+    await runner._drain_watch_notifications(completion_queue)
+
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.source.thread_id == "42"
+    assert synth_event.source.user_id == "proc_owner"
+    assert completion_queue.qsize() == 1
+    assert completion_queue.get_nowait() is async_event
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,6 +8,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+import queue
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -31,6 +32,15 @@ class _FakeRegistry:
         if self._sessions:
             return self._sessions.pop(0)
         return None
+
+
+class _FakeProcessRegistry:
+    """Minimal registry stub for watch notification drain tests."""
+
+    def __init__(self, events):
+        self.completion_queue = queue.Queue()
+        for evt in events:
+            self.completion_queue.put(evt)
 
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
@@ -60,6 +70,10 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     if thread_id:
         d["thread_id"] = thread_id
     return d
+
+
+def _watch_source():
+    return SimpleNamespace(platform=Platform.TELEGRAM, chat_id="123")
 
 
 # ---------------------------------------------------------------------------
@@ -243,3 +257,34 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode, should_inject", [("off", False), ("all", True)])
+async def test_drain_watch_notifications_respects_background_mode(monkeypatch, tmp_path, mode, should_inject):
+    import tools.process_registry as pr_module
+
+    runner = _build_runner(monkeypatch, tmp_path, mode)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.handle_message = AsyncMock()
+
+    events = [
+        {"type": "watch_match", "session_id": "proc_a", "pattern": "ERROR", "output": "ERROR: boom"},
+        {"type": "watch_disabled", "session_id": "proc_a", "message": "disabled"},
+        {"type": "completion", "session_id": "proc_a"},
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeProcessRegistry(events))
+
+    original_event = SimpleNamespace(source=_watch_source())
+
+    await runner._drain_watch_notifications(original_event, mode)
+
+    if should_inject:
+        assert adapter.handle_message.await_count == 2
+        first_message = adapter.handle_message.await_args_list[0].args[0]
+        assert first_message.internal is True
+        assert "Background process" in first_message.text
+    else:
+        assert adapter.handle_message.await_count == 0
+
+    assert pr_module.process_registry.completion_queue.empty()


### PR DESCRIPTION
## What does this PR do?

Makes `display.background_process_notifications: off` disable watch-pattern synthetic reinjection while still draining queued watch events. Non-`off` modes continue to inject notifications using the queued event's originating thread/user context, and `async_delegation` events remain available to their dedicated watcher.

## Related Issue

Fixes #9290

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- drain gateway watch events at the end of every agent turn, regardless of notification mode
- discard drained watch/process events without synthetic reinjection when the mode is `off`
- pass the queued `evt` to `_inject_watch_notification()` in other modes so delivery preserves the originating process context
- requeue `async_delegation` events for the dedicated async-delegation watcher
- add regressions for `off`, `all`, origin routing, queue draining, and delegation retention

## How to Test

```bash
python -m pytest -q \
  tests/gateway/test_background_process_notifications.py \
  tests/tools/test_watch_patterns.py \
  tests/scripts/test_release_acp_registry.py
ruff check .
python scripts/check-windows-footguns.py --all
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<details>
<summary>Before/After</summary>

### Before

On the pre-fix implementation, the complete queue-drain harness output was:

```text
manual_inject_handle_message_calls= 1
queue_drain_handle_message_calls= 2
queue_empty= True
```

Even with notifications set to `off`, queued watch events were synthetically reinjected.

### After

With this commit, the same complete harness output is:

```text
queue_drain_handle_message_calls= 0
queue_empty= True
```

Complete focused regression-suite output:

```text
.................................................................        [100%]
65 passed in 1.33s
```

</details>

## Additional Verification

- `scripts/run_tests.sh -j 16`: 40,267 tests passed. Fifteen unrelated failures and three process-exit timeouts remained; the recurring functional failures were reproduced on the unmodified `upstream/main` baseline, and the one branch-only file-state failure passed on an isolated rerun.
- `ruff check .`: passed (apart from the repository's pre-existing invalid-`noqa` warnings).
- `git diff --check`: passed.
- `python scripts/check-windows-footguns.py --all`: passed across 757 Python files.

