### PR TITLE
fix: deduplicate /model picker entries across provider sources

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1002,6 +1002,14 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+
+            # Deduplicate against built-in / overlay providers using a
+            # case-insensitive slug so that e.g. user-defined "NVIDIA"
+            # doesn't create a second entry next to built-in "nvidia".
+            normalized_slug = ep_name.lower()
+            if normalized_slug in seen_slugs:
+                continue
+
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
@@ -1029,6 +1037,7 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(normalized_slug)
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named
@@ -1068,7 +1077,11 @@ def list_authenticated_providers(
                 groups[slug]["models"].append(default_model)
 
         for slug, grp in groups.items():
-            if slug in seen_slugs:
+            # Check both the full "custom:foo" slug and the bare name
+            # so that providers already registered from built-in or
+            # user-defined sections (with slug "foo") are not duplicated.
+            bare = slug.removeprefix("custom:") if slug.startswith("custom:") else slug
+            if slug in seen_slugs or bare in seen_slugs:
                 continue
             results.append({
                 "slug": slug,

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -117,6 +117,140 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
 
 
 # =============================================================================
+# Tests for provider deduplication (#9545)
+# =============================================================================
+
+def test_list_authenticated_providers_dedupes_user_and_builtin_case_insensitive(monkeypatch):
+    """User-defined provider with uppercase slug should not duplicate a built-in.
+
+    Regression test for #9545: a user-defined provider named 'NVIDIA' appeared
+    alongside the built-in 'nvidia', producing two entries.
+    """
+    # Fake a built-in "nvidia" provider with credentials
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "nvidia": {"env": ["NVIDIA_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "nvidia": "nvidia",
+    })
+    monkeypatch.setattr("agent.models_dev.get_provider_info", lambda pid: None)
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", {})
+    monkeypatch.setattr("hermes_cli.models._PROVIDER_MODELS", [("nvidia", ["model-a"])])
+    monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+
+    user_providers = {
+        "NVIDIA": {
+            "name": "NVIDIA",
+            "api": "https://integrate.api.nvidia.com/v1",
+            "models": ["model-1", "model-2"],
+        },
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    nvidia_entries = [p for p in providers if "nvidia" in p["slug"].lower()]
+    assert len(nvidia_entries) == 1, (
+        f"Expected exactly 1 nvidia entry, got {len(nvidia_entries)}: "
+        f"{[e['slug'] for e in nvidia_entries]}"
+    )
+
+
+def test_list_authenticated_providers_dedupes_custom_provider_with_prefix(monkeypatch):
+    """custom_providers entry should not duplicate a user-defined provider.
+
+    Regression test for #9545: a custom_providers entry with slug
+    'custom:nvidia' was not matched against 'nvidia' in seen_slugs.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", {})
+
+    user_providers = {
+        "nvidia": {
+            "name": "NVIDIA",
+            "api": "https://integrate.api.nvidia.com/v1",
+            "models": ["model-1", "model-2"],
+        },
+    }
+
+    # This compatibility view generates slug "custom:nvidia" which
+    # previously slipped past the seen_slugs check.
+    custom_providers = [
+        {
+            "name": "NVIDIA",
+            "base_url": "https://integrate.api.nvidia.com/v1",
+            "model": "model-1",
+        },
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+    nvidia_entries = [p for p in providers if "nvidia" in p["slug"].lower()]
+    assert len(nvidia_entries) == 1, (
+        f"Expected exactly 1 nvidia entry, got {len(nvidia_entries)}: "
+        f"{[e['slug'] for e in nvidia_entries]}"
+    )
+
+
+def test_list_authenticated_providers_triple_entry_regression(monkeypatch):
+    """Full regression for #9545: built-in + user-defined + custom_providers.
+
+    When NVIDIA appears in all three sources, only one entry should show.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "nvidia": {"env": ["NVIDIA_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "nvidia": "nvidia",
+    })
+    monkeypatch.setattr("agent.models_dev.get_provider_info", lambda pid: None)
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", {})
+    monkeypatch.setattr("hermes_cli.models._PROVIDER_MODELS", [("nvidia", ["model-a"])])
+    monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+
+    user_providers = {
+        "NVIDIA": {
+            "name": "NVIDIA",
+            "api": "https://integrate.api.nvidia.com/v1",
+            "models": ["model-1", "model-2"],
+        },
+    }
+
+    custom_providers = [
+        {
+            "name": "NVIDIA",
+            "base_url": "https://integrate.api.nvidia.com/v1",
+            "model": "model-1",
+        },
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+    nvidia_entries = [p for p in providers if "nvidia" in p["slug"].lower()]
+    assert len(nvidia_entries) == 1, (
+        f"Expected exactly 1 nvidia entry, got {len(nvidia_entries)}: "
+        f"{[(e['slug'], e['source']) for e in nvidia_entries]}"
+    )
+    # The built-in entry should win (it's added first)
+    assert nvidia_entries[0]["source"] == "built-in"
+
+
+# =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #9545 — the `/model` provider picker was showing triple entries for the same provider when it appeared in multiple loading paths (built-in, user-defined `providers:` config, and legacy `custom_providers` compatibility view).

## Root Cause

Two missing deduplication checks in `list_authenticated_providers()`:

1. **Section 3 (user-defined providers):** Never checked or updated `seen_slugs`, so e.g. `"NVIDIA"` from `providers:` config slipped past the built-in `"nvidia"` entry due to case mismatch.

2. **Section 4 (custom_providers):** `custom_provider_slug()` adds a `"custom:"` prefix, so `"custom:nvidia"` never matched `"nvidia"` in `seen_slugs`.

## Fix

- **Section 3:** Add case-insensitive `seen_slugs` check and update (`ep_name.lower()`) before appending user-defined providers.
- **Section 4:** Also compare the bare name (strip `"custom:"` prefix) against `seen_slugs` during the dedup check.

## Changes

- `hermes_cli/model_switch.py` — 2 targeted fixes in `list_authenticated_providers()`
- `tests/hermes_cli/test_user_providers_model_switch.py` — 3 new regression tests covering:
  - Case-insensitive dedup between built-in and user-defined
  - `custom:` prefix dedup against user-defined
  - Full triple-entry scenario (all 3 sources)

## Testing

All 12 tests in `test_user_providers_model_switch.py` pass ✅  
All 11 tests in related custom provider test files pass ✅