### PR TITLE
feat(memory): add mem0 HTTP provider

### DIFF
--- a/plugins/memory/mem0_http/README.md
+++ b/plugins/memory/mem0_http/README.md
@@ -1,0 +1,41 @@
+# Mem0 HTTP Memory Provider
+
+Direct HTTP integration with the Mem0 API using Hermes' memory-provider interface.
+
+## Why this provider exists
+
+- avoids the heavy `mem0ai` SDK dependency
+- keeps the Docker image smaller
+- uses the Mem0 REST API directly
+
+## Setup
+
+```bash
+hermes config set memory.provider mem0_http
+```
+
+Then set:
+
+```bash
+MEM0_API_KEY=your-key
+MEM0_USER_ID=hermes-agent
+MEM0_AGENT_ID=hermes-agent
+```
+
+Optional:
+
+```bash
+MEM0_BASE_URL=https://api.mem0.ai
+```
+
+## Config file
+
+Config file: `$HERMES_HOME/mem0_http.json`
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `mem0_profile` | Retrieve all stored memories for the configured scope |
+| `mem0_search` | Semantic search with scope filters |
+| `mem0_conclude` | Store a fact verbatim (no inference) |

--- a/plugins/memory/mem0_http/__init__.py
+++ b/plugins/memory/mem0_http/__init__.py
@@ -1,0 +1,486 @@
+"""Mem0 HTTP memory plugin — MemoryProvider interface.
+
+Direct HTTP integration with the Mem0 Platform API.
+
+Config via environment variables:
+  MEM0_API_KEY       — Mem0 Platform API key (required)
+  MEM0_BASE_URL      — API base URL (default: https://api.mem0.ai)
+  MEM0_USER_ID       — User identifier (default: hermes-user)
+  MEM0_AGENT_ID      — Agent identifier (default: hermes)
+
+Or via $HERMES_HOME/mem0_http.json.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.mem0.ai"
+
+# Circuit breaker: after this many consecutive failures, pause API calls
+# for _BREAKER_COOLDOWN_SECS to avoid hammering a down server.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/mem0_http.json overrides."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "api_key": os.environ.get("MEM0_API_KEY", ""),
+        "base_url": os.environ.get("MEM0_BASE_URL", _DEFAULT_BASE_URL),
+        "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
+        "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
+        "rerank": True,
+        "version": "v2",
+    }
+
+    config_path = get_hermes_home() / "mem0_http.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items() if v not in (None, "")})
+        except Exception:
+            pass
+
+    return config
+
+
+PROFILE_SCHEMA = {
+    "name": "mem0_profile",
+    "description": (
+        "Retrieve all stored memories about the current Mem0 identity. "
+        "Use at conversation start for a profile overview."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+SEARCH_SCHEMA = {
+    "name": "mem0_search",
+    "description": (
+        "Search Mem0 memories by meaning. Returns relevant facts ranked by similarity."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "rerank": {
+                "type": "boolean",
+                "description": "Enable reranking for precision (default: false).",
+            },
+            "top_k": {"type": "integer", "description": "Max results (default: 10, max: 50)."},
+        },
+        "required": ["query"],
+    },
+}
+
+CONCLUDE_SCHEMA = {
+    "name": "mem0_conclude",
+    "description": (
+        "Store a durable fact about the current Mem0 identity. Stored verbatim."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conclusion": {"type": "string", "description": "The fact to store."},
+        },
+        "required": ["conclusion"],
+    },
+}
+
+
+class _Client:
+    """Minimal Mem0 HTTP client."""
+
+    def __init__(self, api_key: str, base_url: str):
+        self.api_key = api_key.strip()
+        self.base_url = base_url.rstrip("/")
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Token {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Dict[str, Any] | None = None,
+        json_body: Dict[str, Any] | None = None,
+        timeout: float = 8.0,
+    ) -> Any:
+        import requests
+
+        response = requests.request(
+            method.upper(),
+            f"{self.base_url}{path}",
+            params=params,
+            json=json_body,
+            headers=self._headers(),
+            timeout=timeout,
+        )
+        try:
+            payload = response.json()
+        except Exception:
+            payload = response.text
+        if not response.ok:
+            if isinstance(payload, dict):
+                message = payload.get("message") or payload.get("error") or payload
+            else:
+                message = payload
+            raise RuntimeError(
+                f"Mem0 {method.upper()} {path} failed ({response.status_code}): {message}"
+            )
+        return payload
+
+    @staticmethod
+    def _scope_and(filters: Dict[str, Any]) -> Dict[str, Any]:
+        clauses = []
+        for key, value in filters.items():
+            if value:
+                clauses.append({key: value})
+        if not clauses:
+            return {}
+        if len(clauses) == 1:
+            return {"OR": clauses}
+        return {"AND": clauses}
+
+    def add_messages(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        user_id: str,
+        agent_id: str,
+        version: str,
+        infer: bool = True,
+    ) -> Any:
+        payload = {
+            "messages": messages,
+            "user_id": user_id,
+            "version": version,
+        }
+        if agent_id:
+            payload["agent_id"] = agent_id
+        if not infer:
+            payload["infer"] = False
+        return self.request("POST", "/v1/memories/", json_body=payload, timeout=10.0)
+
+    def search(
+        self,
+        query: str,
+        *,
+        filters: Dict[str, Any],
+        rerank: bool,
+        top_k: int,
+    ) -> Any:
+        payload = {
+            "query": query,
+            "filters": self._scope_and(filters),
+            "rerank": rerank,
+            "top_k": top_k,
+        }
+        return self.request("POST", "/v2/memories/search/", json_body=payload, timeout=8.0)
+
+    def get_all(self, *, filters: Dict[str, Any], version: str) -> Any:
+        params = {k: v for k, v in filters.items() if v}
+        if version:
+            params["version"] = version
+        try:
+            return self.request("GET", "/v1/memories/", params=params, timeout=8.0)
+        except Exception:
+            return self.request("GET", "/v1/memories", params=params, timeout=8.0)
+
+
+class Mem0HttpMemoryProvider(MemoryProvider):
+    """Mem0 memory provider implemented via direct HTTP calls."""
+
+    def __init__(self):
+        self._config = None
+        self._client = None
+        self._client_lock = threading.Lock()
+        self._api_key = ""
+        self._base_url = _DEFAULT_BASE_URL
+        self._user_id = "hermes-user"
+        self._agent_id = "hermes"
+        self._rerank = True
+        self._version = "v2"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread = None
+        self._sync_thread = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "mem0_http"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        return bool(cfg.get("api_key"))
+
+    def save_config(self, values, hermes_home):
+        from pathlib import Path
+
+        config_path = Path(hermes_home) / "mem0_http.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2))
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "api_key",
+                "description": "Mem0 Platform API key",
+                "secret": True,
+                "required": True,
+                "env_var": "MEM0_API_KEY",
+                "url": "https://app.mem0.ai",
+            },
+            {
+                "key": "base_url",
+                "description": "Mem0 API base URL",
+                "default": _DEFAULT_BASE_URL,
+                "env_var": "MEM0_BASE_URL",
+            },
+            {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
+            {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
+            {
+                "key": "rerank",
+                "description": "Enable reranking for recall",
+                "default": "true",
+                "choices": ["true", "false"],
+            },
+        ]
+
+    def _get_client(self):
+        with self._client_lock:
+            if self._client is None:
+                self._client = _Client(self._api_key, self._base_url)
+            return self._client
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "Mem0 HTTP circuit breaker tripped after %d consecutive failures. "
+                "Pausing API calls for %ds.",
+                self._consecutive_failures,
+                _BREAKER_COOLDOWN_SECS,
+            )
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._api_key = self._config.get("api_key", "")
+        self._base_url = self._config.get("base_url", _DEFAULT_BASE_URL)
+        self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
+        self._agent_id = self._config.get("agent_id", "hermes")
+        self._rerank = str(self._config.get("rerank", True)).lower() != "false"
+        self._version = self._config.get("version", "v2")
+
+    def _read_scope(self) -> Dict[str, Any]:
+        scope = {"user_id": self._user_id}
+        if self._agent_id:
+            scope["agent_id"] = self._agent_id
+        return scope
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Mem0 HTTP Memory\n"
+            f"Active. User: {self._user_id}. Agent: {self._agent_id or 'unset'}.\n"
+            "Use mem0_search to find memories, mem0_conclude to store facts, "
+            "mem0_profile for a full overview."
+        )
+
+    @staticmethod
+    def _unwrap_results(response: Any) -> list:
+        if isinstance(response, dict):
+            return response.get("results", response.get("memories", []))
+        if isinstance(response, list):
+            return response
+        return []
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Mem0 Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open():
+            return
+
+        def _run():
+            try:
+                client = self._get_client()
+                results = self._unwrap_results(
+                    client.search(
+                        query=query,
+                        filters=self._read_scope(),
+                        rerank=self._rerank,
+                        top_k=5,
+                    )
+                )
+                if results:
+                    lines = [r.get("memory", "") for r in results if r.get("memory")]
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(f"- {line}" for line in lines)
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Mem0 HTTP prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="mem0-http-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open():
+            return
+
+        def _sync():
+            try:
+                client = self._get_client()
+                client.add_messages(
+                    [
+                        {"role": "user", "content": user_content},
+                        {"role": "assistant", "content": assistant_content},
+                    ],
+                    user_id=self._user_id,
+                    agent_id=self._agent_id,
+                    version=self._version,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.warning("Mem0 HTTP sync failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
+        self._sync_thread = threading.Thread(
+            target=_sync, daemon=True, name="mem0-http-sync"
+        )
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "Mem0 API temporarily unavailable (multiple consecutive failures). Will retry automatically."
+            })
+
+        try:
+            client = self._get_client()
+        except Exception as e:
+            return tool_error(str(e))
+
+        if tool_name == "mem0_profile":
+            try:
+                memories = self._unwrap_results(
+                    client.get_all(filters=self._read_scope(), version=self._version)
+                )
+                self._record_success()
+                if not memories:
+                    return json.dumps({"result": "No memories stored yet."})
+                lines = [m.get("memory", "") for m in memories if m.get("memory")]
+                return json.dumps({"result": "\n".join(lines), "count": len(lines)})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"Failed to fetch profile: {e}")
+
+        if tool_name == "mem0_search":
+            query = args.get("query", "")
+            if not query:
+                return tool_error("Missing required parameter: query")
+            rerank = args.get("rerank", False)
+            top_k = min(int(args.get("top_k", 10)), 50)
+            try:
+                results = self._unwrap_results(
+                    client.search(
+                        query=query,
+                        filters=self._read_scope(),
+                        rerank=rerank,
+                        top_k=top_k,
+                    )
+                )
+                self._record_success()
+                if not results:
+                    return json.dumps({"result": "No relevant memories found."})
+                items = [
+                    {"memory": r.get("memory", ""), "score": r.get("score", 0)}
+                    for r in results
+                ]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"Search failed: {e}")
+
+        if tool_name == "mem0_conclude":
+            conclusion = args.get("conclusion", "")
+            if not conclusion:
+                return tool_error("Missing required parameter: conclusion")
+            try:
+                client.add_messages(
+                    [{"role": "user", "content": conclusion}],
+                    user_id=self._user_id,
+                    agent_id=self._agent_id,
+                    version=self._version,
+                    infer=False,
+                )
+                self._record_success()
+                return json.dumps({"result": "Fact stored."})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(f"Failed to store: {e}")
+
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def shutdown(self) -> None:
+        for thread in (self._prefetch_thread, self._sync_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+        with self._client_lock:
+            self._client = None
+
+
+def register(ctx) -> None:
+    """Register Mem0 HTTP as a memory provider plugin."""
+    ctx.register_memory_provider(Mem0HttpMemoryProvider())

--- a/plugins/memory/mem0_http/plugin.yaml
+++ b/plugins/memory/mem0_http/plugin.yaml
@@ -1,0 +1,3 @@
+name: mem0_http
+version: 1.0.0
+description: "Mem0 over direct HTTP — lightweight memory provider without the mem0ai SDK."

--- a/tests/plugins/test_mem0_http_plugin.py
+++ b/tests/plugins/test_mem0_http_plugin.py
@@ -1,0 +1,200 @@
+"""Tests for the Mem0 HTTP memory plugin."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+    monkeypatch.delenv("MEM0_BASE_URL", raising=False)
+    monkeypatch.delenv("MEM0_USER_ID", raising=False)
+    monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+
+
+_repo_root = str(Path(__file__).resolve().parents[2])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from plugins.memory.mem0_http import (  # noqa: E402
+    _Client,
+    Mem0HttpMemoryProvider,
+    _DEFAULT_BASE_URL,
+    _load_config,
+    register,
+)
+
+
+class TestClient:
+    def test_headers_include_token_auth(self):
+        client = _Client("test-key", _DEFAULT_BASE_URL)
+        assert client._headers()["Authorization"] == "Token test-key"
+
+    def test_search_payload_uses_and_filter(self):
+        client = _Client("test-key", _DEFAULT_BASE_URL)
+        with patch.object(client, "request", return_value={"results": []}) as mock_request:
+            client.search(
+                "deploy workflow",
+                filters={"user_id": "hermes-agent", "agent_id": "hermes-agent"},
+                rerank=True,
+                top_k=5,
+            )
+        mock_request.assert_called_once_with(
+            "POST",
+            "/v2/memories/search/",
+            json_body={
+                "query": "deploy workflow",
+                "filters": {"AND": [{"user_id": "hermes-agent"}, {"agent_id": "hermes-agent"}]},
+                "rerank": True,
+                "top_k": 5,
+            },
+            timeout=8.0,
+        )
+
+    def test_add_messages_payload(self):
+        client = _Client("test-key", _DEFAULT_BASE_URL)
+        with patch.object(client, "request", return_value={"results": []}) as mock_request:
+            client.add_messages(
+                [{"role": "user", "content": "fact"}],
+                user_id="hermes-agent",
+                agent_id="hermes-agent",
+                version="v2",
+                infer=False,
+            )
+        mock_request.assert_called_once_with(
+            "POST",
+            "/v1/memories/",
+            json_body={
+                "messages": [{"role": "user", "content": "fact"}],
+                "user_id": "hermes-agent",
+                "agent_id": "hermes-agent",
+                "version": "v2",
+                "infer": False,
+            },
+            timeout=10.0,
+        )
+
+    def test_get_all_tries_trailing_slash_first(self):
+        client = _Client("test-key", _DEFAULT_BASE_URL)
+
+        def fake_request(method, path, **kwargs):
+            if path == "/v1/memories/":
+                raise RuntimeError("404")
+            return {"results": []}
+
+        with patch.object(client, "request", side_effect=fake_request) as mock_request:
+            result = client.get_all(
+                filters={"user_id": "hermes-agent", "agent_id": "hermes-agent"},
+                version="v2",
+            )
+        assert result == {"results": []}
+        assert mock_request.call_count == 2
+
+
+class TestConfig:
+    def test_load_config_defaults(self):
+        cfg = _load_config()
+        assert cfg["base_url"] == _DEFAULT_BASE_URL
+        assert cfg["user_id"] == "hermes-user"
+        assert cfg["agent_id"] == "hermes"
+
+    def test_load_config_from_env(self, monkeypatch):
+        monkeypatch.setenv("MEM0_API_KEY", "key")
+        monkeypatch.setenv("MEM0_BASE_URL", "https://mem0.example")
+        monkeypatch.setenv("MEM0_USER_ID", "hermes-agent")
+        monkeypatch.setenv("MEM0_AGENT_ID", "hermes-agent")
+        cfg = _load_config()
+        assert cfg["api_key"] == "key"
+        assert cfg["base_url"] == "https://mem0.example"
+        assert cfg["user_id"] == "hermes-agent"
+        assert cfg["agent_id"] == "hermes-agent"
+
+
+@pytest.fixture()
+def provider(monkeypatch):
+    monkeypatch.setenv("MEM0_API_KEY", "key")
+    monkeypatch.setenv("MEM0_USER_ID", "hermes-agent")
+    monkeypatch.setenv("MEM0_AGENT_ID", "hermes-agent")
+    p = Mem0HttpMemoryProvider()
+    p.initialize(session_id="sess-1")
+    p._client = MagicMock()
+    return p
+
+
+class TestProvider:
+    def test_is_available_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        assert Mem0HttpMemoryProvider().is_available() is False
+        monkeypatch.setenv("MEM0_API_KEY", "key")
+        assert Mem0HttpMemoryProvider().is_available() is True
+
+    def test_system_prompt_includes_scope(self, provider):
+        block = provider.system_prompt_block()
+        assert "hermes-agent" in block
+        assert "Mem0 HTTP Memory" in block
+
+    def test_profile_uses_scoped_get_all(self, provider):
+        provider._client.get_all.return_value = {
+            "results": [{"memory": "Hermes uses isolated memory."}]
+        }
+        result = json.loads(provider.handle_tool_call("mem0_profile", {}))
+        assert result["count"] == 1
+        provider._client.get_all.assert_called_once_with(
+            filters={"user_id": "hermes-agent", "agent_id": "hermes-agent"},
+            version="v2",
+        )
+
+    def test_search_uses_scoped_filters(self, provider):
+        provider._client.search.return_value = {
+            "results": [{"memory": "Deploy workflow", "score": 0.9}]
+        }
+        result = json.loads(
+            provider.handle_tool_call("mem0_search", {"query": "deploy", "top_k": 3})
+        )
+        assert result["count"] == 1
+        provider._client.search.assert_called_once_with(
+            query="deploy",
+            filters={"user_id": "hermes-agent", "agent_id": "hermes-agent"},
+            rerank=False,
+            top_k=3,
+        )
+
+    def test_conclude_stores_verbatim_fact(self, provider):
+        result = json.loads(
+            provider.handle_tool_call("mem0_conclude", {"conclusion": "Hermes uses HTTP Mem0."})
+        )
+        assert result["result"] == "Fact stored."
+        provider._client.add_messages.assert_called_once_with(
+            [{"role": "user", "content": "Hermes uses HTTP Mem0."}],
+            user_id="hermes-agent",
+            agent_id="hermes-agent",
+            version="v2",
+            infer=False,
+        )
+
+    def test_sync_turn_writes_messages(self, provider):
+        provider.sync_turn("hi", "hello")
+        provider.shutdown()
+        provider._client.add_messages.assert_called_once_with(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+            user_id="hermes-agent",
+            agent_id="hermes-agent",
+            version="v2",
+        )
+
+    def test_register_calls_register_memory_provider(self):
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_memory_provider.assert_called_once()
+        provider = ctx.register_memory_provider.call_args[0][0]
+        assert isinstance(provider, Mem0HttpMemoryProvider)


