### PR TITLE
fix(weixin): align send_image_file to accept standard image_path kwarg

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,11 +1542,17 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: Optional[str] = None,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> SendResult:
+        path = image_path or kwargs.pop("path", None)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {', '.join(sorted(kwargs))}")
+        if not path:
+            raise TypeError("send_image_file() missing required argument: 'image_path'")
         return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
 
     async def send_document(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -364,6 +364,46 @@ class TestWeixinChunkDelivery:
 
 
 class TestWeixinRemoteMediaSafety:
+    def test_send_image_file_accepts_standard_image_path_keyword(self):
+        adapter = _make_adapter()
+        adapter.send_document = AsyncMock(return_value="ok")
+
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/chart.png",
+                caption="图表",
+                metadata={"foo": "bar"},
+            )
+        )
+
+        assert result == "ok"
+        adapter.send_document.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/chart.png",
+            caption="图表",
+            metadata={"foo": "bar"},
+        )
+
+    def test_send_image_file_keeps_backward_compatibility_for_path_keyword(self):
+        adapter = _make_adapter()
+        adapter.send_document = AsyncMock(return_value="ok")
+
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                path="/tmp/chart.png",
+            )
+        )
+
+        assert result == "ok"
+        adapter.send_document.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/chart.png",
+            caption="",
+            metadata=None,
+        )
+
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()
 


### PR DESCRIPTION
## Bug
WeixinAdapter.send_image_file() raised TypeError when called with the standard keyword argument name image_path, because its signature used path instead.

## Root Cause
gateway/platforms/weixin.py: The method accepted path=... but the standard contract (defined in BasePlatformAdapter and used by cron/scheduler.py and all other platform adapters) is image_path=....

## Fix
Updated send_image_file() to accept both image_path (standard) and path (backward compat). Raises TypeError for truly unexpected kwargs or missing path. Original send_image_file → send_document forwarding preserved.

## Testing
- pytest tests/gateway/test_weixin.py::TestWeixinRemoteMediaSafety -v ✓
- pytest tests/cron/test_scheduler.py -k 'live_adapter' -v ✓
- Live test: MEDIA:/tmp/chart.png delivered successfully as image in WeChat ✓