### PR TITLE
fix(stt): respect provider-specific model config

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -784,6 +784,16 @@ class TestTranscribeAudioDispatch:
 
         assert mock_local.call_args[0][1] == "large-v3"
 
+    def test_openai_model_override_is_normalized_for_local_provider(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi"}) as mock_local:
+            from tools.transcription_tools import DEFAULT_LOCAL_MODEL, transcribe_audio
+            transcribe_audio(sample_ogg, model="whisper-1")
+
+        assert mock_local.call_args[0][1] == DEFAULT_LOCAL_MODEL
+
     def test_default_model_used_when_none(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \
              patch("tools.transcription_tools._get_provider", return_value="groq"), \
@@ -995,3 +1005,55 @@ class TestTranscribeAudioMistralDispatch:
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+class TestGetSttModelFromConfig:
+    def test_returns_legacy_model_from_config(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("""stt:
+  model: whisper-large-v3
+""")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+        assert get_stt_model_from_config() == "whisper-large-v3"
+
+    def test_prefers_local_model_for_local_provider(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            """stt:
+  provider: local
+  model: whisper-1
+  local:
+    model: base
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+        assert get_stt_model_from_config() == "base"
+
+    def test_prefers_openai_model_for_openai_provider(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            """stt:
+  provider: openai
+  model: base
+  openai:
+    model: gpt-4o-mini-transcribe
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+        assert get_stt_model_from_config() == "gpt-4o-mini-transcribe"
+
+    def test_returns_none_when_no_stt_section(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("""tts:
+  provider: edge
+""")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from tools.transcription_tools import get_stt_model_from_config
+        assert get_stt_model_from_config() is None

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -154,7 +154,52 @@ def _has_local_command() -> bool:
     return _get_local_command_template() is not None
 
 
+def get_stt_model_from_config() -> Optional[str]:
+    """Read the effective STT model name from config.
+
+    Prefers provider-specific config first:
+      - stt.local.model when provider is local/local_command
+      - stt.openai.model when provider is openai
+      - stt.groq.model when provider is groq (future-compatible)
+
+    Falls back to the legacy top-level ``stt.model`` only when no provider-specific
+    model is configured. Returns ``None`` on any config error.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        stt_config = read_raw_config().get("stt", {})
+        provider = stt_config.get("provider")
+
+        if provider in {"local", "local_command"}:
+            local_model = stt_config.get("local", {}).get("model")
+            if local_model:
+                return local_model
+
+        if provider == "openai":
+            openai_model = stt_config.get("openai", {}).get("model")
+            if openai_model:
+                return openai_model
+
+        if provider == "groq":
+            groq_model = stt_config.get("groq", {}).get("model")
+            if groq_model:
+                return groq_model
+
+        return stt_config.get("model")
+    except Exception:
+        pass
+    return None
+
+
 def _normalize_local_command_model(model_name: Optional[str]) -> str:
+    if not model_name or model_name in OPENAI_MODELS or model_name in GROQ_MODELS:
+        return DEFAULT_LOCAL_MODEL
+    return model_name
+
+
+def _normalize_local_model(model_name: Optional[str]) -> str:
+    """Map cloud-only/empty model names to a valid faster-whisper local model."""
     if not model_name or model_name in OPENAI_MODELS or model_name in GROQ_MODELS:
         return DEFAULT_LOCAL_MODEL
     return model_name
@@ -285,6 +330,8 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
 
     if not _HAS_FASTER_WHISPER:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
+
+    model_name = _normalize_local_model(model_name)
 
     try:
         from faster_whisper import WhisperModel
@@ -596,7 +643,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     if provider == "local":
         local_cfg = stt_config.get("local", {})
-        model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+        model_name = _normalize_local_model(
+            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+        )
         return _transcribe_local(file_path, model_name)
 
     if provider == "local_command":


### PR DESCRIPTION
## Summary
- make `get_stt_model_from_config()` respect provider-specific model config before the legacy top-level `stt.model`
- normalize cloud-only model overrides like `whisper-1` when the active provider is local faster-whisper
- add regression tests for config precedence and local-model normalization

## Why
Current main already guards some provider/model mismatch cases, but two gaps remain:
1. `get_stt_model_from_config()` still ignores `stt.local.model` / `stt.openai.model` / `stt.groq.model`
2. the local faster-whisper path still accepts cloud-only override names at the `transcribe_audio(..., model=...)` entrypoint

This patch makes the effective model selection consistent with the configured provider and avoids feeding `whisper-1` into local faster-whisper.

## Test Plan
- source /root/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py -q
