### PR TITLE
Fix providers config alias handling

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -22,6 +22,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
+from urllib.parse import urlparse
 
 from tools.tool_backend_helpers import managed_nous_tools_enabled as _managed_nous_tools_enabled
 
@@ -1577,10 +1578,21 @@ def _normalize_custom_provider_entry(
     if not isinstance(entry, dict):
         return None
 
+    def _first_string(*keys: str) -> str:
+        for key in keys:
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _is_valid_base_url(value: str) -> bool:
+        parsed = urlparse(value)
+        return bool(parsed.scheme and parsed.netloc)
+
     base_url = ""
-    for url_key in ("api", "url", "base_url"):
+    for url_key in ("api", "url", "base_url", "baseUrl"):
         raw_url = entry.get(url_key)
-        if isinstance(raw_url, str) and raw_url.strip():
+        if isinstance(raw_url, str) and raw_url.strip() and _is_valid_base_url(raw_url.strip()):
             base_url = raw_url.strip()
             break
     if not base_url:
@@ -1604,15 +1616,15 @@ def _normalize_custom_provider_entry(
     if provider_key:
         normalized["provider_key"] = provider_key
 
-    api_key = entry.get("api_key")
-    if isinstance(api_key, str) and api_key.strip():
-        normalized["api_key"] = api_key.strip()
+    api_key = _first_string("api_key", "apiKey")
+    if api_key:
+        normalized["api_key"] = api_key
 
-    key_env = entry.get("key_env")
-    if isinstance(key_env, str) and key_env.strip():
-        normalized["key_env"] = key_env.strip()
+    key_env = _first_string("key_env", "keyEnv")
+    if key_env:
+        normalized["key_env"] = key_env
 
-    api_mode = entry.get("api_mode") or entry.get("transport")
+    api_mode = _first_string("api_mode", "apiMode", "transport")
     if isinstance(api_mode, str) and api_mode.strip():
         normalized["api_mode"] = api_mode.strip()
 
@@ -1731,6 +1743,12 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+_PROVIDER_CAMELCASE_ALIASES = {
+    "apiKey": "api_key",
+    "baseUrl": "base_url",
+    "apiMode": "api_mode",
+    "keyEnv": "key_env",
+}
 
 
 @dataclass
@@ -1836,6 +1854,57 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "fallback_model appears inside custom_providers instead of at root level",
             "Move fallback_model to the top level of config.yaml (no indentation)",
         ))
+
+    # ── providers section: keyed user-defined providers ──────────────────
+    providers = config.get("providers")
+    if providers is not None:
+        if not isinstance(providers, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"providers should be a dict keyed by provider name, got {type(providers).__name__}",
+                "Change to:\n"
+                "  providers:\n"
+                "    my-provider:\n"
+                "      base_url: https://...\n"
+                "      api_key: ...",
+            ))
+        else:
+            for provider_name, entry in providers.items():
+                if not isinstance(entry, dict):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"providers.{provider_name} is not a dict (got {type(entry).__name__})",
+                        "Each provider entry should define base_url/api plus optional api_key, key_env, and model fields",
+                    ))
+                    continue
+
+                used_aliases = [alias for alias in _PROVIDER_CAMELCASE_ALIASES if entry.get(alias)]
+                if used_aliases:
+                    alias_hints = ", ".join(
+                        f"{alias} -> {_PROVIDER_CAMELCASE_ALIASES[alias]}" for alias in used_aliases
+                    )
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"providers.{provider_name} uses camelCase keys: {', '.join(used_aliases)}",
+                        f"Prefer snake_case in config.yaml: {alias_hints}",
+                    ))
+
+                raw_api = entry.get("api")
+                if isinstance(raw_api, str) and raw_api.strip():
+                    parsed = urlparse(raw_api.strip())
+                    if not (parsed.scheme and parsed.netloc):
+                        fallback_url = (
+                            entry.get("base_url")
+                            or entry.get("baseUrl")
+                            or entry.get("url")
+                            or ""
+                        )
+                        if not fallback_url:
+                            issues.append(ConfigIssue(
+                                "warning",
+                                f"providers.{provider_name}.api is not a valid URL: {raw_api.strip()}",
+                                "Use base_url: https://... (or api: https://...) for endpoints; non-URL values are ignored",
+                            ))
 
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,20 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
+
+
+def _get_provider_entry_base_url(entry: Dict[str, Any]) -> str:
+    for key in ("api", "url", "base_url", "baseUrl"):
+        raw_url = entry.get(key)
+        if not isinstance(raw_url, str):
+            continue
+        candidate = raw_url.strip()
+        if not candidate:
+            continue
+        parsed = urlparse(candidate)
+        if parsed.scheme and parsed.netloc:
+            return candidate
+    return ""
 
 
 def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
@@ -285,12 +300,14 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            key_env = str(entry.get("key_env") or entry.get("keyEnv") or "").strip()
+            resolved_api_key = str(entry.get("api_key") or entry.get("apiKey") or "").strip()
+            if not resolved_api_key and key_env:
+                resolved_api_key = os.getenv(key_env, "").strip()
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
-                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                base_url = _get_provider_entry_base_url(entry)
                 if base_url:
                     return {
                         "name": entry.get("name", ep_name),
@@ -304,7 +321,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 display_norm = _normalize_custom_provider_name(display_name)
                 if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
                     # Found match by display name
-                    base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                    base_url = _get_provider_entry_base_url(entry)
                     if base_url:
                         return {
                             "name": display_name,

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -531,6 +531,90 @@ class TestCustomProviderCompatibility:
             }
         ]
 
