### PR TITLE
fix(gateway): skip intermediate stream sends on no-edit platforms

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -79,7 +79,8 @@ class GatewayStreamConsumer:
         self._accumulated = ""
         self._message_id: Optional[str] = None
         self._already_sent = False
-        self._edit_supported = True  # Disabled when progressive edits are no longer usable
+        self._adapter_can_edit = getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)
+        self._edit_supported = self._adapter_can_edit
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
         self._fallback_final_send = False
@@ -171,6 +172,14 @@ class GatewayStreamConsumer:
                         and self._accumulated)
                     or len(self._accumulated) >= self.cfg.buffer_threshold
                 )
+
+                # For platforms that cannot edit messages (QQ, WeChat, etc.),
+                # skip all intermediate sends — only flush on got_done or
+                # commentary so the user sees one complete message instead of
+                # a broken pair.
+                if not self._adapter_can_edit and should_edit and self._accumulated:
+                    if not got_done and commentary_text is None:
+                        should_edit = False
 
                 current_update_visible = False
                 if should_edit and self._accumulated:


### PR DESCRIPTION
## What does this PR do?

Fix message splitting on platforms that cannot edit messages (WeChat, QQ, etc.). The stream consumer now buffers all tokens and sends one complete message at the end, instead of sending an intermediate partial message that splits the response into two bubbles.

## Related Issue

Fixes the root cause behind #8326 (stuck cursor) — while PR #8670 strips the cursor, neither it nor the closed #8407 address the underlying message split.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/stream_consumer.py`
  - `__init__`: Read `SUPPORTS_MESSAGE_EDITING` from the adapter into `_adapter_can_edit`; initialize `_edit_supported` from it instead of hardcoding `True`
  - `run()`: After computing `should_edit`, suppress intermediate flushes when `_adapter_can_edit is False` — only allow sends on `got_done` or `commentary`

### Root cause

Platforms like WeChat (`SUPPORTS_MESSAGE_EDITING = False`) and QQ (plugin-defined) cannot edit sent messages. The stream consumer's `run()` loop previously:

1. Accumulated tokens until buffer threshold / edit interval
2. Called `_send_or_edit()` → sent a new message (`_message_id` was `None`)
3. `edit_message()` returned `success=False` (base stub)
4. Set `_message_id = "__no_edit__"` and `_fallback_final_send = True`
5. On `got_done`, called `_send_fallback_final()` → sent a **second** message

The existing `cursor=""` mitigation in `run.py:7826-7827` only hides the cursor — it doesn't prevent the intermediate send that causes the split.

### Before / after

```
Before (no-edit platform):
  tokens → buffer fills → SEND partial → edit fails →
  fallback → SEND remaining → user sees 2 messages

After (no-edit platform):
  tokens → buffer fills → skip (no-edit) → more tokens →
  got_done → SEND complete → user sees 1 message
```

## How to Test

1. Enable streaming in `config.yaml`:
   ```yaml
   streaming:
     enabled: true
   ```
2. Send a message via WeChat (or any platform with `SUPPORTS_MESSAGE_EDITING = False`)
3. Verify the response arrives as **one** message, not two
4. Verify platforms with editing support (Telegram, Discord) still stream normally
5. Compile check:
   ```bash
   python -m py_compile gateway/stream_consumer.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix — response split into two message bubbles at an arbitrary point:

**QQ** (with stuck cursor ▉):
```
粗体 斜体 ` ▉
```
```
代码`
列表项 1
列表项 2
引用
def hello():
    print("Hello World")
链接
表头1 表头2
内容1 内容2
水平分隔线
```

**WeChat** (same split, no cursor):
```
粗体 斜体 `
```
```
代码`
列表项 1
列表项 2
引用
def hello():
    print("Hello World")
链接
表头1 表头2
内容1 内容2
水平分隔线
```

After fix — one complete message, no split, no stuck cursor.