### PR TITLE
fix(feishu): use Card JSON 2.0 for markdown message rendering

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -430,6 +430,30 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
+def _build_rich_text_payload(content: str) -> str:
+    """Build Feishu interactive card message with markdown component (JSON 2.0).
+
+    Using interactive card type with markdown element for full Markdown support.
+    According to Feishu Card JSON 2.0 docs:
+    - markdown component supports: headings, lists, code blocks, tables, blockquotes, etc.
+    - Must use schema: "2.0" for proper rendering
+    - This renders as native rich text in Feishu client
+    """
+    card = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": content,
+                }
+            ]
+        },
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
 def parse_feishu_post_payload(payload: Any) -> FeishuPostParseResult:
     resolved = _resolve_post_payload(payload)
     if not resolved:
@@ -3159,7 +3183,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+            return "interactive", _build_rich_text_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -279,13 +279,27 @@ File upload routing is automatic based on extension:
 - `.pdf`, `.doc(x)`, `.xls(x)`, `.ppt(x)` → uploaded with their document type
 - Everything else → uploaded as a generic stream file
 
-## Markdown Rendering and Post Fallback
+## Markdown Rendering with Card JSON 2.0
 
-When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **post** message with an embedded `md` tag rather than as plain text. This enables rich rendering in the Feishu client.
+When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **interactive card** using **Card JSON 2.0** structure with the `markdown` element. This enables full rich text rendering in the Feishu client.
 
-If the Feishu API rejects the post payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
+**Supported Markdown Features:**
+
+- Headings (H1-H6)
+- **Bold**, *italic*, and ~~strikethrough~~
+- Code blocks with syntax highlighting (supports 50+ languages)
+- Tables (with pagination for long data)
+- Ordered and unordered lists (nested)
+- Blockquotes
+- Links and @mentions
+
+If the Feishu API rejects the card payload, the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
 
 Plain text messages (no markdown detected) are sent as the simple `text` message type.
+
+**No Configuration Required:**
+
+Markdown rendering is enabled by default — no additional configuration needed.
 
 ## ACK Emoji Reactions
 


### PR DESCRIPTION
## Summary

修复飞书消息中 Markdown 内容渲染为代码块的问题，改用飞书卡片 JSON 2.0 结构实现正确的富文本渲染。

## Changes

- 添加 `_build_rich_text_payload()` 函数，构建符合 Card JSON 2.0 结构的消息
- 修改 `_build_outbound_payload()`，将 Markdown 消息从 `post` 类型改为 `interactive` 卡片类型
- 更新文档 `website/docs/user-guide/messaging/feishu.md`

## Testing

已在实际飞书环境中测试，确认以下 Markdown 元素正确渲染：
- [x] 代码块（带语法高亮）
- [x] 表格
- [x] 有序/无序列表
- [x] 标题
- [x] 粗体/斜体/删除线
- [x] 链接

## Before/After

**Before**: Markdown 内容显示为灰色背景的代码块
**After**: Markdown 内容显示为原生富文本格式