### PR TITLE
fix: set _execution_thread_id before heartbeat thread starts in delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -754,6 +754,7 @@ class AIAgent:
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
         self._execution_thread_id: int | None = None  # Set at run_conversation() start
+        self._main_thread_id: int | None = None  # Set by delegate_tool before spawning
         self._client_lock = threading.RLock()
         
         # Subagent delegation state
@@ -2939,7 +2940,13 @@ class AIAgent:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
+        # Clear the interrupt on the worker's thread ID (set by run_conversation()).
         _set_interrupt(False, self._execution_thread_id)
+        # Also clear on the main thread ID in case an interrupt arrived on the
+        # main thread during delegate_task startup (before run_conversation set
+        # _execution_thread_id).  Both must be cleared to avoid stale state.
+        if self._main_thread_id is not None:
+            _set_interrupt(False, self._main_thread_id)
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""
@@ -7065,6 +7072,11 @@ class AIAgent:
 
         def _run_tool(index, tool_call, function_name, function_args):
             """Worker function executed in a thread."""
+            # Check if interrupt arrived before this tool started.
+            # This mirrors the pre-tool check in _execute_tool_calls_sequential.
+            if self._interrupt_requested:
+                results[index] = (function_name, function_args, f"[Tool execution cancelled — {function_name} was skipped due to user interrupt]", 0.0, False)
+                return
             start = time.time()
             try:
                 result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -385,12 +385,12 @@ def _build_child_agent(
     if child_pool is not None:
         child._credential_pool = child_pool
 
-    # Set execution thread ID before the heartbeat thread starts.  The heartbeat
+    # Set the main thread ID before the heartbeat thread starts.  The heartbeat
     # runs on a daemon thread and may call child.interrupt() before run_conversation()
-    # sets _execution_thread_id internally.  Storing it here ensures the interrupt
-    # is correctly scoped to the conversation thread and visible to is_interrupted().
+    # sets _execution_thread_id internally.  Storing the main thread ID separately
+    # allows clear_interrupt() to clean up both keys (worker ID + main ID).
     # This is safe because _build_child_agent() runs synchronously on the main thread.
-    child._execution_thread_id = threading.current_thread().ident
+    child._main_thread_id = threading.current_thread().ident
 
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -385,6 +385,13 @@ def _build_child_agent(
     if child_pool is not None:
         child._credential_pool = child_pool
 
+    # Set execution thread ID before the heartbeat thread starts.  The heartbeat
+    # runs on a daemon thread and may call child.interrupt() before run_conversation()
+    # sets _execution_thread_id internally.  Storing it here ensures the interrupt
+    # is correctly scoped to the conversation thread and visible to is_interrupted().
+    # This is safe because _build_child_agent() runs synchronously on the main thread.
+    child._execution_thread_id = threading.current_thread().ident
+
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
         lock = getattr(parent_agent, '_active_children_lock', None)


### PR DESCRIPTION
## Summary of Changes

This PR fixes two related issues in the delegate_task interrupt timing race:

### Problem 1: Race window where interrupt stored under main thread ID is never cleared

**Root cause**: In `delegate_tool._run_single_child()`, the heartbeat daemon thread calls `child.interrupt()` before `run_conversation()` has set `_execution_thread_id`. The `interrupt()` call stores the interrupt under `None` (via the still-unset `self._execution_thread_id`). When `run_conversation()` finally sets `_execution_thread_id` and calls `clear_interrupt()`, it only clears the worker thread ID -- the `None` key is never cleaned up.

**Fix**:
- `delegate_tool._build_child_agent()`: store `threading.current_thread().ident` in `child._main_thread_id` instead of `child._execution_thread_id`
- `AIAgent.__init__()`: add `self._main_thread_id: int | None = None`
- `AIAgent.clear_interrupt()`: clear both `self._execution_thread_id` AND `self._main_thread_id`

This ensures that any interrupt arriving on the main thread during startup is correctly cleared when `clear_interrupt()` is called.

### Problem 2: Concurrent tool execution had no interrupt check

**Root cause**: `_execute_tool_calls_concurrent` only had a pre-flight `_interrupt_requested` check. Unlike `_execute_tool_calls_sequential` (which checks before each tool), the concurrent workers had no interrupt awareness -- a tool already running when interrupt fires would complete normally.

**Fix**:
- `_execute_tool_calls_concurrent._run_tool()`: add `_interrupt_requested` check at the top of each worker, cancelling the tool immediately if interrupt is pending

## Files Changed

| File | Change |
|-------|--------|
| `run_agent.py` | `clear_interrupt()` clears two keys; `__init__` adds `_main_thread_id`; `_run_tool` checks `_interrupt_requested` |
| `tools/delegate_tool.py` | stores to `_main_thread_id` instead of `_execution_thread_id` |

## Testing Considerations

1. External interrupt arrives during delegate_task startup (heartbeat fires before `run_conversation()` starts) -> interrupt correctly stored and cleared
2. External interrupt arrives after `run_conversation()` starts -> stored under worker ID, correctly cleared
3. Concurrent tool execution with multiple tools -> each worker checks `_interrupt_requested` and skips if set
4. Sequential tool execution -> unchanged behavior (already had pre-tool check)
5. Parent-child multi-level delegation -> each level has its own `_main_thread_id`/`_execution_thread_id` pair