### PR TITLE
fix(cron): guard against non-dict result from run_conversation

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -827,6 +827,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"— last activity: {_last_desc}"
             )
 
+        # Guard against non-dict returns from run_conversation under error conditions
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
+            )
+
         final_response = result.get("final_response", "") or ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).


### PR DESCRIPTION
## Summary

- Adds a type guard in `cron/scheduler.py` (line ~830) before `result.get("final_response", "")` to check that `result` is actually a `dict`
- Converts an opaque `'int' object has no attribute 'get'` AttributeError into a clear `RuntimeError` with the actual type and value
- The `RuntimeError` is properly caught by the existing `except Exception` handler, which marks the job as failed and delivers the error message

Fixes #9433

## Test plan

- [ ] Trigger a cron job where `agent.run_conversation` returns a non-dict (e.g. an integer under error conditions)
- [ ] Verify the job is marked as failed with a descriptive error message instead of crashing with an `AttributeError`
- [ ] Verify normal cron jobs (where `result` is a dict) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)