### PR TITLE
fix: managed mode PID detection and cron permissions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -65,18 +65,20 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _secure_dir(path: Path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+    """Set directory permissions. Uses group-accessible mode in managed mode."""
     try:
-        os.chmod(path, 0o700)
+        managed = os.environ.get("HERMES_MANAGED") == "true"
+        os.chmod(path, 0o2770 if managed else 0o700)
     except (OSError, NotImplementedError):
         pass  # Windows or other platforms where chmod is not supported
 
 
 def _secure_file(path: Path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
+    """Set file permissions. Uses group-readable mode in managed mode."""
     try:
         if path.exists():
-            os.chmod(path, 0o600)
+            managed = os.environ.get("HERMES_MANAGED") == "true"
+            os.chmod(path, 0o640 if managed else 0o600)
     except (OSError, NotImplementedError):
         pass
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -269,6 +269,14 @@ async def get_status():
     current_ver, latest_ver = check_config_version()
 
     gateway_pid = get_running_pid()
+    # Managed mode (systemd): gateway.pid may not be written, fall back to gateway_state.json
+    if gateway_pid is None:
+        import os as _os
+        _rt = read_runtime_status()
+        if _rt and _rt.get("gateway_state") == "running":
+            _rpid = _rt.get("pid")
+            if _rpid and _os.path.exists(f"/proc/{_rpid}"):
+                gateway_pid = _rpid
     gateway_running = gateway_pid is not None
 
     gateway_state = None


### PR DESCRIPTION
## Summary

Fixes three issues when running hermes-agent under NixOS systemd managed mode (`HERMES_MANAGED=true`):

- **Dashboard shows "gateway not running"**: `get_status()` in `web_server.py` only checks `gateway.pid`, which the managed gateway never writes. Added fallback to `gateway_state.json` with `/proc/{pid}` validation so the dashboard correctly reflects gateway status under systemd.

- **Cron directories reset to 0700**: `_secure_dir()` in `cron/jobs.py` hardcodes `chmod 0700` on every startup, overriding the NixOS module's `2770` (setgid + group-accessible). Now respects `HERMES_MANAGED` env var and uses `2770` in managed mode.

- **Cron files reset to 0600**: `_secure_file()` in `cron/jobs.py` similarly hardcodes `0600`, breaking group-readable access needed by the service user. Now uses `0640` in managed mode.

**Note on .env permissions**: The `.env` file permissions (Fix 3 in #9383) are already handled correctly — `save_env_value()` returns early in managed mode, and `_secure_file()` in `config.py` already has a managed-mode guard. No additional changes needed there.

Fixes #9383

## Files changed

- `hermes_cli/web_server.py` — `get_status()`: fall back to `read_runtime_status()` when `get_running_pid()` returns None
- `cron/jobs.py` — `_secure_dir()` and `_secure_file()`: use group-accessible permissions when `HERMES_MANAGED=true`

## Test plan

- [ ] Verify `get_status()` returns `gateway_running: true` when gateway is running under systemd (no `gateway.pid` file, but `gateway_state.json` has `"gateway_state": "running"`)
- [ ] Verify cron directories retain `2770` permissions after `ensure_dirs()` runs in managed mode
- [ ] Verify cron files retain `0640` permissions after `_secure_file()` runs in managed mode
- [ ] Verify non-managed (standalone) mode still uses `0700`/`0600` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)