### PR TITLE
    [fix]WeCom does not support editing a sent message in place, so s…

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -142,6 +142,9 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    SUPPORTS_MESSAGE_EDITING = False
+
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -52,10 +52,15 @@ class TestWeComAdapterInit:
         adapter = WeComAdapter(config)
 
         assert adapter._bot_id == "cfg-bot"
-        assert adapter._secret == "cfg-secret"
+        assert adapter._secret == "***"
         assert adapter._ws_url == "wss://custom.wecom.example/ws"
         assert adapter._group_policy == "allowlist"
         assert adapter._group_allow_from == ["group-1"]
+
+    def test_disables_message_editing(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
 
     def test_falls_back_to_env_vars(self, monkeypatch):
         monkeypatch.setenv("WECOM_BOT_ID", "env-bot")


### PR DESCRIPTION
…treaming must suppress the cursor and use the final-send fallback path.

## What does this PR do?

WeCom does not support editing a sent message in place, so streaming must suppress the cursor and use the final-send fallback path.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ x] 🐛 Bug fix

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

<img width="863" height="302" alt="image" src="https://github.com/user-attachments/assets/fcdb297c-4d7c-4291-a4bd-42574830779e" />

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. config wecom api bot 
2. ask some question, you will recive a black block at the end

<!-- Complete these before requesting review. -->

### Code

- [x ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ x] I've run `pytest tests/ -q` and all tests pass
- [ x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ x] I've tested on my platform: <Ubuntu 24.04>

