### PR TITLE
fix(gateway): add missing send_voice() override to WhatsApp adapter

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -781,6 +781,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send audio file as native media via bridge."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:

--- a/tests/gateway/test_whatsapp_send_voice.py
+++ b/tests/gateway/test_whatsapp_send_voice.py
@@ -1,0 +1,70 @@
+"""Tests that WhatsApp adapter has send_voice() override.
+
+Issue #9236: WhatsApp was the only platform adapter missing a
+send_voice() override, causing voice messages to fall back to
+plain text instead of native media attachments.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class TestWhatsAppSendVoice:
+    """Verify send_voice is overridden and routes through bridge."""
+
+    def test_send_voice_method_exists(self):
+        """WhatsApp adapter must have its own send_voice override."""
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+        # The method should NOT be the base class fallback
+        assert hasattr(WhatsAppAdapter, "send_voice")
+        assert WhatsAppAdapter.send_voice is not BasePlatformAdapter.send_voice
+
+    def test_send_voice_signature_matches_base(self):
+        """send_voice signature should match the base class interface."""
+        import inspect
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        base_sig = inspect.signature(BasePlatformAdapter.send_voice)
+        wa_sig = inspect.signature(WhatsAppAdapter.send_voice)
+
+        # Both should accept: self, chat_id, audio_path, caption, reply_to, **kwargs
+        base_params = list(base_sig.parameters.keys())
+        wa_params = list(wa_sig.parameters.keys())
+        assert base_params == wa_params
+
+    @pytest.mark.asyncio
+    async def test_send_voice_calls_bridge(self):
+        """send_voice should route through _send_media_to_bridge with type 'audio'."""
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        adapter = object.__new__(WhatsAppAdapter)
+        adapter._send_media_to_bridge = AsyncMock(
+            return_value=MagicMock(success=True, message_id="msg123")
+        )
+
+        result = await adapter.send_voice(
+            chat_id="12345@s.whatsapp.net",
+            audio_path="/tmp/voice.mp3",
+            caption="Hello",
+        )
+
+        adapter._send_media_to_bridge.assert_called_once_with(
+            "12345@s.whatsapp.net", "/tmp/voice.mp3", "audio", "Hello"
+        )
+        assert result.success is True
+
+    def test_all_media_methods_present(self):
+        """WhatsApp adapter should have all media send methods."""
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        for method_name in ("send_image", "send_image_file", "send_video",
+                            "send_document", "send_voice"):
+            method = getattr(WhatsAppAdapter, method_name, None)
+            assert method is not None, f"Missing method: {method_name}"
+            base_method = getattr(BasePlatformAdapter, method_name, None)
+            assert method is not base_method, (
+                f"{method_name} is not overridden (still using base class)"
+            )


### PR DESCRIPTION
## What does this PR do?

Adds the missing `send_voice()` method to the WhatsApp platform adapter. WhatsApp was the only adapter without this override — voice/audio messages fell back to the base class implementation which sent them as plain text paths (e.g. `🔊 Audio: /path/to/file.mp3`) instead of native media attachments.

## Related Issue

Fixes #9236

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Added `send_voice()` to `gateway/platforms/whatsapp.py` that routes through the existing `_send_media_to_bridge()` with `media_type="audio"`, consistent with `send_image`, `send_video`, and `send_document`.

The WhatsApp bridge (`bridge.js`) already handles the `"audio"` media type — it reads the file and sends `sock.sendMessage({ audio: buffer, mimetype: "audio/mpeg" })`. No bridge-side changes needed.

## How to Test

1. Configure Hermes with a WhatsApp gateway
2. Trigger a voice message (e.g., TTS tool output or voice reply)
3. **Before**: User receives plain text like `🔊 Audio: /tmp/hermes_voice/tts_reply_abc123.mp3`
4. **After**: User receives a native audio attachment in WhatsApp

Run the test suite:
```bash
pytest tests/gateway/test_whatsapp_send_voice.py -v
```

Tests verify:
- `send_voice` method exists and is not the base class fallback ✅
- Method signature matches the base class interface ✅
- Routes through `_send_media_to_bridge` with type `"audio"` ✅
- All media methods (image, video, document, voice) are overridden ✅

Full suite:
```bash
pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
