### PR TITLE
feat(dashboard): add profile-aware sessions, analytics, and status views

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -281,74 +281,168 @@ class EnvVarReveal(BaseModel):
 
 
 @app.get("/api/status")
-async def get_status():
-    current_ver, latest_ver = check_config_version()
+async def get_status(profile: Optional[str] = None):
+    profile_info = _list_dashboard_profiles()
+    selected_profile = _resolve_session_profile(profile)
 
-    gateway_pid = get_running_pid()
-    gateway_running = gateway_pid is not None
+    if selected_profile == "all":
+        summaries = []
+        for entry in profile_info["profiles"]:
+            summary = _status_payload_for_profile(entry["name"])
+            summary["profile"] = entry["name"]
+            summaries.append(summary)
+        return {
+            **summaries[0],
+            "selected_profile": "all",
+            "active_profile": profile_info["active_profile"],
+            "available_profiles": profile_info["profiles"],
+            "active_sessions": sum(s.get("active_sessions", 0) for s in summaries),
+            "gateway_running": any(s.get("gateway_running") for s in summaries),
+            "gateway_pid": None,
+            "gateway_state": "running" if any(s.get("gateway_running") for s in summaries) else "stopped",
+            "gateway_platforms": {},
+            "gateway_exit_reason": None,
+            "gateway_updated_at": None,
+            "hermes_home": "all profiles",
+            "profile_summaries": summaries,
+        }
 
+    payload = _status_payload_for_profile(selected_profile)
+    payload.update(
+        {
+            "selected_profile": selected_profile,
+            "active_profile": profile_info["active_profile"],
+            "available_profiles": profile_info["profiles"],
+            "profile_summaries": [
+                {**payload, "profile": selected_profile}
+            ],
+        }
+    )
+    return payload
+
+
+def _gateway_status_for_profile(profile: str) -> Dict[str, Any]:
+    from gateway.status import _read_json_file
+    import os
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        active_profile = get_active_profile_name()
+    except Exception:
+        active_profile = "default"
+
+    if profile == active_profile:
+        gateway_pid = get_running_pid()
+        gateway_running = gateway_pid is not None
+        gateway_state = None
+        gateway_platforms: Dict[str, Any] = {}
+        gateway_exit_reason = None
+        gateway_updated_at = None
+        configured_gateway_platforms: set[str] | None = None
+        try:
+            from gateway.config import load_gateway_config
+            gateway_config = load_gateway_config()
+            configured_gateway_platforms = {
+                platform.value for platform in gateway_config.get_connected_platforms()
+            }
+        except Exception:
+            configured_gateway_platforms = None
+
+        runtime = read_runtime_status()
+        if runtime:
+            gateway_state = runtime.get("gateway_state")
+            gateway_platforms = runtime.get("platforms") or {}
+            if configured_gateway_platforms is not None:
+                gateway_platforms = {
+                    key: value
+                    for key, value in gateway_platforms.items()
+                    if key in configured_gateway_platforms
+                }
+            gateway_exit_reason = runtime.get("exit_reason")
+            gateway_updated_at = runtime.get("updated_at")
+            if not gateway_running:
+                gateway_state = gateway_state if gateway_state in ("stopped", "startup_failed") else "stopped"
+                gateway_platforms = {}
+
+        return {
+            "gateway_running": gateway_running,
+            "gateway_pid": gateway_pid,
+            "gateway_state": gateway_state,
+            "gateway_platforms": gateway_platforms,
+            "gateway_exit_reason": gateway_exit_reason,
+            "gateway_updated_at": gateway_updated_at,
+        }
+
+    if profile == "custom":
+        profile_home = get_hermes_home()
+    else:
+        from hermes_cli.profiles import get_profile_dir
+        profile_home = get_profile_dir(profile)
+
+    pid_path = profile_home / "gateway.pid"
+    runtime_path = profile_home / "gateway_state.json"
+
+    gateway_pid = None
+    gateway_running = False
     gateway_state = None
-    gateway_platforms: dict = {}
+    gateway_platforms: Dict[str, Any] = {}
     gateway_exit_reason = None
     gateway_updated_at = None
-    configured_gateway_platforms: set[str] | None = None
+
     try:
-        from gateway.config import load_gateway_config
-
-        gateway_config = load_gateway_config()
-        configured_gateway_platforms = {
-            platform.value for platform in gateway_config.get_connected_platforms()
-        }
+        if pid_path.exists():
+            raw = pid_path.read_text().strip()
+            if raw:
+                data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
+                pid = int(data.get("pid"))
+                os.kill(pid, 0)
+                gateway_pid = pid
+                gateway_running = True
     except Exception:
-        configured_gateway_platforms = None
+        gateway_pid = None
+        gateway_running = False
 
-    runtime = read_runtime_status()
+    runtime = _read_json_file(runtime_path) if runtime_path.exists() else None
     if runtime:
         gateway_state = runtime.get("gateway_state")
         gateway_platforms = runtime.get("platforms") or {}
-        if configured_gateway_platforms is not None:
-            gateway_platforms = {
-                key: value
-                for key, value in gateway_platforms.items()
-                if key in configured_gateway_platforms
-            }
         gateway_exit_reason = runtime.get("exit_reason")
         gateway_updated_at = runtime.get("updated_at")
         if not gateway_running:
             gateway_state = gateway_state if gateway_state in ("stopped", "startup_failed") else "stopped"
             gateway_platforms = {}
 
