### PR TITLE
Group OpenRouter picker entries across CLI and gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4623,7 +4623,7 @@ class HermesCLI:
                     current_base_url=self.base_url or "",
                     current_api_key=self.api_key or "",
                     is_global=persist_global,
-                    explicit_provider=provider_data.get("slug"),
+                    explicit_provider=provider_data.get("switch_provider") or provider_data.get("id"),
                     user_providers=state.get("user_provs"),
                     custom_providers=state.get("custom_provs"),
                 )
@@ -4642,7 +4642,7 @@ class HermesCLI:
           /model <name> --provider <provider> — switch provider + model
           /model --provider <provider>        — switch to provider, auto-detect model
         """
-        from hermes_cli.model_switch import switch_model, parse_model_flags, list_authenticated_providers
+        from hermes_cli.model_switch import switch_model, parse_model_flags, list_authenticated_picker_entries
         from hermes_cli.providers import get_label
 
         # Parse args from the original command
@@ -4671,8 +4671,9 @@ class HermesCLI:
                 pass
 
             try:
-                providers = list_authenticated_providers(
+                providers = list_authenticated_picker_entries(
                     current_provider=self.provider or "",
+                    current_model=self.model or "",
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=50,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4267,6 +4267,7 @@ class GatewayRunner:
         import yaml
         from hermes_cli.model_switch import (
             switch_model as _switch_model, parse_model_flags,
+            list_authenticated_picker_entries,
             list_authenticated_providers,
         )
         from hermes_cli.providers import get_label
@@ -4323,8 +4324,9 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_authenticated_providers(
+                    providers = list_authenticated_picker_entries(
                         current_provider=current_provider,
+                        current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
@@ -4333,6 +4335,7 @@ class GatewayRunner:
                     providers = []
 
                 if providers:
+                    provider_by_slug = {str(p.get("slug") or p.get("id") or ""): p for p in providers}
                     # Build a callback closure for when the user picks a model.
                     # Captures self + locals needed for the switch logic.
                     _self = self
@@ -4346,6 +4349,7 @@ class GatewayRunner:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
+                        provider_entry = provider_by_slug.get(provider_slug, {})
                         result = _switch_model(
                             raw_input=model_id,
                             current_provider=_cur_provider,
@@ -4353,7 +4357,7 @@ class GatewayRunner:
                             current_base_url=_cur_base_url,
                             current_api_key=_cur_api_key,
                             is_global=False,
-                            explicit_provider=provider_slug,
+                            explicit_provider=provider_entry.get("switch_provider", provider_slug),
                             user_providers=user_provs,
                             custom_providers=custom_provs,
                         )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1084,3 +1084,54 @@ def list_authenticated_providers(
     return results
 
 
+def list_authenticated_picker_entries(
+    current_provider: str = "",
+    current_model: str = "",
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+    max_models: int = 8,
+) -> List[dict]:
+    """Return a shared picker-entry schema for CLI and gateway pickers."""
+    from hermes_cli.models import openrouter_picker_groups, openrouter_vendor_label
+
+    providers = list_authenticated_providers(
+        current_provider=current_provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+        max_models=max_models,
+    )
+    if not providers:
+        return []
+
+    expanded: List[dict] = []
+    current_openrouter_model = normalize_model_for_provider(current_model, "openrouter") if current_provider == "openrouter" else ""
+
+    for provider in providers:
+        if provider.get("slug") != "openrouter":
+            expanded.append({
+                "id": provider["slug"],
+                "slug": provider["slug"],
+                "switch_provider": provider["slug"],
+                "name": provider["name"],
+                "is_current": provider["is_current"],
+                "models": provider.get("models", []),
+                "total_models": provider.get("total_models", len(provider.get("models", []))),
+                "source": provider.get("source", "built-in"),
+            })
+            continue
+
+        for vendor, models in openrouter_picker_groups():
+            model_list = list(models)
+            expanded.append({
+                "id": f"openrouter:{vendor}",
+                "slug": f"openrouter:{vendor}",
+                "switch_provider": "openrouter",
+                "name": f"OpenRouter / {openrouter_vendor_label(vendor)}",
+                "is_current": bool(current_provider == "openrouter" and current_openrouter_model.startswith(f"{vendor}/")),
+                "models": model_list,
+                "total_models": len(model_list),
+                "source": provider.get("source", "built-in"),
+            })
+
+    expanded.sort(key=lambda r: (not r["is_current"], -r["total_models"], r["name"]))
+    return expanded

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -20,6 +20,23 @@ COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
+_OPENROUTER_VENDOR_LABELS: dict[str, str] = {
+    "anthropic": "Anthropic",
+    "arcee-ai": "Arcee",
+    "deepseek": "DeepSeek",
+    "google": "Google",
+    "meta-llama": "Meta Llama",
+    "minimax": "MiniMax",
+    "moonshotai": "Moonshot",
+    "nvidia": "Nvidia",
+    "openai": "OpenAI",
+    "qwen": "Qwen",
+    "stepfun": "StepFun",
+    "x-ai": "X.AI",
+    "xiaomi": "Xiaomi",
+    "z-ai": "Z.AI",
+}
+
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
@@ -56,6 +73,23 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
+
+
+def openrouter_vendor_label(vendor_slug: str) -> str:
+    """Return a human-friendly label for an OpenRouter vendor slug."""
+    label = _OPENROUTER_VENDOR_LABELS.get(vendor_slug)
+    if label:
+        return label
+    bits = [part for part in vendor_slug.replace("_", "-").split("-") if part]
+    return " ".join(part[:1].upper() + part[1:] for part in bits) or vendor_slug
+
+
+def _openrouter_picker_sort_key(model_id: str) -> tuple[str, int, str]:
+    if "/" in model_id:
+        vendor, bare = model_id.split("/", 1)
+    else:
+        vendor, bare = "", model_id
+    return (vendor, 1 if bare.endswith(":free") else 0, bare)
 
 
 def _codex_curated_models() -> list[str]:
@@ -619,14 +653,28 @@ def fetch_openrouter_models(
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
+    """Return the canonical OpenRouter picker catalog, refreshed from the live API when possible."""
     global _openrouter_catalog_cache
 
     if _openrouter_catalog_cache is not None and not force_refresh:
         return list(_openrouter_catalog_cache)
 
-    fallback = list(OPENROUTER_MODELS)
-    preferred_ids = [mid for mid, _ in fallback]
+    models_dev_fallback: list[tuple[str, str]] = []
+    try:
+        from agent.models_dev import list_agentic_models
+
+        models_dev_ids = sorted(
+            {
+                mid for mid in list_agentic_models("openrouter")
+                if isinstance(mid, str) and mid.strip()
+            },
+            key=_openrouter_picker_sort_key,
+        )
+        models_dev_fallback = [(mid, "") for mid in models_dev_ids]
+    except Exception:
+        models_dev_fallback = []
+
+    fallback = models_dev_fallback or list(OPENROUTER_MODELS)
 
     try:
         req = urllib.request.Request(
@@ -642,35 +690,65 @@ def fetch_openrouter_models(
     if not isinstance(live_items, list):
         return list(_openrouter_catalog_cache or fallback)
 
-    live_by_id: dict[str, dict[str, Any]] = {}
+    curated: list[tuple[str, str]] = []
     for item in live_items:
         if not isinstance(item, dict):
             continue
         mid = str(item.get("id") or "").strip()
         if not mid:
             continue
-        live_by_id[mid] = item
-
-    curated: list[tuple[str, str]] = []
-    for preferred_id in preferred_ids:
-        live_item = live_by_id.get(preferred_id)
-        if live_item is None:
+        supported_parameters = {
+            str(param).strip().lower()
+            for param in (item.get("supported_parameters") or [])
+            if str(param).strip()
+        }
+        if "tools" not in supported_parameters and "tool_choice" not in supported_parameters:
             continue
-        desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
-        curated.append((preferred_id, desc))
+        architecture = item.get("architecture")
+        if not isinstance(architecture, dict):
+            continue
+        input_modalities = {
+            str(modality).strip().lower()
+            for modality in (architecture.get("input_modalities") or [])
+            if str(modality).strip()
+        }
+        output_modalities = {
+            str(modality).strip().lower()
+            for modality in (architecture.get("output_modalities") or [])
+            if str(modality).strip()
+        }
+        if "text" not in input_modalities or "text" not in output_modalities:
+            continue
+        if mid in {"openrouter/free", "openrouter/auto"}:
+            continue
+        desc = "free" if _openrouter_model_is_free(item.get("pricing")) else ""
+        curated.append((mid, desc))
 
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 
-    first_id, _ = curated[0]
-    curated[0] = (first_id, "recommended")
+    curated.sort(key=lambda item: _openrouter_picker_sort_key(item[0]))
     _openrouter_catalog_cache = curated
     return list(curated)
 
 
 def model_ids(*, force_refresh: bool = False) -> list[str]:
-    """Return just the OpenRouter model-id strings."""
+    """Return just the OpenRouter picker model-id strings."""
     return [mid for mid, _ in fetch_openrouter_models(force_refresh=force_refresh)]
+
+
+def openrouter_picker_groups(*, force_refresh: bool = False) -> list[tuple[str, tuple[str, ...]]]:
+    """Return ``[(vendor_slug, (model_ids...)), ...]`` for OpenRouter pickers."""
+    grouped: dict[str, list[str]] = {}
+    for model_id in model_ids(force_refresh=force_refresh):
+        if "/" not in model_id:
+            continue
+        vendor, _bare = model_id.split("/", 1)
+        grouped.setdefault(vendor, []).append(model_id)
+    return [
+        (vendor, tuple(models))
+        for vendor, models in sorted(grouped.items(), key=lambda item: item[0])
+    ]
 
 
 

--- a/tests/cli/test_cli_model_picker.py
+++ b/tests/cli/test_cli_model_picker.py
@@ -1,0 +1,81 @@
+"""Tests for the shared /model picker entry schema in the CLI."""
+
+from unittest.mock import patch
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "anthropic/claude-sonnet-4.6"
+    cli_obj.provider = "openrouter"
+    cli_obj.base_url = "https://openrouter.ai/api/v1"
+    cli_obj.api_key = "sk-test"
+    cli_obj.api_mode = "chat_completions"
+    cli_obj.requested_provider = "openrouter"
+    cli_obj._explicit_api_key = ""
+    cli_obj._explicit_base_url = ""
+    cli_obj._attached_images = []
+    return cli_obj
+
+
+def test_handle_model_switch_opens_picker_with_shared_entries(monkeypatch):
+    cli_obj = _make_cli()
+    opened = {}
+
+    monkeypatch.setattr("cli._cprint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda cfg: cfg.get("custom_providers"))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_picker_entries",
+        lambda **_kwargs: [
+            {
+                "id": "openrouter:anthropic",
+                "slug": "openrouter:anthropic",
+                "switch_provider": "openrouter",
+                "name": "OpenRouter / Anthropic",
+                "models": ["anthropic/claude-sonnet-4.6"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+    )
+    cli_obj._open_model_picker = lambda providers, current_model, current_provider, user_provs=None, custom_provs=None: opened.update({
+        "providers": providers,
+        "current_model": current_model,
+        "current_provider": current_provider,
+    })
+
+    cli_obj._handle_model_switch("/model")
+
+    assert opened["providers"][0]["slug"] == "openrouter:anthropic"
+    assert opened["providers"][0]["switch_provider"] == "openrouter"
+    assert opened["current_model"] == "anthropic/claude-sonnet-4.6"
+    assert opened["current_provider"] == "OpenRouter"
+
+
+def test_model_picker_selection_uses_switch_provider(monkeypatch):
+    cli_obj = _make_cli()
+    captured = {}
+
+    cli_obj._model_picker_state = {
+        "stage": "model",
+        "selected": 0,
+        "provider_data": {
+            "id": "openrouter:anthropic",
+            "slug": "openrouter:anthropic",
+            "switch_provider": "openrouter",
+            "name": "OpenRouter / Anthropic",
+        },
+        "model_list": ["anthropic/claude-sonnet-4.6"],
+        "user_provs": None,
+        "custom_provs": None,
+    }
+    cli_obj._close_model_picker = lambda: None
+    cli_obj._apply_model_switch_result = lambda result, persist_global: captured.setdefault("applied", (result, persist_global))
+
+    with patch("hermes_cli.model_switch.switch_model") as mock_switch:
+        mock_switch.return_value = object()
+        cli_obj._handle_model_picker_selection()
+
+    assert mock_switch.call_args.kwargs["explicit_provider"] == "openrouter"

--- a/tests/gateway/test_model_picker_integration.py
+++ b/tests/gateway/test_model_picker_integration.py
@@ -1,0 +1,152 @@
+"""Tests for gateway /model interactive picker integration."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakePickerAdapter:
+    def __init__(self):
+        self._send_model_picker = AsyncMock(side_effect=self._send)
+        self.calls = []
+        self.on_model_selected = None
+
+    async def send_model_picker(self, **kwargs):
+        return await self._send_model_picker(**kwargs)
+
+    async def _send(self, **kwargs):
+        self.calls.append(kwargs)
+        self.on_model_selected = kwargs["on_model_selected"]
+        return SimpleNamespace(success=True)
+
+
+def _make_runner(platform: Platform):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {platform: _FakePickerAdapter()}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._evict_cached_agent = lambda _key: None
+    return runner
+
+
+def _make_event(platform: Platform, text: str = "/model"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=platform, chat_id="12345", chat_type="dm"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", [Platform.TELEGRAM, Platform.DISCORD])
+async def test_handle_model_command_uses_shared_picker_entries(tmp_path, monkeypatch, platform):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"model": {"default": "gpt-5.4", "provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}}
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_picker_entries",
+        lambda **_kwargs: [
+            {
+                "id": "openrouter:anthropic",
+                "slug": "openrouter:anthropic",
+                "switch_provider": "openrouter",
+                "name": "OpenRouter / Anthropic",
+                "models": ["anthropic/claude-sonnet-4.6"],
+                "total_models": 1,
+                "is_current": False,
+            }
+        ],
+    )
+
+    runner = _make_runner(platform)
+    adapter = runner.adapters[platform]
+
+    result = await runner._handle_model_command(_make_event(platform))
+
+    assert result is None
+    adapter._send_model_picker.assert_awaited_once()
+    assert adapter.calls[0]["providers"][0]["slug"] == "openrouter:anthropic"
+    assert adapter.calls[0]["providers"][0]["switch_provider"] == "openrouter"
+    assert adapter.calls[0]["current_model"] == "gpt-5.4"
+    assert adapter.calls[0]["current_provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_model_picker_callback_uses_switch_provider(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"model": {"default": "gpt-5.4", "provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}}
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_picker_entries",
+        lambda **_kwargs: [
+            {
+                "id": "openrouter:anthropic",
+                "slug": "openrouter:anthropic",
+                "switch_provider": "openrouter",
+                "name": "OpenRouter / Anthropic",
+                "models": ["anthropic/claude-sonnet-4.6"],
+                "total_models": 1,
+                "is_current": False,
+            }
+        ],
+    )
+
+    captured = {}
+
+    def _fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            success=True,
+            new_model=kwargs["raw_input"],
+            target_provider=kwargs["explicit_provider"],
+            provider_label="OpenRouter",
+            api_key="picker-key",
+            base_url="",
+            api_mode="chat_completions",
+            model_info=None,
+            warning_message=None,
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch_model)
+
+    runner = _make_runner(Platform.TELEGRAM)
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._handle_model_command(_make_event(Platform.TELEGRAM))
+    confirmation = await adapter.on_model_selected(
+        "12345", "anthropic/claude-sonnet-4.6", "openrouter:anthropic"
+    )
+
+    assert captured["raw_input"] == "anthropic/claude-sonnet-4.6"
+    assert captured["explicit_provider"] == "openrouter"
+    assert captured["current_model"] == "gpt-5.4"
+    assert captured["current_provider"] == "openai-codex"
+    assert "Model switched to `anthropic/claude-sonnet-4.6`" in confirmation

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
+    openrouter_picker_groups,
     filter_nous_free_models, _NOUS_ALLOWED_FREE_MODELS,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
