### PR TITLE
fix(agent): boost max_tokens on length-continuation retries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6271,7 +6271,14 @@ class AIAgent:
         if self.tools:
             api_kwargs["tools"] = self.tools
 
-        if self.max_tokens is not None:
+        # _ephemeral_max_output_tokens is set for one call during length-
+        # continuation retries to boost the output cap for models with a low
+        # default limit (e.g. GLM-4.7 on NVIDIA Build).
+        _ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
+        if _ephemeral_out is not None:
+            self._ephemeral_max_output_tokens = None  # consume immediately
+            api_kwargs.update(self._max_tokens_param(_ephemeral_out))
+        elif self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
         elif self._is_qwen_portal():
             # Qwen Portal defaults to a very low max_tokens when omitted.
@@ -9651,6 +9658,12 @@ class AIAgent:
                 continue
 
             if restart_with_length_continuation:
+                # Boost max_tokens on each continuation attempt so models
+                # with a low default output limit (e.g. GLM-4.7 on NVIDIA
+                # Build) have more room to finish instead of truncating again.
+                _boost_base = self.max_tokens if self.max_tokens else 4096
+                _boost = _boost_base * (length_continue_retries + 1)
+                self._ephemeral_max_output_tokens = min(_boost, 32768)
                 continue
 
             # Guard: if all retries exhausted without a successful response


### PR DESCRIPTION
## Problem

Closes #9372

Models with a low default output limit (e.g. GLM-4.7 on NVIDIA Build) truncate at the same limit on every continuation attempt, exhausting all 3 retries without ever finishing.

## Root Cause

The continuation loop sends the continue prompt but calls the API with the same max_tokens each time. If the model hits the limit on the first call, it hits it again on every retry.

## Fix

Set _ephemeral_max_output_tokens before each continuation retry, growing the budget per attempt (capped at 32K): Retry 1 = max_tokens x 2, Retry 2 = max_tokens x 3.

Also extended _ephemeral_max_output_tokens consumption to the chat_completions path in _build_api_kwargs() so both chat_completions and anthropic_messages modes benefit.

## Before / After

Before: GLM-4.7 truncated x3 at same limit, error.
After: GLM-4.7 retried with growing limit, more room to finish.