### PR TITLE
fix(weixin): align image delivery with shared adapter contract

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,17 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(
+            chat_id,
+            file_path=image_path,
+            caption=caption,
+            metadata=metadata,
+        )
 
     async def send_document(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -363,6 +363,31 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinMediaDelivery:
+    def test_send_image_file_accepts_image_path_keyword(self):
+        adapter = _make_adapter()
+
+        with patch.object(adapter, "send_document", new_callable=AsyncMock) as send_document_mock:
+            send_document_mock.return_value = {"success": True}
+
+            result = asyncio.run(
+                adapter.send_image_file(
+                    chat_id="wxid_test123",
+                    image_path="/tmp/demo.png",
+                    caption="screenshot",
+                    metadata={"source": "test"},
+                )
+            )
+
+        assert result == {"success": True}
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/demo.png",
+            caption="screenshot",
+            metadata={"source": "test"},
+        )
+
+
 class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- align `WeixinAdapter.send_image_file()` with the shared `image_path` keyword contract used by the gateway media pipeline
- add a regression test that exercises the Weixin adapter through the common image-delivery call shape

## Root Cause
The shared gateway attachment path calls `send_image_file(chat_id=..., image_path=...)`, but the Weixin adapter exposed that parameter as `path`. That keyword mismatch caused post-stream screenshot delivery and other native Weixin image sends to fail before the file upload path was reached.

## Validation
- `/Users/skipzhang/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_weixin.py -q`
- `/Users/skipzhang/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q`

## Notes
- not validated end-to-end against a live Weixin send from this checkout
