### PR TITLE
fix: hermes doctor correctly diagnoses image_gen as missing API key

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -823,6 +823,8 @@ def run_doctor(args):
             if env_vars:
                 vars_str = ", ".join(env_vars)
                 check_warn(item["name"], f"(missing {vars_str})")
+            elif item.get("diagnostic_hint"):
+                check_warn(item["name"], f"({item['diagnostic_hint']})")
             else:
                 check_warn(item["name"], "(system dependency not met)")
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -343,3 +343,75 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
     assert "Kimi / Moonshot (China)" in out
     assert "str expected, not NoneType" not in out
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
+
+
+def test_diagnostic_hint_shown_when_env_vars_empty(monkeypatch, tmp_path):
+    """When a tool has no env_vars but has a diagnostic_hint, doctor should show it."""
+    helper = TestDoctorMemoryProviderSection()
+    home = helper._make_hermes_home(tmp_path, provider="")
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (
+            ["terminal"],
+            [{"name": "image_gen", "env_vars": [], "tools": ["image_generate"],
+              "diagnostic_hint": "missing FAL_KEY or Nous auth"}],
+        ),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "image_gen" in out
+    assert "missing FAL_KEY or Nous auth" in out
+    assert "system dependency not met" not in out
+
+
+def test_no_diagnostic_hint_falls_back_to_system_dependency(monkeypatch, tmp_path):
+    """When a tool has no env_vars and no diagnostic_hint, doctor shows 'system dependency not met'."""
+    helper = TestDoctorMemoryProviderSection()
+    home = helper._make_hermes_home(tmp_path, provider="")
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (
+            ["terminal"],
+            [{"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}],
+        ),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "browser" in out
+    assert "system dependency not met" in out

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -490,3 +490,53 @@ class TestThreadSafety:
         toolsets = result_holder["value"]
         assert "gated" in toolsets
         assert toolsets["gated"]["available"] is True
+
+
+class TestDiagnosticHint:
+    """Verify diagnostic_hint propagation through registry."""
+
+    def test_diagnostic_hint_stored_on_entry(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="t", toolset="s", schema=_make_schema(),
+            handler=_dummy_handler, diagnostic_hint="need KEY",
+        )
+        assert reg._tools["t"].diagnostic_hint == "need KEY"
+
+    def test_diagnostic_hint_defaults_to_none(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="t", toolset="s", schema=_make_schema(),
+            handler=_dummy_handler,
+        )
+        assert reg._tools["t"].diagnostic_hint is None
+
+    def test_diagnostic_hint_in_check_tool_availability(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="img",
+            toolset="image_gen",
+            schema=_make_schema(),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+            requires_env=[],
+            diagnostic_hint="missing FAL_KEY or Nous auth",
+        )
+        available, unavailable = reg.check_tool_availability()
+        assert "image_gen" not in available
+        assert len(unavailable) == 1
+        assert unavailable[0]["diagnostic_hint"] == "missing FAL_KEY or Nous auth"
+
+    def test_no_diagnostic_hint_omitted_from_unavailable(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="brw",
+            toolset="browser",
+            schema=_make_schema(),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+            requires_env=[],
+        )
+        available, unavailable = reg.check_tool_availability()
+        assert len(unavailable) == 1
+        assert "diagnostic_hint" not in unavailable[0]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -690,4 +690,5 @@ registry.register(
     requires_env=[],
     is_async=False,  # Switched to sync fal_client API to fix "Event loop is closed" in gateway
     emoji="🎨",
+    diagnostic_hint="missing FAL_KEY or Nous auth",
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -28,12 +28,12 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars",
+        "max_result_size_chars", "diagnostic_hint",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None):
+                 max_result_size_chars=None, diagnostic_hint=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -44,6 +44,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.diagnostic_hint = diagnostic_hint
 
 
 class ToolRegistry:
@@ -134,6 +135,7 @@ class ToolRegistry:
         description: str = "",
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
+        diagnostic_hint: str | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         with self._lock:
@@ -171,6 +173,7 @@ class ToolRegistry:
                 description=description or schema.get("description", ""),
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
+                diagnostic_hint=diagnostic_hint,
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
@@ -374,11 +377,16 @@ class ToolRegistry:
             if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
                 available.append(ts)
             else:
-                unavailable.append({
+                toolset_entries = [e for e in entries if e.toolset == ts]
+                hint = next((e.diagnostic_hint for e in toolset_entries if e.diagnostic_hint), None)
+                info = {
                     "name": ts,
                     "env_vars": entry.requires_env,
-                    "tools": [e.name for e in entries if e.toolset == ts],
-                })
+                    "tools": [e.name for e in toolset_entries],
+                }
+                if hint:
+                    info["diagnostic_hint"] = hint
+                unavailable.append(info)
         return available, unavailable
 
 


### PR DESCRIPTION
Fixes #9516

## Problem

After managed Nous image generation support was added (commit 95dc9aa), `image_generate` was registered with `requires_env=[]` since `FAL_KEY` is no longer the only authentication path. However, `hermes doctor` uses `requires_env` to decide what message to show:

- If `env_vars` is non-empty → shows "missing X, Y, Z"  
- If `env_vars` is empty → shows "system dependency not met"

This means `image_gen` always shows the misleading "system dependency not met" message, even though the actual problem is missing credentials (FAL_KEY or Nous auth).

## Fix

Added a `diagnostic_hint` field to `ToolEntry` in the tool registry. Tools that have complex availability requirements (not just env vars) can now provide a human-readable hint that `hermes doctor` will display instead of the generic "system dependency not met" fallback.

### Changes

- **`tools/registry.py`**: Added `diagnostic_hint` slot to `ToolEntry`, accepted in `register()`, propagated through `check_tool_availability()`
- **`tools/image_generation_tool.py`**: Set `diagnostic_hint="missing FAL_KEY or Nous auth"` on the `image_generate` registration
- **`hermes_cli/doctor.py`**: Check for `diagnostic_hint` before falling back to "system dependency not met"
- **Tests**: 6 new tests covering hint storage, propagation, and display

### Before
```
⚠️ image_gen (system dependency not met)
```

### After
```
⚠️ image_gen (missing FAL_KEY or Nous auth)
```

Tools without a `diagnostic_hint` continue to show "system dependency not met" as before.