### PR TITLE
fix: camofox JS eval endpoint and missing userId

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1748,7 +1748,7 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
     try:
         tab_info = _ensure_tab(task_id or "default")
         tab_id = tab_info.get("tab_id") or tab_info.get("id")
-        resp = _post(f"/tabs/{tab_id}/eval", body={"expression": expression})
+        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": tab_info["user_id"]})
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp


### PR DESCRIPTION
## Problem
Camofox JavaScript evaluation via `browser_console(expression=...)` was broken due to two bugs in `_camofox_eval()`.

## Changes
- Fixed endpoint path: `/tabs/{tabId}/eval` → `/tabs/{tabId}/evaluate` (correct Camofox API)
- Added required `userId` field to request body

## Verification
Tested against live Camofox server (`camofox-browser:135.0.1`) — JS eval now returns results correctly.