### PR TITLE
fix(cron): disable subdirectory hints during scheduled runs

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -58,7 +58,8 @@ class SubdirectoryHintTracker:
             tool_result += hints  # append to the tool result string
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(self, working_dir: Optional[str] = None, *, enabled: bool = True):
+        self.enabled = enabled
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
         self._loaded_dirs: Set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
@@ -73,6 +74,9 @@ class SubdirectoryHintTracker:
 
         Returns formatted hint text to append to the tool result, or None.
         """
+        if not self.enabled:
+            return None
+
         dirs = self._extract_directories(tool_name, tool_args)
         if not dirs:
             return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -1413,6 +1413,7 @@ class AIAgent:
 
         self._subdirectory_hints = SubdirectoryHintTracker(
             working_dir=os.getenv("TERMINAL_CWD") or None,
+            enabled=(platform != "cron"),
         )
         self._user_turn_count = 0
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -183,6 +183,14 @@ class TestSubdirectoryHintTracker:
         assert tracker.check_tool_call("read_file", {}) is None
         assert tracker.check_tool_call("terminal", {"command": ""}) is None
 
+    def test_disabled_tracker_returns_none(self, project):
+        """Disabled trackers should never append hint text."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project), enabled=False)
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+        )
+        assert result is None
+
     def test_url_in_command_ignored(self, project):
         """URLs in shell commands should not be treated as paths."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## Summary
- disable progressive subdirectory hint injection for scheduled cron runs
- keep the existing hint behavior unchanged for interactive/non-cron sessions
- add a regression test for disabled trackers

Related issue: #9441

## Problem
Cron jobs that run simple stdout-passthrough commands can receive extra tool-result text from `SubdirectoryHintTracker`.

In scheduled runs, this means a tool result like:
- `[SILENT]`

can be silently expanded into:
- `[SILENT]`
- `[Subdirectory context discovered: ...]`
- full `AGENTS.md` content

That polluted tool message then becomes the model's only evidence for the final response, which can cause malformed cron deliveries such as:
- `[SION]`
- `[_SUBPROCESS_OUTPUT] ... [/SUBPROCESS_OUTPUT]`
- leaking `AGENTS.md` content directly to Telegram/Discord/etc.

This is especially easy to trigger for cron prompts that intentionally do "run one command and return stdout verbatim".

## Root cause
`AIAgent` always instantiates `SubdirectoryHintTracker`, and both sequential and parallel tool execution append discovered hints directly onto `function_result` before the tool message is stored.

That behavior is useful for interactive coding sessions, but it is unsafe for `platform="cron"` because cron jobs often rely on deterministic, exact tool output.

## Fix
- add an `enabled` flag to `SubdirectoryHintTracker`
- initialize the tracker with `enabled=(platform != "cron")`
- short-circuit `check_tool_call()` when disabled

This keeps the feature unchanged everywhere else while ensuring cron tool results remain clean.

## How to test
- `python -m pytest tests/agent/test_subdirectory_hints.py -q`
- `pytest tests/ -v`

## Manual validation
- verified that `AIAgent(platform="cron")` creates the tracker with `enabled=False`
- verified that a non-cron agent (`platform="telegram"`) still creates the tracker with `enabled=True`

## Platforms tested
- Linux
