### PR TITLE
fix(anthropic): filter empty text blocks from assistant messages

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -958,7 +958,17 @@ def convert_messages_to_anthropic(
                 if isinstance(content, list):
                     converted_content = _convert_content_to_anthropic(content)
                     if isinstance(converted_content, list):
-                        blocks.extend(converted_content)
+                        # Filter out empty text blocks — Bedrock (and strict
+                        # Anthropic-compatible endpoints) reject text blocks
+                        # where "text" is an empty or whitespace-only string.
+                        for blk in converted_content:
+                            if (
+                                isinstance(blk, dict)
+                                and blk.get("type") == "text"
+                                and not blk.get("text", "").strip()
+                            ):
+                                continue  # drop empty text block
+                            blocks.append(blk)
                 else:
                     blocks.append({"type": "text", "text": str(content)})
             for tc in m.get("tool_calls", []):


### PR DESCRIPTION
## Problem

Closes #9486

Bedrock and strict Anthropic-compatible endpoints reject messages where a text content block has an empty `text` field:

```
ValidationException: messages: text content blocks must be non-empty
```

This happens in multi-turn conversations when an assistant message contains an empty text block alongside tool_use blocks.

## Root Cause

In `convert_to_anthropic_messages()`, user messages already had an empty-block guard. Assistant messages were missing it — `converted_content` blocks were extended into the final list without filtering empty text entries.

## Fix

Skip text blocks with empty/whitespace `text` when building the assistant content block list:

```python
for blk in converted_content:
    if (
        isinstance(blk, dict)
        and blk.get("type") == "text"
        and not blk.get("text", "").strip()
    ):
        continue  # drop empty text block
    blocks.append(blk)
```

## Before / After

**Before:** Multi-turn chat with tool calls → empty text block in assistant message → Bedrock 400 error

**After:** Empty text blocks silently dropped → valid message sent → no error