### PR TITLE
fix(packaging): include qrcode in messaging extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
-messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29"]

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -27,3 +27,10 @@ def test_matrix_extra_linux_only_in_all():
         if "matrix" in dep and "linux" in dep
     ]
     assert linux_gated, "expected hermes-agent[matrix] with sys_platform=='linux' marker in [all]"
+
+
+def test_messaging_extra_includes_qrcode_for_weixin_setup():
+    optional_dependencies = _load_optional_dependencies()
+
+    messaging_extra = optional_dependencies["messaging"]
+    assert any(dep.startswith("qrcode") for dep in messaging_extra)

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -16,14 +16,14 @@ This adapter is for **personal WeChat accounts** (微信). If you need enterpris
 
 - A personal WeChat account
 - Python packages: `aiohttp` and `cryptography`
-- The `qrcode` package is optional (for terminal QR rendering during setup)
+- Terminal QR rendering is included when Hermes is installed with the `messaging` extra
 
 Install the required dependencies:
 
 ```bash
 pip install aiohttp cryptography
 # Optional: for terminal QR code display
-pip install qrcode
+pip install hermes-agent[messaging]
 ```
 
 ## Setup
@@ -296,4 +296,4 @@ Only one Weixin gateway instance can use a given token at a time. The adapter ac
 | Voice messages show as text | If WeChat provides a transcription, the adapter uses the text. This is expected behavior |
 | Messages appear duplicated | The adapter deduplicates by message ID. If you see duplicates, check if multiple gateway instances are running |
 | `iLink POST ... HTTP 4xx/5xx` | API error from the iLink service. Check your token validity and network connectivity |
-| Terminal QR code doesn't render | Install `qrcode`: `pip install qrcode`. Alternatively, open the URL printed above the QR |
+| Terminal QR code doesn't render | Reinstall with the messaging extra: `pip install hermes-agent[messaging]`. Alternatively, open the URL printed above the QR |


### PR DESCRIPTION
## Summary
Ship `qrcode` in the `messaging` extra so Weixin setup can render terminal QR codes without requiring a follow-up manual install.

## Related Issue
Fixes #9431

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Add `qrcode>=7.0,<8` to `project.optional-dependencies.messaging`
- Add a metadata regression test asserting the messaging extra includes `qrcode`
- Update the Weixin docs to reflect that QR rendering ships with `hermes-agent[messaging]`

## How to Test
1. `. venv/bin/activate`
2. `python -m pytest tests/test_project_metadata.py tests/test_packaging_metadata.py -q`
3. Install with `pip install hermes-agent[messaging]` and verify Weixin setup can render a terminal QR code without extra packages

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation
- [x] N/A — no config/tool schema updates required
