### PR TITLE
fix: set OpenCode Go supports_models_endpoint to False

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -732,7 +732,7 @@ def run_doctor(args):
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),
-        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         "https://opencode.ai/zen/go/v1/models", "OPENCODE_GO_BASE_URL", True),
+        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         "https://opencode.ai/zen/go/v1/models", "OPENCODE_GO_BASE_URL", False),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""


### PR DESCRIPTION
## Summary

The OpenCode Go provider in doctor.py had `supports_models_endpoint` set to `True`, which caused `hermes doctor` to incorrectly report a health check failure (HTTP 404) when checking the `/v1/models` endpoint.

The OpenCode Go API does **not** expose a `/v1/models` endpoint — it only supports `/v1/chat/completions`. This fix changes the flag to `False` so that `hermes doctor` correctly skips the models endpoint check for this provider and reports a passing health status when the chat completions endpoint is reachable.

## Changes
- `hermes_cli/doctor.py` line 735: Changed `supports_models_endpoint` from `True` to `False` for the OpenCode Go provider config.

## Testing
- Ran `hermes doctor` against an OpenCode Go endpoint; health check now reports success instead of HTTP 404 on `/v1/models`.