### PR TITLE
feat(music): add async background task mechanism and music generation tool

### DIFF
--- a/agent/background_task.py
+++ b/agent/background_task.py
@@ -1,0 +1,172 @@
+"""
+Async detach + wake mechanism for long-running background tasks.
+
+Usage (from a tool handler):
+
+    from agent.background_task import background_tasks, current_session_origin
+
+    origin = current_session_origin()
+    handle = background_tasks.create(
+        coro=_generate(prompt),    # coroutine that returns a wake_text string
+        session_key=origin.session_key,
+        origin=origin,
+        label="music generation",
+    )
+    if handle is None:
+        # No active session (CLI) or a task already running — fall back to sync.
+        return None
+
+    return {"status": "started", "task_id": handle.task_id}
+
+The coroutine should return a string that will be injected as the wake message.
+Any unhandled exception is caught by the gateway wrapper and converted to an
+error wake message automatically.
+
+The gateway drains ``background_tasks`` after each agent turn via
+``background_tasks.drain_pending()``, schedules each entry as an asyncio
+task via ``_run_background_task``, which runs the coroutine and injects
+the result back into the originating session.
+
+Query active task (for duplicate guard / status action):
+
+    handle = background_tasks.get_active(session_key)
+    if handle:
+        return {"status": handle.status, "task_id": handle.task_id}
+"""
+
+import logging
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Coroutine, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionOrigin:
+    """Snapshot of session context variables captured at task-creation time."""
+    session_key: str
+    platform: str
+    chat_id: str
+    thread_id: str = ""
+    user_id: str = ""
+    user_name: str = ""
+
+
+@dataclass
+class BackgroundTaskHandle:
+    task_id: str
+    session_key: str
+    origin: SessionOrigin
+    label: str
+    status: str = "running"  # running | succeeded | failed
+
+
+@dataclass
+class _PendingEntry:
+    coro: Coroutine
+    handle: BackgroundTaskHandle
+
+
+class BackgroundTaskRegistry:
+    """
+    Registry for async background tasks.
+
+    Thread-safe. Shared between tool threads and the gateway asyncio loop.
+    Follows the same pending-list + gateway-drain pattern as
+    ``process_registry.pending_watchers``.
+    """
+
+    def __init__(self) -> None:
+        # Tasks queued for the gateway to schedule (asyncio.create_task).
+        # Drained atomically via drain_pending() — do not access directly.
+        self._pending: list[_PendingEntry] = []
+
+        # One active task per session_key (duplicate guard + status queries).
+        self._active: dict[str, BackgroundTaskHandle] = {}
+
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Tool-facing API
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        coro: Coroutine,
+        session_key: str,
+        origin: SessionOrigin,
+        label: str = "background task",
+    ) -> Optional[BackgroundTaskHandle]:
+        """Register a background task and queue it for gateway scheduling.
+
+        Returns ``None`` if:
+        - ``session_key`` is empty (no gateway session — caller runs sync), or
+        - a task is already active for this session (duplicate guard).
+        """
+        if not session_key:
+            return None
+        with self._lock:
+            if session_key in self._active:
+                return None
+            handle = BackgroundTaskHandle(
+                task_id=str(uuid.uuid4()),
+                session_key=session_key,
+                origin=origin,
+                label=label,
+            )
+            self._active[session_key] = handle
+            self._pending.append(_PendingEntry(coro=coro, handle=handle))
+        logger.debug(
+            "background_task: created %s (%s) for session %.20s",
+            handle.task_id, label, session_key,
+        )
+        return handle
+
+    def get_active(self, session_key: str) -> Optional[BackgroundTaskHandle]:
+        """Return the active task for *session_key*, or ``None``."""
+        with self._lock:
+            return self._active.get(session_key)
+
+    def drain_pending(self) -> "list[_PendingEntry]":
+        """Atomically remove and return all queued pending entries.
+
+        Safe to call from any thread or the asyncio event loop. Use this
+        instead of accessing ``_pending`` directly to avoid races between
+        tool threads appending and drain sites consuming.
+        """
+        with self._lock:
+            entries, self._pending = self._pending, []
+        return entries
+
+    # ------------------------------------------------------------------
+    # Gateway-facing API (called from _run_background_task)
+    # ------------------------------------------------------------------
+
+    def _mark_done(self, handle: BackgroundTaskHandle, status: str) -> None:
+        with self._lock:
+            handle.status = status
+            self._active.pop(handle.session_key, None)
+
+
+# Module-level singleton — import this in tools and gateway.
+background_tasks = BackgroundTaskRegistry()
+
+
+def current_session_origin() -> SessionOrigin:
+    """Read current session context variables and return a ``SessionOrigin``.
+
+    Call this at the start of a tool handler, before any ``await``, so the
+    contextvars are still set for the current task.
+    """
+    from gateway.session_context import get_session_env
+    return SessionOrigin(
+        session_key=get_session_env("HERMES_SESSION_KEY"),
+        platform=get_session_env("HERMES_SESSION_PLATFORM"),
+        chat_id=get_session_env("HERMES_SESSION_CHAT_ID"),
+        thread_id=get_session_env("HERMES_SESSION_THREAD_ID"),
+        user_id=get_session_env("HERMES_SESSION_USER_ID"),
+        user_name=get_session_env("HERMES_SESSION_USER_NAME"),
+    )

--- a/cli.py
+++ b/cli.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sys
 import json
+import asyncio
 import atexit
 import tempfile
 import time
@@ -1804,6 +1805,7 @@ class HermesCLI:
         # mode does not go through run().
         self._agent_running = False
         self._pending_input = queue.Queue()
+        self._pending_background_wakes = queue.Queue()
         self._interrupt_queue = queue.Queue()
         self._should_exit = False
         self._last_ctrl_c_time = 0
@@ -1847,6 +1849,84 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+
+    def _set_cli_session_env(self, session_key: Optional[str] = None) -> list:
+        """Set per-turn session context for CLI tool calls."""
+        from gateway.session_context import set_session_vars
+
+        effective_session_key = (session_key or self.session_id or "").strip()
+        return set_session_vars(
+            platform="cli",
+            chat_id=effective_session_key,
+            chat_name="CLI",
+            session_key=effective_session_key,
+        )
+
+    def _clear_cli_session_env(self, tokens: list) -> None:
+        """Restore CLI session contextvars after a turn completes."""
+        from gateway.session_context import clear_session_vars
+
+        clear_session_vars(tokens)
+
+    def _build_detached_task_followup(self, handle, wake_text: str) -> str | None:
+        """Create a synthetic system follow-up so the CLI agent can reply."""
+        if not wake_text or not isinstance(wake_text, str):
+            return None
+        return (
+            f"[SYSTEM: A background {handle.label} task has completed. "
+            "Reply to the user now with a brief update in your normal assistant voice. "
+            "If the result includes a saved local file path or MEDIA tag, include the exact path "
+            "so the user can find the generated file. Do not mention internal task machinery.\n\n"
+            f"Result:\n{wake_text}]"
+        )
+
+    def _queue_detached_task_followup(self, handle, wake_text: str) -> None:
+        """Queue a synthetic follow-up turn for detached CLI task completion."""
+        followup = self._build_detached_task_followup(handle, wake_text)
+        if not followup:
+            return
+        self._pending_background_wakes.put(followup)
+
+    def _drain_detached_task_followups(self) -> None:
+        """Move queued detached-task follow-ups into the normal CLI input queue."""
+        while not self._pending_background_wakes.empty():
+            try:
+                self._pending_input.put(self._pending_background_wakes.get_nowait())
+            except queue.Empty:
+                break
+
+    def _run_pending_detached_task(self, entry) -> None:
+        """Execute a detached tool task for CLI sessions."""
+        from agent.background_task import background_tasks
+
+        handle = entry.handle
+        try:
+            wake_text = asyncio.run(entry.coro)
+            if not isinstance(wake_text, str):
+                wake_text = f"[SYSTEM: Background task '{handle.label}' completed.]"
+            background_tasks._mark_done(handle, "succeeded")
+        except Exception as exc:
+            wake_text = f"[SYSTEM: Background task '{handle.label}' failed — {exc}]"
+            background_tasks._mark_done(handle, "failed")
+        finally:
+            self._background_tasks.pop(handle.task_id, None)
+
+        self._queue_detached_task_followup(handle, wake_text)
+
+    def _start_pending_detached_tasks(self) -> None:
+        """Drain CLI-detached tool tasks queued during the last agent turn."""
+        from agent.background_task import background_tasks
+
+        for entry in background_tasks.drain_pending():
+            handle = entry.handle
+            thread = threading.Thread(
+                target=self._run_pending_detached_task,
+                args=(entry,),
+                daemon=True,
+                name=f"tool-bg-{handle.task_id}",
+            )
+            self._background_tasks[handle.task_id] = thread
+            thread.start()
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -5717,10 +5797,16 @@ class HermesCLI:
 
                 bg_agent.thinking_callback = _bg_thinking
 
