### PR TITLE
fix: handle Telegram channel-post commands

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -591,6 +591,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._handle_command
             ))
             self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.CHANNEL_POSTS & filters.COMMAND,
+                self._handle_command
+            ))
+            self._app.add_handler(TelegramMessageHandler(
                 filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
                 self._handle_location_message
             ))
@@ -2130,14 +2134,25 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
     
+    @staticmethod
+    def _get_update_message(update: Update) -> Optional[Message]:
+        """Return the Telegram message payload from any supported update type."""
+        return (
+            getattr(update, "message", None)
+            or getattr(update, "edited_message", None)
+            or getattr(update, "channel_post", None)
+            or getattr(update, "edited_channel_post", None)
+        )
+
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
-        if not update.message or not update.message.text:
+        message = self._get_update_message(update)
+        if not message or not message.text:
             return
-        if not self._should_process_message(update.message, is_command=True):
+        if not self._should_process_message(message, is_command=True):
             return
         
-        event = self._build_message_event(update.message, MessageType.COMMAND)
+        event = self._build_message_event(message, MessageType.COMMAND)
         await self.handle_message(event)
     
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -1,0 +1,117 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.base import MessageType  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_auto_discovery(monkeypatch):
+    async def _noop():
+        return []
+
+    monkeypatch.setattr("gateway.platforms.telegram.discover_fallback_ips", _noop)
+
+
+@pytest.mark.asyncio
+async def test_handle_command_accepts_channel_posts():
+    adapter = object.__new__(TelegramAdapter)
+    message = SimpleNamespace(text="/sethome")
+    event = object()
+    adapter._should_process_message = MagicMock(return_value=True)
+    adapter._build_message_event = MagicMock(return_value=event)
+    adapter.handle_message = AsyncMock()
+
+    update = SimpleNamespace(message=None, channel_post=message, edited_channel_post=None)
+
+    await adapter._handle_command(update, None)
+
+    adapter._should_process_message.assert_called_once_with(message, is_command=True)
+    adapter._build_message_event.assert_called_once_with(message, MessageType.COMMAND)
+    adapter.handle_message.assert_awaited_once_with(event)
+
+
+@pytest.mark.asyncio
+async def test_connect_registers_channel_post_command_handler(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    handlers = []
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.TelegramMessageHandler",
+        lambda filters_arg, callback: SimpleNamespace(filters=filters_arg, callback=callback),
+    )
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(side_effect=handlers.append),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    command_handlers = [
+        handler for handler in handlers
+        if getattr(handler, "callback", None) == adapter._handle_command
+    ]
+    assert len(command_handlers) >= 2
+    assert any("CHANNEL_POSTS" in repr(getattr(handler, "filters", "")) for handler in command_handlers)


### PR DESCRIPTION
## Bug Description
Telegram channel posts containing slash commands were not reaching the command handler, so commands like `/sethome` failed when posted from channels.

## Root Cause
The Telegram adapter only registered the normal command handler, and `_handle_command()` only read `update.message`. Telegram channel-post commands arrive via `update.channel_post` / `update.edited_channel_post`, so they were ignored.

## Fix
- register a Telegram command handler for `filters.UpdateType.CHANNEL_POSTS & filters.COMMAND`
- normalize command updates through a small helper that accepts `message`, `edited_message`, `channel_post`, and `edited_channel_post`
- add regression tests covering both channel-post command routing and handler registration

## How to Verify
1. `source venv/bin/activate && python -m pytest tests/gateway/test_telegram_channel_posts.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_reactions.py -q`
2. Post a slash command like `/sethome` in a Telegram channel where Hermes is admin
3. Confirm the command reaches the gateway command handler instead of being ignored

## Test Plan
- [x] Added regression test for this bug
- [x] Existing targeted Telegram tests still pass
- [ ] Manual verification in a live Telegram channel

## Risk Assessment
Low — the change is narrowly scoped to Telegram command update routing and is covered by targeted regression tests.
