### PR TITLE
fix: tolerate Windows stale gateway pid OSError

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -416,7 +416,7 @@ def get_running_pid() -> Optional[int]:
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
         remove_pid_file()
         return None
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -63,6 +63,23 @@ class TestGatewayPidState:
 
         assert status.get_running_pid() == os.getpid()
 
+    def test_get_running_pid_removes_stale_pid_when_windows_kill_check_raises_oserror(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 12345,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+        }))
+
+        def fake_kill(pid, sig):
+            raise OSError("bad process handle")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- treat Windows `OSError` from `os.kill(pid, 0)` as a stale gateway PID check failure
- remove the stale pid file instead of aborting gateway startup
- add a focused regression test covering the Windows OSError branch

Fixes #9574

## Validation
- fallback inline Python check for stale `gateway.pid` cleanup when `os.kill` raises `OSError` (pytest unavailable in the current venv)
