### PR TITLE
fix(providers): accept camelCase aliases and validate URL scheme in providers: config (#9332)

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -408,10 +408,44 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     if not isinstance(entry, dict):
         return None
 
-    # Extract fields
+    # Extract fields.
+    # Accept both snake_case (api_key, base_url) and camelCase (apiKey, baseUrl)
+    # aliases so that hand-written YAML from JavaScript-centric users works
+    # without silent failures. (#9332)
     display_name = entry.get("name", "") or name
-    api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
-    key_env = entry.get("key_env", "") or ""
+
+    # base_url: prefer explicit snake_case keys; fall back to legacy "api"/"url"
+    # aliases; reject values that are clearly not URLs (no scheme) to surface
+    # mis-configured entries early rather than producing cryptic errors.
+    _url_candidates = (
+        entry.get("base_url", "")
+        or entry.get("baseUrl", "")     # camelCase alias
+        or entry.get("url", "")
+        or entry.get("api", "")         # legacy alias
+        or ""
+    )
+    # Warn when a non-URL string lands in a URL field so the user gets a
+    # clear message instead of a downstream Bearer/connection error.
+    if _url_candidates and not (
+        _url_candidates.startswith("http://") or _url_candidates.startswith("https://")
+    ):
+        import logging as _logging
+        _logging.getLogger(__name__).warning(
+            "providers[%s]: base_url value %r does not look like a URL "
+            "(missing http:// or https:// scheme) — check your config.yaml. "
+            "Accepted keys: base_url, baseUrl, url, api.",
+            name, _url_candidates,
+        )
+        _url_candidates = ""
+    api_url = _url_candidates
+
+    # api key env var: accept both snake_case and camelCase.
+    key_env = (
+        entry.get("key_env", "")
+        or entry.get("keyEnv", "")      # camelCase alias
+        or entry.get("api_key_env", "")
+        or ""
+    )
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 
     env_vars: List[str] = []

--- a/tests/hermes_cli/test_providers_config_parsing.py
+++ b/tests/hermes_cli/test_providers_config_parsing.py
@@ -1,0 +1,234 @@
+"""Tests for providers: config parsing — camelCase aliases and URL validation.
+
+Regression tests for #9332:
+- camelCase keys (apiKey, baseUrl, keyEnv) are silently dropped
+- Non-URL strings in base_url/api are silently accepted
+
+Run: pytest tests/hermes_cli/test_providers_config_parsing.py -v
+"""
+import logging
+import pytest
+
+
+def _resolve(name: str, providers_dict: dict):
+    """Thin wrapper to call resolve_user_provider."""
+    from hermes_cli.providers import resolve_user_provider
+    return resolve_user_provider(name, providers_dict)
+
+
+# ---------------------------------------------------------------------------
+# snake_case keys (always worked)
+# ---------------------------------------------------------------------------
+
+class TestSnakeCaseKeys:
+    """Verify existing snake_case behavior is preserved."""
+
+    def test_base_url_snake_case(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "base_url": "https://api.example.com/v1",
+            }
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://api.example.com/v1"
+
+    def test_key_env_snake_case(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "base_url": "https://api.example.com/v1",
+                "key_env": "MY_API_KEY",
+            }
+        })
+        assert pdef is not None
+        assert "MY_API_KEY" in pdef.api_key_env_vars
+
+    def test_legacy_api_field_still_works(self):
+        """Legacy 'api' field (first in lookup order) still accepted as URL."""
+        pdef = _resolve("myprovider", {
+            "myprovider": {"api": "https://api.example.com/v1"}
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://api.example.com/v1"
+
+    def test_legacy_url_field_still_works(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {"url": "https://api.example.com/v1"}
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://api.example.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# camelCase aliases (#9332 fix)
+# ---------------------------------------------------------------------------
+
+class TestCamelCaseAliases:
+    """camelCase keys must now be recognized (#9332)."""
+
+    def test_baseUrl_camelcase_accepted(self):
+        """baseUrl must be treated as an alias for base_url."""
+        pdef = _resolve("myprovider", {
+            "myprovider": {"baseUrl": "https://api.example.com/v1"}
+        })
+        assert pdef is not None, "Provider with camelCase baseUrl should be resolved"
+        assert pdef.base_url == "https://api.example.com/v1"
+
+    def test_apiKey_camelcase_silently_ignored_before_fix(self):
+        """Before fix: apiKey was silently dropped.  After fix: keyEnv alias works.
+
+        Note: 'apiKey' maps to an API key value, not an env var name — config.yaml
+        uses key_env (an env var name).  We test the keyEnv alias for key_env.
+        """
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "baseUrl": "https://api.example.com/v1",
+                "keyEnv": "MY_PROVIDER_KEY",
+            }
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://api.example.com/v1"
+        assert "MY_PROVIDER_KEY" in pdef.api_key_env_vars
+
+    def test_snakecase_takes_precedence_over_camelcase(self):
+        """When both snake_case and camelCase are present, snake_case wins."""
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "base_url": "https://snake.example.com/v1",
+                "baseUrl": "https://camel.example.com/v1",
+            }
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://snake.example.com/v1", \
+            "snake_case base_url should take precedence over camelCase baseUrl"
+
+    def test_camelcase_key_env_alias(self):
+        """keyEnv is recognized as an alias for key_env."""
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "base_url": "https://api.example.com/v1",
+                "keyEnv": "CAMEL_KEY_ENV",
+            }
+        })
+        assert pdef is not None
+        assert "CAMEL_KEY_ENV" in pdef.api_key_env_vars
+
+    def test_both_camelcase_fields_together(self):
+        """A fully camelCase config entry works end-to-end."""
+        pdef = _resolve("myproxy", {
+            "myproxy": {
+                "baseUrl": "https://proxy.example.com/openai",
+                "keyEnv": "PROXY_API_KEY",
+            }
+        })
+        assert pdef is not None
+        assert pdef.base_url == "https://proxy.example.com/openai"
+        assert "PROXY_API_KEY" in pdef.api_key_env_vars
+
+
+# ---------------------------------------------------------------------------
+# URL validation (#9332 fix)
+# ---------------------------------------------------------------------------
+
+class TestURLValidation:
+    """Non-URL strings in url fields must produce a warning and be ignored."""
+
+    def test_non_url_string_in_api_field_rejected(self, caplog):
+        """A bare string like 'openai-reverse-proxy' in 'api' is not a URL."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.providers"):
+            pdef = _resolve("myprovider", {
+                "myprovider": {"api": "openai-reverse-proxy"}
+            })
+        # The invalid URL should be cleared (empty base_url)
+        if pdef:
+            assert pdef.base_url == "", \
+                f"Non-URL 'openai-reverse-proxy' should not be used as base_url, got: {pdef.base_url!r}"
+        # A warning should have been emitted
+        assert any("does not look like a URL" in r.message or "scheme" in r.message
+                   for r in caplog.records), \
+            "Expected a warning about missing URL scheme"
+
+    def test_non_url_string_in_base_url_rejected(self, caplog):
+        """A string without scheme in base_url is rejected with warning."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.providers"):
+            pdef = _resolve("myprovider", {
+                "myprovider": {"base_url": "my-custom-proxy-endpoint"}
+            })
+        if pdef:
+            assert pdef.base_url == ""
+        assert any("does not look like a URL" in r.message or "scheme" in r.message
+                   for r in caplog.records)
+
+    def test_valid_https_url_accepted_without_warning(self, caplog):
+        """Valid https:// URL should pass without warning."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.providers"):
+            pdef = _resolve("myprovider", {
+                "myprovider": {"base_url": "https://api.openai.com/v1"}
+            })
+        assert pdef is not None
+        assert pdef.base_url == "https://api.openai.com/v1"
+        assert not any("does not look like" in r.message for r in caplog.records)
+
+    def test_valid_http_url_accepted(self, caplog):
+        """Local/HTTP endpoints (e.g. Ollama) must also be accepted."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.providers"):
+            pdef = _resolve("ollama-local", {
+                "ollama-local": {"base_url": "http://localhost:11434/v1"}
+            })
+        assert pdef is not None
+        assert pdef.base_url == "http://localhost:11434/v1"
+        assert not any("does not look like" in r.message for r in caplog.records)
+
+    def test_empty_base_url_no_warning(self, caplog):
+        """Empty / missing base_url should NOT warn."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.providers"):
+            pdef = _resolve("myprovider", {
+                "myprovider": {}  # no url fields at all
+            })
+        # No warning about URL scheme
+        assert not any("does not look like" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+
+    def test_none_entry_returns_none(self):
+        pdef = _resolve("myprovider", {"myprovider": None})
+        assert pdef is None
+
+    def test_empty_providers_dict_returns_none(self):
+        pdef = _resolve("myprovider", {})
+        assert pdef is None
+
+    def test_missing_provider_returns_none(self):
+        pdef = _resolve("myprovider", {"otherprovider": {"base_url": "https://x.com"}})
+        assert pdef is None
+
+    def test_name_field_used_as_display_name(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "name": "My Custom Provider",
+                "base_url": "https://api.example.com/v1",
+            }
+        })
+        assert pdef is not None
+        assert pdef.name == "My Custom Provider"
+
+    def test_provider_id_used_when_no_name(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {"base_url": "https://api.example.com/v1"}
+        })
+        assert pdef is not None
+        assert pdef.id == "myprovider"
+
+    def test_transport_field_respected(self):
+        pdef = _resolve("myprovider", {
+            "myprovider": {
+                "base_url": "https://api.example.com/v1",
+                "transport": "anthropic",
+            }
+        })
+        assert pdef is not None
+        assert pdef.transport == "anthropic"


### PR DESCRIPTION
## Summary

Two bugs in `resolve_user_provider()` (`hermes_cli/providers.py`) caused silent misconfigurations in the `providers:` keyed config section.

## Bug 1: camelCase keys silently dropped

Hand-written YAML often uses camelCase — especially by developers coming from JavaScript/TypeScript environments. `baseUrl`, `apiKey`, `keyEnv` were silently dropped, leaving `base_url` empty and `api_key_env_vars` empty.

**User-visible symptom:** `Bearer no-key-required` in outgoing requests and cryptic `APIConnectionError` with no hint that the config key is wrong.

**Fix:** Add camelCase aliases with snake_case taking precedence:

```yaml
# All of these now work:
providers:
  myproxy:
    base_url: https://proxy.example.com/v1   # snake_case (preferred)
    baseUrl: https://proxy.example.com/v1    # camelCase alias (also accepted)
    key_env: MY_PROXY_KEY                    # snake_case (preferred)
    keyEnv: MY_PROXY_KEY                     # camelCase alias (also accepted)
```

Resolution order (first non-empty wins): `base_url` > `baseUrl` > `url` > `api`

## Bug 2: Non-URL strings silently accepted as endpoints

The `api` field lookup accepted the first non-empty string regardless of whether it looks like a URL. A bare string like `openai-reverse-proxy` was silently accepted as the endpoint, causing confusing downstream connection failures.

**Fix:** After resolving the URL candidate, check for `http://` or `https://` prefix. If the string doesn't have a recognisable scheme, emit a `WARNING` with the offending value and the accepted key names, and clear the field.

```
WARNING providers[myprovider]: base_url value 'openai-reverse-proxy' does not look like a URL
(missing http:// or https:// scheme) — check your config.yaml.
Accepted keys: base_url, baseUrl, url, api.
```

## Testing

20 new tests in `tests/hermes_cli/test_providers_config_parsing.py`:

| Class | Tests | Coverage |
|---|---|---|
| `TestSnakeCaseKeys` | 4 | Existing behavior preserved (regression guard) |
| `TestCamelCaseAliases` | 5 | `baseUrl`, `keyEnv`, both together, precedence order |
| `TestURLValidation` | 5 | Non-URL rejection + warning, valid http/https accepted, empty no-warn |
| `TestEdgeCases` | 6 | None entry, empty dict, missing key, name field, transport |

All 20 pass.

Fixes #9332
