### PR TITLE
feat: persist actual per-call cost for OpenRouter responses

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -51,6 +51,12 @@ def _estimate_cost(
     """Estimate the USD cost for a session row or a model/token tuple."""
     if isinstance(session_or_model, dict):
         session = session_or_model
+        actual_cost = session.get("actual_cost_usd")
+        if actual_cost is not None:
+            try:
+                return float(actual_cost), "actual"
+            except (TypeError, ValueError):
+                pass
         model = session.get("model") or ""
         usage = CanonicalUsage(
             input_tokens=session.get("input_tokens") or 0,
@@ -75,6 +81,59 @@ def _estimate_cost(
         base_url=base_url,
     )
     return float(result.amount_usd or 0.0), result.status
+
+
+def _recompute_estimated_cost(session: Dict[str, Any]) -> float:
+    """Recompute estimated cost from tokens, ignoring any persisted actual cost."""
+    model = session.get("model") or ""
+    usage = CanonicalUsage(
+        input_tokens=session.get("input_tokens") or 0,
+        output_tokens=session.get("output_tokens") or 0,
+        cache_read_tokens=session.get("cache_read_tokens") or 0,
+        cache_write_tokens=session.get("cache_write_tokens") or 0,
+    )
+    result = estimate_usage_cost(
+        model,
+        usage,
+        provider=session.get("billing_provider"),
+        base_url=session.get("billing_base_url"),
+    )
+    return float(result.amount_usd or 0.0)
+
+
+def _session_estimated_cost(session: Dict[str, Any]) -> float:
+    """Return persisted estimated cost when present, otherwise recompute it."""
+    stored = session.get("estimated_cost_usd")
+    stored_status = (session.get("cost_status") or "").strip().lower()
+    stored_source = (session.get("cost_source") or "").strip().lower()
+    billing_mode = (session.get("billing_mode") or "").strip().lower()
+    should_trust_stored = (
+        stored is not None
+        and (
+            bool(stored)
+            or stored_status in {"estimated", "included"}
+            or stored_source not in {"", "none", "provider_generation_api"}
+            or billing_mode == "subscription_included"
+        )
+    )
+    if should_trust_stored:
+        try:
+            return float(stored)
+        except (TypeError, ValueError):
+            pass
+    return _recompute_estimated_cost(session)
+
+
+def _preferred_session_cost(session: Dict[str, Any]) -> tuple[float, str]:
+    """Return the best available display cost for a stored session row."""
+    actual_cost = session.get("actual_cost_usd")
+    if actual_cost is not None:
+        try:
+            return float(actual_cost), "actual"
+        except (TypeError, ValueError):
+            pass
+    status = (session.get("cost_status") or "").strip().lower() or "estimated"
+    return _session_estimated_cost(session), status
 
 
 def _format_duration(seconds: float) -> str:
@@ -333,15 +392,22 @@ class InsightsEngine:
         # Cost estimation (weighted by model)
         total_cost = 0.0
         actual_cost = 0.0
+        display_cost = 0.0
+        actual_cost_sessions = 0
         models_with_pricing = set()
         models_without_pricing = set()
         unknown_cost_sessions = 0
         included_cost_sessions = 0
         for s in sessions:
             model = s.get("model") or ""
-            estimated, status = _estimate_cost(s)
-            total_cost += estimated
-            actual_cost += s.get("actual_cost_usd") or 0.0
+            estimated_cost = _session_estimated_cost(s)
+            preferred_cost, status = _preferred_session_cost(s)
+            total_cost += estimated_cost
+            actual_session_cost = s.get("actual_cost_usd") or 0.0
+            actual_cost += actual_session_cost
+            if s.get("actual_cost_usd") is not None:
+                actual_cost_sessions += 1
+            display_cost += preferred_cost
             display = model.split("/")[-1] if "/" in model else (model or "unknown")
             if status == "included":
                 included_cost_sessions += 1
@@ -379,6 +445,12 @@ class InsightsEngine:
             "total_tokens": total_tokens,
             "estimated_cost": total_cost,
             "actual_cost": actual_cost,
+            "display_cost": display_cost,
+            "display_cost_label": (
+                "actual" if actual_cost_sessions == len(sessions) and sessions
+                else ("blended" if actual_cost_sessions > 0 else "estimated")
+            ),
+            "actual_cost_sessions": actual_cost_sessions,
             "total_hours": total_hours,
             "avg_session_duration": avg_duration,
             "avg_messages_per_session": total_messages / len(sessions) if sessions else 0,
@@ -418,8 +490,8 @@ class InsightsEngine:
             d["cache_write_tokens"] += cache_write
             d["total_tokens"] += inp + out + cache_read + cache_write
             d["tool_calls"] += s.get("tool_call_count") or 0
-            estimate, status = _estimate_cost(s)
-            d["cost"] += estimate
+            preferred_cost, status = _preferred_session_cost(s)
+            d["cost"] += preferred_cost
             d["has_pricing"] = _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
             d["cost_status"] = status
 
@@ -637,10 +709,16 @@ class InsightsEngine:
         cache_total = o.get("total_cache_read_tokens", 0) + o.get("total_cache_write_tokens", 0)
         if cache_total > 0:
             lines.append(f"  Cache read:        {o['total_cache_read_tokens']:<12,}  Cache write:     {o['total_cache_write_tokens']:,}")
-        cost_str = f"${o['estimated_cost']:.2f}"
-        if o.get("models_without_pricing"):
+        cost_label = o.get("display_cost_label", "estimated")
+        cost_prefix = {
+            "actual": "Actual cost",
+            "blended": "Cost",
+            "estimated": "Est. cost",
+        }.get(cost_label, "Cost")
+        cost_str = f"${o.get('display_cost', o['estimated_cost']):.2f}"
+        if cost_label == "estimated" and o.get("models_without_pricing"):
             cost_str += " *"
-        lines.append(f"  Total tokens:      {o['total_tokens']:<12,}  Est. cost:       {cost_str}")
+        lines.append(f"  Total tokens:      {o['total_tokens']:<12,}  {cost_prefix + ':':<16} {cost_str}")
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{_format_duration(o['total_hours'] * 3600):<11}  Avg session:     ~{_format_duration(o['avg_session_duration'])}")
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
@@ -745,9 +823,14 @@ class InsightsEngine:
         else:
             lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
         cost_note = ""
-        if o.get("models_without_pricing"):
+        if o.get("models_without_pricing") and o.get("display_cost_label", "estimated") == "estimated":
             cost_note = " _(excludes custom/self-hosted models)_"
-        lines.append(f"**Est. cost:** ${o['estimated_cost']:.2f}{cost_note}")
+        cost_heading = {
+            "actual": "**Actual cost:**",
+            "blended": "**Cost:**",
+            "estimated": "**Est. cost:**",
+        }.get(o.get("display_cost_label", "estimated"), "**Cost:**")
+        lines.append(f"{cost_heading} ${o.get('display_cost', o['estimated_cost']):.2f}{cost_note}")
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{_format_duration(o['total_hours'] * 3600)} | **Avg session:** ~{_format_duration(o['avg_session_duration'])}")
         lines.append("")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -303,6 +303,19 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _read_field(obj: Any, *path: str) -> Any:
+    """Read a nested field from dict- or attribute-based response objects."""
+    current = obj
+    for key in path:
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            current = getattr(current, key, None)
+    return current
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -554,6 +567,39 @@ def estimate_usage_cost(
         fetched_at=entry.fetched_at,
         pricing_version=entry.pricing_version,
         notes=tuple(notes),
+    )
+
+
+def extract_actual_cost_result(
+    response: Any,
+    *,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Optional[CostResult]:
+    """Extract authoritative per-request cost from a provider response when available.
+
+    OpenRouter now includes usage accounting directly in every response, with
+    `usage.cost` present in non-streaming responses and the final streaming chunk.
+    When available, prefer this over local estimation.
+    """
+    route = resolve_billing_route("", provider=provider, base_url=base_url)
+    if route.provider != "openrouter":
+        return None
+
+    cost = _to_decimal(_read_field(response, "usage", "cost"))
+    if cost is None:
+        # Fallbacks for generation metadata or alternate response wrappers.
+        cost = _to_decimal(_read_field(response, "data", "total_cost"))
+    if cost is None:
+        cost = _to_decimal(_read_field(response, "total_cost"))
+    if cost is None:
+        return None
+
+    return CostResult(
+        amount_usd=cost,
+        status="actual",
+        source="provider_generation_api",
+        label=f"${cost:.2f}",
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -95,7 +95,11 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import (
+    estimate_usage_cost,
+    extract_actual_cost_result,
+    normalize_usage,
+)
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
@@ -1427,6 +1431,7 @@ class AIAgent:
         self.session_cache_write_tokens = 0
         self.session_reasoning_tokens = 0
         self.session_estimated_cost_usd = 0.0
+        self.session_actual_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         
@@ -1528,6 +1533,7 @@ class AIAgent:
         self.session_reasoning_tokens = 0
         self.session_api_calls = 0
         self.session_estimated_cost_usd = 0.0
+        self.session_actual_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         
@@ -8820,10 +8826,20 @@ class AIAgent:
                             base_url=self.base_url,
                             api_key=getattr(self, "api_key", ""),
                         )
+                        actual_cost_result = extract_actual_cost_result(
+                            response,
+                            provider=self.provider,
+                            base_url=self.base_url,
+                        )
                         if cost_result.amount_usd is not None:
                             self.session_estimated_cost_usd += float(cost_result.amount_usd)
-                        self.session_cost_status = cost_result.status
-                        self.session_cost_source = cost_result.source
+                        if actual_cost_result and actual_cost_result.amount_usd is not None:
+                            self.session_actual_cost_usd += float(actual_cost_result.amount_usd)
+                            self.session_cost_status = actual_cost_result.status
+                            self.session_cost_source = actual_cost_result.source
+                        else:
+                            self.session_cost_status = cost_result.status
+                            self.session_cost_source = cost_result.source
 
                         # Persist token counts to session DB for /insights.
                         # Do this for every platform with a session_id so non-CLI
@@ -8843,8 +8859,10 @@ class AIAgent:
                                     reasoning_tokens=canonical_usage.reasoning_tokens,
                                     estimated_cost_usd=float(cost_result.amount_usd)
                                     if cost_result.amount_usd is not None else None,
-                                    cost_status=cost_result.status,
-                                    cost_source=cost_result.source,
+                                    actual_cost_usd=float(actual_cost_result.amount_usd)
+                                    if actual_cost_result and actual_cost_result.amount_usd is not None else None,
+                                    cost_status=(actual_cost_result.status if actual_cost_result else cost_result.status),
+                                    cost_source=(actual_cost_result.source if actual_cost_result else cost_result.source),
                                     billing_provider=self.provider,
                                     billing_base_url=self.base_url,
                                     billing_mode="subscription_included"
@@ -10562,6 +10580,7 @@ class AIAgent:
             "total_tokens": self.session_total_tokens,
             "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
             "estimated_cost_usd": self.session_estimated_cost_usd,
+            "actual_cost_usd": self.session_actual_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,
         }

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -622,6 +622,76 @@ class TestEdgeCases:
         assert llama["has_pricing"] is False
         assert llama["cost"] == 0.0
 
+    def test_insights_prefers_actual_cost_when_present(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=10000,
+            output_tokens=5000,
+            billing_provider="openai",
+            estimated_cost_usd=0.75,
+            actual_cost_usd=0.5,
+            cost_status="actual",
+            cost_source="provider_generation_api",
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        overview = report["overview"]
+
+        assert overview["estimated_cost"] == 0.75
+        assert overview["actual_cost"] == 0.5
+        assert overview["display_cost"] == 0.5
+        assert overview["display_cost_label"] == "actual"
+
+        model = next(m for m in report["models"] if m["model"] == "gpt-4o")
+        assert model["cost"] == 0.5
+        assert model["cost_status"] == "actual"
+
+    def test_insights_recomputes_estimate_when_only_actual_cost_is_persisted(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=10000,
+            output_tokens=5000,
+            billing_provider="openai",
+            actual_cost_usd=0.5,
+            cost_status="actual",
+            cost_source="provider_generation_api",
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        overview = report["overview"]
+
+        assert overview["actual_cost"] == 0.5
+        assert overview["display_cost"] == 0.5
+        assert overview["display_cost_label"] == "actual"
+        assert overview["estimated_cost"] != 0.5
+        assert overview["estimated_cost"] > 0
+
+    def test_insights_falls_back_to_estimated_cost_when_actual_missing(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=10000,
+            output_tokens=5000,
+            billing_provider="openai",
+            estimated_cost_usd=0.75,
+            cost_status="estimated",
+            cost_source="official_docs_snapshot",
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        overview = report["overview"]
+
+        assert overview["display_cost"] == 0.75
+        assert overview["display_cost_label"] == "estimated"
+
     def test_single_session_streak(self, db):
         """Single session should have streak of 0 or 1."""
         db.create_session(session_id="s1", source="cli", model="test")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
+    extract_actual_cost_result,
     get_pricing_entry,
     normalize_usage,
 )
@@ -123,3 +124,35 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+
+def test_extract_actual_cost_result_reads_openrouter_usage_cost():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            cost=0.0123,
+            cost_details=SimpleNamespace(upstream_inference_cost=0.01),
+        )
+    )
+
+    result = extract_actual_cost_result(
+        response,
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result is not None
+    assert result.status == "actual"
+    assert float(result.amount_usd) == 0.0123
+    assert result.source == "provider_generation_api"
+
+
+def test_extract_actual_cost_result_ignores_missing_openrouter_usage_cost():
+    response = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=4))
+
+    result = extract_actual_cost_result(
+        response,
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result is None

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -60,3 +60,27 @@ def test_run_conversation_persists_tokens_for_cron_sessions():
     assert result["final_response"] == "done"
     session_db.update_token_counts.assert_called_once()
     assert session_db.update_token_counts.call_args.args[0] == "cron-session"
+
+
+def test_run_conversation_persists_actual_openrouter_cost_when_usage_cost_present():
+    session_db = MagicMock()
+    agent = _make_agent(session_db, platform="telegram")
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.client.chat.completions.create.return_value = _mock_response(
+        usage={
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+            "cost": 0.1234,
+        }
+    )
+
+    result = agent.run_conversation("hello")
+
+    kwargs = session_db.update_token_counts.call_args.kwargs
+    assert result["actual_cost_usd"] == 0.1234
+    assert result["cost_status"] == "actual"
+    assert kwargs["actual_cost_usd"] == 0.1234
+    assert kwargs["cost_status"] == "actual"
+    assert kwargs["cost_source"] == "provider_generation_api"


### PR DESCRIPTION
## Summary
- persist OpenRouter actual per-call cost from response usage accounting into `actual_cost_usd`
- keep estimated and actual cost totals separate in `run_agent` and prefer actual cost in `/insights`
- add regression tests for cost extraction, DB persistence, and insights fallback behavior

## What changed
- added `extract_actual_cost_result()` to read authoritative per-request cost from OpenRouter responses (`usage.cost`, with metadata fallbacks)
- updated `AIAgent` to accumulate `session_actual_cost_usd`, persist `actual_cost_usd`, and mark cost status/source as `actual` when authoritative cost is present
- updated `InsightsEngine` to:
  - preserve estimated totals separately
  - use actual cost when available for display/model breakdowns
  - fall back to estimated cost when actual is missing
- added tests for OpenRouter cost extraction and persistence

## Test Plan
- [x] `source venv/bin/activate && pytest tests/agent/test_usage_pricing.py tests/agent/test_insights.py tests/run_agent/test_token_persistence_non_cli.py -q`
- [x] `source venv/bin/activate && pytest tests/gateway/test_usage_command.py -q`
- [ ] `source venv/bin/activate && python -m pytest tests/ -q` *(currently fails on unrelated pre-existing issues on latest `main`; not caused by this PR)*

Closes #9402