### PR TITLE
feat(codex): support API-key mode for openai-codex

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -67,6 +67,7 @@ DEFAULT_AGENT_KEY_MIN_TTL_SECONDS = 30 * 60  # 30 minutes
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+DEFAULT_OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
@@ -224,7 +225,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
     "ai-gateway": ProviderConfig(
         id="ai-gateway",
-        name="Vercel AI Gateway",
+        name="AI Gateway",
         auth_type="api_key",
         inference_base_url="https://ai-gateway.vercel.sh/v1",
         api_key_env_vars=("AI_GATEWAY_API_KEY",),
@@ -374,6 +375,79 @@ def _resolve_api_key_provider_secret(
             return val, env_var
 
     return "", ""
+
+
+def resolve_configured_codex_api_key_credentials(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Resolve the OpenAI API-key path for the ``openai-codex`` provider.
+
+    ``openai-codex`` historically meant the ChatGPT OAuth-backed Codex
+    endpoint.  Hermes now also supports the direct OpenAI Responses API when
+    the config explicitly selects ``model.provider: openai-codex`` with a
+    non-ChatGPT base URL (or an inline ``model.api_key``).
+
+    To avoid silently hijacking existing OAuth setups, ``OPENAI_API_KEY`` only
+    counts when the config has already selected the API-key mode for Codex.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    model_cfg = config.get("model") if isinstance(config, dict) else {}
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+
+    provider = str(model_cfg.get("provider") or "").strip().lower()
+    cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+    cfg_api_key = ""
+    for field in ("api_key", "api"):
+        value = model_cfg.get(field)
+        if has_usable_secret(value):
+            cfg_api_key = str(value).strip()
+            break
+
+    base_url_points_to_api = bool(cfg_base_url and cfg_base_url != DEFAULT_CODEX_BASE_URL.rstrip("/"))
+    selected = provider == "openai-codex" and (base_url_points_to_api or bool(cfg_api_key))
+    base_url = cfg_base_url if base_url_points_to_api else DEFAULT_OPENAI_API_BASE_URL
+
+    if cfg_api_key:
+        return {
+            "selected": selected,
+            "configured": True,
+            "provider": "openai-codex",
+            "auth_mode": "api_key",
+            "api_key": cfg_api_key,
+            "base_url": base_url,
+            "source": "config:model.api_key",
+        }
+
+    env_api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if selected and has_usable_secret(env_api_key):
+        return {
+            "selected": True,
+            "configured": True,
+            "provider": "openai-codex",
+            "auth_mode": "api_key",
+            "api_key": env_api_key,
+            "base_url": base_url,
+            "source": "env:OPENAI_API_KEY",
+        }
+
+    result = {
+        "selected": selected,
+        "configured": False,
+        "provider": "openai-codex",
+        "auth_mode": "api_key",
+        "api_key": "",
+        "base_url": base_url,
+        "source": "",
+    }
+    if selected:
+        result["error"] = "OPENAI_API_KEY is not set."
+    return result
 
 
 # =============================================================================
@@ -2320,8 +2394,11 @@ def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
     
     Checks the credential pool first (where `hermes auth` stores credentials),
-    then falls back to the legacy provider state.
+    then checks config-selected API-key mode, then falls back to the legacy
+    OAuth provider state.
     """
+    codex_api = resolve_configured_codex_api_key_credentials()
+
     # Check credential pool first — this is where `hermes auth` and
     # `hermes model` store device_code tokens.
     try:
@@ -2329,6 +2406,15 @@ def get_codex_auth_status() -> Dict[str, Any]:
         pool = load_pool("openai-codex")
         if pool and pool.has_credentials():
             entry = pool.select()
+            if entry is not None:
+                entry_auth_type = getattr(entry, "auth_type", "")
+                entry_base_url = (
+                    getattr(entry, "runtime_base_url", None)
+                    or getattr(entry, "base_url", None)
+                    or ""
+                ).rstrip("/")
+                if codex_api.get("selected") and entry_auth_type != "api_key" and entry_base_url == DEFAULT_CODEX_BASE_URL.rstrip("/"):
+                    entry = None
             if entry is not None:
                 api_key = (
                     getattr(entry, "runtime_api_key", None)
@@ -2339,12 +2425,28 @@ def get_codex_auth_status() -> Dict[str, Any]:
                         "logged_in": True,
                         "auth_store": str(_auth_file_path()),
                         "last_refresh": getattr(entry, "last_refresh", None),
-                        "auth_mode": "chatgpt",
+                        "auth_mode": "api_key" if getattr(entry, "auth_type", "") == "api_key" else "chatgpt",
                         "source": f"pool:{getattr(entry, 'label', 'unknown')}",
                         "api_key": api_key,
+                        "base_url": (
+                            getattr(entry, "runtime_base_url", None)
+                            or getattr(entry, "base_url", None)
+                            or ""
+                        ),
                     }
     except Exception:
         pass
+
+    if codex_api.get("selected"):
+        return {
+            "logged_in": bool(codex_api.get("configured")),
+            "auth_store": str(get_config_path()),
+            "auth_mode": "api_key",
+            "source": codex_api.get("source"),
+            "api_key": codex_api.get("api_key"),
+            "base_url": codex_api.get("base_url"),
+            "error": codex_api.get("error"),
+        }
 
     # Fall back to legacy provider state
     try:
@@ -2356,6 +2458,7 @@ def get_codex_auth_status() -> Dict[str, Any]:
             "auth_mode": creds.get("auth_mode"),
             "source": creds.get("source"),
             "api_key": creds.get("api_key"),
+            "base_url": creds.get("base_url"),
         }
     except AuthError as exc:
         return {

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -27,7 +27,7 @@ from agent.credential_pool import (
     load_pool,
 )
 import hermes_cli.auth as auth_mod
-from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth import DEFAULT_OPENAI_API_BASE_URL, PROVIDER_REGISTRY
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -83,9 +83,14 @@ def _normalize_provider(provider: str) -> str:
     return normalized
 
 
-def _provider_base_url(provider: str) -> str:
+def _provider_base_url(provider: str, auth_type: str = "", explicit_base_url: str = "") -> str:
+    explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
+    if explicit_base_url:
+        return explicit_base_url
     if provider == "openrouter":
         return OPENROUTER_BASE_URL
+    if provider == "openai-codex" and auth_type == AUTH_TYPE_API_KEY:
+        return DEFAULT_OPENAI_API_BASE_URL
     if provider.startswith(CUSTOM_POOL_PREFIX):
         from agent.credential_pool import _get_custom_provider_config
 
@@ -169,7 +174,11 @@ def auth_add_command(args) -> None:
             priority=0,
             source=SOURCE_MANUAL,
             access_token=token,
-            base_url=_provider_base_url(provider),
+            base_url=_provider_base_url(
+                provider,
+                AUTH_TYPE_API_KEY,
+                getattr(args, "base_url", None),
+            ),
         )
         pool.add_entry(entry)
         print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2473,7 +2473,7 @@ _FALLBACK_COMMENT = """
 #
 # Supported providers:
 #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
-#   openai-codex (OAuth — hermes auth) — OpenAI Codex
+#   openai-codex (ChatGPT OAuth or OpenAI API key) — OpenAI Codex / Responses API
 #   nous         (OAuth — hermes auth) — Nous Portal
 #   zai          (ZAI_API_KEY)         — Z.AI / GLM
 #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
@@ -2517,7 +2517,7 @@ _COMMENTED_SECTIONS = """
 #
 # Supported providers:
 #   openrouter   (OPENROUTER_API_KEY)  — routes to any model
-#   openai-codex (OAuth — hermes auth) — OpenAI Codex
+#   openai-codex (ChatGPT OAuth or OpenAI API key) — OpenAI Codex / Responses API
 #   nous         (OAuth — hermes auth) — Nous Portal
 #   zai          (ZAI_API_KEY)         — Z.AI / GLM
 #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1425,53 +1425,135 @@ def _model_flow_nous(config, current_model="", args=None):
 
 
 def _model_flow_openai_codex(config, current_model=""):
-    """OpenAI Codex provider: ensure logged in, then pick model."""
+    """OpenAI Codex provider: support either OpenAI API keys or ChatGPT OAuth."""
     from hermes_cli.auth import (
         get_codex_auth_status, _prompt_model_selection, _save_model_choice,
         _update_config_for_provider, _login_openai_codex,
-        PROVIDER_REGISTRY, DEFAULT_CODEX_BASE_URL,
+        PROVIDER_REGISTRY, DEFAULT_CODEX_BASE_URL, DEFAULT_OPENAI_API_BASE_URL,
+        resolve_configured_codex_api_key_credentials, deactivate_provider,
     )
     from hermes_cli.codex_models import get_codex_model_ids
+    from hermes_cli.config import load_config, save_config, save_env_value
+    from hermes_cli.models import fetch_api_models
     import argparse
+    import getpass
 
     status = get_codex_auth_status()
     if not status.get("logged_in"):
-        print("Not logged into OpenAI Codex. Starting login...")
+        print("OpenAI Codex supports both API keys and ChatGPT OAuth.")
+        print("  1. OpenAI API key (Responses API)")
+        print("  2. ChatGPT login (device code)")
         print()
         try:
-            mock_args = argparse.Namespace()
-            _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
-        except SystemExit:
-            print("Login cancelled or failed.")
+            choice = input("Type [1/2]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
             return
-        except Exception as exc:
-            print(f"Login failed: {exc}")
-            return
+        if choice == "2":
+            try:
+                mock_args = argparse.Namespace()
+                _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
+            except SystemExit:
+                print("Login cancelled or failed.")
+                return
+            except Exception as exc:
+                print(f"Login failed: {exc}")
+                return
+            status = get_codex_auth_status()
+            if not status.get("logged_in"):
+                print("Login cancelled or failed.")
+                return
+        else:
+            api_cfg = resolve_configured_codex_api_key_credentials(load_config())
+            existing_key = str(api_cfg.get("api_key") or "").strip()
+            base_url = str(api_cfg.get("base_url") or DEFAULT_OPENAI_API_BASE_URL).strip().rstrip("/")
+            if not existing_key:
+                print("Get an OpenAI API key at: https://platform.openai.com/api-keys")
+                print()
+                try:
+                    existing_key = getpass.getpass("OPENAI_API_KEY (or Enter to cancel): ").strip()
+                except (KeyboardInterrupt, EOFError):
+                    print()
+                    return
+                if not existing_key:
+                    print("Cancelled.")
+                    return
+            try:
+                override = input(f"Base URL [{base_url}]: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                override = ""
+            if override:
+                if not override.startswith(("http://", "https://")):
+                    print("Invalid base URL. Expected http:// or https://.")
+                    return
+                base_url = override.rstrip("/")
 
-    _codex_token = None
+            save_env_value("OPENAI_API_KEY", existing_key)
+            cfg = load_config()
+            model = cfg.get("model")
+            if not isinstance(model, dict):
+                model = {"default": model} if model else {}
+                cfg["model"] = model
+            model["provider"] = "openai-codex"
+            model["base_url"] = base_url or DEFAULT_OPENAI_API_BASE_URL
+            model["api_mode"] = "codex_responses"
+            save_config(cfg)
+            config["model"] = dict(model)
+            deactivate_provider()
+            print("API key saved.")
+            print()
+            status = {
+                "logged_in": True,
+                "auth_mode": "api_key",
+                "api_key": existing_key,
+                "base_url": base_url or DEFAULT_OPENAI_API_BASE_URL,
+            }
+
+    auth_mode = str(status.get("auth_mode") or "chatgpt").strip().lower()
+    _codex_token = str(status.get("api_key") or "").strip()
+    _codex_base_url = str(status.get("base_url") or "").strip().rstrip("/")
+
     # Prefer credential pool (where `hermes auth` stores device_code tokens),
     # fall back to legacy provider state.
-    try:
-        _codex_status = get_codex_auth_status()
-        if _codex_status.get("logged_in"):
-            _codex_token = _codex_status.get("api_key")
-    except Exception:
-        pass
-    if not _codex_token:
-        try:
-            from hermes_cli.auth import resolve_codex_runtime_credentials
-            _codex_creds = resolve_codex_runtime_credentials()
-            _codex_token = _codex_creds.get("api_key")
-        except Exception:
-            pass
-
-    codex_models = get_codex_model_ids(access_token=_codex_token)
+    if auth_mode == "api_key":
+        codex_models = fetch_api_models(_codex_token, _codex_base_url) or get_codex_model_ids()
+    else:
+        if not _codex_token:
+            try:
+                _codex_status = get_codex_auth_status()
+                if _codex_status.get("logged_in"):
+                    _codex_token = _codex_status.get("api_key")
+            except Exception:
+                pass
+        if not _codex_token:
+            try:
+                from hermes_cli.auth import resolve_codex_runtime_credentials
+                _codex_creds = resolve_codex_runtime_credentials()
+                _codex_token = _codex_creds.get("api_key")
+            except Exception:
+                pass
+        codex_models = get_codex_model_ids(access_token=_codex_token)
 
     selected = _prompt_model_selection(codex_models, current_model=current_model)
     if selected:
         _save_model_choice(selected)
-        _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
-        print(f"Default model set to: {selected} (via OpenAI Codex)")
+        if auth_mode == "api_key":
+            cfg = load_config()
+            model = cfg.get("model")
+            if not isinstance(model, dict):
+                model = {"default": model} if model else {}
+                cfg["model"] = model
+            model["provider"] = "openai-codex"
+            model["base_url"] = _codex_base_url or DEFAULT_OPENAI_API_BASE_URL
+            model["api_mode"] = "codex_responses"
+            save_config(cfg)
+            config["model"] = dict(model)
+            deactivate_provider()
+            print(f"Default model set to: {selected} (via OpenAI API)")
+        else:
+            _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
+            print(f"Default model set to: {selected} (via OpenAI Codex)")
     else:
         print("No change.")
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,11 +14,13 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_OPENAI_API_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
     format_auth_error,
     resolve_provider,
+    resolve_configured_codex_api_key_credentials,
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
     resolve_qwen_runtime_credentials,
@@ -275,43 +277,6 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             return None
 
     config = load_config()
-    
-    # First check providers: dict (new-style user-defined providers)
-    providers = config.get("providers")
-    if isinstance(providers, dict):
-        for ep_name, entry in providers.items():
-            if not isinstance(entry, dict):
-                continue
-            # Match exact name or normalized name
-            name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
-
-            if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
-                # Found match by provider key
-                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-                if base_url:
-                    return {
-                        "name": entry.get("name", ep_name),
-                        "base_url": base_url.strip(),
-                        "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
-                    }
-            # Also check the 'name' field if present
-            display_name = entry.get("name", "")
-            if display_name:
-                display_norm = _normalize_custom_provider_name(display_name)
-                if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
-                    # Found match by display name
-                    base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-                    if base_url:
-                        return {
-                            "name": display_name,
-                            "base_url": base_url.strip(),
-                            "api_key": resolved_api_key,
-                            "model": entry.get("default_model", ""),
-                        }
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")
@@ -550,15 +515,33 @@ def _resolve_explicit_runtime(
         }
 
     if provider == "openai-codex":
-        base_url = explicit_base_url or DEFAULT_CODEX_BASE_URL
-        api_key = explicit_api_key
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if cfg_provider == "openai-codex":
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
         last_refresh = None
-        if not api_key:
-            creds = resolve_codex_runtime_credentials()
-            api_key = creds.get("api_key", "")
-            last_refresh = creds.get("last_refresh")
-            if not explicit_base_url:
-                base_url = creds.get("base_url", "").rstrip("/") or base_url
+
+        if explicit_api_key:
+            base_url = explicit_base_url or cfg_base_url or DEFAULT_OPENAI_API_BASE_URL
+            api_key = explicit_api_key
+        else:
+            codex_api = resolve_configured_codex_api_key_credentials({"model": model_cfg})
+            if codex_api.get("configured"):
+                base_url = explicit_base_url or str(codex_api.get("base_url") or "").rstrip("/") or DEFAULT_OPENAI_API_BASE_URL
+                api_key = str(codex_api.get("api_key") or "").strip()
+            elif codex_api.get("selected"):
+                raise AuthError(
+                    codex_api.get("error") or "OpenAI API key is not configured for openai-codex.",
+                    provider="openai-codex",
+                    code="codex_api_key_missing",
+                )
+            else:
+                base_url = explicit_base_url or cfg_base_url or DEFAULT_CODEX_BASE_URL
+                creds = resolve_codex_runtime_credentials()
+                api_key = creds.get("api_key", "")
+                last_refresh = creds.get("last_refresh")
+                if not explicit_base_url:
+                    base_url = creds.get("base_url", "").rstrip("/") or base_url
         return {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
@@ -705,10 +688,21 @@ def resolve_runtime_provider(
         entry = pool.select()
         pool_api_key = ""
         if entry is not None:
-            pool_api_key = (
-                getattr(entry, "runtime_api_key", None)
-                or getattr(entry, "access_token", "")
-            )
+            if provider == "openai-codex":
+                codex_api = resolve_configured_codex_api_key_credentials({"model": model_cfg})
+                entry_auth_type = getattr(entry, "auth_type", "")
+                entry_base_url = (
+                    getattr(entry, "runtime_base_url", None)
+                    or getattr(entry, "base_url", "")
+                    or ""
+                ).rstrip("/")
+                if codex_api.get("selected") and entry_auth_type != "api_key" and entry_base_url == DEFAULT_CODEX_BASE_URL.rstrip("/"):
+                    entry = None
+            if entry is not None:
+                pool_api_key = (
+                    getattr(entry, "runtime_api_key", None)
+                    or getattr(entry, "access_token", "")
+                )
         # For Nous, the pool entry's runtime_api_key is the agent_key — a
         # short-lived inference credential (~30 min TTL).  The pool doesn't
         # refresh it during selection (that would trigger network calls in
@@ -757,6 +751,22 @@ def resolve_runtime_provider(
                         "falling through to next provider.")
 
     if provider == "openai-codex":
+        codex_api = resolve_configured_codex_api_key_credentials({"model": model_cfg})
+        if codex_api.get("configured"):
+            return {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": str(codex_api.get("base_url") or "").rstrip("/"),
+                "api_key": codex_api.get("api_key", ""),
+                "source": codex_api.get("source", "config"),
+                "requested_provider": requested_provider,
+            }
+        if codex_api.get("selected"):
+            raise AuthError(
+                codex_api.get("error") or "OpenAI API key is not configured for openai-codex.",
+                provider="openai-codex",
+                code="codex_api_key_missing",
+            )
         try:
             creds = resolve_codex_runtime_credentials()
             return {

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -11,6 +11,7 @@ import yaml
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_OPENAI_API_BASE_URL,
     PROVIDER_REGISTRY,
     _read_codex_tokens,
     _save_codex_tokens,
@@ -18,6 +19,7 @@ from hermes_cli.auth import (
     _import_codex_cli_tokens,
     get_codex_auth_status,
     get_provider_auth_state,
+    resolve_configured_codex_api_key_credentials,
     resolve_codex_runtime_credentials,
     resolve_provider,
 )
@@ -283,3 +285,56 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["source"] == "hermes-auth-store"
     assert creds["provider"] == "openai-codex"
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+def test_resolve_configured_codex_api_key_credentials_from_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "openai-codex",
+                    "base_url": DEFAULT_OPENAI_API_BASE_URL,
+                }
+            },
+            sort_keys=False,
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    creds = resolve_configured_codex_api_key_credentials()
+
+    assert creds["selected"] is True
+    assert creds["configured"] is True
+    assert creds["api_key"] == "sk-openai-env"
+    assert creds["base_url"] == DEFAULT_OPENAI_API_BASE_URL
+    assert creds["source"] == "env:OPENAI_API_KEY"
+
+
+def test_get_codex_auth_status_prefers_configured_api_key_mode(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "openai-codex",
+                    "base_url": DEFAULT_OPENAI_API_BASE_URL,
+                }
+            },
+            sort_keys=False,
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    status = get_codex_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["auth_mode"] == "api_key"
+    assert status["api_key"] == "sk-openai-env"
+    assert status["base_url"] == DEFAULT_OPENAI_API_BASE_URL

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -184,6 +184,29 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+def test_auth_add_codex_api_key_uses_openai_api_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth import DEFAULT_OPENAI_API_BASE_URL
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "api-key"
+        api_key = "sk-openai-test"
+        label = "api-key"
+        base_url = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual")
+    assert entry["auth_type"] == "api_key"
+    assert entry["base_url"] == DEFAULT_OPENAI_API_BASE_URL
+
+
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent pool auto-seeding from host env vars and file-backed sources

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -107,6 +107,41 @@ def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     assert captured["current_model"] == "openai/gpt-5.4"
 
 
+def test_model_command_uses_openai_api_key_mode_for_codex_list(monkeypatch):
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {
+            "logged_in": True,
+            "auth_mode": "api_key",
+            "api_key": "sk-openai-env",
+            "base_url": "https://api.openai.com/v1",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url: captured.update(
+            {"api_key": api_key, "base_url": base_url}
+        ) or ["gpt-5.4", "gpt-5.4-mini"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_ids, current_model="": captured.update(
+            {"model_ids": list(model_ids), "current_model": current_model}
+        ) or None,
+    )
+
+    _model_flow_openai_codex({}, current_model="gpt-5.4")
+
+    assert captured["api_key"] == "sk-openai-env"
+    assert captured["base_url"] == "https://api.openai.com/v1"
+    assert captured["model_ids"] == ["gpt-5.4", "gpt-5.4-mini"]
+    assert captured["current_model"] == "gpt-5.4"
+
+
 # ── Tests for _normalize_model_for_provider ──────────────────────────
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -148,6 +148,32 @@ def test_resolve_runtime_provider_codex(monkeypatch):
     assert resolved["requested_provider"] == "openai-codex"
 
 
+def test_resolve_runtime_provider_codex_uses_configured_api_key_mode(monkeypatch):
+    def _unexpected_codex_runtime_credentials():
+        raise AssertionError("resolve_codex_runtime_credentials should not be called")
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "base_url": rp.DEFAULT_OPENAI_API_BASE_URL,
+        },
+    )
+    monkeypatch.setattr(rp, "resolve_codex_runtime_credentials", _unexpected_codex_runtime_credentials)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+    assert resolved["provider"] == "openai-codex"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == rp.DEFAULT_OPENAI_API_BASE_URL
+    assert resolved["api_key"] == "sk-openai-env"
+    assert resolved["source"] == "env:OPENAI_API_KEY"
+
+
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- let `openai-codex` work with an API key in addition to ChatGPT OAuth
- persist `provider`, `base_url`, and `api_mode: codex_responses` when configuring the Codex provider
- fetch available models through the API-key flow and add regression coverage for auth, model listing, and runtime resolution
- keep named custom provider resolution on the shared compatibility path so the runtime provider tests stay green

## Testing
```bash
/Users/lcw/.hermes/hermes-agent/venv/bin/python -m pytest /tmp/hermes-pr-codex/tests/hermes_cli/test_auth_codex_provider.py /tmp/hermes-pr-codex/tests/hermes_cli/test_auth_commands.py /tmp/hermes-pr-codex/tests/hermes_cli/test_codex_models.py /tmp/hermes-pr-codex/tests/hermes_cli/test_runtime_provider_resolution.py -q
```