### PR TITLE
fix(spelling): overridable/interruptible spelling corrections (#9335)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -97,8 +97,8 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
-# Canonical set of per-platform overrideable keys (for validation).
-OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+# Canonical set of per-platform overridable keys (for validation).
+OVERRIDABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
 def resolve_display_setting(
@@ -178,7 +178,7 @@ def get_effective_display(user_config: dict, platform_key: str) -> dict[str, Any
     """
     return {
         key: resolve_display_setting(user_config, platform_key, key)
-        for key in OVERRIDEABLE_KEYS
+        for key in OVERRIDABLE_KEYS
     }
 
 

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -353,3 +353,41 @@ class TestStreamingPerPlatform:
             }
         }
         assert resolve_display_setting(config, "email", "streaming") is True
+
+
+# ---------------------------------------------------------------------------
+# Spelling: OVERRIDABLE_KEYS (was OVERRIDEABLE_KEYS — #9335)
+# ---------------------------------------------------------------------------
+
+class TestSpellingOverridable:
+    """OVERRIDABLE_KEYS uses the correct British/American spelling 'overridable'.
+
+    Regression guard for #9335: the constant was previously named
+    OVERRIDEABLE_KEYS (non-standard) and is now OVERRIDABLE_KEYS.
+    """
+
+    def test_overridable_keys_exported(self):
+        """OVERRIDABLE_KEYS must be importable from gateway.display_config."""
+        from gateway.display_config import OVERRIDABLE_KEYS
+        assert OVERRIDABLE_KEYS is not None
+
+    def test_overridable_keys_is_frozenset(self):
+        from gateway.display_config import OVERRIDABLE_KEYS
+        assert isinstance(OVERRIDABLE_KEYS, frozenset)
+
+    def test_overridable_keys_contains_expected_settings(self):
+        from gateway.display_config import OVERRIDABLE_KEYS
+        for key in ("tool_progress", "show_reasoning", "tool_preview_length", "streaming"):
+            assert key in OVERRIDABLE_KEYS, f"Expected '{key}' in OVERRIDABLE_KEYS"
+
+    def test_old_spelling_not_present(self):
+        """The old misspelling OVERRIDEABLE_KEYS must NOT be exported."""
+        import gateway.display_config as dc
+        assert not hasattr(dc, "OVERRIDEABLE_KEYS"), \
+            "OVERRIDEABLE_KEYS should have been renamed to OVERRIDABLE_KEYS"
+
+    def test_get_effective_display_uses_overridable_keys(self):
+        """get_effective_display returns keys from OVERRIDABLE_KEYS."""
+        from gateway.display_config import OVERRIDABLE_KEYS, get_effective_display
+        result = get_effective_display({}, "telegram")
+        assert set(result.keys()) == OVERRIDABLE_KEYS

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -811,7 +811,7 @@ def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str
 
 
 # ============================================================================
-# Audio playback (interruptable)
+# Audio playback (interruptible)
 # ============================================================================
 
 # Global reference to the active playback process so it can be interrupted.
@@ -881,7 +881,7 @@ def play_audio_file(file_path: str) -> bool:
         except Exception as e:
             logger.debug("sounddevice playback failed: %s", e)
 
-    # Fall back to system audio players (using Popen for interruptability)
+    # Fall back to system audio players (using Popen for interruptibility)
     system = platform.system()
     players = []
 


### PR DESCRIPTION
## Summary

Corrects two spelling inconsistencies reported in #9335.

### `gateway/display_config.py`

`OVERRIDEABLE_KEYS` → `OVERRIDABLE_KEYS` (comment + constant + usage)

`overrideable` is a non-standard form. The correct adjective derived from
`override` is `overridable` (drop the final `e` before adding `-able`),
consistent with `overridable` in Java, Ruby, and major English dictionaries.

### `tools/voice_mode.py`

`interruptable` → `interruptible` (comment)  
`interruptability` → `interruptibility` (comment)

The `-ible`/`-ibility` suffix is correct for `interrupt` — consistent with
Python's own documentation and the broader programming ecosystem.

## Scope

All changes are in comments or internal identifiers.  
`OVERRIDABLE_KEYS` is a module-internal constant used only within
`display_config.py` itself — no external API change.

## Testing

5 new regression tests added to `TestSpellingOverridable` in
`tests/gateway/test_display_config.py`:
- `OVERRIDABLE_KEYS` is exported and is a `frozenset`
- It contains the expected display settings
- The old misspelling `OVERRIDEABLE_KEYS` is no longer present
- `get_effective_display()` returns exactly `OVERRIDABLE_KEYS`

All 32 display-config tests pass.

Closes #9335
