### PR TITLE
feat(image): add OpenRouter image generation backend

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -491,6 +491,13 @@ DEFAULT_CONFIG = {
             "timeout": 30,
         },
     },
+    "image_generation": {
+        "provider": "fal",       # fal | openrouter
+        "model": "",             # empty = provider default backend model
+        "base_url": "",          # optional OpenAI-compatible override for openrouter backend
+        "api_key": "",           # optional explicit API key for base_url/openrouter backend
+        "timeout": 120,
+    },
     
     "display": {
         "compact": False,
@@ -703,7 +710,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -719,7 +726,9 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    18: ["OPENROUTER_API_KEY"],
 }
+
 
 # Required environment variables with metadata for migration prompts.
 # LLM provider is required but handled in the setup wizard's provider
@@ -739,11 +748,11 @@ OPTIONAL_ENV_VARS = {
         "advanced": True,
     },
     "OPENROUTER_API_KEY": {
-        "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
+        "description": "OpenRouter API key (for vision, web scraping helpers, MoA, and image generation when image_generation.provider=openrouter)",
         "prompt": "OpenRouter API key",
         "url": "https://openrouter.ai/keys",
         "password": True,
-        "tools": ["vision_analyze", "mixture_of_agents"],
+        "tools": ["vision_analyze", "mixture_of_agents", "image_generate"],
         "category": "provider",
         "advanced": True,
     },
@@ -2214,6 +2223,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
+
+    # ── Version 17 → 18: add image_generation backend config ──
+    if current_ver < 18:
+        config = read_raw_config()
+        image_generation = config.get("image_generation")
+        if not isinstance(image_generation, dict):
+            image_generation = {}
+        changed = False
+        for key, default in DEFAULT_CONFIG.get("image_generation", {}).items():
+            if key not in image_generation:
+                image_generation[key] = default
+                changed = True
+        if changed:
+            config["image_generation"] = image_generation
+            results["config_added"].append("image_generation (default backend config)")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added image_generation backend config")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -240,11 +240,14 @@ def get_nous_subscription_features(
     modal_tool_enabled = _toolset_enabled(config, "terminal")
 
     web_cfg = config.get("web") if isinstance(config.get("web"), dict) else {}
+    image_cfg = config.get("image_generation") if isinstance(config.get("image_generation"), dict) else {}
     tts_cfg = config.get("tts") if isinstance(config.get("tts"), dict) else {}
     browser_cfg = config.get("browser") if isinstance(config.get("browser"), dict) else {}
     terminal_cfg = config.get("terminal") if isinstance(config.get("terminal"), dict) else {}
 
     web_backend = str(web_cfg.get("backend") or "").strip().lower()
