### PR TITLE
fix: honor umask in atomic_json_write/atomic_yaml_write

### DIFF
--- a/tests/hermes_cli/test_atomic_json_write.py
+++ b/tests/hermes_cli/test_atomic_json_write.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import stat
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -157,3 +159,19 @@ class TestAtomicJsonWrite:
         result = json.loads(target.read_text())
         assert "writer" in result
         assert len(result["data"]) == 100
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions")
+    def test_file_permissions_honor_umask(self, tmp_path):
+        """Resulting file should have umask-respecting permissions, not 0600."""
+        # Read current umask without permanently changing it.
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+
+        target = tmp_path / "perms.json"
+        atomic_json_write(target, {"ok": True})
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        # mkstemp creates 0600; after the fix, mode should match what a
+        # plain open() would produce: 0o666 & ~umask.
+        expected = 0o666 & ~current_umask
+        assert mode == expected, f"expected {oct(expected)}, got {oct(mode)}"

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -1,5 +1,8 @@
 """Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
 
+import os
+import stat
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -42,3 +45,16 @@ class TestAtomicYamlWrite:
         text = target.read_text(encoding="utf-8")
         assert "key: value" in text
         assert "# comment" in text
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions")
+    def test_file_permissions_honor_umask(self, tmp_path):
+        """Resulting file should have umask-respecting permissions, not 0600."""
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+
+        target = tmp_path / "perms.yaml"
+        atomic_yaml_write(target, {"ok": True})
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        expected = 0o666 & ~current_umask
+        assert mode == expected, f"expected {oct(expected)}, got {oct(mode)}"

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,13 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def _current_umask() -> int:
+    """Return the process umask without permanently changing it."""
+    mask = os.umask(0)
+    os.umask(mask)
+    return mask
+
+
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
 
 
@@ -71,6 +78,10 @@ def atomic_json_write(
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o666 & ~_current_umask())
+        except OSError:
+            pass
     except BaseException:
         # Intentionally catch BaseException so temp-file cleanup still runs for
         # KeyboardInterrupt/SystemExit before re-raising the original signal.
@@ -119,6 +130,10 @@ def atomic_yaml_write(
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o666 & ~_current_umask())
+        except OSError:
+            pass
     except BaseException:
         # Match atomic_json_write: cleanup must also happen for process-level
         # interruptions before we re-raise them.


### PR DESCRIPTION
## Summary

Fixes #9239 — `/save` and other persistence calls fail with `Permission denied` under NixOS managed mode (and anywhere else the directory's group-write intent matters).

`atomic_json_write` / `atomic_yaml_write` use `tempfile.mkstemp()`, which always creates the temp file with mode `0600` and ignores the process umask. `os.replace()` preserves those bits, so the final file ends up `0600` no matter what. Under the NixOS managed-mode config (state dir is `2770`, setgid, umask `0007`), the user's first `/save` lands as `0600` — owned by the service user but unreadable/unwritable by the shared group, so the next save blows up.

Fix: after `os.replace()`, `chmod` the target to `0o666 & ~umask` so the final mode matches what a plain `open(path, "w")` would have produced. `chmod` failures are swallowed — permission semantics on Windows are already best-effort.

## Root cause trace

- `tempfile.mkstemp()` hard-codes `0600` for security, ignores umask (documented behavior).
- `os.replace(tmp, target)` preserves source permissions (documented behavior).
- Introduced as atomic-write became the default for session/state files (f6857414 and follow-ups).
- All callers are affected: session saves, models.dev cache, prompt snapshot, gateway config, doctor rewrites, weixin state, process_registry checkpoint, and more — but the symptom only surfaces when the directory's intended permissions are wider than `0600`.

## Test plan

- [x] `tests/hermes_cli/test_atomic_json_write.py::TestAtomicJsonWrite::test_file_permissions_honor_umask`
- [x] `tests/hermes_cli/test_atomic_yaml_write.py::TestAtomicYamlWrite::test_file_permissions_honor_umask`
- [x] Existing crash-safety / cleanup tests continue to pass (no signature change, only an extra post-replace `chmod`).
- [x] Windows path skipped via `pytest.mark.skipif(sys.platform == "win32")`.

## Notes

- Matches the fix proposed by the issue reporter in #9239.
- No API/signature changes; purely a permission-semantics fix.
- `_current_umask()` helper uses the standard `os.umask(0); os.umask(mask)` idiom — Python has no read-only umask API.
