### PR TITLE
feat(config): support custom provider HTTP headers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -16,6 +16,7 @@ import logging
 import os
 from pathlib import Path
 
+from agent.client_headers import get_model_custom_headers, merge_default_headers
 from hermes_constants import get_hermes_home
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
@@ -253,6 +254,7 @@ def build_anthropic_client(api_key: str, base_url: str = None):
     from httpx import Timeout
 
     normalized_base_url = _normalize_base_url_text(base_url)
+    custom_headers = get_model_custom_headers()
     kwargs = {
         "timeout": Timeout(timeout=900.0, connect=10.0),
     }
@@ -269,7 +271,12 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         # Anthropic OAuth/setup tokens.
         kwargs["auth_token"] = api_key
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            kwargs["default_headers"] = merge_default_headers(
+                {"anthropic-beta": ",".join(common_betas)},
+                custom_headers,
+            )
+        elif custom_headers:
+            kwargs["default_headers"] = dict(custom_headers)
     elif _is_third_party_anthropic_endpoint(base_url):
         # Third-party proxies (Azure AI Foundry, AWS Bedrock, etc.) use their
         # own API keys with x-api-key auth. Skip OAuth detection — their keys
@@ -277,23 +284,36 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         # misclassified as OAuth tokens.
         kwargs["api_key"] = api_key
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            kwargs["default_headers"] = merge_default_headers(
+                {"anthropic-beta": ",".join(common_betas)},
+                custom_headers,
+            )
+        elif custom_headers:
+            kwargs["default_headers"] = dict(custom_headers)
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.
         all_betas = common_betas + _OAUTH_ONLY_BETAS
         kwargs["auth_token"] = api_key
-        kwargs["default_headers"] = {
-            "anthropic-beta": ",".join(all_betas),
-            "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            "x-app": "cli",
-        }
+        kwargs["default_headers"] = merge_default_headers(
+            {
+                "anthropic-beta": ",".join(all_betas),
+                "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                "x-app": "cli",
+            },
+            custom_headers,
+        )
     else:
         # Regular API key → x-api-key header + common betas
         kwargs["api_key"] = api_key
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            kwargs["default_headers"] = merge_default_headers(
+                {"anthropic-beta": ",".join(common_betas)},
+                custom_headers,
+            )
+        elif custom_headers:
+            kwargs["default_headers"] = dict(custom_headers)
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from openai import OpenAI
 
+from agent.client_headers import get_model_custom_headers, merge_default_headers
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -120,6 +121,10 @@ _OR_HEADERS = {
     "X-OpenRouter-Title": "Hermes Agent",
     "X-OpenRouter-Categories": "productivity,cli-agent",
 }
+
+
+def _headers_with_config(base_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    return merge_default_headers(base_headers, get_model_custom_headers())
 
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
@@ -724,6 +729,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
+            extra_headers = _headers_with_config(extra.get("default_headers"))
+            if extra_headers:
+                extra["default_headers"] = extra_headers
             return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -745,6 +753,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
+        extra_headers = _headers_with_config(extra.get("default_headers"))
+        if extra_headers:
+            extra["default_headers"] = extra_headers
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -763,14 +774,14 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
         return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                       default_headers=_headers_with_config(_OR_HEADERS)), _OPENROUTER_MODEL
 
     or_key = os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+                   default_headers=_headers_with_config(_OR_HEADERS)), _OPENROUTER_MODEL
 
 
 def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
@@ -794,13 +805,14 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
                          model, "vision" if vision else "text")
     except Exception:
         pass
-    return (
-        OpenAI(
-            api_key=_nous_api_key(nous),
-            base_url=str(nous.get("inference_base_url") or _nous_base_url()).rstrip("/"),
-        ),
-        model,
-    )
+    openai_kwargs = {
+        "api_key": _nous_api_key(nous),
+        "base_url": str(nous.get("inference_base_url") or _nous_base_url()).rstrip("/"),
+    }
+    merged_headers = _headers_with_config()
+    if merged_headers:
+        openai_kwargs["default_headers"] = merged_headers
+    return (OpenAI(**openai_kwargs), model)
 
 
 def _read_main_model() -> str:
@@ -912,9 +924,17 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
     model = _read_main_model() or "gpt-4o-mini"
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     if custom_mode == "codex_responses":
-        real_client = OpenAI(api_key=custom_key, base_url=custom_base)
+        openai_kwargs = {"api_key": custom_key, "base_url": custom_base}
+        merged_headers = _headers_with_config()
+        if merged_headers:
+            openai_kwargs["default_headers"] = merged_headers
+        real_client = OpenAI(**openai_kwargs)
         return CodexAuxiliaryClient(real_client, model), model
