### PR TITLE
fix: add KimiCLI User-Agent header to auxiliary client custom endpoint paths

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -936,10 +936,13 @@ def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
         return None, None
     model = _read_main_model() or "gpt-4o-mini"
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
+    extra = {}
+    if "api.kimi.com" in custom_base.lower():
+        extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
     if custom_mode == "codex_responses":
-        real_client = OpenAI(api_key=custom_key, base_url=custom_base)
+        real_client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
         return CodexAuxiliaryClient(real_client, model), model
-    return OpenAI(api_key=custom_key, base_url=custom_base), model
+    return OpenAI(api_key=custom_key, base_url=custom_base, **extra), model
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
@@ -1472,7 +1475,10 @@ def resolve_provider_client(
                     model or _read_main_model() or "gpt-4o-mini",
                     provider,
                 )
-                client = OpenAI(api_key=custom_key, base_url=custom_base)
+                extra = {}
+                if "api.kimi.com" in custom_base.lower():
+                    extra["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
+                client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
                 client = _wrap_if_needed(client, final_model, custom_base)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s)",


### PR DESCRIPTION
## Summary
- Fix 403 `access_terminated_error` when Kimi Coding is the main provider and auxiliary tasks (title generation, memory flush) hit the API without the required `User-Agent: KimiCLI/1.30.0` header
- Two code paths in `_try_custom_endpoint()` and the named custom provider fallback in `resolve_provider_client()` created bare OpenAI clients, missing the header check that exists in all other Kimi-facing paths

## Test plan
- [ ] Set `provider: kimi-coding` as main provider with a `sk-kimi-` API key
- [ ] Send a message and confirm auxiliary tasks (title generation, memory flush) no longer return 403
- [ ] Verify main chat completions still work as before