### PR TITLE
fix: accept ALIBABA_API_KEY as fallback and fix error messages for alibaba provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2341,9 +2341,15 @@ def call_llm(
             # through OpenRouter (which causes confusing 404s).
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                if _pconfig and _pconfig.api_key_env_vars:
+                    _env_hint = ' or '.join(_pconfig.api_key_env_vars)
+                else:
+                    _env_hint = f'{_explicit.upper()}_API_KEY'
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             # For auto/custom with no credentials, try the full auto chain
@@ -2546,9 +2552,15 @@ async def async_call_llm(
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                if _pconfig and _pconfig.api_key_env_vars:
+                    _env_hint = ' or '.join(_pconfig.api_key_env_vars)
+                else:
+                    _env_hint = f'{_explicit.upper()}_API_KEY'
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             if not resolved_base_url:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -195,7 +195,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
         inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        api_key_env_vars=("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(

--- a/run_agent.py
+++ b/run_agent.py
@@ -937,9 +937,15 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        from hermes_cli.auth import PROVIDER_REGISTRY
+                        _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                        if _pconfig and _pconfig.api_key_env_vars:
+                            _env_hint = ' or '.join(_pconfig.api_key_env_vars)
+                        else:
+                            _env_hint = f'{_explicit.upper()}_API_KEY'
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key

--- a/tests/hermes_cli/test_alibaba_env_var.py
+++ b/tests/hermes_cli/test_alibaba_env_var.py
@@ -1,0 +1,53 @@
+"""Tests for alibaba provider env var handling (issue #9506)."""
+
+import os
+import sys
+import types
+
+import pytest
+
+# Ensure dotenv doesn't interfere
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.auth import PROVIDER_REGISTRY
+
+
+class TestAlibabaEnvVars:
+    """Verify the alibaba provider accepts both DASHSCOPE_API_KEY and ALIBABA_API_KEY."""
+
+    def test_alibaba_registered(self):
+        assert "alibaba" in PROVIDER_REGISTRY
+
+    def test_dashscope_is_primary(self):
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        assert pconfig.api_key_env_vars[0] == "DASHSCOPE_API_KEY"
+
+    def test_alibaba_api_key_is_fallback(self):
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        assert "ALIBABA_API_KEY" in pconfig.api_key_env_vars
+
+    def test_env_var_order(self):
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        assert pconfig.api_key_env_vars == ("DASHSCOPE_API_KEY", "ALIBABA_API_KEY")
+
+
+class TestAlibabaErrorMessage:
+    """Verify error messages show actual env var names from the registry."""
+
+    def test_error_message_shows_dashscope(self):
+        """The error hint for alibaba must mention DASHSCOPE_API_KEY, not ALIBABA_API_KEY."""
+        pconfig = PROVIDER_REGISTRY.get("alibaba")
+        assert pconfig and pconfig.api_key_env_vars
+        env_hint = ' or '.join(pconfig.api_key_env_vars)
+        assert "DASHSCOPE_API_KEY" in env_hint
+
+    def test_error_message_does_not_guess_from_name(self):
+        """The old code used {provider.upper()}_API_KEY which gives ALIBABA_API_KEY.
+        The new code should use the registry, so DASHSCOPE_API_KEY comes first."""
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        env_hint = ' or '.join(pconfig.api_key_env_vars)
+        # The hint should start with DASHSCOPE_API_KEY, not ALIBABA_API_KEY
+        assert env_hint.startswith("DASHSCOPE_API_KEY")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -130,7 +130,7 @@ PROVIDER_ENV_VARS = (
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
-    "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
+    "DASHSCOPE_API_KEY", "ALIBABA_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
@@ -146,6 +146,9 @@ def _clear_provider_env(monkeypatch):
 
 class TestResolveProvider:
     """Test resolve_provider() with new providers."""
+
+    def test_explicit_alibaba(self):
+        assert resolve_provider("alibaba") == "alibaba"
 
     def test_explicit_zai(self):
         assert resolve_provider("zai") == "zai"
@@ -261,6 +264,14 @@ class TestResolveProvider:
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
         assert resolve_provider("auto") == "kilocode"
 
+    def test_auto_detects_dashscope_key(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
+        assert resolve_provider("auto") == "alibaba"
+
+    def test_auto_detects_alibaba_fallback_key(self, monkeypatch):
+        monkeypatch.setenv("ALIBABA_API_KEY", "test-alibaba-key")
+        assert resolve_provider("auto") == "alibaba"
+
     def test_auto_detects_hf_token(self, monkeypatch):
         monkeypatch.setenv("HF_TOKEN", "hf_test_token")
         assert resolve_provider("auto") == "huggingface"
@@ -302,6 +313,28 @@ class TestApiKeyProviderStatus:
         status = get_api_key_provider_status("zai")
         assert status["configured"] is True
         assert status["key_source"] == "ZAI_API_KEY"
+
+    def test_alibaba_primary_env_var(self, monkeypatch):
+        """DASHSCOPE_API_KEY should be the primary env var for alibaba."""
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "dashscope-primary-key")
+        status = get_api_key_provider_status("alibaba")
+        assert status["configured"] is True
+        assert status["key_source"] == "DASHSCOPE_API_KEY"
+
+    def test_alibaba_fallback_env_var(self, monkeypatch):
+        """ALIBABA_API_KEY should work as fallback when DASHSCOPE_API_KEY is not set."""
+        monkeypatch.setenv("ALIBABA_API_KEY", "alibaba-fallback-key")
+        status = get_api_key_provider_status("alibaba")
+        assert status["configured"] is True
+        assert status["key_source"] == "ALIBABA_API_KEY"
+
+    def test_alibaba_primary_takes_priority(self, monkeypatch):
+        """DASHSCOPE_API_KEY should take priority over ALIBABA_API_KEY."""
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "dashscope-key")
+        monkeypatch.setenv("ALIBABA_API_KEY", "alibaba-key")
+        status = get_api_key_provider_status("alibaba")
+        assert status["configured"] is True
+        assert status["key_source"] == "DASHSCOPE_API_KEY"
 
     def test_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-key")
@@ -986,3 +1019,34 @@ class TestHuggingFaceModels:
         from hermes_cli.models import _PROVIDER_LABELS
         assert "huggingface" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["huggingface"] == "Hugging Face"
+
+
+class TestAlibabaProviderConfig:
+    """Tests for alibaba provider configuration and env var handling (#9506)."""
+
+    def test_alibaba_registry_has_both_env_vars(self):
+        """alibaba provider should accept both DASHSCOPE_API_KEY and ALIBABA_API_KEY."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        assert "DASHSCOPE_API_KEY" in pconfig.api_key_env_vars
+        assert "ALIBABA_API_KEY" in pconfig.api_key_env_vars
+
+    def test_alibaba_dashscope_is_primary(self):
+        """DASHSCOPE_API_KEY should be checked before ALIBABA_API_KEY."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        dashscope_idx = pconfig.api_key_env_vars.index("DASHSCOPE_API_KEY")
+        alibaba_idx = pconfig.api_key_env_vars.index("ALIBABA_API_KEY")
+        assert dashscope_idx < alibaba_idx
+
+    def test_error_message_shows_correct_env_vars(self):
+        """Error message for alibaba should mention DASHSCOPE_API_KEY, not just ALIBABA_API_KEY."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        provider = "alibaba"
+        pconfig = PROVIDER_REGISTRY.get(provider)
+        if pconfig and pconfig.api_key_env_vars:
+            env_hint = ' or '.join(pconfig.api_key_env_vars)
+        else:
+            env_hint = f'{provider.upper()}_API_KEY'
+        assert "DASHSCOPE_API_KEY" in env_hint
+        assert "ALIBABA_API_KEY" in env_hint

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1047,6 +1047,21 @@ def test_alibaba_anthropic_endpoint_override_uses_anthropic_messages(monkeypatch
     assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic"
 
 
+def test_alibaba_fallback_alibaba_api_key(monkeypatch):
+    """ALIBABA_API_KEY should work as fallback for alibaba provider (#9506)."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.setenv("ALIBABA_API_KEY", "test-alibaba-fallback-key")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_key"] == "test-alibaba-fallback-key"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+
 def test_opencode_zen_gpt_defaults_to_responses(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "gpt-5.4"})


### PR DESCRIPTION
## Summary

Fixes #9506

The `alibaba` provider error message incorrectly showed `ALIBABA_API_KEY` as the required environment variable, but the actual env var Hermes reads is `DASHSCOPE_API_KEY`. This caused user confusion — setting `ALIBABA_API_KEY` had no effect.

## Changes

### 1. Accept both env vars (backward compatibility)
- Added `ALIBABA_API_KEY` as a fallback in the alibaba `ProviderConfig.api_key_env_vars` tuple
- `DASHSCOPE_API_KEY` remains the primary (checked first), `ALIBABA_API_KEY` is the fallback

### 2. Fix error messages to show actual env var names
- Updated error messages in `run_agent.py` and `agent/auxiliary_client.py` (3 locations) to look up actual env var names from `PROVIDER_REGISTRY` instead of guessing from provider name
- Before: *"Set the ALIBABA_API_KEY environment variable"*
- After: *"Set the DASHSCOPE_API_KEY or ALIBABA_API_KEY environment variable"*
- This fix benefits all providers — any provider whose env var name doesn't match `{PROVIDER.upper()}_API_KEY` will now show the correct hint

### 3. Tests
- New dedicated test file `tests/hermes_cli/test_alibaba_env_var.py` with 6 tests covering registry config and error message content
- Added alibaba tests to existing test files:
  - `test_api_key_providers.py`: provider resolution, status with primary/fallback env vars, priority order, error message verification
  - `test_runtime_provider_resolution.py`: runtime resolution with `ALIBABA_API_KEY` fallback

## Testing
```
pytest tests/hermes_cli/test_alibaba_env_var.py -v  # 6 passed
pytest tests/hermes_cli/test_api_key_providers.py -q  # 136 passed
pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_alibaba_fallback_alibaba_api_key -v  # 1 passed
```

Full test suite: 11157 passed (all pre-existing failures unrelated).