### PR TITLE
fix: handle oversized Slack message edits

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -100,6 +100,13 @@ class SlackAdapter(BasePlatformAdapter):
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
         self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
+        # Track the parent thread root for editable bot messages so later edits
+        # can keep any overflow chunks in the correct Slack thread.
+        self._edit_thread_roots: Dict[str, str] = {}
+        # Track overflow replies created when editing long messages so future
+        # edits can update/delete prior overflow chunks instead of appending
+        # stale duplicates.
+        self._edit_overflow_replies: Dict[str, List[str]] = {}
         # Track threads where the bot has been @mentioned — once mentioned,
         # respond to ALL subsequent messages in that thread automatically.
         self._mentioned_threads: set = set()
@@ -292,14 +299,9 @@ class SlackAdapter(BasePlatformAdapter):
             # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
             if sent_ts:
-                self._bot_message_ts.add(sent_ts)
-                # Also register the thread root so replies-to-my-replies work
+                self._track_bot_message_ts(sent_ts, thread_ts)
                 if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
-                if len(self._bot_message_ts) > self._BOT_TS_MAX:
-                    excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-                    for old_ts in list(self._bot_message_ts)[:excess]:
-                        self._bot_message_ts.discard(old_ts)
+                    self._remember_edit_thread_root(sent_ts, thread_ts)
 
             return SendResult(
                 success=True,
@@ -322,11 +324,53 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            client = self._get_client(chat_id)
+            thread_root_ts = self._edit_thread_roots.get(message_id, message_id)
+            prior_reply_ts = list(self._edit_overflow_replies.get(message_id, []))
+            current_reply_ts: List[str] = []
+
+            await client.chat_update(
                 channel=chat_id,
                 ts=message_id,
-                text=formatted,
+                text=chunks[0],
             )
+            self._track_bot_message_ts(message_id)
+
+            shared_count = min(len(prior_reply_ts), len(chunks) - 1)
+
+            for index in range(shared_count):
+                reply_ts = prior_reply_ts[index]
+                await client.chat_update(
+                    channel=chat_id,
+                    ts=reply_ts,
+                    text=chunks[index + 1],
+                )
+                current_reply_ts.append(reply_ts)
+                self._track_bot_message_ts(reply_ts, message_id)
+
+            for chunk in chunks[1 + shared_count:]:
+                result = await client.chat_postMessage(
+                    channel=chat_id,
+                    text=chunk,
+                    mrkdwn=True,
+                    thread_ts=thread_root_ts,
+                )
+                sent_ts = result.get("ts") if result else None
+                if sent_ts:
+                    current_reply_ts.append(sent_ts)
+                    self._track_bot_message_ts(sent_ts, thread_root_ts)
+
+            for reply_ts in prior_reply_ts[shared_count:]:
+                await client.chat_delete(channel=chat_id, ts=reply_ts)
+                self._bot_message_ts.discard(reply_ts)
+
+            if current_reply_ts:
+                self._edit_overflow_replies[message_id] = current_reply_ts
+                self._prune_edit_tracking_maps()
+            else:
+                self._edit_overflow_replies.pop(message_id, None)
+
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -337,6 +381,43 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
             return SendResult(success=False, error=str(e))
+
+    def _track_bot_message_ts(
+        self,
+        sent_ts: Optional[str],
+        thread_ts: Optional[str] = None,
+    ) -> None:
+        """Track bot-authored message timestamps with bounded growth."""
+        if not sent_ts:
+            return
+
+        self._bot_message_ts.add(sent_ts)
+        if thread_ts:
+            self._bot_message_ts.add(thread_ts)
+        if len(self._bot_message_ts) > self._BOT_TS_MAX:
+            excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
+            for old_ts in list(self._bot_message_ts)[:excess]:
+                self._bot_message_ts.discard(old_ts)
+
+    def _remember_edit_thread_root(self, message_ts: str, thread_root_ts: str) -> None:
+        """Remember the root thread_ts for an editable Slack message."""
+        self._edit_thread_roots[message_ts] = thread_root_ts
+        self._prune_edit_tracking_maps()
+
+    def _prune_edit_tracking_maps(self) -> None:
+        """Keep edit-tracking caches bounded on long-lived gateway processes."""
+        max_entries = self._BOT_TS_MAX
+        if len(self._edit_thread_roots) > max_entries:
+            excess = len(self._edit_thread_roots) - max_entries // 2
+            for old_ts in list(self._edit_thread_roots)[:excess]:
+                self._edit_thread_roots.pop(old_ts, None)
+                self._edit_overflow_replies.pop(old_ts, None)
+
+        if len(self._edit_overflow_replies) > max_entries:
+            excess = len(self._edit_overflow_replies) - max_entries // 2
+            for old_ts in list(self._edit_overflow_replies)[:excess]:
+                self._edit_overflow_replies.pop(old_ts, None)
+                self._edit_thread_roots.pop(old_ts, None)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Show a typing/status indicator using assistant.threads.setStatus.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -967,6 +967,157 @@ class TestEditMessageStreamingPipeline:
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
 
     @pytest.mark.asyncio
+    async def test_edit_message_splits_overflow_into_thread_replies(self, adapter):
+        """Long edits should update the root and post overflow chunks in a thread."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "ts1.reply"})
+        adapter._app.client.chat_delete = AsyncMock(return_value={"ok": True})
+
+        raw_content = "\n".join(
+            f"**Line {i:04d}** " + ("x" * 120)
+            for i in range(1200)
+        )
+        formatted = adapter.format_message(raw_content)
+        expected_chunks = adapter.truncate_message(
+            formatted, adapter.MAX_MESSAGE_LENGTH
+        )
+        assert len(expected_chunks) > 1
+
+        result = await adapter.edit_message("C123", "ts1", raw_content)
+
+        assert result.success is True
+        adapter._app.client.chat_update.assert_called_once_with(
+            channel="C123",
+            ts="ts1",
+            text=expected_chunks[0],
+        )
+        assert adapter._app.client.chat_postMessage.await_count == len(expected_chunks) - 1
+        for index, call in enumerate(adapter._app.client.chat_postMessage.await_args_list, start=1):
+            assert call.kwargs == {
+                "channel": "C123",
+                "text": expected_chunks[index],
+                "mrkdwn": True,
+                "thread_ts": "ts1",
+            }
+        adapter._app.client.chat_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_edit_message_reuses_and_deletes_prior_overflow_replies(self, adapter):
+        """Repeated edits should reconcile prior overflow replies instead of duplicating them."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=[
+                {"ok": True, "ts": "ts1.reply1"},
+                {"ok": True, "ts": "ts1.reply2"},
+            ]
+        )
+        adapter._app.client.chat_delete = AsyncMock(return_value={"ok": True})
+
+        first_content = "\n".join(
+            f"**Line {i:04d}** " + ("x" * 120)
+            for i in range(800)
+        )
+        first_chunks = adapter.truncate_message(
+            adapter.format_message(first_content), adapter.MAX_MESSAGE_LENGTH
+        )
+        assert len(first_chunks) > 2
+
+        result = await adapter.edit_message("C123", "ts1", first_content)
+
+        assert result.success is True
+        assert adapter._edit_overflow_replies["ts1"] == ["ts1.reply1", "ts1.reply2"]
+        assert adapter._app.client.chat_postMessage.await_count == 2
+
+        adapter._app.client.chat_update.reset_mock()
+        adapter._app.client.chat_delete.reset_mock()
+
+        second_content = "\n".join(
+            f"**Line {i:04d}** " + ("y" * 120)
+            for i in range(500)
+        )
+        second_chunks = adapter.truncate_message(
+            adapter.format_message(second_content), adapter.MAX_MESSAGE_LENGTH
+        )
+        assert len(second_chunks) == 2
+
+        result = await adapter.edit_message("C123", "ts1", second_content)
+
+        assert result.success is True
+        assert adapter._app.client.chat_postMessage.await_count == 2
+        assert [call.kwargs for call in adapter._app.client.chat_update.await_args_list] == [
+            {"channel": "C123", "ts": "ts1", "text": second_chunks[0]},
+            {"channel": "C123", "ts": "ts1.reply1", "text": second_chunks[1]},
+        ]
+        adapter._app.client.chat_delete.assert_awaited_once_with(
+            channel="C123",
+            ts="ts1.reply2",
+        )
+        assert adapter._edit_overflow_replies["ts1"] == ["ts1.reply1"]
+
+    @pytest.mark.asyncio
+    async def test_edit_message_tracks_root_and_overflow_with_bounded_growth(self, adapter):
+        """Long edits should track root + replies without bypassing the timestamp cap."""
+        adapter._BOT_TS_MAX = 4
+        adapter._bot_message_ts = {"old1", "old2", "old3", "old4"}
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "ts1.reply1"})
+        adapter._app.client.chat_delete = AsyncMock(return_value={"ok": True})
+
+        raw_content = "\n".join(
+            f"**Line {i:04d}** " + ("z" * 120)
+            for i in range(800)
+        )
+
+        result = await adapter.edit_message("C123", "ts1", raw_content)
+
+        assert result.success is True
+        assert len(adapter._bot_message_ts) <= adapter._BOT_TS_MAX
+        assert "ts1" in adapter._bot_message_ts
+        assert "ts1.reply1" in adapter._bot_message_ts
+
+    @pytest.mark.asyncio
+    async def test_edit_message_uses_saved_thread_root_for_overflow_replies(self, adapter):
+        """Overflow replies for edited thread messages should stay in the original thread root."""
+        adapter._edit_thread_roots["ts1.reply"] = "thread.root"
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "ts1.reply.child"})
+        adapter._app.client.chat_delete = AsyncMock(return_value={"ok": True})
+
+        raw_content = "\n".join(
+            f"**Line {i:04d}** " + ("q" * 120)
+            for i in range(800)
+        )
+
+        result = await adapter.edit_message("C123", "ts1.reply", raw_content)
+
+        assert result.success is True
+        for call in adapter._app.client.chat_postMessage.await_args_list:
+            assert call.kwargs["thread_ts"] == "thread.root"
+
+    def test_prune_edit_tracking_maps_bounds_cache(self, adapter):
+        """Edit tracking maps should be pruned to avoid unbounded growth."""
+        adapter._BOT_TS_MAX = 4
+        adapter._edit_thread_roots = {
+            "m1": "t1",
+            "m2": "t2",
+            "m3": "t3",
+            "m4": "t4",
+            "m5": "t5",
+        }
+        adapter._edit_overflow_replies = {
+            "m1": ["r1"],
+            "m2": ["r2"],
+            "m3": ["r3"],
+            "m4": ["r4"],
+            "m5": ["r5"],
+        }
+
+        adapter._prune_edit_tracking_maps()
+
+        assert len(adapter._edit_thread_roots) <= adapter._BOT_TS_MAX // 2
+        assert len(adapter._edit_overflow_replies) <= adapter._BOT_TS_MAX // 2
+
+    @pytest.mark.asyncio
     async def test_edit_message_not_connected(self, adapter):
         """edit_message returns failure when adapter is not connected."""
         adapter._app = None


### PR DESCRIPTION
## Summary
- chunk oversized Slack edits before calling `chat.update`
- reuse or delete overflow thread replies across repeated edits to avoid stale duplicates
- keep overflow replies in the correct parent thread and bound in-memory tracking caches
- add regression tests covering overflow splitting, repeated edits, thread-root handling, and cache pruning

## Test Plan
- `. .venv/bin/activate && pytest tests/gateway/test_slack.py -q -o 'addopts='`
