### PR TITLE
fix(agent): increase tool call truncation retries from 1 to 3 with max_tokens boost

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8716,12 +8716,18 @@ class AIAgent:
                         if self.api_mode == "chat_completions":
                             assistant_message = response.choices[0].message
                             if assistant_message.tool_calls:
-                                if truncated_tool_call_retries < 1:
+                                if truncated_tool_call_retries < 3:
                                     truncated_tool_call_retries += 1
                                     self._vprint(
-                                        f"{self.log_prefix}⚠️  Truncated tool call detected — retrying API call...",
+                                        f"{self.log_prefix}⚠️  Truncated tool call detected — retrying API call "
+                                        f"({truncated_tool_call_retries}/3)...",
                                         force=True,
                                     )
+                                    # Boost max_tokens on each retry so the model
+                                    # has more room to complete the tool call JSON.
+                                    _tc_boost_base = self.max_tokens if self.max_tokens else 4096
+                                    _tc_boost = min(_tc_boost_base * (truncated_tool_call_retries + 1), 32768)
+                                    self._ephemeral_max_output_tokens = _tc_boost
                                     # Don't append the broken response to messages;
                                     # just re-run the same API call from the current
                                     # message state, giving the model another chance.


### PR DESCRIPTION
## Problem

Referenced in #7237

Tool calls with large arguments (write_file, complex JSON) fail after a single retry when the model hits max_tokens mid-JSON. The retry used the same max_tokens so it truncated again.

## Fix

- Raise truncated_tool_call_retries limit from 1 to 3
- Boost _ephemeral_max_output_tokens on each retry (2x, 3x, 4x base, capped at 32K)
- Log retry count as (n/3)

## Before / After

Before: truncated tool call → 1 retry at same limit → error
After: truncated tool call → 3 retries with growing limit → completes