+    image_provider = str(image_cfg.get("provider") or "fal").strip().lower()
+    image_model = str(image_cfg.get("model") or "").strip()
     tts_provider = str(tts_cfg.get("provider") or "edge").strip().lower()
     browser_provider_explicit = "cloud_provider" in browser_cfg
     browser_provider = normalize_browser_cloud_provider(
@@ -262,6 +265,7 @@ def get_nous_subscription_features(
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
     direct_fal = bool(get_env_value("FAL_KEY"))
+    direct_openrouter_image = bool(str(image_cfg.get("api_key") or "").strip() or get_env_value("OPENROUTER_API_KEY"))
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
     direct_camofox = bool(get_env_value("CAMOFOX_URL"))
@@ -295,9 +299,22 @@ def get_nous_subscription_features(
         managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily
     )
 
-    image_managed = image_tool_enabled and managed_image_available and not direct_fal
-    image_active = bool(image_tool_enabled and (image_managed or direct_fal))
-    image_available = bool(managed_image_available or direct_fal)
+    image_managed = bool(
+        image_tool_enabled
+        and image_provider == "fal"
+        and managed_image_available
+        and not direct_fal
+    )
+    if image_provider == "openrouter":
+        image_available = bool(direct_openrouter_image)
+        image_active = bool(image_tool_enabled and direct_openrouter_image)
+        image_current_provider = image_model or "OpenRouter"
+        image_explicit_configured = bool(direct_openrouter_image)
+    else:
+        image_active = bool(image_tool_enabled and (image_managed or direct_fal))
+        image_available = bool(managed_image_available or direct_fal)
+        image_current_provider = "FAL" if direct_fal else ("Nous Subscription" if image_managed else "")
+        image_explicit_configured = direct_fal
 
     tts_current_provider = tts_provider or "edge"
     tts_managed = (
@@ -390,8 +407,8 @@ def get_nous_subscription_features(
             managed_by_nous=image_managed,
             direct_override=image_active and not image_managed,
             toolset_enabled=image_tool_enabled,
-            current_provider="FAL" if direct_fal else ("Nous Subscription" if image_managed else ""),
-            explicit_configured=direct_fal,
+            current_provider=image_current_provider,
+            explicit_configured=image_explicit_configured,
         ),
         "tts": NousFeatureState(
             key="tts",

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -141,9 +141,19 @@ def show_status(args):
     image_generation_model = ""
     image_generation_provider_error = ""
     if isinstance(image_generation_cfg, dict):
-        image_generation_provider = str(image_generation_cfg.get("provider") or "").strip().lower()
         image_generation_model = str(image_generation_cfg.get("model") or "").strip()
-        image_generation_provider_error = str(image_generation_cfg.get("provider_error") or "").strip()
+        raw_image_generation_provider = str(image_generation_cfg.get("provider") or "").strip()
+        try:
+            from tools.image_generation_tool import _normalize_image_provider
+            image_generation_provider = _normalize_image_provider(raw_image_generation_provider)
+        except Exception:
+            image_generation_provider = raw_image_generation_provider.lower()
+        try:
+            from tools.image_generation_tool import _load_image_generation_config
+            normalized_image_cfg = _load_image_generation_config()
+            image_generation_provider_error = str(normalized_image_cfg.get("provider_error") or "").strip()
+        except Exception as exc:
+            image_generation_provider_error = str(exc)
     
     for name, env_var in keys.items():
         value = get_env_value(env_var) or ""
@@ -163,11 +173,12 @@ def show_status(args):
                 ready = bool(check_fal_api_key())
             except Exception:
                 ready = bool(get_env_value("FAL_KEY"))
-        label = image_generation_provider
+        label = image_generation_provider or str(image_generation_cfg.get("provider") or "").strip().lower()
         if image_generation_model:
             label = f"{label} ({image_generation_model})"
         if image_generation_provider_error:
             label = f"{label} — invalid config: {image_generation_provider_error}"
+            ready = False
         print(f"  {'Image Gen':<12}  {check_mark(ready)} {label}")
 
     from hermes_cli.auth import get_anthropic_key

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -18,6 +18,7 @@ from hermes_cli.models import provider_label
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_constants import OPENROUTER_MODELS_URL
+from tools.image_generation_tool import check_fal_api_key
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
 def check_mark(ok: bool) -> str:
@@ -138,9 +139,11 @@ def show_status(args):
     image_generation_cfg = config.get("image_generation", {}) if isinstance(config, dict) else {}
     image_generation_provider = ""
     image_generation_model = ""
+    image_generation_provider_error = ""
     if isinstance(image_generation_cfg, dict):
-        image_generation_provider = str(image_generation_cfg.get("provider") or "").strip()
+        image_generation_provider = str(image_generation_cfg.get("provider") or "").strip().lower()
         image_generation_model = str(image_generation_cfg.get("model") or "").strip()
+        image_generation_provider_error = str(image_generation_cfg.get("provider_error") or "").strip()
     
     for name, env_var in keys.items():
         value = get_env_value(env_var) or ""
@@ -156,10 +159,15 @@ def show_status(args):
                 or get_env_value("OPENROUTER_API_KEY")
             )
         elif image_generation_provider == "fal":
-            ready = bool(get_env_value("FAL_KEY"))
+            try:
+                ready = bool(check_fal_api_key())
+            except Exception:
+                ready = bool(get_env_value("FAL_KEY"))
         label = image_generation_provider
         if image_generation_model:
             label = f"{label} ({image_generation_model})"
+        if image_generation_provider_error:
+            label = f"{label} — invalid config: {image_generation_provider_error}"
         print(f"  {'Image Gen':<12}  {check_mark(ready)} {label}")
 
     from hermes_cli.auth import get_anthropic_key

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -134,12 +134,33 @@ def show_status(args):
         "ElevenLabs": "ELEVENLABS_API_KEY",
         "GitHub": "GITHUB_TOKEN",
     }
+
+    image_generation_cfg = config.get("image_generation", {}) if isinstance(config, dict) else {}
+    image_generation_provider = ""
+    image_generation_model = ""
+    if isinstance(image_generation_cfg, dict):
+        image_generation_provider = str(image_generation_cfg.get("provider") or "").strip()
+        image_generation_model = str(image_generation_cfg.get("model") or "").strip()
     
     for name, env_var in keys.items():
         value = get_env_value(env_var) or ""
         has_key = bool(value)
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
+
+    if image_generation_provider:
+        ready = False
+        if image_generation_provider == "openrouter":
+            ready = bool(
+                str(image_generation_cfg.get("api_key") or "").strip()
+                or get_env_value("OPENROUTER_API_KEY")
+            )
+        elif image_generation_provider == "fal":
+            ready = bool(get_env_value("FAL_KEY"))
+        label = image_generation_provider
+        if image_generation_model:
+            label = f"{label} ({image_generation_model})"
+        print(f"  {'Image Gen':<12}  {check_mark(ready)} {label}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -228,6 +228,7 @@ TOOL_CATEGORIES = {
                 "requires_nous_auth": True,
                 "managed_nous_feature": "image_gen",
                 "override_env_vars": ["FAL_KEY"],
+                "image_generation_provider": "fal",
             },
             {
                 "name": "FAL.ai",
@@ -235,6 +236,17 @@ TOOL_CATEGORIES = {
                 "env_vars": [
                     {"key": "FAL_KEY", "prompt": "FAL API key", "url": "https://fal.ai/dashboard/keys"},
                 ],
+                "image_generation_provider": "fal",
+                "image_generation_model": "fal-ai/flux-2-pro",
+            },
+            {
+                "name": "OpenRouter",
+                "tag": "OpenRouter image generation (Gemini/GPT Image allowlist)",
+                "env_vars": [
+                    {"key": "OPENROUTER_API_KEY", "prompt": "OpenRouter API key", "url": "https://openrouter.ai/keys"},
+                ],
+                "image_generation_provider": "openrouter",
+                "image_generation_model": "google/gemini-3.1-flash-image-preview",
             },
         ],
     },
@@ -621,11 +633,26 @@ def _toolset_has_keys(ts_key: str, config: dict = None) -> bool:
         except Exception:
             return False
 
-    if ts_key in {"web", "image_gen", "tts", "browser"}:
+    if ts_key in {"web", "tts", "browser"}:
         features = get_nous_subscription_features(config)
         feature = features.features.get(ts_key)
         if feature and (feature.available or feature.managed_by_nous):
             return True
+
+    if ts_key == "image_gen":
+        features = get_nous_subscription_features(config)
+        feature = features.features.get(ts_key)
+        if feature and (feature.available or feature.managed_by_nous):
+            return True
+
+        image_cfg = config.get("image_generation", {})
+        if not isinstance(image_cfg, dict):
+            image_cfg = {}
+        provider = str(image_cfg.get("provider") or "fal").strip().lower()
+        explicit_api_key = str(image_cfg.get("api_key") or "").strip()
+        if provider == "openrouter":
+            return bool(explicit_api_key or get_env_value("OPENROUTER_API_KEY"))
+        return bool(get_env_value("FAL_KEY"))
 
     # Check TOOL_CATEGORIES first (provider-aware)
     cat = TOOL_CATEGORIES.get(ts_key)
@@ -794,6 +821,13 @@ def _toolset_needs_configuration_prompt(ts_key: str, config: dict) -> bool:
         browser_cfg = config.get("browser", {})
         return not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg
     if ts_key == "image_gen":
+        image_cfg = config.get("image_generation", {})
+        if not isinstance(image_cfg, dict):
+            return True
+        provider = str(image_cfg.get("provider") or "").strip().lower()
+        explicit_api_key = str(image_cfg.get("api_key") or "").strip()
+        if provider == "openrouter":
+            return not bool(explicit_api_key or get_env_value("OPENROUTER_API_KEY"))
         return not get_env_value("FAL_KEY")
 
     return not _toolset_has_keys(ts_key, config)
@@ -875,7 +909,13 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
         if feature is None:
             return False
         if managed_feature == "image_gen":
-            return feature.managed_by_nous
+            if provider.get("image_generation_provider") == "fal":
+                image_cfg = config.get("image_generation", {})
+                if isinstance(image_cfg, dict):
+                    current_provider = str(image_cfg.get("provider") or "fal").strip().lower()
+                    if current_provider == "fal":
+                        return feature.managed_by_nous
+            return feature.managed_by_nous and not provider.get("image_generation_provider")
         if provider.get("tts_provider"):
             return (
                 feature.managed_by_nous
@@ -897,6 +937,16 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
     if provider.get("web_backend"):
         current = config.get("web", {}).get("backend")
         return current == provider["web_backend"]
+    if provider.get("image_generation_provider"):
+        image_cfg = config.get("image_generation", {})
+        if not isinstance(image_cfg, dict):
+            return False
+        current_provider = str(image_cfg.get("provider") or "fal").strip().lower()
+        if current_provider != provider["image_generation_provider"]:
+            return False
+        model = str(image_cfg.get("model") or "").strip()
+        expected_model = str(provider.get("image_generation_model") or "").strip()
+        return not expected_model or not model or model == expected_model
     return False
 
 
@@ -941,6 +991,14 @@ def _configure_provider(provider: dict, config: dict):
     if provider.get("web_backend"):
         config.setdefault("web", {})["backend"] = provider["web_backend"]
         _print_success(f"  Web backend set to: {provider['web_backend']}")
+
+    image_generation_provider = provider.get("image_generation_provider")
+    if image_generation_provider:
+        image_cfg = config.setdefault("image_generation", {})
+        image_cfg["provider"] = image_generation_provider
+        if provider.get("image_generation_model"):
+            image_cfg["model"] = provider["image_generation_model"]
+        _print_success(f"  Image generation backend set to: {image_generation_provider}")
 
     if not env_vars:
         if provider.get("post_setup"):
@@ -1150,6 +1208,14 @@ def _reconfigure_provider(provider: dict, config: dict):
     if provider.get("web_backend"):
         config.setdefault("web", {})["backend"] = provider["web_backend"]
         _print_success(f"  Web backend set to: {provider['web_backend']}")
+
+    image_generation_provider = provider.get("image_generation_provider")
+    if image_generation_provider:
+        image_cfg = config.setdefault("image_generation", {})
+        image_cfg["provider"] = image_generation_provider
+        if provider.get("image_generation_model"):
+            image_cfg["model"] = provider["image_generation_model"]
+        _print_success(f"  Image generation backend set to: {image_generation_provider}")
 
     if not env_vars:
         if provider.get("post_setup"):

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -944,6 +944,8 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
         current_provider = str(image_cfg.get("provider") or "fal").strip().lower()
         if current_provider != provider["image_generation_provider"]:
             return False
+        if current_provider == "openrouter":
+            return True
         model = str(image_cfg.get("model") or "").strip()
         expected_model = str(provider.get("image_generation_model") or "").strip()
         return not expected_model or not model or model == expected_model

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -459,7 +459,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -477,7 +477,7 @@ class TestCustomProviderCompatibility:
         config_path.write_text(
             yaml.safe_dump(
                 {
-                    "_config_version": 17,
+                    "_config_version": 18,
                     "providers": {
                         "openai-direct": {
                             "api": "https://api.openai.com/v1",
@@ -506,7 +506,7 @@ class TestCustomProviderCompatibility:
         config_path.write_text(
             yaml.safe_dump(
                 {
-                    "_config_version": 17,
+                    "_config_version": 18,
                     "providers": {
                         "my-provider": {
                             "name": "My Provider",
@@ -537,7 +537,7 @@ class TestCustomProviderCompatibility:
         config_path.write_text(
             yaml.safe_dump(
                 {
-                    "_config_version": 17,
+                    "_config_version": 18,
                     "custom_providers": [
                         {
                             "name": "OpenAI Direct",
@@ -570,7 +570,7 @@ class TestCustomProviderCompatibility:
         config_path.write_text(
             yaml.safe_dump(
                 {
-                    "_config_version": 17,
+                    "_config_version": 18,
                     "custom_providers": [
                         {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "qwen3-coder"},
                         {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "glm-5.1"},
@@ -587,6 +587,58 @@ class TestCustomProviderCompatibility:
         assert len(compatible) == 3
         models = [e.get("model") for e in compatible]
         assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
+
+
+class TestImageGenerationConfig:
+    def test_default_config_contains_image_generation_backend(self):
+        assert DEFAULT_CONFIG["image_generation"] == {
+            "provider": "fal",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+        }
+
+    def test_load_config_preserves_image_generation_override(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "image_generation": {
+                        "provider": "openrouter",
+                        "model": "google/gemini-2.5-flash-image",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["image_generation"]["provider"] == "openrouter"
+        assert config["image_generation"]["model"] == "google/gemini-2.5-flash-image"
+        assert config["image_generation"]["timeout"] == 120
+
+    def test_migrate_to_v18_adds_image_generation_defaults(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({"_config_version": 17, "model": {"provider": "openrouter", "default": "openai/gpt-5.4"}}),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 18
+        assert raw["image_generation"] == {
+            "provider": "fal",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+        }
 
 
 class TestInterimAssistantMessageConfig:
@@ -606,6 +658,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -23,6 +23,51 @@ def test_get_nous_subscription_features_recognizes_direct_exa_backend(monkeypatc
     assert features.web.current_provider == "exa"
 
 
+def test_get_nous_subscription_features_recognizes_openrouter_image_generation(monkeypatch):
+    env = {"OPENROUTER_API_KEY": "or-key"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "image_gen")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: vendor == "fal-queue")
+
+    features = ns.get_nous_subscription_features(
+        {"image_generation": {"provider": "openrouter", "model": "google/gemini-3.1-flash-image-preview"}}
+    )
+
+    assert features.image_gen.available is True
+    assert features.image_gen.active is True
+    assert features.image_gen.managed_by_nous is False
+    assert features.image_gen.direct_override is True
+    assert features.image_gen.current_provider == "google/gemini-3.1-flash-image-preview"
+    assert features.image_gen.explicit_configured is True
+
+
+def test_get_nous_subscription_features_does_not_mark_openrouter_image_generation_as_managed(monkeypatch):
+    env = {"OPENROUTER_API_KEY": "or-key"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "image_gen")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: vendor == "fal-queue")
+
+    features = ns.get_nous_subscription_features(
+        {"image_generation": {"provider": "openrouter", "model": "openai/gpt-5-image-mini"}}
+    )
+
+    assert features.image_gen.managed_by_nous is False
+    assert features.image_gen.current_provider == "openai/gpt-5-image-mini"
+
+
+
 def test_get_nous_subscription_features_prefers_managed_modal_in_auto_mode(monkeypatch):
     monkeypatch.setenv("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1")
     monkeypatch.setattr(ns, "get_env_value", lambda name: "")

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -96,11 +96,57 @@ def test_show_status_fal_backend_uses_runtime_readiness(monkeypatch, capsys, tmp
         raising=False,
     )
     monkeypatch.setattr("hermes_cli.status.check_fal_api_key", lambda: True, raising=False)
+    monkeypatch.setattr(
+        "tools.image_generation_tool._load_image_generation_config",
+        lambda: {
+            "provider": "fal",
+            "model": "fal-ai/flux-2-pro",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+            "provider_error": "",
+        },
+        raising=False,
+    )
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "✓ fal (fal-ai/flux-2-pro)" in output
+
+
+def test_show_status_surfaces_invalid_image_generation_provider(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.status.load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "image_generation": {
+                "provider": "OpenRuter",
+                "model": "google/gemini-2.5-flash-image",
+            },
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tools.image_generation_tool._load_image_generation_config",
+        lambda: {
+            "provider": "fal",
+            "model": "google/gemini-2.5-flash-image",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+            "provider_error": "Unsupported image_generation.provider 'OpenRuter'. Supported providers: ['fal', 'openrouter']",
+        },
+        raising=False,
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Image Gen" in output
+    assert "invalid config" in output
+    assert "OpenRuter" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -51,12 +51,56 @@ def test_show_status_marks_image_generation_unready_without_active_backend_key(m
         },
         raising=False,
     )
+    monkeypatch.setattr("hermes_cli.status.check_fal_api_key", lambda: False, raising=False)
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Image Gen" in output
     assert "✗ fal (fal-ai/flux-2-pro)" in output
+
+
+def test_show_status_normalizes_image_generation_provider_case(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setattr(
+        "hermes_cli.status.load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "image_generation": {
+                "provider": "OpenRouter",
+                "model": "google/gemini-3.1-flash-image-preview",
+            },
+        },
+        raising=False,
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "✓ openrouter (google/gemini-3.1-flash-image-preview)" in output
+
+
+def test_show_status_fal_backend_uses_runtime_readiness(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.status.load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "image_generation": {
+                "provider": "fal",
+                "model": "fal-ai/flux-2-pro",
+            },
+        },
+        raising=False,
+    )
+    monkeypatch.setattr("hermes_cli.status.check_fal_api_key", lambda: True, raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "✓ fal (fal-ai/flux-2-pro)" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,58 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_includes_image_generation_backend(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setattr(
+        "hermes_cli.status.load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "image_generation": {
+                "provider": "openrouter",
+                "model": "google/gemini-3.1-flash-image-preview",
+            },
+        },
+        raising=False,
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Image Gen" in output
+    assert "openrouter (google/gemini-3.1-flash-image-preview)" in output
+
+
+def test_show_status_marks_image_generation_unready_without_active_backend_key(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.status.load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "image_generation": {
+                "provider": "fal",
+                "model": "fal-ai/flux-2-pro",
+            },
+        },
+        raising=False,
+    )
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Image Gen" in output
+    assert "✗ fal (fal-ai/flux-2-pro)" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -219,6 +219,20 @@ def test_is_provider_active_for_image_gen_openrouter():
     assert _is_provider_active(provider, config) is True
 
 
+def test_is_provider_active_for_image_gen_openrouter_accepts_other_supported_model():
+    provider = TOOL_CATEGORIES["image_gen"]["providers"][2]
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {
+        "image_generation": {
+            "provider": "openrouter",
+            "model": "google/gemini-2.5-flash-image",
+        }
+    }
+
+    assert _is_provider_active(provider, config) is True
+
+
 def test_is_provider_active_for_image_gen_fal():
     provider = TOOL_CATEGORIES["image_gen"]["providers"][1]
     from hermes_cli.tools_config import _is_provider_active

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -114,7 +114,7 @@ def test_get_platform_tools_no_mcp_sentinel_does_not_affect_other_platforms():
 def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "auth.json").write_text(
-        '{"active_provider":"openai-codex","providers":{"openai-codex":{"tokens":{"access_token": "codex-...oken","refresh_token": "codex-...oken"}}}}'
+        '{"active_provider":"openai-codex","providers":{"openai-codex":{"tokens":{"access_token": "***","refresh_token": "***"}}}}'
     )
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -126,6 +126,125 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     )
 
     assert _toolset_has_keys("vision") is True
+
+
+def test_toolset_has_keys_for_image_gen_accepts_openrouter_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    config = {
+        "image_generation": {
+            "provider": "openrouter",
+            "model": "google/gemini-3.1-flash-image-preview",
+        }
+    }
+
+    assert _toolset_has_keys("image_gen", config) is True
+
+
+def test_toolset_has_keys_for_image_gen_accepts_config_stored_openrouter_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    config = {
+        "image_generation": {
+            "provider": "openrouter",
+            "api_key": "config-only-openrouter-key",
+        }
+    }
+
+    assert _toolset_has_keys("image_gen", config) is True
+
+
+def test_toolset_has_keys_for_image_gen_rejects_wrong_provider_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    config = {
+        "image_generation": {
+            "provider": "fal",
+            "model": "fal-ai/flux-2-pro",
+        }
+    }
+
+    assert _toolset_has_keys("image_gen", config) is False
+
+
+def test_toolset_needs_configuration_prompt_for_image_gen_checks_openrouter_key(monkeypatch):
+    from hermes_cli.tools_config import _toolset_needs_configuration_prompt
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    assert _toolset_needs_configuration_prompt("image_gen", {"image_generation": {"provider": "openrouter"}}) is True
+    assert _toolset_needs_configuration_prompt(
+        "image_gen",
+        {"image_generation": {"provider": "openrouter", "api_key": "config-key"}},
+    ) is False
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    assert _toolset_needs_configuration_prompt("image_gen", {"image_generation": {"provider": "openrouter"}}) is False
+
+
+def test_configure_provider_sets_image_generation_backend(monkeypatch):
+    provider = TOOL_CATEGORIES["image_gen"]["providers"][2]
+    config = {"image_generation": {}}
+
+    monkeypatch.setattr("hermes_cli.tools_config.get_env_value", lambda key: "or-key" if key == "OPENROUTER_API_KEY" else "")
+    monkeypatch.setattr("hermes_cli.tools_config.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.tools_config._print_success", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.tools_config._print_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.tools_config._print_warning", lambda *args, **kwargs: None)
+
+    _configure_provider(provider, config)
+
+    assert config["image_generation"]["provider"] == "openrouter"
+    assert config["image_generation"]["model"] == "google/gemini-3.1-flash-image-preview"
+
+
+def test_is_provider_active_for_image_gen_openrouter():
+    provider = TOOL_CATEGORIES["image_gen"]["providers"][2]
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {
+        "image_generation": {
+            "provider": "openrouter",
+            "model": "google/gemini-3.1-flash-image-preview",
+        }
+    }
+
+    assert _is_provider_active(provider, config) is True
+
+
+def test_is_provider_active_for_image_gen_fal():
+    provider = TOOL_CATEGORIES["image_gen"]["providers"][1]
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {
+        "image_generation": {
+            "provider": "fal",
+            "model": "fal-ai/flux-2-pro",
+        }
+    }
+
+    assert _is_provider_active(provider, config) is True
+
+
+def test_is_provider_active_for_image_gen_rejects_different_provider():
+    provider = TOOL_CATEGORIES["image_gen"]["providers"][2]
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {
+        "image_generation": {
+            "provider": "fal",
+            "model": "fal-ai/flux-2-pro",
+        }
+    }
+
+    assert _is_provider_active(provider, config) is False
 
 
 def test_save_platform_tools_preserves_mcp_server_names():

--- a/tests/tools/test_image_generation_tool_openrouter.py
+++ b/tests/tools/test_image_generation_tool_openrouter.py
@@ -325,6 +325,120 @@ def test_openrouter_provider_allows_default_landscape_for_model_without_aspect_r
     assert "extra_body" not in captured["create_kwargs"]
 
 
+def test_openrouter_provider_rejects_unknown_provider_in_config(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "OpenRuter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo"))
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Unsupported image_generation.provider" in result["error"]
+
+
+def test_openrouter_provider_extracts_image_from_string_content_data_url(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image-cache")
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Here is your image: data:image/png;base64,"
+                    + base64.b64encode(PNG_BYTES).decode("ascii"),
+                }
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, {}),
+        raising=False,
+    )
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo"))
+
+    assert result["success"] is True
+    assert result["image"].endswith(".png")
+
+
+def test_openrouter_provider_extracts_image_from_string_content_markdown_url(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "![generated](https://example.com/generated.png)",
+                }
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, {}),
+        raising=False,
+    )
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo"))
+
+    assert result["success"] is True
+    assert result["image"] == "https://example.com/generated.png"
+
+
 def test_check_image_generation_requirements_accepts_openrouter_backend(tmp_path, monkeypatch):
     (tmp_path / "config.yaml").write_text(
         yaml.safe_dump({"image_generation": {"provider": "openrouter"}}),

--- a/tests/tools/test_image_generation_tool_openrouter.py
+++ b/tests/tools/test_image_generation_tool_openrouter.py
@@ -452,3 +452,18 @@ def test_check_image_generation_requirements_accepts_openrouter_backend(tmp_path
     from tools import image_generation_tool
 
     assert image_generation_tool.check_image_generation_requirements() is True
+
+
+def test_check_image_generation_requirements_rejects_invalid_provider_config(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"image_generation": {"provider": "OpenRuter"}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FAL_KEY", "fal-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    assert image_generation_tool.check_image_generation_requirements() is False

--- a/tests/tools/test_image_generation_tool_openrouter.py
+++ b/tests/tools/test_image_generation_tool_openrouter.py
@@ -1,0 +1,340 @@
+import base64
+import json
+import types
+
+import yaml
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake png data"
+
+
+class _FakeOpenRouterResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+def _fake_openrouter_client(payload, captured: dict):
+    def create(**kwargs):
+        captured["create_kwargs"] = kwargs
+        return _FakeOpenRouterResponse(payload)
+
+    return types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=create)
+        )
+    )
+
+
+def test_openrouter_provider_includes_input_images_as_message_blocks(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    source_a = tmp_path / "item-a.png"
+    source_b = tmp_path / "item-b.jpg"
+    source_a.write_bytes(PNG_BYTES)
+    source_b.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"fake jpg data")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image-cache")
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "images": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,"
+                                + base64.b64encode(PNG_BYTES).decode("ascii")
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    captured = {}
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, captured),
+        raising=False,
+    )
+
+    result = json.loads(
+        image_generation_tool.image_generate_tool(
+            "combine these product shots into one clean catalog composition",
+            input_images=[str(source_a), str(source_b)],
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["create_kwargs"]["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "combine these product shots into one clean catalog composition"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode("ascii")}},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64," + base64.b64encode(b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"fake jpg data").decode("ascii")}},
+            ],
+        }
+    ]
+
+
+def test_openrouter_provider_rejects_missing_input_image(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    missing = tmp_path / "missing.png"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    result = json.loads(
+        image_generation_tool.image_generate_tool(
+            "combine these product shots",
+            input_images=[str(missing)],
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "Input image does not exist" in result["error"]
+
+
+def test_openrouter_provider_materializes_data_url_to_local_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image-cache")
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Generated image",
+                    "images": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,"
+                                + base64.b64encode(PNG_BYTES).decode("ascii")
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    captured = {}
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, captured),
+        raising=False,
+    )
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a sunset"))
+
+    assert result["success"] is True
+    assert result["image"].startswith(str(tmp_path))
+    assert result["image"].endswith(".png")
+    assert (tmp_path / "image-cache").exists()
+    assert captured["create_kwargs"]["model"] == "google/gemini-2.5-flash-image"
+    assert captured["create_kwargs"]["modalities"] == ["image", "text"]
+    assert captured["create_kwargs"]["messages"] == [
+        {"role": "user", "content": "make a sunset"}
+    ]
+
+
+def test_openrouter_provider_sends_image_config_aspect_ratio(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-2.5-flash-image",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image-cache")
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "images": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,"
+                                + base64.b64encode(PNG_BYTES).decode("ascii")
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    captured = {}
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, captured),
+        raising=False,
+    )
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo", aspect_ratio="square"))
+
+    assert result["success"] is True
+    assert captured["create_kwargs"]["extra_body"] == {"image_config": {"aspect_ratio": "1:1"}}
+
+
+def test_openrouter_provider_rejects_unsupported_aspect_ratio_model(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "openai/gpt-5-image-mini",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo", aspect_ratio="square"))
+
+    assert result["success"] is False
+    assert result["error_type"] == "ValueError"
+    assert "does not support Hermes aspect_ratio control" in result["error"]
+
+
+def test_openrouter_provider_allows_default_landscape_for_model_without_aspect_ratio_control(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "image_generation": {
+                    "provider": "openrouter",
+                    "model": "openai/gpt-5-image-mini",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "image-cache")
+
+    from tools import image_generation_tool
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "images": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,"
+                                + base64.b64encode(PNG_BYTES).decode("ascii")
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    captured = {}
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_openrouter_client",
+        lambda *_args, **_kwargs: _fake_openrouter_client(payload, captured),
+        raising=False,
+    )
+
+    result = json.loads(image_generation_tool.image_generate_tool("make a logo"))
+
+    assert result["success"] is True
+    assert "extra_body" not in captured["create_kwargs"]
+
+
+def test_check_image_generation_requirements_accepts_openrouter_backend(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"image_generation": {"provider": "openrouter"}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+    from tools import image_generation_tool
+
+    assert image_generation_tool.check_image_generation_requirements() is True

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -955,6 +955,10 @@ def check_image_generation_requirements() -> bool:
         bool: True if requirements are met, False otherwise
     """
     image_config = _load_image_generation_config()
+    provider_error = str(image_config.get("provider_error") or "").strip()
+    if provider_error:
+        return False
+
     provider = _normalize_image_provider(image_config.get("provider"))
 
     if provider == IMAGE_PROVIDER_OPENROUTER:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -28,15 +28,19 @@ Usage:
     )
 """
 
+import base64
 import json
 import logging
+import mimetypes
 import os
 import datetime
 import threading
 import uuid
 from typing import Dict, Any, Optional, Union
 from urllib.parse import urlencode
+from pathlib import Path
 import fal_client
+from hermes_constants import OPENROUTER_BASE_URL
 from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled
@@ -45,11 +49,38 @@ logger = logging.getLogger(__name__)
 
 # Configuration for image generation
 DEFAULT_MODEL = "fal-ai/flux-2-pro"
+DEFAULT_OPENROUTER_MODEL = "google/gemini-3.1-flash-image-preview"
 DEFAULT_ASPECT_RATIO = "landscape"
 DEFAULT_NUM_INFERENCE_STEPS = 50
 DEFAULT_GUIDANCE_SCALE = 4.5
 DEFAULT_NUM_IMAGES = 1
 DEFAULT_OUTPUT_FORMAT = "png"
+
+IMAGE_PROVIDER_FAL = "fal"
+IMAGE_PROVIDER_OPENROUTER = "openrouter"
+
+SUPPORTED_OPENROUTER_IMAGE_MODELS = frozenset({
+    "google/gemini-2.5-flash-image",
+    "google/gemini-3.1-flash-image-preview",
+    "openai/gpt-5-image-mini",
+})
+
+_OPENROUTER_TEXT_AND_IMAGE_MODELS = frozenset({
+    "google/gemini-2.5-flash-image",
+    "google/gemini-3.1-flash-image-preview",
+    "openai/gpt-5-image-mini",
+})
+
+_OPENROUTER_IMAGE_CONFIG_ASPECT_RATIO_MODELS = frozenset({
+    "google/gemini-2.5-flash-image",
+    "google/gemini-3.1-flash-image-preview",
+})
+
+_OPENROUTER_ASPECT_RATIO_MAP = {
+    "square": "1:1",
+    "portrait": "9:16",
+    "landscape": "16:9",
+}
 
 # Safety settings
 ENABLE_SAFETY_CHECKER = False
@@ -214,6 +245,310 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     )
 
 
+def _normalize_image_provider(provider: Any) -> str:
+    normalized = str(provider or "").strip().lower()
+    if normalized == IMAGE_PROVIDER_OPENROUTER:
+        return IMAGE_PROVIDER_OPENROUTER
+    return IMAGE_PROVIDER_FAL
+
+
+def _load_image_generation_config() -> Dict[str, Any]:
+    config = {
+        "provider": IMAGE_PROVIDER_FAL,
+        "model": DEFAULT_MODEL,
+        "base_url": "",
+        "api_key": "",
+        "timeout": 120,
+    }
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config().get("image_generation", {})
+        if not isinstance(loaded, dict):
+            return config
+
+        provider = _normalize_image_provider(loaded.get("provider"))
+        model = str(loaded.get("model") or "").strip()
+        if not model:
+            model = DEFAULT_OPENROUTER_MODEL if provider == IMAGE_PROVIDER_OPENROUTER else DEFAULT_MODEL
+
+        timeout = loaded.get("timeout", config["timeout"])
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            timeout = config["timeout"]
+
+        config.update({
+            "provider": provider,
+            "model": model,
+            "base_url": str(loaded.get("base_url") or "").strip(),
+            "api_key": str(loaded.get("api_key") or "").strip(),
+            "timeout": timeout,
+        })
+    except Exception:
+        pass
+    return config
+
+
+def _openrouter_api_key_available(config: Optional[Dict[str, Any]] = None) -> bool:
+    image_config = config or _load_image_generation_config()
+    return bool(str(image_config.get("api_key") or "").strip() or os.getenv("OPENROUTER_API_KEY"))
+
+
+def _get_openrouter_client(config: Optional[Dict[str, Any]] = None):
+    image_config = config or _load_image_generation_config()
+    explicit_base_url = str(image_config.get("base_url") or "").strip()
+    explicit_api_key = str(image_config.get("api_key") or "").strip()
+
+    if explicit_base_url or explicit_api_key:
+        from openai import OpenAI
+
+        api_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY", "").strip()
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable not set")
+
+        base_url = explicit_base_url or OPENROUTER_BASE_URL
+        extra = {}
+        if "openrouter.ai" in base_url.lower():
+            try:
+                from agent.auxiliary_client import _OR_HEADERS
+
+                extra["default_headers"] = dict(_OR_HEADERS)
+            except Exception:
+                pass
+        return OpenAI(api_key=api_key, base_url=base_url, **extra)
+
+    from agent.auxiliary_client import resolve_provider_client
+
+    client, _resolved_model = resolve_provider_client(
+        IMAGE_PROVIDER_OPENROUTER,
+        model=str(image_config.get("model") or DEFAULT_OPENROUTER_MODEL),
+    )
+    if client is None:
+        raise ValueError("OPENROUTER_API_KEY environment variable not set")
+    return client
+
+
+def _openrouter_modalities_for_model(model: str) -> list[str]:
+    if model in _OPENROUTER_TEXT_AND_IMAGE_MODELS:
+        return ["image", "text"]
+    return ["image"]
+
+
+def _openrouter_image_config_for_request(model: str, aspect_ratio: str) -> Optional[Dict[str, Any]]:
+    normalized_aspect_ratio = str(aspect_ratio or DEFAULT_ASPECT_RATIO).strip().lower()
+    requested_ratio = _OPENROUTER_ASPECT_RATIO_MAP.get(normalized_aspect_ratio)
+    if not requested_ratio:
+        raise ValueError(f"Unsupported aspect_ratio '{aspect_ratio}' for OpenRouter image generation")
+
+    if model in _OPENROUTER_IMAGE_CONFIG_ASPECT_RATIO_MODELS:
+        return {"aspect_ratio": requested_ratio}
+
+    if normalized_aspect_ratio == DEFAULT_ASPECT_RATIO:
+        return None
+
+    raise ValueError(
+        f"OpenRouter model '{model}' does not support Hermes aspect_ratio control; "
+        "choose a Gemini image model or use the default landscape setting"
+    )
+
+
+def _image_extension_from_media_type(media_type: str) -> str:
+    normalized = str(media_type or "").strip().lower()
+    if normalized == "image/jpeg":
+        return ".jpg"
+    if normalized in {"image/png", "image/webp", "image/gif", "image/bmp"}:
+        return "." + normalized.rsplit("/", 1)[-1]
+    return ".png"
+
+
+def _image_media_type_from_path(path: str) -> str:
+    guessed = (mimetypes.guess_type(path)[0] or "").lower()
+    if guessed.startswith("image/"):
+        return guessed
+
+    suffix = Path(path).suffix.lower()
+    if suffix in {".jpg", ".jpeg"}:
+        return "image/jpeg"
+    if suffix == ".png":
+        return "image/png"
+    if suffix == ".webp":
+        return "image/webp"
+    if suffix == ".gif":
+        return "image/gif"
+    if suffix == ".bmp":
+        return "image/bmp"
+    raise ValueError(f"Unsupported input image type for '{path}'")
+
+
+def _input_image_to_openrouter_url(image_ref: str) -> str:
+    value = str(image_ref or "").strip()
+    if not value:
+        raise ValueError("Input image reference must be a non-empty string")
+    if value.startswith("data:image/"):
+        return value
+    if value.startswith(("http://", "https://")):
+        return value
+
+    image_path = Path(value)
+    if not image_path.exists():
+        raise ValueError(f"Input image does not exist: {value}")
+    if not image_path.is_file():
+        raise ValueError(f"Input image path is not a file: {value}")
+
+    media_type = _image_media_type_from_path(value)
+    encoded = base64.b64encode(image_path.read_bytes()).decode("ascii")
+    return f"data:{media_type};base64,{encoded}"
+
+
+def _build_openrouter_messages(prompt: str, input_images: Optional[list[str]] = None) -> list[Dict[str, Any]]:
+    prompt_text = prompt.strip()
+    if not input_images:
+        return [{"role": "user", "content": prompt_text}]
+
+    content: list[Dict[str, Any]] = [{"type": "text", "text": prompt_text}]
+    for image_ref in input_images:
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": _input_image_to_openrouter_url(image_ref)},
+            }
+        )
+    return [{"role": "user", "content": content}]
+
+
+def _materialize_image_reference(image_ref: str) -> str:
+    image_ref = str(image_ref or "").strip()
+    if not image_ref.startswith("data:"):
+        return image_ref
+
+    header, separator, encoded = image_ref.partition(",")
+    if not separator:
+        raise ValueError("Malformed image data URL returned by OpenRouter")
+    if ";base64" not in header.lower():
+        raise ValueError("Unsupported non-base64 image data URL returned by OpenRouter")
+
+    media_type = "image/png"
+    if ":" in header and ";" in header:
+        media_type = header.split(":", 1)[1].split(";", 1)[0].strip() or media_type
+
+    try:
+        image_bytes = base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise ValueError("Invalid base64 image data returned by OpenRouter") from exc
+
+    from gateway.platforms.base import cache_image_from_bytes
+
+    return cache_image_from_bytes(image_bytes, _image_extension_from_media_type(media_type))
+
+
+def _extract_image_url_from_entry(entry: Any) -> str:
+    if not isinstance(entry, dict):
+        return ""
+
+    image_url = entry.get("image_url")
+    if isinstance(image_url, dict):
+        url = image_url.get("url", "")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    elif isinstance(image_url, str) and image_url.strip():
+        return image_url.strip()
+
+    url = entry.get("url")
+    if isinstance(url, str) and url.strip():
+        return url.strip()
+
+    b64_json = entry.get("b64_json")
+    if isinstance(b64_json, str) and b64_json.strip():
+        return f"data:image/png;base64,{b64_json.strip()}"
+
+    return ""
+
+
+def _extract_openrouter_image_references(payload: Dict[str, Any]) -> list[str]:
+    image_refs: list[str] = []
+
+    for choice in payload.get("choices", []):
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            continue
+
+        images = message.get("images")
+        if isinstance(images, list):
+            for entry in images:
+                image_ref = _extract_image_url_from_entry(entry)
+                if image_ref:
+                    image_refs.append(image_ref)
+
+        content = message.get("content")
+        if isinstance(content, list):
+            for entry in content:
+                image_ref = _extract_image_url_from_entry(entry)
+                if image_ref:
+                    image_refs.append(image_ref)
+
+    data = payload.get("data")
+    if isinstance(data, list):
+        for entry in data:
+            image_ref = _extract_image_url_from_entry(entry)
+            if image_ref:
+                image_refs.append(image_ref)
+
+    return image_refs
+
+
+def _generate_via_openrouter(
+    prompt: str,
+    *,
+    aspect_ratio: str,
+    input_images: Optional[list[str]],
+    image_config: Dict[str, Any],
+    debug_call_data: Dict[str, Any],
+    start_time: datetime.datetime,
+) -> str:
+    model = str(image_config.get("model") or DEFAULT_OPENROUTER_MODEL).strip()
+    if model not in SUPPORTED_OPENROUTER_IMAGE_MODELS:
+        raise ValueError(
+            "Unsupported OpenRouter image model "
+            f"'{model}'. Supported models: {sorted(SUPPORTED_OPENROUTER_IMAGE_MODELS)}"
+        )
+
+    request_image_config = _openrouter_image_config_for_request(model, aspect_ratio)
+    client = _get_openrouter_client(image_config)
+    create_kwargs = {
+        "model": model,
+        "messages": _build_openrouter_messages(prompt, input_images),
+        "modalities": _openrouter_modalities_for_model(model),
+        "stream": False,
+        "timeout": image_config.get("timeout", 120),
+    }
+    if request_image_config:
+        create_kwargs["extra_body"] = {"image_config": request_image_config}
+
+    logger.info("Generating image with OpenRouter model: %s", model)
+    result = client.chat.completions.create(**create_kwargs)
+    payload = result.model_dump() if hasattr(result, "model_dump") else result
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid response from OpenRouter image API")
+
+    image_refs = _extract_openrouter_image_references(payload)
+    if not image_refs:
+        raise ValueError("OpenRouter returned no images")
+
+    image_path_or_url = _materialize_image_reference(image_refs[0])
+    generation_time = (datetime.datetime.now() - start_time).total_seconds()
+
+    debug_call_data["success"] = True
+    debug_call_data["images_generated"] = len(image_refs)
+    debug_call_data["generation_time"] = generation_time
+    _debug.log_call("image_generate_tool", debug_call_data)
+    _debug.save()
+
+    return json.dumps({"success": True, "image": image_path_or_url}, indent=2, ensure_ascii=False)
+
+
 def _validate_parameters(
     image_size: Union[str, Dict[str, int]], 
     num_inference_steps: int,
@@ -355,16 +690,16 @@ def image_generate_tool(
     guidance_scale: float = DEFAULT_GUIDANCE_SCALE,
     num_images: int = DEFAULT_NUM_IMAGES,
     output_format: str = DEFAULT_OUTPUT_FORMAT,
-    seed: Optional[int] = None
+    seed: Optional[int] = None,
+    input_images: Optional[list[str]] = None,
 ) -> str:
     """
-    Generate images from text prompts using FAL.ai's FLUX 2 Pro model with automatic upscaling.
-    
-    Uses the synchronous fal_client API to avoid event loop lifecycle issues.
-    The async API's global httpx.AsyncClient (cached via @cached_property) breaks
-    when asyncio.run() destroys and recreates event loops between calls, which
-    happens in the gateway's thread-pool pattern.
-    
+    Generate images from text prompts using the configured backend.
+
+    Default behavior preserves the existing FAL.ai FLUX 2 Pro + auto-upscale path.
+    When config.yaml sets image_generation.provider=openrouter, Hermes routes through
+    OpenRouter image generation and materializes returned data URLs into local files.
+
     Args:
         prompt (str): The text prompt describing the desired image
         aspect_ratio (str): Image aspect ratio - "landscape", "square", or "portrait" (default: "landscape")
@@ -373,21 +708,25 @@ def image_generate_tool(
         num_images (int): Number of images to generate (1-4, default: 1)
         output_format (str): Image format "jpeg" or "png" (default: "png")
         seed (Optional[int]): Random seed for reproducible results (optional)
-    
+        input_images (Optional[list[str]]): Optional list of local file paths, URLs, or data URLs to use as image inputs for OpenRouter image-edit/compositing flows.
+
     Returns:
         str: JSON string containing minimal generation results:
              {
                  "success": bool,
-                 "image": str or None  # URL of the upscaled image, or None if failed
+                 "image": str or None  # URL/path of the generated image, or None if failed
              }
     """
+    image_config = _load_image_generation_config()
+    provider = _normalize_image_provider(image_config.get("provider"))
+
     # Validate and map aspect_ratio to actual image_size
     aspect_ratio_lower = aspect_ratio.lower().strip() if aspect_ratio else DEFAULT_ASPECT_RATIO
     if aspect_ratio_lower not in ASPECT_RATIO_MAP:
         logger.warning("Invalid aspect_ratio '%s', defaulting to '%s'", aspect_ratio, DEFAULT_ASPECT_RATIO)
         aspect_ratio_lower = DEFAULT_ASPECT_RATIO
     image_size = ASPECT_RATIO_MAP[aspect_ratio_lower]
-    
+
     debug_call_data = {
         "parameters": {
             "prompt": prompt,
@@ -397,35 +736,51 @@ def image_generate_tool(
             "guidance_scale": guidance_scale,
             "num_images": num_images,
             "output_format": output_format,
-            "seed": seed
+            "seed": seed,
+            "input_images": list(input_images or []),
+            "provider": provider,
+            "provider_model": image_config.get("model"),
         },
         "error": None,
         "success": False,
         "images_generated": 0,
         "generation_time": 0
     }
-    
+
     start_time = datetime.datetime.now()
-    
+
     try:
-        logger.info("Generating %s image(s) with FLUX 2 Pro: %s", num_images, prompt[:80])
-        
         # Validate prompt
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
-        
+
+        if provider == IMAGE_PROVIDER_OPENROUTER:
+            return _generate_via_openrouter(
+                prompt,
+                aspect_ratio=aspect_ratio_lower,
+                input_images=input_images,
+                image_config=image_config,
+                debug_call_data=debug_call_data,
+                start_time=start_time,
+            )
+
+        if input_images:
+            raise ValueError("input_images is currently supported only for the OpenRouter backend")
+
+        logger.info("Generating %s image(s) with FLUX 2 Pro: %s", num_images, prompt[:80])
+
         # Check API key availability
         if not (os.getenv("FAL_KEY") or _resolve_managed_fal_gateway()):
             message = "FAL_KEY environment variable not set"
             if managed_nous_tools_enabled():
                 message += " and managed FAL gateway is unavailable"
             raise ValueError(message)
-        
+
         # Validate other parameters
         validated_params = _validate_parameters(
             image_size, num_inference_steps, guidance_scale, num_images, output_format, "none"
         )
-        
+
         # Prepare arguments for FAL.ai FLUX 2 Pro API
         arguments = {
             "prompt": prompt.strip(),
@@ -438,36 +793,36 @@ def image_generate_tool(
             "safety_tolerance": SAFETY_TOLERANCE,
             "sync_mode": True  # Use sync mode for immediate results
         }
-        
+
         # Add seed if provided
         if seed is not None and isinstance(seed, int):
             arguments["seed"] = seed
-        
+
         logger.info("Submitting generation request to FAL.ai FLUX 2 Pro...")
         logger.info("  Model: %s", DEFAULT_MODEL)
         logger.info("  Aspect Ratio: %s -> %s", aspect_ratio_lower, image_size)
         logger.info("  Steps: %s", validated_params['num_inference_steps'])
         logger.info("  Guidance: %s", validated_params['guidance_scale'])
-        
+
         # Submit request to FAL.ai using sync API (avoids cached event loop issues)
         handler = _submit_fal_request(
             DEFAULT_MODEL,
             arguments=arguments,
         )
-        
+
         # Get the result (sync — blocks until done)
         result = handler.get()
-        
+
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
-        
+
         # Process the response
         if not result or "images" not in result:
             raise ValueError("Invalid response from FAL.ai API - no images returned")
-        
+
         images = result.get("images", [])
         if not images:
             raise ValueError("No images were generated")
-        
+
         # Format image data and upscale images
         formatted_images = []
         for img in images:
@@ -477,10 +832,10 @@ def image_generate_tool(
                     "width": img.get("width", 0),
                     "height": img.get("height", 0)
                 }
-                
+
                 # Attempt to upscale the image
                 upscaled_image = _upscale_image(img["url"], prompt.strip())
-                
+
                 if upscaled_image:
                     # Use upscaled image if successful
                     formatted_images.append(upscaled_image)
@@ -489,34 +844,34 @@ def image_generate_tool(
                     logger.warning("Using original image as fallback")
                     original_image["upscaled"] = False
                     formatted_images.append(original_image)
-        
+
         if not formatted_images:
             raise ValueError("No valid image URLs returned from API")
-        
+
         upscaled_count = sum(1 for img in formatted_images if img.get("upscaled", False))
         logger.info("Generated %s image(s) in %.1fs (%s upscaled)", len(formatted_images), generation_time, upscaled_count)
-        
+
         # Prepare successful response - minimal format
         response_data = {
             "success": True,
             "image": formatted_images[0]["url"] if formatted_images else None
         }
-        
+
         debug_call_data["success"] = True
         debug_call_data["images_generated"] = len(formatted_images)
         debug_call_data["generation_time"] = generation_time
-        
+
         # Log debug information
         _debug.log_call("image_generate_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(response_data, indent=2, ensure_ascii=False)
-        
+
     except Exception as e:
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
         error_msg = f"Error generating image: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
+
         # Include error details so callers can diagnose failures
         response_data = {
             "success": False,
@@ -524,19 +879,19 @@ def image_generate_tool(
             "error": str(e),
             "error_type": type(e).__name__,
         }
-        
+
         debug_call_data["error"] = error_msg
         debug_call_data["generation_time"] = generation_time
         _debug.log_call("image_generate_tool", debug_call_data)
         _debug.save()
-        
+
         return json.dumps(response_data, indent=2, ensure_ascii=False)
 
 
 def check_fal_api_key() -> bool:
     """
     Check if the FAL.ai API key is available in environment variables.
-    
+
     Returns:
         bool: True if API key is set, False otherwise
     """
@@ -546,19 +901,25 @@ def check_fal_api_key() -> bool:
 def check_image_generation_requirements() -> bool:
     """
     Check if all requirements for image generation tools are met.
-    
+
     Returns:
         bool: True if requirements are met, False otherwise
     """
+    image_config = _load_image_generation_config()
+    provider = _normalize_image_provider(image_config.get("provider"))
+
+    if provider == IMAGE_PROVIDER_OPENROUTER:
+        return _openrouter_api_key_available(image_config)
+
     try:
         # Check API key
         if not check_fal_api_key():
             return False
-        
+
         # Check if fal_client is available
         import fal_client  # noqa: F401 — SDK presence check
         return True
-        
+
     except ImportError:
         return False
 
@@ -646,7 +1007,7 @@ from tools.registry import registry, tool_error
 
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
-    "description": "Generate high-quality images from text prompts using FLUX 2 Pro model with automatic 2x upscaling. Creates detailed, artistic images that are automatically upscaled for hi-rez results. Returns a single upscaled image URL. Display it using markdown: ![description](URL)",
+    "description": "Generate high-quality images from text prompts using the configured backend. FAL preserves the legacy FLUX+upscale path; OpenRouter routes through supported image models and returns a local cached file when providers emit base64 data URLs.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -657,8 +1018,46 @@ IMAGE_GENERATE_SCHEMA = {
             "aspect_ratio": {
                 "type": "string",
                 "enum": ["landscape", "square", "portrait"],
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "description": "Requested aspect ratio. Hermes maps this to the backend's native size/aspect controls when supported.",
                 "default": "landscape"
+            },
+            "num_inference_steps": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Number of inference steps. Supported by FAL backend; currently ignored by OpenRouter image backends.",
+                "default": 50
+            },
+            "guidance_scale": {
+                "type": "number",
+                "minimum": 0.1,
+                "maximum": 20.0,
+                "description": "Prompt guidance scale. Supported by FAL backend; currently ignored by OpenRouter image backends.",
+                "default": 4.5
+            },
+            "num_images": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 4,
+                "description": "Number of images to generate. Currently Hermes returns the first successful image in the response.",
+                "default": 1
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["jpeg", "png"],
+                "description": "Preferred output format. Supported by FAL backend; OpenRouter returns the provider-native encoded image.",
+                "default": "png"
+            },
+            "seed": {
+                "type": ["integer", "null"],
+                "description": "Optional random seed for reproducible generations when supported by the backend.",
+                "default": None
+            },
+            "input_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional image inputs for image-to-image or compositing flows. Each entry may be an absolute local file path, an http/https URL, or a data:image/... URL. Currently supported only on the OpenRouter backend.",
+                "default": []
             }
         },
         "required": ["prompt"]
@@ -673,11 +1072,12 @@ def _handle_image_generate(args, **kw):
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=args.get("aspect_ratio", "landscape"),
-        num_inference_steps=50,
-        guidance_scale=4.5,
-        num_images=1,
-        output_format="png",
-        seed=None,
+        num_inference_steps=args.get("num_inference_steps", 50),
+        guidance_scale=args.get("guidance_scale", 4.5),
+        num_images=args.get("num_images", 1),
+        output_format=args.get("output_format", "png"),
+        seed=args.get("seed"),
+        input_images=args.get("input_images"),
     )
 
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -33,6 +33,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 import datetime
 import threading
 import uuid
@@ -58,6 +59,7 @@ DEFAULT_OUTPUT_FORMAT = "png"
 
 IMAGE_PROVIDER_FAL = "fal"
 IMAGE_PROVIDER_OPENROUTER = "openrouter"
+_SUPPORTED_IMAGE_PROVIDERS = frozenset({IMAGE_PROVIDER_FAL, IMAGE_PROVIDER_OPENROUTER})
 
 SUPPORTED_OPENROUTER_IMAGE_MODELS = frozenset({
     "google/gemini-2.5-flash-image",
@@ -247,9 +249,14 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
 
 def _normalize_image_provider(provider: Any) -> str:
     normalized = str(provider or "").strip().lower()
-    if normalized == IMAGE_PROVIDER_OPENROUTER:
-        return IMAGE_PROVIDER_OPENROUTER
-    return IMAGE_PROVIDER_FAL
+    if not normalized:
+        return IMAGE_PROVIDER_FAL
+    if normalized in _SUPPORTED_IMAGE_PROVIDERS:
+        return normalized
+    raise ValueError(
+        f"Unsupported image_generation.provider '{provider}'. "
+        f"Supported providers: {sorted(_SUPPORTED_IMAGE_PROVIDERS)}"
+    )
 
 
 def _load_image_generation_config() -> Dict[str, Any]:
@@ -259,6 +266,7 @@ def _load_image_generation_config() -> Dict[str, Any]:
         "base_url": "",
         "api_key": "",
         "timeout": 120,
+        "provider_error": "",
     }
     try:
         from hermes_cli.config import load_config
@@ -284,9 +292,10 @@ def _load_image_generation_config() -> Dict[str, Any]:
             "base_url": str(loaded.get("base_url") or "").strip(),
             "api_key": str(loaded.get("api_key") or "").strip(),
             "timeout": timeout,
+            "provider_error": "",
         })
-    except Exception:
-        pass
+    except Exception as exc:
+        config["provider_error"] = str(exc)
     return config
 
 
@@ -465,6 +474,34 @@ def _extract_image_url_from_entry(entry: Any) -> str:
     return ""
 
 
+def _extract_image_refs_from_content_string(content: str) -> list[str]:
+    text = str(content or "").strip()
+    if not text:
+        return []
+
+    refs: list[str] = []
+
+    for match in re.finditer(r"data:image/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+", text):
+        refs.append(match.group(0))
+
+    markdown_pattern = re.compile(r"!\[[^\]]*\]\((https?://[^)\s]+|data:image/[^)\s]+)\)")
+    for match in markdown_pattern.finditer(text):
+        refs.append(match.group(1))
+
+    url_pattern = re.compile(r"https?://\S+")
+    for match in url_pattern.finditer(text):
+        candidate = match.group(0).rstrip(').,]')
+        refs.append(candidate)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for ref in refs:
+        if ref and ref not in seen:
+            seen.add(ref)
+            deduped.append(ref)
+    return deduped
+
+
 def _extract_openrouter_image_references(payload: Dict[str, Any]) -> list[str]:
     image_refs: list[str] = []
 
@@ -488,6 +525,8 @@ def _extract_openrouter_image_references(payload: Dict[str, Any]) -> list[str]:
                 image_ref = _extract_image_url_from_entry(entry)
                 if image_ref:
                     image_refs.append(image_ref)
+        elif isinstance(content, str):
+            image_refs.extend(_extract_image_refs_from_content_string(content))
 
     data = payload.get("data")
     if isinstance(data, list):
@@ -496,7 +535,13 @@ def _extract_openrouter_image_references(payload: Dict[str, Any]) -> list[str]:
             if image_ref:
                 image_refs.append(image_ref)
 
-    return image_refs
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for ref in image_refs:
+        if ref and ref not in seen:
+            seen.add(ref)
+            deduped.append(ref)
+    return deduped
 
 
 def _generate_via_openrouter(
@@ -718,7 +763,8 @@ def image_generate_tool(
              }
     """
     image_config = _load_image_generation_config()
-    provider = _normalize_image_provider(image_config.get("provider"))
+    provider_error = str(image_config.get("provider_error") or "").strip()
+    provider = _normalize_image_provider(image_config.get("provider")) if not provider_error else IMAGE_PROVIDER_FAL
 
     # Validate and map aspect_ratio to actual image_size
     aspect_ratio_lower = aspect_ratio.lower().strip() if aspect_ratio else DEFAULT_ASPECT_RATIO
@@ -753,6 +799,9 @@ def image_generate_tool(
         # Validate prompt
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
+
+        if provider_error:
+            raise ValueError(provider_error)
 
         if provider == IMAGE_PROVIDER_OPENROUTER:
             return _generate_via_openrouter(


### PR DESCRIPTION
## Summary

- add OpenRouter as a first-class backend for the canonical `image_generate` tool
- preserve the existing FAL lane while routing supported OpenRouter image models through the same tool contract
- materialize provider-returned image data URLs into local cached artifacts and add regression coverage for config/status/setup integration

## Motivation

Hermes image generation previously centered on the FAL lane, which made OpenRouter-based image generation awkward and encouraged provider-specific sprawl. This change keeps `image_generate` as the canonical tool while allowing OpenRouter-backed image generation and image-to-image composition under a single, test-covered interface.

## Changes

- add `image_generation` provider/model config support for OpenRouter-aware runtime selection
- extend `tools/image_generation_tool.py` to:
  - route between FAL and OpenRouter backends
  - allowlist supported OpenRouter image models
  - pass provider-native aspect ratio controls via `extra_body.image_config`
  - normalize `input_images` into multimodal OpenRouter requests
  - extract images from `choices[].message.images`, `message.content`, or `data[]`
  - materialize `data:image/...;base64,...` responses into local cache files
- update CLI/setup/status/subscription logic so readiness checks and UX match runtime behavior
- add targeted tests for:
  - OpenRouter backend readiness
  - config/status/tools-config integration
  - aspect-ratio behavior
  - input-image request shaping
  - data-URL materialization

## Test Plan

- [x] Targeted regression tests pass
  - `python -m pytest tests/tools/test_image_generation_tool_openrouter.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_status.py tests/hermes_cli/test_nous_subscription.py tests/hermes_cli/test_config.py -q`
- [x] Live prompt-only E2E passes against OpenRouter
- [x] Live `input_images` composition E2E passes against OpenRouter
- [x] Generated artifacts were verified to exist locally and match requested square output behavior
- [x] `hermes status` reflects `Image Gen ✓ openrouter (google/gemini-3.1-flash-image-preview)`

## Screenshots / Examples

Local verified artifacts:
- prompt-only output: `/Users/admin/.hermes/image_cache/img_aef0561b88db.png`
- input image used for composition: `/Users/admin/Downloads/1.png`
- composition output: `/Users/admin/.hermes/image_cache/img_b4f6967d7c6c.png`

## Notes for Reviewers

- this PR intentionally keeps `image_generate` as the canonical tool instead of adding provider-specific tool names
- FAL behavior remains as the compatibility-preserving lane
- OpenRouter image responses are treated defensively because providers may return data URLs instead of hosted URLs
- aspect-ratio control is allowlisted per model; unsupported models fail clearly instead of silently returning the wrong shape
