### PR TITLE
fix(config): validate providers config entries — reject non-URL base, accept camelCase aliases

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -12,6 +12,7 @@ This module provides:
 - hermes config wizard   - Re-run setup wizard
 """
 
+import logging
 import os
 import platform
 import re
@@ -22,6 +23,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
+
+logger = logging.getLogger(__name__)
 
 from tools.tool_backend_helpers import managed_nous_tools_enabled as _managed_nous_tools_enabled
 
@@ -1577,12 +1580,53 @@ def _normalize_custom_provider_entry(
     if not isinstance(entry, dict):
         return None
 
+    # Accept camelCase aliases commonly used in hand-written configs.
+    _CAMEL_ALIASES: Dict[str, str] = {
+        "apiKey": "api_key",
+        "baseUrl": "base_url",
+        "apiMode": "api_mode",
+        "keyEnv": "key_env",
+        "defaultModel": "default_model",
+        "contextLength": "context_length",
+        "rateLimitDelay": "rate_limit_delay",
+    }
+    _KNOWN_KEYS = {
+        "name", "api", "url", "base_url", "api_key", "key_env",
+        "api_mode", "transport", "model", "default_model", "models",
+        "context_length", "rate_limit_delay",
+    }
+    for camel, snake in _CAMEL_ALIASES.items():
+        if camel in entry and snake not in entry:
+            logger.warning(
+                "providers.%s: camelCase key '%s' auto-mapped to '%s' "
+                "(use snake_case to avoid this warning)",
+                provider_key or "?", camel, snake,
+            )
+            entry[snake] = entry[camel]
+    unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
+    if unknown:
+        logger.warning(
+            "providers.%s: unknown config keys ignored: %s",
+            provider_key or "?", ", ".join(sorted(unknown)),
+        )
+
+    from urllib.parse import urlparse
+
     base_url = ""
-    for url_key in ("api", "url", "base_url"):
+    for url_key in ("base_url", "url", "api"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
-            base_url = raw_url.strip()
-            break
+            candidate = raw_url.strip()
+            parsed = urlparse(candidate)
+            if parsed.scheme and parsed.netloc:
+                base_url = candidate
+                break
+            else:
+                logger.warning(
+                    "providers.%s: '%s' value '%s' is not a valid URL "
+                    "(no scheme or host) — skipped",
+                    provider_key or "?", url_key, candidate,
+                )
     if not base_url:
         return None
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -1,0 +1,137 @@
+"""Tests for providers config entry validation and normalization.
+
+Covers Issue #9332: camelCase keys silently ignored, non-URL strings
+accepted as base_url, and unknown keys go unreported.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+class TestNormalizeCustomProviderEntry:
+    """Tests for _normalize_custom_provider_entry validation."""
+
+    def test_valid_entry_snake_case(self):
+        """Standard snake_case entry should normalize correctly."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["name"] == "myhost"
+        assert result["base_url"] == "https://api.example.com/v1"
+        assert result["api_key"] == "sk-test-key"
+
+    def test_camel_case_api_key_mapped(self):
+        """camelCase apiKey should be auto-mapped to api_key."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "apiKey": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["api_key"] == "sk-test-key"
+
+    def test_camel_case_base_url_mapped(self):
+        """camelCase baseUrl should be auto-mapped to base_url."""
+        entry = {
+            "baseUrl": "https://api.example.com/v1",
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["base_url"] == "https://api.example.com/v1"
+
+    def test_non_url_api_field_rejected(self):
+        """Non-URL string in 'api' field should be skipped with a warning."""
+        entry = {
+            "api": "openai-reverse-proxy",
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="nvidia")
+        # Should return None because no valid URL was found
+        assert result is None
+
+    def test_valid_url_in_api_field_accepted(self):
+        """Valid URL in 'api' field should still be accepted."""
+        entry = {
+            "api": "https://integrate.api.nvidia.com/v1",
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="nvidia")
+        assert result is not None
+        assert result["base_url"] == "https://integrate.api.nvidia.com/v1"
+
+    def test_base_url_preferred_over_api(self):
+        """base_url should be checked before api field."""
+        entry = {
+            "base_url": "https://correct.example.com/v1",
+            "api": "https://wrong.example.com/v1",
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["base_url"] == "https://correct.example.com/v1"
+
+    def test_unknown_keys_logged(self, caplog):
+        """Unknown config keys should produce a warning."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-test-key",
+            "unknownField": "value",
+            "anotherBad": 42,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_camel_case_warning_logged(self, caplog):
+        """camelCase alias mapping should produce a warning."""
+        entry = {
+            "baseUrl": "https://api.example.com/v1",
+            "apiKey": "sk-test-key",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        camel_warnings = [r for r in caplog.records if "camelcase" in r.message.lower() or "auto-mapped" in r.message.lower()]
+        assert len(camel_warnings) >= 1
+
+    def test_snake_case_takes_precedence_over_camel(self):
+        """If both snake_case and camelCase exist, snake_case wins."""
+        entry = {
+            "api_key": "snake-key",
+            "apiKey": "camel-key",
+            "base_url": "https://api.example.com/v1",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_key"] == "snake-key"
+
+    def test_non_dict_returns_none(self):
+        """Non-dict entry should return None."""
+        assert _normalize_custom_provider_entry("not-a-dict") is None
+        assert _normalize_custom_provider_entry(42) is None
+        assert _normalize_custom_provider_entry(None) is None
+
+    def test_no_url_returns_none(self):
+        """Entry with no valid URL in any field should return None."""
+        entry = {
+            "api_key": "sk-test-key",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is None
+
+    def test_no_name_returns_none(self):
+        """Entry with no name and no provider_key should return None."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="")
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

Fixes silent misconfiguration in `providers:` config entries that caused cryptic `APIConnectionError` and `Bearer no-key-required` failures.

Three issues are addressed:

1. **Non-URL strings silently accepted as base_url**: The `api` field was checked first in the URL lookup order `("api", "url", "base_url")`, and any non-empty string was accepted without URL validation. A value like `openai-reverse-proxy` would be used as the endpoint, causing `Invalid URL` errors at runtime.

2. **camelCase keys silently ignored**: Hand-written configs using `apiKey`, `baseUrl`, etc. were silently dropped because only snake_case (`api_key`, `base_url`) was recognized. This left the provider with no credentials.

3. **Unknown keys unreported**: Typos and unsupported fields in provider entries produced no warning, making config debugging difficult.

## Related Issue

Fixes #9332

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **URL validation**: Base URL candidates are now validated via `urlparse()` — must have both scheme and netloc. Non-URL strings are skipped with a clear warning naming the field and value.
- **URL field priority reordered**: Changed from `("api", "url", "base_url")` to `("base_url", "url", "api")` so explicit `base_url` takes precedence.
- **camelCase aliases**: Common camelCase keys (`apiKey` → `api_key`, `baseUrl` → `base_url`, `apiMode` → `api_mode`, etc.) are auto-mapped with a deprecation warning.
- **Unknown key warnings**: Unrecognized config keys are logged at WARNING level to surface typos early.
- **Logging setup**: Added `logging` import and module-level logger to `hermes_cli/config.py`.

## How to Test

1. Create a provider entry with a non-URL `api` field:
   ```yaml
   providers:
     nvidia:
       api: openai-reverse-proxy
       api_key: sk-test
   ```
   **Before**: Silently accepted, fails at runtime with `Invalid URL`.
   **After**: Entry is rejected at config load with a clear warning.

2. Create a provider entry with camelCase keys:
   ```yaml
   providers:
     myhost:
       baseUrl: https://api.example.com/v1
       apiKey: sk-test
   ```
   **Before**: Both keys silently ignored, no URL and no key found.
   **After**: Auto-mapped to `base_url` and `api_key` with deprecation warnings.

3. Run the test suite:
   ```bash
   pytest tests/hermes_cli/test_provider_config_validation.py -v
   ```

4. Run full suite:
   ```bash
   pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
