### PR TITLE
fix: harden Copilot ACP chat compatibility

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -28,6 +28,52 @@ _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.D
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
 
+class _CompatNamespace(SimpleNamespace):
+    def items(self):
+        return self.__dict__.items()
+
+    def keys(self):
+        return self.__dict__.keys()
+
+    def values(self):
+        return self.__dict__.values()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.__dict__.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.__dict__
+
+    def model_dump(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+class _ACPChatCompletionStream:
+    def __init__(self, chunks: list[_CompatNamespace]):
+        self._chunks = chunks
+        self.response = None
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+    def close(self) -> None:
+        return None
+
+
+def _coerce_timeout_seconds(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+
+    for attr in ("read", "timeout", "connect", "write", "pool"):
+        value = getattr(timeout, attr, None)
+        if isinstance(value, (int, float)):
+            return float(value)
+
+    return _DEFAULT_TIMEOUT_SECONDS
+
+
 def _resolve_command() -> str:
     return (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
@@ -181,12 +227,12 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str
             call_id = f"acp_call_{len(extracted)+1}"
 
         extracted.append(
-            SimpleNamespace(
+            _CompatNamespace(
                 id=call_id,
                 call_id=call_id,
                 response_item_id=None,
                 type="function",
-                function=SimpleNamespace(name=fn_name.strip(), arguments=fn_args),
+                function=_CompatNamespace(name=fn_name.strip(), arguments=fn_args),
             )
         )
 
@@ -245,6 +291,9 @@ class _ACPChatCompletions:
         self._client = client
 
     def create(self, **kwargs: Any) -> Any:
+        if kwargs.pop("stream", False):
+            kwargs.pop("stream_options", None)
+            return self._client._create_chat_completion_stream(**kwargs)
         return self._client._create_chat_completion(**kwargs)
 
 
@@ -315,18 +364,18 @@ class CopilotACPClient:
         )
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
-            timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
+            timeout_seconds=_coerce_timeout_seconds(timeout),
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
-        usage = SimpleNamespace(
+        usage = _CompatNamespace(
             prompt_tokens=0,
             completion_tokens=0,
             total_tokens=0,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            prompt_tokens_details=_CompatNamespace(cached_tokens=0),
         )
-        assistant_message = SimpleNamespace(
+        assistant_message = _CompatNamespace(
             content=cleaned_text,
             tool_calls=tool_calls,
             reasoning=reasoning_text or None,
@@ -334,12 +383,78 @@ class CopilotACPClient:
             reasoning_details=None,
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
-        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
-        return SimpleNamespace(
+        choice = _CompatNamespace(message=assistant_message, finish_reason=finish_reason)
+        return _CompatNamespace(
             choices=[choice],
             usage=usage,
             model=model or "copilot-acp",
         )
+
+    def _create_chat_completion_stream(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> _ACPChatCompletionStream:
+        response = self._create_chat_completion(
+            model=model,
+            messages=messages,
+            timeout=timeout,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        choice = response.choices[0]
+        message = choice.message
+        raw_tool_calls = getattr(message, "tool_calls", None) or []
+        stream_tool_calls = None
+        if raw_tool_calls:
+            stream_tool_calls = []
+            for index, tool_call in enumerate(raw_tool_calls):
+                fn = getattr(tool_call, "function", None)
+                stream_tool_calls.append(
+                    _CompatNamespace(
+                        index=index,
+                        id=getattr(tool_call, "id", None),
+                        type="function",
+                        function=_CompatNamespace(
+                            name=getattr(fn, "name", None),
+                            arguments=getattr(fn, "arguments", None),
+                        ),
+                    )
+                )
+
+        delta = _CompatNamespace(
+            content=getattr(message, "content", None),
+            tool_calls=stream_tool_calls,
+            reasoning_content=getattr(message, "reasoning_content", None),
+            reasoning=getattr(message, "reasoning", None),
+        )
+        chunks = [
+            _CompatNamespace(
+                choices=[
+                    _CompatNamespace(
+                        index=0,
+                        delta=delta,
+                        finish_reason=getattr(choice, "finish_reason", "stop"),
+                    )
+                ],
+                usage=None,
+                model=getattr(response, "model", model or "copilot-acp"),
+            )
+        ]
+        if getattr(response, "usage", None) is not None:
+            chunks.append(
+                _CompatNamespace(
+                    choices=[],
+                    usage=response.usage,
+                    model=getattr(response, "model", model or "copilot-acp"),
+                )
+            )
+        return _ACPChatCompletionStream(chunks)
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -1,0 +1,69 @@
+import httpx
+
+from agent.copilot_acp_client import CopilotACPClient, _coerce_timeout_seconds
+
+
+def test_coerce_timeout_seconds_prefers_read_timeout():
+    timeout = httpx.Timeout(connect=5.0, read=42.0, write=9.0, pool=3.0)
+
+    assert _coerce_timeout_seconds(timeout) == 42.0
+
+
+def test_chat_completions_stream_returns_chunk_sequence(monkeypatch):
+    client = CopilotACPClient(acp_command="copilot", acp_args=["--acp", "--stdio"])
+
+    monkeypatch.setattr(
+        client,
+        "_run_prompt",
+        lambda prompt_text, timeout_seconds: ("OK from stream", None),
+    )
+
+    stream = client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[{"role": "user", "content": "say ok"}],
+        stream=True,
+        timeout=httpx.Timeout(connect=1.0, read=12.0, write=1.0, pool=1.0),
+    )
+    chunks = list(stream)
+
+    assert len(chunks) == 2
+    assert chunks[0].choices[0].delta.content == "OK from stream"
+    assert chunks[0].choices[0].finish_reason == "stop"
+    assert chunks[1].choices == []
+    assert chunks[1].usage.prompt_tokens == 0
+
+
+def test_chat_completions_stream_with_tool_calls(monkeypatch):
+    client = CopilotACPClient(acp_command="copilot", acp_args=["--acp", "--stdio"])
+    tool_response = (
+        "I will use the tool. "
+        '<tool_call>{"id": "call_1", "type": "function", '
+        '"function": {"name": "read_file", '
+        '"arguments": "{\\"path\\": \\"/tmp/test.txt\\"}"}}</tool_call>'
+    )
+
+    monkeypatch.setattr(
+        client,
+        "_run_prompt",
+        lambda prompt_text, timeout_seconds: (tool_response, None),
+    )
+
+    stream = client.chat.completions.create(
+        model="gpt-4.1",
+        messages=[{"role": "user", "content": "read file"}],
+        stream=True,
+        timeout=10.0,
+    )
+    chunks = list(stream)
+
+    assert len(chunks) == 2
+    assert chunks[0].choices[0].delta.content == "I will use the tool."
+    assert chunks[0].choices[0].finish_reason == "tool_calls"
+    assert chunks[0].choices[0].delta.tool_calls is not None
+    assert len(chunks[0].choices[0].delta.tool_calls) == 1
+    assert chunks[0].choices[0].delta.tool_calls[0].index == 0
+    assert chunks[0].choices[0].delta.tool_calls[0].id == "call_1"
+    assert chunks[0].choices[0].delta.tool_calls[0].type == "function"
+    assert chunks[0].choices[0].delta.tool_calls[0].function.name == "read_file"
+    assert chunks[0].choices[0].delta.tool_calls[0].function.arguments == '{"path": "/tmp/test.txt"}'
+    assert chunks[1].usage.prompt_tokens == 0


### PR DESCRIPTION
## Summary
- accept `httpx.Timeout` objects in the Copilot ACP adapter instead of assuming a plain float
- return mapping-like response objects compatible with downstream Hermes expectations
- provide a stream-compatible chunk iterator for `stream=True` calls
- add focused regression coverage for timeout coercion and stream chunk generation

Fixes #9572

## Validation
- fallback inline Python check for timeout coercion and stream chunk sequence (pytest unavailable in the current venv)
