### PR TITLE
fix(display): cap tool previews for tiny max_len values

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -270,7 +270,10 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     if not preview:
         return None
     if max_len > 0 and len(preview) > max_len:
-        preview = preview[:max_len - 3] + "..."
+        if max_len <= 3:
+            preview = "." * max_len
+        else:
+            preview = preview[:max_len - 3] + "..."
     return preview
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -59,6 +59,14 @@ class TestBuildToolPreview:
         assert result is not None
         assert len(result) <= 43  # max_len + "..."
 
+    def test_tiny_max_len_stays_bounded(self):
+        """Tiny positive limits should still cap output length."""
+        long_cmd = "abcdefghijklmnopqrstuvwxyz"
+
+        assert build_tool_preview("terminal", {"command": long_cmd}, max_len=3) == "..."
+        assert build_tool_preview("terminal", {"command": long_cmd}, max_len=2) == ".."
+        assert build_tool_preview("terminal", {"command": long_cmd}, max_len=1) == "."
+
     def test_process_tool_with_none_args(self):
         """Process tool special case should also handle None args."""
         assert build_tool_preview("process", None) is None


### PR DESCRIPTION
## Summary
Fix `build_tool_preview()` so tiny positive `max_len` values still respect the configured limit.

## Related Issue
Fixes #9439

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Handle `max_len <= 3` as a special-case truncation path in `agent/display.py`
- Add regression coverage for `max_len` values `1`, `2`, and `3` in `tests/agent/test_display.py`

## How to Test
1. `. venv/bin/activate`
2. `python -m pytest tests/agent/test_display.py -q`
3. Confirm the tiny-limit assertions pass and all display tests remain green

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — no docs/config/tool schema updates required
