### PR TITLE
fix(gateway): prefer pid file for manual status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2987,8 +2987,16 @@ def gateway_command(args):
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
         else:
-            # Check for manually running processes
-            pids = find_gateway_pids()
+            # For manual/foreground runs, prefer the PID-file helper first.
+            # It is more robust in containers where `ps`-based discovery can
+            # fail or omit the foreground gateway process.
+            try:
+                from gateway.status import get_running_pid
+            except Exception:
+                get_running_pid = None
+
+            running_pid = get_running_pid() if get_running_pid is not None else None
+            pids = [running_pid] if running_pid is not None else find_gateway_pids()
             if pids:
                 print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
                 print("  (Running manually, not as a system service)")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -547,6 +547,26 @@ class TestGatewaySystemServiceRouting:
         assert "nohup hermes gateway" in out
         assert "install as user service" not in out
 
+    def test_gateway_status_prefers_pid_file_helper_for_manual_gateway(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 1)
+        monkeypatch.setattr(
+            gateway_cli,
+            "find_gateway_pids",
+            lambda exclude_pids=None, all_profiles=False: (_ for _ in ()).throw(
+                AssertionError("find_gateway_pids should not be used when PID-file detection succeeds")
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+        out = capsys.readouterr().out
+        assert "Gateway is running (PID: 1)" in out
+        assert "Running manually, not as a system service" in out
+
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("plist\n", encoding="utf-8")


### PR DESCRIPTION
## What does this PR do?

Fixes a remaining Docker false negative in `hermes gateway status` when the gateway is running as the container foreground process.

After `#7032`, the packaged image includes `procps`, so `ps` is available. But the manual gateway status path in `hermes_cli/gateway.py` still relies on `find_gateway_pids()`, which shells out to `ps eww -ax -o pid=,command=`. In the Docker environment I tested, that probe can still fail even though the gateway is actually running as PID 1 and the runtime state files are correct.

This PR makes `hermes gateway status` prefer the existing PID-file based helper from `gateway.status` before falling back to raw process scanning. That is the right approach because Hermes already persists authoritative gateway runtime metadata in `gateway.pid` / `gateway_state.json`, and that path is more robust in container foreground mode than shelling out to `ps`.

## Related Issue

Related to:
- #4776
- #4792
- #7032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `hermes_cli/gateway.py` so manual `hermes gateway status` prefers `gateway.status.get_running_pid()` before `find_gateway_pids()`
- Added a regression test in `tests/hermes_cli/test_gateway_service.py` covering the manual gateway status path when PID-file metadata is valid but process scanning is unreliable

## How to Test

1. Build and run Hermes in Docker with `hermes gateway run` as the main container process
2. Confirm the gateway is actually running via `gateway.pid` / `gateway_state.json`
3. Run `hermes gateway status`

Before this change:
- `hermes gateway status` can incorrectly report `✗ Gateway is not running`

After this change:
- `hermes gateway status` reports `✓ Gateway is running (PID: 1)`

Automated validation performed:
- `pytest -o addopts="" tests/test_hermes_constants.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_runtime_health.py tests/hermes_cli/test_container_aware_cli.py tests/hermes_cli/test_status.py tests/gateway/test_status.py -k "not test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout and not test_supports_systemd_services_returns_true_when_systemctl_present and not test_system_unit_includes_local_bin_in_path"`
- Result: `110 passed, 3 deselected`

The three deselected tests are systemd/root-oriented service-install cases that are not relevant to the Docker foreground `gateway status` path this PR changes.

Manual validation performed:
- Built and ran the patched image in Docker Compose
- Confirmed `hermes gateway status` changed from a false negative to:
  - `✓ Gateway is running (PID: 1)`
  - `(Running manually, not as a system service)`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Docker Compose

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:
```text
✗ Gateway is not running
```

After:
```text
✓ Gateway is running (PID: 1)
  (Running manually, not as a system service)
```
