### PR TITLE
[codex] fix missing clear_session_context logging helper

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -78,6 +78,17 @@ def set_session_context(session_id: str) -> None:
     _session_context.session_id = session_id
 
 
+def clear_session_context() -> None:
+    """Clear the session ID for the current thread.
+
+    Safe to call even when no session context is currently set.
+    """
+    try:
+        del _session_context.session_id
+    except AttributeError:
+        pass
+
+
 
 # ---------------------------------------------------------------------------
 # Record factory — injects session_tag into every LogRecord at creation


### PR DESCRIPTION
## Summary

Restore the public `hermes_logging.clear_session_context()` helper.

## Root Cause

`hermes_logging` still documented and tested `clear_session_context()` as part of the session-context API, but the function itself was missing. That broke the logging test suite and left callers without the documented way to clear per-thread session tags.

## What Changed

- restore `clear_session_context()` in `hermes_logging.py`
- make it a safe no-op when no session context is set

## Validation

- `python -m pytest -o addopts='' tests/test_hermes_logging.py -q`