### PR DESCRIPTION
## What does this PR do?

- add a new `mem0_http` memory provider that integrates with Mem0 over direct HTTP
- keep the existing SDK-based `mem0` provider unchanged to minimize migration risk
- add focused tests covering config loading, scoped search/write payloads, and provider registration



## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

  - Add a new mem0_http memory provider under plugins/memory/mem0_http/ that integrates with Mem0 over
    direct HTTP instead of the mem0ai SDK.
  - Keep the existing mem0 provider unchanged so current users are unaffected.
  - Support MEM0_API_KEY, MEM0_BASE_URL, MEM0_USER_ID, and MEM0_AGENT_ID for configuration.
  - Expose the same core tool surface: mem0_profile, mem0_search, and mem0_conclude.
  - Scope reads and writes with user_id and agent_id for better isolation between agents.
  - Add focused tests for config loading, payload construction, provider registration, and tool behavior.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

  - Run the focused provider tests:
    pytest tests/plugins/test_mem0_http_plugin.py -v
  - Optionally verify end-to-end by setting:
    memory.provider: mem0_http
    and:
    `MEM0_API_KEY`, `MEM0_USER_ID`, `MEM0_AGENT_ID`
  - Then confirm Hermes can:
    mem0_profile
    mem0_search
    mem0_conclude

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

