### PR TITLE
fix(model-switch): normalize OpenCode Anthropic base URLs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -713,6 +713,14 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(target_provider, base_url)
 
+    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but
+    # Anthropic Messages requests need the provider root so the Anthropic SDK
+    # appends /v1/messages exactly once. Normalize the returned base URL here so
+    # session-scoped /model overrides in the gateway don't cache the wrong /v1
+    # endpoint for MiniMax/Claude Anthropic-mode requests.
+    if api_mode == "anthropic_messages" and target_provider in {"opencode-zen", "opencode-go"}:
+        base_url = re.sub(r"/v1/?$", "", base_url)
+
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model)
 

--- a/tests/hermes_cli/test_opencode_go_model_switch_runtime.py
+++ b/tests/hermes_cli/test_opencode_go_model_switch_runtime.py
@@ -1,0 +1,43 @@
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_switch_model_normalizes_opencode_go_minimax_base_url(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "test-key",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="minimax-m2.7",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        current_api_key="",
+        explicit_provider="opencode-go",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "opencode-go"
+    assert result.new_model == "minimax-m2.7"
+    assert result.api_mode == "anthropic_messages"
+    assert result.base_url == "https://opencode.ai/zen/go"


### PR DESCRIPTION
## What does this PR do?

Fixes a runtime bug for OpenCode Anthropic-mode models selected through the shared /model switch pipeline.

OpenCode Go MiniMax models use the Anthropic Messages API, but /model was returning and caching the OpenAI-style base URL https://opencode.ai/zen/go/v1 even when the selected model required anthropic_messages. In gateway sessions, that unnormalized base_url was stored in _session_model_overrides and reused on later chat turns, causing Hermes to hit the bare /v1 endpoint instead of letting the Anthropic SDK construct /v1/messages.

This change normalizes OpenCode base URLs in hermes_cli/model_switch.py whenever the selected provider/model combination resolves to anthropic_messages, so session-scoped overrides cache the provider root (https://opencode.ai/zen/go) instead of the OpenAI-style /v1 base.

This is the right place to fix it because the shared runtime resolver already performs this normalization, but the /model switch result did not. The gateway trusts the switch result directly for session overrides, so the normalization must also happen in the model-switch pipeline.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated hermes_cli/model_switch.py to strip trailing /v1 from OpenCode base URLs when api_mode == "anthropic_messages" for:
  - opencode-go
  - opencode-zen
- Added regression test tests/hermes_cli/test_opencode_go_model_switch_runtime.py
- Verified that switching to minimax-m2.7 --provider opencode-go now returns:
  - api_mode == "anthropic_messages"
  - base_url == "https://opencode.ai/zen/go"

## How to Test

1. Reproduce the pre-fix failure by switching to:
   - /model minimax-m2.7 --provider opencode-go
2. Try sending a normal chat message in the same gateway session.
3. Before this fix, Hermes could fail with:

```
⚠️  API call failed (attempt 1/3): NotFoundError [HTTP 404]
   🔌 Provider: opencode-go  Model: minimax-m2.7
   🌐 Endpoint: https://opencode.ai/zen/go/v1
   📝 Error: HTTP 404 — Not Found | opencode
 🔌 Provider: opencode-go  Model: minimax-m2.7
   🌐 Endpoint: https://opencode.ai/zen/go/v1
   💡 This type of error won't be fixed by retrying.
```
4. With this fix, the /model pipeline normalizes the cached base URL to https://opencode.ai/zen/go, so Anthropic-mode requests can resolve to /v1/messages correctly.
5. Run the regression tests:
   - python -m pytest tests/hermes_cli/test_opencode_go_model_switch_runtime.py -q
   - python -m pytest tests/hermes_cli/test_model_provider_persistence.py -q

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ x I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

#### Before the fix:
<img width="629" height="598" alt="image" src="https://github.com/user-attachments/assets/907f6c8d-5819-40b9-a4dd-c4d111407957" />

<img width="903" height="712" alt="image" src="https://github.com/user-attachments/assets/0a4bcc77-740b-4ee0-9310-9f2e8bd20e58" />

#### After the fix:

<img width="829" height="715" alt="image" src="https://github.com/user-attachments/assets/13faa38d-d081-409f-9827-b335c02ad5c7" />



