### PR TITLE
fix: replace loop.run_in_executor with asyncio.to_thread in gateway runner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5376,8 +5376,7 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            result = await asyncio.to_thread(run_sync)
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -5559,8 +5558,7 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            result = await asyncio.to_thread(run_sync)
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -8356,7 +8354,7 @@ class GatewayRunner:
             _warning_fired = False
             loop = asyncio.get_event_loop()
             _executor_task = asyncio.ensure_future(
-                loop.run_in_executor(None, run_sync)
+                asyncio.to_thread(run_sync)
             )
 
             _inactivity_timeout = False


### PR DESCRIPTION
## Summary

Replace the deprecated `loop.run_in_executor(None, fn)` pattern with `asyncio.to_thread()` in three locations within `gateway/run.py`.

## Problem

When cron jobs run inside the gateway process, they need to deliver results via the gateway's live adapters (particularly Feishu). The old `loop.run_in_executor(None, run_sync)` pattern could cause async context issues that prevented the cron delivery code from correctly acquiring the gateway's event loop and adapters, leading to intermittent push failures.

## Solution

`asyncio.to_thread()` properly coordinates the thread/async boundary, ensuring that the gateway's event loop remains accessible to the cron delivery path. This fixes intermittent cron push failures when the scheduler runs inside the gateway process.

## Changes

- `gateway/run.py`: 3× `loop.run_in_executor(None, run_sync)` → `asyncio.to_thread(run_sync)`
