### PR TITLE
feat(cli): improve status bar context with profile, reasoning, and fast mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1905,7 +1905,21 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "reasoning_label": None,
+            "fast_label": None,
         }
+
+        reasoning_config = getattr(self, "reasoning_config", None)
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                snapshot["reasoning_label"] = "R:off"
+            elif reasoning_config.get("enabled"):
+                effort = str(reasoning_config.get("effort") or "on").strip().lower() or "on"
+                snapshot["reasoning_label"] = f"R:{effort}"
+
+        service_tier = getattr(self, "service_tier", None)
+        if service_tier == "priority":
+            snapshot["fast_label"] = "FAST"
 
         if not agent:
             return snapshot
@@ -2057,7 +2071,8 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            extras = [label for label in (snapshot.get("reasoning_label"), snapshot.get("fast_label")) if label]
+            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label, *extras]
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -2115,10 +2130,22 @@ class HermesCLI:
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
+                    ]
+                    if snapshot.get("reasoning_label"):
+                        frags.extend([
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-dim", snapshot["reasoning_label"]),
+                        ])
+                    if snapshot.get("fast_label"):
+                        frags.extend([
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-strong", snapshot["fast_label"]),
+                        ])
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
                         ("class:status-bar", " "),
-                    ]
+                    ])
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:

--- a/cli.py
+++ b/cli.py
@@ -1889,7 +1889,17 @@ class HermesCLI:
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile_name = get_active_profile_name()
+        except Exception:
+            profile_name = "default"
+        profile_label = str(profile_name or "default")
+        if len(profile_label) > 16:
+            profile_label = f"{profile_label[:13]}..."
         snapshot = {
+            "profile_name": profile_name,
+            "profile_label": profile_label,
             "model_name": model_name,
             "model_short": model_short,
             "duration": format_duration_compact(elapsed_seconds),
@@ -2057,10 +2067,10 @@ class HermesCLI:
             duration_label = snapshot["duration"]
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {snapshot['profile_label']} · {snapshot['model_short']} · {duration_label}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot['profile_label']}", snapshot['model_short'], percent_label]
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -2072,7 +2082,7 @@ class HermesCLI:
                 context_label = "ctx --"
 
             extras = [label for label in (snapshot.get("reasoning_label"), snapshot.get("fast_label")) if label]
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label, *extras]
+            parts = [f"⚕ {snapshot['profile_label']}", snapshot['model_short'], context_label, percent_label, *extras]
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -2094,6 +2104,8 @@ class HermesCLI:
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
+                    ("class:status-bar-strong", snapshot["profile_label"]),
+                    ("class:status-bar-dim", " · "),
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
@@ -2105,6 +2117,8 @@ class HermesCLI:
                 if width < 76:
                     frags = [
                         ("class:status-bar", " ⚕ "),
+                        ("class:status-bar-strong", snapshot["profile_label"]),
+                        ("class:status-bar-dim", " · "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
@@ -2123,6 +2137,8 @@ class HermesCLI:
                     bar_style = self._status_bar_context_style(percent)
                     frags = [
                         ("class:status-bar", " ⚕ "),
+                        ("class:status-bar-strong", snapshot["profile_label"]),
+                        ("class:status-bar-dim", " │ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -80,6 +80,24 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_build_status_bar_text_shows_reasoning_and_fast_when_enabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+        cli_obj.service_tier = "priority"
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "R:high" in text
+        assert "FAST" in text
+
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
 
@@ -197,6 +215,25 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
         assert "200K" not in text
+
+    def test_status_bar_fragments_show_reasoning_and_fast_when_enabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10000,
+            completion_tokens=2400,
+            total_tokens=12400,
+            api_calls=7,
+            context_tokens=12400,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        cli_obj.service_tier = "priority"
+        cli_obj._status_bar_visible = True
+
+        joined = "".join(text for _, text in cli_obj._get_status_bar_fragments())
+
+        assert "R:medium" in joined
+        assert "FAST" in joined
 
     def test_build_status_bar_text_handles_missing_agent(self):
         cli_obj = _make_cli()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -11,6 +11,8 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj.reasoning_config = None
+    cli_obj.service_tier = None
     return cli_obj
 
 
@@ -72,8 +74,10 @@ class TestCLIStatusBar:
             context_length=200_000,
         )
 
-        text = cli_obj._build_status_bar_text(width=120)
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="main"):
+            text = cli_obj._build_status_bar_text(width=120)
 
+        assert "main" in text
         assert "claude-sonnet-4-20250514" in text
         assert "12.4K/200K" in text
         assert "6%" in text
@@ -93,8 +97,10 @@ class TestCLIStatusBar:
         cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
         cli_obj.service_tier = "priority"
 
-        text = cli_obj._build_status_bar_text(width=120)
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="main"):
+            text = cli_obj._build_status_bar_text(width=120)
 
+        assert "main" in text
         assert "R:high" in text
         assert "FAST" in text
 
@@ -209,9 +215,11 @@ class TestCLIStatusBar:
             context_length=200_000,
         )
 
-        text = cli_obj._build_status_bar_text(width=60)
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="main"):
+            text = cli_obj._build_status_bar_text(width=60)
 
         assert "⚕" in text
+        assert "main" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
         assert "200K" not in text
@@ -230,17 +238,22 @@ class TestCLIStatusBar:
         cli_obj.service_tier = "priority"
         cli_obj._status_bar_visible = True
 
-        joined = "".join(text for _, text in cli_obj._get_status_bar_fragments())
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="main"), \
+             patch.object(HermesCLI, "_get_tui_terminal_width", return_value=160):
+            joined = "".join(text for _, text in cli_obj._get_status_bar_fragments())
 
+        assert "main" in joined
         assert "R:medium" in joined
         assert "FAST" in joined
 
     def test_build_status_bar_text_handles_missing_agent(self):
         cli_obj = _make_cli()
 
-        text = cli_obj._build_status_bar_text(width=100)
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="main"):
+            text = cli_obj._build_status_bar_text(width=100)
 
         assert "⚕" in text
+        assert "main" in text
         assert "claude-sonnet-4-20250514" in text
 
     def test_minimal_tui_chrome_threshold(self):


### PR DESCRIPTION
## Summary
- show the active profile name in the CLI status bar
- show reasoning effort in the status bar when enabled
- show FAST mode in the status bar when priority processing is enabled
- add status bar regression tests for the new labels

## Test Plan
- python -m pytest tests/cli/test_cli_status_bar.py -q