### PR TITLE
fix: accept ALIBABA_API_KEY as fallback for alibaba provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -206,7 +206,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
         inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        api_key_env_vars=("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1047,6 +1047,33 @@ def test_alibaba_anthropic_endpoint_override_uses_anthropic_messages(monkeypatch
     assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic"
 
 
+def test_alibaba_fallback_to_alibaba_api_key(monkeypatch):
+    """alibaba provider should accept ALIBABA_API_KEY when DASHSCOPE_API_KEY is absent."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.setenv("ALIBABA_API_KEY", "test-alibaba-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_key"] == "test-alibaba-key"
+
+
+def test_alibaba_dashscope_key_takes_precedence(monkeypatch):
+    """DASHSCOPE_API_KEY should take precedence over ALIBABA_API_KEY."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "primary-key")
+    monkeypatch.setenv("ALIBABA_API_KEY", "fallback-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["api_key"] == "primary-key"
+
+
 def test_opencode_zen_gpt_defaults_to_responses(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "gpt-5.4"})


### PR DESCRIPTION
## Summary

Fixes #9506 (remaining half)

The error-message half of this issue was already merged via #10563. This PR now carries only the unique remaining fix: accept `ALIBABA_API_KEY` as a fallback so users who intuitively set the provider-named env var aren't stuck.

- Add `ALIBABA_API_KEY` as a fallback in the alibaba provider's `api_key_env_vars`
- `DASHSCOPE_API_KEY` retains precedence when both are set

## Test plan

- `test_alibaba_fallback_to_alibaba_api_key` — verifies `ALIBABA_API_KEY` is accepted when `DASHSCOPE_API_KEY` is absent
- `test_alibaba_dashscope_key_takes_precedence` — verifies `DASHSCOPE_API_KEY` wins when both are set