### PR TITLE
[codex] fix approval session cleanup

### DIFF
--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -73,6 +73,7 @@ def _clear_approval_state():
     mod._gateway_queues.clear()
     mod._gateway_notify_cbs.clear()
     mod._session_approved.clear()
+    mod._session_yolo.clear()
     mod._permanent_approved.clear()
     mod._pending.clear()
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -297,6 +297,24 @@ def approve_session(session_key: str, pattern_key: str):
         _session_approved.setdefault(session_key, set()).add(pattern_key)
 
 
+def clear_session(session_key: str) -> None:
+    """Clear all in-memory approval state for a session key.
+
+    Safe to call even when the session has no tracked approval state.
+    Any blocked gateway approvals for the session are unblocked.
+    """
+    if not session_key:
+        return
+    with _lock:
+        _pending.pop(session_key, None)
+        _session_approved.pop(session_key, None)
+        _session_yolo.discard(session_key)
+        _gateway_notify_cbs.pop(session_key, None)
+        entries = _gateway_queues.pop(session_key, [])
+    for entry in entries:
+        entry.event.set()
+
+
 def enable_session_yolo(session_key: str) -> None:
     """Enable YOLO bypass for a single session key."""
     if not session_key:


### PR DESCRIPTION
## Summary

Restore explicit approval-session cleanup in `tools/approval.py`.

## Root Cause

The approval module no longer exposed a session cleanup helper, which broke tests and left session-scoped approval state harder to reset deterministically.

## What Changed

- restore `clear_session(session_key)` in `tools/approval.py`
- clear leaked session-scoped YOLO state in the approval gateway tests

## Validation

- `python -m pytest -o addopts='' tests/tools/test_yolo_mode.py tests/gateway/test_approve_deny_commands.py -q`
