### PR TITLE
fix(auxiliary): clamp temperature=1.0 on OAuth + Opus 4.6 to fix vision tool

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -516,6 +516,13 @@ class _AnthropicCompletionsAdapter:
         if temperature is not None:
             anthropic_kwargs["temperature"] = temperature
 
+        # OAuth + Opus 4.6 rejects any temperature other than 1.0 with a
+        # cryptic "Invalid request data" 400. Clamp to 1.0 to keep vision
+        # and other low-temp auxiliary calls working.
+        if self._is_oauth and "opus-4-6" in str(model).lower():
+            if anthropic_kwargs.get("temperature") not in (None, 1, 1.0):
+                anthropic_kwargs["temperature"] = 1.0
+
         response = self._client.messages.create(**anthropic_kwargs)
         assistant_message, finish_reason = normalize_anthropic_response(response)
 


### PR DESCRIPTION
## Problem

Anthropic's OAuth endpoint rejects any `temperature != 1.0` on `claude-opus-4-6` with a cryptic `Invalid request data` 400 error. This breaks the vision tool (which hardcodes `temperature=0.1`) and any other low-temperature auxiliary call when:

1. The user authenticates via OAuth (`sk-ant-oat*` setup-token or subscription token)
2. The resolved auxiliary model is Opus 4.6

### Repro

```python
vision_analyze(image_url="/tmp/any.png", question="describe this")
```

Fails with:
```
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'Invalid request data'}, 'request_id': 'req_011Ca3...'}
```

Root cause isolated via direct SDK test:
- `temperature=None` → OK
- `temperature=1.0` → OK
- `temperature=0.5` → 400 Invalid request data
- `temperature=0.1` → 400 Invalid request data

Confirmed only on Opus 4.6 via OAuth. API-key auth accepts all temperatures. Sonnet/Haiku on OAuth accept all temperatures.

## Fix

In `_AnthropicCompletionsAdapter.create`, clamp temperature to `1.0` when `is_oauth=True` and the model contains `opus-4-6`. Other models and auth modes are unaffected.

## Testing

- Vision tool: fails pre-patch, works post-patch with OAuth + Opus 4.6 aux client.
- Non-vision auxiliary calls with temperature=1.0 or None: unchanged.
- API-key auth: unchanged (no clamping applied).
- Sonnet/Haiku OAuth: unchanged (no clamping applied).

## Notes

- This is a server-side quirk on Anthropic's infrastructure, not documented. The error message gives no hint that temperature is the issue.
- Alternative would be to patch `vision_tools.py` to drop temperature, but the adapter-level fix covers all callers uniformly (e.g. `summarization`, `compression`, future aux tasks) that might pass low temperatures.