### PR TITLE
Fix FreeBSD gateway process detection

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -157,6 +157,15 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
+def _gateway_ps_command() -> list[str]:
+    """Return the ``ps`` invocation used to discover manual gateway processes."""
+    # FreeBSD's ``ps eww`` prefixes the command column with environment
+    # assignments, which breaks the simple substring matching below.
+    # ``ww`` preserves full-width output without injecting env vars.
+    width_flags = "ww" if sys.platform.startswith("freebsd") else "eww"
+    return ["ps", width_flags, "-ax", "-o", "pid=,command="]
+
+
 def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = False) -> list:
     """Find PIDs of running gateway processes.
 
@@ -222,7 +231,7 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
+                _gateway_ps_command(),
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -799,6 +799,30 @@ class TestFindGatewayPidsExclude:
 
         assert pids == [100]
 
+    def test_freebsd_uses_ww_and_detects_gateway_process(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli.sys, "platform", "freebsd15")
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        def fake_run(cmd, **kwargs):
+            assert cmd == ["ps", "ww", "-ax", "-o", "pid=,command="]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "87727 /home/pader/.hermes/hermes-agent/venv/bin/python3 "
+                    "/home/pader/.local/bin/hermes gateway run -v (python3.11)\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert pids == [87727]
+
 
 # ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)


### PR DESCRIPTION
## Summary
- use `ps ww` on FreeBSD when discovering manual gateway processes so the command column is not prefixed with environment variables
- keep the existing `ps eww` behaviour on other Unix platforms where profile detection still benefits from env visibility
- add regression coverage proving FreeBSD output is parsed correctly and the gateway PID is detected

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_update_gateway_restart.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -o addopts='' tests/hermes_cli/test_status.py -q`

## Issues
- fixes #9069
