### PR TITLE
fix: resolve remaining 4 CI test failures

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -238,6 +238,10 @@ def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
 
 def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
     _write_auth_store(
         tmp_path,
         {
@@ -281,6 +285,10 @@ def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
 
 def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
     _write_auth_store(
         tmp_path,
         {

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -380,7 +380,7 @@ class TestStubSchemaDrift(unittest.TestCase):
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
     # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete"}
+    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -29,8 +29,11 @@ class TestInterruptModule:
 
     def test_thread_safety(self):
         """Set from one thread targeting another thread's ident."""
-        from tools.interrupt import set_interrupt, is_interrupted
+        from tools.interrupt import set_interrupt, is_interrupted, _interrupted_threads, _lock
         set_interrupt(False)
+        # Clear any stale thread idents left by prior tests in this worker.
+        with _lock:
+            _interrupted_threads.clear()
 
         seen = {"value": False}
 


### PR DESCRIPTION
## Summary

Follow-up to #9483. Fixes the remaining 4 CI failures that were pre-existing on main.

| Test | Root Cause | Fix |
|------|-----------|-----|
| `test_auth_remove_accepts_label_target` | `_seed_from_singletons` auto-seeds extra credentials from CI env | Suppress seeding (same pattern as sibling tests) |
| `test_auth_remove_prefers_exact_numeric_label_over_index` | Same as above | Same fix |
| `test_thread_safety` | Thread ident reuse + stale `_interrupted_threads` from prior xdist tests | Clear the set at test start |
| `test_stubs_cover_all_schema_params` | `watch_patterns` added to terminal schema but not to test's blocked params | Add to `_BLOCKED_TERMINAL_PARAMS` |

3 files changed, 13 insertions, 2 deletions.