### PR TITLE
fix: use builtin cd in command wrapper to bypass shell aliases

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -342,7 +342,7 @@ class BaseEnvironment(ABC):
         quoted_cwd = (
             shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
         )
-        parts.append(f"cd {quoted_cwd} || exit 126")
+        parts.append(f"builtin cd {quoted_cwd} || exit 126")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")


### PR DESCRIPTION
## Problem

Shell version managers like **frum** (Ruby), **rvm**, **nvm**, **chruby**, and others commonly alias `cd` to a wrapper function that runs additional logic after directory changes (e.g., auto-switching language versions).

When Hermes captures the login shell environment into a session snapshot (`init_session`), these aliases are preserved. If the wrapper function fails in the subprocess context (e.g., `frum` not fully initialized or not on PATH), every `cd` returns a non-zero exit code.

Since `_wrap_command()` uses `cd <cwd> || exit 126`, **every terminal command silently fails with exit code 126 and empty output** — a confusing experience with no error message.

## Root Cause

In `tools/environments/base.py`, line 345:

```python
parts.append(f"cd {quoted_cwd} || exit 126")
```

The bare `cd` resolves to whatever alias or function the snapshot defined. For example, frum installs:

```bash
alias cd='__frumcd'

__frumcd () {
    \cd "$@" || return $?;
    frum --log-level quiet local   # <-- this fails in subprocess context
}
```

The real `cd` succeeds, but `frum` fails, so `__frumcd` returns non-zero, triggering `exit 126`.

## Fix

Use `builtin cd` which tells bash to use the real `cd` builtin directly, bypassing any aliases or shell functions:

```python
parts.append(f"builtin cd {quoted_cwd} || exit 126")
```

This is safe because:
- `builtin` is a bash built-in itself, always available
- It does exactly what we want: change directory, nothing else
- Version managers' `cd` hooks still work in interactive shells — only the Hermes command wrapper is affected

## Affected Users

Anyone using a Ruby/Node/Python version manager that hooks into `cd`:
- **frum** (Ruby) — confirmed affected
- **rvm** — uses `cd` function
- **chruby** — uses `cd` function
- **nvm** — can hook into `cd` via `nvm use` auto-detection
- Any tool that aliases or wraps `cd`