-    active_sessions = 0
-    try:
-        from hermes_state import SessionDB
-        db = SessionDB()
-        try:
-            sessions = db.list_sessions_rich(limit=50)
-            now = time.time()
-            active_sessions = sum(
-                1 for s in sessions
-                if s.get("ended_at") is None
-                and (now - s.get("last_active", s.get("started_at", 0))) < 300
-            )
-        finally:
-            db.close()
-    except Exception:
-        pass
-
     return {
-        "version": __version__,
-        "release_date": __release_date__,
-        "hermes_home": str(get_hermes_home()),
-        "config_path": str(get_config_path()),
-        "env_path": str(get_env_path()),
-        "config_version": current_ver,
-        "latest_config_version": latest_ver,
         "gateway_running": gateway_running,
         "gateway_pid": gateway_pid,
         "gateway_state": gateway_state,
         "gateway_platforms": gateway_platforms,
         "gateway_exit_reason": gateway_exit_reason,
         "gateway_updated_at": gateway_updated_at,
+    }
+
+
+def _status_payload_for_profile(profile: str) -> Dict[str, Any]:
+    current_ver, latest_ver = check_config_version()
+    gateway = _gateway_status_for_profile(profile)
+    sessions = _load_sessions_for_profile(profile)
+    active_sessions = sum(1 for s in sessions if s.get("is_active"))
+
+    if profile == "custom":
+        profile_home = get_hermes_home()
+    else:
+        from hermes_cli.profiles import get_profile_dir
+        profile_home = get_profile_dir(profile)
+
+    return {
+        "version": __version__,
+        "release_date": __release_date__,
+        "hermes_home": str(profile_home),
+        "config_path": str(profile_home / "config.yaml"),
+        "env_path": str(profile_home / ".env"),
+        "config_version": current_ver,
+        "latest_config_version": latest_ver,
+        **gateway,
         "active_sessions": active_sessions,
     }
 
@@ -2001,10 +2095,8 @@ async def update_config_raw(body: RawConfigUpdate):
 # ---------------------------------------------------------------------------
 
 
