### PR TITLE
fix(config): validate provider URLs and accept alias keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -15,6 +15,7 @@ This module provides:
 import os
 import platform
 import re
+import logging
 import stat
 import subprocess
 import sys
@@ -22,6 +23,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
+from urllib.parse import urlparse
 
 from tools.tool_backend_helpers import managed_nous_tools_enabled as _managed_nous_tools_enabled
 
@@ -58,6 +60,8 @@ _EXTRA_ENV_KEYS = frozenset({
 import yaml
 
 from hermes_cli.colors import Colors, color
+
+logger = logging.getLogger(__name__)
 from hermes_cli.default_soul import DEFAULT_SOUL_MD
 
 
@@ -1643,12 +1647,46 @@ def _normalize_custom_provider_entry(
     if not isinstance(entry, dict):
         return None
 
+    provider_label = provider_key.strip() or str(entry.get("name") or "").strip() or "<unknown>"
+    entry = dict(entry)
+
+    alias_fields = {
+        "apiKey": "api_key",
+        "baseUrl": "base_url",
+        "apiMode": "api_mode",
+        "keyEnv": "key_env",
+        "defaultModel": "default_model",
+        "contextLength": "context_length",
+        "rateLimitDelay": "rate_limit_delay",
+    }
+    for alias, canonical in alias_fields.items():
+        if canonical not in entry and alias in entry:
+            entry[canonical] = entry[alias]
+            logger.warning(
+                "providers.%s uses deprecated field '%s'; use '%s' instead",
+                provider_label,
+                alias,
+                canonical,
+            )
+
+    def _is_valid_base_url(value: str) -> bool:
+        parsed = urlparse(value)
+        return bool(parsed.scheme and parsed.netloc)
+
     base_url = ""
     for url_key in ("api", "url", "base_url"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
-            base_url = raw_url.strip()
-            break
+            candidate = raw_url.strip()
+            if _is_valid_base_url(candidate):
+                base_url = candidate
+                break
+            logger.warning(
+                "Ignoring non-URL value for providers.%s.%s: %r",
+                provider_label,
+                url_key,
+                candidate,
+            )
     if not base_url:
         return None
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -26,7 +26,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import get_compatible_custom_providers, load_config, _normalize_custom_provider_entry
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -275,46 +275,43 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             return None
 
     config = load_config()
-    
+
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
-            if not isinstance(entry, dict):
+            normalized = _normalize_custom_provider_entry(entry, provider_key=str(ep_name))
+            if not normalized:
                 continue
-            # Match exact name or normalized name
-            name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
-            # Fall back to inline api_key when key_env is absent or unresolvable
-            if not resolved_api_key:
-                resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            provider_key = str(normalized.get("provider_key") or ep_name).strip()
+            provider_key_norm = _normalize_custom_provider_name(provider_key)
+            display_name = str(normalized.get("name") or ep_name).strip()
+            display_norm = _normalize_custom_provider_name(display_name)
+            key_env = str(normalized.get("key_env", "") or "").strip()
+            resolved_api_key = str(normalized.get("api_key", "") or "").strip()
+            if key_env and not resolved_api_key:
+                resolved_api_key = os.getenv(key_env, "").strip()
 
-            if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
-                # Found match by provider key
-                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-                if base_url:
-                    return {
-                        "name": entry.get("name", ep_name),
-                        "base_url": base_url.strip(),
-                        "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
-                    }
-            # Also check the 'name' field if present
-            display_name = entry.get("name", "")
-            if display_name:
-                display_norm = _normalize_custom_provider_name(display_name)
-                if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
-                    # Found match by display name
-                    base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-                    if base_url:
-                        return {
-                            "name": display_name,
-                            "base_url": base_url.strip(),
-                            "api_key": resolved_api_key,
-                            "model": entry.get("default_model", ""),
-                        }
+            if requested_norm in {
+                provider_key,
+                provider_key_norm,
+                f"custom:{provider_key_norm}",
+                display_name,
+                display_norm,
+                f"custom:{display_norm}",
+            }:
+                result = {
+                    "name": display_name,
+                    "base_url": str(normalized["base_url"]).strip(),
+                    "api_key": resolved_api_key,
+                    "model": str(normalized.get("model", "") or "").strip(),
+                }
+                if key_env:
+                    result["key_env"] = key_env
+                api_mode = str(normalized.get("api_mode", "") or "").strip()
+                if api_mode:
+                    result["api_mode"] = api_mode
+                return result
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -531,6 +531,63 @@ class TestCustomProviderCompatibility:
             }
         ]
 
+    def test_compatible_custom_providers_accepts_camel_case_aliases(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "nvidia": {
+                            "name": "NVIDIA",
+                            "api": "openai-reverse-proxy",
+                            "baseUrl": "https://integrate.api.nvidia.com/v1",
+                            "apiKey": "${NVIDIA_API_KEY}",
+                            "apiMode": "chat_completions",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == [
+            {
+                "name": "NVIDIA",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+                "provider_key": "nvidia",
+                "api_key": "${NVIDIA_API_KEY}",
+                "api_mode": "chat_completions",
+            }
+        ]
+        assert "openai-reverse-proxy" in caplog.text
+
+    def test_compatible_custom_providers_rejects_non_url_api_without_fallback(self, tmp_path, caplog):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "broken": {
+                            "name": "Broken Provider",
+                            "api": "openai-reverse-proxy",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible == []
+        assert "openai-reverse-proxy" in caplog.text
+
     def test_dedup_across_legacy_and_providers(self, tmp_path):
         """Same name+url in both schemas should not produce duplicates."""
         config_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
Tighten `providers:` normalization so invalid `api` strings are no longer silently treated as `base_url`, while camelCase aliases like `apiKey`, `baseUrl`, and `apiMode` continue to work with deprecation warnings.

## Related Issue
Fixes #9332

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Validate `providers.*` URL candidates before accepting them as `base_url`
- Accept common camelCase aliases (`apiKey`, `baseUrl`, `apiMode`, etc.) and warn about deprecated field names
- Reuse the same normalized provider view in `runtime_provider` so direct `providers:` resolution honors aliases, `api_key`, and `api_mode`
- Add regression coverage for camelCase aliases and invalid non-URL `api` values

## How to Test
1. `. venv/bin/activate`
2. `python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_runtime_provider_resolution.py -q`
3. Verify a `providers:` entry with `baseUrl`/`apiKey` resolves correctly and that a non-URL `api:` value is ignored with a warning

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — no docs/config example updates required for this bugfix
