### PR TITLE
fix(acp): validate method_id in authenticate against advertised provider (#9438)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -70,6 +70,14 @@ except Exception:
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 
 
+def _canonical_provider_id(value: str | None) -> str | None:
+    """Normalize a provider/method id so `initialize()` and `authenticate()` compare apples to apples."""
+    if not isinstance(value, str):
+        return None
+    canonical = value.strip().lower()
+    return canonical or None
+
+
 def _extract_text(
     prompt: list[
         TextContentBlock
@@ -224,7 +232,7 @@ class HermesACPAgent(acp.Agent):
         resolved_protocol_version = (
             protocol_version if isinstance(protocol_version, int) else acp.PROTOCOL_VERSION
         )
-        provider = detect_provider()
+        provider = _canonical_provider_id(detect_provider())
         auth_methods = None
         if provider:
             auth_methods = [
@@ -257,9 +265,17 @@ class HermesACPAgent(acp.Agent):
         )
 
     async def authenticate(self, method_id: str, **kwargs: Any) -> AuthenticateResponse | None:
-        if has_provider():
-            return AuthenticateResponse()
-        return None
+        provider = _canonical_provider_id(detect_provider())
+        if not provider:
+            return None
+        if not isinstance(method_id, str) or _canonical_provider_id(method_id) != provider:
+            logger.info(
+                "authenticate: rejecting method_id=%r; advertised method id is %r",
+                method_id,
+                provider,
+            )
+            return None
+        return AuthenticateResponse()
 
     # ---- Session management -------------------------------------------------
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -93,22 +93,68 @@ class TestInitialize:
 
 class TestAuthenticate:
     @pytest.mark.asyncio
-    async def test_authenticate_with_provider_configured(self, agent, monkeypatch):
+    async def test_authenticate_with_matching_method_id(self, agent, monkeypatch):
         monkeypatch.setattr(
-            "acp_adapter.server.has_provider",
-            lambda: True,
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
         )
         resp = await agent.authenticate(method_id="openrouter")
         assert isinstance(resp, AuthenticateResponse)
 
     @pytest.mark.asyncio
+    async def test_authenticate_accepts_case_insensitive_method_id(self, agent, monkeypatch):
+        """initialize() advertises the lowercased provider id; accept equivalent casings."""
+        monkeypatch.setattr(
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
+        )
+        resp = await agent.authenticate(method_id="  OpenRouter  ")
+        assert isinstance(resp, AuthenticateResponse)
+
+    @pytest.mark.asyncio
     async def test_authenticate_without_provider(self, agent, monkeypatch):
         monkeypatch.setattr(
-            "acp_adapter.server.has_provider",
-            lambda: False,
+            "acp_adapter.server.detect_provider",
+            lambda: None,
         )
         resp = await agent.authenticate(method_id="openrouter")
         assert resp is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_rejects_unknown_method_id(self, agent, monkeypatch):
+        """Regression for #9438: method_id that does not match the advertised provider is rejected."""
+        monkeypatch.setattr(
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
+        )
+        resp = await agent.authenticate(method_id="definitely-not-advertised")
+        assert resp is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_rejects_non_string_method_id(self, agent, monkeypatch):
+        """Defensive: non-string method_id must not be accepted."""
+        monkeypatch.setattr(
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
+        )
+        assert await agent.authenticate(method_id=None) is None  # type: ignore[arg-type]
+        assert await agent.authenticate(method_id="") is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_canonicalizes_provider_and_method(self, agent, monkeypatch):
+        """If detect_provider() ever returns non-canonical casing, both initialize() and
+        authenticate() should still agree on the advertised id."""
+        monkeypatch.setattr(
+            "acp_adapter.server.detect_provider",
+            lambda: "  OpenRouter  ",
+        )
+        init = await agent.initialize(protocol_version=1)
+        assert init.auth_methods is not None
+        advertised_id = init.auth_methods[0].id
+        assert advertised_id == "openrouter"
+
+        resp = await agent.authenticate(method_id=advertised_id)
+        assert isinstance(resp, AuthenticateResponse)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #9438

## What does this PR do?

`HermesACPAgent.authenticate()` ignored the `method_id` argument — it returned `AuthenticateResponse()` for **any** requested auth method as long as *some* provider was configured. Meanwhile `initialize()` advertises exactly one `AuthMethodAgent` whose `id` is the resolved provider. This PR makes `authenticate()` match `method_id` against that same advertised id, so stale/unknown method ids are rejected.

To prevent drift between the id `initialize()` publishes and the one `authenticate()` compares against, both paths now route the provider spelling through a shared `_canonical_provider_id()` helper (strip + lowercase + None-guard). Previously `authenticate()` implicitly depended on `detect_provider()` always returning canonical casing — a silent cross-module invariant flagged during review.

## Related Issue

Fixes #9438

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (defense-in-depth for ACP auth)

## Changes Made

- `acp_adapter/server.py` — add `_canonical_provider_id()` helper; `initialize()` canonicalizes the advertised id; `authenticate()` returns `None` when no provider is configured, `method_id` is not a non-empty string, or the canonicalized `method_id` does not equal the advertised provider (logged at INFO).
- `tests/acp/test_server.py` — replace the `has_provider` monkeypatch with `detect_provider` (which `authenticate()` now uses directly) and add regressions: unknown method_id rejection, case-insensitive match, non-string method_id, and initialize/authenticate canonicalization agreement.

Diff: 2 files, +71/-9.

## How to Test

Reproduction from the issue:

\`\`\`python
import asyncio
from unittest.mock import MagicMock
from acp_adapter.server import HermesACPAgent
from acp_adapter.session import SessionManager
import acp_adapter.server as server_mod

async def main():
    agent = HermesACPAgent(session_manager=SessionManager(agent_factory=lambda: MagicMock()))
    server_mod.detect_provider = lambda: 'openrouter'
    print('matching:', (await agent.authenticate(method_id='openrouter')) is not None)
    print('bogus:   ', (await agent.authenticate(method_id='definitely-not-advertised')) is not None)

asyncio.run(main())
\`\`\`

Before this PR:
\`\`\`
matching: True
bogus:    True
\`\`\`

After:
\`\`\`
matching: True
bogus:    False
\`\`\`

Run the ACP server test module:

\`\`\`bash
pytest tests/acp/test_server.py -v
\`\`\`

57 tests pass (52 existing + 5 updated/new around `authenticate`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] Searched for existing PRs — none touching `acp_adapter/server.py` auth
- [x] PR contains **only** changes related to this security fix
- [x] Ran `pytest tests/acp/test_server.py -v` — all pass
- [x] Added regression tests for the reported bug + related edge cases
- [x] Tested on Ubuntu 24.04 (Python 3.11)

### Documentation & Housekeeping

- [x] No doc changes needed — N/A
- [x] No config keys changed — N/A
- [x] No architecture/workflow changes — N/A
- [x] Pure-Python string/type comparison, no cross-platform concerns — N/A
- [x] No tool behavior changes — N/A

## Follow-up (not in this PR)

A follow-up could cache the advertised `method_id` on the connection/session at `initialize()` time instead of recomputing `detect_provider()` at `authenticate()` time. That would also close a latent TOCTOU between initialize and authenticate (provider credentials changing mid-handshake). Happy to open a separate PR if maintainers want that — keeping this one minimal and focused on the reported issue.