### PR TITLE
test(gateway): guard /stop against session suspension regression

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -431,6 +431,7 @@ AUTHOR_MAP = {
     "dyxushuai@gmail.com": "dyxushuai",
     "33860762+etcircle@users.noreply.github.com": "etcircle",
     "liujinkun@bytedance.com": "liujinkun2025",
+    "lubrsy706@gmail.com": "Lubrsy706",
     "dmayhem93@gmail.com": "dmahan93",
     "fr@tecompanytea.com": "ifrederico",
     "cdanis@gmail.com": "cdanis",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -67,6 +67,7 @@ def _ensure_discord_mock():
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -394,6 +394,7 @@ async def test_stop_during_sentinel_force_cleans_session():
         assert session_key not in runner._running_agents, (
             "/stop must remove sentinel so the session is unlocked"
         )
+        runner.session_store.suspend_session.assert_not_called()
 
         # Should NOT be queued as pending
         adapter = runner.adapters[Platform.TELEGRAM]
@@ -444,6 +445,7 @@ async def test_stop_hard_kills_running_agent():
     # Must return a confirmation
     assert result is not None
     assert "stopped" in result.lower()
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------
@@ -475,6 +477,7 @@ async def test_stop_clears_pending_messages():
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
     adapter.get_pending_message.assert_called_once_with(session_key)
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -361,6 +361,7 @@ async def test_stop_during_sentinel_force_cleans_session():
         assert session_key not in runner._running_agents, (
             "/stop must remove sentinel so the session is unlocked"
         )
+        runner.session_store.suspend_session.assert_not_called()
 
         # Should NOT be queued as pending
         adapter = runner.adapters[Platform.TELEGRAM]
@@ -411,6 +412,7 @@ async def test_stop_hard_kills_running_agent():
     # Must return a confirmation
     assert result is not None
     assert "stopped" in result.lower()
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------
@@ -442,6 +444,7 @@ async def test_stop_clears_pending_messages():
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
     adapter.get_pending_message.assert_called_once_with(session_key)
+    runner.session_store.suspend_session.assert_not_called()
 
 
 # ------------------------------------------------------------------

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -128,9 +128,10 @@ class TestGeminiModelCatalog:
     def test_provider_models_exist(self):
         assert "gemini" in _PROVIDER_MODELS
         models = _PROVIDER_MODELS["gemini"]
-        assert "gemini-2.5-pro" in models
-        assert "gemini-2.5-flash" in models
+        assert "gemini-3.1-pro-preview" in models
+        assert "gemini-3-flash-preview" in models
         assert "gemma-4-31b-it" not in models
+        assert "gemini-2.5-pro" not in models
 
     def test_provider_models_has_3x(self):
         models = _PROVIDER_MODELS["gemini"]

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,7 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         agent.model = "gpt-5"
         messages = [
             {"role": "system", "content": "You are helpful."},
@@ -344,14 +349,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## What does this PR do?
Adds regression coverage for the post-#9224 /stop behavior so future changes cannot reintroduce session_store.suspend_session() in the active-agent stop paths.

## Why?
Issue #9241 calls out a missing regression test after #9224 removed the unintended session reset behavior from /stop.

## How to test
- ./venv/bin/python -m pytest tests/gateway/test_session_race_guard.py -q
- ./venv/bin/python -m pytest tests/gateway/test_command_bypass_active_session.py -q

## Platforms tested
- macOS

## Related issues
- Closes #9241