### PR TITLE
Fix custom provider API key precedence

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -898,6 +898,19 @@ def _current_custom_base_url() -> str:
     return custom_base or ""
 
 
+def _main_custom_api_key_for_base_url(base_url: str) -> str:
+    """Return the active main custom-endpoint key when it targets the same URL."""
+    normalized_base = str(base_url or "").strip().rstrip("/")
+    if not normalized_base:
+        return ""
+    main_base, main_key, _ = _resolve_custom_runtime()
+    if not main_base or not main_key:
+        return ""
+    if main_base.rstrip("/") != normalized_base:
+        return ""
+    return main_key
+
+
 def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
     runtime = _resolve_custom_runtime()
     if len(runtime) == 2:
@@ -1398,6 +1411,7 @@ def resolve_provider_client(
             custom_base = explicit_base_url.strip()
             custom_key = (
                 (explicit_api_key or "").strip()
+                or _main_custom_api_key_for_base_url(custom_base)
                 or os.getenv("OPENAI_API_KEY", "").strip()
                 or "no-key-required"  # local servers don't need auth
             )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -229,9 +229,19 @@ def _try_resolve_from_custom_pool(
     base_url: str,
     provider_label: str,
     api_mode_override: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    pool_key_override: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
-    pool_key = get_custom_provider_pool_key(base_url)
+    """Check if a credential pool exists for a custom endpoint and return a runtime dict if so.
+
+    Explicit API keys must win over pooled credentials. When the caller knows
+    the intended saved provider, ``pool_key_override`` avoids ambiguous
+    base_url-first matching for different custom providers that share one
+    endpoint.
+    """
+    if has_usable_secret(explicit_api_key):
+        return None
+    pool_key = pool_key_override or get_custom_provider_pool_key(base_url)
     if not pool_key:
         return None
     try:
@@ -286,7 +296,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            if not resolved_api_key and key_env:
+                resolved_api_key = os.getenv(key_env, "").strip()
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
@@ -380,7 +392,17 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_key_override = ""
+    custom_name = str(custom_provider.get("name") or "").strip()
+    if custom_name:
+        pool_key_override = f"custom:{_normalize_custom_provider_name(custom_name)}"
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        explicit_api_key=explicit_api_key,
+        pool_key_override=pool_key_override or None,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -492,7 +514,10 @@ def _resolve_openrouter_runtime(
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
         pool_result = _try_resolve_from_custom_pool(
-            base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
+            base_url,
+            effective_provider,
+            _parse_api_mode(model_cfg.get("api_mode")),
+            explicit_api_key=explicit_api_key or (cfg_api_key if use_config_base_url else None),
         )
         if pool_result:
             return pool_result

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -155,6 +155,34 @@ class TestResolveProviderClientNamedCustom:
         assert client is None
 
 
+def test_explicit_custom_base_url_inherits_main_custom_key(tmp_path, monkeypatch):
+    _write_config(tmp_path, {
+        "model": {
+            "default": "main-model",
+            "provider": "custom",
+            "base_url": "https://gateway.example.com/v1",
+            "api_key": "main-custom-key",
+        },
+    })
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client(
+            "custom",
+            "aux-model",
+            explicit_base_url="https://gateway.example.com/v1",
+            explicit_api_key="",
+        )
+
+    assert client is not None
+    assert model == "aux-model"
+    assert mock_openai.call_args.kwargs["base_url"] == "https://gateway.example.com/v1"
+    assert mock_openai.call_args.kwargs["api_key"] == "main-custom-key"
+
+
 class TestResolveProviderClientModelNormalization:
     """Direct-provider auxiliary routing should normalize models like main runtime."""
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -493,6 +493,38 @@ def test_custom_endpoint_uses_config_api_key_over_env(monkeypatch):
     assert resolved["api_key"] == "config-api-key"
 
 
+def test_custom_endpoint_config_api_key_skips_ambiguous_custom_pool(monkeypatch):
+    """Explicit config api_key must win over a same-base_url custom pool match."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "config-key",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: (_ for _ in ()).throw(
+            AssertionError("custom credential pool should be skipped when config api_key is set")
+        ),
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "https://api.example.com/v1"
+    assert resolved["api_key"] == "config-key"
+    assert resolved["source"] == "env/config"
+    assert resolved.get("credential_pool") is None
+
+
 def test_custom_endpoint_uses_config_api_field_when_no_api_key(monkeypatch):
     """provider: custom with 'api' in config uses it as api_key (#1760)."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
@@ -570,6 +602,62 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["api_key"] == "local-provider-key"
     assert resolved["requested_provider"] == "local"
     assert resolved["source"] == "custom_provider:Local"
+
+
+def test_named_custom_provider_uses_its_own_pool_when_base_url_is_shared(monkeypatch):
+    class _Entry:
+        access_token = "provider-b-pool-key"
+        source = "config:Provider B"
+        base_url = "https://api.example.com/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Provider A",
+                    "base_url": "https://api.example.com/v1",
+                    "api_key": "key-a",
+                },
+                {
+                    "name": "Provider B",
+                    "base_url": "https://api.example.com/v1",
+                    "api_key": "key-b",
+                },
+            ]
+        },
+    )
+
+    def _load_pool(provider):
+        assert provider == "custom:provider-b"
+        return _Pool()
+
+    monkeypatch.setattr(rp, "load_pool", _load_pool)
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("named custom providers should resolve before provider fallback")
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:provider-b")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.example.com/v1"
+    assert resolved["api_key"] == "provider-b-pool-key"
+    assert resolved["requested_provider"] == "custom:provider-b"
+    assert resolved["source"] == "pool:custom:provider-b"
 
 
 def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- prefer explicit/configured custom API keys over ambiguous custom credential-pool matches
- resolve named custom providers against their own pool key even when multiple providers share one `base_url`
- let auxiliary explicit custom overrides inherit the main custom endpoint key when targeting the same endpoint
- keep `providers:` named custom entries honoring inline `api_key` values before falling back to `key_env`

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_runtime_provider_resolution.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/agent/test_auxiliary_named_custom_providers.py -q`

## Issues
- fixes #9315
- fixes #9318
