### PR TITLE
[codex] fix runtime tool compatibility

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -443,11 +443,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             call_kwargs = {
                 "task": "compression",
                 "main_runtime": {
-                    "model": self.model,
-                    "provider": self.provider,
-                    "base_url": self.base_url,
-                    "api_key": self.api_key,
-                    "api_mode": self.api_mode,
+                    "model": getattr(self, "model", None),
+                    "provider": getattr(self, "provider", None),
+                    "base_url": getattr(self, "base_url", None),
+                    "api_key": getattr(self, "api_key", None),
+                    "api_mode": getattr(self, "api_mode", None),
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": summary_budget * 2,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2923,7 +2923,7 @@ class AIAgent:
         # Signal all tools to abort any in-flight operations immediately.
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.
-        _set_interrupt(True, self._execution_thread_id)
+        _set_interrupt(True, getattr(self, "_execution_thread_id", None))
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -2939,7 +2939,7 @@ class AIAgent:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
-        _set_interrupt(False, self._execution_thread_id)
+        _set_interrupt(False, getattr(self, "_execution_thread_id", None))
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -120,9 +120,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, watch_patterns: list = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "watch_patterns": watch_patterns}',
     ),
 }
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -97,6 +97,10 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/etc/", "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+_SENSITIVE_PREFIX_EXCEPTIONS = (
+    "/var/folders/",
+    "/private/var/folders/",
+)
 
 
 def _check_sensitive_path(filepath: str) -> str | None:
@@ -110,6 +114,9 @@ def _check_sensitive_path(filepath: str) -> str | None:
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    for prefix in _SENSITIVE_PREFIX_EXCEPTIONS:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
## Summary

Restore a handful of small runtime/tool compatibility edges.

## Root Cause

Several independently small drifts accumulated: the sandbox terminal stub no longer matched the real schema, temp files under macOS `/var/folders` were blocked as sensitive system writes, interrupt paths assumed `_execution_thread_id` always existed, and the context compressor expected more runtime fields than minimal test instances provide.

## What Changed

- sync the execute-code terminal stub with the real terminal schema
- carve macOS temp directories out of the sensitive-path write blocker
- make `AIAgent.interrupt()` and `clear_interrupt()` tolerate partially constructed agents
- make context-compressor summary generation robust with minimal runtime state

## Validation

- `python -m pytest -o addopts='' tests/tools/test_file_staleness.py tests/tools/test_code_execution.py::TestStubSchemaDrift::test_stubs_cover_all_schema_params tests/cli/test_cli_interrupt_subagent.py::TestCLISubagentInterrupt::test_full_delegate_interrupt_flow tests/agent/test_compress_focus.py -q`
