### PR TITLE
feat(config): support user-defined custom HTTP headers for LLM API requests

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -295,6 +295,16 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    # Merge user-defined custom headers from config.yaml.
+    # Applied last so user values can override provider defaults.
+    try:
+        from hermes_cli.config import get_custom_headers
+        custom = get_custom_headers()
+        if custom:
+            kwargs.setdefault("default_headers", {}).update(custom)
+    except Exception:
+        pass
+
     return _anthropic_sdk.Anthropic(**kwargs)
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -121,6 +121,23 @@ _OR_HEADERS = {
     "X-OpenRouter-Categories": "productivity,cli-agent",
 }
 
+
+def _merge_custom_headers(headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Merge user-defined custom_headers from config.yaml into *headers*.
+
+    Returns a new dict with provider headers first, then custom headers on top
+    so user values can override defaults.
+    """
+    merged = dict(headers) if headers else {}
+    try:
+        from hermes_cli.config import get_custom_headers
+        custom = get_custom_headers()
+        if custom:
+            merged.update(custom)
+    except Exception:
+        pass
+    return merged
+
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
 # when the auxiliary client is backed by Nous Portal.
@@ -719,11 +736,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             extra = {}
             if "api.kimi.com" in base_url.lower():
-                extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+                extra["default_headers"] = _merge_custom_headers({"User-Agent": "KimiCLI/1.30.0"})
             elif "api.githubcopilot.com" in base_url.lower():
                 from hermes_cli.models import copilot_default_headers
 
-                extra["default_headers"] = copilot_default_headers()
+                extra["default_headers"] = _merge_custom_headers(copilot_default_headers())
             return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -740,11 +757,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         extra = {}
         if "api.kimi.com" in base_url.lower():
-            extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+            extra["default_headers"] = _merge_custom_headers({"User-Agent": "KimiCLI/1.30.0"})
         elif "api.githubcopilot.com" in base_url.lower():
             from hermes_cli.models import copilot_default_headers
 
-            extra["default_headers"] = copilot_default_headers()
+            extra["default_headers"] = _merge_custom_headers(copilot_default_headers())
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -763,14 +780,14 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
         return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                       default_headers=_merge_custom_headers(_OR_HEADERS)), _OPENROUTER_MODEL
 
     or_key = os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                   default_headers=_merge_custom_headers(_OR_HEADERS)), _OPENROUTER_MODEL
 
 
 def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -1236,13 +1253,17 @@ def _to_async_client(sync_client, model: str):
     }
     base_lower = str(sync_client.base_url).lower()
     if "openrouter" in base_lower:
-        async_kwargs["default_headers"] = dict(_OR_HEADERS)
+        async_kwargs["default_headers"] = _merge_custom_headers(dict(_OR_HEADERS))
     elif "api.githubcopilot.com" in base_lower:
         from hermes_cli.models import copilot_default_headers
 
-        async_kwargs["default_headers"] = copilot_default_headers()
+        async_kwargs["default_headers"] = _merge_custom_headers(copilot_default_headers())
     elif "api.kimi.com" in base_lower:
-        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+        async_kwargs["default_headers"] = _merge_custom_headers({"User-Agent": "KimiCLI/1.30.0"})
+    else:
+        _custom_only = _merge_custom_headers()
+        if _custom_only:
+            async_kwargs["default_headers"] = _custom_only
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -1419,10 +1440,10 @@ def resolve_provider_client(
             )
             extra = {}
             if "api.kimi.com" in custom_base.lower():
-                extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+                extra["default_headers"] = _merge_custom_headers({"User-Agent": "KimiCLI/1.30.0"})
             elif "api.githubcopilot.com" in custom_base.lower():
                 from hermes_cli.models import copilot_default_headers
-                extra["default_headers"] = copilot_default_headers()
+                extra["default_headers"] = _merge_custom_headers(copilot_default_headers())
             client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base)
             return (_to_async_client(client, final_model) if async_mode
@@ -1522,6 +1543,7 @@ def resolve_provider_client(
             from hermes_cli.models import copilot_default_headers
 
             headers.update(copilot_default_headers())
+        headers = _merge_custom_headers(headers) if headers else _merge_custom_headers()
 
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -50,6 +50,17 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+# =============================================================================
+# Custom HTTP Headers
+# =============================================================================
+# Extra headers added to every outgoing LLM API request (Anthropic & OpenAI).
+# Useful for request-origin tagging, internal auditing, compliance, or
+# routing through corporate API gateways.
+#
+# custom_headers:
+#   X-Request-Source: "my-service"
+#   X-Cost-Center: "team-ai"
+
   # ── Token limits — two settings, easy to confuse ──────────────────────────
   #
   # context_length: TOTAL context window (input + output tokens combined).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -310,6 +310,7 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    "custom_headers": {},
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
@@ -2447,6 +2448,23 @@ def load_config() -> Dict[str, Any]:
             print(f"Warning: Failed to load config: {e}")
     
     return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+
+
+def get_custom_headers() -> Dict[str, str]:
+    """Return user-defined custom HTTP headers from config.yaml.
+
+    Reads the top-level ``custom_headers`` mapping and returns a plain
+    ``dict[str, str]``.  Values are coerced to strings so callers can
+    safely merge them into HTTP header dicts.
+    """
+    try:
+        cfg = load_config()
+        raw = cfg.get("custom_headers", {})
+        if not isinstance(raw, dict):
+            return {}
+        return {str(k): str(v) for k, v in raw.items()}
+    except Exception:
+        return {}
 
 
 _SECURITY_COMMENT = """

--- a/tests/agent/test_custom_headers.py
+++ b/tests/agent/test_custom_headers.py
@@ -1,0 +1,132 @@
+"""Tests for custom_headers feature — user-defined HTTP headers injected into LLM clients."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import hermes_cli.config  # ensure module is loaded for patching
+import agent.anthropic_adapter  # noqa: F401
+import agent.auxiliary_client  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# get_custom_headers (config layer)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomHeaders:
+    def test_returns_empty_dict_when_not_configured(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert hermes_cli.config.get_custom_headers() == {}
+
+    def test_returns_headers_from_config(self):
+        cfg = {"custom_headers": {"X-Request-Source": "my-agent", "X-Team": "infra"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            result = hermes_cli.config.get_custom_headers()
+            assert result == {"X-Request-Source": "my-agent", "X-Team": "infra"}
+
+    def test_coerces_values_to_strings(self):
+        cfg = {"custom_headers": {"X-Retry": 3, "X-Debug": True}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            result = hermes_cli.config.get_custom_headers()
+            assert result == {"X-Retry": "3", "X-Debug": "True"}
+
+    def test_ignores_non_dict_custom_headers(self):
+        cfg = {"custom_headers": "not-a-dict"}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert hermes_cli.config.get_custom_headers() == {}
+
+    def test_returns_empty_on_load_config_failure(self):
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert hermes_cli.config.get_custom_headers() == {}
+
+
+# ---------------------------------------------------------------------------
+# build_anthropic_client — custom headers injection
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicClientCustomHeaders:
+    """Verify custom_headers are merged into the Anthropic client's default_headers."""
+
+    def test_custom_headers_merged_with_api_key_auth(self):
+        custom = {"X-Request-Source": "my-agent"}
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            agent.anthropic_adapter.build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["X-Request-Source"] == "my-agent"
+            # Provider headers must still be present
+            assert "anthropic-beta" in kwargs["default_headers"]
+
+    def test_custom_headers_merged_with_oauth_token(self):
+        custom = {"X-Audit": "yes"}
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            agent.anthropic_adapter.build_anthropic_client("sk-ant-oat01-" + "x" * 60)
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["X-Audit"] == "yes"
+            assert "anthropic-beta" in kwargs["default_headers"]
+            assert "x-app" in kwargs["default_headers"]
+
+    def test_custom_headers_merged_with_bearer_auth(self):
+        custom = {"X-Source": "internal"}
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            agent.anthropic_adapter.build_anthropic_client(
+                "minimax-key", base_url="https://api.minimax.io/anthropic")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["X-Source"] == "internal"
+
+    def test_no_custom_headers_when_empty(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.config.get_custom_headers", return_value={}):
+            agent.anthropic_adapter.build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            # Should still work normally — no extra keys injected
+            assert "X-Request-Source" not in kwargs.get("default_headers", {})
+
+    def test_custom_headers_override_provider_headers(self):
+        """User-defined headers should take precedence over provider defaults."""
+        custom = {"x-app": "my-custom-app"}
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            agent.anthropic_adapter.build_anthropic_client("sk-ant-oat01-" + "x" * 60)
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["x-app"] == "my-custom-app"
+
+
+# ---------------------------------------------------------------------------
+# _merge_custom_headers (auxiliary client layer)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeCustomHeaders:
+    def test_merges_into_existing_headers(self):
+        custom = {"X-Request-Source": "test"}
+        with patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            result = agent.auxiliary_client._merge_custom_headers({"Existing": "value"})
+            assert result == {"Existing": "value", "X-Request-Source": "test"}
+
+    def test_returns_custom_only_when_no_base(self):
+        custom = {"X-Request-Source": "test"}
+        with patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            result = agent.auxiliary_client._merge_custom_headers()
+            assert result == {"X-Request-Source": "test"}
+
+    def test_returns_empty_when_nothing_configured(self):
+        with patch("hermes_cli.config.get_custom_headers", return_value={}):
+            result = agent.auxiliary_client._merge_custom_headers()
+            assert result == {}
+
+    def test_custom_overrides_base(self):
+        custom = {"X-OpenRouter-Title": "My Agent"}
+        with patch("hermes_cli.config.get_custom_headers", return_value=custom):
+            result = agent.auxiliary_client._merge_custom_headers(
+                {"X-OpenRouter-Title": "Hermes Agent"})
+            assert result["X-OpenRouter-Title"] == "My Agent"
+
+    def test_graceful_on_import_failure(self):
+        with patch("hermes_cli.config.get_custom_headers", side_effect=ImportError):
+            result = agent.auxiliary_client._merge_custom_headers({"Keep": "this"})
+            assert result == {"Keep": "this"}


### PR DESCRIPTION
## Summary

- Add `custom_headers` config field in config.yaml, merged into all outgoing LLM API requests (Anthropic + OpenAI/OpenRouter)

Closes #9398

## Test plan

- [x] 15 new unit tests covering config loading, Anthropic client, and auxiliary client
- [x] No regressions in existing tests