### PR TITLE
fix(cron): guard against non-dict conversation results

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -829,6 +829,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"— last activity: {_last_desc}"
             )
 
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
+            )
+
         final_response = result.get("final_response", "") or ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -711,6 +711,40 @@ class TestRunJobSessionPersistence:
         # But the output log should show the placeholder
         assert "(No response generated)" in output
 
+    def test_run_job_rejects_non_dict_run_conversation_result(self, tmp_path):
+        job = {
+            "id": "bad-result-job",
+            "name": "bad result",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = 123
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert "RuntimeError" in error
+        assert "returned int instead of dict" in error
+        assert "123" in output
+
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {
             "id": "test-job",


### PR DESCRIPTION
## Summary
Guard `cron.scheduler.run_job()` against non-dict returns from `agent.run_conversation()` so cron failures surface a clear runtime error instead of crashing with `AttributeError`.

## Related Issue
Fixes #9433

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Add a result type guard before `final_response` extraction in `cron/scheduler.py`
- Add a regression test covering `run_conversation()` returning an `int`

## How to Test
1. `. venv/bin/activate`
2. `python -m pytest tests/cron/test_scheduler.py -q`
3. Confirm `run_job()` reports a `RuntimeError` mentioning the unexpected return type instead of an `AttributeError`

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — no docs/config/tool schema updates required