@@ -11,7 +12,7 @@ from hermes_cli.models import (
 import hermes_cli.models as _models_mod
 
 LIVE_OPENROUTER_MODELS = [
-    ("anthropic/claude-opus-4.6", "recommended"),
+    ("anthropic/claude-opus-4.6", ""),
     ("qwen/qwen3.6-plus", ""),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
 ]
@@ -69,24 +70,51 @@ class TestFetchOpenRouterModels:
                 return False
 
             def read(self):
-                return b'{"data":[{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"}},{"id":"qwen/qwen3.6-plus","pricing":{"prompt":"0.000000325","completion":"0.00000195"}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"}}]}'
+                return b'{"data":[{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},"supported_parameters":["tools","tool_choice"],"architecture":{"input_modalities":["text","image"],"output_modalities":["text"]}},{"id":"qwen/qwen3.6-plus","pricing":{"prompt":"0.000000325","completion":"0.00000195"},"supported_parameters":["tools","tool_choice"],"architecture":{"input_modalities":["text"],"output_modalities":["text"]}},{"id":"nvidia/nemotron-3-super-120b-a12b:free","pricing":{"prompt":"0","completion":"0"},"supported_parameters":["tools","tool_choice"],"architecture":{"input_modalities":["text"],"output_modalities":["text"]}}]}'
 
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
         with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == [
-            ("anthropic/claude-opus-4.6", "recommended"),
-            ("qwen/qwen3.6-plus", ""),
+            ("anthropic/claude-opus-4.6", ""),
             ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
+            ("qwen/qwen3.6-plus", ""),
         ]
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):
         monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