-    return OpenAI(api_key=custom_key, base_url=custom_base), model
+    openai_kwargs = {"api_key": custom_key, "base_url": custom_base}
+    merged_headers = _headers_with_config()
+    if merged_headers:
+        openai_kwargs["default_headers"] = merged_headers
+    return OpenAI(**openai_kwargs), model
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
@@ -934,7 +954,11 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
-    real_client = OpenAI(api_key=codex_token, base_url=base_url)
+    openai_kwargs = {"api_key": codex_token, "base_url": base_url}
+    merged_headers = _headers_with_config()
+    if merged_headers:
+        openai_kwargs["default_headers"] = merged_headers
+    real_client = OpenAI(**openai_kwargs)
     return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 
@@ -1236,13 +1260,17 @@ def _to_async_client(sync_client, model: str):
     }
     base_lower = str(sync_client.base_url).lower()
     if "openrouter" in base_lower:
-        async_kwargs["default_headers"] = dict(_OR_HEADERS)
+        async_kwargs["default_headers"] = _headers_with_config(dict(_OR_HEADERS))
     elif "api.githubcopilot.com" in base_lower:
         from hermes_cli.models import copilot_default_headers
 
-        async_kwargs["default_headers"] = copilot_default_headers()
+        async_kwargs["default_headers"] = _headers_with_config(copilot_default_headers())
     elif "api.kimi.com" in base_lower:
-        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+        async_kwargs["default_headers"] = _headers_with_config({"User-Agent": "KimiCLI/1.30.0"})
+    else:
+        merged_headers = _headers_with_config()
+        if merged_headers:
+            async_kwargs["default_headers"] = merged_headers
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -1423,6 +1451,9 @@ def resolve_provider_client(
             elif "api.githubcopilot.com" in custom_base.lower():
                 from hermes_cli.models import copilot_default_headers
                 extra["default_headers"] = copilot_default_headers()
+            extra_headers = _headers_with_config(extra.get("default_headers"))
+            if extra_headers:
+                extra["default_headers"] = extra_headers
             client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base)
             return (_to_async_client(client, final_model) if async_mode
@@ -1457,7 +1488,11 @@ def resolve_provider_client(
                     model or custom_entry.get("model") or _read_main_model() or "gpt-4o-mini",
                     provider,
                 )
-                client = OpenAI(api_key=custom_key, base_url=custom_base)
+                openai_kwargs = {"api_key": custom_key, "base_url": custom_base}
+                merged_headers = _headers_with_config()
+                if merged_headers:
+                    openai_kwargs["default_headers"] = merged_headers
+                client = OpenAI(**openai_kwargs)
                 client = _wrap_if_needed(client, final_model, custom_base)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s)",
