### PR TITLE
fix(gateway): recover progress coalescing after stale edits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,7 +69,19 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_PROGRESS_EDIT_INTERVAL_SECONDS = 1.5
+_STALE_PROGRESS_EDIT_MARKERS = (
+    "message to edit not found",
+    "message_id_invalid",
+)
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+
+
+def _is_stale_progress_edit_error(error: Any) -> bool:
+    """Return whether an edit failed because its message anchor is gone."""
+    normalized = str(error or "").lower()
+    return any(marker in normalized for marker in _STALE_PROGRESS_EDIT_MARKERS)
+
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -17560,7 +17572,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             progress_msg_id = None   # ID of the current progress message to edit
             can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
-            _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+            _ROLL_NO_ROLL = "no_roll"
+            _ROLL_HANDLED = "handled"
+            _ROLL_NEEDS_FALLBACK = "needs_fallback"
 
             _progress_len_fn = (
                 adapter.message_len_fn
@@ -17642,26 +17656,103 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _track_progress_result(result)
                 return result
 
-            async def _roll_progress_overflow_if_needed() -> bool:
+            async def _send_progress_groups(groups: list[list]) -> None:
+                """Best-effort delivery of every pre-sized progress group."""
+                for group in groups:
+                    try:
+                        result = await _send_progress_text(_progress_text(group))
+                    except Exception as exc:
+                        logger.warning(
+                            "[%s] Failed to deliver progress fallback group: %s",
+                            adapter.name,
+                            exc,
+                        )
+                        continue
+                    if not result.success:
+                        logger.warning(
+                            "[%s] Failed to deliver progress fallback group: %s",
+                            adapter.name,
+                            getattr(result, "error", "unknown error"),
+                        )
+
+            async def _replace_stale_progress_anchor(error, full_text: str):
+                """Replace a deleted edit anchor and report the delivery outcome."""
+                nonlocal progress_msg_id, can_edit
+                if not _is_stale_progress_edit_error(error):
+                    return "not_stale"
+
+                # Never retry the known-dead anchor, including when replacement
+                # delivery itself raises or returns an unsuccessful result.
+                progress_msg_id = None
+                try:
+                    replacement = await _send_progress_text(full_text)
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Failed to replace stale progress anchor: %s",
+                        adapter.name,
+                        exc,
+                    )
+                    can_edit = False
+                    return "failed"
+
+                if replacement.success:
+                    if replacement.message_id:
+                        progress_msg_id = replacement.message_id
+                        can_edit = True
+                        return "editable"
+                    # The text landed, but the adapter provided no future edit
+                    # anchor. Stay send-only without duplicating this update.
+                    can_edit = False
+                    return "delivered"
+
+                can_edit = False
+                return "failed"
+
+            async def _roll_progress_overflow_if_needed() -> str:
                 """Start fresh editable progress bubbles before a bubble exceeds limit.
 
-                Returns True when it delivered/split the current buffer and the
-                caller should skip the normal send/edit path for this tick.
+                Return ``no_roll`` when the buffer fits, ``handled`` when all
+                overflow groups were delivered, or ``needs_fallback`` when the
+                old anchor failed and the caller must deliver the whole buffer.
                 """
                 nonlocal progress_msg_id, progress_lines, can_edit
                 if not progress_lines or not can_edit:
-                    return False
+                    return _ROLL_NO_ROLL
                 groups = _split_progress_groups(progress_lines)
                 if len(groups) <= 1:
-                    return False
+                    return _ROLL_NO_ROLL
 
                 first_text = _progress_text(groups[0])
                 if progress_msg_id is not None:
-                    result = await _edit_progress_message(progress_msg_id, first_text)
-                    if not result.success:
-                        can_edit = False
-                        # Fall back to the existing non-edit behavior below.
-                        return False
+                    try:
+                        result = await _edit_progress_message(progress_msg_id, first_text)
+                    except Exception as exc:
+                        recovery = await _replace_stale_progress_anchor(exc, first_text)
+                        if recovery == "failed":
+                            await _send_progress_groups(groups)
+                            progress_lines = groups[-1]
+                            return _ROLL_HANDLED
+                        if recovery == "not_stale":
+                            progress_msg_id = None
+                            can_edit = False
+                            return _ROLL_NEEDS_FALLBACK
+                        result = None
+                    if result is not None and not result.success:
+                        recovery = await _replace_stale_progress_anchor(
+                            getattr(result, "error", ""), first_text
+                        )
+                        if recovery == "failed":
+                            # The dead anchor and its first replacement both
+                            # failed. Retry every already-sized group here so
+                            # the normal path cannot collapse the fallback to
+                            # only the line that triggered rollover.
+                            await _send_progress_groups(groups)
+                            progress_lines = groups[-1]
+                            return _ROLL_HANDLED
+                        if recovery == "not_stale":
+                            progress_msg_id = None
+                            can_edit = False
+                            return _ROLL_NEEDS_FALLBACK
                 else:
                     result = await _send_progress_text(first_text)
                     if result.success and result.message_id:
@@ -17676,7 +17767,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # just its lines so subsequent edits update it instead of
                 # replaying the full historical transcript into new messages.
                 progress_lines = groups[-1]
-                return True
+                return _ROLL_HANDLED
+
+            async def _fallback_progress_lines(lines: list) -> None:
+                """Deliver a complete buffer in bounded send-only groups."""
+                nonlocal progress_msg_id, can_edit
+                progress_msg_id = None
+                can_edit = False
+                await _send_progress_groups(_split_progress_groups(lines))
+
+            async def _flush_editable_progress_buffer() -> None:
+                """Finalize pending editable progress, falling back on any failure."""
+                if not (can_edit and progress_lines and progress_msg_id):
+                    return
+
+                roll_outcome = await _roll_progress_overflow_if_needed()
+                if roll_outcome == _ROLL_NEEDS_FALLBACK:
+                    await _fallback_progress_lines(progress_lines)
+                    return
+                if roll_outcome == _ROLL_HANDLED and not can_edit:
+                    # Overflow recovery already delivered every group.
+                    return
+                if not can_edit or progress_msg_id is None:
+                    # A non-stale overflow edit failure disabled editing before
+                    # the final flush could run. Preserve the complete buffer.
+                    await _fallback_progress_lines(progress_lines)
+                    return
+
+                full_text = _progress_text(progress_lines)
+                try:
+                    result = await _edit_progress_message(progress_msg_id, full_text)
+                except Exception as exc:
+                    recovery = await _replace_stale_progress_anchor(exc, full_text)
+                    if recovery not in ("editable", "delivered"):
+                        await _fallback_progress_lines(progress_lines)
+                    return
+
+                if result.success:
+                    return
+                recovery = await _replace_stale_progress_anchor(
+                    getattr(result, "error", ""), full_text
+                )
+                if recovery not in ("editable", "delivered"):
+                    await _fallback_progress_lines(progress_lines)
 
             while True:
                 try:
@@ -17709,9 +17842,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Handle dedup messages: update last line with repeat counter
                     if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                         _, base_msg, count = raw
-                        if progress_lines:
-                            progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                        msg = progress_lines[-1] if progress_lines else base_msg
+                        dedup_msg = f"{base_msg} (×{count + 1})"
+                        if can_edit and progress_lines:
+                            progress_lines[-1] = dedup_msg
+                            msg = progress_lines[-1]
+                        else:
+                            await _send_progress_text(dedup_msg)
+                            _last_edit_ts = time.monotonic()
+                            continue
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
                         # the current tool-progress bubble so the next tool
@@ -17730,7 +17868,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         msg = raw
                         progress_lines.append(msg)
 
-                    if await _roll_progress_overflow_if_needed():
+                    roll_outcome = await _roll_progress_overflow_if_needed()
+                    if roll_outcome == _ROLL_NEEDS_FALLBACK:
+                        await _fallback_progress_lines(progress_lines)
+                        progress_lines = []
+                    if roll_outcome in (_ROLL_HANDLED, _ROLL_NEEDS_FALLBACK):
                         _last_edit_ts = time.monotonic()
                         await asyncio.sleep(0.3)
                         if _run_still_current():
@@ -17742,7 +17884,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # (grammY auto-retry pattern: proactively rate-limit
                     # instead of reacting to 429s.)
                     _now = time.monotonic()
-                    _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
+                    _remaining = _PROGRESS_EDIT_INTERVAL_SECONDS - (_now - _last_edit_ts)
                     if _remaining > 0:
                         # Wait out the throttle interval, then loop back to
                         # drain any additional queued messages before sending
@@ -17762,8 +17904,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # Transient network errors (ConnectError, timeouts)
                             # must not permanently disable progress-message
                             # editing — the next cycle can catch up.  Only
-                            # permanent failures (flood control, message not
-                            # found, permissions) should set can_edit = False.
+                            # A deleted/invalid anchor is replaced below;
+                            # other permanent failures disable editing.
                             if getattr(result, "retryable", False):
                                 logger.debug(
                                     "[%s] Transient edit failure — keeping can_edit=True",
@@ -17778,20 +17920,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     adapter.name,
                                 )
                                 _last_edit_ts = time.monotonic()
+                                _flood_result = await adapter.send(
+                                    chat_id=source.chat_id,
+                                    content=msg,
+                                    reply_to=_progress_reply_to,
+                                    metadata=_progress_metadata,
+                                )
+                                _track_progress_result(_flood_result)
+                            elif _is_stale_progress_edit_error(_err):
+                                # The editable bubble was deleted or otherwise
+                                # invalidated. Re-send the complete accumulated
+                                # progress so the replacement is self-contained,
+                                # then continue coalescing against its new ID.
+                                recovery = await _replace_stale_progress_anchor(
+                                    _err, full_text
+                                )
+                                if recovery == "failed":
+                                    await _send_progress_text(full_text)
                             else:
                                 can_edit = False
-                            _flood_result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=msg,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
-                            if (
-                                _cleanup_progress
-                                and getattr(_flood_result, "success", False)
-                                and getattr(_flood_result, "message_id", None)
-                            ):
-                                _cleanup_msg_ids.append(str(_flood_result.message_id))
+                                progress_msg_id = None
+                                await _send_progress_text(msg)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
@@ -17831,38 +17980,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             raw = progress_queue.get_nowait()
                             if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                                 _, base_msg, count = raw
-                                if progress_lines:
-                                    progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                                    await _roll_progress_overflow_if_needed()
+                                dedup_msg = f"{base_msg} (×{count + 1})"
+                                if can_edit and progress_lines:
+                                    progress_lines[-1] = dedup_msg
+                                    roll_outcome = await _roll_progress_overflow_if_needed()
+                                    if roll_outcome == _ROLL_NEEDS_FALLBACK:
+                                        await _fallback_progress_lines(progress_lines)
+                                        progress_lines = []
+                                    elif roll_outcome == _ROLL_HANDLED and not can_edit:
+                                        progress_lines = []
+                                else:
+                                    await _send_progress_text(dedup_msg)
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
                                 # one for any tool lines that arrived after.
