### PR TITLE
fix: honor custom provider key_env for matching base_url

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -362,6 +362,32 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     return None
 
 
+def _resolve_custom_provider_env_api_key(base_url: str) -> str:
+    """Resolve a custom provider API key from key_env by matching base_url."""
+    normalized_url = (base_url or "").strip().rstrip("/")
+    if not normalized_url:
+        return ""
+
+    try:
+        custom_providers = get_compatible_custom_providers(load_config())
+    except Exception:
+        return ""
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
+        if entry_url != normalized_url:
+            continue
+        key_env = str(entry.get("key_env", "") or "").strip()
+        if not key_env:
+            return ""
+        api_key = os.getenv(key_env, "").strip()
+        return api_key if has_usable_secret(api_key) else ""
+
+    return ""
+
+
 def _resolve_named_custom_runtime(
     *,
     requested_provider: str,
@@ -458,6 +484,10 @@ def _resolve_openrouter_runtime(
     # OPENAI_API_KEY so the OpenRouter key doesn't leak to an unrelated
     # provider (issues #420, #560).
     _is_openrouter_url = "openrouter.ai" in base_url
+    custom_provider_env_key = ""
+    if not _is_openrouter_url:
+        custom_provider_env_key = _resolve_custom_provider_env_api_key(base_url)
+
     if _is_openrouter_url:
         api_key_candidates = [
             explicit_api_key,
@@ -473,6 +503,7 @@ def _resolve_openrouter_runtime(
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
             (os.getenv("OLLAMA_API_KEY") if _is_ollama_url else ""),
+            custom_provider_env_key,
             os.getenv("OPENAI_API_KEY"),
             os.getenv("OPENROUTER_API_KEY"),
         ]
@@ -523,6 +554,26 @@ def _resolve_explicit_runtime(
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
     if not explicit_api_key and not explicit_base_url:
         return None
+
+    if provider == "custom":
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if cfg_provider == "custom":
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        base_url = explicit_base_url or cfg_base_url
+        api_key = explicit_api_key or _resolve_custom_provider_env_api_key(base_url)
+        if not base_url:
+            return None
+        return {
+            "provider": "custom",
+            "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
+            or _detect_api_mode_for_url(base_url)
+            or "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key or "no-key-required",
+            "source": "explicit",
+            "requested_provider": requested_provider,
+        }
 
     if provider == "anthropic":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -536,6 +536,41 @@ def test_custom_endpoint_explicit_custom_prefers_config_key(monkeypatch):
     assert resolved["api_key"] == "sk-vllm-key"
 
 
+def test_custom_endpoint_explicit_custom_uses_matching_key_env(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://proxy.example.com/v1",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Proxy",
+                    "base_url": "https://proxy.example.com/v1",
+                    "key_env": "PROXY_API_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setenv("PROXY_API_KEY", "env-proxy-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-proxy-key"
+    assert resolved["requested_provider"] == "custom"
+
+
 def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- resolve `custom_providers[*].key_env` by matching `base_url` when runtime config uses top-level `model.provider: custom`
- reuse the same lookup for both openrouter/custom fallback resolution and explicit custom runtime resolution
- add a regression test covering `model.provider=custom` + `model.base_url` + matching `custom_providers.key_env`

## Testing
- python3 -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -k \"matching_key_env or explicit_custom_prefers_config_key or named_custom_provider_uses_key_env_from_providers_dict\"
- python3 -m py_compile hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py