### PR TITLE
[codex] fix systemd detection on WSL and Linux

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -355,11 +355,9 @@ def _wsl_systemd_operational() -> bool:
 def supports_systemd_services() -> bool:
     if not is_linux() or is_termux() or is_container():
         return False
-    if shutil.which("systemctl") is None:
-        return False
     if is_wsl():
         return _wsl_systemd_operational()
-    return True
+    return shutil.which("systemctl") is not None
 
 
 def is_macos() -> bool:

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -145,6 +145,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda name: "/usr/bin/systemctl")
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):


### PR DESCRIPTION
## Summary

Reconcile systemd support detection between WSL and native Linux.

## Root Cause

The gateway systemd capability check treated WSL and native Linux the same, which conflicted with the intended behavior: WSL should use the operational systemd probe, while native Linux should still require the `systemctl` binary.

## What Changed

- keep WSL routed through `_wsl_systemd_operational()`
- keep native Linux gated on `systemctl` availability
- align the WSL tests with that split behavior

## Validation

- `python -m pytest -o addopts='' tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL tests/hermes_cli/test_gateway_service.py::TestGatewayServiceDetection::test_supports_systemd_services_requires_systemctl_binary -q`