+    def test_providers_dict_accepts_camelcase_aliases(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "nvidia": {
+                            "name": "NVIDIA",
+                            "baseUrl": "https://integrate.api.nvidia.com/v1",
+                            "apiKey": "env:NVIDIA_API_KEY",
+                            "apiMode": "chat_completions",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == [
+            {
+                "name": "NVIDIA",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+                "provider_key": "nvidia",
+                "api_key": "env:NVIDIA_API_KEY",
+                "api_mode": "chat_completions",
+            }
+        ]
+
+    def test_providers_dict_ignores_invalid_api_when_valid_base_url_exists(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "nvidia": {
+                            "name": "NVIDIA",
+                            "api": "openai-reverse-proxy",
+                            "baseUrl": "https://integrate.api.nvidia.com/v1",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == [
+            {
+                "name": "NVIDIA",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+                "provider_key": "nvidia",
+            }
+        ]
+
+    def test_providers_dict_drops_entry_when_no_valid_url_is_present(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "nvidia": {
+                            "name": "NVIDIA",
+                            "api": "openai-reverse-proxy",
+                            "apiKey": "env:NVIDIA_API_KEY",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == []
+
     def test_dedup_across_legacy_and_providers(self, tmp_path):
         """Same name+url in both schemas should not produce duplicates."""
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -159,6 +159,52 @@ class TestMissingModelSection:
         assert not any("no 'model' section" in i.message for i in issues)
 
 
+class TestProvidersValidation:
+    """Validate providers: dict structure diagnostics."""
+
+    def test_warns_on_camelcase_provider_keys(self):
+        issues = validate_config_structure({
+            "providers": {
+                "nvidia": {
+                    "baseUrl": "https://integrate.api.nvidia.com/v1",
+                    "apiKey": "${NVIDIA_API_KEY}",
+                    "apiMode": "chat_completions",
+                }
+            }
+        })
+
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any("uses camelCase keys" in i.message for i in warnings)
+        assert any("baseUrl -> base_url" in i.hint for i in warnings)
+
+    def test_warns_on_invalid_provider_api_without_fallback_url(self):
+        issues = validate_config_structure({
+            "providers": {
+                "nvidia": {
+                    "api": "openai-reverse-proxy",
+                    "apiKey": "${NVIDIA_API_KEY}",
+                }
+            }
+        })
+
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any("is not a valid URL" in i.message for i in warnings)
+
+    def test_does_not_warn_on_invalid_api_when_base_url_fallback_exists(self):
+        issues = validate_config_structure({
+            "providers": {
+                "nvidia": {
+                    "api": "openai-reverse-proxy",
+                    "baseUrl": "https://integrate.api.nvidia.com/v1",
+                }
+            }
+        })
+
+        warnings = [i for i in issues if i.severity == "warning"]
+        invalid_api = [i for i in warnings if "is not a valid URL" in i.message]
+        assert invalid_api == []
+
+
 class TestConfigIssueDataclass:
     """ConfigIssue should be a proper dataclass."""
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -170,6 +170,58 @@ def test_get_named_custom_provider_finds_by_display_name(monkeypatch, tmp_path):
     assert result["base_url"] == "http://ollama.example.com/v1"
 
 
+def test_get_named_custom_provider_accepts_camelcase_aliases(monkeypatch, tmp_path):
+    """providers: entries should accept baseUrl/apiKey aliases at runtime."""
+    config = {
+        "providers": {
+            "nvidia-direct": {
+                "baseUrl": "https://integrate.api.nvidia.com/v1",
+                "apiKey": "nvidia-key",
+                "apiMode": "chat_completions",
+                "name": "NVIDIA Direct",
+                "default_model": "llama-3.1",
+            }
+        }
+    }
+
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = rp._get_named_custom_provider("nvidia-direct")
+
+    assert result is not None
+    assert result["base_url"] == "https://integrate.api.nvidia.com/v1"
+    assert result["api_key"] == "nvidia-key"
+    assert result["model"] == "llama-3.1"
+
+
+def test_get_named_custom_provider_ignores_invalid_api_when_baseurl_exists(monkeypatch, tmp_path):
+    """A non-URL api field must not shadow a valid baseUrl entry."""
+    config = {
+        "providers": {
+            "nvidia-direct": {
+                "api": "openai-reverse-proxy",
+                "baseUrl": "https://integrate.api.nvidia.com/v1",
+                "name": "NVIDIA Direct",
+            }
+        }
+    }
+
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = rp._get_named_custom_provider("nvidia-direct")
+
+    assert result is not None
+    assert result["base_url"] == "https://integrate.api.nvidia.com/v1"
+
+
 def test_get_named_custom_provider_falls_back_to_legacy_format(monkeypatch, tmp_path):
     """Should still work with custom_providers: list format."""
     config = {


### PR DESCRIPTION
## Summary
- accept common camelCase aliases in `providers:` entries (`apiKey`, `baseUrl`, `apiMode`, `keyEnv`)
- stop treating non-URL `api:` values as endpoint base URLs when a valid URL field exists
- ignore provider entries that do not contain any valid absolute URL instead of materializing broken runtime endpoints
- add config diagnostics for camelCase aliases and invalid non-URL `api:` values

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_config.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_config_validation.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_user_providers_model_switch.py -q`

## Issues
- fixes #9332
