### PR TITLE
fix: prevent load_pool from pruning env-seeded credentials when env var is absent

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1311,16 +1311,28 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
 
 def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources: Set[str]) -> bool:
-    retained = [
-        entry
-        for entry in entries
-        if _is_manual_source(entry.source)
-        or entry.source in active_sources
-        or not (
-            entry.source.startswith("env:")
-            or entry.source in {"claude_code", "hermes_pkce"}
-        )
-    ]
+    retained: List[PooledCredential] = []
+    for entry in entries:
+        if _is_manual_source(entry.source) or entry.source in active_sources:
+            retained.append(entry)
+            continue
+        if entry.source.startswith("env:"):
+            env_var = entry.source[4:]
+            if env_var not in os.environ:
+                # Env var absent from this process – keep the entry; another
+                # process may still provide it.
+                retained.append(entry)
+            elif not os.environ[env_var].strip():
+                # Env var present but empty/whitespace – positive removal signal.
+                pass  # pruned
+            else:
+                retained.append(entry)
+            continue
+        if entry.source in {"claude_code", "hermes_pkce"}:
+            # Non-env singleton source not in active_sources → prune.
+            continue
+        # Unknown source type – keep.
+        retained.append(entry)
     if len(retained) == len(entries):
         return False
     entries[:] = retained

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -405,7 +405,9 @@ def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
 
 def test_load_pool_removes_stale_seeded_env_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # Set to empty string — positive evidence of removal (absent env vars are
+    # now preserved because another process may still provide the credential).
+    monkeypatch.setenv("OPENROUTER_API_KEY", "")
     _write_auth_store(
         tmp_path,
         {
@@ -1156,3 +1158,83 @@ def test_load_pool_does_not_seed_qwen_oauth_when_no_token(tmp_path, monkeypatch)
 
     assert not pool.has_credentials()
     assert pool.entries() == []
+
+
+# ---------------------------------------------------------------------------
+# _prune_stale_seeded_entries unit tests
+# ---------------------------------------------------------------------------
+
+def _make_entry(provider="openai", source="env:OPENAI_API_KEY", **kw):
+    from agent.credential_pool import PooledCredential
+    defaults = dict(
+        id="cred-x",
+        label="test",
+        auth_type="api_key",
+        priority=0,
+        access_token="sk-test",
+    )
+    defaults.update(kw)
+    return PooledCredential(provider=provider, source=source, **defaults)
+
+
+def test_prune_preserves_env_entry_when_env_var_absent(monkeypatch):
+    """env var not in os.environ → entry must be preserved (belongs to another process)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from agent.credential_pool import _prune_stale_seeded_entries
+
+    entries = [_make_entry(source="env:OPENAI_API_KEY")]
+    changed = _prune_stale_seeded_entries(entries, active_sources=set())
+    assert not changed
+    assert len(entries) == 1
+
+
+def test_prune_removes_env_entry_when_env_var_empty(monkeypatch):
+    """env var set to '' → entry must be pruned (positive evidence of removal)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+
+    from agent.credential_pool import _prune_stale_seeded_entries
+
+    entries = [_make_entry(source="env:OPENAI_API_KEY")]
+    changed = _prune_stale_seeded_entries(entries, active_sources=set())
+    assert changed
+    assert len(entries) == 0
+
+
+def test_prune_removes_singleton_when_not_active():
+    """claude_code source not in active_sources → pruned."""
+    from agent.credential_pool import _prune_stale_seeded_entries
+
+    entries = [_make_entry(provider="anthropic", source="claude_code")]
+    changed = _prune_stale_seeded_entries(entries, active_sources=set())
+    assert changed
+    assert len(entries) == 0
+
+
+def test_prune_preserves_manual_entries_always():
+    """Manual source entries must never be pruned."""
+    from agent.credential_pool import _prune_stale_seeded_entries
+
+    entries = [_make_entry(source="manual")]
+    changed = _prune_stale_seeded_entries(entries, active_sources=set())
+    assert not changed
+    assert len(entries) == 1
+
+
+def test_prune_preserves_env_entry_from_different_provider(monkeypatch):
+    """Multi-provider: env var absent for one provider → its entry kept."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+
+    from agent.credential_pool import _prune_stale_seeded_entries
+
+    entries = [
+        _make_entry(provider="openai", source="env:OPENAI_API_KEY"),
+        _make_entry(provider="google", source="env:GEMINI_API_KEY", id="cred-g"),
+    ]
+    # OPENAI_API_KEY is present but not in active_sources, and not empty → kept
+    # GEMINI_API_KEY is absent → kept (may belong to another process)
+    changed = _prune_stale_seeded_entries(entries, active_sources=set())
+    assert not changed
+    assert len(entries) == 2
+


### PR DESCRIPTION
## Problem

`load_pool()` has a destructive side effect: when the current process's `os.environ` does not contain the env var that originally seeded a credential entry, `_prune_stale_seeded_entries()` removes the entry and writes the pruned list back to `~/.hermes/auth.json`. Other processes that *do* have the env var re-seed it on their next call, causing `auth.json` to oscillate between states.

Fixes #9331

## Root Cause

`_prune_stale_seeded_entries()` removes any entry whose `source` (e.g. `env:MINIMAX_API_KEY`) is not in `active_sources`. But `active_sources` is built only from the **current process's** `os.environ` — if this process doesn't have the var, the entry is incorrectly classified as stale.

## Fix

Only prune env-seeded entries when there is **positive evidence** the source is stale:
- Env var **absent** from `os.environ`: **preserve** the entry (another process may have it)
- Env var **present but empty**: **prune** (explicit removal)
- Env var **present with value**: **preserve** (still valid)
- Non-env singleton sources (`claude_code`, `hermes_pkce`): existing behavior preserved

This makes `load_pool()` read-safe for multi-process environments while still cleaning up genuinely stale entries.

## Testing

Added 5 regression tests covering:
- Entry preserved when env var is absent from current process
- Entry pruned when env var is explicitly empty
- Singleton (claude_code) pruned when not in active_sources
- Manual entries never pruned
- Multi-provider: absent env var entries preserved independently
- Updated existing `test_load_pool_removes_stale_seeded_env_entry` to use explicit empty env var (positive removal signal) instead of `delenv`

Full test suite: all credential_pool tests pass (31/31, excluding 1 pre-existing upstream failure in `test_explicit_reset_timestamp_overrides_default_429_ttl`).