### PR TITLE
feat(cli): add configurable Ctrl+W boundaries

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -275,6 +275,7 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
+            "ctrlw_word_boundary": "whitespace",
 
             "skin": "default",
         },
@@ -1624,6 +1625,8 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        _ctrlw = CLI_CONFIG["display"].get("ctrlw_word_boundary", "whitespace")
+        self.ctrlw_word_boundary = self._normalize_ctrlw_word_boundary(_ctrlw)
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -4473,6 +4476,23 @@ class HermesCLI:
         else:
             _ask()
         return result[0]
+
+    @staticmethod
+    def _normalize_ctrlw_word_boundary(value: Any) -> str:
+        """Normalize Ctrl+W config to a supported mode."""
+        mode = str(value or "").strip().lower()
+        return "alphanumeric" if mode == "alphanumeric" else "whitespace"
+
+    def _ctrlw_uses_whitespace_boundary(self) -> bool:
+        """Return True when Ctrl+W should delete back to whitespace only."""
+        return self.ctrlw_word_boundary != "alphanumeric"
+
+    def _handle_ctrl_w(self, event) -> None:
+        """Dispatch Ctrl+W to prompt_toolkit's builtin kill-word implementation."""
+        from prompt_toolkit.key_binding.bindings import named_commands
+
+        binding = named_commands.get_by_name("unix-word-rubout")
+        binding.handler(event, WORD=self._ctrlw_uses_whitespace_boundary())
 
     def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
@@ -8425,6 +8445,11 @@ class HermesCLI:
         def handle_ctrl_enter(event):
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
             event.current_buffer.insert_text('\n')
