### PR TITLE
fix(doctor): report missing image provider setup

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -133,6 +133,14 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+# Toolsets with multiple setup paths cannot expose a single missing env var.
+# Give those toolsets an actionable fallback instead of misclassifying them as
+# missing a system dependency.
+_TOOLSET_SETUP_HINTS: dict[str, str] = {
+    "image_gen": "(no image generation provider available; configure one with 'hermes tools')",
+}
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     updated_available = list(available)
@@ -212,10 +220,14 @@ def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
 
 
 def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
-    """Filter unavailable API-key toolsets to those enabled for the CLI."""
+    """Filter unavailable setup-gated toolsets to those enabled for the CLI."""
     api_key_unavailable = [
         item for item in unavailable
-        if item.get("missing_vars") or item.get("env_vars")
+        if (
+            item.get("missing_vars")
+            or item.get("env_vars")
+            or item.get("name") in _TOOLSET_SETUP_HINTS
+        )
     ]
     enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     if enabled_toolsets is None:
@@ -2190,7 +2202,8 @@ def run_doctor(args):
                 vars_str = ", ".join(env_vars)
                 check_warn(item["name"], f"(missing {vars_str})")
             else:
-                check_warn(item["name"], "(system dependency not met)")
+                hint = _TOOLSET_SETUP_HINTS.get(item.get("name"))
+                check_warn(item["name"], hint or "(system dependency not met)")
 
         # Count missing API-key requirements only for toolsets enabled in the
         # current CLI platform. Default-off or explicitly disabled toolsets may

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -97,6 +97,17 @@ def _honcho_is_configured_for_doctor() -> bool:
         return False
 
 
+# Per-toolset setup hints shown by `hermes doctor` when a toolset's check_fn
+# reports it unavailable but the registry does not expose specific missing
+# env vars (e.g. the backend has multiple auth paths). Without a hint the
+# doctor falls back to the generic "(system dependency not met)" label,
+# which misleads users whose actual blocker is a missing credential /
+# account configuration rather than a system package.
+_TOOLSET_SETUP_HINTS: dict[str, str] = {
+    "image_gen": "(missing FAL_KEY — or sign in via Nous Portal for managed image generation)",
+}
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     if not _honcho_is_configured_for_doctor():
@@ -823,10 +834,16 @@ def run_doctor(args):
                 vars_str = ", ".join(env_vars)
                 check_warn(item["name"], f"(missing {vars_str})")
             else:
-                check_warn(item["name"], "(system dependency not met)")
+                hint = _TOOLSET_SETUP_HINTS.get(item.get("name"))
+                check_warn(item["name"], hint or "(system dependency not met)")
 
-        # Count disabled tools with API key requirements
-        api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
+        # Count disabled tools that look like a configuration/credentials issue
+        # (either explicit missing env vars, or a curated setup hint) so we
+        # nudge the user toward `hermes setup` when it's actually actionable.
+        api_disabled = [
+            u for u in unavailable
+            if (u.get("missing_vars") or u.get("env_vars") or _TOOLSET_SETUP_HINTS.get(u.get("name")))
+        ]
         if api_disabled:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -56,6 +56,7 @@ class TestDoctorToolAvailabilitySummary:
         unavailable = [
             {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
             {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+            {"name": "image_gen", "env_vars": []},
         ]
         monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"web"})
 
@@ -67,12 +68,13 @@ class TestDoctorToolAvailabilitySummary:
         unavailable = [
             {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
             {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+            {"name": "image_gen", "env_vars": []},
         ]
         monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
 
         filtered = doctor._missing_api_key_toolsets_for_summary(unavailable)
 
-        assert [item["name"] for item in filtered] == ["rl", "web"]
+        assert [item["name"] for item in filtered] == ["rl", "web", "image_gen"]
 
 
 class TestDoctorEnvFileEncoding:
@@ -695,6 +697,59 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
     assert "npm install -g agent-browser && agent-browser install" in out
+
+
+def test_run_doctor_image_gen_hint_uses_real_provider_discovery(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(
+        doctor_mod,
+        "_enabled_cli_toolsets_for_doctor",
+        lambda: {"image_gen"},
+    )
+
+    import model_tools
+    import tools.image_generation_tool as image_tool
+    from agent.image_gen_registry import list_providers
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    _ensure_plugins_discovered()
+    monkeypatch.setattr(image_tool, "check_fal_api_key", lambda: False)
+    for provider in list_providers():
+        monkeypatch.setattr(provider, "is_available", lambda: False)
+
+    assert image_tool.check_image_generation_requirements() is False
+    requirements = model_tools.TOOLSET_REQUIREMENTS["image_gen"]
+    image_gen = {
+        "name": "image_gen",
+        "env_vars": requirements["env_vars"],
+        "tools": requirements["tools"],
+    }
+    assert image_gen["env_vars"] == []
+    monkeypatch.setattr(
+        model_tools,
+        "check_tool_availability",
+        lambda: ([], [image_gen]),
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    image_line = next(line for line in out.splitlines() if "image_gen (" in line)
+    assert "no image generation provider available" in image_line
+    assert "hermes tools" in image_line
+    assert "system dependency not met" not in image_line
+    assert "hermes setup" in out
 
 
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -292,3 +292,57 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
     assert "npm install -g agent-browser && agent-browser install" in out
+
+
+def test_run_doctor_image_gen_reports_credential_hint_not_system_dependency(monkeypatch, tmp_path):
+    """image_gen has multiple auth paths (FAL_KEY or managed Nous), so its
+    registry entry exposes no ``env_vars``. Without a hint, doctor used to
+    mislead users with "(system dependency not met)". It should now surface
+    a credential-focused setup hint and count the toolset toward the
+    'hermes setup' nudge. See issue NousResearch/hermes-agent#9516.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (
+            ["terminal"],
+            [{"name": "image_gen", "env_vars": [], "tools": ["image_generate"]}],
+        ),
+        TOOLSET_REQUIREMENTS={
+            "terminal": {"name": "terminal"},
+            "image_gen": {"name": "image_gen"},
+        },
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "image_gen" in out
+    # Misleading label must be gone: image_gen is the only unavailable
+    # toolset in this test, and it now has a curated hint.
+    assert "system dependency not met" not in out
+    # Actionable hint should be present.
+    assert "FAL_KEY" in out
+    assert "Nous Portal" in out
+    # The hint should nudge the user toward `hermes setup`, same as any
+    # other credential-gated toolset.
+    assert "hermes setup" in out


### PR DESCRIPTION
## Summary

Fixes #9516 — `hermes doctor` no longer reports `image_gen (system dependency not met)` when image generation is unavailable because no configured provider is ready.

Image generation now supports multiple registered providers and authentication paths, while the tool registry intentionally exposes no single required environment variable. Doctor therefore needs a provider-neutral setup hint instead of naming one credential or misclassifying the failure as a missing system package.

## Changes

- Show `image_gen (no image generation provider available; configure one with 'hermes tools')` when the registry reports `image_gen` unavailable without missing environment variables.
- Preserve the generic `system dependency not met` fallback for toolsets that genuinely fail a system requirement.
- Keep `_missing_api_key_toolsets_for_summary()` and its enabled-CLI-toolset filter, extending it only to curated setup-gated toolsets.
- Exercise the registered image-provider discovery path in the regression test instead of relying only on a fabricated availability result.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q` — 67 passed
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `git diff --check origin/main...HEAD`

No API or registry contract changes.