### PR TITLE
feat(web): add context window support to dashboard config

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -96,6 +96,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Default model (e.g. anthropic/claude-sonnet-4.6)",
         "category": "general",
     },
+    "model_context_length": {
+        "type": "number",
+        "description": "Context window override (0 = auto-detect from model metadata)",
+        "category": "general",
+    },
     "terminal.backend": {
         "type": "select",
         "description": "Terminal execution backend",
@@ -245,6 +250,17 @@ def _build_schema_from_config(
 
 
 CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
+
+# Inject virtual fields that don't live in DEFAULT_CONFIG but are surfaced
+# by the normalize/denormalize cycle.  Insert model_context_length right after
+# the "model" key so it renders adjacent in the frontend.
+_mcl_entry = _SCHEMA_OVERRIDES["model_context_length"]
+_ordered_schema: Dict[str, Dict[str, Any]] = {}
+for _k, _v in CONFIG_SCHEMA.items():
+    _ordered_schema[_k] = _v
+    if _k == "model":
+        _ordered_schema["model_context_length"] = _mcl_entry
+CONFIG_SCHEMA = _ordered_schema
 
 
 class ConfigUpdate(BaseModel):
@@ -408,11 +424,19 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     or a dict (``{default: ..., provider: ..., base_url: ...}``).  The schema is built
     from DEFAULT_CONFIG where ``model`` is a string, but user configs often have the
     dict form.  Normalize to the string form so the frontend schema matches.
+
+    Also surfaces ``model_context_length`` as a top-level field so the web UI can
+    display and edit it.  A value of 0 means "auto-detect".
     """
     config = dict(config)  # shallow copy
     model_val = config.get("model")
     if isinstance(model_val, dict):
+        # Extract context_length before flattening the dict
+        ctx_len = model_val.get("context_length", 0)
         config["model"] = model_val.get("default", model_val.get("name", ""))
+        config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
+    else:
+        config["model_context_length"] = 0
     return config
 
 
@@ -433,6 +457,97 @@ async def get_schema():
     return {"fields": CONFIG_SCHEMA, "category_order": _CATEGORY_ORDER}
 
 
+@app.get("/api/model/info")
+async def get_model_info():
+    """Return resolved model metadata for the currently configured model.
+
+    Calls the same context-length resolution chain the agent uses, so the
+    frontend can display "Auto-detected: 200K" alongside the override field.
+    Also returns model capabilities (vision, reasoning, tools) when available.
+    """
+    try:
+        cfg = load_config()
+        model_cfg = cfg.get("model", "")
+
+        # Extract model name and provider from the config
+        if isinstance(model_cfg, dict):
+            model_name = model_cfg.get("default", model_cfg.get("name", ""))
+            provider = model_cfg.get("provider", "")
+            base_url = model_cfg.get("base_url", "")
+            config_ctx = model_cfg.get("context_length")
+        else:
+            model_name = str(model_cfg) if model_cfg else ""
+            provider = ""
+            base_url = ""
+            config_ctx = None
+
+        if not model_name:
+            return {
+                "model": "",
+                "provider": provider,
+                "auto_context_length": 0,
+                "config_context_length": 0,
+                "effective_context_length": 0,
+                "capabilities": {},
+            }
+
+        # Resolve auto-detected context length (pass config_ctx=None to get
+        # purely auto-detected value, then separately report the override)
+        try:
+            from agent.model_metadata import get_model_context_length
+            auto_ctx = get_model_context_length(
+                model=model_name,
+                base_url=base_url,
+                provider=provider,
+                config_context_length=None,  # ignore override — we want auto value
+            )
+        except Exception:
+            auto_ctx = 0
+
+        config_ctx_int = 0
+        if isinstance(config_ctx, int) and config_ctx > 0:
+            config_ctx_int = config_ctx
+
+        # Effective is what the agent actually uses
+        effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx
+
+        # Try to get model capabilities from models.dev
+        caps = {}
+        try:
+            from agent.models_dev import get_model_capabilities
+            mc = get_model_capabilities(provider=provider, model=model_name)
+            if mc is not None:
+                caps = {
+                    "supports_tools": mc.supports_tools,
+                    "supports_vision": mc.supports_vision,
+                    "supports_reasoning": mc.supports_reasoning,
+                    "context_window": mc.context_window,
+                    "max_output_tokens": mc.max_output_tokens,
+                    "model_family": mc.model_family,
+                }
+        except Exception:
+            pass
+
+        return {
+            "model": model_name,
+            "provider": provider,
+            "auto_context_length": auto_ctx,
+            "config_context_length": config_ctx_int,
+            "effective_context_length": effective_ctx,
+            "capabilities": caps,
+        }
+    except Exception:
+        _log.exception("GET /api/model/info failed")
+        return {
+            "model": "",
+            "provider": "",
+            "auto_context_length": 0,
+            "config_context_length": 0,
+            "effective_context_length": 0,
+            "capabilities": {},
+        }
+
+
 def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     """Reverse _normalize_config_for_web before saving.
 
@@ -440,11 +555,23 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     to recover model subkeys (provider, base_url, api_mode, etc.) that were
     stripped from the GET response.  The frontend only sees model as a flat
     string; the rest is preserved transparently.
+
+    Also handles ``model_context_length`` — writes it back into the model dict
+    as ``context_length``.  A value of 0 or absent means "auto-detect" (omitted
+    from the dict so get_model_context_length() uses its normal resolution).
     """
     config = dict(config)
     # Remove any _model_meta that might have leaked in (shouldn't happen
     # with the stripped GET response, but be defensive)
     config.pop("_model_meta", None)
+
+    # Extract and remove model_context_length before processing model
+    ctx_override = config.pop("model_context_length", 0)
+    if not isinstance(ctx_override, int):
+        try:
+            ctx_override = int(ctx_override)
+        except (TypeError, ValueError):
+            ctx_override = 0
 
     model_val = config.get("model")
     if isinstance(model_val, str) and model_val:
@@ -455,7 +582,20 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
             if isinstance(disk_model, dict):
                 # Preserve all subkeys, update default with the new value
                 disk_model["default"] = model_val
+                # Write context_length into the model dict (0 = remove/auto)
+                if ctx_override > 0:
+                    disk_model["context_length"] = ctx_override
+                else:
+                    disk_model.pop("context_length", None)
                 config["model"] = disk_model
+            else:
+                # Model was previously a bare string — upgrade to dict if
+                # user is setting a context_length override
+                if ctx_override > 0:
+                    config["model"] = {
+                        "default": model_val,
+                        "context_length": ctx_override,
+                    }
         except Exception:
             pass  # can't read disk config — just use the string form
     return config

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -673,3 +673,282 @@ class TestNewEndpoints:
         resp = self.client.get("/api/auth/session-token")
         assert resp.status_code == 200
         assert resp.json()["token"] == _SESSION_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Model context length: normalize/denormalize + /api/model/info
+# ---------------------------------------------------------------------------
+
+
+class TestModelContextLength:
+    """Tests for model_context_length in normalize/denormalize and /api/model/info."""
+
+    def test_normalize_extracts_context_length_from_dict(self):
+        """normalize should surface context_length from model dict."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "provider": "openrouter",
+                "context_length": 200000,
+            }
+        }
+        result = _normalize_config_for_web(cfg)
+        assert result["model"] == "anthropic/claude-opus-4.6"
+        assert result["model_context_length"] == 200000
+
+    def test_normalize_bare_string_model_yields_zero(self):
+        """normalize should set model_context_length=0 for bare string model."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        result = _normalize_config_for_web({"model": "anthropic/claude-sonnet-4"})
+        assert result["model"] == "anthropic/claude-sonnet-4"
+        assert result["model_context_length"] == 0
+
+    def test_normalize_dict_without_context_length_yields_zero(self):
+        """normalize should default to 0 when model dict has no context_length."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {"model": {"default": "test/model", "provider": "openrouter"}}
+        result = _normalize_config_for_web(cfg)
+        assert result["model_context_length"] == 0
+
+    def test_normalize_non_int_context_length_yields_zero(self):
+        """normalize should coerce non-int context_length to 0."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        cfg = {"model": {"default": "test/model", "context_length": "invalid"}}
+        result = _normalize_config_for_web(cfg)
+        assert result["model_context_length"] == 0
+
+    def test_denormalize_writes_context_length_into_model_dict(self):
+        """denormalize should write model_context_length back into model dict."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        # Set up disk config with model as a dict
+        save_config({
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "openrouter"}
+        })
+
+        result = _denormalize_config_from_web({
+            "model": "anthropic/claude-opus-4.6",
+            "model_context_length": 100000,
+        })
+        assert isinstance(result["model"], dict)
+        assert result["model"]["context_length"] == 100000
+        assert "model_context_length" not in result  # virtual field removed
+
+    def test_denormalize_zero_removes_context_length(self):
+        """denormalize with model_context_length=0 should remove context_length key."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "provider": "openrouter",
+                "context_length": 50000,
+            }
+        })
+
+        result = _denormalize_config_from_web({
+            "model": "anthropic/claude-opus-4.6",
+            "model_context_length": 0,
+        })
+        assert isinstance(result["model"], dict)
+        assert "context_length" not in result["model"]
+
+    def test_denormalize_upgrades_bare_string_to_dict(self):
+        """denormalize should upgrade bare string model to dict when context_length set."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        # Disk has model as bare string
+        save_config({"model": "anthropic/claude-sonnet-4"})
+
+        result = _denormalize_config_from_web({
+            "model": "anthropic/claude-sonnet-4",
+            "model_context_length": 65000,
+        })
+        assert isinstance(result["model"], dict)
+        assert result["model"]["default"] == "anthropic/claude-sonnet-4"
+        assert result["model"]["context_length"] == 65000
+
+    def test_denormalize_bare_string_stays_string_when_zero(self):
+        """denormalize should keep bare string model as string when context_length=0."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({"model": "anthropic/claude-sonnet-4"})
+
+        result = _denormalize_config_from_web({
+            "model": "anthropic/claude-sonnet-4",
+            "model_context_length": 0,
+        })
+        assert result["model"] == "anthropic/claude-sonnet-4"
+
+    def test_denormalize_coerces_string_context_length(self):
+        """denormalize should handle string model_context_length from frontend."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {"default": "test/model", "provider": "openrouter"}
+        })
+
+        result = _denormalize_config_from_web({
+            "model": "test/model",
+            "model_context_length": "32000",
+        })
+        assert isinstance(result["model"], dict)
+        assert result["model"]["context_length"] == 32000
+
+
+class TestModelContextLengthSchema:
+    """Tests for model_context_length placement in CONFIG_SCHEMA."""
+
+    def test_schema_has_model_context_length(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+        assert "model_context_length" in CONFIG_SCHEMA
+
+    def test_schema_model_context_length_after_model(self):
+        """model_context_length should appear immediately after model in schema."""
+        from hermes_cli.web_server import CONFIG_SCHEMA
+        keys = list(CONFIG_SCHEMA.keys())
+        model_idx = keys.index("model")
+        assert keys[model_idx + 1] == "model_context_length"
+
+    def test_schema_model_context_length_is_number(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+        entry = CONFIG_SCHEMA["model_context_length"]
+        assert entry["type"] == "number"
+        assert "category" in entry
+
+
+class TestModelInfoEndpoint:
+    """Tests for GET /api/model/info endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        from hermes_cli.web_server import app
+        self.client = TestClient(app)
+
+    def test_model_info_returns_200(self):
+        resp = self.client.get("/api/model/info")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "model" in data
+        assert "provider" in data
+        assert "auto_context_length" in data
+        assert "config_context_length" in data
+        assert "effective_context_length" in data
+        assert "capabilities" in data
+
+    def test_model_info_with_dict_config(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "provider": "openrouter",
+                "context_length": 100000,
+            }
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=200000):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["model"] == "anthropic/claude-opus-4.6"
+        assert data["provider"] == "openrouter"
+        assert data["auto_context_length"] == 200000
+        assert data["config_context_length"] == 100000
+        assert data["effective_context_length"] == 100000  # override wins
+
+    def test_model_info_auto_detect_when_no_override(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "openrouter"}
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=200000):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["auto_context_length"] == 200000
+        assert data["config_context_length"] == 0
+        assert data["effective_context_length"] == 200000  # auto wins
+
+    def test_model_info_empty_model(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {"model": ""})
+
+        resp = self.client.get("/api/model/info")
+        data = resp.json()
+        assert data["model"] == ""
+        assert data["effective_context_length"] == 0
+
+    def test_model_info_bare_string_model(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": "anthropic/claude-sonnet-4"
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=200000):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["model"] == "anthropic/claude-sonnet-4"
+        assert data["provider"] == ""
+        assert data["config_context_length"] == 0
+        assert data["effective_context_length"] == 200000
+
+    def test_model_info_capabilities(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "openrouter"}
+        })
+
+        mock_caps = MagicMock()
+        mock_caps.supports_tools = True
+        mock_caps.supports_vision = True
+        mock_caps.supports_reasoning = True
+        mock_caps.context_window = 200000
+        mock_caps.max_output_tokens = 32000
+        mock_caps.model_family = "claude-opus"
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=200000), \
+             patch("agent.models_dev.get_model_capabilities", return_value=mock_caps):
+            resp = self.client.get("/api/model/info")
+
+        caps = resp.json()["capabilities"]
+        assert caps["supports_tools"] is True
+        assert caps["supports_vision"] is True
+        assert caps["supports_reasoning"] is True
+        assert caps["max_output_tokens"] == 32000
+        assert caps["model_family"] == "claude-opus"
+
+    def test_model_info_graceful_on_metadata_error(self, monkeypatch):
+        """Endpoint should return zeros on import/resolution errors, not 500."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": "some/obscure-model"
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", side_effect=Exception("boom")):
+            resp = self.client.get("/api/model/info")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["auto_context_length"] == 0

--- a/web/src/components/ModelInfoCard.tsx
+++ b/web/src/components/ModelInfoCard.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import {
+  Brain,
+  Eye,
+  Gauge,
+  Lightbulb,
+  Wrench,
+  Loader2,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import type { ModelInfoResponse } from "@/lib/api";
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n % 1_000 === 0 ? 0 : 1)}K`;
+  return String(n);
+}
+
+interface ModelInfoCardProps {
+  /** Current model string from config state — used to detect changes */
+  currentModel: string;
+  /** Bumped after config saves to trigger re-fetch */
+  refreshKey?: number;
+}
+
+export function ModelInfoCard({ currentModel, refreshKey = 0 }: ModelInfoCardProps) {
+  const [info, setInfo] = useState<ModelInfoResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [lastFetchKey, setLastFetchKey] = useState("");
+
+  useEffect(() => {
+    if (!currentModel) return;
+    // Re-fetch when model changes OR when refreshKey bumps (after save)
+    const fetchKey = `${currentModel}:${refreshKey}`;
+    if (fetchKey === lastFetchKey) return;
+    setLastFetchKey(fetchKey);
+    setLoading(true);
+    api
+      .getModelInfo()
+      .then(setInfo)
+      .catch(() => setInfo(null))
+      .finally(() => setLoading(false));
+  }, [currentModel, refreshKey, lastFetchKey]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading model info…
+      </div>
+    );
+  }
+
+  if (!info || !info.model) return null;
+
+  const caps = info.capabilities;
+  const hasCaps = caps && Object.keys(caps).length > 0;
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5 space-y-2">
+      {/* Context window */}
+      <div className="flex items-center gap-4 text-xs">
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <Gauge className="h-3.5 w-3.5" />
+          <span className="font-medium">Context Window</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="font-mono font-semibold text-foreground">
+            {formatTokenCount(info.effective_context_length)}
+          </span>
+          {info.config_context_length > 0 ? (
+            <span className="text-amber-500/80 text-[10px]">
+              (override — auto: {formatTokenCount(info.auto_context_length)})
+            </span>
+          ) : (
+            <span className="text-muted-foreground/60 text-[10px]">auto-detected</span>
+          )}
+        </div>
+      </div>
+
+      {/* Max output */}
+      {hasCaps && caps.max_output_tokens && caps.max_output_tokens > 0 && (
+        <div className="flex items-center gap-4 text-xs">
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <Lightbulb className="h-3.5 w-3.5" />
+            <span className="font-medium">Max Output</span>
+          </div>
+          <span className="font-mono font-semibold text-foreground">
+            {formatTokenCount(caps.max_output_tokens)}
+          </span>
+        </div>
+      )}
+
+      {/* Capability badges */}
+      {hasCaps && (
+        <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+          {caps.supports_tools && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+              <Wrench className="h-2.5 w-2.5" /> Tools
+            </span>
+          )}
+          {caps.supports_vision && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400">
+              <Eye className="h-2.5 w-2.5" /> Vision
+            </span>
+          )}
+          {caps.supports_reasoning && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-purple-500/10 px-2 py-0.5 text-[10px] font-medium text-purple-600 dark:text-purple-400">
+              <Brain className="h-2.5 w-2.5" /> Reasoning
+            </span>
+          )}
+          {caps.model_family && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              {caps.model_family}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ModelInfoCard.tsx
+++ b/web/src/components/ModelInfoCard.tsx
@@ -51,7 +51,7 @@ export function ModelInfoCard({ currentModel, refreshKey = 0 }: ModelInfoCardPro
     );
   }
 
-  if (!info || !info.model) return null;
+  if (!info || !info.model || info.effective_context_length <= 0) return null;
 
   const caps = info.capabilities;
   const hasCaps = caps && Object.keys(caps).length > 0;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -43,6 +43,7 @@ export const api = {
   getConfig: () => fetchJSON<Record<string, unknown>>("/api/config"),
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
+  getModelInfo: () => fetchJSON<ModelInfoResponse>("/api/model/info"),
   saveConfig: (config: Record<string, unknown>) =>
     fetchJSON<{ ok: boolean }>("/api/config", {
       method: "PUT",
@@ -323,6 +324,24 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+}
+
+// ── Model info types ──────────────────────────────────────────────────
+
+export interface ModelInfoResponse {
+  model: string;
+  provider: string;
+  auto_context_length: number;
+  config_context_length: number;
+  effective_context_length: number;
+  capabilities: {
+    supports_tools?: boolean;
+    supports_vision?: boolean;
+    supports_reasoning?: boolean;
+    context_window?: number;
+    max_output_tokens?: number;
+    model_family?: string;
+  };
 }
 
 // ── OAuth provider types ────────────────────────────────────────────────

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -17,6 +17,7 @@ import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { AutoField } from "@/components/AutoField";
+import { ModelInfoCard } from "@/components/ModelInfoCard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -66,6 +67,7 @@ export default function ConfigPage() {
   const [yamlLoading, setYamlLoading] = useState(false);
   const [yamlSaving, setYamlSaving] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>("");
+  const [modelInfoRefreshKey, setModelInfoRefreshKey] = useState(0);
   const { toast, showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -153,6 +155,7 @@ export default function ConfigPage() {
     try {
       await api.saveConfig(config);
       showToast("Configuration saved", "success");
+      setModelInfoRefreshKey((k) => k + 1);
     } catch (e) {
       showToast(`Failed to save: ${e}`, "error");
     } finally {
@@ -165,6 +168,7 @@ export default function ConfigPage() {
     try {
       await api.saveConfigRaw(yamlText);
       showToast("YAML config saved", "success");
+      setModelInfoRefreshKey((k) => k + 1);
       api.getConfig().then(setConfig).catch(() => {});
     } catch (e) {
       showToast(`Failed to save YAML: ${e}`, "error");
@@ -217,6 +221,7 @@ export default function ConfigPage() {
   const renderFields = (fields: [string, Record<string, unknown>][], showCategory = false) => {
     let lastSection = "";
     let lastCat = "";
+    const currentModel = config ? String(getNestedValue(config, "model") ?? "") : "";
     return fields.map(([key, s]) => {
       const parts = key.split(".");
       const section = parts.length > 1 ? parts[0] : "";
@@ -253,6 +258,12 @@ export default function ConfigPage() {
               onChange={(v) => setConfig(setNestedValue(config, key, v))}
             />
           </div>
+          {/* Inject model info card right after the model field */}
+          {key === "model" && currentModel && (
+            <div className="py-1">
+              <ModelInfoCard currentModel={currentModel} refreshKey={modelInfoRefreshKey} />
+            </div>
+          )}
         </div>
       );
     });


### PR DESCRIPTION
## Summary

Adds context window visibility and override support to the dashboard config page. Users can now see what context window Hermes auto-detected for their model, and optionally override it.

Salvaged from PR #9320 by @kshitijk4poor (cherry-picked with authorship preserved).

## Changes

### From PR #9320 (kshitijk4poor)
- **`GET /api/model/info`** — New endpoint resolving model metadata via `get_model_context_length()` + `get_model_capabilities()`
- **`_normalize_config_for_web()`** — Surfaces `context_length` from model dict as `model_context_length`
- **`_denormalize_config_from_web()`** — Writes `model_context_length` back into model dict; 0 = auto-detect (removes key)
- **`ModelInfoCard`** — New React component showing context window, max output tokens, capability badges
- **`ConfigPage`** — Injects ModelInfoCard between model field and context_length override

### Follow-up fixes
- Guard against `effective_context_length <= 0` — hide card instead of showing "Context Window: 0"
- Added 19 tests covering:
  - normalize/denormalize round-trip (dict extraction, bare string, zero removal, string coercion)
  - CONFIG_SCHEMA ordering (model_context_length immediately after model)
  - `/api/model/info` endpoint (dict config, bare string, empty model, capabilities, graceful error handling)

## Test results
- 66/66 web_server tests pass (was 47, +19 new)
- 1969/1969 hermes_cli tests pass (10 pre-existing failures unrelated)

Closes #9320