@@ -1523,6 +1558,7 @@ def resolve_provider_client(
 
             headers.update(copilot_default_headers())
 
+        headers = _headers_with_config(headers)
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/agent/client_headers.py
+++ b/agent/client_headers.py
@@ -1,0 +1,48 @@
+"""Shared helpers for provider-specific HTTP headers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def get_model_custom_headers(config: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    """Return sanitized ``model.custom_headers`` from config.yaml."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            return {}
+
+    model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return {}
+
+    raw_headers = model_cfg.get("custom_headers")
+    if not isinstance(raw_headers, dict):
+        return {}
+
+    headers: Dict[str, str] = {}
+    for key, value in raw_headers.items():
+        if not isinstance(key, str):
+            continue
+        clean_key = key.strip()
+        if not clean_key:
+            continue
+        if isinstance(value, str):
+            clean_value = value.strip()
+        else:
+            clean_value = str(value).strip() if value is not None else ""
+        if clean_value:
+            headers[clean_key] = clean_value
+    return headers
+
+
+def merge_default_headers(*header_sets: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Merge header dictionaries in order, skipping empty inputs."""
+    merged: Dict[str, str] = {}
+    for header_set in header_sets:
+        if header_set:
+            merged.update(header_set)
+    return merged

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -50,6 +50,12 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # Optional extra HTTP headers to attach to provider requests.
+  # Useful for internal routing, auditing, or cost-center tagging.
+  # custom_headers:
+  #   X-Source: "hermes-agent"
+  #   X-Cost-Center: "team-ai-infra"
+
   # ── Token limits — two settings, easy to confuse ──────────────────────────
   #
   # context_length: TOTAL context window (input + output tokens combined).

--- a/run_agent.py
+++ b/run_agent.py
@@ -43,6 +43,7 @@ import fire
 from datetime import datetime
 from pathlib import Path
 
+from agent.client_headers import get_model_custom_headers, merge_default_headers
 from hermes_constants import get_hermes_home
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -894,6 +895,7 @@ class AIAgent:
                 if effective_key and len(effective_key) > 12:
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
         else:
+            custom_headers = get_model_custom_headers()
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
@@ -918,6 +920,11 @@ class AIAgent:
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
+                if custom_headers:
+                    client_kwargs["default_headers"] = merge_default_headers(
+                        client_kwargs.get("default_headers"),
+                        custom_headers,
+                    )
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -931,6 +938,8 @@ class AIAgent:
                     # Preserve any default_headers the router set
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    elif custom_headers:
+                        client_kwargs["default_headers"] = dict(custom_headers)
                 else:
                     # When the user explicitly chose a non-OpenRouter provider
                     # but no credentials were found, fail fast with a clear
@@ -952,6 +961,11 @@ class AIAgent:
                             "X-OpenRouter-Categories": "productivity,cli-agent",
                         },
                     }
+                    if custom_headers:
+                        client_kwargs["default_headers"] = merge_default_headers(
+                            client_kwargs.get("default_headers"),
+                            custom_headers,
+                        )
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -115,6 +115,15 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14"
             }
 
+    def test_custom_headers_merge_with_anthropic_defaults(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("agent.anthropic_adapter.get_model_custom_headers", return_value={"X-Source": "hermes-agent"}):
+            build_anthropic_client("sk-ant-api03-something")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["X-Source"] == "hermes-agent"
+            betas = kwargs["default_headers"]["anthropic-beta"]
+            assert "interleaved-thinking-2025-05-14" in betas
+
 
 class TestReadClaudeCodeCredentials:
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -459,10 +459,14 @@ class TestExplicitProviderRouting:
     def test_explicit_openrouter(self, monkeypatch):
         """provider='openrouter' should use OPENROUTER_API_KEY."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-explicit")
-        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch("agent.auxiliary_client.get_model_custom_headers", return_value={"X-Source": "hermes-agent"}):
             mock_openai.return_value = MagicMock()
             client, model = resolve_provider_client("openrouter")
             assert client is not None
+        headers = mock_openai.call_args.kwargs["default_headers"]
+        assert headers["X-Source"] == "hermes-agent"
+        assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
 
     def test_explicit_kimi(self, monkeypatch):
         """provider='kimi-coding' should use KIMI_API_KEY."""

--- a/tests/agent/test_client_headers.py
+++ b/tests/agent/test_client_headers.py
@@ -1,0 +1,37 @@
+"""Tests for shared client header helpers."""
+
+from agent.client_headers import get_model_custom_headers, merge_default_headers
+
+
+def test_get_model_custom_headers_sanitizes_entries():
+    headers = get_model_custom_headers(
+        {
+            "model": {
+                "custom_headers": {
+                    " X-Source ": " hermes-agent ",
+                    "": "ignored",
+                    "X-Empty": "   ",
+                    "X-Number": 42,
+                    7: "ignored",
+                }
+            }
+        }
+    )
+
+    assert headers == {
+        "X-Source": "hermes-agent",
+        "X-Number": "42",
+    }
+
+
+def test_merge_default_headers_prefers_later_values():
+    merged = merge_default_headers(
+        {"X-Source": "base", "X-Base": "1"},
+        {"X-Source": "override", "X-Custom": "2"},
+    )
+
+    assert merged == {
+        "X-Source": "override",
+        "X-Base": "1",
+        "X-Custom": "2",
+    }


### PR DESCRIPTION
## Summary
Add `model.custom_headers` support so Hermes can attach user-defined HTTP headers to provider requests across the main agent runtime, auxiliary OpenAI-compatible clients, and native Anthropic clients.

## Related Issue
Fixes #9398

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Add shared header helpers in `agent/client_headers.py` to sanitize and merge `model.custom_headers`
- Merge configured headers into native Anthropic client defaults without dropping required beta headers
- Merge configured headers into OpenAI-compatible clients in `agent/auxiliary_client.py`
- Apply the same configured headers to the main runtime client path in `run_agent.py`
- Document the new `model.custom_headers` option in `cli-config.yaml.example`
- Add regression coverage for header sanitization, Anthropic header merging, and OpenRouter auxiliary client merging

## How to Test
1. `. venv/bin/activate`
2. `python -m py_compile agent/client_headers.py agent/anthropic_adapter.py agent/auxiliary_client.py run_agent.py`
3. `python -m pytest tests/agent/test_client_headers.py tests/agent/test_anthropic_adapter.py::TestBuildAnthropicClient::test_custom_headers_merge_with_anthropic_defaults tests/agent/test_auxiliary_client.py::TestExplicitProviderRouting::test_explicit_openrouter -q`
4. Set in `config.yaml`:
   ```yaml
   model:
     custom_headers:
       X-Source: hermes-agent
       X-Cost-Center: team-ai-infra
   ```
   Then verify provider requests include those headers.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation / examples
- [x] I've updated `cli-config.yaml.example`
- [x] N/A — no architecture/workflow docs changed
