### PR TITLE
fix(model_switch): properly load models for custom and dynamic providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -818,6 +818,12 @@ def list_authenticated_providers(
 
         # Use curated list, falling back to models.dev if no curated list
         model_ids = curated.get(hermes_id, [])
+        if not model_ids:
+            mdev_models = pdata.get("models", {})
+            if isinstance(mdev_models, dict):
+                model_ids = [k for k, v in mdev_models.items() if isinstance(v, dict) and v.get("tool_call")]
+                if not model_ids:
+                    model_ids = list(mdev_models.keys())
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -992,6 +998,16 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model:
                 models_list.append(default_model)
+
+            cfg_models = entry.get("models", [])
+            if isinstance(cfg_models, list):
+                for m in cfg_models:
+                    if m and m not in models_list:
+                        models_list.append(m)
+            elif isinstance(cfg_models, dict):
+                for m in cfg_models.keys():
+                    if m and m not in models_list:
+                        models_list.append(m)
 
             results.append({
                 "slug": slug,


### PR DESCRIPTION
## What does this PR do?

This PR fixes two distinct bugs in the [hermes_cli/model_switch.py](cci:7://file:///home/waheed/hermes-agent/hermes_cli/model_switch.py:0:0-0:0) [list_authenticated_providers](cci:1://file:///home/waheed/hermes-agent/hermes_cli/model_switch.py:752:0-1026:18) logic that caused valid providers to show exactly 0 available models in the Telegram interactive [send_model_picker](cci:1://file:///home/waheed/hermes-agent/gateway/platforms/telegram.py:1118:4-1189:58) and CLI model selections:

1. **Custom Providers Issue**: The logic completely ignored the `models:` dictionary/list block for `custom_providers` defined in `~/.hermes/config.yaml`, only looking for `model:` strings. It now properly recursively parses the [models](cci:1://file:///home/waheed/hermes-agent/hermes_cli/models.py:1727:0-1737:77) dictionary or list array so all custom models are detected.
2. **Missing `models.dev` Fallback**: For built-in APIs that intentionally lack a curated list (such as `togetherai`), the code had a comment saying `# fallback to models.dev` but just grabbed an empty list from the curated dictionary. It now implements the actual fallback to dynamically hit the live `models.dev` dictionary and properly lists only agentic (`tool_call=True`) models for these providers.

## Related Issue

Fixes # (Leave blank if you don't have an issue to link)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [hermes_cli/model_switch.py](cci:7://file:///home/waheed/hermes-agent/hermes_cli/model_switch.py:0:0-0:0): Added fallback logic inside [list_authenticated_providers()](cci:1://file:///home/waheed/hermes-agent/hermes_cli/model_switch.py:752:0-1026:18) (around line 818) to read `pdata.get("models")` and filter for `v.get("tool_call")` if `curated.get()` is empty.
- [hermes_cli/model_switch.py](cci:7://file:///home/waheed/hermes-agent/hermes_cli/model_switch.py:0:0-0:0): Updated the `custom_providers` extraction logic (around line 999) to parse `entry.get("models")` and merge its keys into `models_list`, identical to how `user_providers` defines them.

## How to Test

1. Configure a `custom_providers` endpoint in `~/.hermes/config.yaml` with a robust `models:` dictionary (like 15 models).
2. Authenticate a built-in provider that isn't statically tracked in `_PROVIDER_MODELS` (like Together AI).
3. Open Telegram and trigger `/model` or use `hermes model` in the CLI. Note that before this PR they would say 0 models. Both will now properly display all available models.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) ([fix(scope):](cci:1://file:///home/waheed/hermes-agent/hermes_cli/models.py:1134:0-1139:14), `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated [cli-config.yaml.example](cci:7://file:///home/waheed/hermes-agent/cli-config.yaml.example:0:0-0:0) if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
