### PR TITLE
feat(cli): support full multiline prompt echo

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -273,6 +273,7 @@ def load_cli_config() -> Dict[str, Any]:
             "compact": False,
             "resume_display": "full",
             "show_reasoning": False,
+            "show_full_prompt": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
 
@@ -1588,6 +1589,7 @@ class HermesCLI:
         max_turns: int = None,
         verbose: bool = False,
         compact: bool = False,
+        show_full_prompt: bool = None,
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
@@ -1604,6 +1606,7 @@ class HermesCLI:
             max_turns: Maximum tool-calling iterations shared with subagents (default: 90)
             verbose: Enable verbose logging
             compact: Use compact display mode
+            show_full_prompt: Print full multiline prompts instead of the compact first-line preview
             resume: Session ID to resume (restores conversation history from SQLite)
             pass_session_id: Include the session ID in the agent's system prompt
         """
@@ -1621,6 +1624,9 @@ class HermesCLI:
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
+        # show_full_prompt: print full multiline prompts instead of "first line (+N lines)"
+        _sfp = CLI_CONFIG["display"].get("show_full_prompt", False)
+        self.show_full_prompt = bool(_sfp) if show_full_prompt is None else bool(show_full_prompt)
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
@@ -4473,6 +4479,29 @@ class HermesCLI:
         else:
             _ask()
         return result[0]
+
+    def _format_submitted_user_input(self, user_input: str) -> str:
+        """Format the just-submitted user input for scrollback."""
+        line_count = user_input.count("\n") + 1
+        accent = _accent_hex()
+
+        if self.show_full_prompt and line_count > 1:
+            lines = user_input.split("\n")
+            header = (
+                f"[bold {accent}]●[/] [bold]{_escape(lines[0])}[/] "
+                f"[dim]({line_count} lines total)[/]"
+            )
+            rest = "\n".join(f"  [bold]{_escape(line)}[/]" for line in lines[1:])
+            return f"{header}\n{rest}" if rest else header
+
+        if line_count > 1:
+            first_line = user_input.split("\n", 1)[0]
+            return (
+                f"[bold {accent}]●[/] [bold]{_escape(first_line)}[/] "
+                f"[dim](+{line_count - 1} lines)[/]"
+            )
+
+        return f"[bold {accent}]●[/] [bold]{_escape(user_input)}[/]"
 
     def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
@@ -9556,36 +9585,29 @@ class HermesCLI:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
                         print()
                         ChatConsole().print(_user_bar)
-                        # Show any surrounding user text alongside the paste summary
-                        split_parts = _paste_ref_re.split(user_input)
-                        visible_user_text = " ".join(
-                            split_parts[i].strip() for i in range(0, len(split_parts), 2) if split_parts[i].strip()
-                        )
-                        if visible_user_text:
-                            ChatConsole().print(
-                                f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(visible_user_text)}[/] "
-                                f"[dim]({n_pastes} pasted block{'s' if n_pastes > 1 else ''}, {total_lines} lines total)[/]"
-                            )
+                        if self.show_full_prompt:
+                            ChatConsole().print(self._format_submitted_user_input(expanded))
                         else:
-                            ChatConsole().print(
-                                f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(f'[Pasted text: {total_lines} lines]')}[/]"
+                            # Show any surrounding user text alongside the paste summary
+                            split_parts = _paste_ref_re.split(user_input)
+                            visible_user_text = " ".join(
+                                split_parts[i].strip() for i in range(0, len(split_parts), 2) if split_parts[i].strip()
                             )
+                            if visible_user_text:
+                                ChatConsole().print(
+                                    f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(visible_user_text)}[/] "
+                                    f"[dim]({n_pastes} pasted block{'s' if n_pastes > 1 else ''}, {total_lines} lines total)[/]"
+                                )
+                            else:
+                                ChatConsole().print(
+                                    f"[bold {_accent_hex()}]\u25cf[/] [bold]{_escape(f'[Pasted text: {total_lines} lines]')}[/]"
+                                )
                         user_input = expanded
                     else:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
-                        if '\n' in user_input:
-                            first_line = user_input.split('\n')[0]
-                            line_count = user_input.count('\n') + 1
-                            print()
-                            ChatConsole().print(_user_bar)
-                            ChatConsole().print(
-                                f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
-                                f"[dim](+{line_count - 1} lines)[/]"
-                            )
-                        else:
-                            print()
-                            ChatConsole().print(_user_bar)
-                            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                        print()
+                        ChatConsole().print(_user_bar)
+                        ChatConsole().print(self._format_submitted_user_input(user_input))
                     
                     # Show image attachment count
                     if submit_images:
@@ -9798,6 +9820,7 @@ def main(
     verbose: bool = False,
     quiet: bool = False,
     compact: bool = False,
+    show_full_prompt: bool = None,
     list_tools: bool = False,
     list_toolsets: bool = False,
     gateway: bool = False,
@@ -9823,6 +9846,7 @@ def main(
         max_turns: Maximum tool-calling iterations (default: 60)
         verbose: Enable verbose logging
         compact: Use compact display mode
+        show_full_prompt: Print full multiline prompts in CLI scrollback
         list_tools: List available tools and exit
         list_toolsets: List available toolsets and exit
         resume: Resume a previous session by its ID (e.g., 20260225_143052_a1b2c3)
@@ -9837,6 +9861,7 @@ def main(
         python cli.py -q "Describe this" --image ~/storage/shared/Pictures/cat.png
         python cli.py --list-tools               # List tools and exit
         python cli.py --resume 20260225_143052_a1b2c3  # Resume session
+        python cli.py --show-full-prompt        # Echo full multiline prompts in scrollback
         python cli.py -w                         # Start in isolated git worktree
         python cli.py -w -q "Fix issue #123"     # Single query in worktree
     """
