### PR TITLE
fix: avoid lockfile rewrites during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2954,26 +2954,32 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     if not (web_dir / "package.json").exists():
         return True
     import shutil
+    lockfile_exists = (web_dir / "package-lock.json").exists()
     npm = shutil.which("npm")
     if not npm:
         if fatal:
+            install_hint = "npm ci" if lockfile_exists else "npm install"
             print("Web UI frontend not built and npm is not available.")
-            print("Install Node.js, then run:  cd web && npm install && npm run build")
+            print(f"Install Node.js, then run:  cd web && {install_hint} && npm run build")
         return not fatal
+
+    install_cmd = [npm, "ci", "--silent"] if lockfile_exists else [npm, "install", "--silent"]
+    install_hint = "npm ci" if lockfile_exists else "npm install"
+
     print("→ Building web UI...")
-    r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
+    r1 = subprocess.run(install_cmd, cwd=web_dir, capture_output=True)
     if r1.returncode != 0:
-        print(f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
+        print(f"  {'✗' if fatal else '⚠'} Web UI {install_hint} failed"
               + ("" if fatal else " (hermes web will not be available)"))
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print(f"  Run manually:  cd web && {install_hint} && npm run build")
         return False
     r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
     if r2.returncode != 0:
         print(f"  {'✗' if fatal else '⚠'} Web UI build failed"
               + ("" if fatal else " (hermes web will not be available)"))
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print(f"  Run manually:  cd web && {install_hint} && npm run build")
         return False
     print("  ✓ Web UI built")
     return True

--- a/tests/hermes_cli/test_web_build_install_mode.py
+++ b/tests/hermes_cli/test_web_build_install_mode.py
@@ -1,0 +1,77 @@
+import subprocess
+
+from hermes_cli.main import _build_web_ui
+
+
+def test_build_web_ui_uses_npm_ci_when_package_lock_exists(tmp_path, monkeypatch):
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}", encoding="utf-8")
+    (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert _build_web_ui(web_dir) is True
+    assert calls[0][0] == ["/usr/bin/npm", "ci", "--silent"]
+    assert calls[1][0] == ["/usr/bin/npm", "run", "build"]
+    assert calls[0][1]["cwd"] == web_dir
+
+
+def test_build_web_ui_uses_npm_install_without_lockfile(tmp_path, monkeypatch):
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert _build_web_ui(web_dir) is True
+    assert calls[0][0] == ["/usr/bin/npm", "install", "--silent"]
+    assert calls[1][0] == ["/usr/bin/npm", "run", "build"]
+
+
+def test_build_web_ui_fatal_message_recommends_npm_ci_with_lockfile(tmp_path, monkeypatch, capsys):
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}", encoding="utf-8")
+    (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["/usr/bin/npm", "ci"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert _build_web_ui(web_dir, fatal=True) is False
+    out = capsys.readouterr().out
+    assert "npm ci" in out
+    assert "npm install" not in out
+
+
+def test_build_web_ui_missing_npm_uses_install_hint_without_lockfile(tmp_path, monkeypatch, capsys):
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    assert _build_web_ui(web_dir, fatal=True) is False
+    out = capsys.readouterr().out
+    assert "npm install" in out
+    assert "npm ci" not in out


### PR DESCRIPTION
## Summary
- use `npm ci --silent` when `web/package-lock.json` exists during `hermes update` web builds
- keep `npm install --silent` as the fallback when no lockfile exists
- add regression tests covering install mode selection and fatal manual-build hints

## Testing
- `python -m pytest tests/hermes_cli/test_web_build_install_mode.py -q`
- `python -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_gateway_restart.py -q`
- `cd web && npm ci && npm run build`