+        with patch("agent.models_dev.list_agentic_models", side_effect=RuntimeError("no models.dev")), \
+             patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
             models = fetch_openrouter_models(force_refresh=True)
 
         assert models == OPENROUTER_MODELS
+
+    def test_falls_back_to_models_dev_when_live_fetch_fails(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch("agent.models_dev.list_agentic_models", return_value=["openai/gpt-5.4", "anthropic/claude-opus-4.6"]), \
+             patch("hermes_cli.models.urllib.request.urlopen", side_effect=OSError("boom")):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert models == [
+            ("anthropic/claude-opus-4.6", ""),
+            ("openai/gpt-5.4", ""),
+        ]
+
+
+class TestOpenRouterPickerGroups:
+    def test_groups_models_by_vendor(self):
+        with patch("hermes_cli.models.model_ids", return_value=[
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.4",
+        ]):
+            groups = openrouter_picker_groups()
+
+        assert groups == [
+            ("anthropic", ("anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6")),
+            ("openai", ("openai/gpt-5.4",)),
+        ]
 
 
 class TestFindOpenrouterSlug:


### PR DESCRIPTION
## Summary

This PR defines one shared picker-entry schema for Hermes interactive model pickers and uses it across:

- CLI `/model`
- Telegram `/model`
- Discord `/model`

The practical user-facing change is that OpenRouter entries are grouped by vendor/provider instead of appearing as one giant flat picker.

## What changed

- added a shared interactive picker-entry builder in `hermes_cli/model_switch.py`
- updated the CLI `/model` modal to consume that picker-entry schema
- updated the gateway `/model` picker flow to consume the same schema
- grouped OpenRouter picker entries by vendor/provider in `hermes_cli/models.py`
- kept model switching canonical by mapping grouped OpenRouter entries back to `provider=openrouter`

## Why

OpenRouter now exposes too many models for a flat interactive picker to stay usable.

This keeps the change minimal on `main` by reusing the existing provider -> model picker contract in CLI and gateway, instead of introducing a new picker protocol.

## Scope

This PR is intentionally limited to interactive picker data flow and OpenRouter grouping.

Not included:
- unrelated dependency or infra changes
- broad selector architecture refactors
- new outbound POST/PUT behavior

## Testing

Ran:

- `/Users/gguthrie/Desktop/Hermes-Agent/venv/bin/python -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_custom_provider_model_switch.py tests/cli/test_cli_model_picker.py tests/gateway/test_model_picker_integration.py tests/gateway/test_telegram_approval_buttons.py -q`

Result:
- `140 passed`
