### PR TITLE
feat(feishu): add FEISHU_GROUP_MENTION_REQUIRED to allow group responses without @mention

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -258,6 +258,7 @@ class FeishuAdapterSettings:
     encrypt_key: str
     verification_token: str
     group_policy: str
+    group_mention_required: bool
     allowed_group_users: frozenset[str]
     bot_open_id: str
     bot_user_id: str
@@ -1095,6 +1096,7 @@ class FeishuAdapter(BasePlatformAdapter):
             encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
             verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            group_mention_required=os.getenv("FEISHU_GROUP_MENTION_REQUIRED", "true").strip().lower() not in ("false", "0", "no", "off"),
             allowed_group_users=frozenset(
                 item.strip()
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
@@ -1155,6 +1157,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
+        self._group_mention_required = settings.group_mention_required
         self._bot_open_id = settings.bot_open_id
         self._bot_user_id = settings.bot_user_id
         self._bot_name = settings.bot_name
@@ -3013,9 +3016,16 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Require an explicit @mention before group messages enter the agent.
+
+        When FEISHU_GROUP_MENTION_REQUIRED=false, every group message that
+        passes the group-policy gate is accepted without an @mention.
+        """
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # Allow bypassing the @mention requirement via env var.
+        if not self._group_mention_required:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:


### PR DESCRIPTION
## Summary

Add a new environment variable `FEISHU_GROUP_MENTION_REQUIRED` that controls whether an explicit @mention is needed before the bot responds to group messages on Feishu/Lark.

## Motivation

Currently, the Feishu adapter **always** requires an `@mention` for group messages — there is no way to make the bot respond to all messages in a group chat. For small team groups where the bot should act as an always-on assistant, this is a friction point.

## Changes

- Added `FEISHU_GROUP_MENTION_REQUIRED` env var (default: `true`)
- When set to `false`, the bot responds to **all** messages in groups where `FEISHU_GROUP_POLICY` allows access, without requiring an @mention
- Existing behavior (mention required) is fully preserved by default
- Zero breaking changes

## Usage

```env
FEISHU_GROUP_POLICY=open
FEISHU_GROUP_MENTION_REQUIRED=false
```

## Files Changed

- `gateway/platforms/feishu.py` — 4 minimal touch points:
  1. `FeishuAdapterSettings` dataclass: added `group_mention_required: bool`
  2. Settings construction: reads `FEISHU_GROUP_MENTION_REQUIRED` env var
  3. `_apply_settings()`: stores the setting on the adapter instance
  4. `_should_accept_group_message()`: early-return `True` when mention not required

## Testing

Manually tested on a live Feishu workspace:
- ✅ `FEISHU_GROUP_MENTION_REQUIRED=false` → bot responds to all group messages
- ✅ `FEISHU_GROUP_MENTION_REQUIRED=true` (default) → original behavior preserved, @mention required
- ✅ DM behavior completely unaffected
- ✅ `FEISHU_GROUP_POLICY` gating still respected in both modes