### PR TITLE
fix(cli): make _context_completions an instance method (fixes #9531)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Summary
- Removes the `@staticmethod` decorator from `SlashCommandCompleter._context_completions` so its call to `self._fuzzy_file_completions(...)` resolves.

## Reproducer
1. Start `hermes chat` on current `main`
2. Type `@` at the prompt
3. `NameError: name 'self' is not defined` is raised

## Root cause
#9467 introduced `self._fuzzy_file_completions(word, query, limit)` inside `_context_completions` (lines 805-807), but `_context_completions` is declared `@staticmethod` (line 737). Static methods have no bound `self`, so the name resolves to the enclosing scope, which fails at runtime.

## Fix
Convert `_context_completions` to a regular instance method (adds `self` as the first parameter, drops the decorator). Its single caller at line 976 already uses `self._context_completions(ctx_word)`, so no call-site change is needed.

## Test plan
- [x] AST parses clean (`python -m py_compile hermes_cli/commands.py`)
- [ ] Typing `@` at the CLI prompt lists static refs without raising
- [ ] Typing `@fo` yields fuzzy file completions via `_fuzzy_file_completions`

Resolves #9531.