### PR TITLE
fix(display): handle small max_len values in build_tool_preview()

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -270,7 +270,10 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     if not preview:
         return None
     if max_len > 0 and len(preview) > max_len:
-        preview = preview[:max_len - 3] + "..."
+        if max_len < 4:
+            preview = preview[:max_len]
+        else:
+            preview = preview[:max_len - 3] + "..."
     return preview
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -57,7 +57,7 @@ class TestBuildToolPreview:
         long_cmd = "a" * 100
         result = build_tool_preview("terminal", {"command": long_cmd}, max_len=40)
         assert result is not None
-        assert len(result) <= 43  # max_len + "..."
+        assert len(result) <= 40
 
     def test_process_tool_with_none_args(self):
         """Process tool special case should also handle None args."""
@@ -87,6 +87,48 @@ class TestBuildToolPreview:
         result = build_tool_preview("session_search", {"query": "find something"})
         assert result is not None
         assert "find something" in result
+
+    # -- max_len edge cases (small values) ----------------------------------
+
+    def test_max_len_zero_means_unlimited(self):
+        """max_len=0 should not truncate at all."""
+        long_cmd = "a" * 200
+        result = build_tool_preview("terminal", {"command": long_cmd}, max_len=0)
+        assert result == long_cmd
+
+    def test_max_len_1(self):
+        result = build_tool_preview("terminal", {"command": "hello"}, max_len=1)
+        assert result is not None
+        assert len(result) <= 1
+
+    def test_max_len_2(self):
+        result = build_tool_preview("terminal", {"command": "hello"}, max_len=2)
+        assert result is not None
+        assert len(result) <= 2
+
+    def test_max_len_3(self):
+        result = build_tool_preview("terminal", {"command": "hello"}, max_len=3)
+        assert result is not None
+        assert len(result) <= 3
+
+    def test_max_len_4_uses_ellipsis(self):
+        """max_len=4 is the first value where ellipsis fits (1 char + '...')."""
+        result = build_tool_preview("terminal", {"command": "hello world"}, max_len=4)
+        assert result is not None
+        assert len(result) <= 4
+        assert result.endswith("...")
+
+    def test_max_len_normal_truncation(self):
+        """Standard truncation should use ellipsis and respect max_len."""
+        result = build_tool_preview("terminal", {"command": "a" * 50}, max_len=20)
+        assert result is not None
+        assert len(result) <= 20
+        assert result.endswith("...")
+
+    def test_max_len_no_truncation_when_short(self):
+        """When preview fits within max_len, no truncation should occur."""
+        result = build_tool_preview("terminal", {"command": "hi"}, max_len=10)
+        assert result == "hi"
 
     def test_false_like_args_zero(self):
         """Non-dict falsy values should return None, not crash."""


### PR DESCRIPTION
## Problem

`build_tool_preview()` in `agent/display.py` breaks its `max_len` contract when `max_len < 4`. The truncation logic:

```python
preview[:max_len - 3] + "..."
```

produces a negative slice index for `max_len` values of 1, 2, or 3, resulting in output that **exceeds** the specified `max_len`.

For example, with `max_len=1` and `preview="hello"`:
- `preview[1-3]` → `preview[-2]` → `"lo"` + `"..."` → `"lo..."` (length 5, violates max_len=1)

## Fix

When `max_len < 4`, hard-truncate to `max_len` without ellipsis, since there is no room for even one character plus `"..."`. For `max_len >= 4`, the existing ellipsis logic works correctly.

Also fixes an incorrect existing test assertion that allowed `len(result) <= 43` instead of `<= 40` for `max_len=40`.

## Tests

Added 7 new test cases covering:
- `max_len=0` (unlimited — no truncation)
- `max_len=1, 2, 3` (small values — hard truncate, no ellipsis)
- `max_len=4` (first value where ellipsis fits)
- Normal truncation with ellipsis
- No truncation when preview fits within max_len

All 31 display tests pass. Full test suite shows no regressions.

Fixes #9439