### PR TITLE
fix: use dedicated TELEGRAM_PROXY env var for Telegram platform

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -540,7 +540,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
 
-            proxy_url = resolve_proxy_url()
+            proxy_url = resolve_proxy_url("TELEGRAM_PROXY")
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))
             fallback_ips = self._fallback_ips()
             if not fallback_ips:

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -46,7 +46,7 @@ _SEED_FALLBACK_IPS: list[str] = ["149.154.167.220"]
 def _resolve_proxy_url() -> str | None:
     # Delegate to shared implementation (env vars + macOS system proxy detection)
     from gateway.platforms.base import resolve_proxy_url
-    return resolve_proxy_url()
+    return resolve_proxy_url("TELEGRAM_PROXY")
 
 
 class TelegramFallbackTransport(httpx.AsyncBaseTransport):


### PR DESCRIPTION
## Summary

Pass `TELEGRAM_PROXY` as the `platform_env_var` to `resolve_proxy_url()` in both `telegram.py` and `telegram_network.py`, consistent with how Discord already uses `DISCORD_PROXY`.

## Problem

When `HTTP_PROXY`/`HTTPS_PROXY` is set globally to route Telegram traffic through a proxy (required in some regions), it also forces all other outbound connections through the proxy — including LLM API calls (Anthropic, OpenAI, etc.) and custom providers. This can cause unnecessary latency or connection failures for services that do not need a proxy.

## Solution

The `resolve_proxy_url()` helper in `base.py` already supports a `platform_env_var` parameter for platform-specific proxy env vars. This PR simply passes `"TELEGRAM_PROXY"` so users can set:

```env
TELEGRAM_PROXY=http://proxy:8080
```

instead of the global `HTTP_PROXY`/`HTTPS_PROXY`.

**Fallback behavior is preserved** — when `TELEGRAM_PROXY` is not set, it falls back to `HTTPS_PROXY` → `HTTP_PROXY` → `ALL_PROXY` → macOS system proxy, so existing setups are unaffected.

## Changes

- `gateway/platforms/telegram.py` — 1 line: `resolve_proxy_url()` → `resolve_proxy_url("TELEGRAM_PROXY")`
- `gateway/platforms/telegram_network.py` — 1 line: same change

## Testing

- Verified Telegram bot connects successfully via `TELEGRAM_PROXY`
- Verified Anthropic API connects directly without proxy interference
- No behavior change when `TELEGRAM_PROXY` is unset (falls back to global proxy vars as before)