### PR TITLE
fix(honcho): add lazy submodule shim for broader pytest collection

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -15,10 +15,33 @@ Config: Uses the existing Honcho config chain:
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import threading
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+
+
+def __getattr__(name: str):
+    """Lazily expose Honcho submodules as package attributes.
+
+    Broader pytest collection can resolve monkeypatch paths like
+    ``plugins.memory.honcho.client.HonchoClientConfig`` via package
+    attributes before the submodule has been imported. Mirror the parent
+    plugins.memory lazy-submodule behavior here so those dotted lookups stay
+    importable during collection-order changes.
+    """
+    py_candidate = _PACKAGE_DIR / f"{name}.py"
+    pkg_candidate = _PACKAGE_DIR / name
+    if py_candidate.exists() or (pkg_candidate.is_dir() and (pkg_candidate / "__init__.py").exists()):
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error


### PR DESCRIPTION
## Summary
- add a `__getattr__` lazy-submodule shim to `plugins.memory.honcho`
- keep dotted lookups like `plugins.memory.honcho.client.*` importable during broader pytest collection
- restore the honcho doctor/collection regression on top of current upstream `main`

## Validation
- `python -m pytest -q tests/hermes_cli/test_doctor.py tests/honcho_plugin/test_client.py tests/honcho_plugin/test_session.py`
- `110 passed, 3 warnings in 9.74s`