### PR TITLE
fix(cli): show history when resuming a session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3252,7 +3252,8 @@ class HermesCLI:
             padding=(0, 1),
             style=_history_text_c,
         )
-        self.console.print(panel)
+        out_console = ChatConsole() if getattr(self, "_app", None) else self.console
+        out_console.print(panel)
 
     def _try_attach_clipboard_image(self) -> bool:
         """Check clipboard for an image and attach it if found.
@@ -4228,6 +4229,7 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            self._display_resumed_history()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -245,6 +245,23 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_resume_command_displays_resumed_history_when_messages_exist(self):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {"title": "Past Session"}
+        cli._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "What were we doing?"},
+            {"role": "assistant", "content": "We were fixing the dashboard."},
+        ]
+        cli._session_db.reopen_session.return_value = None
+        cli._display_resumed_history = MagicMock()
+
+        with patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="old_session"):
+            cli._handle_resume_command("/resume old_session")
+
+        cli._display_resumed_history.assert_called_once_with()
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Summary
- show the resumed conversation recap when using `/resume <session>` inside the CLI
- route resumed history rendering through the TUI-safe output path when prompt_toolkit is active
- add a regression test covering `/resume` history display

## Test Plan
- python -m pytest tests/cli/test_cli_init.py tests/cli/test_resume_display.py -q