-@app.get("/api/analytics/usage")
-async def get_usage_analytics(days: int = 30):
-    from hermes_state import SessionDB
-    db = SessionDB()
+def _usage_analytics_for_profile(profile: str, days: int) -> Dict[str, Any]:
+    db = _session_db_for_profile(profile)
     try:
         cutoff = time.time() - (days * 86400)
         cur = db._conn.execute("""
@@ -2043,10 +2135,65 @@ async def get_usage_analytics(days: int = 30):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
-
-        return {"daily": daily, "by_model": by_model, "totals": totals, "period_days": days}
+        return {"daily": daily, "by_model": by_model, "totals": totals, "period_days": days, "selected_profile": profile}
     finally:
         db.close()
+
+
+@app.get("/api/analytics/usage")
+async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
+    selected_profile = _resolve_session_profile(profile)
+    profile_info = _list_dashboard_profiles()
+
+    if selected_profile == "all":
+        summaries = []
+        daily_map: Dict[str, Dict[str, Any]] = {}
+        model_map: Dict[str, Dict[str, Any]] = {}
+        totals = {
+            "total_input": 0,
+            "total_output": 0,
+            "total_cache_read": 0,
+            "total_reasoning": 0,
+            "total_estimated_cost": 0,
+            "total_actual_cost": 0,
+            "total_sessions": 0,
+        }
+        for entry in profile_info["profiles"]:
+            summary = _usage_analytics_for_profile(entry["name"], days)
+            summary["profile"] = entry["name"]
+            summaries.append(summary)
+            for row in summary["daily"]:
+                day = row["day"]
+                agg = daily_map.setdefault(day, {"day": day, "input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0, "reasoning_tokens": 0, "estimated_cost": 0, "actual_cost": 0, "sessions": 0})
+                for key in ("input_tokens", "output_tokens", "cache_read_tokens", "reasoning_tokens", "estimated_cost", "actual_cost", "sessions"):
+                    agg[key] += row.get(key) or 0
+            for row in summary["by_model"]:
+                model = row["model"] or "unknown"
+                agg = model_map.setdefault(model, {"model": model, "input_tokens": 0, "output_tokens": 0, "estimated_cost": 0, "sessions": 0})
+                for key in ("input_tokens", "output_tokens", "estimated_cost", "sessions"):
+                    agg[key] += row.get(key) or 0
+            for key in totals:
+                totals[key] += summary["totals"].get(key) or 0
+        daily = [daily_map[k] for k in sorted(daily_map)]
+        by_model = sorted(model_map.values(), key=lambda r: (r.get("input_tokens", 0) + r.get("output_tokens", 0)), reverse=True)
+        return {
+            "daily": daily,
+            "by_model": by_model,
+            "totals": totals,
+            "period_days": days,
+            "selected_profile": "all",
+            "active_profile": profile_info["active_profile"],
+            "available_profiles": profile_info["profiles"],
+            "profile_summaries": summaries,
+        }
+
+    payload = _usage_analytics_for_profile(selected_profile, days)
+    payload.update({
+        "active_profile": profile_info["active_profile"],
+        "available_profiles": profile_info["profiles"],
+        "profile_summaries": [{**payload, "profile": selected_profile}],
+    })
+    return payload
 
 
 def mount_spa(application: FastAPI):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -353,65 +353,176 @@ async def get_status():
     }
 
 
-@app.get("/api/sessions")
-async def get_sessions(limit: int = 20, offset: int = 0):
+@app.get("/api/profiles")
+async def get_profiles():
+    return _list_dashboard_profiles()
+
+
+def _list_dashboard_profiles() -> Dict[str, Any]:
+    """Return profile choices for the dashboard session browser."""
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
-        try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
-            total = db.session_count()
-            now = time.time()
-            for s in sessions:
-                s["is_active"] = (
-                    s.get("ended_at") is None
-                    and (now - s.get("last_active", s.get("started_at", 0))) < 300
-                )
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
-        finally:
-            db.close()
-    except Exception as e:
+        from hermes_cli.profiles import get_active_profile_name, list_profiles
+
+        active_profile = get_active_profile_name()
+        profiles = [
+            {"name": p.name, "label": p.name, "is_active": p.name == active_profile}
+            for p in list_profiles()
+        ]
+        if active_profile not in {p["name"] for p in profiles}:
+            profiles.insert(0, {"name": active_profile, "label": active_profile, "is_active": True})
+        return {"active_profile": active_profile, "profiles": profiles}
+    except Exception:
+        active_profile = "default"
+        return {
+            "active_profile": active_profile,
+            "profiles": [{"name": active_profile, "label": active_profile, "is_active": True}],
+        }
+
+
+def _resolve_session_profile(profile: Optional[str]) -> str:
+    info = _list_dashboard_profiles()
+    active_profile = info["active_profile"]
+    requested = (profile or active_profile).strip() if isinstance(profile, str) else active_profile
+    if requested in ("", "current", "active"):
+        return active_profile
+    if requested == "all":
+        return "all"
+    available = {p["name"] for p in info["profiles"]}
+    if requested not in available:
+        raise HTTPException(status_code=404, detail=f"Unknown profile: {requested}")
+    return requested
+
+
+def _session_db_for_profile(profile: Optional[str]):
+    from hermes_state import SessionDB
+    from hermes_cli.profiles import get_profile_dir, get_active_profile_name
+
+    resolved = profile or get_active_profile_name()
+    if resolved in ("current", "active"):
+        resolved = get_active_profile_name()
+    if resolved == "custom":
+        db_path = get_hermes_home() / "state.db"
+    else:
+        db_path = get_profile_dir(resolved) / "state.db"
+    return SessionDB(db_path=db_path)
+
+
+def _load_sessions_for_profile(profile: str, include_children: bool = False) -> List[Dict[str, Any]]:
+    db = _session_db_for_profile(profile)
+    try:
+        sessions = db.list_sessions_rich(limit=100000, offset=0, include_children=include_children)
+    finally:
+        db.close()
+
+    now = time.time()
+    for session in sessions:
+        session["profile"] = profile
+        session["is_active"] = (
+            session.get("ended_at") is None
+            and (now - session.get("last_active", session.get("started_at", 0))) < 300
+        )
+    return sessions
+
+
+def _search_sessions_for_profile(profile: str, query: str, limit: int) -> List[Dict[str, Any]]:
+    db = _session_db_for_profile(profile)
+    try:
+        matches = db.search_messages(query=query, limit=limit)
+    finally:
+        db.close()
+
+    results = []
+    seen = set()
+    for match in matches:
+        sid = match["session_id"]
+        key = (profile, sid)
+        if key in seen:
+            continue
+        seen.add(key)
+        results.append(
+            {
+                "session_id": sid,
+                "profile": profile,
+                "snippet": match.get("snippet", ""),
+                "role": match.get("role"),
+                "source": match.get("source"),
+                "model": match.get("model"),
+                "session_started": match.get("session_started"),
+            }
+        )
+    return results
+
+
+@app.get("/api/sessions")
+async def get_sessions(limit: int = 20, offset: int = 0, profile: Optional[str] = None):
+    try:
+        selected_profile = _resolve_session_profile(profile)
+        profile_info = _list_dashboard_profiles()
+        available_profiles = profile_info["profiles"]
+
+        if selected_profile == "all":
+            sessions: List[Dict[str, Any]] = []
+            for entry in available_profiles:
+                profile_sessions = _load_sessions_for_profile(entry["name"])
+                for session in profile_sessions:
+                    session.setdefault("profile", entry["name"])
+                sessions.extend(profile_sessions)
+            sessions.sort(key=lambda s: s.get("started_at", 0), reverse=True)
+        else:
+            sessions = _load_sessions_for_profile(selected_profile)
+            for session in sessions:
+                session.setdefault("profile", selected_profile)
+
+        total = len(sessions)
+        page = sessions[offset:offset + limit]
+        return {
+            "sessions": page,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "selected_profile": selected_profile,
+            "active_profile": profile_info["active_profile"],
+            "available_profiles": available_profiles,
+        }
+    except HTTPException:
+        raise
+    except Exception:
         _log.exception("GET /api/sessions failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
+async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
     """Full-text search across session message content using FTS5."""
     if not q or not q.strip():
-        return {"results": []}
+        return {"results": [], "selected_profile": _resolve_session_profile(profile)}
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
-        try:
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
-            import re
-            terms = []
-            for token in re.findall(r'"[^"]*"|\S+', q.strip()):
-                if token.startswith('"') or token.endswith("*"):
-                    terms.append(token)
-                else:
-                    terms.append(token + "*")
-            prefix_query = " ".join(terms)
-            matches = db.search_messages(query=prefix_query, limit=limit)
-            # Group by session_id — return unique sessions with their best snippet
-            seen: dict = {}
-            for m in matches:
-                sid = m["session_id"]
-                if sid not in seen:
-                    seen[sid] = {
-                        "session_id": sid,
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    }
-            return {"results": list(seen.values())}
-        finally:
-            db.close()
+        # Auto-add prefix wildcards so partial words match
+        # e.g. "nimb" → "nimb*" matches "nimby"
+        # Preserve quoted phrases and existing wildcards as-is
+        import re
+        terms = []
+        for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+            if token.startswith('"') or token.endswith("*"):
+                terms.append(token)
+            else:
+                terms.append(token + "*")
+        prefix_query = " ".join(terms)
+
+        selected_profile = _resolve_session_profile(profile)
+        profile_info = _list_dashboard_profiles()
+        if selected_profile == "all":
+            results: List[Dict[str, Any]] = []
+            per_profile_limit = max(limit, 20)
+            for entry in profile_info["profiles"]:
+                results.extend(_search_sessions_for_profile(entry["name"], prefix_query, per_profile_limit))
+            results.sort(key=lambda r: r.get("session_started") or 0, reverse=True)
+            results = results[:limit]
+        else:
+            results = _search_sessions_for_profile(selected_profile, prefix_query, limit)
+        return {"results": results, "selected_profile": selected_profile}
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("GET /api/sessions/search failed")
         raise HTTPException(status_code=500, detail="Search failed")
@@ -1598,41 +1709,48 @@ async def cancel_oauth_session(session_id: str, request: Request):
 
 
 @app.get("/api/sessions/{session_id}")
-async def get_session_detail(session_id: str):
-    from hermes_state import SessionDB
-    db = SessionDB()
+async def get_session_detail(session_id: str, profile: Optional[str] = None):
+    selected_profile = _resolve_session_profile(profile)
+    if selected_profile == "all":
+        raise HTTPException(status_code=400, detail="Specify a profile when viewing a single session")
+    db = _session_db_for_profile(selected_profile)
     try:
         sid = db.resolve_session_id(session_id)
         session = db.get_session(sid) if sid else None
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
+        session["profile"] = selected_profile
         return session
     finally:
         db.close()
 
 
 @app.get("/api/sessions/{session_id}/messages")
-async def get_session_messages(session_id: str):
-    from hermes_state import SessionDB
-    db = SessionDB()
+async def get_session_messages(session_id: str, profile: Optional[str] = None):
+    selected_profile = _resolve_session_profile(profile)
+    if selected_profile == "all":
+        raise HTTPException(status_code=400, detail="Specify a profile when viewing session messages")
+    db = _session_db_for_profile(selected_profile)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
         messages = db.get_messages(sid)
-        return {"session_id": sid, "messages": messages}
+        return {"session_id": sid, "profile": selected_profile, "messages": messages}
     finally:
         db.close()
 
 
 @app.delete("/api/sessions/{session_id}")
-async def delete_session_endpoint(session_id: str):
-    from hermes_state import SessionDB
-    db = SessionDB()
+async def delete_session_endpoint(session_id: str, profile: Optional[str] = None):
+    selected_profile = _resolve_session_profile(profile)
+    if selected_profile == "all":
+        raise HTTPException(status_code=400, detail="Specify a profile when deleting a session")
+    db = _session_db_for_profile(selected_profile)
     try:
         if not db.delete_session(session_id):
             raise HTTPException(status_code=404, detail="Session not found")
-        return {"ok": True}
+        return {"ok": True, "profile": selected_profile}
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -207,6 +207,50 @@ class TestWebServerEndpoints:
         assert data["active_profile"] == "main"
         assert [p["name"] for p in data["profiles"]] == ["default", "main", "pawmela"]
 
+    def test_get_status_all_profiles_returns_profile_summaries(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "_list_dashboard_profiles",
+            lambda: {
+                "active_profile": "main",
+                "profiles": [
+                    {"name": "main", "label": "main", "is_active": True},
+                    {"name": "pawmela", "label": "pawmela", "is_active": False},
+                ],
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_status_payload_for_profile",
+            lambda profile: {
+                "selected_profile": profile,
+                "active_sessions": 2 if profile == "main" else 1,
+                "gateway_running": profile == "main",
+                "gateway_pid": 123 if profile == "main" else None,
+                "gateway_state": "running" if profile == "main" else "stopped",
+                "gateway_platforms": {},
+                "gateway_exit_reason": None,
+                "gateway_updated_at": None,
+                "hermes_home": f"/tmp/{profile}",
+                "version": "0.9.0",
+                "release_date": "2026.4.13",
+                "config_path": f"/tmp/{profile}/config.yaml",
+                "env_path": f"/tmp/{profile}/.env",
+                "config_version": 1,
+                "latest_config_version": 1,
+            },
+        )
+
+        resp = self.client.get("/api/status?profile=all")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["selected_profile"] == "all"
+        assert data["active_sessions"] == 3
+        assert len(data["profile_summaries"]) == 2
+        assert [p["profile"] for p in data["profile_summaries"]] == ["main", "pawmela"]
+
     def test_get_sessions_all_profiles_aggregates_and_tags_profile(self, monkeypatch):
         import hermes_cli.web_server as web_server
 
@@ -763,6 +807,39 @@ class TestNewEndpoints:
         assert "totals" in data
         assert isinstance(data["daily"], list)
         assert "total_sessions" in data["totals"]
+
+    def test_analytics_usage_all_profiles(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "_list_dashboard_profiles",
+            lambda: {
+                "active_profile": "main",
+                "profiles": [
+                    {"name": "main", "label": "main", "is_active": True},
+                    {"name": "pawmela", "label": "pawmela", "is_active": False},
+                ],
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_usage_analytics_for_profile",
+            lambda profile, days: {
+                "daily": [{"day": "2026-04-14", "input_tokens": 10, "output_tokens": 5, "cache_read_tokens": 0, "reasoning_tokens": 0, "estimated_cost": 0, "actual_cost": 0, "sessions": 1}],
+                "by_model": [{"model": f"{profile}-model", "input_tokens": 10, "output_tokens": 5, "estimated_cost": 0, "sessions": 1}],
+                "totals": {"total_input": 10, "total_output": 5, "total_cache_read": 0, "total_reasoning": 0, "total_estimated_cost": 0, "total_actual_cost": 0, "total_sessions": 1},
+                "period_days": days,
+                "selected_profile": profile,
+            },
+        )
+
+        resp = self.client.get("/api/analytics/usage?days=7&profile=all")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["selected_profile"] == "all"
+        assert data["totals"]["total_sessions"] == 2
+        assert len(data["profile_summaries"]) == 2
 
     def test_session_token_endpoint(self):
         from hermes_cli.web_server import _SESSION_TOKEN

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -185,6 +185,102 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_get_profiles_lists_active_and_available_profiles(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "_list_dashboard_profiles",
+            lambda: {
+                "active_profile": "main",
+                "profiles": [
+                    {"name": "default", "label": "default", "is_active": False},
+                    {"name": "main", "label": "main", "is_active": True},
+                    {"name": "pawmela", "label": "pawmela", "is_active": False},
+                ],
+            },
+        )
+
+        resp = self.client.get("/api/profiles")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["active_profile"] == "main"
+        assert [p["name"] for p in data["profiles"]] == ["default", "main", "pawmela"]
+
+    def test_get_sessions_all_profiles_aggregates_and_tags_profile(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            web_server,
+            "_list_dashboard_profiles",
+            lambda: {
+                "active_profile": "main",
+                "profiles": [
+                    {"name": "main", "label": "main", "is_active": True},
+                    {"name": "pawmela", "label": "pawmela", "is_active": False},
+                ],
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_sessions_for_profile",
+            lambda profile, include_children=False: [
+                {
+                    "id": f"{profile}-1",
+                    "title": f"{profile} session",
+                    "started_at": 100 if profile == "main" else 200,
+                    "last_active": 100 if profile == "main" else 200,
+                    "ended_at": None,
+                    "message_count": 1,
+                    "tool_call_count": 0,
+                    "source": "cli",
+                    "model": "gpt-5.4",
+                    "preview": "hi",
+                }
+            ],
+        )
+
+        resp = self.client.get("/api/sessions?profile=all")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["selected_profile"] == "all"
+        assert data["total"] == 2
+        assert [s["profile"] for s in data["sessions"]] == ["pawmela", "main"]
+        assert data["available_profiles"][0]["name"] == "main"
+
+    def test_get_session_messages_uses_selected_profile(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        class _DB:
+            def resolve_session_id(self, session_id):
+                return session_id if session_id == "abc123" else None
+
+            def get_messages(self, session_id):
+                return [{"role": "user", "content": "hello from pawmela"}]
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            web_server,
+            "_list_dashboard_profiles",
+            lambda: {
+                "active_profile": "main",
+                "profiles": [
+                    {"name": "main", "label": "main", "is_active": True},
+                    {"name": "pawmela", "label": "pawmela", "is_active": False},
+                ],
+            },
+        )
+        monkeypatch.setattr(web_server, "_session_db_for_profile", lambda profile: _DB())
+
+        resp = self.client.get("/api/sessions/abc123/messages?profile=pawmela")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "abc123"
+        assert data["profile"] == "pawmela"
+        assert data["messages"][0]["content"] == "hello from pawmela"
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,14 +22,26 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
-  getSessions: (limit = 20, offset = 0) =>
-    fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
-  getSessionMessages: (id: string) =>
-    fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
-  deleteSession: (id: string) =>
-    fetchJSON<{ ok: boolean }>(`/api/sessions/${encodeURIComponent(id)}`, {
+  getProfiles: () => fetchJSON<ProfilesResponse>("/api/profiles"),
+  getSessions: (limit = 20, offset = 0, profile?: string) => {
+    const qs = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    if (profile) qs.set("profile", profile);
+    return fetchJSON<PaginatedSessions>(`/api/sessions?${qs.toString()}`);
+  },
+  getSessionMessages: (id: string, profile?: string) => {
+    const qs = new URLSearchParams();
+    if (profile) qs.set("profile", profile);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages${suffix}`);
+  },
+  deleteSession: (id: string, profile?: string) => {
+    const qs = new URLSearchParams();
+    if (profile) qs.set("profile", profile);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return fetchJSON<{ ok: boolean }>(`/api/sessions/${encodeURIComponent(id)}${suffix}`, {
       method: "DELETE",
-    }),
+    });
+  },
   getLogs: (params: { file?: string; lines?: number; level?: string; component?: string }) => {
     const qs = new URLSearchParams();
     if (params.file) qs.set("file", params.file);
@@ -110,8 +122,11 @@ export const api = {
   getToolsets: () => fetchJSON<ToolsetInfo[]>("/api/tools/toolsets"),
 
   // Session search (FTS5)
-  searchSessions: (q: string) =>
-    fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}`),
+  searchSessions: (q: string, profile?: string) => {
+    const qs = new URLSearchParams({ q });
+    if (profile) qs.set("profile", profile);
+    return fetchJSON<SessionSearchResponse>(`/api/sessions/search?${qs.toString()}`);
+  },
 
   // OAuth provider management
   getOAuthProviders: () =>
@@ -196,6 +211,7 @@ export interface StatusResponse {
 
 export interface SessionInfo {
   id: string;
+  profile: string | null;
   source: string | null;
   model: string | null;
   title: string | null;
@@ -215,6 +231,9 @@ export interface PaginatedSessions {
   total: number;
   limit: number;
   offset: number;
+  selected_profile: string;
+  active_profile: string;
+  available_profiles: ProfileOption[];
 }
 
 export interface EnvVarInfo {
@@ -242,6 +261,7 @@ export interface SessionMessage {
 
 export interface SessionMessagesResponse {
   session_id: string;
+  profile: string;
   messages: SessionMessage[];
 }
 
@@ -313,8 +333,20 @@ export interface ToolsetInfo {
   tools: string[];
 }
 
+export interface ProfileOption {
+  name: string;
+  label: string;
+  is_active: boolean;
+}
+
+export interface ProfilesResponse {
+  active_profile: string;
+  profiles: ProfileOption[];
+}
+
 export interface SessionSearchResult {
   session_id: string;
+  profile: string;
   snippet: string;
   role: string | null;
   source: string | null;
@@ -324,6 +356,7 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+  selected_profile?: string;
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,7 +21,12 @@ async function getSessionToken(): Promise<string> {
 }
 
 export const api = {
-  getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getStatus: (profile?: string) => {
+    const qs = new URLSearchParams();
+    if (profile) qs.set("profile", profile);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return fetchJSON<StatusResponse>(`/api/status${suffix}`);
+  },
   getProfiles: () => fetchJSON<ProfilesResponse>("/api/profiles"),
   getSessions: (limit = 20, offset = 0, profile?: string) => {
     const qs = new URLSearchParams({ limit: String(limit), offset: String(offset) });
@@ -50,8 +55,11 @@ export const api = {
     if (params.component && params.component !== "all") qs.set("component", params.component);
     return fetchJSON<LogsResponse>(`/api/logs?${qs.toString()}`);
   },
-  getAnalytics: (days: number) =>
-    fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
+  getAnalytics: (days: number, profile?: string) => {
+    const qs = new URLSearchParams({ days: String(days) });
+    if (profile) qs.set("profile", profile);
+    return fetchJSON<AnalyticsResponse>(`/api/analytics/usage?${qs.toString()}`);
+  },
   getConfig: () => fetchJSON<Record<string, unknown>>("/api/config"),
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
@@ -192,8 +200,22 @@ export interface PlatformStatus {
   updated_at: string;
 }
 
+export interface ProfileStatusSummary {
+  profile: string;
+  active_sessions: number;
+  gateway_running: boolean;
+  gateway_pid: number | null;
+  gateway_state: string | null;
+  gateway_platforms: Record<string, PlatformStatus>;
+  gateway_exit_reason: string | null;
+  gateway_updated_at: string | null;
+  hermes_home: string;
+}
+
 export interface StatusResponse {
   active_sessions: number;
+  active_profile: string;
+  available_profiles: ProfileOption[];
   config_path: string;
   config_version: number;
   env_path: string;
@@ -205,7 +227,9 @@ export interface StatusResponse {
   gateway_updated_at: string | null;
   hermes_home: string;
   latest_config_version: number;
+  profile_summaries: ProfileStatusSummary[];
   release_date: string;
+  selected_profile: string;
   version: string;
 }
 
@@ -289,9 +313,28 @@ export interface AnalyticsModelEntry {
   sessions: number;
 }
 
-export interface AnalyticsResponse {
+export interface ProfileAnalyticsSummary {
+  profile: string;
   daily: AnalyticsDailyEntry[];
   by_model: AnalyticsModelEntry[];
+  totals: {
+    total_input: number;
+    total_output: number;
+    total_cache_read: number;
+    total_reasoning: number;
+    total_estimated_cost: number;
+    total_actual_cost: number;
+    total_sessions: number;
+  };
+}
+
+export interface AnalyticsResponse {
+  active_profile: string;
+  available_profiles: ProfileOption[];
+  daily: AnalyticsDailyEntry[];
+  by_model: AnalyticsModelEntry[];
+  profile_summaries: ProfileAnalyticsSummary[];
+  selected_profile: string;
   totals: {
     total_input: number;
     total_output: number;

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -229,6 +229,8 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
 
 export default function AnalyticsPage() {
   const [days, setDays] = useState(30);
+  const [selectedProfile, setSelectedProfile] = useState("all");
+  const [availableProfiles, setAvailableProfiles] = useState<Array<{ name: string; label: string; is_active: boolean }>>([]);
   const [data, setData] = useState<AnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -238,11 +240,14 @@ export default function AnalyticsPage() {
     setLoading(true);
     setError(null);
     api
-      .getAnalytics(days)
-      .then(setData)
+      .getAnalytics(days, selectedProfile)
+      .then((resp) => {
+        setData(resp);
+        setAvailableProfiles(resp.available_profiles ?? []);
+      })
       .catch((err) => setError(String(err)))
       .finally(() => setLoading(false));
-  }, [days]);
+  }, [days, selectedProfile]);
 
   useEffect(() => {
     load();
@@ -251,19 +256,34 @@ export default function AnalyticsPage() {
   return (
     <div className="flex flex-col gap-6">
       {/* Period selector */}
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground font-medium">{t.analytics.period}</span>
-        {PERIODS.map((p) => (
-          <Button
-            key={p.label}
-            variant={days === p.days ? "default" : "outline"}
-            size="sm"
-            className="text-xs h-7"
-            onClick={() => setDays(p.days)}
-          >
-            {p.label}
-          </Button>
-        ))}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground font-medium">{t.analytics.period}</span>
+          {PERIODS.map((p) => (
+            <Button
+              key={p.label}
+              variant={days === p.days ? "default" : "outline"}
+              size="sm"
+              className="text-xs h-7"
+              onClick={() => setDays(p.days)}
+            >
+              {p.label}
+            </Button>
+          ))}
+        </div>
+        <select
+          value={selectedProfile}
+          onChange={(e) => setSelectedProfile(e.target.value)}
+          className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground sm:w-44"
+          aria-label="Filter analytics by profile"
+        >
+          <option value="all">All profiles</option>
+          {availableProfiles.map((profile) => (
+            <option key={profile.name} value={profile.name}>
+              {profile.is_active ? `${profile.label} (active)` : profile.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       {loading && !data && (

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -177,6 +177,7 @@ function SessionRow({
   isExpanded,
   onToggle,
   onDelete,
+  selectedProfile,
 }: {
   session: SessionInfo;
   snippet?: string;
@@ -184,6 +185,7 @@ function SessionRow({
   isExpanded: boolean;
   onToggle: () => void;
   onDelete: () => void;
+  selectedProfile: string;
 }) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -194,12 +196,12 @@ function SessionRow({
     if (isExpanded && messages === null && !loading) {
       setLoading(true);
       api
-        .getSessionMessages(session.id)
+        .getSessionMessages(session.id, session.profile ?? (selectedProfile === "all" ? undefined : selectedProfile))
         .then((resp) => setMessages(resp.messages))
         .catch((err) => setError(String(err)))
         .finally(() => setLoading(false));
     }
-  }, [isExpanded, session.id, messages, loading]);
+  }, [isExpanded, session.id, session.profile, selectedProfile, messages, loading]);
 
   const sourceInfo = (session.source ? SOURCE_CONFIG[session.source] : null) ?? { icon: Globe, color: "text-muted-foreground" };
   const SourceIcon = sourceInfo.icon;
@@ -254,6 +256,11 @@ function SessionRow({
           <Badge variant="outline" className="text-[10px]">
             {session.source ?? "local"}
           </Badge>
+          {(selectedProfile === "all" || session.profile) && (
+            <Badge variant="secondary" className="text-[10px]">
+              {session.profile ?? selectedProfile}
+            </Badge>
+          )}
           <Button
             variant="ghost"
             size="icon"
@@ -298,27 +305,30 @@ export default function SessionsPage() {
   const PAGE_SIZE = 20;
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<SessionSearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
+  const [selectedProfile, setSelectedProfile] = useState<string>("all");
+  const [availableProfiles, setAvailableProfiles] = useState<Array<{ name: string; label: string; is_active: boolean }>>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const { t } = useI18n();
 
-  const loadSessions = useCallback((p: number) => {
+  const loadSessions = useCallback((p: number, profile: string) => {
     setLoading(true);
     api
-      .getSessions(PAGE_SIZE, p * PAGE_SIZE)
+      .getSessions(PAGE_SIZE, p * PAGE_SIZE, profile)
       .then((resp) => {
         setSessions(resp.sessions);
         setTotal(resp.total);
+        setAvailableProfiles(resp.available_profiles);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
   useEffect(() => {
-    loadSessions(page);
-  }, [loadSessions, page]);
+    loadSessions(page, selectedProfile);
+  }, [loadSessions, page, selectedProfile]);
 
   // Debounced FTS search
   useEffect(() => {
@@ -333,7 +343,7 @@ export default function SessionsPage() {
     setSearching(true);
     debounceRef.current = setTimeout(() => {
       api
-        .searchSessions(search.trim())
+        .searchSessions(search.trim(), selectedProfile)
         .then((resp) => setSearchResults(resp.results))
         .catch(() => setSearchResults(null))
         .finally(() => setSearching(false));
@@ -342,31 +352,31 @@ export default function SessionsPage() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [search]);
+  }, [search, selectedProfile]);
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (id: string, profile: string | null) => {
     try {
-      await api.deleteSession(id);
-      setSessions((prev) => prev.filter((s) => s.id !== id));
+      await api.deleteSession(id, profile ?? (selectedProfile === "all" ? undefined : selectedProfile));
+      setSessions((prev) => prev.filter((s) => !(s.id === id && (s.profile ?? selectedProfile) === (profile ?? selectedProfile))));
       setTotal((prev) => prev - 1);
-      if (expandedId === id) setExpandedId(null);
+      if (expandedKey === `${profile ?? selectedProfile}:${id}`) setExpandedKey(null);
     } catch {
       // ignore
     }
   };
 
-  // Build snippet map from search results (session_id → snippet)
+  // Build snippet map from search results ((profile:session_id) → snippet)
   const snippetMap = new Map<string, string>();
   if (searchResults) {
     for (const r of searchResults) {
-      snippetMap.set(r.session_id, r.snippet);
+      snippetMap.set(`${r.profile}:${r.session_id}`, r.snippet);
     }
   }
 
   // When searching, filter sessions to those with FTS matches;
   // when not searching, show all sessions
   const filtered = searchResults
-    ? sessions.filter((s) => snippetMap.has(s.id))
+    ? sessions.filter((s) => snippetMap.has(`${s.profile ?? selectedProfile}:${s.id}`))
     : sessions;
 
   if (loading) {
@@ -388,27 +398,47 @@ export default function SessionsPage() {
             {total}
           </Badge>
         </div>
-        <div className="relative w-full sm:w-64">
-          {searching ? (
-            <div className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
-          ) : (
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          )}
-          <Input
-            placeholder={t.sessions.searchPlaceholder}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-7 h-8 text-xs"
-          />
-          {search && (
-            <button
-              type="button"
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
-              onClick={() => setSearch("")}
-            >
-              <X className="h-3 w-3" />
-            </button>
-          )}
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+          <select
+            value={selectedProfile}
+            onChange={(e) => {
+              setSelectedProfile(e.target.value);
+              setPage(0);
+              setExpandedKey(null);
+            }}
+            className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground sm:w-44"
+            aria-label="Filter sessions by profile"
+          >
+            <option value="all">All profiles</option>
+            {availableProfiles.map((profile) => (
+              <option key={profile.name} value={profile.name}>
+                {profile.is_active ? `${profile.label} (active)` : profile.label}
+              </option>
+            ))}
+          </select>
+          <div className="relative w-full sm:w-64">
+            {searching ? (
+              <div className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
+            ) : (
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            )}
+            <Input
+              placeholder={t.sessions.searchPlaceholder}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8 pr-7 h-8 text-xs"
+            />
+            {search && (
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
+                onClick={() => setSearch("")}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        </div>
         </div>
       </div>
 
@@ -427,15 +457,16 @@ export default function SessionsPage() {
           <div className="flex flex-col gap-1.5">
             {filtered.map((s) => (
               <SessionRow
-                key={s.id}
+                key={`${s.profile ?? selectedProfile}:${s.id}`}
                 session={s}
-                snippet={snippetMap.get(s.id)}
+                snippet={snippetMap.get(`${s.profile ?? selectedProfile}:${s.id}`)}
                 searchQuery={search || undefined}
-                isExpanded={expandedId === s.id}
+                isExpanded={expandedKey === `${s.profile ?? selectedProfile}:${s.id}`}
                 onToggle={() =>
-                  setExpandedId((prev) => (prev === s.id ? null : s.id))
+                  setExpandedKey((prev) => (prev === `${s.profile ?? selectedProfile}:${s.id}` ? null : `${s.profile ?? selectedProfile}:${s.id}`))
                 }
-                onDelete={() => handleDelete(s.id)}
+                onDelete={() => handleDelete(s.id, s.profile)}
+                selectedProfile={selectedProfile}
               />
             ))}
           </div>

--- a/web/src/pages/StatusPage.tsx
+++ b/web/src/pages/StatusPage.tsx
@@ -17,19 +17,20 @@ import { Badge } from "@/components/ui/badge";
 import { useI18n } from "@/i18n";
 
 export default function StatusPage() {
+  const [selectedProfile, setSelectedProfile] = useState("all");
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const { t } = useI18n();
 
   useEffect(() => {
     const load = () => {
-      api.getStatus().then(setStatus).catch(() => {});
-      api.getSessions(50).then((resp) => setSessions(resp.sessions)).catch(() => {});
+      api.getStatus(selectedProfile).then(setStatus).catch(() => {});
+      api.getSessions(50, 0, selectedProfile).then((resp) => setSessions(resp.sessions)).catch(() => {});
     };
     load();
     const interval = setInterval(load, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [selectedProfile]);
 
   if (!status) {
     return (
@@ -115,6 +116,22 @@ export default function StatusPage() {
 
   return (
     <div className="flex flex-col gap-6">
+      <div className="flex justify-end">
+        <select
+          value={selectedProfile}
+          onChange={(e) => setSelectedProfile(e.target.value)}
+          className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground sm:w-44"
+          aria-label="Filter status by profile"
+        >
+          <option value="all">All profiles</option>
+          {status.available_profiles.map((profile) => (
+            <option key={profile.name} value={profile.name}>
+              {profile.is_active ? `${profile.label} (active)` : profile.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
       {/* Alert banner — breaks grid monotony for critical states */}
       {alerts.length > 0 && (
         <div className="border border-destructive/30 bg-destructive/[0.06] p-4">
@@ -158,6 +175,32 @@ export default function StatusPage() {
         ))}
       </div>
 
+      {selectedProfile === "all" && status.profile_summaries.length > 0 && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Database className="h-5 w-5 text-muted-foreground" />
+              <CardTitle className="text-base">Profile Overview</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {status.profile_summaries.map((summary) => (
+              <div key={summary.profile} className="border border-border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-sm">{summary.profile}</span>
+                  <Badge variant={summary.gateway_running ? "success" : "outline"} className="text-[10px]">
+                    {summary.gateway_running ? "gateway on" : "gateway off"}
+                  </Badge>
+                </div>
+                <div className="mt-2 text-xs text-muted-foreground">
+                  {summary.active_sessions} active session{summary.active_sessions === 1 ? "" : "s"}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
       {platforms.length > 0 && (
         <PlatformsCard platforms={platforms} platformStateBadge={PLATFORM_STATE_BADGE} />
       )}
@@ -185,6 +228,11 @@ export default function StatusPage() {
                       <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
                       {t.common.live}
                     </Badge>
+                    {(selectedProfile === "all" || s.profile) && (
+                      <Badge variant="secondary" className="text-[10px] shrink-0">
+                        {s.profile ?? selectedProfile}
+                      </Badge>
+                    )}
                   </div>
 
                   <span className="text-xs text-muted-foreground truncate">
@@ -213,7 +261,14 @@ export default function StatusPage() {
                 className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border border-border p-3 w-full"
               >
                 <div className="flex flex-col gap-1 min-w-0 w-full">
-                  <span className="font-medium text-sm truncate">{s.title ?? t.common.untitled}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm truncate">{s.title ?? t.common.untitled}</span>
+                    {(selectedProfile === "all" || s.profile) && (
+                      <Badge variant="secondary" className="text-[10px] shrink-0">
+                        {s.profile ?? selectedProfile}
+                      </Badge>
+                    )}
+                  </div>
 
                   <span className="text-xs text-muted-foreground truncate">
                     <span className="font-mono-ui">{(s.model ?? t.common.unknown).split("/").pop()}</span> · {s.message_count} {t.common.msgs} · {timeAgo(s.last_active)}


### PR DESCRIPTION
## Summary
- add profile-aware session browsing to the dashboard, including an all-profiles view
- add profile filters to analytics and status pages
- show per-session / per-page profile context in the UI
- add backend API support and regression tests for profile-aware dashboard browsing

Note: this combines the sessions and analytics/status dashboard changes into one PR because the analytics/status profile filters depend on the profile-aware session/dashboard plumbing introduced here.

## Test Plan
- python -m pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_profiles.py -q
- cd web && npm run build