### PR TITLE
feat(cli): render final replies with markdown emphasis

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -341,8 +341,10 @@ PLATFORM_HINTS = {
         "destination — put the primary content directly in your response."
     ),
     "cli": (
-        "You are a CLI AI Agent. Try not to use markdown but simple text "
-        "renderable inside a terminal."
+        "You are a CLI AI Agent. Prefer concise, terminal-friendly responses. "
+        "Use compact Markdown when it improves scanability, especially for short "
+        "headings, lists, quotes, and fenced code blocks. Avoid heavy formatting "
+        "or unnecessary verbosity."
     ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "

--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import re
 import shutil
 import sys
 import json
@@ -568,6 +569,8 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.markup import escape as _escape
 from rich.panel import Panel
+from rich.segment import Segment
+from rich.style import Style
 from rich.text import Text as _RichText
 
 import fire
@@ -1062,17 +1065,106 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+_NUMERIC_HIGHLIGHT_RE = re.compile(
+    r"""
+    (?P<date>
+        (?<![\w./-])
+        \d{4}[-/]\d{1,2}[-/]\d{1,2}
+        (?![\w/-])
+    )
+    |
+    (?P<currency>
+        (?<![\w./-])
+        (?:[$€£¥￥])\d[\d,]*(?:\.\d+)?
+        (?!\.\d)(?![\w/-])
+    )
+    |
+    (?P<percent>
+        (?<![\w./-])
+        \d[\d,]*(?:\.\d+)?%
+        (?!\.\d)(?![\w/-])
+    )
+    |
+    (?P<cjk_quantity>
+        (?<![\w./-])
+        \d[\d,]*(?:\.\d+)?(?:万元|亿元|美元|人民币|万|亿|元|年|月|日|号|天|小时|分钟|秒|个|次|条|名|位|项|页|章|节|集|票|W|w)
+        (?!\.\d)(?![\w/-])
+    )
+    |
+    (?P<number>
+        (?<![\w./-])
+        (?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?
+        (?!\.\d)(?![\w/-])
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _numeric_highlight_style() -> Style:
+    """Return the CLI style used for high-value numeric tokens."""
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+
+        color = get_active_skin().get_color("ui_label", "#4dd0e1")
+    except Exception:
+        color = "#4dd0e1"
+    return Style.parse(f"bold {color}")
+
+
+def _highlight_numeric_segment(segment: Segment, numeric_style: Style):
+    """Apply conservative numeric emphasis to plain markdown text segments."""
+    if segment.control is not None or not segment.text or not any(ch.isdigit() for ch in segment.text):
+        yield segment
+        return
+
+    style = segment.style or Style.null()
+    if style != Style.null():
+        yield segment
+        return
+
+    last = 0
+    matched = False
+    for match in _NUMERIC_HIGHLIGHT_RE.finditer(segment.text):
+        start, end = match.span()
+        if start > last:
+            yield Segment(segment.text[last:start], segment.style)
+        yield Segment(segment.text[start:end], numeric_style)
+        last = end
+        matched = True
+
+    if not matched:
+        yield segment
+        return
+
+    if last < len(segment.text):
+        yield Segment(segment.text[last:], segment.style)
+
+
+class _AssistantMarkdown(Markdown):
+    """Markdown renderable with conservative emphasis for important numbers."""
+
+    def __rich_console__(self, console, options):
+        numeric_style = _numeric_highlight_style()
+        for part in super().__rich_console__(console, options):
+            if isinstance(part, Segment):
+                yield from _highlight_numeric_segment(part, numeric_style)
+            else:
+                yield part
+
+
 def _assistant_response_renderable(text: str):
     """Render final assistant replies as markdown when safe for the CLI.
 
     This upgrades the final assistant panel from plain ANSI text to semantic
     markdown rendering for headings, strong text, lists, blockquotes, and
-    fenced code blocks while keeping ANSI passthrough for escape-coded output.
+    fenced code blocks, then adds conservative emphasis for high-value numbers
+    in plain prose while keeping ANSI passthrough for escape-coded output.
     """
     text = text or ""
     if "\x1b" in text:
         return _rich_text_from_ansi(text)
-    return Markdown(
+    return _AssistantMarkdown(
         text,
         code_theme="monokai",
         inline_code_theme="monokai",

--- a/cli.py
+++ b/cli.py
@@ -1229,6 +1229,24 @@ def _cprint(text: str):
     _pt_print(_PT_ANSI(text))
 
 
+def _relative_time(ts) -> str:
+    """Format a timestamp as relative time for CLI session listings."""
+    if not ts:
+        return "?"
+    delta = time.time() - ts
+    if delta < 60:
+        return "just now"
+    if delta < 3600:
+        return f"{int(delta / 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta / 3600)}h ago"
+    if delta < 172800:
+        return "yesterday"
+    if delta < 604800:
+        return f"{int(delta / 86400)}d ago"
+    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+
 # ---------------------------------------------------------------------------
 # File-drop / local attachment detection — extracted as pure helpers for tests.
 # ---------------------------------------------------------------------------
@@ -4146,8 +4164,6 @@ class HermesCLI:
         sessions = self._list_recent_sessions(limit=limit)
         if not sessions:
             return False
-
-        from hermes_cli.main import _relative_time
 
         print()
         if reason == "history":

--- a/cli.py
+++ b/cli.py
@@ -565,6 +565,7 @@ except Exception:
 
 from rich import box as rich_box
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.text import Text as _RichText
@@ -1059,6 +1060,25 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     ``[not markup]`` while still interpreting real ANSI color codes.
     """
     return _RichText.from_ansi(text or "")
+
+
+def _assistant_response_renderable(text: str):
+    """Render final assistant replies as markdown when safe for the CLI.
+
+    This upgrades the final assistant panel from plain ANSI text to semantic
+    markdown rendering for headings, strong text, lists, blockquotes, and
+    fenced code blocks while keeping ANSI passthrough for escape-coded output.
+    """
+    text = text or ""
+    if "\x1b" in text:
+        return _rich_text_from_ansi(text)
+    return Markdown(
+        text,
+        code_theme="monokai",
+        inline_code_theme="monokai",
+        hyperlinks=False,
+        style="none",
+    )
 
 
 def _cprint(text: str):
@@ -5755,7 +5775,7 @@ class HermesCLI:
 
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _assistant_response_renderable(response),
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -5880,7 +5900,7 @@ class HermesCLI:
                         _resp_color = "#4F6D4A"
 
                     ChatConsole().print(Panel(
-                        _rich_text_from_ansi(response),
+                        _assistant_response_renderable(response),
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -7873,7 +7893,7 @@ class HermesCLI:
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _assistant_response_renderable(response),
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/cli.py
+++ b/cli.py
@@ -571,6 +571,7 @@ from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.segment import Segment
 from rich.style import Style
+from rich.theme import Theme
 from rich.text import Text as _RichText
 
 import fire
@@ -1101,14 +1102,58 @@ _NUMERIC_HIGHLIGHT_RE = re.compile(
 )
 
 
-def _numeric_highlight_style() -> Style:
-    """Return the CLI style used for high-value numeric tokens."""
+def _assistant_markdown_palette() -> dict[str, str]:
+    """Return a muted Hermes-aligned palette for markdown emphasis."""
     try:
         from hermes_cli.skin_engine import get_active_skin
 
-        color = get_active_skin().get_color("ui_label", "#4dd0e1")
+        skin = get_active_skin()
+        return {
+            "heading": skin.get_color("session_label", "#DAA520"),
+            "accent": skin.get_color("response_border", "#DAA520"),
+            "muted": skin.get_color("banner_dim", "#B8860B"),
+            "text": skin.get_color("banner_text", "#FFF8DC"),
+            "code_bg": "#1F1A12",
+        }
     except Exception:
-        color = "#4dd0e1"
+        return {
+            "heading": "#DAA520",
+            "accent": "#DAA520",
+            "muted": "#B8860B",
+            "text": "#FFF8DC",
+            "code_bg": "#1F1A12",
+        }
+
+
+def _assistant_markdown_theme() -> Theme:
+    """Build a muted Hermes markdown theme instead of Rich defaults."""
+    palette = _assistant_markdown_palette()
+    return Theme(
+        {
+            "markdown.h1": f"bold {palette['accent']}",
+            "markdown.h1.border": palette["muted"],
+            "markdown.h2": f"bold underline {palette['heading']}",
+            "markdown.h3": f"bold {palette['heading']}",
+            "markdown.h4": f"bold {palette['muted']}",
+            "markdown.h5": f"underline {palette['muted']}",
+            "markdown.h6": palette["muted"],
+            "markdown.strong": f"bold {palette['heading']}",
+            "markdown.block_quote": palette["muted"],
+            "markdown.item.bullet": f"bold {palette['muted']}",
+            "markdown.item.number": f"bold {palette['muted']}",
+            "markdown.hr": palette["muted"],
+            "markdown.link": f"underline {palette['heading']}",
+            "markdown.link_url": f"underline {palette['muted']}",
+            "markdown.code": f"bold {palette['text']} on {palette['code_bg']}",
+            "markdown.code_block": f"{palette['text']} on {palette['code_bg']}",
+        },
+        inherit=True,
+    )
+
+
+def _numeric_highlight_style() -> Style:
+    """Return the CLI style used for high-value numeric tokens."""
+    color = _assistant_markdown_palette()["heading"]
     return Style.parse(f"bold {color}")
 
 
@@ -1119,7 +1164,7 @@ def _highlight_numeric_segment(segment: Segment, numeric_style: Style):
         return
 
     style = segment.style or Style.null()
-    if style != Style.null():
+    if style.bgcolor is not None:
         yield segment
         return
 
@@ -1129,7 +1174,7 @@ def _highlight_numeric_segment(segment: Segment, numeric_style: Style):
         start, end = match.span()
         if start > last:
             yield Segment(segment.text[last:start], segment.style)
-        yield Segment(segment.text[start:end], numeric_style)
+        yield Segment(segment.text[start:end], style + numeric_style)
         last = end
         matched = True
 
@@ -1146,11 +1191,12 @@ class _AssistantMarkdown(Markdown):
 
     def __rich_console__(self, console, options):
         numeric_style = _numeric_highlight_style()
-        for part in super().__rich_console__(console, options):
-            if isinstance(part, Segment):
-                yield from _highlight_numeric_segment(part, numeric_style)
-            else:
-                yield part
+        with console.use_theme(_assistant_markdown_theme()):
+            for part in super().__rich_console__(console, options):
+                if isinstance(part, Segment):
+                    yield from _highlight_numeric_segment(part, numeric_style)
+                else:
+                    yield part
 
 
 def _assistant_response_renderable(text: str):
@@ -1166,8 +1212,8 @@ def _assistant_response_renderable(text: str):
         return _rich_text_from_ansi(text)
     return _AssistantMarkdown(
         text,
-        code_theme="monokai",
-        inline_code_theme="monokai",
+        code_theme="native",
+        inline_code_theme="nord",
         hyperlinks=False,
         style="none",
     )

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -771,6 +771,16 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 
+    def test_cli_platform_hint_encourages_compact_markdown_only_for_cli(self):
+        cli_hint = PLATFORM_HINTS["cli"].lower()
+        assert "compact markdown" in cli_hint
+        assert "terminal-friendly" in cli_hint
+
+        sms_hint = PLATFORM_HINTS["sms"].lower()
+        email_hint = PLATFORM_HINTS["email"].lower()
+        assert "compact markdown" not in sms_hint
+        assert "compact markdown" not in email_hint
+
 
 # =========================================================================
 # Environment hints
@@ -1032,6 +1042,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -5,6 +5,7 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
 
@@ -253,6 +254,60 @@ class TestAssistantResponseRenderable:
             )
 
         assert isinstance(renderable, Markdown)
+
+    def test_plain_assistant_reply_highlights_important_numbers_only(self):
+        import importlib
+
+        prompt_toolkit_stubs = {
+            "prompt_toolkit": MagicMock(),
+            "prompt_toolkit.history": MagicMock(),
+            "prompt_toolkit.styles": MagicMock(),
+            "prompt_toolkit.patch_stdout": MagicMock(),
+            "prompt_toolkit.application": MagicMock(),
+            "prompt_toolkit.layout": MagicMock(),
+            "prompt_toolkit.layout.processors": MagicMock(),
+            "prompt_toolkit.filters": MagicMock(),
+            "prompt_toolkit.layout.dimension": MagicMock(),
+            "prompt_toolkit.layout.menus": MagicMock(),
+            "prompt_toolkit.widgets": MagicMock(),
+            "prompt_toolkit.key_binding": MagicMock(),
+            "prompt_toolkit.completion": MagicMock(),
+            "prompt_toolkit.formatted_text": MagicMock(),
+            "prompt_toolkit.auto_suggest": MagicMock(),
+        }
+        with patch.dict(sys.modules, prompt_toolkit_stubs):
+            import cli as _cli_mod
+
+            _cli_mod = importlib.reload(_cli_mod)
+            renderable = _cli_mod._assistant_response_renderable(
+                "Top 10 trends hit 78% on 2026-04-14 with $99 revenue and 7800万元.\n\n"
+                "`v1.2.3` stays inline code.\n\n"
+                "/path/123 and gpt-4.1 stay plain."
+            )
+
+        console = Console(force_terminal=True, color_system="truecolor", width=100)
+        segments = [segment for segment in console.render(renderable) if segment.text.strip()]
+
+        highlighted = {
+            segment.text.strip(): segment.style
+            for segment in segments
+            if segment.style is not None and getattr(segment.style.color, "triplet", None) is not None
+        }
+        assert highlighted["10"].bold is True
+        assert highlighted["78%"].color.triplet.hex == "#4dd0e1"
+        assert highlighted["2026-04-14"].color.triplet.hex == "#4dd0e1"
+        assert highlighted["$99"].color.triplet.hex == "#4dd0e1"
+        assert highlighted["7800万元"].color.triplet.hex == "#4dd0e1"
+
+        assert "/path/123" not in highlighted
+        assert "gpt-4.1" not in highlighted
+        assert any(
+            segment.text.strip() == "/path/123 and gpt-4.1 stay plain." and segment.style is None
+            for segment in segments
+        )
+        inline_code_segment = next(segment for segment in segments if segment.text.strip() == "v1.2.3")
+        assert "v1.2.3" not in highlighted
+        assert inline_code_segment.style.bgcolor is not None
 
     def test_ansi_assistant_reply_keeps_ansi_fallback(self):
         import importlib

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -225,6 +225,47 @@ class TestHistoryDisplay:
 
 
 class TestAssistantResponseRenderable:
+    def test_plain_assistant_reply_uses_hermes_markdown_theme(self):
+        import importlib
+
+        prompt_toolkit_stubs = {
+            "prompt_toolkit": MagicMock(),
+            "prompt_toolkit.history": MagicMock(),
+            "prompt_toolkit.styles": MagicMock(),
+            "prompt_toolkit.patch_stdout": MagicMock(),
+            "prompt_toolkit.application": MagicMock(),
+            "prompt_toolkit.layout": MagicMock(),
+            "prompt_toolkit.layout.processors": MagicMock(),
+            "prompt_toolkit.filters": MagicMock(),
+            "prompt_toolkit.layout.dimension": MagicMock(),
+            "prompt_toolkit.layout.menus": MagicMock(),
+            "prompt_toolkit.widgets": MagicMock(),
+            "prompt_toolkit.key_binding": MagicMock(),
+            "prompt_toolkit.completion": MagicMock(),
+            "prompt_toolkit.formatted_text": MagicMock(),
+            "prompt_toolkit.auto_suggest": MagicMock(),
+        }
+        with patch.dict(sys.modules, prompt_toolkit_stubs):
+            import cli as _cli_mod
+
+            _cli_mod = importlib.reload(_cli_mod)
+            renderable = _cli_mod._assistant_response_renderable(
+                "## Heading\n\n- item\n\n> quote\n\n**bold**"
+            )
+
+        console = Console(force_terminal=True, color_system="truecolor", width=100)
+        segments = [segment for segment in console.render(renderable) if segment.text.strip()]
+
+        heading_segment = next(segment for segment in segments if segment.text.strip() == "Heading")
+        bullet_segment = next(segment for segment in segments if segment.text.strip() == "•")
+        quote_bar = next(segment for segment in segments if segment.text.strip() == "▌")
+        strong_segment = next(segment for segment in segments if segment.text.strip() == "bold")
+
+        assert heading_segment.style.color.triplet.hex == "#daa520"
+        assert bullet_segment.style.color.triplet.hex == "#b8860b"
+        assert quote_bar.style.color.triplet.hex == "#b8860b"
+        assert strong_segment.style.color.triplet.hex == "#daa520"
+
     def test_plain_assistant_reply_uses_markdown_rendering(self):
         import importlib
 
@@ -294,10 +335,10 @@ class TestAssistantResponseRenderable:
             if segment.style is not None and getattr(segment.style.color, "triplet", None) is not None
         }
         assert highlighted["10"].bold is True
-        assert highlighted["78%"].color.triplet.hex == "#4dd0e1"
-        assert highlighted["2026-04-14"].color.triplet.hex == "#4dd0e1"
-        assert highlighted["$99"].color.triplet.hex == "#4dd0e1"
-        assert highlighted["7800万元"].color.triplet.hex == "#4dd0e1"
+        assert highlighted["78%"].color.triplet.hex == "#daa520"
+        assert highlighted["2026-04-14"].color.triplet.hex == "#daa520"
+        assert highlighted["$99"].color.triplet.hex == "#daa520"
+        assert highlighted["7800万元"].color.triplet.hex == "#daa520"
 
         assert "/path/123" not in highlighted
         assert "gpt-4.1" not in highlighted
@@ -306,7 +347,7 @@ class TestAssistantResponseRenderable:
             for segment in segments
         )
         inline_code_segment = next(segment for segment in segments if segment.text.strip() == "v1.2.3")
-        assert "v1.2.3" not in highlighted
+        assert inline_code_segment.style.color.triplet.hex != "#daa520"
         assert inline_code_segment.style.bgcolor is not None
 
     def test_ansi_assistant_reply_keeps_ansi_fallback(self):

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -5,6 +5,9 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+from rich.markdown import Markdown
+from rich.text import Text
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -218,6 +221,67 @@ class TestHistoryDisplay:
         assert "20260401_201329_d85961" in output
         assert "/resume" in output
         assert "Current preview" not in output
+
+
+class TestAssistantResponseRenderable:
+    def test_plain_assistant_reply_uses_markdown_rendering(self):
+        import importlib
+
+        prompt_toolkit_stubs = {
+            "prompt_toolkit": MagicMock(),
+            "prompt_toolkit.history": MagicMock(),
+            "prompt_toolkit.styles": MagicMock(),
+            "prompt_toolkit.patch_stdout": MagicMock(),
+            "prompt_toolkit.application": MagicMock(),
+            "prompt_toolkit.layout": MagicMock(),
+            "prompt_toolkit.layout.processors": MagicMock(),
+            "prompt_toolkit.filters": MagicMock(),
+            "prompt_toolkit.layout.dimension": MagicMock(),
+            "prompt_toolkit.layout.menus": MagicMock(),
+            "prompt_toolkit.widgets": MagicMock(),
+            "prompt_toolkit.key_binding": MagicMock(),
+            "prompt_toolkit.completion": MagicMock(),
+            "prompt_toolkit.formatted_text": MagicMock(),
+            "prompt_toolkit.auto_suggest": MagicMock(),
+        }
+        with patch.dict(sys.modules, prompt_toolkit_stubs):
+            import cli as _cli_mod
+
+            _cli_mod = importlib.reload(_cli_mod)
+            renderable = _cli_mod._assistant_response_renderable(
+                "# Title\n\n**bold**\n\n- one\n- two\n\n> quote\n\n```python\nprint('hi')\n```"
+            )
+
+        assert isinstance(renderable, Markdown)
+
+    def test_ansi_assistant_reply_keeps_ansi_fallback(self):
+        import importlib
+
+        prompt_toolkit_stubs = {
+            "prompt_toolkit": MagicMock(),
+            "prompt_toolkit.history": MagicMock(),
+            "prompt_toolkit.styles": MagicMock(),
+            "prompt_toolkit.patch_stdout": MagicMock(),
+            "prompt_toolkit.application": MagicMock(),
+            "prompt_toolkit.layout": MagicMock(),
+            "prompt_toolkit.layout.processors": MagicMock(),
+            "prompt_toolkit.filters": MagicMock(),
+            "prompt_toolkit.layout.dimension": MagicMock(),
+            "prompt_toolkit.layout.menus": MagicMock(),
+            "prompt_toolkit.widgets": MagicMock(),
+            "prompt_toolkit.key_binding": MagicMock(),
+            "prompt_toolkit.completion": MagicMock(),
+            "prompt_toolkit.formatted_text": MagicMock(),
+            "prompt_toolkit.auto_suggest": MagicMock(),
+        }
+        with patch.dict(sys.modules, prompt_toolkit_stubs):
+            import cli as _cli_mod
+
+            _cli_mod = importlib.reload(_cli_mod)
+            renderable = _cli_mod._assistant_response_renderable("\x1b[31mred\x1b[0m")
+
+        assert isinstance(renderable, Text)
+        assert renderable.plain == "red"
 
     def test_resume_without_target_lists_recent_sessions(self, capsys):
         cli = _make_cli()


### PR DESCRIPTION
## What does this PR do?

This PR improves final assistant reply readability in the Hermes CLI by rendering safe final replies as terminal-friendly markdown instead of flat plain text.

Scope is intentionally narrow:

- CLI only
- no agent logic changes
- no tool behavior changes
- no non-CLI channel changes

User-facing impact:

- clearer hierarchy for headings, bold text, lists, blockquotes, and fenced code blocks
- better scanability for high-signal numeric values in prose
- styling aligned with the Hermes CLI palette instead of Rich's default markdown colors

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Render final assistant replies in `cli.py` through Rich markdown when the response is safe to treat as markdown, while preserving ANSI fallback behavior
- Add CLI-only prompt guidance in `agent/prompt_builder.py` to encourage compact markdown when it improves terminal readability
- Apply Hermes-aligned styling for headings, strong text, lists, blockquotes, and fenced code blocks
- Add conservative emphasis for important numeric tokens in plain prose
- Avoid a heavy `hermes_cli.main` import in recent session display so the history path stays lightweight
- Add and update tests covering markdown rendering, ANSI fallback, numeric emphasis, and CLI-only prompt guidance

## How to Test

1. Run Hermes in the CLI and use this prompt:

   ```text
   Please produce a compact but polished markdown response about "2026 AI product growth review" that is optimized for terminal readability.

   Your response must include:
   1. One level-2 heading
   2. One short intro paragraph
   3. One bold takeaway sentence
   4. One unordered list with 4 bullet points
   5. One ordered list with 3 items
   6. One blockquote
   7. One fenced JSON code block
   8. One inline code example
   9. One markdown link
   10. One horizontal rule

   Include these values in the response:
   78%, $99, 2026-04-14, $7.8M, 3 phases, 12 weeks

   Also include these plain-text edge cases:
   /data/reports/2026/q2
   v1.2.3
   gpt-4.1

   Keep the response concise and do not use tables.
   ```

2. Confirm that:

   - markdown structure is visibly clearer in the CLI
   - important numeric values are emphasized
   - file paths, model names, and version strings are not incorrectly emphasized
   - ANSI-colored output still falls back correctly
   - non-CLI channels are unaffected

3. Run local verification:

   ```bash
   source .venv/bin/activate
   python -m pytest tests/cli/test_cli_init.py tests/cli/test_stream_delta_think_tag.py tests/cli/test_resume_display.py tests/agent/test_prompt_builder.py -q -k 'AssistantResponseRenderable or show_history or resume_without_target_lists_recent_sessions or platform_hints_known_platforms or cli_platform_hint_encourages_compact_markdown_only_for_cli'
   python -m pytest tests/e2e/ -v --tb=short
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 CLI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="1247" height="1201" alt="CLI markdown rendering screenshot" src="https://github.com/user-attachments/assets/619647e3-cbb9-431a-85dd-d002d0a4f40e" />

- `python -m pytest tests/cli/test_cli_init.py tests/cli/test_stream_delta_think_tag.py tests/cli/test_resume_display.py tests/agent/test_prompt_builder.py -q -k 'AssistantResponseRenderable or show_history or resume_without_target_lists_recent_sessions or platform_hints_known_platforms or cli_platform_hint_encourages_compact_markdown_only_for_cli'` -> `7 passed in 30.95s`
- `python -m pytest tests/e2e/ -v --tb=short` -> `48 passed in 21.29s`
- `python -m pytest tests/ -q` still does not pass locally on macOS 26.3.1 after rebasing onto `origin/main`: `13 failed, 2957 passed, 5 skipped, 128 warnings in 395.30s`
- The same full-suite command also fails on a clean `origin/main` worktree in the same local environment: `17 failed, 3828 passed, 5 skipped, 124 warnings in 466.85s`
- The unchecked full-suite box therefore reflects local baseline failures rather than a regression introduced by this CLI-only PR