+
+        @kb.add('c-w', eager=True)
+        def handle_ctrl_w(event):
+            """Ctrl+W deletes using configurable word boundaries."""
+            self._handle_ctrl_w(event)
 
         @kb.add('tab', eager=True)
         def handle_tab(event):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -496,6 +496,7 @@ DEFAULT_CONFIG = {
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
         "show_reasoning": False,
+        "ctrlw_word_boundary": "whitespace",  # whitespace | alphanumeric
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
@@ -700,7 +701,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -2165,6 +2166,20 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 
+    # ── Version 17 → 18: add explicit Ctrl+W word-boundary mode ──
+    if current_ver < 18:
+        config = read_raw_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        if "ctrlw_word_boundary" not in display:
+            display["ctrlw_word_boundary"] = "whitespace"
+            config["display"] = display
+            results["config_added"].append("display.ctrlw_word_boundary=whitespace (default)")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added display.ctrlw_word_boundary=whitespace")
+
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")
     
@@ -2935,6 +2950,7 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
+    print(f"  Ctrl+W:       {display.get('ctrlw_word_boundary', 'whitespace')}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
 
     # Terminal

--- a/tests/cli/test_cli_ctrlw_word_boundary.py
+++ b/tests/cli/test_cli_ctrlw_word_boundary.py
@@ -1,0 +1,53 @@
+"""Tests for configurable Ctrl+W word-boundary handling."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli(mode: str):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.ctrlw_word_boundary = mode
+    return cli_obj
+
+
+class TestCtrlWWordBoundaryHelpers:
+    def test_normalize_ctrlw_word_boundary_accepts_alphanumeric(self):
+        assert HermesCLI._normalize_ctrlw_word_boundary("alphanumeric") == "alphanumeric"
+
+    def test_normalize_ctrlw_word_boundary_defaults_to_whitespace(self):
+        assert HermesCLI._normalize_ctrlw_word_boundary("bogus") == "whitespace"
+        assert HermesCLI._normalize_ctrlw_word_boundary("") == "whitespace"
+        assert HermesCLI._normalize_ctrlw_word_boundary(None) == "whitespace"
+
+    def test_ctrlw_uses_whitespace_boundary_for_default_mode(self):
+        cli_obj = _make_cli("whitespace")
+        assert cli_obj._ctrlw_uses_whitespace_boundary() is True
+
+    def test_ctrlw_uses_non_whitespace_boundary_for_alphanumeric_mode(self):
+        cli_obj = _make_cli("alphanumeric")
+        assert cli_obj._ctrlw_uses_whitespace_boundary() is False
+
+    def test_handle_ctrl_w_dispatches_builtin_with_whitespace_mode(self):
+        cli_obj = _make_cli("whitespace")
+        fake_event = SimpleNamespace()
+        handler = MagicMock()
+        fake_binding = SimpleNamespace(handler=handler)
+
+        with patch("prompt_toolkit.key_binding.bindings.named_commands.get_by_name", return_value=fake_binding) as mock_get:
+            cli_obj._handle_ctrl_w(fake_event)
+
+        mock_get.assert_called_once_with("unix-word-rubout")
+        handler.assert_called_once_with(fake_event, WORD=True)
+
+    def test_handle_ctrl_w_dispatches_builtin_with_alphanumeric_mode(self):
+        cli_obj = _make_cli("alphanumeric")
+        fake_event = SimpleNamespace()
+        handler = MagicMock()
+        fake_binding = SimpleNamespace(handler=handler)
+
+        with patch("prompt_toolkit.key_binding.bindings.named_commands.get_by_name", return_value=fake_binding):
+            cli_obj._handle_ctrl_w(fake_event)
+
+        handler.assert_called_once_with(fake_event, WORD=False)

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -96,6 +96,20 @@ class TestVerboseAndToolProgress:
         assert cli.tool_progress_mode in ("off", "new", "all", "verbose")
 
 
+class TestCtrlWWordBoundary:
+    def test_default_ctrlw_word_boundary_is_whitespace(self):
+        cli = _make_cli()
+        assert cli.ctrlw_word_boundary == "whitespace"
+
+    def test_ctrlw_word_boundary_config_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"ctrlw_word_boundary": "alphanumeric"}})
+        assert cli.ctrlw_word_boundary == "alphanumeric"
+
+    def test_unknown_ctrlw_word_boundary_falls_back_to_whitespace(self):
+        cli = _make_cli(config_overrides={"display": {"ctrlw_word_boundary": "bogus"}})
+        assert cli.ctrlw_word_boundary == "whitespace"
+
+
 class TestBusyInputMode:
     def test_default_busy_input_mode_is_interrupt(self):
         cli = _make_cli()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -70,6 +70,7 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["display"]["ctrlw_word_boundary"] == "whitespace"
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -459,7 +460,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,6 +607,26 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
+
+
+class TestCtrlWWordBoundaryConfig:
+    def test_default_config_sets_ctrlw_word_boundary(self):
+        assert DEFAULT_CONFIG["display"]["ctrlw_word_boundary"] == "whitespace"
+
+    def test_migrate_to_v18_adds_ctrlw_word_boundary(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({"_config_version": 17, "display": {"tool_progress": "off"}}),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 18
+        assert raw["display"]["tool_progress"] == "off"
+        assert raw["display"]["ctrlw_word_boundary"] == "whitespace"

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 17
+        assert DEFAULT_CONFIG["_config_version"] == 18


### PR DESCRIPTION
## Summary
- add `display.ctrlw_word_boundary` with `whitespace` (default) and `alphanumeric` modes for TUI Ctrl+W behavior
- route Ctrl+W through prompt_toolkit's builtin `unix-word-rubout` implementation with configurable `WORD=True/False`
- add config migration/default coverage and direct tests for Ctrl+W dispatch behavior

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/bytedance/.pyenv/versions/3.10.12/bin/python3 -m pytest -o addopts='' tests/cli/test_cli_ctrlw_word_boundary.py tests/cli/test_cli_init.py tests/hermes_cli/test_config.py tests/tools/test_browser_camofox_state.py -q

Closes #9025