-                                await _roll_progress_overflow_if_needed()
-                                if can_edit and progress_lines and progress_msg_id:
-                                    _pending_text = _progress_text(progress_lines)
-                                    try:
-                                        await _edit_progress_message(progress_msg_id, _pending_text)
-                                    except Exception:
-                                        pass
+                                await _flush_editable_progress_buffer()
                                 progress_msg_id = None
                                 progress_lines = []
                                 last_progress_msg[0] = None
                                 repeat_count[0] = 0
                             else:
+                                if not can_edit:
+                                    await _send_progress_text(str(raw))
+                                    continue
                                 progress_lines.append(raw)
-                                await _roll_progress_overflow_if_needed()
+                                roll_outcome = await _roll_progress_overflow_if_needed()
+                                if roll_outcome == _ROLL_NEEDS_FALLBACK:
+                                    await _fallback_progress_lines(progress_lines)
+                                    progress_lines = []
+                                elif roll_outcome == _ROLL_HANDLED and not can_edit:
+                                    progress_lines = []
                         except Exception:
                             break
-                    # Final edit with all remaining tools (only if editing works)
-                    if can_edit and progress_lines and progress_msg_id:
-                        await _roll_progress_overflow_if_needed()
-                    if can_edit and progress_lines and progress_msg_id:
-                        full_text = _progress_text(progress_lines)
-                        try:
-                            await _edit_progress_message(progress_msg_id, full_text)
-                        except Exception:
-                            pass
+                    # Final edit with all remaining tools. Any edit/replacement
+                    # failure falls back to bounded sends before this task exits.
+                    await _flush_editable_progress_buffer()
                     return
                 except Exception as e:
                     logger.error("Progress message error: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7574,6 +7574,22 @@ class GatewayRunner:
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
+            def _progress_edit_requires_send_only(error: str) -> bool:
+                err = (error or "").lower()
+                return any(
+                    pattern in err
+                    for pattern in (
+                        "flood",
+                        "retry after",
+                        "too many requests",
+                        "edit not supported",
+                        "editing not supported",
+                        "can't edit",
+                        "cannot edit",
+                        "edit_message not implemented",
+                    )
+                )
+
             while True:
                 try:
                     raw = progress_queue.get_nowait()
@@ -7611,16 +7627,36 @@ class GatewayRunner:
                         )
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
-                            if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — disable further edits,
-                                # switch to sending new messages only for
-                                # important updates.  Don't block 23s.
+                            if _progress_edit_requires_send_only(_err):
+                                # Platform-level or flood-control failure:
+                                # disable edits and fall back to fresh sends.
                                 logger.info(
-                                    "[%s] Progress edits disabled due to flood control",
+                                    "[%s] Progress edits disabled after edit failure: %s",
                                     adapter.name,
+                                    _err or "unknown error",
                                 )
-                            can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                                can_edit = False
+                                await adapter.send(
+                                    chat_id=source.chat_id,
+                                    content=msg,
+                                    metadata=_progress_metadata,
+                                )
+                            else:
+                                # Recoverable failure (for example, the old
+                                # progress message disappeared or changed
+                                # threads). Re-send the full accumulated body
+                                # as a new progress anchor and keep editing on.
+                                progress_msg_id = None
+                                resend = await adapter.send(
+                                    chat_id=source.chat_id,
+                                    content=full_text,
+                                    metadata=_progress_metadata,
+                                )
+                                if resend.success and resend.message_id:
+                                    progress_msg_id = resend.message_id
+                                    can_edit = True
+                                else:
+                                    can_edit = False
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -104,6 +104,10 @@ _USER_BOUNDARY_END_REASONS = (
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_STALE_PROGRESS_EDIT_MARKERS = (
+    "message to edit not found",
+    "message_id_invalid",
+)
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
@@ -150,6 +154,12 @@ _HYGIENE_COOLDOWN_LADDER_MULTIPLIERS = (1, 3, 9)
 # from "compaction silently switched off". 1h is well past the point where a
 # retry is cheap and still recovers within a session.
 _HYGIENE_COOLDOWN_MAX_SECONDS = 3600.0
+
+
+def _is_stale_progress_edit_error(error: Any) -> bool:
+    """Return whether a progress edit failed because its anchor is gone."""
+    normalized = str(error or "").lower()
+    return any(marker in normalized for marker in _STALE_PROGRESS_EDIT_MARKERS)
 
 
 def _hygiene_cooldown_for_failure(
@@ -4460,10 +4470,27 @@ class TurnRunner:
             groups: list[list] = []
             current: list = []
             for line in lines:
-                candidate = current + [line]
+                line_text = str(line)
+                if _progress_len_fn(line_text) > _PROGRESS_TEXT_LIMIT:
+                    if current:
+                        groups.append(current)
+                        current = []
+                    from gateway.platforms.helpers import split_text_fence_aware
+
+                    chunks = split_text_fence_aware(
+                        line_text,
+                        _PROGRESS_TEXT_LIMIT,
+                        len_fn=_progress_len_fn,
+                        prefer_paragraphs=False,
+                        balance_fences=True,
+                    )
+                    groups.extend([[chunk] for chunk in chunks])
+                    continue
+
+                candidate = current + [line_text]
                 if current and _progress_len_fn(_progress_text(candidate)) > _PROGRESS_TEXT_LIMIT:
                     groups.append(current)
-                    current = [line]
+                    current = [line_text]
                 else:
                     current = candidate
             if current:
@@ -4488,49 +4515,185 @@ class TurnRunner:
             _track_progress_result(result)
             return result
 
-        async def _roll_progress_overflow_if_needed() -> bool:
-            """Start fresh editable progress bubbles before a bubble exceeds limit.
+        async def _replace_stale_progress_anchor(error, full_text: str) -> str:
+            """Replace a deleted edit anchor and report its delivery state."""
+            nonlocal progress_msg_id, can_edit
+            if not _is_stale_progress_edit_error(error):
+                return "not_stale"
 
-                Returns True when it delivered/split the current buffer, or when
-                a transient edit failure left the buffer and message identity
-                intact for a later retry.  In either case the caller should skip
-                the normal send/edit path for this tick.
-                """
+            # Do not retry the known-dead ID, even when the replacement send
+            # itself fails. A later update may still be delivered send-only.
+            progress_msg_id = None
+            try:
+                replacement = await _send_progress_text(full_text)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Failed to replace stale progress anchor: %s",
+                    adapter.name,
+                    exc,
+                )
+                can_edit = False
+                return "failed"
+
+            if not replacement.success:
+                logger.warning(
+                    "[%s] Failed to replace stale progress anchor: %s",
+                    adapter.name,
+                    getattr(replacement, "error", "unknown error"),
+                )
+                can_edit = False
+                return "failed"
+            if not replacement.message_id:
+                # The update landed, but the adapter did not expose an ID for
+                # future edits. Switch to send-only without replaying it.
+                can_edit = False
+                return "delivered"
+
+            progress_msg_id = replacement.message_id
+            can_edit = True
+            return "editable"
+
+        async def _send_progress_groups(groups: list[list]) -> None:
+            """Best-effort delivery of pre-sized groups without retry loops."""
+            for group in groups:
+                try:
+                    result = await _send_progress_text(_progress_text(group))
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Failed to deliver progress fallback group: %s",
+                        adapter.name,
+                        exc,
+                    )
+                    continue
+                if result is not None and not result.success:
+                    logger.warning(
+                        "[%s] Failed to deliver progress fallback group: %s",
+                        adapter.name,
+                        getattr(result, "error", "unknown error"),
+                    )
+
+        async def _fallback_progress_lines(lines: list) -> None:
+            """Deliver a complete buffer in bounded send-only groups."""
+            nonlocal progress_msg_id, progress_lines, can_edit
+            progress_msg_id = None
+            can_edit = False
+            await _send_progress_groups(_split_progress_groups(lines))
+            progress_lines = []
+
+        async def _roll_progress_overflow_if_needed() -> str:
+            """Split an oversized buffer while preserving its newest anchor."""
             nonlocal progress_msg_id, progress_lines, can_edit
             if not progress_lines or not can_edit:
-                return False
+                return "no_roll"
             groups = _split_progress_groups(progress_lines)
             if len(groups) <= 1:
-                return False
+                return "no_roll"
 
             first_text = _progress_text(groups[0])
             if progress_msg_id is not None:
-                result = await _edit_progress_message(progress_msg_id, first_text)
-                if not result.success:
+                try:
+                    result = await _edit_progress_message(
+                        progress_msg_id, first_text
+                    )
+                except Exception as exc:
+                    recovery = await _replace_stale_progress_anchor(
+                        exc, first_text
+                    )
+                    if recovery == "not_stale":
+                        progress_msg_id = None
+                        can_edit = False
+                        return "needs_fallback"
+                    if recovery == "failed":
+                        return "needs_fallback"
+                    result = None
+                if result is not None and not result.success:
                     if getattr(result, "retryable", False):
                         logger.debug(
                             "[%s] Transient overflow edit failure — keeping can_edit=True",
                             adapter.name,
                         )
-                        return True
-                    can_edit = False
-                    # Fall back to the existing non-edit behavior below.
-                    return False
+                        return "deferred"
+                    recovery = await _replace_stale_progress_anchor(
+                        getattr(result, "error", ""), first_text
+                    )
+                    if recovery in ("not_stale", "failed"):
+                        progress_msg_id = None
+                        can_edit = False
+                        return "needs_fallback"
             else:
-                result = await _send_progress_text(first_text)
+                try:
+                    result = await _send_progress_text(first_text)
+                except Exception:
+                    return "needs_fallback"
                 if result.success and result.message_id:
                     progress_msg_id = result.message_id
+                else:
+                    progress_msg_id = None
+                    can_edit = False
 
             for group in groups[1:]:
-                result = await _send_progress_text(_progress_text(group))
-                if result.success and result.message_id:
+                try:
+                    result = await _send_progress_text(_progress_text(group))
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Failed to deliver progress overflow group: %s",
+                        adapter.name,
+                        exc,
+                    )
+                    progress_msg_id = None
+                    can_edit = False
+                    continue
+                if can_edit and result.success and result.message_id:
                     progress_msg_id = result.message_id
+                elif not result.success or not result.message_id:
+                    progress_msg_id = None
+                    can_edit = False
 
             # The newest continuation is now the only mutable bubble.  Keep
             # just its lines so subsequent edits update it instead of
             # replaying the full historical transcript into new messages.
