### PR TITLE
fix(cli): report image_gen setup hints in doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -97,18 +97,61 @@ def _honcho_is_configured_for_doctor() -> bool:
         return False
 
 
+def _image_gen_missing_vars_for_doctor() -> list[str] | None:
+    """Return actionable missing-vars hints for image generation in doctor output."""
+    try:
+        import fal_client  # noqa: F401 — SDK presence check for doctor messaging
+    except ImportError:
+        return None
+
+    if os.getenv("FAL_KEY"):
+        return None
+
+    try:
+        from hermes_cli.nous_subscription import get_nous_subscription_features
+        from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+        features = get_nous_subscription_features()
+    except Exception:
+        return ["FAL_KEY"]
+
+    if features.image_gen.available:
+        return None
+
+    if managed_nous_tools_enabled():
+        if not features.nous_auth_present:
+            return ["FAL_KEY or Nous auth"]
+        return ["FAL_KEY or managed FAL gateway"]
+
+    return ["FAL_KEY"]
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
-    if not _honcho_is_configured_for_doctor():
+    honcho_configured = _honcho_is_configured_for_doctor()
+    image_gen_missing_vars = _image_gen_missing_vars_for_doctor()
+
+    if not honcho_configured and not image_gen_missing_vars:
         return available, unavailable
 
     updated_available = list(available)
     updated_unavailable = []
     for item in unavailable:
-        if item.get("name") == "honcho":
+        if item.get("name") == "honcho" and honcho_configured:
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
             continue
+
+        if (
+            item.get("name") == "image_gen"
+            and not (item.get("missing_vars") or item.get("env_vars"))
+            and image_gen_missing_vars
+        ):
+            updated_item = dict(item)
+            updated_item["missing_vars"] = image_gen_missing_vars
+            updated_unavailable.append(updated_item)
+            continue
+
         updated_unavailable.append(item)
     return updated_available, updated_unavailable
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -69,6 +69,23 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [honcho_entry]
 
+    def test_adds_image_gen_missing_vars_when_sdk_is_present_but_not_configured(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: False)
+        monkeypatch.setattr(doctor, "_image_gen_missing_vars_for_doctor", lambda: ["FAL_KEY"])
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [{"name": "image_gen", "env_vars": [], "tools": ["image_generate"]}],
+        )
+
+        assert available == []
+        assert unavailable == [{
+            "name": "image_gen",
+            "env_vars": [],
+            "tools": ["image_generate"],
+            "missing_vars": ["FAL_KEY"],
+        }]
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):
@@ -119,6 +136,47 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
         doctor_mod.run_doctor(Namespace(fix=False))
 
     assert seen["interactive"] == "1"
+
+
+def test_run_doctor_reports_image_gen_as_missing_fal_key(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod, "_image_gen_missing_vars_for_doctor", lambda: ["FAL_KEY"])
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (
+            ["terminal"],
+            [{"name": "image_gen", "env_vars": [], "tools": ["image_generate"]}],
+        ),
+        TOOLSET_REQUIREMENTS={
+            "terminal": {"name": "terminal"},
+            "image_gen": {"name": "image_gen"},
+        },
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "image_gen (missing FAL_KEY)" in out
+    assert "image_gen (system dependency not met)" not in out
 
 
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- fix misleading `hermes doctor` output for `image_gen`
- report missing image-generation setup/auth hints instead of a generic system dependency error
- add regression coverage for the doctor override path and user-visible output

## Root cause
`image_generate` now supports either direct `FAL_KEY` access or managed Nous image generation, so it no longer advertises `requires_env=["FAL_KEY"]` in the registry. `hermes doctor` falls back to `(system dependency not met)` whenever a toolset has no `env_vars` / `missing_vars`, which made `image_gen` look like an OS dependency problem even when `fal_client` was installed and only auth/config was missing.

## Test Plan
- [x] `/home/spacex/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q`
- [x] `/home/spacex/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_nous_subscription.py -q`

Fixes #9516