-                result = bg_agent.run_conversation(
-                    user_message=prompt,
-                    task_id=task_id,
-                )
+                tokens = self._set_cli_session_env(task_id)
+                try:
+                    result = bg_agent.run_conversation(
+                        user_message=prompt,
+                        task_id=task_id,
+                    )
+                finally:
+                    self._clear_cli_session_env(tokens)
+
+                self._start_pending_detached_tasks()
 
                 response = result.get("final_response", "") if result else ""
                 if not response and result and result.get("error"):
@@ -7676,6 +7762,7 @@ class HermesCLI:
                 if _msn:
                     agent_message = _msn + "\n\n" + agent_message
                     self._pending_model_switch_note = None
+                tokens = self._set_cli_session_env()
                 try:
                     result = self.agent.run_conversation(
                         user_message=agent_message,
@@ -7695,6 +7782,8 @@ class HermesCLI:
                         "failed": True,
                         "error": _summary,
                     }
+                finally:
+                    self._clear_cli_session_env(tokens)
 
             # Start agent in background thread (daemon so it cannot keep the
             # process alive when the user closes the terminal tab — SIGHUP
@@ -7749,6 +7838,7 @@ class HermesCLI:
                     agent_thread.join(0.1)
 
             agent_thread.join()  # Ensure agent thread completes
+            self._start_pending_detached_tasks()
 
             # Proactively clean up async clients whose event loop is dead.
             # The agent thread may have created AsyncOpenAI clients bound
@@ -8229,6 +8319,7 @@ class HermesCLI:
         # State for async operation
         self._agent_running = False
         self._pending_input = queue.Queue()     # For normal input (commands + new queries)
+        self._pending_background_wakes = queue.Queue()  # For detached-task follow-up turns
         self._interrupt_queue = queue.Queue()   # For messages typed while agent is running
         self._should_exit = False
         self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
@@ -9489,6 +9580,7 @@ class HermesCLI:
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:
+                            self._drain_detached_task_followups()
                             self._check_config_mcp_changes()
                             # Check for background process notifications (completions
                             # and watch pattern matches) while agent is idle.