-            progress_lines = groups[-1]
-            return True
+            progress_lines = groups[-1] if can_edit else []
+            return "handled"
+
+        async def _flush_progress_buffer() -> None:
+            """Finalize pending progress, falling back on any edit failure."""
+            nonlocal progress_lines, progress_msg_id, can_edit
+            if not progress_lines:
+                return
+            if not can_edit:
+                await _fallback_progress_lines(progress_lines)
+                return
+
+            roll_outcome = await _roll_progress_overflow_if_needed()
+            if roll_outcome in ("deferred", "needs_fallback"):
+                await _fallback_progress_lines(progress_lines)
+                return
+            if not progress_lines:
+                return
+            if progress_msg_id is None:
+                await _fallback_progress_lines(progress_lines)
+                return
+
+            full_text = _progress_text(progress_lines)
+            try:
+                result = await _edit_progress_message(progress_msg_id, full_text)
+            except Exception as exc:
+                recovery = await _replace_stale_progress_anchor(exc, full_text)
+                if recovery not in ("editable", "delivered"):
+                    await _fallback_progress_lines(progress_lines)
+                elif not can_edit:
+                    progress_lines = []
+                return
+
+            if result.success:
+                return
+            recovery = await _replace_stale_progress_anchor(
+                getattr(result, "error", ""), full_text
+            )
+            if recovery not in ("editable", "delivered"):
+                await _fallback_progress_lines(progress_lines)
+            elif not can_edit:
+                progress_lines = []
 
         while True:
             try:
@@ -4563,9 +4726,14 @@ class TurnRunner:
                 # Handle dedup messages: update last line with repeat counter
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
-                    if progress_lines:
-                        progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                    msg = progress_lines[-1] if progress_lines else base_msg
+                    dedup_msg = f"{base_msg} (×{count + 1})"
+                    if can_edit and progress_lines:
+                        progress_lines[-1] = dedup_msg
+                        msg = dedup_msg
+                    else:
+                        await _send_progress_text(dedup_msg)
+                        _last_edit_ts = time.monotonic()
+                        continue
                 elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                     # Content bubble just landed on the platform — close off
                     # the current tool-progress bubble so the next tool
@@ -4575,6 +4743,7 @@ class TurnRunner:
                     # order. Mirrors GatewayStreamConsumer.on_segment_break
                     # on the content side. (Issue: tool + content
                     # linearization regression after PR #7885.)
+                    await _flush_progress_buffer()
                     progress_msg_id = None
                     progress_lines = []
                     ctx.last_progress_msg[0] = None
@@ -4584,7 +4753,10 @@ class TurnRunner:
                     msg = raw
                     progress_lines.append(msg)
 
-                if await _roll_progress_overflow_if_needed():
+                roll_outcome = await _roll_progress_overflow_if_needed()
+                if roll_outcome == "needs_fallback":
+                    await _fallback_progress_lines(progress_lines)
+                if roll_outcome != "no_roll":
                     _last_edit_ts = time.monotonic()
                     await asyncio.sleep(0.3)
                     if ctx._run_still_current():
@@ -4609,9 +4781,25 @@ class TurnRunner:
 
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
-                    result = await _edit_progress_message(progress_msg_id, full_text)
-                    if not result.success:
+                    full_text = _progress_text(progress_lines)
+                    try:
+                        result = await _edit_progress_message(
+                            progress_msg_id, full_text
+                        )
+                    except Exception as exc:
+                        recovery = await _replace_stale_progress_anchor(
+                            exc, full_text
+                        )
+                        if recovery == "not_stale":
+                            raise
+                        if recovery == "failed":
+                            await _fallback_progress_lines(progress_lines)
+                        elif recovery == "delivered":
+                            progress_lines = []
+                        result = None
+                    if result is None and not can_edit:
+                        progress_lines = []
+                    if result is not None and not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
                         # Transient network errors (ConnectError, timeouts)
                         # must not permanently disable progress-message
@@ -4632,42 +4820,32 @@ class TurnRunner:
                                 adapter.name,
                             )
                             _last_edit_ts = time.monotonic()
+                            await _send_progress_text(msg)
+                        elif _is_stale_progress_edit_error(_err):
+                            recovery = await _replace_stale_progress_anchor(
+                                _err, full_text
+                            )
+                            if recovery == "failed":
+                                await _fallback_progress_lines(progress_lines)
+                            elif recovery == "delivered":
+                                progress_lines = []
                         else:
                             can_edit = False
-                        _flood_result = await adapter.send(
-                            chat_id=ctx.source.chat_id,
-                            content=msg,
-                            reply_to=ctx._progress_reply_to,
-                            metadata=ctx._progress_metadata,
-                        )
-                        if (
-                            ctx._cleanup_progress
-                            and getattr(_flood_result, "success", False)
-                            and getattr(_flood_result, "message_id", None)
-                        ):
-                            ctx._cleanup_msg_ids.append(str(_flood_result.message_id))
+                            progress_msg_id = None
+                            await _send_progress_text(msg)
+                            progress_lines = []
                 else:
                     if can_edit:
                         # First tool: send all accumulated text as new message
