### PR TITLE
[codex] fix gateway session compatibility

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -101,6 +101,21 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
+def get_platform_defaults(platform_key: str) -> dict[str, Any]:
+    """Return a copy of the built-in defaults for a platform."""
+    defaults = _PLATFORM_DEFAULTS.get(platform_key, {})
+    merged = {**_GLOBAL_DEFAULTS, **defaults}
+    return dict(merged)
+
+
+def get_effective_display(user_config: dict, platform_key: str) -> dict[str, Any]:
+    """Return the resolved display config for a platform."""
+    return {
+        key: resolve_display_setting(user_config, platform_key, key)
+        for key in OVERRIDEABLE_KEYS
+    }
+
+
 def resolve_display_setting(
     user_config: dict,
     platform_key: str,

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -82,20 +82,21 @@ class PairingStore:
       - _rate_limits.json         : rate limit tracking
     """
 
-    def __init__(self):
-        PAIRING_DIR.mkdir(parents=True, exist_ok=True)
+    def __init__(self, base_dir: Optional[Path] = None):
+        self._base_dir = base_dir or PAIRING_DIR
+        self._base_dir.mkdir(parents=True, exist_ok=True)
         # Protects all read-modify-write cycles. The gateway runs multiple
         # platform adapters concurrently in threads sharing one PairingStore.
         self._lock = threading.RLock()
 
     def _pending_path(self, platform: str) -> Path:
-        return PAIRING_DIR / f"{platform}-pending.json"
+        return self._base_dir / f"{platform}-pending.json"
 
     def _approved_path(self, platform: str) -> Path:
-        return PAIRING_DIR / f"{platform}-approved.json"
+        return self._base_dir / f"{platform}-approved.json"
 
     def _rate_limit_path(self) -> Path:
-        return PAIRING_DIR / "_rate_limits.json"
+        return self._base_dir / "_rate_limits.json"
 
     def _load_json(self, path: Path) -> dict:
         if path.exists():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -621,7 +621,10 @@ class GatewayRunner:
         
         # DM pairing store for code-based user authorization
         from gateway.pairing import PairingStore
-        self.pairing_store = PairingStore()
+        _pairing_dir = _hermes_home / "pairing"
+        if not _pairing_dir.exists():
+            _pairing_dir = _hermes_home / "platforms" / "pairing"
+        self.pairing_store = PairingStore(_pairing_dir)
         
         # Event hook system
         from gateway.hooks import HookRegistry
@@ -5809,10 +5812,10 @@ class GatewayRunner:
         # --- cycle mode (per-platform) ----------------------------------------
         cycle = ["off", "new", "all", "verbose"]
         descriptions = {
-            "off": "⚙️ Tool progress: **OFF** — no tool activity shown.",
-            "new": "⚙️ Tool progress: **NEW** — shown when tool changes (preview length: `display.tool_preview_length`, default 40).",
-            "all": "⚙️ Tool progress: **ALL** — every tool call shown (preview length: `display.tool_preview_length`, default 40).",
-            "verbose": "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments.",
+            "off": "⚙️ /verbose: tool progress **OFF** — no tool activity shown.",
+            "new": "⚙️ /verbose: tool progress **NEW** — shown when tool changes (preview length: `display.tool_preview_length`, default 40).",
+            "all": "⚙️ /verbose: tool progress **ALL** — every tool call shown (preview length: `display.tool_preview_length`, default 40).",
+            "verbose": "⚙️ /verbose: tool progress **VERBOSE** — every tool call with full arguments.",
         }
 
         # Read current effective mode for this platform via the resolver

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -169,8 +169,9 @@ def test_session_key_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
 
 
-def test_set_session_env_includes_session_key():
+def test_set_session_env_includes_session_key(monkeypatch):
     """_set_session_env should propagate session_key from SessionContext."""
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     runner = object.__new__(GatewayRunner)
     source = SessionSource(
         platform=Platform.TELEGRAM,

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -373,6 +373,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
             platform=Platform.TELEGRAM,
             chat_id="-1001",
             chat_type="group",
+            user_id="tg-user-1",
             thread_id="17585",
         ),
         message_id="1",


### PR DESCRIPTION
## Summary

Restore gateway session/path compatibility for display, pairing, and session context handling.

## Root Cause

A few gateway-core paths diverged together: display helper APIs went missing, pairing storage used a module-level directory instead of instance-owned state, and some gateway tests depended on cleaner session-context isolation.

## What Changed

- restore display helper APIs in `gateway/display_config.py`
- make `PairingStore` own its base directory and wire `GatewayRunner` to it
- fix session-context and hygiene test isolation
- keep the `/verbose` messaging response aligned with the command contract

## Validation

- `python -m pytest -o addopts='' tests/gateway/test_display_config.py tests/gateway/test_internal_event_bypass_pairing.py::test_non_internal_event_without_user_triggers_pairing tests/gateway/test_session_env.py::test_set_session_env_includes_session_key tests/gateway/test_session_hygiene.py::test_session_hygiene_messages_stay_in_originating_topic 'tests/e2e/test_platform_commands.py::TestSlashCommands::test_verbose_responds[telegram]' 'tests/e2e/test_platform_commands.py::TestSlashCommands::test_verbose_responds[discord]' 'tests/e2e/test_platform_commands.py::TestSlashCommands::test_verbose_responds[slack]' -q`
