### PR TITLE
fix(gateway): pass reply_to for Feishu thread routing on status/progress/stream messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7547,6 +7547,11 @@ class GatewayRunner:
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        # Feishu's CreateMessage API does not support thread_id — only the
+        # ReplyMessage API does (via reply_in_thread).  When we have a thread
+        # context, pass event_message_id as reply_to so the adapter uses Reply
+        # instead of Create, keeping messages inside the thread.
+        _progress_reply_to = event_message_id if _progress_thread_id else None
 
         async def send_progress_messages():
             if not progress_queue:
@@ -7620,15 +7625,15 @@ class GatewayRunner:
                                     adapter.name,
                                 )
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            await adapter.send(chat_id=source.chat_id, content=msg, reply_to=_progress_reply_to, metadata=_progress_metadata)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            result = await adapter.send(chat_id=source.chat_id, content=full_text, reply_to=_progress_reply_to, metadata=_progress_metadata)
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            result = await adapter.send(chat_id=source.chat_id, content=msg, reply_to=_progress_reply_to, metadata=_progress_metadata)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
 
@@ -7708,6 +7713,7 @@ class GatewayRunner:
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_reply_to = _progress_reply_to
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
@@ -7717,6 +7723,7 @@ class GatewayRunner:
                     _status_adapter.send(
                         _status_chat_id,
                         message,
+                        reply_to=_status_reply_to,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,
@@ -7831,6 +7838,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=_progress_reply_to,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta
@@ -8339,6 +8347,7 @@ class GatewayRunner:
                     await _notify_adapter.send(
                         source.chat_id,
                         f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
+                        reply_to=_progress_reply_to,
                         metadata=_status_thread_metadata,
                     )
                 except Exception as _ne:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -70,11 +70,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -403,6 +405,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
+                    reply_to=self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:
@@ -479,6 +482,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self.reply_to,
                 metadata=self.metadata,
             )
             if result.success:
@@ -574,6 +578,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:


### PR DESCRIPTION
## Problem

Feishu's CreateMessage API does not support `thread_id` — only the ReplyMessage API does (via `reply_in_thread`). Several message-sending paths in the gateway only passed `metadata={'thread_id': ...}` without `reply_to`, causing these messages to appear **outside the conversation thread** on Feishu as standalone messages:

- **Context pressure warnings** ("⚠️ Context: ▰▰▰▰... 93% to compaction")
- **Connection retry notifications** ("⚠️ Connection to provider dropped... Reconnecting")
- **Long-running heartbeats** ("⏳ Still working... 10 min elapsed")
- **Tool progress updates** (when edit_message fallback triggers)
- **Stream consumer messages** (first message + fallback chunks)

## Root Cause

The `_send_raw_message` method in `feishu.py` uses the ReplyMessage API (which supports threading) only when `reply_to` is provided. When only `metadata={'thread_id': ...}` is passed, it falls through to CreateMessage, which ignores thread_id entirely.

The tool progress path already had a comment documenting this behavior but the fix was incomplete — it was never applied to status callbacks, long-running notifications, or the stream consumer.

## Fix

1. Added `_progress_reply_to = event_message_id if _progress_thread_id else None` as a shared variable
2. Threaded `reply_to` through all affected send paths:
   - `send_progress_messages()` — 3 send calls
   - `_status_callback_sync()` — context pressure, connection retry
   - `_notify_long_running()` — heartbeat notifications
   - `GatewayStreamConsumer` — added `reply_to` constructor param, used in initial send + fallback paths

## Files Changed

- `gateway/run.py` — 5 send calls + new `_progress_reply_to` variable
- `gateway/stream_consumer.py` — new `reply_to` param + 4 send calls

## Testing

- Non-thread conversations: `_progress_reply_to` is `None`, behavior unchanged
- Other platforms: `reply_to=None` is the default, no behavioral change
- Feishu threads: messages now use ReplyMessage API and appear inside the thread