### PR TITLE
[codex] fix provider auth compatibility

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -637,18 +637,15 @@ def _nous_base_url() -> str:
 def _read_codex_access_token() -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
-    If a credential pool exists but currently has no selectable runtime entry
-    (for example all pool slots are marked exhausted), fall back to the
-    profile's auth.json token instead of hard-failing. This keeps explicit
-    fallback-to-Codex working when the pool state is stale but the stored OAuth
-    token is still valid.
-    """
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        token = _pool_runtime_api_key(entry)
-        if token:
-            return token
+    Prefer the active profile's auth.json store when it exists. If the profile
+    has no Codex token (or only an expired one), return None rather than
+    leaking a token from an unrelated local credential pool into the current
+    runtime context.
 
+    When no profile auth store exists, fall back to the credential pool so
+    pool-backed Codex sessions still work.
+    """
+    auth_path = get_hermes_home() / "auth.json"
     try:
         from hermes_cli.auth import _read_codex_tokens
         data = _read_codex_tokens()
@@ -674,7 +671,15 @@ def _read_codex_access_token() -> Optional[str]:
         return access_token.strip()
     except Exception as exc:
         logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
-        return None
+        if auth_path.exists():
+            return None
+
+    pool_present, entry = _select_pool_entry("openai-codex")
+    if pool_present:
+        token = _pool_runtime_api_key(entry)
+        if token:
+            return token
+    return None
 
 
 def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -918,20 +923,13 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
+    codex_token = _read_codex_access_token()
+    if not codex_token:
+        return None, None
     pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
-        else:
-            codex_token = _read_codex_access_token()
-            if not codex_token:
-                return None, None
-            base_url = _CODEX_AUX_BASE_URL
+    if pool_present and entry is not None:
+        base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
     else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
         base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
     real_client = OpenAI(api_key=codex_token, base_url=base_url)
@@ -973,7 +971,7 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
         pass
 
     from agent.anthropic_adapter import _is_oauth_token
-    is_oauth = _is_oauth_token(token)
+    is_oauth = _is_oauth_token(token) or not str(token).startswith("sk-ant-api")
     model = _API_KEY_PROVIDER_AUX_MODELS.get("anthropic", "claude-haiku-4-5-20251001")
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
@@ -1646,6 +1644,12 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
         api_mode=api_mode,
         main_runtime=main_runtime,
     )
+
+
+def get_vision_auxiliary_client(provider: Optional[str] = None):
+    """Return ``(client, model)`` for vision tasks using auto/provider routing."""
+    _effective_provider, client, model = resolve_vision_provider_client(provider)
+    return client, model
 
 
 _VISION_AUTO_PROVIDER_ORDER = (

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -781,6 +781,9 @@ class CredentialPool:
         cleared_any = False
         available: List[PooledCredential] = []
         for entry in self._entries:
+            exhausted_until = _exhausted_until(entry)
+            if entry.last_status == STATUS_EXHAUSTED and exhausted_until is not None and now < exhausted_until:
+                continue
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
             # by other processes (Claude Code CLI, other Hermes profiles).
@@ -801,9 +804,6 @@ class CredentialPool:
                     entry = synced
                     cleared_any = True
             if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry)
-                if exhausted_until is not None and now < exhausted_until:
-                    continue
                 if clear_expired:
                     cleared = replace(
                         entry,
@@ -1153,6 +1153,12 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             )
 
     elif provider == "openai-codex":
+        # If the pool already contains explicit manual entries, do not
+        # auto-seed an extra singleton device_code credential from auth.json
+        # or the external Codex CLI file. The pool contents are already
+        # authoritative in that case.
+        if any(_is_manual_source(entry.source) for entry in entries):
+            return changed, active_sources
         state = _load_provider_state(auth_store, "openai-codex")
         tokens = state.get("tokens") if isinstance(state, dict) else None
         # Fallback: import from Codex CLI (~/.codex/auth.json) if Hermes auth

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -929,7 +929,7 @@ def list_authenticated_providers(
             "is_user_defined": False,
             "models": top,
             "total_models": total,
-            "source": "hermes",
+            "source": "built-in",
         })
         seen_slugs.add(pid)
         seen_slugs.add(hermes_slug)
@@ -1082,5 +1082,4 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -286,7 +286,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            direct_api_key = str(entry.get("api_key", "") or "").strip()
+            resolved_api_key = direct_api_key or (os.getenv(key_env, "").strip() if key_env else "")
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.auxiliary_client import (
     get_text_auxiliary_client,
+    get_vision_auxiliary_client,
     get_available_vision_backends,
     resolve_vision_provider_client,
     resolve_provider_client,

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -5,6 +5,12 @@ import os
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_anthropic_env(monkeypatch):
+    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+
 def _write_config(tmp_path, config: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Restore provider/auth compatibility across auxiliary routing and runtime resolution.

## Root Cause

A few auth and fallback paths diverged: named custom providers from `providers:` lost direct API keys, Codex token resolution leaked across contexts, and auxiliary-provider oauth detection/helpers drifted from current expectations.

## What Changed

- fix Codex token fallback and expiry handling in `agent/auxiliary_client.py`
- restore the vision helper wrapper and oauth detection behavior
- respect direct API keys in `providers:` runtime resolution
- normalize provider list metadata for Hermes overlay providers
- respect explicit cooldown reset timestamps in the credential pool

## Validation

- `python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_opencode_go_in_model_list.py tests/agent/test_credential_pool.py::test_explicit_reset_timestamp_overrides_default_429_ttl -q`
