### PR TITLE
fix: build web UI during installation (web_dist missing from pip package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An AI agent with advanced tool-calling capabilities, featuring a flexible toolsets system for organizing and managing tools.",
   "private": true,
   "scripts": {
+    "build": "cd web && npm install && npm run build",
     "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'"
   },
   "repository": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1079,6 +1079,15 @@ install_node_deps() {
         npm install --silent 2>/dev/null || {
             log_warn "npm install failed (browser tools may not work)"
         }
+
+        # Build the web UI (web_dist/ is included in the pip package)
+        log_info "Building web UI..."
+        if ! npm run build 2>/dev/null; then
+            log_warn "Web UI build failed — CLI may lack the Web UI (not required for core functionality)"
+        else
+            log_success "Web UI built successfully"
+        fi
+
         log_success "Node.js dependencies installed"
 
         # Install Playwright browser + system dependencies.


### PR DESCRIPTION
## Problem

The install script runs `npm install` but never runs `npm run build`, so `web_dist/` is never created. The `pyproject.toml` declares `hermes_cli = ['web_dist/**/*']` as package data, but `web_dist` only exists after building the TypeScript web app.

Result: fresh installs are missing the Web UI even though the CLI says everything succeeded.

## Fix

1. **package.json**: Added a `build` script that enters the `web/` subdirectory, installs deps there, and runs the Vite build.
2. **scripts/install.sh**: Calls `npm run build` after `npm install` in `install_node_deps()`. Failure is a warning (not fatal) since the CLI works without the Web UI.

## Testing

Before the fix: `ls web_dist` → does not exist  
After the fix: `ls web_dist` → contains built assets (or warning if build fails)