@@ -9912,6 +9937,7 @@ def main(
         max_turns=max_turns,
         verbose=verbose,
         compact=compact,
+        show_full_prompt=show_full_prompt,
         resume=resume,
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -496,6 +496,7 @@ DEFAULT_CONFIG = {
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
         "show_reasoning": False,
+        "show_full_prompt": False,
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
@@ -700,7 +701,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -2165,6 +2166,20 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 
+    # ── Version 17 → 18: add explicit full-prompt display toggle ──
+    if current_ver < 18:
+        config = read_raw_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        if "show_full_prompt" not in display:
+            display["show_full_prompt"] = False
+            config["display"] = display
+            results["config_added"].append("display.show_full_prompt=false (default)")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added display.show_full_prompt=false")
+
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")
     
@@ -2935,6 +2950,7 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
+    print(f"  Full prompt:  {'on' if display.get('show_full_prompt', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
 
     # Terminal

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -96,6 +96,23 @@ class TestVerboseAndToolProgress:
         assert cli.tool_progress_mode in ("off", "new", "all", "verbose")
 
 
+class TestShowFullPrompt:
+    def test_show_full_prompt_defaults_off(self):
+        cli = _make_cli()
+        assert cli.show_full_prompt is False
+
+    def test_show_full_prompt_config_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"show_full_prompt": True}})
+        assert cli.show_full_prompt is True
+
+    def test_show_full_prompt_cli_arg_overrides_config(self):
+        cli = _make_cli(
+            config_overrides={"display": {"show_full_prompt": False}},
+            show_full_prompt=True,
+        )
+        assert cli.show_full_prompt is True
+
+
 class TestBusyInputMode:
     def test_default_busy_input_mode_is_interrupt(self):
         cli = _make_cli()

--- a/tests/cli/test_cli_show_full_prompt.py
+++ b/tests/cli/test_cli_show_full_prompt.py
@@ -1,0 +1,41 @@
+"""Tests for full prompt echo formatting in the CLI."""
+
+from cli import HermesCLI
+
+
+def _make_cli(show_full_prompt: bool):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.show_full_prompt = show_full_prompt
+    return cli_obj
+
+
+class TestSubmittedPromptFormatting:
+    def test_multiline_prompt_uses_compact_preview_by_default(self):
+        cli_obj = _make_cli(show_full_prompt=False)
+
+        rendered = cli_obj._format_submitted_user_input("alpha\nbeta\ngamma")
+
+        assert "alpha" in rendered
+        assert "(+2 lines)" in rendered
+        assert "beta" not in rendered
+        assert "gamma" not in rendered
+
+    def test_multiline_prompt_can_render_full_text(self):
+        cli_obj = _make_cli(show_full_prompt=True)
+
+        rendered = cli_obj._format_submitted_user_input("alpha\nbeta\ngamma")
+
+        assert "alpha" in rendered
+        assert "beta" in rendered
+        assert "gamma" in rendered
+        assert "(3 lines total)" in rendered
+        assert "(+2 lines)" not in rendered
+
+    def test_single_line_prompt_is_unchanged(self):
+        cli_obj = _make_cli(show_full_prompt=True)
+
+        rendered = cli_obj._format_submitted_user_input("just one line")
+
+        assert "just one line" in rendered
+        assert "lines total" not in rendered
+        assert "(+" not in rendered


### PR DESCRIPTION
## Summary
- add `--show-full-prompt` plus `display.show_full_prompt` so CLI users can echo full multiline prompts in scrollback
- keep the existing compact first-line preview as the default, but show the full expanded text when the flag/config is enabled
- include config migration/defaults and tests for init precedence plus prompt formatting behavior

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/bytedance/.pyenv/versions/3.10.12/bin/python3 -m pytest -o addopts='' tests/cli/test_cli_show_full_prompt.py tests/cli/test_cli_init.py -q

Closes #9195