### PR TITLE
fix(agent): handle multi-part user_message in logging/codex-ack helpers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -353,6 +353,51 @@ def _sanitize_surrogates(text: str) -> str:
     return text
 
 
+def _user_message_text(user_message) -> str:
+    """Best-effort string representation of a possibly-multi-part user message.
+
+    The agent loop's ``user_message`` parameter is typed as ``str`` but in
+    practice can also be an OpenAI-style multi-part list of content parts
+    (``[{type:"text",text:"..."}, {type:"image_url",image_url:{...}}, ...]``)
+    when the request comes through the OpenAI-compat HTTP API server. The
+    raw multi-part list must be passed to the LLM unchanged so vision-capable
+    models receive their image parts, but anywhere we want to *display* or
+    *pattern-match* the text (logging previews, codex-ack heuristics, etc.)
+    we need a flat string. This helper is the single place that flattening
+    happens — keep it small and side-effect-free.
+
+    - ``str`` → returned as-is
+    - ``list`` of OpenAI content parts → join the ``text`` of each text part
+      with spaces; non-text parts are summarised as ``[image]``/``[audio]``/
+      ``[file]`` so that previews don't lose track of their existence
+    - ``None`` → empty string
+    - anything else → ``str(...)``
+    """
+    if user_message is None:
+        return ""
+    if isinstance(user_message, str):
+        return user_message
+    if isinstance(user_message, list):
+        parts: list[str] = []
+        for part in user_message:
+            if isinstance(part, dict):
+                ptype = part.get("type")
+                if ptype == "text":
+                    parts.append(str(part.get("text", "")))
+                elif ptype in ("image_url", "input_image"):
+                    parts.append("[image]")
+                elif ptype in ("input_audio", "audio"):
+                    parts.append("[audio]")
+                elif ptype in ("file", "input_file"):
+                    parts.append("[file]")
+                else:
+                    parts.append(f"[{ptype or 'part'}]")
+            elif isinstance(part, str):
+                parts.append(part)
+        return " ".join(p for p in parts if p)
+    return str(user_message)
+
+
 def _sanitize_messages_surrogates(messages: list) -> bool:
     """Sanitize surrogate characters from all string content in a messages list.
 
@@ -1939,7 +1984,7 @@ class AIAgent:
             "path",
         )
 
-        user_text = (user_message or "").strip().lower()
+        user_text = _user_message_text(user_message).strip().lower()
         user_targets_workspace = (
             any(marker in user_text for marker in workspace_markers)
             or "~/" in user_text
@@ -7618,7 +7663,8 @@ class AIAgent:
         self.iteration_budget = IterationBudget(self.max_iterations)
 
         # Log conversation turn start for debugging/observability
-        _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
+        _preview_text = _user_message_text(user_message)
+        _msg_preview = (_preview_text[:80] + "...") if len(_preview_text) > 80 else _preview_text
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
@@ -7666,7 +7712,8 @@ class AIAgent:
         self._persist_user_message_idx = current_turn_user_idx
         
         if not self.quiet_mode:
-            self._safe_print(f"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'")
+            _print_text = _user_message_text(user_message)
+            self._safe_print(f"💬 Starting conversation: '{_print_text[:60]}{'...' if len(_print_text) > 60 else ''}'")
         
         # ── System prompt (cached per session for prefix caching) ──
         # Built once on first call, reused for all subsequent calls.


### PR DESCRIPTION
## Summary

`AIAgent.run_conversation`'s `user_message` parameter is typed as `str` but in practice can also be an OpenAI-style multi-part list of content parts (`[{type:\"text\",text:\"...\"}, {type:\"image_url\",image_url:{...}}, ...]`) when the request comes through the OpenAI-compat HTTP API server (`gateway/platforms/api_server.py:570` and `:981` forward the raw `content` field straight through, and for vision requests that field is a list of dicts).

The list **must** reach the LLM unchanged so vision-capable models receive their image parts — but three places in `run_agent.py` assumed a `str` and either crashed or printed garbage on a list. This PR routes those three sites through a single small helper.

## The bugs

1. **Top of `run_conversation` (`run_agent.py:7621-7622`)** — fatal:
   ```python
   _msg_preview = (user_message[:80] + \"...\") if len(user_message) > 80 else user_message
   _msg_preview = _msg_preview.replace(\"\\n\", \" \")
   ```
   `[:80]` returns a sublist of dict parts, then `.replace()` raises:
   ```
   AttributeError: 'list' object has no attribute 'replace'
   ```
   …failing the entire turn before the agent even starts. Stack trace shows it inside the api_server's `_run_agent` executor.

2. **Banner print a few lines below (`run_agent.py:7669`)** — non-fatal but ugly:
   ```python
   self._safe_print(f\"💬 Starting conversation: '{user_message[:60]}{'...' if len(user_message) > 60 else ''}'\")
   ```
   `[:60]` returns a sublist of dicts; `len()` returns the part count, not chars; the user sees a literal Python repr of a list of dicts.

3. **`_looks_like_codex_intermediate_ack` (`run_agent.py:1942`)** — fatal for any Codex-routed vision request:
   ```python
   user_text = (user_message or \"\").strip().lower()
   ```
   A truthy list passes `(list or \"\")` unchanged, then `.strip()` raises `AttributeError`.

## The fix

A single new module-level helper, kept right next to the existing `_sanitize_surrogates` / `_sanitize_messages_surrogates` helpers, with a small dispatch:

```python
def _user_message_text(user_message) -> str:
    if user_message is None: return \"\"
    if isinstance(user_message, str): return user_message
    if isinstance(user_message, list):
        parts = []
        for part in user_message:
            if isinstance(part, dict):
                ptype = part.get(\"type\")
                if ptype == \"text\":            parts.append(str(part.get(\"text\", \"\")))
                elif ptype in (\"image_url\", \"input_image\"): parts.append(\"[image]\")
                elif ptype in (\"input_audio\", \"audio\"):    parts.append(\"[audio]\")
                elif ptype in (\"file\", \"input_file\"):       parts.append(\"[file]\")
                else:                            parts.append(f\"[{ptype or 'part'}]\")
            elif isinstance(part, str):       parts.append(part)
        return \" \".join(p for p in parts if p)
    return str(user_message)
```

All three call sites now go through it. The list itself is **left untouched** in `messages.append({\"role\": \"user\", \"content\": user_message})` further down `run_conversation`, so the LLM still receives the original multi-part content and vision continues to work end-to-end.

## Why it was dormant

The `body_limit_middleware` and aiohttp `client_max_size` in `gateway/platforms/api_server.py` enforced a hardcoded **1 MB** body cap (the subject of #8328) that rejected most images at the transport layer before they could reach this code path. With that cap raised, this latent crash became immediately reachable for anyone POSTing a vision request to `/v1/chat/completions` with a base64-encoded image larger than ~700 KB.

The two PRs are independent (different files, different bugs, no shared code) and can land in either order, but neither alone is enough to make image attachments via the gateway work end-to-end. **Tested locally with both applied.**

## Verification

Generated a 14.84 MiB random-pixel PNG (so it's a real PNG and doesn't compress to nothing), base64-encoded into a 19.78 MiB OpenAI multi-part chat-completions request, POSTed through the local gateway against an Ollama + `gemma4:26b` backend.

**Before this PR (with #8328 also applied to get past the body cap):**
```
HTTP 500 Internal Server Error
{\"error\": {\"message\": \"Internal server error: 'list' object has no attribute 'replace'\", ...}}
```
…with `AttributeError: 'list' object has no attribute 'replace'` at `run_agent.py:7622` in the gateway error log.

**After this PR (with #8328 also applied):**
```
payload size: 20745027 bytes = 19.78 MiB
HTTP 200  (63.2s)
model reply: 'OK'
```
The model returned exactly the single word the test asked for. ~63 s of that was Ollama's vision encoder chewing the noisy 14 MiB image, not Hermes.

## Test plan

- [x] Module compiles (`python -m py_compile run_agent.py`)
- [x] Helper exercised against 12 input shapes (str, None, empty list, single text part, text+image, text+text, image+text, audio, file, unknown type, empty dict, raw string in list, int) — all pass
- [x] End-to-end POST of a 19.78 MiB multi-part chat-completion to the local gateway returns 200 + the expected text reply (with #8328 also applied)
- [ ] Reviewer: existing tests in `tests/run_agent/` still pass (no `user_message[...]` literals there to update)
- [ ] Reviewer: vision through hosted providers (Anthropic, OpenAI, Gemini) also works — should, since the fix is purely on the *string-flattening for logging* side and never touches what's sent to the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)