-                        full_text = "\n".join(progress_lines)
-                        result = await adapter.send(
-                            chat_id=ctx.source.chat_id,
-                            content=full_text,
-                            reply_to=ctx._progress_reply_to,
-                            metadata=ctx._progress_metadata,
+                        result = await _send_progress_text(
+                            _progress_text(progress_lines)
                         )
                     else:
                         # Editing unsupported: send just this line
-                        result = await adapter.send(
-                            chat_id=ctx.source.chat_id,
-                            content=msg,
-                            reply_to=ctx._progress_reply_to,
-                            metadata=ctx._progress_metadata,
-                        )
+                        result = await _send_progress_text(msg)
+                        progress_lines = []
                     if result.success and result.message_id:
                         progress_msg_id = result.message_id
-                        if ctx._cleanup_progress:
-                            ctx._cleanup_msg_ids.append(str(result.message_id))
 
                 _last_edit_ts = time.monotonic()
 
@@ -4685,38 +4863,45 @@ class TurnRunner:
                         raw = ctx.progress_queue.get_nowait()
                         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                             _, base_msg, count = raw
-                            if progress_lines:
-                                progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                                await _roll_progress_overflow_if_needed()
+                            dedup_msg = f"{base_msg} (×{count + 1})"
+                            if can_edit and progress_lines:
+                                progress_lines[-1] = dedup_msg
+                                roll_outcome = (
+                                    await _roll_progress_overflow_if_needed()
+                                )
+                                if roll_outcome == "needs_fallback":
+                                    await _fallback_progress_lines(
+                                        progress_lines
+                                    )
+                            else:
+                                await _send_progress_text(dedup_msg)
                         elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                             # Content-bubble marker during drain: close off
                             # the current progress bubble and start a fresh
                             # one for any tool lines that arrived after.
-                            await _roll_progress_overflow_if_needed()
-                            if can_edit and progress_lines and progress_msg_id:
-                                _pending_text = _progress_text(progress_lines)
-                                try:
-                                    await _edit_progress_message(progress_msg_id, _pending_text)
-                                except Exception:
-                                    pass
+                            await _flush_progress_buffer()
                             progress_msg_id = None
                             progress_lines = []
                             ctx.last_progress_msg[0] = None
                             ctx.repeat_count[0] = 0
                         else:
+                            if not can_edit:
+                                await _send_progress_text(str(raw))
+                                continue
                             progress_lines.append(raw)
-                            await _roll_progress_overflow_if_needed()
-                    except Exception:
+                            roll_outcome = (
+                                await _roll_progress_overflow_if_needed()
+                            )
+                            if roll_outcome == "needs_fallback":
+                                await _fallback_progress_lines(progress_lines)
+                    except Exception as exc:
+                        logger.warning(
+                            "[%s] Failed to drain progress update: %s",
+                            adapter.name,
+                            exc,
+                        )
                         break
-                # Final edit with all remaining tools (only if editing works)
-                if can_edit and progress_lines and progress_msg_id:
-                    await _roll_progress_overflow_if_needed()
-                if can_edit and progress_lines and progress_msg_id:
-                    full_text = _progress_text(progress_lines)
-                    try:
-                        await _edit_progress_message(progress_msg_id, full_text)
-                    except Exception:
-                        pass
+                await _flush_progress_buffer()
                 return
             except Exception as e:
                 logger.error("Progress message error: %s", e)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "lidangjiang@gmail.com": "Lidang-Jiang",  # PRs #9341/#9345 (gateway notification + progress recovery)
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "135129512+ansel-f@users.noreply.github.com": "ansel-f",  # PR #62388 salvage (approval: allow exact verifier temp cleanup without broadening rm safety boundary)
     "robert@modern-minds.ai": "Hopfensaft",  # PR #31933 salvage (dashboard: align approvals.mode dropdown with canonical engine values)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -226,6 +227,347 @@ class ManyProgressLinesAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+
+class SynchronizedProgressAgent:
+    """Emit progress lines after the adapter confirms each prior operation."""
+
+    adapter = None
+    expected_operations: tuple[int | None, ...] = ()
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        assert self.adapter is not None
+        for index, expected_count in enumerate(self.expected_operations):
+            callback("tool.started", "terminal", f"command-{index + 1}", {})
+            if expected_count is not None:
+                self.adapter.wait_for_operation_count(expected_count)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FourStageProgressAgent(SynchronizedProgressAgent):
+    expected_operations = (1, 3, 5, 6)
+
+
+class ThreeStageSendOnlyProgressAgent(SynchronizedProgressAgent):
+    expected_operations = (1, 3, 4)
+
+
+class ThreeStageReplacementFailureAgent(SynchronizedProgressAgent):
+    expected_operations = (1, 4, 5)
+
+
+class ThreeStageTransientProgressAgent(SynchronizedProgressAgent):
+    expected_operations = (1, 2, 3)
+
+
+class FastCancellationProgressAgent(SynchronizedProgressAgent):
+    expected_operations = (1, None)
+
+
+class OverflowRecoveryProgressAgent(SynchronizedProgressAgent):
+    """Trigger rollover, then wait for a follow-up edit against its new anchor."""
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        assert self.adapter is not None
+        callback("tool.started", "terminal", "first", {})
+        self.adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "x" * 100, {})
+        self.adapter.wait_for_operation_count(4)
+        callback("tool.started", "terminal", "third", {})
+        self.adapter.wait_for_operation_count(5)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class OverflowReplacementFailureProgressAgent(SynchronizedProgressAgent):
+    """Wait until every overflow fallback group is delivered before continuing."""
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        assert self.adapter is not None
+        callback("tool.started", "terminal", "first", {})
+        self.adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "x" * 100, {})
+        self.adapter.wait_for_operation_count(5)
+        callback("tool.started", "terminal", "third", {})
+        self.adapter.wait_for_operation_count(6)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class CancellationOverflowProgressAgent(SynchronizedProgressAgent):
+    """Leave an overflowing second line for the cancellation drain."""
+
+    emit_reset = False
+    emit_dedup = False
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        assert self.adapter is not None
+        callback("tool.started", "terminal", "first", {})
+        self.adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "x" * 100, {})
+        if self.emit_dedup:
+            callback("tool.started", "terminal", "x" * 100, {})
+        if self.emit_reset:
+            assert self.interim_assistant_callback is not None
+            self.interim_assistant_callback("stream segment", already_streamed=False)
+            self.adapter.wait_for_sent_content("stream segment")
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ProgressEditFailureAdapter(ProgressCaptureAdapter):
+    """Capture progress-anchor recovery after configured edit failures."""
+
+    edit_errors: tuple[str, ...] = ()
+    edit_retryable: tuple[bool, ...] = ()
+    fail_replacement_send = False
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._next_message_id = 0
+        self._operation_condition = threading.Condition()
+        self.deleted = []
+        self.delivered = []
+        self.successful_send_attempts = []
+
+    def _record_operation(self) -> None:
+        with self._operation_condition:
+            self._operation_condition.notify_all()
+
+    def wait_for_operation_count(self, expected_count: int) -> None:
+        with self._operation_condition:
+            completed = self._operation_condition.wait_for(
+                lambda: len(self.sent) + len(self.edits) >= expected_count,
+                timeout=3.0,
+            )
+        assert completed, f"timed out waiting for progress operation {expected_count}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        self._next_message_id += 1
+        self._record_operation()
+        if self.fail_replacement_send and self._next_message_id == 2:
+            return SendResult(success=False, error="replacement send failed")
+        result = SendResult(success=True, message_id=f"progress-{self._next_message_id}")
+        self.delivered.append(content)
+        self.successful_send_attempts.append(self._next_message_id)
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        self._record_operation()
+        edit_index = len(self.edits) - 1
+        if edit_index < len(self.edit_errors):
+            retryable = (
+                self.edit_retryable[edit_index]
+                if edit_index < len(self.edit_retryable)
+                else False
+            )
+            return SendResult(
+                success=False,
+                error=self.edit_errors[edit_index],
+                retryable=retryable,
+            )
+        return SendResult(success=True, message_id=message_id)
+
+    async def delete_message(self, chat_id, message_id) -> SendResult:
+        self.deleted.append({"chat_id": chat_id, "message_id": message_id})
+        return SendResult(success=True, message_id=message_id)
+
+
+class StaleProgressEditAdapter(ProgressEditFailureAdapter):
+    edit_errors = (
+        "Bad Request: message to edit not found",
+        "Bad Request: MESSAGE_ID_INVALID",
+    )
+
+
+class TransientProgressEditAdapter(ProgressEditFailureAdapter):
+    edit_errors = ("httpx.ConnectError: connection reset",)
+    edit_retryable = (True,)
+
+
+class FailedReplacementProgressEditAdapter(ProgressEditFailureAdapter):
+    edit_errors = ("Bad Request: message to edit not found",)
+    fail_replacement_send = True
+
+
+class RaisingReplacementProgressEditAdapter(ProgressEditFailureAdapter):
+    edit_errors = ("Bad Request: message to edit not found",)
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if self._next_message_id == 1:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            self._next_message_id += 1
+            self._record_operation()
+            raise RuntimeError("replacement send exploded")
+        return await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+
+class NoIdReplacementProgressEditAdapter(ProgressEditFailureAdapter):
+    edit_errors = ("Bad Request: message to edit not found",)
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+        if self._next_message_id == 2:
+            return SendResult(success=True, message_id=None)
+        return result
+
+
+class StaleSmallLimitProgressAdapter(SmallLimitProgressAdapter):
+    MAX_MESSAGE_LENGTH = 60
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._operation_condition = threading.Condition()
+        self._failed_first_edit = False
+        self.delivered = []
+
+    def _record_operation(self) -> None:
+        with self._operation_condition:
+            self._operation_condition.notify_all()
+
+    def wait_for_operation_count(self, expected_count: int) -> None:
+        with self._operation_condition:
+            completed = self._operation_condition.wait_for(
+                lambda: len(self.sent) + len(self.edits) >= expected_count,
+                timeout=3.0,
+            )
+        assert completed, f"timed out waiting for progress operation {expected_count}"
+
+    def wait_for_sent_content(self, expected: str) -> None:
+        with self._operation_condition:
+            completed = self._operation_condition.wait_for(
+                lambda: any(expected in call["content"] for call in self.sent),
+                timeout=3.0,
+            )
+        assert completed, f"timed out waiting for sent content {expected!r}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+        if result.success:
+            self.delivered.append(content)
+        self._record_operation()
+        return result
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        self._record_operation()
+        if not self._failed_first_edit:
+            self._failed_first_edit = True
+            return SendResult(success=False, error="Bad Request: message to edit not found")
+        return SendResult(success=True, message_id=message_id)
+
+
+class FailedReplacementSmallLimitProgressAdapter(StaleSmallLimitProgressAdapter):
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if len(self.sent) == 1:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            self._next_id += 1
+            self._record_operation()
+            return SendResult(success=False, error="replacement send failed")
+        return await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+
+class CancellationOverflowFailureAdapter(StaleSmallLimitProgressAdapter):
+    """Fail only edits of the overflowing tool-progress bubble."""
+
+    MAX_MESSAGE_LENGTH = 60
+    edit_error = "Bad Request: not enough rights to edit the message"
+    edit_retryable = False
+    raise_progress_edit = False
+
+    async def edit_message(
+        self,
+        chat_id,
+        message_id,
+        content,
+        *,
+        finalize: bool = False,
+        metadata=None,
+    ) -> SendResult:
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            self.oversized_edits.append(content)
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        self._record_operation()
+        if message_id == "progress-1":
+            if self.raise_progress_edit:
+                raise RuntimeError("progress edit exploded")
+            return SendResult(
+                success=False,
+                error=self.edit_error,
+                retryable=self.edit_retryable,
+            )
+        return SendResult(success=True, message_id=message_id)
 
 
 class DelayedInterimAgent:
@@ -746,6 +1088,8 @@ async def _run_with_agent(
     chat_type="group",
     thread_id="17585",
     adapter_cls=ProgressCaptureAdapter,
+    event_message_id=None,
+    progress_edit_interval=None,
 ):
     if config_data:
         import yaml
