### PR TITLE
fix(status): detect system-level gateway service in hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -364,6 +364,7 @@ def show_status(args):
                 _gw_svc = get_service_name()
             except Exception:
                 _gw_svc = "hermes-gateway"
+            # Check user-level service first
             try:
                 result = subprocess.run(
                     ["systemctl", "--user", "is-active", _gw_svc],
@@ -372,10 +373,26 @@ def show_status(args):
                     timeout=5
                 )
                 is_active = result.stdout.strip() == "active"
+                manager = "systemd (user)"
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 is_active = False
+                manager = "systemd (user)"
+            # If not active at user level, check system-level service
+            if not is_active:
+                try:
+                    result = subprocess.run(
+                        ["systemctl", "is-active", _gw_svc],
+                        capture_output=True,
+                        text=True,
+                        timeout=5
+                    )
+                    is_active = result.stdout.strip() == "active"
+                    if is_active:
+                        manager = "systemd (system)"
+                except (FileNotFoundError, subprocess.TimeoutExpired):
+                    pass
             print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-            print("  Manager:      systemd (user)")
+            print(f"  Manager:      {manager}")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label


### PR DESCRIPTION
## Problem

When the gateway is installed as a **system-level** systemd service via `sudo hermes gateway install --system`, `hermes status` incorrectly reports **"stopped"** because it only checks `systemctl --user is-active` (user-level).

```
◆ Gateway Service
  Status:       ✗ stopped        ← wrong!
  Manager:      systemd (user)
```

But the gateway is actually running:
```
● hermes-gateway.service - Hermes Agent Gateway
     Active: active (running)
     Loaded: loaded (/etc/systemd/system/hermes-gateway.service; enabled)
```

## Root Cause

In `hermes_cli/status.py`, the Linux gateway status check only queries the user-level systemd service:
```python
result = subprocess.run(["systemctl", "--user", "is-active", _gw_svc], ...)
```

It never falls back to checking system-level services (`systemctl is-active`), which is what `--system` installs create.

## Fix

After the user-level check fails, fall back to `systemctl is-active` (system-level). Regular users can query system service status without sudo. Report the correct manager type:

- `systemd (user)` — user-level service
- `systemd (system)` — system-level service

## After fix

```
◆ Gateway Service
  Status:       ✓ running
  Manager:      systemd (system)
```