@@ -9638,6 +9730,7 @@ class HermesCLI:
                                     self._pending_input.put(_synth)
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
+                        self._drain_detached_task_followups()
 
                 except Exception as e:
                     print(f"Error: {e}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3653,6 +3653,14 @@ class GatewayRunner:
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 
+            # Schedule any background tasks queued during this agent turn.
+            try:
+                from agent.background_task import background_tasks
+                for entry in background_tasks.drain_pending():
+                    asyncio.create_task(self._run_detached_task(entry))
+            except Exception as e:
+                logger.error("Background task scheduling error: %s", e)
+
             # Drain watch pattern notifications that arrived during the agent run.
             # Watch events and completions share the same queue; completions are
             # already handled by the per-process watcher task above, so we only
@@ -7141,6 +7149,80 @@ class GatewayRunner:
                 return f"{prefix}\n\n{user_text}"
             return prefix
         return user_text
+
+    # ------------------------------------------------------------------
+    # Background task support (agent/background_task.py)
+    # ------------------------------------------------------------------
+
+    async def _inject_background_wake(self, origin, wake_text: str) -> None:
+        """Inject a background-task completion as a synthetic internal message.
+
+        Constructs a MessageEvent with ``internal=True`` (skips auth) and
+        routes it through the originating platform adapter so the agent runs
+        again and delivers the result to the user.
+        """
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+
+        if not origin.chat_id:
+            logger.warning("background_task: no chat_id in origin, cannot wake session")
+            return
+
+        adapter = None
+        for p, a in self.adapters.items():
+            if p.value == origin.platform:
+                adapter = a
+                break
+        if adapter is None:
+            logger.warning("background_task: no adapter for platform %r, dropping wake", origin.platform)
+            return
+
+        try:
+            source = SessionSource(
+                platform=Platform(origin.platform),
+                chat_id=origin.chat_id,
+                thread_id=origin.thread_id or None,
+                user_id=origin.user_id or None,
+                user_name=origin.user_name or None,
+            )
+            event = MessageEvent(
+                text=wake_text,
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            logger.info(
+                "background_task: waking session %.20s on %s",
+                origin.session_key, origin.platform,
+            )
+            await adapter.handle_message(event)
+        except Exception as exc:
+            logger.error("background_task: wake injection failed: %s", exc)
+
+    async def _run_detached_task(self, entry) -> None:
+        """Run a background task coroutine and inject the wake event on completion.
+
+        ``entry`` is a ``_PendingEntry`` from ``background_tasks.pending``.
+        The coroutine should return a string that becomes the wake message text.
+        Any unhandled exception is caught and converted to an error wake message.
+        """
+        from agent.background_task import background_tasks
+
+        handle = entry.handle
+        try:
+            wake_text = await entry.coro
+            if not isinstance(wake_text, str):
+                wake_text = f"[SYSTEM: Background task '{handle.label}' completed.]"
+            background_tasks._mark_done(handle, "succeeded")
+        except Exception as exc:
+            logger.error("background_task: task %s failed: %s", handle.task_id, exc, exc_info=True)
+            wake_text = f"[SYSTEM: Background task '{handle.label}' failed — {exc}]"
+            background_tasks._mark_done(handle, "failed")
+
+        await self._inject_background_wake(handle.origin, wake_text)
+
+    # ------------------------------------------------------------------
 
     async def _inject_watch_notification(self, synth_text: str, original_event) -> None:
         """Inject a watch-pattern notification as a synthetic message event.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("music_gen",       "🎵 Music Generation",          "music_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/model_tools.py
+++ b/model_tools.py
@@ -142,6 +142,7 @@ def _discover_tools():
         "tools.vision_tools",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
+        "tools.music_generation_tool",
         "tools.skills_tool",
         "tools.skill_manager_tool",
         "tools.browser_tool",

--- a/tests/cli/test_cli_detached_tasks.py
+++ b/tests/cli/test_cli_detached_tasks.py
@@ -1,0 +1,113 @@
+import time
+import queue
+
+from agent.background_task import SessionOrigin, background_tasks
+from cli import HermesCLI
+from gateway.session_context import get_session_env
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.session_id = "cli-session-123"
+    cli_obj._background_tasks = {}
+    cli_obj._app = None
+    cli_obj._agent_running = False
+    cli_obj._spinner_text = ""
+    cli_obj._pending_background_wakes = queue.Queue()
+    cli_obj._pending_input = queue.Queue()
+    return cli_obj
+
+
+def _clear_background_registry():
+    with background_tasks._lock:
+        background_tasks._pending.clear()
+        background_tasks._active.clear()
+
+
+def test_cli_session_env_uses_contextvars(monkeypatch):
+    cli_obj = _make_cli()
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+    tokens = cli_obj._set_cli_session_env()
+    try:
+        assert get_session_env("HERMES_SESSION_PLATFORM") == "cli"
+        assert get_session_env("HERMES_SESSION_CHAT_ID") == "cli-session-123"
+        assert get_session_env("HERMES_SESSION_KEY") == "cli-session-123"
+    finally:
+        cli_obj._clear_cli_session_env(tokens)
+
+    assert get_session_env("HERMES_SESSION_PLATFORM") == ""
+    assert get_session_env("HERMES_SESSION_CHAT_ID") == ""
+    assert get_session_env("HERMES_SESSION_KEY") == ""
+
+
+def test_cli_starts_pending_detached_tasks():
+    cli_obj = _make_cli()
+    _clear_background_registry()
+
+    async def _done():
+        return "Music generation completed."
+
+    handle = background_tasks.create(
+        coro=_done(),
+        session_key=cli_obj.session_id,
+        origin=SessionOrigin(
+            session_key=cli_obj.session_id,
+            platform="cli",
+            chat_id=cli_obj.session_id,
+        ),
+        label="music generation",
+    )
+
+    assert handle is not None
+    cli_obj._start_pending_detached_tasks()
+
+    deadline = time.time() + 2
+    while time.time() < deadline and handle.task_id in cli_obj._background_tasks:
+        time.sleep(0.01)
+
+    assert background_tasks.get_active(cli_obj.session_id) is None
+    assert handle.task_id not in cli_obj._background_tasks
+    followup = cli_obj._pending_background_wakes.get_nowait()
+    assert "Music generation completed." in followup
+
+
+def test_cli_queues_detached_task_followup_for_agent_reply():
+    cli_obj = _make_cli()
+    _clear_background_registry()
+
+    async def _done():
+        return "Music generation completed.\nSaved: /tmp/night-drive.mp3\nMEDIA:/tmp/night-drive.mp3"
+
+    handle = background_tasks.create(
+        coro=_done(),
+        session_key=cli_obj.session_id,
+        origin=SessionOrigin(
+            session_key=cli_obj.session_id,
+            platform="cli",
+            chat_id=cli_obj.session_id,
+        ),
+        label="music generation",
+    )
+
+    assert handle is not None
+    cli_obj._start_pending_detached_tasks()
+
+    deadline = time.time() + 2
+    while time.time() < deadline and handle.task_id in cli_obj._background_tasks:
+        time.sleep(0.01)
+
+    followup = cli_obj._pending_background_wakes.get_nowait()
+    assert "Reply to the user now with a brief update" in followup
+    assert "Saved: /tmp/night-drive.mp3" in followup
+    assert "MEDIA:/tmp/night-drive.mp3" in followup
+
+
+def test_cli_drains_detached_followups_into_pending_input():
+    cli_obj = _make_cli()
+    cli_obj._pending_background_wakes.put("[SYSTEM: Background task completed.]")
+
+    cli_obj._drain_detached_task_followups()
+
+    assert cli_obj._pending_background_wakes.empty()
+    assert cli_obj._pending_input.get_nowait() == "[SYSTEM: Background task completed.]"

--- a/tests/tools/test_music_generation_tool.py
+++ b/tests/tools/test_music_generation_tool.py
@@ -1,0 +1,227 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+from agent.background_task import BackgroundTaskHandle, SessionOrigin
+
+
+def _mock_response(payload):
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return response
+
+
+def test_prompt_only_flow_generates_lyrics_before_creating_song(monkeypatch):
+    from tools.music_generation_tool import SENSEAUDIO_MUSIC_MODEL, music_generate_tool
+
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.post.side_effect = [
+        _mock_response(
+            {
+                "data": [
+                    {
+                        "text": "[intro-medium] ; [verse] Soft lights glow tonight ; [chorus] Drift into the lo-fi haze",
+                        "title": "Midnight Notes",
+                    }
+                ]
+            }
+        ),
+        _mock_response({"task_id": "song-task-123"}),
+    ]
+
+    pending_data = {
+        "status": "SUCCESS",
+        "response": {
+            "data": [
+                {
+                    "audio_url": "https://example.com/track.mp3",
+                    "cover_url": "https://example.com/cover.jpg",
+                    "duration": 98,
+                    "title": "Midnight Notes",
+                    "lyrics": "[intro-medium] ; [verse] Soft lights glow tonight ; [chorus] Drift into the lo-fi haze",
+                }
+            ]
+        },
+    }
+
+    monkeypatch.setenv("SENSEAUDIO_API_KEY", "test-key")
+
+    background_create = MagicMock(return_value=None)
+
+    with patch("tools.music_generation_tool.current_session_origin", return_value=SessionOrigin("", "", "")), \
+         patch("tools.music_generation_tool.httpx.Client", return_value=client), \
+         patch("tools.music_generation_tool.background_tasks.create", background_create), \
+         patch("tools.music_generation_tool._download_track_to_local", return_value="/tmp/midnight-notes.mp3"), \
+         patch("tools.music_generation_tool._poll_sync", return_value=pending_data):
+        result = json.loads(
+            music_generate_tool(
+                prompt="Relaxing lo-fi music for studying and cafe ambience.",
+                style="lo-fi",
+            )
+        )
+
+    assert result["provider"] == "senseaudio"
+    assert result["tracks"][0]["url"] == "https://example.com/track.mp3"
+    assert result["tracks"][0]["localPath"] == "/tmp/midnight-notes.mp3"
+    background_create.assert_not_called()
+
+    assert client.post.call_count == 2
+
+    lyrics_call = client.post.call_args_list[0]
+    assert lyrics_call.args[0].endswith("/music/lyrics/create")
+    assert lyrics_call.kwargs["json"] == {
+        "prompt": "Relaxing lo-fi music for studying and cafe ambience.",
+        "provider": SENSEAUDIO_MUSIC_MODEL,
+    }
+
+    song_call = client.post.call_args_list[1]
+    assert song_call.args[0].endswith("/music/song/create")
+    assert song_call.kwargs["json"] == {
+        "model": SENSEAUDIO_MUSIC_MODEL,
+        "lyrics": "[intro-medium] ; [verse] Soft lights glow tonight ; [chorus] Drift into the lo-fi haze",
+        "custom_mode": False,
+        "instrumental": False,
+        "style": "lo-fi",
+        "title": "Midnight Notes",
+    }
+
+
+def test_create_song_surfaces_senseaudio_error_details():
+    from tools.music_generation_tool import _create_song
+
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 400
+    response.json.return_value = {
+        "code": "invalid",
+        "message": "Invalid lyrics format",
+        "ref_code": 400709,
+    }
+    response.text = '{"code":"invalid","message":"Invalid lyrics format","ref_code":400709}'
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400 Bad Request",
+        request=MagicMock(),
+        response=response,
+    )
+
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.post.return_value = response
+
+    with patch("tools.music_generation_tool.httpx.Client", return_value=client):
+        try:
+            _create_song("lo-fi prompt")
+        except ValueError as exc:
+            assert "Invalid lyrics format" in str(exc)
+            assert "code=invalid" in str(exc)
+            assert "ref_code=400709" in str(exc)
+        else:
+            raise AssertionError("Expected _create_song() to raise ValueError")
+
+
+def test_music_generate_returns_started_for_cli_session(monkeypatch):
+    from tools.music_generation_tool import music_generate_tool
+
+    monkeypatch.setenv("SENSEAUDIO_API_KEY", "test-key")
+
+    handle = BackgroundTaskHandle(
+        task_id="bg-task-1",
+        session_key="cli-session-123",
+        origin=SessionOrigin(
+            session_key="cli-session-123",
+            platform="cli",
+            chat_id="cli-session-123",
+        ),
+        label="music generation",
+    )
+
+    def _fake_create(*, coro, session_key, origin, label):
+        coro.close()
+        return handle
+
+    with patch(
+        "tools.music_generation_tool.current_session_origin",
+        return_value=SessionOrigin("cli-session-123", "cli", "cli-session-123"),
+    ), \
+         patch(
+             "tools.music_generation_tool._create_lyrics_from_prompt",
+             return_value={"lyrics": "[verse] hello world", "title": "Test Song"},
+         ), \
+         patch("tools.music_generation_tool._create_song", return_value="sense-task-1"), \
+         patch("tools.music_generation_tool.background_tasks.create", side_effect=_fake_create), \
+         patch("tools.music_generation_tool._poll_sync") as mock_poll_sync:
+        result = json.loads(music_generate_tool(prompt="warm lofi beat"))
+
+    assert result["status"] == "started"
+    assert result["task_id"] == "sense-task-1"
+    assert "background" in result["message"].lower()
+    mock_poll_sync.assert_not_called()
+
+
+def test_music_generation_poll_timeout_extended_to_30_minutes():
+    from tools.music_generation_tool import POLL_MAX_WAIT
+
+    assert POLL_MAX_WAIT == 1800
+
+
+def test_format_result_downloads_tracks_to_local_paths():
+    from tools.music_generation_tool import _format_result
+
+    pending_data = {
+        "status": "SUCCESS",
+        "response": {
+            "data": [
+                {
+                    "audio_url": "https://example.com/generated.mp3",
+                    "cover_url": "https://example.com/cover.jpg",
+                    "duration": 123,
+                    "title": "Night Drive",
+                    "lyrics": "[verse] neon lights blur",
+                }
+            ]
+        },
+    }
+
+    with patch(
+        "tools.music_generation_tool._download_track_to_local",
+        return_value="/tmp/night-drive.mp3",
+    ) as mock_download:
+        result = _format_result(pending_data, ignored_overrides=[])
+
+    mock_download.assert_called_once_with(
+        "https://example.com/generated.mp3",
+        file_name="Night Drive.mp3",
+    )
+    track = result["tracks"][0]
+    assert track["url"] == "https://example.com/generated.mp3"
+    assert track["localPath"] == "/tmp/night-drive.mp3"
+    assert track["mediaTag"] == "MEDIA:/tmp/night-drive.mp3"
+    assert track["metadata"]["source_url"] == "https://example.com/generated.mp3"
+
+
+def test_wake_message_includes_local_media_delivery_path():
+    from tools.music_generation_tool import _wake_message
+
+    message = _wake_message(
+        {
+            "tracks": [
+                {
+                    "url": "https://example.com/generated.mp3",
+                    "localPath": "/tmp/night-drive.mp3",
+                    "fileName": "Night Drive.mp3",
+                    "mediaTag": "MEDIA:/tmp/night-drive.mp3",
+                    "metadata": {
+                        "title": "Night Drive",
+                        "duration": 123,
+                    },
+                }
+            ],
+            "lyrics": ["[verse] neon lights blur"],
+        }
+    )
+
+    assert "Saved: /tmp/night-drive.mp3" in message
+    assert "MEDIA:/tmp/night-drive.mp3" in message

--- a/tests/tools/test_music_generation_tool.py
+++ b/tests/tools/test_music_generation_tool.py
@@ -225,3 +225,32 @@ def test_wake_message_includes_local_media_delivery_path():
 
     assert "Saved: /tmp/night-drive.mp3" in message
     assert "MEDIA:/tmp/night-drive.mp3" in message
+
+
+def test_get_music_provider_defaults_to_senseaudio():
+    from tools.music_generation_tool import DEFAULT_PROVIDER, _get_provider
+
+    assert DEFAULT_PROVIDER == "senseaudio"
+    assert _get_provider({}) == "senseaudio"
+
+
+def test_music_generate_dispatches_generate_to_configured_provider():
+    from tools.music_generation_tool import music_generate_tool
+
+    with patch("tools.music_generation_tool._load_music_config", return_value={"provider": "senseaudio"}), \
+         patch("tools.music_generation_tool._senseaudio_generate", return_value='{"status":"started"}') as mock_generate:
+        result = music_generate_tool(prompt="warm lofi beat")
+
+    assert json.loads(result) == {"status": "started"}
+    mock_generate.assert_called_once()
+
+
+def test_music_generate_dispatches_status_to_configured_provider():
+    from tools.music_generation_tool import music_generate_tool
+
+    with patch("tools.music_generation_tool._load_music_config", return_value={"provider": "senseaudio"}), \
+         patch("tools.music_generation_tool._senseaudio_status", return_value='{"status":"running"}') as mock_status:
+        result = music_generate_tool(action="status")
+
+    assert json.loads(result) == {"status": "running"}
+    mock_status.assert_called_once()

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -12,10 +12,6 @@ Workflow:
            → returns GenerateMusicRuntimeResult when done
   status   → GET /v1/music/song/pending/:task_id for the active task
 
-In gateway sessions (Telegram, Discord, etc.) generation runs as a
-background task so the agent turn is not blocked.  In CLI mode the
-tool falls back to a synchronous polling loop.
-
 Environment:
   SENSEAUDIO_API_KEY  — required
   SENSEAUDIO_BASE_URL — optional override (default: https://api.senseaudio.cn/v1)
@@ -45,7 +41,9 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-SENSEAUDIO_BASE_URL = os.getenv("SENSEAUDIO_BASE_URL", "https://api.senseaudio.cn/v1")
+DEFAULT_PROVIDER = "senseaudio"
+DEFAULT_SENSEAUDIO_BASE_URL = "https://api.senseaudio.cn/v1"
+SENSEAUDIO_BASE_URL = os.getenv("SENSEAUDIO_BASE_URL", DEFAULT_SENSEAUDIO_BASE_URL)
 SENSEAUDIO_MUSIC_MODEL = "senseaudio-music-1.0-260319"
 
 POLL_INTERVAL = 5     # seconds between status checks
@@ -53,9 +51,9 @@ POLL_MAX_WAIT = 1800  # total timeout (30 minutes)
 
 _debug = DebugSession("music_tools", env_var="MUSIC_TOOLS_DEBUG")
 
-# session_key → SenseAudio task_id, for status queries
-_active_task_ids: Dict[str, str] = {}
-_active_task_ids_lock = threading.Lock()
+# session_key → {"provider": str, "task_id": str}
+_active_music_tasks: Dict[str, Dict[str, str]] = {}
+_active_music_tasks_lock = threading.Lock()
 
 
 def _get_music_output_dir() -> Path:
@@ -89,16 +87,57 @@ def _download_track_to_local(audio_url: str, *, file_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _load_music_config() -> Dict[str, Any]:
+    """Load the ``music`` section from user config, falling back to defaults."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        return config.get("music", {})
+    except ImportError:
+        logger.debug("hermes_cli.config not available, using default music config")
+        return {}
+    except Exception as exc:
+        logger.warning("Failed to load music config: %s", exc, exc_info=True)
+        return {}
+
+
+def _get_provider(music_config: Dict[str, Any]) -> str:
+    """Return the configured music provider name."""
+    return (music_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+
+
+def _get_senseaudio_config(music_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return the provider-specific SenseAudio config section."""
+    config = music_config or {}
+    provider_cfg = config.get("senseaudio", {})
+    return provider_cfg if isinstance(provider_cfg, dict) else {}
+
+
+# ---------------------------------------------------------------------------
 # API helpers
 # ---------------------------------------------------------------------------
 
-def _api_key() -> Optional[str]:
-    return os.getenv("SENSEAUDIO_API_KEY")
+def _api_key(music_config: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    senseaudio_cfg = _get_senseaudio_config(music_config)
+    return (senseaudio_cfg.get("api_key") or os.getenv("SENSEAUDIO_API_KEY") or "").strip() or None
 
 
-def _auth_headers() -> Dict[str, str]:
+def _base_url(music_config: Optional[Dict[str, Any]] = None) -> str:
+    senseaudio_cfg = _get_senseaudio_config(music_config)
+    return (senseaudio_cfg.get("base_url") or os.getenv("SENSEAUDIO_BASE_URL") or DEFAULT_SENSEAUDIO_BASE_URL).rstrip("/")
+
+
+def _model_name(music_config: Optional[Dict[str, Any]] = None) -> str:
+    senseaudio_cfg = _get_senseaudio_config(music_config)
+    return (senseaudio_cfg.get("model") or SENSEAUDIO_MUSIC_MODEL).strip()
+
+
+def _auth_headers(music_config: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
     return {
-        "Authorization": f"Bearer {_api_key()}",
+        "Authorization": f"Bearer {_api_key(music_config)}",
         "Content-Type": "application/json",
     }
 
@@ -138,16 +177,19 @@ def _raise_for_status_with_details(resp: httpx.Response) -> None:
         raise
 
 
-def _create_lyrics_from_prompt(prompt: str) -> Dict[str, Optional[str]]:
+def _create_lyrics_from_prompt(
+    prompt: str,
+    music_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Optional[str]]:
     """Convert a free-form prompt into structured lyrics via SenseAudio."""
     body = {
         "prompt": prompt,
-        "provider": SENSEAUDIO_MUSIC_MODEL,
+        "provider": _model_name(music_config),
     }
 
-    url = f"{SENSEAUDIO_BASE_URL}/music/lyrics/create"
+    url = f"{_base_url(music_config)}/music/lyrics/create"
     with httpx.Client(timeout=30) as client:
-        resp = client.post(url, json=body, headers=_auth_headers())
+        resp = client.post(url, json=body, headers=_auth_headers(music_config))
         _raise_for_status_with_details(resp)
         data = resp.json()
 
@@ -169,6 +211,7 @@ def _create_song(
     style: Optional[str] = None,
     vocal_gender: Optional[str] = None,
     title: Optional[str] = None,
+    music_config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Submit a song creation request. Returns the SenseAudio task_id."""
     # custom_mode=True: model uses `lyrics` field as a free-form prompt.
@@ -176,7 +219,7 @@ def _create_song(
     custom_mode = lyrics is None
 
     body: Dict[str, Any] = {
-        "model": SENSEAUDIO_MUSIC_MODEL,
+        "model": _model_name(music_config),
         "lyrics": lyrics if lyrics is not None else prompt,
         "custom_mode": custom_mode,
         "instrumental": instrumental,
@@ -188,9 +231,9 @@ def _create_song(
     if title:
         body["title"] = title
 
-    url = f"{SENSEAUDIO_BASE_URL}/music/song/create"
+    url = f"{_base_url(music_config)}/music/song/create"
     with httpx.Client(timeout=30) as client:
-        resp = client.post(url, json=body, headers=_auth_headers())
+        resp = client.post(url, json=body, headers=_auth_headers(music_config))
         _raise_for_status_with_details(resp)
         data = resp.json()
 
@@ -200,20 +243,20 @@ def _create_song(
     return task_id
 
 
-def _query_status(task_id: str) -> Dict[str, Any]:
+def _query_status(task_id: str, music_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Call the pending endpoint once. Returns the raw response dict."""
-    url = f"{SENSEAUDIO_BASE_URL}/music/song/pending/{task_id}"
+    url = f"{_base_url(music_config)}/music/song/pending/{task_id}"
     with httpx.Client(timeout=30) as client:
-        resp = client.get(url, headers=_auth_headers())
+        resp = client.get(url, headers=_auth_headers(music_config))
         _raise_for_status_with_details(resp)
         return resp.json()
 
 
-def _poll_sync(task_id: str) -> Dict[str, Any]:
+def _poll_sync(task_id: str, music_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Block until the task reaches SUCCESS/FAILED or POLL_MAX_WAIT elapses."""
     deadline = time.monotonic() + POLL_MAX_WAIT
     while time.monotonic() < deadline:
-        data = _query_status(task_id)
+        data = _query_status(task_id, music_config=music_config)
         status = data.get("status", "")
         if status == "SUCCESS":
             return data
@@ -225,12 +268,16 @@ def _poll_sync(task_id: str) -> Dict[str, Any]:
     )
 
 
-async def _poll_async(task_id: str, session_key: str) -> str:
+async def _poll_async(
+    task_id: str,
+    session_key: str,
+    music_config: Optional[Dict[str, Any]] = None,
+) -> str:
     """Background coroutine: poll until done, return the agent wake message."""
     deadline = time.monotonic() + POLL_MAX_WAIT
     try:
         while time.monotonic() < deadline:
-            data = _query_status(task_id)
+            data = _query_status(task_id, music_config=music_config)
             status = data.get("status", "")
             if status == "SUCCESS":
                 result = _format_result(data, ignored_overrides=[])
@@ -240,8 +287,8 @@ async def _poll_async(task_id: str, session_key: str) -> str:
             await asyncio.sleep(POLL_INTERVAL)
         return f"Music generation timed out after {POLL_MAX_WAIT}s (task_id={task_id})."
     finally:
-        with _active_task_ids_lock:
-            _active_task_ids.pop(session_key, None)
+        with _active_music_tasks_lock:
+            _active_music_tasks.pop(session_key, None)
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +367,120 @@ def _wake_message(result: Dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Provider: SenseAudio
+# ---------------------------------------------------------------------------
+
+def _senseaudio_status(
+    *,
+    session_key: str,
+    music_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Query status for the active SenseAudio task in this session."""
+    with _active_music_tasks_lock:
+        task_info = _active_music_tasks.get(session_key)
+
+    task_id = (task_info or {}).get("task_id", "")
+    if not task_id:
+        handle = background_tasks.get_active(session_key)
+        if handle:
+            return tool_result(status=handle.status, task_id=handle.task_id)
+        return tool_error("No active music generation task for this session.")
+
+    try:
+        data = _query_status(task_id, music_config=music_config)
+        return tool_result(
+            status=data.get("status"),
+            task_id=task_id,
+            details=data,
+        )
+    except Exception as exc:
+        logger.error("Status query failed for task %s: %s", task_id, exc)
+        return tool_error(f"Failed to query task status: {exc}")
+
+
+def _senseaudio_generate(
+    *,
+    prompt: str,
+    lyrics: Optional[str],
+    instrumental: bool,
+    style: Optional[str],
+    vocal_gender: Optional[str],
+    title: Optional[str],
+    ignored_overrides: List[Dict[str, Any]],
+    origin,
+    session_key: str,
+    music_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Generate music via SenseAudio with sync or detached completion."""
+    if not prompt and not lyrics:
+        return tool_error("prompt is required for music generation")
+
+    if not _api_key(music_config):
+        return tool_error("SENSEAUDIO_API_KEY environment variable not set")
+
+    try:
+        resolved_lyrics = lyrics
+        resolved_title = title
+        if not resolved_lyrics:
+            generated = _create_lyrics_from_prompt(prompt, music_config=music_config)
+            resolved_lyrics = generated["lyrics"]
+            if not resolved_title:
+                resolved_title = generated.get("title")
+
+        task_id = _create_song(
+            prompt,
+            lyrics=resolved_lyrics,
+            instrumental=instrumental,
+            style=style,
+            vocal_gender=vocal_gender,
+            title=resolved_title,
+            music_config=music_config,
+        )
+        logger.info("SenseAudio song task created: %s", task_id)
+    except Exception as exc:
+        logger.error("Failed to create SenseAudio song task: %s", exc, exc_info=True)
+        return tool_error(f"Failed to start music generation: {exc}")
+
+    if session_key:
+        with _active_music_tasks_lock:
+            _active_music_tasks[session_key] = {
+                "provider": "senseaudio",
+                "task_id": task_id,
+            }
+
+    if session_key:
+        handle = background_tasks.create(
+            coro=_poll_async(task_id, session_key, music_config=music_config),
+            session_key=session_key,
+            origin=origin,
+            label="music generation",
+        )
+        if handle is not None:
+            logger.info("Music generation running in background, task_id=%s", task_id)
+            return tool_result(
+                status="started",
+                task_id=task_id,
+                message="Music is generating in the background. You will be notified automatically when it's ready. Do not check status again unless the user explicitly asks for a progress update.",
+            )
+
+    try:
+        pending_data = _poll_sync(task_id, music_config=music_config)
+        result = _format_result(pending_data, ignored_overrides)
+        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": True})
+        _debug.save()
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("Music generation polling failed: %s", exc, exc_info=True)
+        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": False, "error": str(exc)})
+        _debug.save()
+        return tool_error(f"Music generation failed: {exc}")
+    finally:
+        if session_key:
+            with _active_music_tasks_lock:
+                _active_music_tasks.pop(session_key, None)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -367,103 +528,31 @@ def music_generate_tool(
     if images is not None:
         ignored_overrides.append({"key": "images", "value": images})
 
+    music_config = _load_music_config()
+    provider = _get_provider(music_config)
     origin = current_session_origin()
     session_key = origin.session_key
 
-    # ----------------------------------------------------------------
-    # action: status — query the active task for this session
-    # ----------------------------------------------------------------
-    if action == "status":
-        with _active_task_ids_lock:
-            task_id = _active_task_ids.get(session_key)
-
-        if not task_id:
-            # Also check the background task handle (task may not have a SA task_id yet)
-            handle = background_tasks.get_active(session_key)
-            if handle:
-                return tool_result(status=handle.status, task_id=handle.task_id)
-            return tool_error("No active music generation task for this session.")
-
-        try:
-            data = _query_status(task_id)
-            return tool_result(
-                status=data.get("status"),
-                task_id=task_id,
-                details=data,
+    if provider == "senseaudio":
+        if action == "status":
+            return _senseaudio_status(
+                session_key=session_key,
+                music_config=music_config,
             )
-        except Exception as e:
-            logger.error("Status query failed for task %s: %s", task_id, e)
-            return tool_error(f"Failed to query task status: {e}")
-
-    # ----------------------------------------------------------------
-    # action: generate
-    # ----------------------------------------------------------------
-    if not prompt and not lyrics:
-        return tool_error("prompt is required for music generation")
-
-    if not _api_key():
-        return tool_error("SENSEAUDIO_API_KEY environment variable not set")
-
-    # Submit the generation job
-    try:
-        resolved_lyrics = lyrics
-        resolved_title = title
-        if not resolved_lyrics:
-            generated = _create_lyrics_from_prompt(prompt)
-            resolved_lyrics = generated["lyrics"]
-            if not resolved_title:
-                resolved_title = generated.get("title")
-
-        task_id = _create_song(
-            prompt,
-            lyrics=resolved_lyrics,
+        return _senseaudio_generate(
+            prompt=prompt,
+            lyrics=lyrics,
             instrumental=instrumental,
             style=style,
             vocal_gender=vocal_gender,
-            title=resolved_title,
-        )
-        logger.info("SenseAudio song task created: %s", task_id)
-    except Exception as e:
-        logger.error("Failed to create SenseAudio song task: %s", e, exc_info=True)
-        return tool_error(f"Failed to start music generation: {e}")
-
-    # Persist task_id so status queries can reach the SenseAudio API
-    if session_key:
-        with _active_task_ids_lock:
-            _active_task_ids[session_key] = task_id
-
-    # Try background task (gateway session: Telegram / Discord / etc.)
-    if session_key:
-        handle = background_tasks.create(
-            coro=_poll_async(task_id, session_key),
-            session_key=session_key,
+            title=title,
+            ignored_overrides=ignored_overrides,
             origin=origin,
-            label="music generation",
+            session_key=session_key,
+            music_config=music_config,
         )
-        if handle is not None:
-            logger.info("Music generation running in background, task_id=%s", task_id)
-            return tool_result(
-                status="started",
-                task_id=task_id,
-                message="Music is generating in the background. You will be notified when it's ready.",
-            )
 
-    # Fallback: synchronous polling (CLI mode — no active gateway session)
-    try:
-        pending_data = _poll_sync(task_id)
-        result = _format_result(pending_data, ignored_overrides)
-        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": True})
-        _debug.save()
-        return json.dumps(result, ensure_ascii=False)
-    except Exception as e:
-        logger.error("Music generation polling failed: %s", e, exc_info=True)
-        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": False, "error": str(e)})
-        _debug.save()
-        return tool_error(f"Music generation failed: {e}")
-    finally:
-        if session_key:
-            with _active_task_ids_lock:
-                _active_task_ids.pop(session_key, None)
+    return tool_error(f"Unknown music provider: {provider}")
 
 
 # ---------------------------------------------------------------------------
@@ -473,7 +562,11 @@ def music_generate_tool(
 def check_music_generation_requirements() -> bool:
     try:
         import httpx  # noqa: F401
-        return bool(_api_key())
+        music_config = _load_music_config()
+        provider = _get_provider(music_config)
+        if provider == "senseaudio":
+            return bool(_api_key(music_config))
+        return False
     except ImportError:
         return False
 
@@ -487,8 +580,9 @@ MUSIC_GENERATE_SCHEMA = {
     "description": (
         "Generate music from a text prompt. "
         "Generation runs in the background "
-        "and you are notified when the audio is ready. "
-        "Use action='status' to check an in-progress generation."
+        "and you are notified automatically when the audio is ready. "
+        "After starting a generation, do not call this tool again to poll for status unless the user explicitly asks for a progress update. "
+        "Use action='status' only when the user explicitly wants to check an in-progress generation."
     ),
     "parameters": {
         "type": "object",
@@ -505,7 +599,7 @@ MUSIC_GENERATE_SCHEMA = {
                 "enum": ["generate", "status"],
                 "description": (
                     "'generate' starts a new generation task (default). "
-                    "'status' queries the active task for this session."
+                    "'status' queries the active task for this session, but only use it when the user explicitly asks to check progress."
                 ),
                 "default": "generate",
             },

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""
+Music Generation Tool
+
+Generates music using the SenseAudio API (senseaudio.cn).
+
+Workflow:
+  generate(prompt-only) → POST /v1/music/lyrics/create → structured lyrics
+                       → POST /v1/music/song/create → task_id
+  generate(with lyrics) → POST /v1/music/song/create → task_id
+           → background task polls GET /v1/music/song/pending/:task_id
+           → returns GenerateMusicRuntimeResult when done
+  status   → GET /v1/music/song/pending/:task_id for the active task
+
+In gateway sessions (Telegram, Discord, etc.) generation runs as a
+background task so the agent turn is not blocked.  In CLI mode the
+tool falls back to a synchronous polling loop.
+
+Environment:
+  SENSEAUDIO_API_KEY  — required
+  SENSEAUDIO_BASE_URL — optional override (default: https://api.senseaudio.cn/v1)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.background_task import background_tasks, current_session_origin
+from hermes_constants import get_hermes_dir
+from tools.debug_helpers import DebugSession
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SENSEAUDIO_BASE_URL = os.getenv("SENSEAUDIO_BASE_URL", "https://api.senseaudio.cn/v1")
+SENSEAUDIO_MUSIC_MODEL = "senseaudio-music-1.0-260319"
+
+POLL_INTERVAL = 5     # seconds between status checks
+POLL_MAX_WAIT = 1800  # total timeout (30 minutes)
+
+_debug = DebugSession("music_tools", env_var="MUSIC_TOOLS_DEBUG")
+
+# session_key → SenseAudio task_id, for status queries
+_active_task_ids: Dict[str, str] = {}
+_active_task_ids_lock = threading.Lock()
+
+
+def _get_music_output_dir() -> Path:
+    return get_hermes_dir("cache/music", "music_cache")
+
+
+def _sanitize_track_stem(name: str) -> str:
+    stem = Path(name).stem.strip()
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", stem).strip("-.")
+    return sanitized or "track"
+
+
+def _download_track_to_local(audio_url: str, *, file_name: str) -> str:
+    """Download a generated track to Hermes-managed local storage."""
+    out_dir = _get_music_output_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    suffix = Path(file_name).suffix or ".mp3"
+    output_path = out_dir / f"{_sanitize_track_stem(file_name)}-{uuid.uuid4().hex[:8]}{suffix}"
+
+    with httpx.Client(timeout=60, follow_redirects=True) as client:
+        resp = client.get(audio_url)
+        _raise_for_status_with_details(resp)
+        content = resp.content
+
+    if not content:
+        raise ValueError(f"Downloaded empty audio file from SenseAudio: {audio_url}")
+
+    output_path.write_bytes(content)
+    return str(output_path)
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+def _api_key() -> Optional[str]:
+    return os.getenv("SENSEAUDIO_API_KEY")
+
+
+def _auth_headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_api_key()}",
+        "Content-Type": "application/json",
+    }
+
+
+def _raise_for_status_with_details(resp: httpx.Response) -> None:
+    """Raise HTTP errors with provider response details when available."""
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        detail = ""
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = None
+
+        if isinstance(payload, dict):
+            message = payload.get("message") or payload.get("error")
+            code = payload.get("code")
+            ref_code = payload.get("ref_code")
+            extras = []
+            if code:
+                extras.append(f"code={code}")
+            if ref_code is not None:
+                extras.append(f"ref_code={ref_code}")
+            if message:
+                detail = str(message)
+                if extras:
+                    detail = f"{detail} ({', '.join(extras)})"
+
+        if not detail:
+            text = resp.text.strip()
+            if text:
+                detail = text[:500]
+
+        if detail:
+            raise ValueError(f"SenseAudio API error {resp.status_code}: {detail}") from exc
+        raise
+
+
+def _create_lyrics_from_prompt(prompt: str) -> Dict[str, Optional[str]]:
+    """Convert a free-form prompt into structured lyrics via SenseAudio."""
+    body = {
+        "prompt": prompt,
+        "provider": SENSEAUDIO_MUSIC_MODEL,
+    }
+
+    url = f"{SENSEAUDIO_BASE_URL}/music/lyrics/create"
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(url, json=body, headers=_auth_headers())
+        _raise_for_status_with_details(resp)
+        data = resp.json()
+
+    items = data.get("data") or []
+    first = items[0] if items else {}
+    lyrics_text = (first.get("text") or "").strip()
+    if not lyrics_text:
+        raise ValueError(f"SenseAudio did not return generated lyrics: {data}")
+
+    title = (first.get("title") or "").strip() or None
+    return {"lyrics": lyrics_text, "title": title}
+
+
+def _create_song(
+    prompt: str,
+    *,
+    lyrics: Optional[str] = None,
+    instrumental: bool = False,
+    style: Optional[str] = None,
+    vocal_gender: Optional[str] = None,
+    title: Optional[str] = None,
+) -> str:
+    """Submit a song creation request. Returns the SenseAudio task_id."""
+    # custom_mode=True: model uses `lyrics` field as a free-form prompt.
+    # custom_mode=False: model treats `lyrics` as structured lyrics with section tags.
+    custom_mode = lyrics is None
+
+    body: Dict[str, Any] = {
+        "model": SENSEAUDIO_MUSIC_MODEL,
+        "lyrics": lyrics if lyrics is not None else prompt,
+        "custom_mode": custom_mode,
+        "instrumental": instrumental,
+    }
+    if style:
+        body["style"] = style
+    if vocal_gender:
+        body["vocal_gender"] = vocal_gender
+    if title:
+        body["title"] = title
+
+    url = f"{SENSEAUDIO_BASE_URL}/music/song/create"
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(url, json=body, headers=_auth_headers())
+        _raise_for_status_with_details(resp)
+        data = resp.json()
+
+    task_id = data.get("task_id")
+    if not task_id:
+        raise ValueError(f"SenseAudio did not return a task_id: {data}")
+    return task_id
+
+
+def _query_status(task_id: str) -> Dict[str, Any]:
+    """Call the pending endpoint once. Returns the raw response dict."""
+    url = f"{SENSEAUDIO_BASE_URL}/music/song/pending/{task_id}"
+    with httpx.Client(timeout=30) as client:
+        resp = client.get(url, headers=_auth_headers())
+        _raise_for_status_with_details(resp)
+        return resp.json()
+
+
+def _poll_sync(task_id: str) -> Dict[str, Any]:
+    """Block until the task reaches SUCCESS/FAILED or POLL_MAX_WAIT elapses."""
+    deadline = time.monotonic() + POLL_MAX_WAIT
+    while time.monotonic() < deadline:
+        data = _query_status(task_id)
+        status = data.get("status", "")
+        if status == "SUCCESS":
+            return data
+        if status == "FAILED":
+            raise RuntimeError(f"SenseAudio task {task_id} failed: {data}")
+        time.sleep(POLL_INTERVAL)
+    raise TimeoutError(
+        f"SenseAudio task {task_id} did not complete within {POLL_MAX_WAIT}s"
+    )
+
+
+async def _poll_async(task_id: str, session_key: str) -> str:
+    """Background coroutine: poll until done, return the agent wake message."""
+    deadline = time.monotonic() + POLL_MAX_WAIT
+    try:
+        while time.monotonic() < deadline:
+            data = _query_status(task_id)
+            status = data.get("status", "")
+            if status == "SUCCESS":
+                result = _format_result(data, ignored_overrides=[])
+                return _wake_message(result)
+            if status == "FAILED":
+                return f"Music generation failed (task_id={task_id})."
+            await asyncio.sleep(POLL_INTERVAL)
+        return f"Music generation timed out after {POLL_MAX_WAIT}s (task_id={task_id})."
+    finally:
+        with _active_task_ids_lock:
+            _active_task_ids.pop(session_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Result formatting
+# ---------------------------------------------------------------------------
+
+def _format_result(
+    pending_data: Dict[str, Any],
+    ignored_overrides: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Convert SenseAudio pending response → GenerateMusicRuntimeResult."""
+    items = (pending_data.get("response") or {}).get("data") or []
+    tracks = []
+    lyrics_list = []
+
+    for item in items:
+        audio_url = item.get("audio_url", "")
+        cover_url = item.get("cover_url", "")
+        duration = item.get("duration")
+        item_title = item.get("title", "")
+        raw_lyrics = item.get("lyrics", "")
+        file_name = f"{item_title or 'track'}.mp3"
+        local_path = _download_track_to_local(audio_url, file_name=file_name) if audio_url else ""
+
+        tracks.append({
+            "url": audio_url,
+            "mimeType": "audio/mpeg",
+            "fileName": file_name,
+            "localPath": local_path or None,
+            "mediaTag": f"MEDIA:{local_path}" if local_path else None,
+            "metadata": {
+                "cover_url": cover_url,
+                "duration": duration,
+                "title": item_title,
+                "source_url": audio_url,
+            },
+        })
+        if raw_lyrics:
+            lyrics_list.append(raw_lyrics)
+
+    return {
+        "tracks": tracks,
+        "provider": "senseaudio",
+        "model": SENSEAUDIO_MUSIC_MODEL,
+        "lyrics": lyrics_list or None,
+        "ignoredOverrides": ignored_overrides,
+    }
+
+
+def _wake_message(result: Dict[str, Any]) -> str:
+    """Build the text injected into the session when background generation completes."""
+    tracks = result.get("tracks") or []
+    if not tracks:
+        return "Music generation completed but no tracks were returned."
+
+    lines = ["Music generation completed."]
+    for track in tracks:
+        meta = track.get("metadata") or {}
+        label = meta.get("title") or track.get("fileName", "track")
+        duration = meta.get("duration")
+        suffix = f" ({duration}s)" if duration else ""
+        lines.append(f"Track: {label}{suffix}")
+        local_path = track.get("localPath")
+        if local_path:
+            lines.append(f"Saved: {local_path}")
+            lines.append(track.get("mediaTag") or f"MEDIA:{local_path}")
+        elif track.get("url"):
+            lines.append(f"Source: {track['url']}")
+        if meta.get("cover_url"):
+            lines.append(f"Cover: {meta['cover_url']}")
+
+    if result.get("lyrics"):
+        lines.append(f"Lyrics:\n{result['lyrics'][0]}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def music_generate_tool(
+    prompt: str = "",
+    action: str = "generate",
+    lyrics: Optional[str] = None,
+    instrumental: bool = False,
+    style: Optional[str] = None,
+    vocal_gender: Optional[str] = None,
+    title: Optional[str] = None,
+    # Unsupported params — collected and surfaced in ignoredOverrides
+    durationSeconds: Optional[float] = None,
+    format: Optional[str] = None,       # noqa: A002
+    image: Optional[str] = None,
+    images: Optional[List[str]] = None,
+) -> str:
+    """
+    Generate music using SenseAudio. Returns a JSON string.
+
+    Args:
+        prompt:          Music style/mood description (required for generate)
+        action:          "generate" (default) or "status"
+        lyrics:          Structured lyrics; if omitted the model improvises from prompt
+        instrumental:    True for no-vocals generation
+        style:           Style hint, e.g. "jazz", "pop"
+        vocal_gender:    "f" or "m"
+        title:           Optional song title
+        durationSeconds: Ignored — SenseAudio does not support duration control
+        format:          Ignored — output format is fixed by the provider
+        image/images:    Ignored — SenseAudio music API has no image input
+
+    Returns:
+        JSON string with fields: tracks, provider, model, lyrics,
+        ignoredOverrides (GenerateMusicRuntimeResult shape)
+    """
+    # Collect unsupported params so the caller knows what was dropped
+    ignored_overrides: List[Dict[str, Any]] = []
+    if durationSeconds is not None:
+        ignored_overrides.append({"key": "durationSeconds", "value": durationSeconds})
+    if format is not None:
+        ignored_overrides.append({"key": "format", "value": format})
+    if image is not None:
+        ignored_overrides.append({"key": "image", "value": image})
+    if images is not None:
+        ignored_overrides.append({"key": "images", "value": images})
+
+    origin = current_session_origin()
+    session_key = origin.session_key
+
+    # ----------------------------------------------------------------
+    # action: status — query the active task for this session
+    # ----------------------------------------------------------------
+    if action == "status":
+        with _active_task_ids_lock:
+            task_id = _active_task_ids.get(session_key)
+
+        if not task_id:
+            # Also check the background task handle (task may not have a SA task_id yet)
+            handle = background_tasks.get_active(session_key)
+            if handle:
+                return tool_result(status=handle.status, task_id=handle.task_id)
+            return tool_error("No active music generation task for this session.")
+
+        try:
+            data = _query_status(task_id)
+            return tool_result(
+                status=data.get("status"),
+                task_id=task_id,
+                details=data,
+            )
+        except Exception as e:
+            logger.error("Status query failed for task %s: %s", task_id, e)
+            return tool_error(f"Failed to query task status: {e}")
+
+    # ----------------------------------------------------------------
+    # action: generate
+    # ----------------------------------------------------------------
+    if not prompt and not lyrics:
+        return tool_error("prompt is required for music generation")
+
+    if not _api_key():
+        return tool_error("SENSEAUDIO_API_KEY environment variable not set")
+
+    # Submit the generation job
+    try:
+        resolved_lyrics = lyrics
+        resolved_title = title
+        if not resolved_lyrics:
+            generated = _create_lyrics_from_prompt(prompt)
+            resolved_lyrics = generated["lyrics"]
+            if not resolved_title:
+                resolved_title = generated.get("title")
+
+        task_id = _create_song(
+            prompt,
+            lyrics=resolved_lyrics,
+            instrumental=instrumental,
+            style=style,
+            vocal_gender=vocal_gender,
+            title=resolved_title,
+        )
+        logger.info("SenseAudio song task created: %s", task_id)
+    except Exception as e:
+        logger.error("Failed to create SenseAudio song task: %s", e, exc_info=True)
+        return tool_error(f"Failed to start music generation: {e}")
+
+    # Persist task_id so status queries can reach the SenseAudio API
+    if session_key:
+        with _active_task_ids_lock:
+            _active_task_ids[session_key] = task_id
+
+    # Try background task (gateway session: Telegram / Discord / etc.)
+    if session_key:
+        handle = background_tasks.create(
+            coro=_poll_async(task_id, session_key),
+            session_key=session_key,
+            origin=origin,
+            label="music generation",
+        )
+        if handle is not None:
+            logger.info("Music generation running in background, task_id=%s", task_id)
+            return tool_result(
+                status="started",
+                task_id=task_id,
+                message="Music is generating in the background. You will be notified when it's ready.",
+            )
+
+    # Fallback: synchronous polling (CLI mode — no active gateway session)
+    try:
+        pending_data = _poll_sync(task_id)
+        result = _format_result(pending_data, ignored_overrides)
+        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": True})
+        _debug.save()
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as e:
+        logger.error("Music generation polling failed: %s", e, exc_info=True)
+        _debug.log_call("music_generate_tool", {"task_id": task_id, "success": False, "error": str(e)})
+        _debug.save()
+        return tool_error(f"Music generation failed: {e}")
+    finally:
+        if session_key:
+            with _active_task_ids_lock:
+                _active_task_ids.pop(session_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_music_generation_requirements() -> bool:
+    try:
+        import httpx  # noqa: F401
+        return bool(_api_key())
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+MUSIC_GENERATE_SCHEMA = {
+    "name": "music_generate",
+    "description": (
+        "Generate music from a text prompt. "
+        "Generation runs in the background "
+        "and you are notified when the audio is ready. "
+        "Use action='status' to check an in-progress generation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Text prompt describing the desired music — style, mood, theme, etc. "
+                    "Required when action='generate'."
+                ),
+            },
+            "action": {
+                "type": "string",
+                "enum": ["generate", "status"],
+                "description": (
+                    "'generate' starts a new generation task (default). "
+                    "'status' queries the active task for this session."
+                ),
+                "default": "generate",
+            },
+            "lyrics": {
+                "type": "string",
+                "description": (
+                    "Structured lyrics text. Supports section tags: "
+                    "[verse], [chorus], [bridge], [intro-short], [outro-medium], etc. "
+                    "If omitted the model generates music directly from the prompt."
+                ),
+            },
+            "instrumental": {
+                "type": "boolean",
+                "description": "Set true to generate instrumental-only music (no vocals).",
+                "default": False,
+            },
+            "style": {
+                "type": "string",
+                "description": "Musical style hint, e.g. 'jazz', 'lo-fi', 'classical'.",
+            },
+            "vocal_gender": {
+                "type": "string",
+                "enum": ["f", "m"],
+                "description": "'f' for female vocals, 'm' for male vocals.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional song title.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _handle_music_generate(args: Dict[str, Any], **kw) -> str:
+    return music_generate_tool(
+        prompt=args.get("prompt", ""),
+        action=args.get("action", "generate"),
+        lyrics=args.get("lyrics"),
+        instrumental=bool(args.get("instrumental", False)),
+        style=args.get("style"),
+        vocal_gender=args.get("vocal_gender"),
+        title=args.get("title"),
+    )
+
+
+registry.register(
+    name="music_generate",
+    toolset="music_gen",
+    schema=MUSIC_GENERATE_SCHEMA,
+    handler=_handle_music_generate,
+    check_fn=check_music_generation_requirements,
+    requires_env=["SENSEAUDIO_API_KEY"],
+    is_async=False,
+    emoji="🎵",
+)

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -214,14 +214,12 @@ def _create_song(
     music_config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Submit a song creation request. Returns the SenseAudio task_id."""
-    # custom_mode=True: model uses `lyrics` field as a free-form prompt.
-    # custom_mode=False: model treats `lyrics` as structured lyrics with section tags.
-    custom_mode = lyrics is None
-
+    # custom_mode=True causes a 400 "无效的歌词格式" from the SenseAudio API.
+    # Always use custom_mode=False with structured lyrics from lyrics/create.
     body: Dict[str, Any] = {
         "model": _model_name(music_config),
-        "lyrics": lyrics if lyrics is not None else prompt,
-        "custom_mode": custom_mode,
+        "lyrics": lyrics,
+        "custom_mode": False,
         "instrumental": instrumental,
     }
     if style:

--- a/toolsets.py
+++ b/toolsets.py
@@ -37,6 +37,8 @@ _HERMES_CORE_TOOLS = [
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
     "vision_analyze", "image_generate",
+    # Music generation
+    "music_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -88,6 +90,12 @@ TOOLSETS = {
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
+        "includes": []
+    },
+
+    "music_gen": {
+        "description": "Music generation tools",
+        "tools": ["music_generate"],
         "includes": []
     },
     


### PR DESCRIPTION
## Why

Hermes already had background agent sessions and background process notifications, but it did not yet have a generic tool-level detach-and-wake mechanism for long-running tool calls.

This branch adds that missing runtime primitive and uses it to ship music generation as a first-class tool. It also follows up by refactoring the music tool toward the repo’s existing multi-provider media-tool style so future provider expansion is easier, while tightening the tool prompt so models rely on background completion instead of repeatedly polling for status.

## Summary

### 1) Generic async detach + wake mechanism
- Adds `agent/background_task.py` with a shared `BackgroundTaskRegistry`
- Introduces:
  - `SessionOrigin` snapshots for cross-thread/session wake routing
  - `BackgroundTaskHandle` for active-task tracking
  - `drain_pending()` / `get_active()` / `_mark_done()` lifecycle helpers
- Supports one active detached task per session as a duplicate guard
- Provides a reusable pattern for long-running tools that need to:
  - start quickly
  - continue in the background
  - wake the original session when work completes

### 2) CLI and gateway integration for detached tool tasks
- Updates `cli.py` to:
  - set/clear per-turn session contextvars for tool calls
  - run pending detached tasks in daemon threads
  - queue synthetic follow-up turns when background work completes
  - drain those follow-ups back into the normal CLI input loop
- Updates `gateway/run.py` to:
  - drain pending detached tasks after each agent turn
  - run them via `asyncio.create_task(...)`
  - inject completion events back into the originating platform session

### 3) New music generation tool
- Adds `tools/music_generation_tool.py` with `music_generate`
- The first provider implementation is currently backed by SenseAudio
- Integrates music generation through:
  - prompt → lyrics generation
  - song creation
  - pending-task polling
  - local audio download + media-tag delivery
- Supports:
  - `action="generate"`
  - `action="status"`
  - instrumental generation
  - lyric-driven generation
  - detached background completion for active sessions
- Returns structured JSON output with tracks, metadata, lyrics, and error details


### 4) Tool discovery and toolset wiring
- Registers `music_generate` in `model_tools.py`
- Adds a dedicated `music_gen` toolset in `toolsets.py`
- Exposes the tool in default core tools so it is available in the normal media-generation workflow
- Adds the `music_gen` row to `hermes tools` / tool configuration UI

### 5) Music tool follow-up refactor for future provider expansion
- Refactors `music_generation_tool.py` into a single-file provider-dispatch shape aligned with existing STT/TTS patterns
- Adds:
  - `_load_music_config()`
  - `_get_provider()`
  - provider-specific SenseAudio config helpers
  - `_senseaudio_generate(...)`
  - `_senseaudio_status(...)`
- Keeps current SenseAudio behavior intact while making the next provider easier to add

### 6) Background-task prompt guidance for model behavior
- Tightens the `music_generate` tool description so models are told:
  - generation runs in the background
  - completion will arrive automatically
  - `action="status"` should only be used when the user explicitly asks for a progress update
- Updates the `started` response message with the same guidance to reduce repeated status polling

## Safety and Regression Notes

- No new privileged execution surface was introduced.
- The detached task runtime is intentionally generic and scoped to session wake-up behavior rather than a new execution backend.
- Music generation reuses the new detach-and-wake path instead of introducing a separate long-running-tool mechanism.
- The provider refactor is internal-only for now: current runtime behavior remains SenseAudio-backed.
- Regression risk was reduced with targeted coverage for detached task scheduling, CLI wake injection, music generation flow, and provider dispatch.

## Files Changed

New:
- `agent/background_task.py`
- `tests/cli/test_cli_detached_tasks.py`
- `tests/tools/test_music_generation_tool.py`
- `tools/music_generation_tool.py`

Updated:
- `cli.py`
- `gateway/run.py`
- `hermes_cli/tools_config.py`
- `model_tools.py`
- `toolsets.py`

## Test Evidence

### Automated tests

Ran targeted suites covering detached task scheduling, CLI wake handling, and music generation behavior:

- `tests/tools/test_music_generation_tool.py`
- `tests/cli/test_cli_detached_tasks.py`

Result: targeted suite passed in the repo venv.

### Manual smoke tests

Validated interactively in the CLI during development:

- music generation starts as a detached background task
- completion wake messages are routed back through the CLI follow-up path
- the tool prompt now explicitly discourages repeated status polling unless the user asks for progress
<img width="1184" height="596" alt="screenshot2026-04-14 12 19 16pm" src="https://github.com/user-attachments/assets/6b45ef76-a519-4803-aa80-711d0d8ee85f" />