@@ -761,8 +1105,17 @@ async def _run_with_agent(
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     adapter = adapter_cls(platform=platform)
+    if issubclass(agent_cls, SynchronizedProgressAgent):
+        agent_cls.adapter = adapter
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
+    if progress_edit_interval is not None:
+        monkeypatch.setattr(
+            gateway_run,
+            "_PROGRESS_EDIT_INTERVAL_SECONDS",
+            progress_edit_interval,
+            raising=False,
+        )
     if config_data and "streaming" in config_data:
         runner.config.streaming = StreamingConfig.from_dict(config_data["streaming"])
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
@@ -791,8 +1144,362 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_run_agent_replaces_stale_progress_anchor_and_keeps_coalescing(monkeypatch, tmp_path):
+    """Deleted progress messages should be replaced with the full accumulated text."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FourStageProgressAgent,
+        session_id="sess-progress-stale-anchor",
+        config_data={"display": {"tool_progress": "all", "cleanup_progress": True}},
+        platform=Platform.FEISHU,
+        adapter_cls=StaleProgressEditAdapter,
+        event_message_id="trigger-message",
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits[:3]] == [
+        "progress-1",
+        "progress-2",
+        "progress-3",
+    ]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[2]["content"] == adapter.edits[1]["content"]
+    assert adapter.edits[2]["content"].startswith(f'{adapter.sent[2]["content"]}\n')
+    assert all(call["reply_to"] == "trigger-message" for call in adapter.sent[:3])
+    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.sent[:3])
+    cleanup = adapter.pop_post_delivery_callback("agent:main:feishu:group:-1001:17585")
+    assert callable(cleanup)
+    cleanup_result = cleanup()
+    if asyncio.iscoroutine(cleanup_result):
+        await cleanup_result
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if len(adapter.deleted) >= 3:
+            break
+    assert {call["message_id"] for call in adapter.deleted} >= {
+        "progress-1",
+        "progress-2",
+        "progress-3",
+    }
+
+
+@pytest.mark.parametrize(
+    "edit_error",
+    [
+        "Bad Request: not enough rights to edit the message",
+        "Forbidden: bot was blocked by the user",
+        "unexpected permanent adapter failure",
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_agent_does_not_replace_non_stale_progress_anchor(monkeypatch, tmp_path, edit_error):
+    """Permission, blocked, and unknown edit failures must remain send-only."""
+
+    class PermanentProgressEditAdapter(ProgressEditFailureAdapter):
+        edit_errors = (edit_error,)
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStageSendOnlyProgressAgent,
+        session_id="sess-progress-permanent-edit-error",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=PermanentProgressEditAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 1
+    assert len(adapter.sent) == 3
+    assert adapter.sent[1]["content"] != adapter.edits[0]["content"]
+    assert "\n" not in adapter.sent[2]["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retries_progress_edit_after_transient_failure(monkeypatch, tmp_path):
+    """A retryable edit failure must keep the existing anchor editable."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStageTransientProgressAgent,
+        session_id="sess-progress-transient-edit-error",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=TransientProgressEditAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert [call["message_id"] for call in adapter.edits[:2]] == [
+        "progress-1",
+        "progress-1",
+    ]
+    assert adapter.edits[1]["content"].startswith(f'{adapter.edits[0]["content"]}\n')
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [FailedReplacementProgressEditAdapter, RaisingReplacementProgressEditAdapter],
+)
+@pytest.mark.asyncio
+async def test_run_agent_stays_send_only_when_replacement_anchor_send_fails(
+    monkeypatch, tmp_path, adapter_cls
+):
+    """A failed replacement send must retry the complete accumulated text."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStageReplacementFailureAgent,
+        session_id="sess-progress-replacement-send-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=adapter_cls,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert len(adapter.sent) == 4
+    assert adapter.sent[2]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[2]["content"].startswith(f'{adapter.sent[0]["content"]}\n')
+    assert 2 not in adapter.successful_send_attempts
+    assert 3 in adapter.successful_send_attempts
+    assert adapter.delivered[1:] == [adapter.sent[2]["content"], adapter.sent[3]["content"]]
+    assert "\n" in adapter.sent[2]["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_does_not_duplicate_successful_replacement_without_message_id(
+    monkeypatch, tmp_path
+):
+    """A delivered replacement without an edit ID should switch to send-only."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ThreeStageSendOnlyProgressAgent,
+        session_id="sess-progress-replacement-without-id",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=NoIdReplacementProgressEditAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert len(adapter.sent) == 3
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[1]["content"] in adapter.delivered
+    assert "\n" not in adapter.sent[2]["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_recovers_stale_anchor_during_progress_overflow(monkeypatch, tmp_path):
+    """Rollover edits should replace a deleted anchor before sending later groups."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowRecoveryProgressAgent,
+        session_id="sess-progress-overflow-stale-anchor",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=StaleSmallLimitProgressAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits[0]["message_id"] == "progress-1"
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.edits[1]["message_id"] == "progress-3"
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_progress_overflow_stays_send_only_when_replacement_fails(monkeypatch, tmp_path):
+    """A failed rollover replacement must deliver every bounded fallback group."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        OverflowReplacementFailureProgressAgent,
+        session_id="sess-progress-overflow-replacement-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=FailedReplacementSmallLimitProgressAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert len(adapter.sent) == 5
+    fallback_groups = [call["content"] for call in adapter.sent[2:4]]
+    assert fallback_groups[0] == adapter.edits[0]["content"]
+    assert "\n".join(fallback_groups).startswith(f'{adapter.sent[0]["content"]}\n')
+    assert adapter.sent[3]["content"] != adapter.sent[4]["content"]
+    assert adapter.delivered == [adapter.sent[0]["content"], *fallback_groups, adapter.sent[4]["content"]]
+    assert all(len(text) <= adapter.MAX_MESSAGE_LENGTH for text in fallback_groups)
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+def _assert_cancellation_overflow_fallback(adapter, *, expect_dedup: bool = False) -> None:
+    progress_edits = [call for call in adapter.edits if call["message_id"] == "progress-1"]
+    assert [call["message_id"] for call in progress_edits] == ["progress-1"]
+
+    first_group = progress_edits[0]["content"]
+    progress_sends = [
+        call["content"]
+        for call in adapter.sent
+        if (call["content"] == first_group or "x" * 20 in call["content"])
+        and " (×" not in call["content"]
+    ]
+    assert len(progress_sends) == 3
+    fallback_groups = progress_sends[1:]
+    assert "\n".join(fallback_groups).startswith(f"{progress_sends[0]}\n")
+    assert all(len(text) <= adapter.MAX_MESSAGE_LENGTH for text in fallback_groups)
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+    dedup_texts = [call["content"] for call in adapter.sent if call["content"].endswith(" (×2)")]
+    assert bool(dedup_texts) is expect_dedup
+
+
+@pytest.mark.parametrize(
+    ("emit_reset", "retryable", "raise_progress_edit", "emit_dedup"),
+    [
+        (False, False, False, False),
+        (False, True, False, False),
+        (False, False, True, False),
+        (True, False, False, False),
+        (True, False, True, False),
+        (False, False, False, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cancellation_overflow_falls_back_before_exit_or_reset(
+    monkeypatch, tmp_path, emit_reset, retryable, raise_progress_edit, emit_dedup
+):
+    """Every rollover failure must flush bounded progress before exit or reset."""
+
+    class DrainAgent(CancellationOverflowProgressAgent):
+        pass
+
+    class DrainFailureAdapter(CancellationOverflowFailureAdapter):
+        pass
+
+    DrainAgent.emit_reset = emit_reset
+    DrainAgent.emit_dedup = emit_dedup
+    DrainFailureAdapter.edit_retryable = retryable
+    DrainFailureAdapter.raise_progress_edit = raise_progress_edit
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DrainAgent,
+        session_id="sess-progress-cancellation-overflow-edit-failure",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": emit_reset,
+            }
+        },
+        adapter_cls=DrainFailureAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert any("stream segment" in call["content"] for call in adapter.sent) is emit_reset
+    _assert_cancellation_overflow_fallback(adapter, expect_dedup=emit_dedup)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_recovers_stale_anchor_during_cancellation_drain(monkeypatch, tmp_path):
+    """The final cancellation-drain edit should replace a deleted anchor."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FastCancellationProgressAgent,
+        session_id="sess-progress-cancellation-stale-anchor",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=StaleProgressEditAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [FailedReplacementProgressEditAdapter, RaisingReplacementProgressEditAdapter],
+)
+@pytest.mark.asyncio
+async def test_cancellation_drain_falls_back_when_stale_replacement_fails(
+    monkeypatch, tmp_path, adapter_cls
+):
+    """Final-drain recovery failures should still deliver the accumulated text."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FastCancellationProgressAgent,
+        session_id="sess-progress-cancellation-replacement-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=adapter_cls,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert len(adapter.sent) == 3
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[2]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[2]["content"].startswith(f'{adapter.sent[0]["content"]}\n')
+    assert "\n" in adapter.sent[2]["content"]
+    assert 2 not in adapter.successful_send_attempts
+    assert 3 in adapter.successful_send_attempts
+    assert adapter.delivered[-1] == adapter.sent[2]["content"]
+
+
+@pytest.mark.parametrize(
+    ("edit_error", "retryable"),
+    [
+        ("httpx.ConnectError: connection reset", True),
+        ("flood_control:30.0", False),
+        ("Bad Request: not enough rights to edit the message", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cancellation_drain_falls_back_after_non_stale_edit_failure(
+    monkeypatch, tmp_path, edit_error, retryable
+):
+    """Every failed final-drain edit must deliver the complete pending text."""
+
+    class FinalDrainEditFailureAdapter(ProgressEditFailureAdapter):
+        edit_errors = (edit_error,)
+        edit_retryable = (retryable,)
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FastCancellationProgressAgent,
+        session_id="sess-progress-cancellation-non-stale-edit-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=FinalDrainEditFailureAdapter,
+        progress_edit_interval=0,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["message_id"] for call in adapter.edits] == ["progress-1"]
+    assert len(adapter.sent) == 2
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[1]["content"].startswith(f'{adapter.sent[0]["content"]}\n')
+    assert "\n" in adapter.sent[1]["content"]
+    assert adapter.delivered[-1] == adapter.sent[1]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -17,8 +17,10 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     def __init__(self, platform=Platform.TELEGRAM):
         super().__init__(PlatformConfig(enabled=True, token="***"), platform)
         self.sent = []
+        self.sent_message_ids = []
         self.edits = []
         self.typing = []
+        self._send_seq = 0
 
     async def connect(self) -> bool:
         return True
@@ -27,6 +29,8 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         return None
 
     async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._send_seq += 1
+        message_id = f"progress-{self._send_seq}"
         self.sent.append(
             {
                 "chat_id": chat_id,
@@ -35,7 +39,8 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
                 "metadata": metadata,
             }
         )
-        return SendResult(success=True, message_id="progress-1")
+        self.sent_message_ids.append(message_id)
+        return SendResult(success=True, message_id=message_id)
 
     async def edit_message(self, chat_id, message_id, content) -> SendResult:
         self.edits.append(
@@ -69,6 +74,46 @@ class FakeAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+
+class RecoveringAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "pwd", {})
+        time.sleep(0.15)
+        self.tool_progress_callback("tool.started", "browser_navigate", "https://example.com", {})
+        time.sleep(0.15)
+        self.tool_progress_callback("tool.started", "execute_code", "print(1)", {})
+        time.sleep(0.15)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RecoveringProgressAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._edit_results = [
+            SendResult(success=False, error="message to edit not found"),
+            SendResult(success=True, message_id="progress-2"),
+        ]
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        if self._edit_results:
+            return self._edit_results.pop(0)
+        return SendResult(success=True, message_id=message_id)
 
 
 class LongPreviewAgent:
@@ -157,6 +202,62 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     ]
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_recovers_after_edit_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = RecoveringAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = RecoveringProgressAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    monotonic_value = {"value": -2.0}
+
+    def _fake_monotonic():
+        monotonic_value["value"] += 2.0
+        return monotonic_value["value"]
+
+    monkeypatch.setattr(gateway_run.time, "monotonic", _fake_monotonic)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-recover",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    progress_ids = [
+        message_id
+        for call, message_id in zip(adapter.sent, adapter.sent_message_ids)
+        if any(
+            marker in call["content"]
+            for marker in ("terminal", "browser_navigate", "execute_code")
+        )
+    ][:2]
+    assert len(progress_ids) == 2
+    assert [call["message_id"] for call in adapter.edits] == progress_ids
+    assert progress_ids[0] != progress_ids[1]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -197,6 +198,188 @@ class RetryableOverflowEditProgressAdapter(SmallLimitProgressAdapter):
                 error_kind="transient",
             )
         return await super().edit_message(chat_id, message_id, content)
+
+
+class ProgressEditFailureAdapter(ProgressCaptureAdapter):
+    """Fail the first edit and expose each send/edit to the sync fake agent."""
+
+    edit_error = "Bad Request: message to edit not found"
+    replacement_message_id = "progress-2"
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._next_message_id = 0
+        self._operation_count = 0
+        self._operation_condition = threading.Condition()
+        self.deleted = []
+
+    def _record_operation(self):
+        with self._operation_condition:
+            self._operation_count += 1
+            self._operation_condition.notify_all()
+
+    def wait_for_operation_count(self, expected):
+        with self._operation_condition:
+            completed = self._operation_condition.wait_for(
+                lambda: self._operation_count >= expected,
+                timeout=5,
+            )
+        assert completed, (
+            f"timed out waiting for {expected} progress operations; "
+            f"observed {self._operation_count}"
+        )
+
+    def wait_for_sent_content(self, expected):
+        with self._operation_condition:
+            completed = self._operation_condition.wait_for(
+                lambda: any(expected in call["content"] for call in self.sent),
+                timeout=5,
+            )
+        assert completed, f"timed out waiting for sent content {expected!r}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        self._next_message_id += 1
+        if self._next_message_id == 2:
+            message_id = self.replacement_message_id
+        else:
+            message_id = f"progress-{self._next_message_id}"
+        self._record_operation()
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        self._record_operation()
+        if len(self.edits) == 1:
+            return SendResult(success=False, error=self.edit_error)
+        return SendResult(success=True, message_id=message_id)
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.append((chat_id, message_id))
+        return True
+
+
+class NoIdReplacementProgressAdapter(ProgressEditFailureAdapter):
+    """Model connectors that deliver a replacement without returning its ID."""
+
+    replacement_message_id = None
+
+
+class PermanentResetProgressAdapter(ProgressEditFailureAdapter):
+    """Enter send-only mode before a content-bubble reset."""
+
+    edit_error = "Forbidden: bot was blocked by the user"
+
+
+class FailedReplacementProgressAdapter(ProgressEditFailureAdapter):
+    """Return a failed result while trying to send the replacement anchor."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if self._next_message_id == 1:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            self._next_message_id += 1
+            self._record_operation()
+            return SendResult(success=False, error="replacement send failed")
+        return await super().send(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+
+class RaisingReplacementProgressAdapter(ProgressEditFailureAdapter):
+    """Raise while trying to send the replacement anchor."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if self._next_message_id == 1:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            self._next_message_id += 1
+            self._record_operation()
+            raise RuntimeError("replacement send exploded")
+        return await super().send(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+
+class StaleOverflowProgressAdapter(SmallLimitProgressAdapter):
+    """Invalidate the first edit while the progress buffer is rolling over."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self._failed_first_edit = False
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            self.oversized_edits.append(content)
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        if not self._failed_first_edit:
+            self._failed_first_edit = True
+            return SendResult(
+                success=False,
+                error="Bad Request: message to edit not found",
+            )
+        return SendResult(success=True, message_id=message_id)
+
+
+class FailedReplacementOverflowProgressAdapter(StaleOverflowProgressAdapter):
+    """Fail the stale-anchor replacement during overflow rollover."""
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        if len(self.sent) == 1:
+            if len(content) > self.MAX_MESSAGE_LENGTH:
+                self.oversized_sends.append(content)
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            return SendResult(success=False, error="replacement send failed")
+        return await super().send(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
 
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
@@ -431,6 +614,147 @@ class ManyProgressLinesAgent:
         for idx in range(1, 8):
             cb("tool.started", "terminal", f"overflow-line-{idx}-" + "x" * 45, {})
         time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class SynchronizedFourStageProgressAgent:
+    """Trigger one live edit, then leave a final line for cancellation drain."""
+
+    adapter = None
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        adapter = type(self).adapter
+        assert callback is not None
+        assert adapter is not None
+
+        callback("tool.started", "terminal", "first command", {})
+        adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "second command", {})
+        callback("tool.started", "terminal", "third command", {})
+        adapter.wait_for_operation_count(3)
+        callback("tool.started", "terminal", "fourth command", {})
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class CancellationStaleProgressAgent:
+    """Leave the second update queued so final flush must replace the anchor."""
+
+    adapter = None
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        adapter = type(self).adapter
+        assert callback is not None
+        assert adapter is not None
+        callback("tool.started", "terminal", "first command", {})
+        adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "second command", {})
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class LongThinkingProgressAgent:
+    """Emit one progress item that exceeds the adapter's message limit."""
+
+    thinking_text = "x" * 400
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        assert callback is not None
+        callback("_thinking", self.thinking_text)
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ResetAfterStaleProgressAgent:
+    """Insert a content bubble after recovery, then emit fresh progress."""
+
+    adapter = None
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.interim_assistant_callback = kwargs.get(
+            "interim_assistant_callback"
+        )
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        interim_callback = self.interim_assistant_callback
+        adapter = type(self).adapter
+        assert callback is not None
+        assert interim_callback is not None
+        assert adapter is not None
+
+        callback("tool.started", "terminal", "first command", {})
+        adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "second command", {})
+        callback("tool.started", "terminal", "third command", {})
+        adapter.wait_for_operation_count(3)
+        interim_callback("stream segment", already_streamed=False)
+        adapter.wait_for_sent_content("stream segment")
+        # Let the edit throttle expire and the queued reset close the previous
+        # anchor before emitting the first line of the new progress bubble.
+        time.sleep(1.6)
+        callback("tool.started", "terminal", "fourth command", {})
+        adapter.wait_for_sent_content("fourth command")
+        callback("tool.started", "terminal", "fifth command", {})
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class SendOnlyDedupProgressAgent:
+    """Repeat a line after a permanent edit failure switched to send-only."""
+
+    adapter = None
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        callback = self.tool_progress_callback
+        adapter = type(self).adapter
+        assert callback is not None
+        assert adapter is not None
+
+        callback("tool.started", "terminal", "first command", {})
+        adapter.wait_for_operation_count(1)
+        callback("tool.started", "terminal", "second command", {})
+        callback("tool.started", "terminal", "repeated command", {})
+        adapter.wait_for_operation_count(3)
+        callback("tool.started", "terminal", "repeated command", {})
         return {
             "final_response": "done",
             "messages": [],
@@ -1006,6 +1330,7 @@ async def _run_with_agent(
     adapter_cls=ProgressCaptureAdapter,
     user_id=None,
     scope_id=None,
+    event_message_id=None,
 ):
     if config_data:
         import yaml
@@ -1021,6 +1346,16 @@ async def _run_with_agent(
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     adapter = adapter_cls(platform=platform)
+    if issubclass(
+        agent_cls,
+        (
+            SynchronizedFourStageProgressAgent,
+            CancellationStaleProgressAgent,
+            ResetAfterStaleProgressAgent,
+            SendOnlyDedupProgressAgent,
+        ),
+    ):
+        agent_cls.adapter = adapter
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
@@ -1053,8 +1388,333 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_stale_progress_edit_replaces_anchor_and_keeps_editing(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SynchronizedFourStageProgressAgent,
+        session_id="sess-stale-progress-edit",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "cleanup_progress": True,
+            }
+        },
+        platform=Platform.FEISHU,
+        chat_id="chat-1",
+        thread_id="17585",
+        adapter_cls=ProgressEditFailureAdapter,
+        event_message_id="trigger-message",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits[0]["message_id"] == "progress-1"
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert any(edit["message_id"] == "progress-2" for edit in adapter.edits[1:])
+    assert adapter.edits[-1]["content"].startswith(
+        adapter.sent[1]["content"] + "\n"
+    )
+    assert all(call["reply_to"] == "trigger-message" for call in adapter.sent)
+    assert all(
+        (call["metadata"] or {}).get("thread_id") == "17585"
+        for call in adapter.sent
+    )
+
+    cleanup = adapter.pop_post_delivery_callback(
+        "agent:main:feishu:group:chat-1:17585"
+    )
+    assert cleanup is not None
+    cleanup_result = cleanup()
+    if cleanup_result is not None:
+        await cleanup_result
+    for _ in range(10):
+        if len(adapter.deleted) == 2:
+            break
+        await asyncio.sleep(0.01)
+    assert set(adapter.deleted) == {("chat-1", "progress-1"), ("chat-1", "progress-2")}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "edit_error",
+    [
+        "Bad Request: message can't be edited",
+        "Forbidden: bot was blocked by the user",
+        "unexpected permanent adapter failure",
+    ],
+)
+async def test_non_stale_progress_edit_failures_remain_send_only(
+    monkeypatch, tmp_path, edit_error
+):
+    adapter_cls = type(
+        "PermanentProgressEditFailureAdapter",
+        (ProgressEditFailureAdapter,),
+        {"edit_error": edit_error},
+    )
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SynchronizedFourStageProgressAgent,
+        session_id="sess-permanent-progress-edit",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 1
+    assert len(adapter.sent) == 3
+    assert adapter.sent[1]["content"] != adapter.edits[0]["content"]
+    assert "first command" not in adapter.sent[1]["content"]
+    assert "fourth command" in adapter.sent[2]["content"]
+
+
+@pytest.mark.asyncio
+async def test_stale_progress_replacement_without_id_avoids_duplicate_history(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SynchronizedFourStageProgressAgent,
+        session_id="sess-stale-progress-no-id",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=NoIdReplacementProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 1
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert "first command" not in adapter.sent[2]["content"]
+    assert "fourth command" in adapter.sent[2]["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [FailedReplacementProgressAdapter, RaisingReplacementProgressAdapter],
+)
+async def test_failed_stale_replacement_falls_back_to_full_send_only_history(
+    monkeypatch, tmp_path, adapter_cls
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SynchronizedFourStageProgressAgent,
+        session_id="sess-stale-progress-replacement-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 1
+    assert len(adapter.sent) == 4
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert adapter.sent[2]["content"] == adapter.edits[0]["content"]
+    assert "first command" in adapter.sent[2]["content"]
+    assert "fourth command" in adapter.sent[3]["content"]
+
+
+@pytest.mark.asyncio
+async def test_stale_progress_anchor_recovers_during_overflow_rollover(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyProgressLinesAgent,
+        session_id="sess-stale-progress-overflow",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=StaleOverflowProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits[0]["message_id"] == "progress-1"
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert any(edit["message_id"] != "progress-1" for edit in adapter.edits[1:])
+    delivered_text = "\n".join(
+        [call["content"] for call in adapter.sent[1:]]
+        + [edit["content"] for edit in adapter.edits[1:]]
+    )
+    assert "first-short" in delivered_text
+    for index in range(1, 8):
+        assert f"overflow-line-{index}" in delivered_text
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_failed_stale_replacement_during_overflow_sends_bounded_groups(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyProgressLinesAgent,
+        session_id="sess-stale-progress-overflow-replacement-failure",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=FailedReplacementOverflowProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert [edit["message_id"] for edit in adapter.edits] == ["progress-1"]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    fallback_text = "\n".join(call["content"] for call in adapter.sent[2:])
+    assert "first-short" in fallback_text
+    for index in range(1, 8):
+        assert f"overflow-line-{index}" in fallback_text
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_single_oversized_progress_line_is_split_before_delivery(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        LongThinkingProgressAgent,
+        session_id="sess-oversized-progress-line",
+        config_data={
+            "display": {
+                "thinking_progress": True,
+                "tool_progress": "off",
+            }
+        },
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) > 1
+    assert "".join(call["content"] for call in adapter.sent) == (
+        "💬 " + LongThinkingProgressAgent.thinking_text
+    )
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_stale_progress_anchor_recovers_during_cancellation_flush(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CancellationStaleProgressAgent,
+        session_id="sess-stale-progress-cancellation",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=ProgressEditFailureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert [edit["message_id"] for edit in adapter.edits] == ["progress-1"]
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    assert "first command" in adapter.sent[1]["content"]
+    assert "second command" in adapter.sent[1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_progress_reset_closes_recovered_anchor_before_new_tool_line(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ResetAfterStaleProgressAgent,
+        session_id="sess-stale-progress-reset",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": True,
+            }
+        },
+        adapter_cls=ProgressEditFailureAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
+    segment_index = next(
+        index
+        for index, call in enumerate(adapter.sent)
+        if "stream segment" in call["content"]
+    )
+    fresh_progress = adapter.sent[segment_index + 1 :]
+    assert any("fourth command" in call["content"] for call in fresh_progress)
+    assert all(
+        "fourth command" not in edit["content"]
+        for edit in adapter.edits
+        if edit["message_id"] == "progress-2"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [PermanentResetProgressAdapter, NoIdReplacementProgressAdapter],
+)
+async def test_progress_reset_preserves_send_only_mode(
+    monkeypatch, tmp_path, adapter_cls
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ResetAfterStaleProgressAgent,
+        session_id="sess-send-only-progress-reset",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": True,
+            }
+        },
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "done"
+    assert [edit["message_id"] for edit in adapter.edits] == ["progress-1"]
+    fourth_line = next(
+        call["content"]
+        for call in adapter.sent
+        if "fourth command" in call["content"]
+    )
+    fifth_line = next(
+        call["content"]
+        for call in adapter.sent
+        if "fifth command" in call["content"]
+    )
+    assert "first command" not in fourth_line
+    assert "first command" not in fifth_line
+
+
+@pytest.mark.asyncio
+async def test_send_only_progress_dedup_delivers_repeat_counter(
+    monkeypatch, tmp_path
+):
+    adapter_cls = type(
+        "PermanentDedupProgressEditAdapter",
+        (ProgressEditFailureAdapter,),
+        {"edit_error": "Forbidden: bot was blocked by the user"},
+    )
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SendOnlyDedupProgressAgent,
+        session_id="sess-send-only-progress-dedup",
+        config_data={"display": {"tool_progress": "all"}},
+        adapter_cls=adapter_cls,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.edits) == 1
+    assert adapter.sent[-1]["content"].endswith("repeated command (×2)")
+    assert "first command" not in adapter.sent[-1]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_progress_edit_transient.py
+++ b/tests/gateway/test_telegram_progress_edit_transient.py
@@ -4,15 +4,18 @@ Issue: #27828
 
 When ``edit_message_text`` fails with a transient network error (e.g.
 ``httpx.ConnectError``), the gateway must NOT permanently disable progress-
-message editing.  Only permanent failures (flood control, message-not-found,
-permissions) should set ``can_edit = False``.
+message editing. Deleted/invalid edit anchors should be replaced, while
+permissions and other permanent failures should set ``can_edit = False``.
 
-Two layers are tested:
+Three contracts are tested directly:
 
 1. The ``_TRANSIENT_EDIT_MARKERS`` / retryable classification logic in
    ``TelegramAdapter.edit_message``.
-2. The ``send_progress_messages`` caller in ``run.py`` honours
-   ``result.retryable`` and keeps ``can_edit = True``.
+2. The ``SendResult.retryable`` transport field.
+3. The production stale-anchor classifier in ``gateway.run``.
+
+The real ``send_progress_messages`` behavior is covered by
+``test_run_progress_topics.py`` instead of duplicating its state machine here.
 """
 
 from __future__ import annotations
@@ -21,6 +24,7 @@ from __future__ import annotations
 import pytest
 
 from gateway.platforms.base import SendResult
+from gateway.run import _is_stale_progress_edit_error
 
 
 # ---------------------------------------------------------------------------
@@ -42,24 +46,10 @@ _TRANSIENT_MARKERS = (
     "httpx",
 )
 
-_PERMANENT_MARKERS = (
-    "message to edit not found",
-    "message can't be edited",
-    "not enough rights",
-    "message_id_invalid",
-)
-
-
 def _is_transient(error_str: str) -> bool:
     """Mirrors the classification logic added to TelegramAdapter.edit_message."""
     err = error_str.lower()
     return any(m in err for m in _TRANSIENT_MARKERS)
-
-
-def _is_permanent(error_str: str) -> bool:
-    err = error_str.lower()
-    return any(m in err for m in _PERMANENT_MARKERS)
-
 
 # ---------------------------------------------------------------------------
 # 1. Error classification — transient vs permanent
@@ -98,6 +88,20 @@ def test_permanent_errors_are_not_transient(error_str):
     )
 
 
+@pytest.mark.parametrize(
+    ("error_str", "expected"),
+    [
+        ("Bad Request: message to edit not found", True),
+        ("Bad Request: MESSAGE_ID_INVALID", True),
+        ("Bad Request: not enough rights to edit the message", False),
+        ("Forbidden: bot was blocked by the user", False),
+        ("unexpected permanent adapter failure", False),
+    ],
+)
+def test_stale_progress_edit_error_classification(error_str, expected):
+    assert _is_stale_progress_edit_error(error_str) is expected
+
+
 # ---------------------------------------------------------------------------
 # 2. SendResult retryable field
 # ---------------------------------------------------------------------------
@@ -115,67 +119,3 @@ def test_send_result_retryable_can_be_set_true():
 def test_send_result_retryable_false_for_permanent():
     r = SendResult(success=False, error="message to edit not found")
     assert r.retryable is False
-
-
-# ---------------------------------------------------------------------------
-# 3. run.py logic — retryable result must NOT set can_edit=False
-#    We simulate the relevant block from send_progress_messages():
-#
-#      if not result.success:
-#          if getattr(result, 'retryable', False):
-#              continue           # <-- keep can_edit=True
-#          ...
-#          can_edit = False
-#
-# ---------------------------------------------------------------------------
-
-def _simulate_progress_loop(edit_results):
-    """
-    Simulate the can_edit decision for a sequence of edit_message results.
-
-    Returns the final value of can_edit after processing all results.
-    """
-    can_edit = True
-    for result in edit_results:
-        if not result.success:
-            if getattr(result, "retryable", False):
-                # Transient — keep can_edit True and skip to next cycle
-                continue
-            can_edit = False
-            break
-    return can_edit
-
-
-def test_transient_failure_keeps_can_edit_true():
-    """A single transient network error must not disable progress editing."""
-    results = [
-        SendResult(success=False, error="httpx.ConnectError", retryable=True),
-        SendResult(success=True, message_id="42"),
-    ]
-    assert _simulate_progress_loop(results) is True
-
-
-def test_permanent_failure_sets_can_edit_false():
-    """A permanent edit failure must disable progress editing."""
-    results = [
-        SendResult(success=False, error="message to edit not found", retryable=False),
-    ]
-    assert _simulate_progress_loop(results) is False
-
-
-def test_multiple_transient_then_success_keeps_can_edit_true():
-    """Multiple transient failures followed by success keep can_edit=True."""
-    results = [
-        SendResult(success=False, error="httpx.ConnectError", retryable=True),
-        SendResult(success=False, error="server disconnected", retryable=True),
-        SendResult(success=True, message_id="99"),
-    ]
-    assert _simulate_progress_loop(results) is True
-
-
-def test_flood_control_sets_can_edit_false():
-    """Flood control (non-retryable) must disable progress editing."""
-    results = [
-        SendResult(success=False, error="flood_control:30.0", retryable=False),
-    ]
-    assert _simulate_progress_loop(results) is False

--- a/tests/gateway/test_telegram_progress_edit_transient.py
+++ b/tests/gateway/test_telegram_progress_edit_transient.py
@@ -4,15 +4,18 @@ Issue: #27828
 
 When ``edit_message_text`` fails with a transient network error (e.g.
 ``httpx.ConnectError``), the gateway must NOT permanently disable progress-
-message editing.  Only permanent failures (flood control, message-not-found,
-permissions) should set ``can_edit = False``.
+message editing. Deleted or invalid edit anchors should be replaced, while
+permissions and other permanent failures should set ``can_edit = False``.
 
-Two layers are tested:
+Three contracts are tested directly:
 
 1. The ``_TRANSIENT_EDIT_MARKERS`` / retryable classification logic in
    ``TelegramAdapter.edit_message``.
-2. The ``send_progress_messages`` caller in ``run.py`` honours
-   ``result.retryable`` and keeps ``can_edit = True``.
+2. The ``SendResult.retryable`` transport field.
+3. The production stale-anchor classifier in ``gateway.run``.
+
+The real ``send_progress_messages`` behavior is covered by
+``test_run_progress_topics.py`` instead of duplicating its state machine here.
 """
 
 from __future__ import annotations
@@ -21,6 +24,7 @@ from __future__ import annotations
 import pytest
 
 from gateway.platforms.base import SendResult
+from gateway.run import _is_stale_progress_edit_error
 
 
 # ---------------------------------------------------------------------------
@@ -42,24 +46,10 @@ _TRANSIENT_MARKERS = (
     "httpx",
 )
 
-_PERMANENT_MARKERS = (
-    "message to edit not found",
-    "message can't be edited",
-    "not enough rights",
-    "message_id_invalid",
-)
-
-
 def _is_transient(error_str: str) -> bool:
     """Mirrors the classification logic added to TelegramAdapter.edit_message."""
     err = error_str.lower()
     return any(m in err for m in _TRANSIENT_MARKERS)
-
-
-def _is_permanent(error_str: str) -> bool:
-    err = error_str.lower()
-    return any(m in err for m in _PERMANENT_MARKERS)
-
 
 # ---------------------------------------------------------------------------
 # 1. Error classification — transient vs permanent
@@ -98,6 +88,24 @@ def test_permanent_errors_are_not_transient(error_str):
     )
 
 
+@pytest.mark.parametrize(
+    ("error_str", "expected"),
+    [
+        ("Bad Request: message to edit not found", True),
+        ("Bad Request: MESSAGE_ID_INVALID", True),
+        ("BAD REQUEST: MESSAGE TO EDIT NOT FOUND", True),
+        ("Bad Request: message can't be edited", False),
+        ("Bad Request: not enough rights to edit the message", False),
+        ("Forbidden: bot was blocked by the user", False),
+        ("httpx.ConnectError: connection reset", False),
+        ("flood_control:30.0", False),
+        ("unexpected permanent adapter failure", False),
+    ],
+)
+def test_stale_progress_edit_error_classification(error_str, expected):
+    assert _is_stale_progress_edit_error(error_str) is expected
+
+
 # ---------------------------------------------------------------------------
 # 2. SendResult retryable field
 # ---------------------------------------------------------------------------
@@ -107,32 +115,16 @@ def test_send_result_retryable_default_is_false():
     assert r.retryable is False
 
 
-# ---------------------------------------------------------------------------
-# 3. run.py logic — retryable result must NOT set can_edit=False
-#    We simulate the relevant block from send_progress_messages():
-#
-#      if not result.success:
-#          if getattr(result, 'retryable', False):
-#              continue           # <-- keep can_edit=True
-#          ...
-#          can_edit = False
-#
-# ---------------------------------------------------------------------------
+def test_send_result_retryable_can_be_set_true():
+    result = SendResult(
+        success=False,
+        error="httpx.ConnectError: connection reset",
+        retryable=True,
+    )
+    assert result.retryable is True
 
-def _simulate_progress_loop(edit_results):
-    """
-    Simulate the can_edit decision for a sequence of edit_message results.
 
-    Returns the final value of can_edit after processing all results.
-    """
-    can_edit = True
-    for result in edit_results:
-        if not result.success:
-            if getattr(result, "retryable", False):
-                # Transient — keep can_edit True and skip to next cycle
-                continue
-            can_edit = False
-            break
-    return can_edit
-
+def test_send_result_retryable_false_for_permanent():
+    result = SendResult(success=False, error="message to edit not found")
+    assert result.retryable is False
 


### PR DESCRIPTION
## Summary

- Recover editable progress coalescing only when an edit fails with a verified stale/deleted-message error (`message to edit not found` or `MESSAGE_ID_INVALID`).
- Replace the dead anchor with the complete coalesced history, then continue editing the replacement message instead of silently dropping earlier progress.
- Keep permission, `Forbidden`, and other non-stale permanent failures in send-only mode, matching the reviewer-requested failure boundary.
- Split oversized progress lines at the gateway boundary and preserve bounded, lossless fallback delivery across overflow, reset, cancellation, and no-message-ID paths.
- Add real callback → queue → `TurnRunner.send_progress_messages` regression coverage, including stale replacement, permanent failures, overflow, cancellation, reset, deduplication, and routing metadata.

Fixes #9136

## Root cause

After a progress message was deleted or otherwise became stale, the next edit failure permanently disabled editing and sent only the newest incremental line. Earlier lines already coalesced into the stale message were therefore absent from the replacement history, and later progress could no longer coalesce into a new editable anchor.

The recovery path now distinguishes verified stale/deleted-message failures from every other edit failure. Only verified stale failures clear the dead message ID and send the complete accumulated progress as a replacement. A successful replacement ID becomes the new editable anchor; a send without an ID remains send-only without duplication; and a failed replacement falls back to bounded send-only delivery.

<details><summary>Before/After</summary>

### Before

Command run against the latest `upstream/main` (`c896c09c4`) with the new regression test applied but without the production fix:

```text
scripts/run_tests.sh tests/gateway/test_run_progress_topics.py -q -k test_stale_progress_edit_replaces_anchor_and_keeps_editing
```

Complete output:

```text
▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
▶ pre-compiling bytecode cache
▶ launching test runner
Discovered 1 test files (~38 tests) under ['tests/gateway/test_run_progress_topics.py']; running with -j 32
[100.0% |    38/~38 | ✓0 | ✗1] ✗ tests/gateway/test_run_progress_topics.py (1✗, 12.4s)

  ╔╍ Failed: tests/gateway/test_run_progress_topics.py ╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍
  ║ WARNING  hermes_state:hermes_state.py:1296 state.db (async_delegation): linked SQLite 3.50.4 is vulnerable to the WAL-reset corruption bug (https://sqlite.org/wal.html#walresetbug) — using journal_mode=DELETE instead of enabling WAL. Upgrade to SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6); Hermes-managed installs can repair the embedded runtime with `hermes update`. See `hermes doctor`. This warning fires once per process per database.
  ║ =============================== warnings summary ===============================
  ║ tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║   <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/lark_oapi/ws/pb/google/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  ║     __import__('pkg_resources').declare_namespace(__name__)
  ║ 
  ║ tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║   <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/lark_oapi/ws/pb/google/__init__.py:2: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws.pb.google')`.
  ║   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  ║     __import__('pkg_resources').declare_namespace(__name__)
  ║ 
  ║ tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║   <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws.pb')`.
  ║   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  ║     declare_namespace(parent)
  ║ 
  ║ tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║   <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws')`.
  ║   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  ║     declare_namespace(parent)
  ║ 
  ║ tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║   <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi')`.
  ║   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
  ║     declare_namespace(parent)
  ║ 
  ║ -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  ║ =========================== short test summary info ============================
  ║ FAILED tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ║ 1 failed, 41 deselected, 5 warnings in 5.03s
  ║
  ║  Repro: python -m pytest tests/gateway/test_run_progress_topics.py -q -k test_stale_progress_edit_replaces_anchor_and_keeps_editing
  ╚╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍


=== Summary: 1 files, 0 tests passed, 1 failed (100% complete) in 12.4s (32 workers) ===
  Durations cached to test_durations.json (1 files)

=== Per-file subprocess time distribution ===
  Files:   1
  Total subprocess CPU-wall: 12.4s  (runner wall: 12.4s, parallelism: 32x)
  P50: 12.37s  P90: 12.37s  P95: 12.37s  P99: 12.37s  Max: 12.37s
  <1s: 0 files (0%)  <2s: 0 files (0%)
  Top 10 slowest:
     12.37s  tests/gateway/test_run_progress_topics.py

=== Failure output ===

--- tests/gateway/test_run_progress_topics.py ---
F                                                                        [100%]
=================================== FAILURES ===================================
__________ test_stale_progress_edit_replaces_anchor_and_keeps_editing __________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object>
tmp_path = PosixPath('<PYTEST_TMP>/test_stale_progress_edit_repla0')

    @pytest.mark.asyncio
    async def test_stale_progress_edit_replaces_anchor_and_keeps_editing(
        monkeypatch, tmp_path
    ):
        adapter, result = await _run_with_agent(
            monkeypatch,
            tmp_path,
            SynchronizedFourStageProgressAgent,
            session_id="sess-stale-progress-edit",
            config_data={
                "display": {
                    "tool_progress": "all",
                    "cleanup_progress": True,
                }
            },
            platform=Platform.FEISHU,
            chat_id="chat-1",
            thread_id="17585",
            adapter_cls=ProgressEditFailureAdapter,
            event_message_id="trigger-message",
        )
    
        assert result["final_response"] == "done"
        assert adapter.edits[0]["message_id"] == "progress-1"
>       assert adapter.sent[1]["content"] == adapter.edits[0]["content"]
E       AssertionError: assert '⚙️ Running third command' == '⚙️ Running f...third command'
E         
E         - ⚙️ Running first command
E         - ⚙️ Running second command
E           ⚙️ Running third command

tests/gateway/test_run_progress_topics.py:1420: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  hermes_state:hermes_state.py:1296 state.db (async_delegation): linked SQLite 3.50.4 is vulnerable to the WAL-reset corruption bug (https://sqlite.org/wal.html#walresetbug) — using journal_mode=DELETE instead of enabling WAL. Upgrade to SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6); Hermes-managed installs can repair the embedded runtime with `hermes update`. See `hermes doctor`. This warning fires once per process per database.
=============================== warnings summary ===============================
tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/lark_oapi/ws/pb/google/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    __import__('pkg_resources').declare_namespace(__name__)

tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/lark_oapi/ws/pb/google/__init__.py:2: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws.pb.google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    __import__('pkg_resources').declare_namespace(__name__)

tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws.pb')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(parent)

tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi.ws')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(parent)

tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
  <HOME>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pkg_resources/__init__.py:2560: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('lark_oapi')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(parent)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/gateway/test_run_progress_topics.py::test_stale_progress_edit_replaces_anchor_and_keeps_editing
1 failed, 41 deselected, 5 warnings in 5.03s

=== 1 file with test failures (1 test failed) ===
  tests/gateway/test_run_progress_topics.py  (1 test failed)
```

The stale edit falls back to only `Running third command`; the already-coalesced first and second lines are missing.

### After

The same command on commit `59590d637`:

```text
scripts/run_tests.sh tests/gateway/test_run_progress_topics.py -q -k test_stale_progress_edit_replaces_anchor_and_keeps_editing
```

Complete output:

```text
▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
▶ pre-compiling bytecode cache
▶ launching test runner
Discovered 1 test files (~38 tests) under ['tests/gateway/test_run_progress_topics.py']; running with -j 32
[100.0% |    38/~38 | ✓1 | ✗0] ✓ tests/gateway/test_run_progress_topics.py (1✓, 6.0s)

=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 6.0s (32 workers) ===
  Durations cached to test_durations.json (1 files)

=== Per-file subprocess time distribution ===
  Files:   1
  Total subprocess CPU-wall: 6.0s  (runner wall: 6.0s, parallelism: 32x)
  P50: 5.99s  P90: 5.99s  P95: 5.99s  P99: 5.99s  Max: 5.99s
  <1s: 0 files (0%)  <2s: 0 files (0%)
  Top 10 slowest:
      5.99s  tests/gateway/test_run_progress_topics.py
```

</details>

## Test plan

- [x] Verified stale edit replaces the dead anchor with the complete coalesced history and keeps editing the replacement.
- [x] Non-stale permanent failures remain send-only and do not re-anchor.
- [x] Replacement sends that fail or return no message ID avoid loops and duplicate history.
- [x] Overflow, cancellation, final flush, reset, deduplication, and oversized single-line paths remain bounded and lossless.
- [x] Existing cleanup, display configuration, routing, and turn-context behavior remains covered.

```text
scripts/run_tests.sh tests/gateway/test_telegram_progress_edit_transient.py tests/gateway/test_run_progress_topics.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_display_config.py tests/gateway/test_turn_context.py -q
```

<details><summary>Complete regression log</summary>

```text
▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
▶ pre-compiling bytecode cache
▶ launching test runner
Discovered 5 test files (~72 tests) under ['tests/gateway/test_telegram_progress_edit_transient.py', 'tests/gateway/test_run_progress_topics.py', 'tests/gateway/test_run_cleanup_progress.py', 'tests/gateway/test_display_config.py', 'tests/gateway/test_turn_context.py']; running with -j 32
[  8.3% |     6/~72 | ✓6 | ✗0] ✓ tests/gateway/test_turn_context.py (6✓, 4.7s)
[ 36.1% |    26/~72 | ✓26 | ✗ 0] ✓ tests/gateway/test_display_config.py (20✓, 4.9s)
[ 44.4% |    32/~72 | ✓53 | ✗ 0] ✓ tests/gateway/test_telegram_progress_edit_transient.py (27✓, 4.9s)
[ 47.2% |    34/~72 | ✓55 | ✗ 0] ✓ tests/gateway/test_run_cleanup_progress.py (2✓, 5.8s)
[100.0% |    72/~72 | ✓97 | ✗ 0] ✓ tests/gateway/test_run_progress_topics.py (42✓, 45.9s)

=== Summary: 5 files, 97 tests passed, 0 failed (100% complete) in 45.9s (32 workers) ===
  Durations cached to test_durations.json (5 files)

=== Per-file subprocess time distribution ===
  Files:   5
  Total subprocess CPU-wall: 66.2s  (runner wall: 45.9s, parallelism: 32x)
  P50: 4.87s  P90: 45.93s  P95: 45.93s  P99: 45.93s  Max: 45.93s
  <1s: 0 files (0%)  <2s: 0 files (0%)
  Top 10 slowest:
     45.93s  tests/gateway/test_run_progress_topics.py
      5.80s  tests/gateway/test_run_cleanup_progress.py
      4.87s  tests/gateway/test_telegram_progress_edit_transient.py
      4.85s  tests/gateway/test_display_config.py
      4.72s  tests/gateway/test_turn_context.py
```

</details>

## Additional verification

- `ruff check .`: passed with 0 diagnostics.
- CI-style ruff/ty comparison against `upstream/main`: 0 new ruff issues and 0 new ty issues.
- `python -m compileall`: passed for the changed Python files.
- `scripts/check-windows-footguns.py --all`: passed, 0 findings across 962 files.
- Bandit comparison for `gateway/run.py`: 0 high findings on both revisions, 1 unchanged medium finding, and 149 low findings on the PR versus 151 on base.
- Independent code review: no remaining critical, high, or medium findings.
