### PR TITLE
fix(gateway): propagate contextvars to agent worker threads via asyncio.to_thread

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5378,8 +5378,10 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            # Use asyncio.to_thread instead of run_in_executor to
+            # propagate contextvars (session context) into the worker
+            # thread.  Fixes #9354.
+            result = await asyncio.to_thread(run_sync)
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -5561,8 +5563,8 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            # Use asyncio.to_thread to propagate contextvars.  Fixes #9354.
+            result = await asyncio.to_thread(run_sync)
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -8361,9 +8363,10 @@ class GatewayRunner:
             _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
-            loop = asyncio.get_event_loop()
+            # Use asyncio.to_thread to propagate contextvars (session
+            # context) into the worker thread.  Fixes #9354.
             _executor_task = asyncio.ensure_future(
-                loop.run_in_executor(None, run_sync)
+                asyncio.to_thread(run_sync)
             )
 
             _inactivity_timeout = False

--- a/tests/gateway/test_contextvars_propagation.py
+++ b/tests/gateway/test_contextvars_propagation.py
@@ -1,0 +1,82 @@
+"""Tests that gateway agent threads propagate contextvars.
+
+asyncio.to_thread() propagates contextvars automatically, whereas
+loop.run_in_executor() does not.  Issue #9354 showed that session
+context (platform, chat_id, thread_id) was lost when the agent ran
+in a thread pool, breaking tools that call get_session_env().
+
+These tests verify that contextvars survive into worker threads when
+using asyncio.to_thread().
+"""
+
+import asyncio
+import contextvars
+
+import pytest
+
+
+# A minimal contextvar to simulate gateway session context
+_TEST_VAR: contextvars.ContextVar[str] = contextvars.ContextVar("_TEST_VAR", default="")
+
+
+class TestContextVarsPropagation:
+    """Verify contextvars propagation behaviour of asyncio.to_thread vs run_in_executor."""
+
+    @pytest.mark.asyncio
+    async def test_to_thread_propagates_contextvars(self):
+        """asyncio.to_thread should propagate contextvars to the worker thread."""
+        _TEST_VAR.set("hello-from-gateway")
+
+        def worker():
+            return _TEST_VAR.get()
+
+        result = await asyncio.to_thread(worker)
+        assert result == "hello-from-gateway"
+
+    @pytest.mark.asyncio
+    async def test_run_in_executor_does_not_propagate(self):
+        """loop.run_in_executor does NOT propagate contextvars (the bug)."""
+        _TEST_VAR.set("should-not-appear")
+
+        def worker():
+            return _TEST_VAR.get()
+
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, worker)
+        # run_in_executor does NOT propagate; worker sees the default
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_ensure_future_to_thread_propagates(self):
+        """asyncio.ensure_future(asyncio.to_thread(...)) should also propagate."""
+        _TEST_VAR.set("timeout-path")
+
+        def worker():
+            return _TEST_VAR.get()
+
+        task = asyncio.ensure_future(asyncio.to_thread(worker))
+        result = await task
+        assert result == "timeout-path"
+
+    @pytest.mark.asyncio
+    async def test_gateway_session_context_pattern(self):
+        """Simulate the gateway session_context pattern with multiple vars."""
+        platform_var: contextvars.ContextVar[str] = contextvars.ContextVar("platform", default="")
+        chat_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("chat_id", default="")
+        thread_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("thread_id", default="")
+
+        platform_var.set("telegram")
+        chat_id_var.set("12345")
+        thread_id_var.set("topic-678")
+
+        def run_sync():
+            return {
+                "platform": platform_var.get(),
+                "chat_id": chat_id_var.get(),
+                "thread_id": thread_id_var.get(),
+            }
+
+        result = await asyncio.to_thread(run_sync)
+        assert result["platform"] == "telegram"
+        assert result["chat_id"] == "12345"
+        assert result["thread_id"] == "topic-678"


### PR DESCRIPTION
## What does this PR do?

Fixes session context (`platform`, `chat_id`, `thread_id`) being lost when the gateway runs agent tasks in thread pool workers, causing tools like `cronjob` to see empty session values and create jobs with `origin: null`.

The root cause is that `loop.run_in_executor()` does **not** propagate `contextvars` to worker threads, while `asyncio.to_thread()` does (it copies the current context automatically).

## Related Issue

Fixes #9354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Replaced `loop.run_in_executor(None, run_sync)` with `asyncio.to_thread(run_sync)` in three gateway agent execution paths:

1. **`/background` command handler** (~line 5382): Background tasks now see the correct session context
2. **`/btw` command handler** (~line 5565): Side-channel queries preserve session routing
3. **Main agent timeout path** (~line 8366): The `asyncio.ensure_future(loop.run_in_executor(...))` pattern replaced with `asyncio.ensure_future(asyncio.to_thread(...))`

No behavioral changes beyond the contextvars fix — `asyncio.to_thread` uses the same default executor as `run_in_executor(None, ...)`.

## How to Test

1. In a Telegram forum topic, create a cron job with `deliver: "origin"`
2. Check the persisted job — `origin` should now contain the correct platform/chat/thread
3. **Before this fix**: `origin` was `null` because `thread_id` contextvar was empty in the worker thread

Regression tests:
```bash
pytest tests/gateway/test_contextvars_propagation.py -v
```

Tests verify:
- `asyncio.to_thread` propagates contextvars ✅
- `loop.run_in_executor` does NOT propagate (the bug) ✅
- `ensure_future(to_thread(...))` also propagates ✅
- Multi-var gateway session pattern works correctly ✅

Full suite:
```bash
pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
