### PR TITLE
fix(cli): let enter submit on terminals sending c-j

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8425,11 +8425,6 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
-        @kb.add('c-j')
-        def handle_ctrl_enter(event):
-            """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""
-            event.current_buffer.insert_text('\n')
-
         @kb.add('tab', eager=True)
         def handle_tab(event):
             """Tab: accept completion, auto-suggestion, or start completions.

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,6 +3,7 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
+import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -147,6 +148,45 @@ class TestBusyInputMode:
             cli._interrupt_queue.put(text)
         assert cli._interrupt_queue.get_nowait() == "redirect"
         assert cli._pending_input.empty()
+
+
+class TestKeyBindings:
+    def test_run_does_not_override_prompt_toolkit_ctrl_j_submit(self, monkeypatch):
+        cli_obj = _make_cli()
+
+        class RecordingKeyBindings:
+            def __init__(self):
+                self.bindings = []
+
+            def add(self, *keys, **kwargs):
+                def decorator(fn):
+                    self.bindings.append((keys, kwargs, fn.__name__))
+                    return fn
+
+                return decorator
+
+        captured = {}
+
+        def fake_keybindings():
+            kb = RecordingKeyBindings()
+            captured["kb"] = kb
+            return kb
+
+        def fake_application(*args, **kwargs):
+            raise RuntimeError("stop-after-bindings")
+
+        monkeypatch.setitem(cli_obj.run.__globals__, "KeyBindings", fake_keybindings)
+        monkeypatch.setitem(cli_obj.run.__globals__, "Application", fake_application)
+        monkeypatch.setattr(cli_obj, "show_banner", lambda: None)
+        cli_obj.console = MagicMock()
+
+        with pytest.raises(RuntimeError, match="stop-after-bindings"):
+            cli_obj.run()
+
+        registered = [keys for keys, _kwargs, _name in captured["kb"].bindings]
+        assert ("enter",) in registered
+        assert ("escape", "enter") in registered
+        assert ("c-j",) not in registered
 
 
 class TestSingleQueryState:


### PR DESCRIPTION
## Summary
Remove Hermes' custom `c-j` newline binding so terminals that send `\n` for Enter fall back to prompt_toolkit's built-in submit remapping.

## Related Issue
Fixes #9299

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Remove the custom `@kb.add('c-j')` newline override in `cli.py`
- Add a regression test that inspects run-time key binding registration and asserts `c-j` is no longer shadowed

## How to Test
1. `. venv/bin/activate`
2. `python -m pytest tests/cli/test_cli_init.py -q`
3. In a terminal that sends `\n` for Enter, verify Enter submits and `Alt+Enter` still inserts a newline

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — no docs/config/tool schema updates required
