### PR TITLE
feat(agent): OTel observability integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ hermes_cli/web_dist/
 # Release script temp files
 .release_notes.md
 mini-swe-agent/
+otel/promtail/promtail-positions.yaml
 
 # Nix
 .direnv/

--- a/README.md
+++ b/README.md
@@ -108,6 +108,85 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 ---
 
+## Observability — OTel Tracing & Metrics
+
+Hermes Agent has built-in OpenTelemetry instrumentation. Enable it to get full traces and metrics in Grafana.
+
+**1. Start the observability stack** (Grafana + Tempo + Prometheus + Loki):
+From with the hermes-agent folder
+```bash
+docker run -d \
+  --name otel-lgtm \
+  --network host \
+  --restart unless-stopped \
+  -v ./otel//otel-lgtm/otelcol-config.yaml:/otel-lgtm/otelcol-config.yaml:ro \
+  grafana/otel-lgtm:latest
+
+```
+
+Ports exposed: Grafana (3000), Tempo (3200), Prometheus (9090), Loki (3100), OTLP receiver (4317/4318).
+
+**2. Install OTel packages:**
+
+```bash
+~/.hermes/hermes-agent/venv/bin/pip install \
+    opentelemetry-api \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp-proto-http \
+    opentelemetry-sem-conv
+```
+
+**3. Enable and configure:**
+
+```bash
+export OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_SERVICE_NAME=hermes-agent
+```
+
+> **Note:** Use port **4318** (HTTP), not 4317 (gRPC). `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` must also be set.
+
+Changes made to .env will be persisted.
+
+**4. Restart the gateway** so env vars take effect:
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart hermes-gateway
+```
+
+**5. Open Grafana** at `http://your-server:3000` (admin/admin). Traces appear under the Tempo datasource, metrics under Prometheus.
+
+**6. Verify datasources before importing dashboards:**
+
+- Go to **Connections -> Data sources** in Grafana.
+- Confirm a **Tempo** datasource exists and is healthy.
+- Confirm a **Prometheus** datasource exists and is healthy.
+- If either is missing, create it first (Tempo for traces, Prometheus for metrics), then import dashboards.
+
+**Available metrics:**
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `hermes.queries.total` | Counter | Total queries |
+| `hermes.tool_calls.total` | Counter | Tool calls by name/type |
+| `hermes.query.latency_seconds` | Histogram | End-to-end query latency |
+| `hermes.tool.latency_seconds` | Histogram | Per-tool latency |
+| `hermes.errors.total` | Counter | Errors by type |
+| `hermes.active_conversations` | UpDownCounter | Live conversations |
+| `hermes.conversation.state` | Observable Gauge | State per conversation (0=idle, 1=thinking, 2=tool_executing, 3=waiting_for_user) |
+
+A pre-built Grafana dashboard is available at `grafana-dashboards/hermes_observability_dashboard.json`.
+Import it after datasource verification so panel queries bind correctly.
+
+**6. To Disable Observability:**
+```bash
+export OTEL_ENABLED=false
+```
+
+
+---
+
 ## Migrating from OpenClaw
 
 If you're coming from OpenClaw, Hermes can automatically import your settings, memories, skills, and API keys.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,36 @@ sudo systemctl daemon-reload && sudo systemctl restart hermes-gateway
 - Confirm a **Prometheus** datasource exists and is healthy.
 - If either is missing, create it first (Tempo for traces, Prometheus for metrics), then import dashboards.
 
+**7. Optional: ship Hermes logs to Loki with Promtail**
+
+Promtail config templates are included under `otel/promtail/`.
+
+Scrape targets:
+- `~/.hermes/logs/gateway.log` (`app=hermes-agent`, `component=gateway`)
+- `~/.hermes/logs/agent.log` (`app=hermes-agent`, `component=agent`)
+- `~/.hermes/logs/errors.log` (`app=hermes-agent`, `component=errors`)
+- `~/.hermes/sessions/*.jsonl` (`app=hermes-agent`, `component=sessions`)
+
+Loki push endpoint:
+- `http://localhost:3100/loki/api/v1/push`
+
+> Ensure Loki is running and reachable at `http://localhost:3100` before enabling Promtail.
+
+Example install flow (Linux/systemd):
+```bash
+sudo install -m 0755 /path/to/promtail /usr/local/bin/promtail
+mkdir -p ~/.hermes/promtail
+cp otel/promtail/promtail-config.yaml ~/.hermes/promtail/promtail-config.yaml
+touch ~/.hermes/promtail/promtail-positions.yaml
+
+# edit otel/promtail/promtail-hermes.service and replace YOUR_USER
+sudo cp otel/promtail/promtail-hermes.service /etc/systemd/system/promtail-hermes.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now promtail-hermes
+```
+
+> `promtail-positions.yaml` is runtime state and should not be committed.
+
 **Available metrics:**
 
 | Metric | Type | Description |

--- a/agent/otel_shim.py
+++ b/agent/otel_shim.py
@@ -44,18 +44,42 @@ import time
 import logging
 import re
 import json
+import threading
 from typing import Optional, Any
 from datetime import datetime, timezone
 #import fs
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.trace import Status, StatusCode
+try:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    from opentelemetry.trace import Status, StatusCode
+    _OTEL_IMPORT_OK = True
+except ImportError:
+    trace = None
+    metrics = None
+    TracerProvider = None
+    BatchSpanProcessor = None
+    MeterProvider = None
+    PeriodicExportingMetricReader = None
+    Resource = None
+    SERVICE_NAME = "service.name"
+    SERVICE_VERSION = "service.version"
+    OTLPSpanExporter = None
+    OTLPMetricExporter = None
+    _OTEL_IMPORT_OK = False
+
+    class StatusCode:
+        OK = "ok"
+        ERROR = "error"
+
+    class Status:
+        def __init__(self, *_args, **_kwargs):
+            pass
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +126,18 @@ _query_counter             = None
 _tool_counter             = None
 _query_latency_hist       = None
 _tool_latency_hist        = None
+_tool_stalled_counter     = None
 _error_counter            = None
 _active_conversations_gauge = None
 _llm_latency_hist         = None
 _llm_error_counter        = None
 _state_gauge              = None
 _state_duration_hist      = None
+_subagent_duration_hist   = None
+_subagent_outcome_counter = None
+_subagent_stalled_counter = None
+_TOOL_HEARTBEAT_INTERVAL_SECS = int(os.getenv("OTEL_TOOL_HEARTBEAT_INTERVAL_SECS", "30"))
+_TOOL_STALL_THRESHOLD_SECS = int(os.getenv("OTEL_TOOL_STALL_THRESHOLD_SECS", "300"))
 
 
 def _parse_headers(header_str: str) -> dict:
@@ -166,10 +196,15 @@ def _init_otel() -> None:
     global _error_counter, _active_conversations_gauge
     global _llm_latency_hist, _llm_error_counter
     global _state_gauge, _state_duration_hist
+    global _subagent_duration_hist, _subagent_outcome_counter, _subagent_stalled_counter
+    global _tool_stalled_counter
 
     if _otel_initialised:
         return
     _otel_initialised = True
+    if not _OTEL_IMPORT_OK:
+        logger.warning("OTEL_INIT: OpenTelemetry packages not installed; instrumentation disabled")
+        return
 
     logger.info("OTEL_INIT: starting initialization — endpoint=%s", OTEL_EXPORTER_OTLP_ENDPOINT)
 
@@ -238,6 +273,11 @@ def _init_otel() -> None:
         description="Per-tool call latency in seconds",
         unit="s",
     )
+    _tool_stalled_counter = _meter.create_counter(
+        name="hermes.tool.stalled.total",
+        description="Total number of tool calls detected as stalled",
+        unit="1",
+    )
 
     # UpDownCounter for active conversations
     _active_conversations_gauge = _meter.create_up_down_counter(
@@ -271,6 +311,22 @@ def _init_otel() -> None:
         name="hermes.conversation.state_duration_seconds",
         description="Time spent in each conversation state",
         unit="s",
+    )
+
+    _subagent_duration_hist = _meter.create_histogram(
+        name="hermes.subagent.duration_seconds",
+        description="Subagent task duration in seconds",
+        unit="s",
+    )
+    _subagent_outcome_counter = _meter.create_counter(
+        name="hermes.subagent.outcome.total",
+        description="Total subagent outcomes by status",
+        unit="1",
+    )
+    _subagent_stalled_counter = _meter.create_counter(
+        name="hermes.subagent.stalled.total",
+        description="Total subagent stall detections",
+        unit="1",
     )
 
     logger.info(
@@ -321,15 +377,16 @@ def merge_callbacks(*callback_dicts) -> dict:
             result[name] = fns[0]
         else:
             # Wrap all of them in a single dispatcher
-            def make_dispatcher(fs):
+            def make_dispatcher(fs, cb_name: str):
                 def dispatcher(*args, **kwargs):
                     for f in fs:
                         try:
                             f(*args, **kwargs)
                         except Exception:
-                            logger.exception("callback %s.%s raised", name, f.__name__)
+                            fn_name = getattr(f, "__name__", None) or getattr(f, "_mock_name", None) or type(f).__name__
+                            logger.exception("callback %s.%s raised", cb_name, fn_name)
                 return dispatcher
-            result[name] = make_dispatcher(fns)
+            result[name] = make_dispatcher(fns, name)
 
     return result
 
@@ -363,8 +420,12 @@ class OtelShim:
         conversation_id: Optional[str] = None,
         extra_attributes: Optional[dict] = None,
     ):
-        if OTEL_ENABLED:
+        if OTEL_ENABLED and _OTEL_IMPORT_OK:
             _init_otel()
+        elif OTEL_ENABLED and not _OTEL_IMPORT_OK:
+            logger.warning(
+                "OTEL requested but opentelemetry packages are unavailable; set OTEL_ENABLED=false or install deps"
+            )
 
         self._agent            = agent
         self._conversation_id = conversation_id or f"conv-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
@@ -378,6 +439,12 @@ class OtelShim:
         self._llm_span        : Optional[Any]    = None
         self._llm_start       : Optional[float]  = None
         self._llm_call_count  : int              = 0
+        self._subagent_spans: dict[str, dict[str, Any]] = {}
+        self._subagent_lock = threading.Lock()
+        self._tool_heartbeat_stop: dict[str, threading.Event] = {}
+        self._tool_heartbeat_threads: dict[str, threading.Thread] = {}
+        self._tool_stalled: set[str] = set()
+        self._tool_lock = threading.Lock()
 
         # ── State machine ──────────────────────────────────────────────────────
         # States:  idle=0 | thinking=1 | tool_executing=2 | waiting_for_user=3
@@ -611,6 +678,135 @@ class OtelShim:
             self._span.record_exception(Exception(error_message))
             self._span.set_status(Status(StatusCode.ERROR, error_message))
 
+    def record_runtime_event(self, event_name: str, **attributes: Any) -> None:
+        """Attach a runtime event to the active root conversation span."""
+        if not self._otel_enabled or not self._span:
+            return
+        try:
+            self._span.add_event(event_name, attributes={**attributes, **self._base_labels()})
+        except Exception:
+            pass
+
+    def _root_context(self):
+        """Return context anchored to root conversation span when available."""
+        if not self._otel_enabled or trace is None or not self._span:
+            return None
+        try:
+            return trace.set_span_in_context(self._span)
+        except Exception:
+            return None
+
+    def start_subagent_span(
+        self,
+        *,
+        task_index: int,
+        goal: str,
+        toolsets: Optional[list[str]] = None,
+        model: Optional[str] = None,
+    ) -> Optional[str]:
+        """Start a child span for delegated subagent execution."""
+        if not self._otel_enabled or _tracer is None:
+            return None
+        handle = f"subagent-{task_index}-{time.time_ns()}"
+        attrs = {
+            "subagent.task_index": task_index,
+            "subagent.goal.preview": (goal or "")[:200],
+            "subagent.goal.length": len(goal or ""),
+            "subagent.model": model or "",
+            "subagent.toolsets": ",".join(toolsets or []),
+            "conversation.id": self._conversation_id,
+            **self._base_labels(),
+        }
+        parent_ctx = trace.set_span_in_context(self._span) if self._span else None
+        span = _tracer.start_span(name="subagent.run", context=parent_ctx, attributes=attrs)
+        span.__enter__()
+        with self._subagent_lock:
+            self._subagent_spans[handle] = {"span": span, "start": time.perf_counter(), "stalled": False}
+        return handle
+
+    def record_subagent_event(self, handle: Optional[str], event_name: str, **attributes: Any) -> None:
+        """Attach a subagent lifecycle event to the child span."""
+        if not handle:
+            return
+        with self._subagent_lock:
+            entry = self._subagent_spans.get(handle)
+        if not entry:
+            return
+        span = entry.get("span")
+        if not span:
+            return
+        try:
+            span.add_event(event_name, attributes={**attributes, **self._base_labels()})
+        except Exception:
+            pass
+
+    def record_subagent_stalled(self, handle: Optional[str], *, elapsed_seconds: float, current_tool: str = "") -> None:
+        """Record a stall event exactly once per subagent run."""
+        if not handle:
+            return
+        should_emit = False
+        with self._subagent_lock:
+            entry = self._subagent_spans.get(handle)
+            if entry and not entry.get("stalled"):
+                entry["stalled"] = True
+                should_emit = True
+        if not should_emit:
+            return
+        if _subagent_stalled_counter is not None:
+            try:
+                _subagent_stalled_counter.add(1, self._base_labels({"subagent.current_tool": current_tool or ""}))
+            except Exception:
+                pass
+        self.record_subagent_event(
+            handle,
+            "subagent.stalled",
+            elapsed_seconds=round(elapsed_seconds, 3),
+            current_tool=current_tool or "",
+        )
+
+    def end_subagent_span(
+        self,
+        handle: Optional[str],
+        *,
+        outcome: str,
+        api_calls: int = 0,
+        error: Optional[str] = None,
+    ) -> None:
+        """Close delegated subagent span and emit metrics."""
+        if not handle:
+            return
+        with self._subagent_lock:
+            entry = self._subagent_spans.pop(handle, None)
+        if not entry:
+            return
+        span = entry.get("span")
+        elapsed = max(0.0, time.perf_counter() - float(entry.get("start") or 0.0))
+
+        if _subagent_duration_hist is not None:
+            try:
+                _subagent_duration_hist.record(elapsed, self._base_labels({"subagent.outcome": outcome}))
+            except Exception:
+                pass
+        if _subagent_outcome_counter is not None:
+            try:
+                _subagent_outcome_counter.add(1, self._base_labels({"subagent.outcome": outcome}))
+            except Exception:
+                pass
+
+        if span:
+            try:
+                span.set_attribute("subagent.outcome", outcome)
+                span.set_attribute("subagent.api_calls", int(api_calls or 0))
+                span.set_attribute("subagent.duration_seconds", round(elapsed, 3))
+                if error:
+                    span.set_attribute("subagent.error", str(error)[:500])
+                    span.set_status(Status(StatusCode.ERROR, str(error)[:200]))
+                else:
+                    span.set_status(Status(StatusCode.OK))
+                span.__exit__(None, None, None)
+            except Exception:
+                pass
+
     # ------------------------------------------------------------------
     # Internal callbacks — wired to AIAgent
     # ------------------------------------------------------------------
@@ -636,6 +832,7 @@ class OtelShim:
 
         span = _tracer.start_span(
             name=f"tool.{tool_name}",
+            context=self._root_context(),
             attributes={
                 "tool.call_id": tool_call_id,
                 "tool.name":    tool_name,
@@ -645,6 +842,63 @@ class OtelShim:
         )
         span.__enter__()
         self._tool_spans[tool_call_id] = span
+        self.record_runtime_event(
+            "tool.started",
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+        )
+
+        # Emit heartbeat/stall events while a tool call runs so long gaps are observable.
+        stop_event = threading.Event()
+        with self._tool_lock:
+            self._tool_heartbeat_stop[tool_call_id] = stop_event
+            self._tool_stalled.discard(tool_call_id)
+
+        def _heartbeat_loop() -> None:
+            while not stop_event.wait(_TOOL_HEARTBEAT_INTERVAL_SECS):
+                start_ts = self._tool_start.get(tool_call_id)
+                span_obj = self._tool_spans.get(tool_call_id)
+                if not start_ts:
+                    return
+                elapsed = max(0.0, time.perf_counter() - start_ts)
+                if span_obj:
+                    try:
+                        span_obj.add_event(
+                            "tool.heartbeat",
+                            attributes={
+                                "tool.call_id": tool_call_id,
+                                "tool.name": tool_name,
+                                "tool.elapsed_seconds": round(elapsed, 3),
+                                **self._base_labels(),
+                            },
+                        )
+                    except Exception:
+                        pass
+                if elapsed >= _TOOL_STALL_THRESHOLD_SECS and tool_call_id not in self._tool_stalled:
+                    self._tool_stalled.add(tool_call_id)
+                    if span_obj:
+                        try:
+                            span_obj.add_event(
+                                "tool.stalled",
+                                attributes={
+                                    "tool.call_id": tool_call_id,
+                                    "tool.name": tool_name,
+                                    "tool.elapsed_seconds": round(elapsed, 3),
+                                    **self._base_labels(),
+                                },
+                            )
+                        except Exception:
+                            pass
+                    if _tool_stalled_counter is not None:
+                        try:
+                            _tool_stalled_counter.add(1, self._base_labels({"tool.name": tool_name}))
+                        except Exception:
+                            pass
+
+        heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
+        with self._tool_lock:
+            self._tool_heartbeat_threads[tool_call_id] = heartbeat_thread
+        heartbeat_thread.start()
 
     def _on_tool_complete(
         self,
@@ -656,6 +910,14 @@ class OtelShim:
         if not OTEL_ENABLED:
             return
 
+        with self._tool_lock:
+            stop_event = self._tool_heartbeat_stop.pop(tool_call_id, None)
+            heartbeat_thread = self._tool_heartbeat_threads.pop(tool_call_id, None)
+        if stop_event:
+            stop_event.set()
+        if heartbeat_thread and heartbeat_thread.is_alive():
+            heartbeat_thread.join(timeout=0.2)
+
         start = self._tool_start.pop(tool_call_id, None)
         span  = self._tool_spans.pop(tool_call_id, None)
         latency = time.perf_counter() - start if start else 0.0
@@ -666,11 +928,13 @@ class OtelShim:
             is_error = _is_error_result(function_result)
             span.set_attribute("tool.result_length", len(function_result) if function_result else 0)
             span.set_attribute("tool.error", is_error)
+            span.set_attribute("tool.stalled", tool_call_id in self._tool_stalled)
             span.set_status(Status(StatusCode.OK if not is_error else StatusCode.ERROR))
             span.__exit__(None, None, None)
 
             if is_error:
                 _error_counter.add(1, self._base_labels({"error.type": "tool", "tool.name": tool_name}))
+        self._tool_stalled.discard(tool_call_id)
 
         # State: back to thinking (1) — agent will call LLM again next
         self._set_state(1)
@@ -756,6 +1020,7 @@ class OtelShim:
         span_name = f"llm.{api_mode} {self._llm_call_count}/{model}"
         self._llm_span = _tracer.start_span(
             name=span_name,
+            context=self._root_context(),
             attributes={
                 "llm.model":       model,
                 "llm.provider":    provider or "unknown",

--- a/agent/otel_shim.py
+++ b/agent/otel_shim.py
@@ -1,0 +1,900 @@
+"""
+OpenTelemetry Shim for Hermes AIAgent.
+
+Wraps an AIAgent instance and instruments all callbacks to produce:
+  - Traces : one trace per run_conversation(), one span per tool call
+  - Metrics: counters + latency histograms exported via OTLP
+
+Usage::
+
+    from run_agent import AIAgent
+    from agent.otel_shim import OtelShim, wrapped_chat
+
+    agent = AIAgent(model="anthropic/claude-sonnet-4")
+    shim  = OtelShim(agent)
+
+    response = wrapped_chat(agent, "your query here", shim)
+
+Or step-by-step for gateway/cron integration::
+
+    shim  = OtelShim(agent)
+    agent = AIAgent(model="...", **shim.callbacks)
+
+    shim.start_trace(user_message)
+    try:
+        result = agent.run_conversation(user_message=user_message)
+        final  = result.get("final_response", "")
+        shim.end_trace(final, success=True)
+    except Exception as exc:
+        shim.record_error(str(exc), type(exc).__name__)
+        shim.end_trace(str(exc), success=False)
+        raise
+
+Enable via env vars::
+
+    export OTEL_ENABLED=true
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+    export OTEL_SERVICE_NAME=hermes-agent
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import logging
+import re
+import json
+from typing import Optional, Any
+from datetime import datetime, timezone
+#import fs
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.trace import Status, StatusCode
+
+logger = logging.getLogger(__name__)
+
+# Ensure INFO logs are visible from the very first import — before setup_logging() runs
+# in gateway. Only configure if no handlers are already present (let setup_logging own stdout).
+if not logger.handlers and not logging.getLogger().handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("%(name)s: %(levelname)s %(message)s"))
+    _h.setLevel(logging.INFO)
+    logging.getLogger().addHandler(_h)
+    logging.getLogger().setLevel(logging.INFO)
+
+# -------------------------------------------------------------------------
+# Config — all via environment variables
+# -------------------------------------------------------------------------
+
+OTEL_ENABLED                 = os.getenv("OTEL_ENABLED", "false").lower() in ("1", "true", "yes")
+OTEL_EXPORTER_OTLP_ENDPOINT  = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+OTEL_EXPORTER_OTLP_HEADERS   = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+OTEL_SERVICE_NAME            = os.getenv("OTEL_SERVICE_NAME", "hermes-agent")
+OTEL_SERVICE_VERSION         = os.getenv("OTEL_SERVICE_VERSION", "0.8.0")
+OTEL_ENVIRONMENT             = os.getenv("OTEL_ENVIRONMENT", "development")
+OTEL_PROFILE                 = os.getenv("OTEL_PROFILE", "")
+OTEL_METRICS_INTERVAL_SECS   = int(os.getenv("OTEL_METRICS_INTERVAL_SECS", "10"))
+
+logger.info(
+    "OTEL_CONFIG: enabled=%s endpoint=%s service=%s",
+    OTEL_ENABLED, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — initialised once per process
+# ---------------------------------------------------------------------------
+
+_otel_initialised = False
+_tracer: Optional[trace.Tracer] = None
+_meter:  Optional[metrics.Meter] = None
+
+# State names indexed by integer value for logging / trace attributes
+_STATE_NAMES = ("idle", "thinking", "tool_executing", "waiting_for_user")
+
+# Metrics instruments (created once, reused across all conversations)
+_query_counter             = None
+_tool_counter             = None
+_query_latency_hist       = None
+_tool_latency_hist        = None
+_error_counter            = None
+_active_conversations_gauge = None
+_llm_latency_hist         = None
+_llm_error_counter        = None
+_state_gauge              = None
+_state_duration_hist      = None
+
+
+def _parse_headers(header_str: str) -> dict:
+    """Parse 'key1=val1,key2=val2' into a dict. Empty string → {}."""
+    out = {}
+    for part in header_str.split(","):
+        part = part.strip()
+        if not part or "=" not in part:
+            continue
+        k, v = part.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+# ── State machine collector ─────────────────────────────────────────────────
+# All active OtelShim instances register here so the observable gauge can
+# report their current state values.  Thread-safe enough for production use.
+# (Defined at module level so _init_otel() can reference them as closures.)
+_state_shims: list = []
+_state_shims_lock = __import__("threading").Lock()
+
+
+def _register_state_shim(shim) -> None:
+    with _state_shims_lock:
+        if shim not in _state_shims:
+            _state_shims.append(shim)
+
+
+def _state_gather_callback(options) -> None:
+    """Called by the observable gauge — yields one Observation per active shim.
+
+    The callback must be a generator that yields Observation objects.
+    Using Observation directly (not options.observe) for SDK compatibility.
+    """
+    from opentelemetry.metrics import Observation as _Obs
+    with _state_shims_lock:
+        for shim in _state_shims:
+            try:
+                state_name = _STATE_NAMES[shim._state] if shim._state < len(_STATE_NAMES) else str(shim._state)
+                yield _Obs(
+                    float(shim._state),
+                    {
+                        "conversation_id":    shim._conversation_id[-12:],
+                        "conversation_state": state_name,
+                        **shim._base_labels(),
+                    },
+                )
+            except Exception:
+                pass
+
+
+def _init_otel() -> None:
+    global _otel_initialised, _tracer, _meter
+    global _query_counter, _tool_counter
+    global _query_latency_hist, _tool_latency_hist
+    global _error_counter, _active_conversations_gauge
+    global _llm_latency_hist, _llm_error_counter
+    global _state_gauge, _state_duration_hist
+
+    if _otel_initialised:
+        return
+    _otel_initialised = True
+
+    logger.info("OTEL_INIT: starting initialization — endpoint=%s", OTEL_EXPORTER_OTLP_ENDPOINT)
+
+    resource = Resource.create({
+        SERVICE_NAME:            OTEL_SERVICE_NAME,
+        SERVICE_VERSION:         OTEL_SERVICE_VERSION,
+        "deployment.environment": OTEL_ENVIRONMENT,
+        "hermes.profile":         OTEL_PROFILE,
+    })
+
+    headers = _parse_headers(OTEL_EXPORTER_OTLP_HEADERS)
+    use_tls = OTEL_EXPORTER_OTLP_ENDPOINT.startswith("https://")
+
+    logger.info("OTEL_INIT: creating OTLP span exporter — endpoint=%s insecure=%s", OTEL_EXPORTER_OTLP_ENDPOINT, not use_tls)
+
+    # ---- Traces ----
+    trace_provider = TracerProvider(resource=resource)
+    _trace_endpoint = OTEL_EXPORTER_OTLP_ENDPOINT.rstrip("/") + "/v1/traces"
+    trace_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(
+                endpoint=_trace_endpoint,
+            )
+        )
+    )
+    trace.set_tracer_provider(trace_provider)
+    _tracer = trace.get_tracer(__name__)
+
+    # ---- Metrics ----
+    _metric_endpoint = OTEL_EXPORTER_OTLP_ENDPOINT.rstrip("/") + "/v1/metrics"
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(
+            endpoint=_metric_endpoint,
+        ),
+        export_interval_millis=OTEL_METRICS_INTERVAL_SECS * 1000,
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    metrics.set_meter_provider(meter_provider)
+    _meter = metrics.get_meter(__name__)
+
+    # Counters
+    _query_counter = _meter.create_counter(
+        name="hermes.queries.total",
+        description="Total number of queries processed",
+        unit="1",
+    )
+    _tool_counter = _meter.create_counter(
+        name="hermes.tool_calls.total",
+        description="Total number of tool calls",
+        unit="1",
+    )
+    _error_counter = _meter.create_counter(
+        name="hermes.errors.total",
+        description="Total number of errors",
+        unit="1",
+    )
+
+    # Histograms
+    _query_latency_hist = _meter.create_histogram(
+        name="hermes.query.latency_seconds",
+        description="End-to-end query latency in seconds",
+        unit="s",
+    )
+    _tool_latency_hist = _meter.create_histogram(
+        name="hermes.tool.latency_seconds",
+        description="Per-tool call latency in seconds",
+        unit="s",
+    )
+
+    # UpDownCounter for active conversations
+    _active_conversations_gauge = _meter.create_up_down_counter(
+        name="hermes.active_conversations",
+        description="Number of currently active conversations",
+        unit="1",
+    )
+
+    # LLM latency histogram
+    _llm_latency_hist = _meter.create_histogram(
+        name="hermes.llm.latency_seconds",
+        description="LLM API call latency in seconds",
+        unit="s",
+    )
+    _llm_error_counter = _meter.create_counter(
+        name="hermes.llm.errors.total",
+        description="Total number of LLM API errors",
+        unit="1",
+    )
+
+    # State gauge — observable gauge reporting current conversation state
+    _state_gauge = _meter.create_observable_gauge(
+        name="hermes.conversation.state",
+        description="Current state of each active conversation (0=idle, 1=thinking, 2=tool_executing, 3=waiting_for_user)",
+        unit="1",
+        callbacks=[_state_gather_callback],
+    )
+
+    # State duration histogram — time spent in each state per conversation
+    _state_duration_hist = _meter.create_histogram(
+        name="hermes.conversation.state_duration_seconds",
+        description="Time spent in each conversation state",
+        unit="s",
+    )
+
+    logger.info(
+        "OTEL_INIT: complete — tracer=%s meter=%s endpoint=%s",
+        _tracer, _meter, OTEL_EXPORTER_OTLP_ENDPOINT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# OtelShim — the main wrapper class
+# ---------------------------------------------------------------------------
+
+def _no_op(*args, **kwargs) -> None:
+    """Sentinel used when no agent is available (bg/btw agents are ephemeral)."""
+    pass
+
+
+def merge_callbacks(*callback_dicts) -> dict:
+    """
+    Merge multiple per-name callback dicts into one.
+
+    For keys where multiple dicts have a value, all values are combined into
+    a single list so no callback is lost.  This allows the OTel shim to sit
+    alongside existing TUI/display callbacks without replacing them.
+
+    Example::
+
+        merged = merge_callbacks(
+            {"tool_start_callback": cli._on_tool_start},
+            shim.callbacks,
+        )
+        # → AIAgent(tool_start_callback=merged["tool_start_callback"])
+    """
+    from collections import defaultdict
+
+    result: dict = {}
+    by_name: dict = defaultdict(list)
+
+    for d in callback_dicts:
+        if not d:
+            continue
+        for name, fn in d.items():
+            if fn is not None:
+                by_name[name].append(fn)
+
+    for name, fns in by_name.items():
+        if len(fns) == 1:
+            result[name] = fns[0]
+        else:
+            # Wrap all of them in a single dispatcher
+            def make_dispatcher(fs):
+                def dispatcher(*args, **kwargs):
+                    for f in fs:
+                        try:
+                            f(*args, **kwargs)
+                        except Exception:
+                            logger.exception("callback %s.%s raised", name, f.__name__)
+                return dispatcher
+            result[name] = make_dispatcher(fns)
+
+    return result
+
+
+class OtelShim:
+    """
+    Wraps an AIAgent instance and wires every callback to produce
+    OpenTelemetry traces and metrics.
+
+    ``agent`` may be ``None`` — the shim still initialises the OTel SDK
+    (once per process) so that metrics/traces are exported.  When agent is
+    ``None``, the ``callbacks`` dict returns no-op stubs; pass the callbacks
+    to ``AIAgent`` via ``merge_callbacks(shim.callbacks, your_callbacks)``::
+
+        shim    = OtelShim(None)   # no agent needed just to initialise
+        shim2   = OtelShim(agent)
+        merged  = merge_callbacks(shim.callbacks, existing_tui_callbacks)
+        agent   = AIAgent(model="...", **merged)
+
+    Or use the two-step::
+
+        shim   = OtelShim(agent)
+        agent  = AIAgent(model="...", **shim.callbacks)   # replaces existing
+
+    Prefer ``merge_callbacks`` when existing callbacks (TUI display) must be preserved.
+    """
+
+    def __init__(
+        self,
+        agent: Any = None,
+        conversation_id: Optional[str] = None,
+        extra_attributes: Optional[dict] = None,
+    ):
+        if OTEL_ENABLED:
+            _init_otel()
+
+        self._agent            = agent
+        self._conversation_id = conversation_id or f"conv-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
+        self._extra           = extra_attributes or {}
+        self._trace_active    = False
+        self._tool_spans      = {}   # tool_call_id → span
+        self._tool_start      = {}   # tool_call_id → start_time (perf_counter)
+        self._query_start     : Optional[float] = None
+        self._span            : Optional[Any]    = None
+        # LLM API call tracking
+        self._llm_span        : Optional[Any]    = None
+        self._llm_start       : Optional[float]  = None
+        self._llm_call_count  : int              = 0
+
+        # ── State machine ──────────────────────────────────────────────────────
+        # States:  idle=0 | thinking=1 | tool_executing=2 | waiting_for_user=3
+        self._state       : int = 0
+        self._state_start : float = time.perf_counter()  # when current state began
+        self._state_start_ts : Optional[float] = None   # wall-clock start (for duration)
+
+        # Register this shim's state getter with the module-level collector
+        _register_state_shim(self)
+
+        # If agent is None, callbacks are no-ops (bg/btw path: shim exists on HermesCLI
+        # but individual AIAgent instances are created without going through _init_agent)
+        if agent is None:
+            self.callbacks = {k: _no_op for k in (
+                "tool_start_callback", "tool_complete_callback",
+                "thinking_callback", "step_callback", "status_callback",
+                "clarify_callback", "stream_delta_callback",
+                "pre_api_request_callback", "stream_complete_callback",
+            )}
+        else:
+            self.callbacks = {
+                "tool_start_callback":      self._on_tool_start,
+                "tool_complete_callback":  self._on_tool_complete,
+                "thinking_callback":       self._on_thinking,
+                "step_callback":           self._on_step,
+                "status_callback":         self._on_status,
+                "clarify_callback":       self._on_clarify,
+                "stream_delta_callback":   self._on_stream_delta,
+                "pre_api_request_callback": self._on_pre_api_request,
+                "stream_complete_callback": self._on_stream_complete,
+            }
+
+    @property
+    def _otel_enabled(self) -> bool:
+        """True when OTel is both enabled and successfully initialised."""
+        return OTEL_ENABLED and _otel_initialised
+
+    # ------------------------------------------------------------------
+    # State machine
+    # ------------------------------------------------------------------
+
+    def _set_state(self, new_state: int) -> None:
+        """
+        Transition to a new state, recording the duration spent in the previous one.
+
+        States:
+            0 = idle
+            1 = thinking  (LLM API call in progress)
+            2 = tool_executing
+            3 = waiting_for_user  (clarify_callback fired, agent paused)
+        """
+        if not OTEL_ENABLED:
+            return
+
+        old_state = self._state
+
+        # Record how long we were in the previous state
+        if old_state != new_state:
+            now       = time.perf_counter()
+            wall_now = time.time()
+            elapsed  = now - self._state_start
+
+            if self._state_start_ts is not None:
+                wall_elapsed = wall_now - self._state_start_ts
+            else:
+                wall_elapsed = elapsed
+
+            state_name = _STATE_NAMES[old_state] if old_state < len(_STATE_NAMES) else str(old_state)
+
+            # Histogram — time in this state for this conversation
+            try:
+                _state_duration_hist.record(
+                    wall_elapsed,
+                    {
+                        "conversation.state": state_name,
+                        "conversation.id":     self._conversation_id,
+                        **self._base_labels(),
+                    },
+                )
+            except Exception as e:
+                logger.warning("_set_state: histogram record failed: %s", e)
+
+            # Add a trace event for every state transition
+            if self._span:
+                self._span.add_event(
+                    name=f"state.{state_name}.duration",
+                    attributes={
+                        "state.from":   state_name,
+                        "state.to":     _STATE_NAMES[new_state] if new_state < len(_STATE_NAMES) else str(new_state),
+                        "state.duration_ms": round(wall_elapsed * 1000, 2),
+                        **self._base_labels(),
+                    },
+                )
+
+            logger.debug(
+                "OTEL_STATE: conv=%s %s → %s (%.0fms)",
+                self._conversation_id, state_name,
+                _STATE_NAMES[new_state] if new_state < len(_STATE_NAMES) else str(new_state),
+                wall_elapsed * 1000,
+            )
+
+            self._state       = new_state
+            self._state_start = now
+            self._state_start_ts = wall_now
+
+    # ------------------------------------------------------------------
+    # Attribute helpers
+    # ------------------------------------------------------------------
+
+    def _base_labels(self, extra: Optional[dict] = None) -> dict:
+        """
+        Build a label dict with user.id, platform, and profile prepended.
+
+        These three labels are the primary dimension for per-conversation
+        observability.  They are attached to every metric and span so that
+        dashboards can filter/slice by who sent the message, which platform
+        it came from, and which Hermes profile was active.
+        """
+        labels = {
+            "user.id":    self._extra.get("user.id", ""),
+            "platform":   self._extra.get("platform", ""),
+            "profile":    self._extra.get("profile", ""),
+        }
+        if extra:
+            labels.update(extra)
+        return labels
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start_trace(self, user_message: str) -> None:
+        """Call BEFORE run_conversation() to open the top-level span."""
+        if not OTEL_ENABLED:
+            return
+
+        self._query_start  = time.perf_counter()
+        self._trace_active = True
+
+        base = self._base_labels()
+        attrs = {
+            "conversation.id":    self._conversation_id,
+            "user.query":         user_message[:500],
+            "user.query.length":  len(user_message),
+            "agent.model":        getattr(self._agent, "model", "unknown"),
+            **base,
+            **self._extra,
+            # spanmetrics connector sees these underscore names (dots are sanitized to underscores by Prometheus)
+            "user_id":   base.get("user.id",   ""),
+            "platform":  base.get("platform",  ""),
+            "profile":   base.get("profile",   ""),
+        }
+
+        logger.info(
+            "OTEL_START_TRACE: conv=%s query_len=%d OTEL_ENABLED=%s _otel_initialised=%s",
+            self._conversation_id, len(user_message), OTEL_ENABLED, _otel_initialised,
+        )
+
+        if _tracer is None:
+            logger.error("OTEL_START_TRACE: _tracer is None — _init_otel() likely failed, skipping trace")
+            return
+
+        self._span = _tracer.start_span(
+            name=f"agent.query {self._conversation_id[-12:]}",
+            attributes=attrs,
+        )
+        self._span.__enter__()
+
+        _active_conversations_gauge.add(1, self._base_labels({"conversation.state": "active"}))
+        _query_counter.add(1, self._base_labels({"query.type": _classify_query(user_message)}))
+
+        # State: enter thinking (1) — first LLM call will follow shortly
+        self._set_state(1)
+
+    def end_trace(self, final_response: str, success: bool = True) -> None:
+        """Call AFTER run_conversation() returns to close the span."""
+        if not OTEL_ENABLED:
+            logger.warning("OTEL_END_TRACE: early-exit — OTEL_ENABLED=%s", OTEL_ENABLED)
+            return
+        if not self._trace_active:
+            logger.warning("OTEL_END_TRACE: early-exit — _trace_active=False (span=%s)", self._span)
+            return
+
+        elapsed = time.perf_counter() - self._query_start
+        logger.info("OTEL_END_TRACE: conv=%s elapsed=%.3fs success=%s span=%s", self._conversation_id, elapsed, success, self._span)
+
+        try:
+            _query_latency_hist.record(elapsed, self._base_labels({"conversation.id": self._conversation_id}))
+        except Exception as e:
+            logger.warning("OTEL_END_TRACE: histogram record failed: %s", e)
+
+        # Close any open LLM span
+        if self._llm_span:
+            try:
+                self._llm_span.set_attribute("llm.error", "conversation_ended")
+                self._llm_span.set_status(Status(StatusCode.ERROR, "Conversation ended"))
+                self._llm_span.__exit__(None, None, None)
+            except Exception:
+                pass
+            self._llm_span = None
+
+        span = self._span
+        self._span = None
+        self._trace_active = False
+
+        # Transition to idle — records the final state's duration before the trace closes
+        self._set_state(0)
+
+        if span:
+            try:
+                span.set_attribute("conversation.success", success)
+                span.set_attribute("response.length", len(final_response) if final_response else 0)
+                span.set_status(Status(StatusCode.OK if success else StatusCode.ERROR))
+                span.__exit__(None, None, None)
+            except Exception as e:
+                logger.error("OTEL_END_TRACE: span.__exit__ failed: %s", e)
+
+        try:
+            _active_conversations_gauge.add(-1, self._base_labels({"conversation.state": "ended"}))
+        except Exception as e:
+            logger.warning("OTEL_END_TRACE: gauge update failed: %s", e)
+
+        logger.debug("trace ended — latency=%.3fs success=%s", elapsed, success)
+
+    def record_error(self, error_message: str, error_type: str = "generic") -> None:
+        """Call on any error path to record it in traces and metrics."""
+        if not OTEL_ENABLED:
+            return
+        _error_counter.add(1, self._base_labels({"error.type": error_type}))
+        if self._span:
+            self._span.record_exception(Exception(error_message))
+            self._span.set_status(Status(StatusCode.ERROR, error_message))
+
+    # ------------------------------------------------------------------
+    # Internal callbacks — wired to AIAgent
+    # ------------------------------------------------------------------
+
+    def _on_tool_start(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        tool_args: dict,
+    ) -> None:
+        if not OTEL_ENABLED:
+            return
+
+        self._set_state(2)
+
+        start = time.perf_counter()
+        self._tool_start[tool_call_id] = start
+
+        _tool_counter.add(1, self._base_labels({
+            "tool.name": tool_name,
+            "tool.type": _classify_tool(tool_name),
+        }))
+
+        span = _tracer.start_span(
+            name=f"tool.{tool_name}",
+            attributes={
+                "tool.call_id": tool_call_id,
+                "tool.name":    tool_name,
+                "tool.args":    _sanitise_args(tool_args),
+                **self._base_labels(),
+            },
+        )
+        span.__enter__()
+        self._tool_spans[tool_call_id] = span
+
+    def _on_tool_complete(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        tool_args: dict,
+        function_result: str,
+    ) -> None:
+        if not OTEL_ENABLED:
+            return
+
+        start = self._tool_start.pop(tool_call_id, None)
+        span  = self._tool_spans.pop(tool_call_id, None)
+        latency = time.perf_counter() - start if start else 0.0
+
+        _tool_latency_hist.record(latency, self._base_labels({"tool.name": tool_name}))
+
+        if span:
+            is_error = _is_error_result(function_result)
+            span.set_attribute("tool.result_length", len(function_result) if function_result else 0)
+            span.set_attribute("tool.error", is_error)
+            span.set_status(Status(StatusCode.OK if not is_error else StatusCode.ERROR))
+            span.__exit__(None, None, None)
+
+            if is_error:
+                _error_counter.add(1, self._base_labels({"error.type": "tool", "tool.name": tool_name}))
+
+        # State: back to thinking (1) — agent will call LLM again next
+        self._set_state(1)
+
+    def _on_thinking(self, thinking: str) -> None:
+        if not OTEL_ENABLED or not self._span:
+            return
+        self._span.add_event(
+            name="model.thinking",
+            attributes={
+                "thinking.length": len(thinking),
+                "thinking.preview": thinking[:200],
+            },
+        )
+
+    def _on_step(self, *args, **kwargs) -> None:
+        if not OTEL_ENABLED or not self._span:
+            return
+        # run_agent calls step_callback(iteration, prev_tools)
+        step_info = args[0] if args else kwargs.get("step_info")
+        try:
+            step_str = str(step_info)[:300]
+        except Exception:
+            step_str = "<unstringable>"
+        self._span.add_event(name="agent.step", attributes={"step.info": step_str})
+
+    def _on_status(self, *args, **kwargs) -> None:
+        if not OTEL_ENABLED or not self._span:
+            return
+        # run_agent calls status_callback(event_type, message)
+        status_type = args[0] if args else kwargs.get("status_type") or "unknown"
+        message = args[1] if len(args) > 1 else kwargs.get("message", "")
+        self._span.add_event(
+            name=f"status.{status_type}",
+            attributes={"status.message": message[:500]},
+        )
+        if status_type in ("error", "warning"):
+            _error_counter.add(1, self._base_labels({"status.type": status_type}))
+
+    def _on_clarify(self, *args, **kwargs) -> None:
+        if not OTEL_ENABLED or not self._span:
+            return
+        # run_agent calls clarify_callback(question, choices)
+        question = args[0] if args else kwargs.get("question", "")
+        choices = args[1] if len(args) > 1 else kwargs.get("choices", [])
+        self._span.add_event(
+            name="agent.clarify",
+            attributes={
+                "clarify.question":     question[:500],
+                "clarify.choice_count": len(choices) if choices else 0,
+            },
+        )
+        # State: waiting_for_user (3) — agent paused, awaiting user response
+        self._set_state(3)
+
+    def _on_stream_delta(self, *args, **kwargs) -> None:
+        if not OTEL_ENABLED or not self._span:
+            return
+        # run_agent calls stream_delta_callback(string)
+        delta_text = args[0] if args else kwargs.get("delta_text") or ""
+        if not isinstance(delta_text, str):
+            delta_text = str(delta_text) if delta_text is not None else ""
+        self._span.add_event(
+            name="stream.token",
+            attributes={"token.length": len(delta_text)},
+        )
+
+    def _on_pre_api_request(
+        self,
+        model: str,
+        provider: str,
+        api_mode: str,
+        message_count: int,
+        tool_count: int,
+        approx_input_tokens: int,
+        api_call_number: int,
+    ) -> None:
+        """Called before every LLM API request (from pre_api_request plugin hook)."""
+        if not OTEL_ENABLED:
+            return
+        self._llm_call_count += 1
+        self._llm_start = time.perf_counter()
+        span_name = f"llm.{api_mode} {self._llm_call_count}/{model}"
+        self._llm_span = _tracer.start_span(
+            name=span_name,
+            attributes={
+                "llm.model":       model,
+                "llm.provider":    provider or "unknown",
+                "llm.api_mode":    api_mode,
+                "llm.call_number": self._llm_call_count,
+                "llm.message_count": message_count,
+                "llm.tool_count":  tool_count,
+                "llm.input_tokens_approx": approx_input_tokens,
+                **self._base_labels(),
+            },
+        )
+        self._llm_span.__enter__()
+
+    def _on_stream_complete(
+        self,
+        output_tokens: int,
+        finish_reason: str,
+        model: str,
+        provider: str,
+        error: Optional[str] = None,
+    ) -> None:
+        """Called when an LLM streaming response completes (from stream_consumer post_hook)."""
+        if not OTEL_ENABLED:
+            return
+        elapsed = time.perf_counter() - self._llm_start if self._llm_start else 0.0
+
+        if self._llm_span:
+            self._llm_span.set_attribute("llm.output_tokens", output_tokens or 0)
+            self._llm_span.set_attribute("llm.finish_reason", finish_reason or "unknown")
+            if error:
+                self._llm_span.set_attribute("llm.error", error)
+                self._llm_span.set_status(Status(StatusCode.ERROR, error))
+            else:
+                self._llm_span.set_status(Status(StatusCode.OK))
+            self._llm_span.__exit__(None, None, None)
+            self._llm_span = None
+
+        _llm_latency_hist.record(elapsed, self._base_labels({
+            "llm.model":    model or "unknown",
+            "llm.provider": provider or "unknown",
+            "llm.finish_reason": finish_reason or "unknown",
+        }))
+        if error:
+            _llm_error_counter.add(1, self._base_labels({
+                "llm.model":    model or "unknown",
+                "llm.provider": provider or "unknown",
+                "error.type":   "llm",
+            }))
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def wrapped_chat(agent: Any, message: str, shim: OtelShim, **kwargs) -> str:
+    """
+    One-shot convenience: start trace → run_conversation → end trace → return.
+
+    Use this instead of calling ``agent.run_conversation()`` directly when
+    using ``OtelShim``::
+
+        shim = OtelShim(agent)
+        response = wrapped_chat(agent, "your query", shim)
+    """
+    shim.start_trace(message)
+    try:
+        result = agent.run_conversation(user_message=message, **kwargs)
+        final_response = (
+            result.get("final_response", "") if isinstance(result, dict)
+            else str(result)
+        )
+        shim.end_trace(final_response, success=True)
+        return final_response
+    except Exception as exc:
+        shim.record_error(str(exc), type(exc).__name__)
+        shim.end_trace(str(exc), success=False)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Private utilities
+# ---------------------------------------------------------------------------
+
+def _classify_query(query: str) -> str:
+    """Coarse intent label for query counter."""
+    q = query.lower()
+    if any(k in q for k in ("cob", "close of business", "end of day", "batch", "end-of-day")):
+        return "cob"
+    if any(k in q for k in ("status", "health", "check")):
+        return "status"
+    if any(k in q for k in ("run", "execute", "start", "trigger")):
+        return "action"
+    if any(k in q for k in ("report", "summary", "summarise")):
+        return "report"
+    return "general"
+
+
+def _classify_tool(tool_name: str) -> str:
+    """Coarse type label for tool counter."""
+    prefixes = {
+        "shell":   ("terminal", "bash", "shell", "process"),
+        "file":    ("file", "read", "write", "patch", "search_files"),
+        "web":     ("web", "http", "fetch", "browse", "scrape"),
+        "delegate":("delegate", "spawn", "subagent"),
+        "browser": ("browser", "click", "navigate", "type"),
+        "mcp":     ("mcp_",),
+    }
+    for category, prefixes_list in prefixes.items():
+        if any(tool_name.startswith(p) for p in prefixes_list):
+            return category
+    return "other"
+
+
+_SECRET_RE = re.compile(r'("(?:api_key|token|secret|password|auth|credential|key)[^"]*"\s*:\s*")[^"]+(")', re.IGNORECASE)
+
+
+def _sanitise_args(args: dict, max_len: int = 600) -> str:
+    """JSON-encode args, truncate, redact common secret field values."""
+    if not args:
+        return "{}"
+    try:
+        raw = json.dumps(args, default=str, separators=(",", ":"))
+    except Exception:
+        raw = str(args)
+    raw = _SECRET_RE.sub(r'\1***\2', raw)
+    if len(raw) > max_len:
+        raw = raw[:max_len] + "...[truncated]"
+    return raw
+
+
+def _is_error_result(result: str) -> bool:
+    """Heuristic: does a tool result string look like an error?"""
+    if not result:
+        return False
+    result_lower = result.lower()
+    signals = (
+        "error", "exception", "traceback", "failed", "failure",
+        "invalid", "denied", "unauthorized", "timeout",
+        "not found", "command failed", "returned non-zero", "refused",
+        "no such file", "connection refused",
+    )
+    return any(sig in result_lower for sig in signals)

--- a/cli.py
+++ b/cli.py
@@ -7986,7 +7986,11 @@ class HermesCLI:
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
             # ── OTel: close the trace span ──────────────────────────────────────
-            if self._otel_shim and self._otel_shim._trace_active:
+            if (
+                self._otel_shim
+                and self._otel_shim._trace_active
+                and self._otel_shim._otel_enabled
+            ):
                 response_text = (
                     (result.get("final_response", "") if result else "")
                     or ""

--- a/cli.py
+++ b/cli.py
@@ -575,6 +575,14 @@ import fire
 from run_agent import AIAgent
 from model_tools import get_tool_definitions, get_toolset_for_tool
 
+# OTel observability shim — auto-activated when OTEL_ENABLED=true
+try:
+    from agent.otel_shim import OtelShim, merge_callbacks
+    _otel_shim_class = OtelShim
+except ImportError:
+    _otel_shim_class = None  # otel extra not installed
+    merge_callbacks = None
+
 # Extracted CLI modules (Phase 3)
 from hermes_cli.banner import build_welcome_banner
 from hermes_cli.commands import SlashCommandCompleter, SlashCommandAutoSuggest
@@ -1850,6 +1858,8 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        # OTel observability shim — auto-initialised when OTEL_ENABLED=true
+        self._otel_shim: "OtelShim" = None
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -2858,6 +2868,17 @@ class HermesCLI:
                 pass
         
         try:
+            #OTel shim: init once, reuse for all subsequent agents ──────────
+            if _otel_shim_class is not None and self._otel_shim is None:
+                import os as _os
+                if _os.getenv("OTEL_ENABLED", "false").lower() in ("1", "true", "yes"):
+                    self._otel_shim = _otel_shim_class(
+                        agent=None,
+                        conversation_id=self.session_id,
+                        extra_attributes={"cli.session_id": self.session_id},
+                    )
+                    logger.info("OTel shim activated — traces and metrics will be exported")
+
             runtime = runtime_override or {
                 "api_key": self.api_key,
                 "base_url": self.base_url,
@@ -2868,6 +2889,13 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            _otel_cbs = self._otel_shim.callbacks if self._otel_shim else {}
+            _inline_tui_cbs = {
+                "tool_start_callback":    self._on_tool_start if self._inline_diffs_enabled else None,
+                "tool_complete_callback": self._on_tool_complete if self._inline_diffs_enabled else None,
+            
+            }
+            _merged = merge_callbacks(_inline_tui_cbs, _otel_cbs)
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -7700,6 +7728,11 @@ class HermesCLI:
                         "error": _summary,
                     }
 
+            if self._otel_shim and self._otel_shim._otel_enabled:
+                self._otel_shim.start_trace(
+                   user_message=message if isinstance(message, str) else str(message)[:200]
+                )
+
             # Start agent in background thread (daemon so it cannot keep the
             # process alive when the user closes the terminal tab — SIGHUP
             # exits the main thread and daemon threads are reaped automatically).
@@ -7952,6 +7985,19 @@ class HermesCLI:
                 stop_event.set()
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
+            # ── OTel: close the trace span ──────────────────────────────────────
+            if self._otel_shim and self._otel_shim._trace_active:
+                response_text = (
+                    (result.get("final_response", "") if result else "")
+                    or ""
+                )
+                success = (
+                    result.get("completed", False) is True
+                    and not result.get("failed", False)
+                    and not result.get("partial", False)
+                    and response_text
+                )
+                self._otel_shim.end_trace(response_text, success=success)
     
     def _print_exit_summary(self):
         """Print session resume info on exit, similar to Claude Code."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1394,6 +1394,18 @@ class GatewayRunner:
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
+                _otel_shim = getattr(agent, "_otel_shim", None)
+                if _otel_shim and getattr(_otel_shim, "_otel_enabled", False):
+                    _otel_shim.record_runtime_event(
+                        "gateway.shutdown.interrupt_sent",
+                        session_key=session_key,
+                        reason=reason,
+                    )
+                    # Force-close in-flight trace spans during shutdown so
+                    # long-running turns are visible in Tempo even when the
+                    # process exits before normal run_conversation unwind.
+                    if getattr(_otel_shim, "_trace_active", False):
+                        _otel_shim.end_trace("Gateway shutdown interrupt", success=False)
                 agent.interrupt(reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key[:20])
             except Exception as e:
@@ -2029,6 +2041,18 @@ class GatewayRunner:
             timeout = self._restart_drain_timeout
             active_agents, timed_out = await self._drain_active_agents(timeout)
             if timed_out:
+                for _session_key, _agent in active_agents.items():
+                    try:
+                        _otel_shim = getattr(_agent, "_otel_shim", None)
+                        if _otel_shim and getattr(_otel_shim, "_otel_enabled", False):
+                            _otel_shim.record_runtime_event(
+                                "gateway.shutdown.drain_timeout",
+                                timeout_seconds=timeout,
+                                active_agents=self._running_agent_count(),
+                                session_key=_session_key,
+                            )
+                    except Exception:
+                        pass
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
                     timeout,
@@ -2041,6 +2065,20 @@ class GatewayRunner:
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
+                if self._running_agents:
+                    for _session_key, _agent in list(self._running_agents.items()):
+                        if _agent is _AGENT_PENDING_SENTINEL:
+                            continue
+                        try:
+                            _otel_shim = getattr(_agent, "_otel_shim", None)
+                            if _otel_shim and getattr(_otel_shim, "_otel_enabled", False):
+                                _otel_shim.record_runtime_event(
+                                    "gateway.shutdown.interrupt_incomplete",
+                                    session_key=_session_key,
+                                    active_agents=self._running_agent_count(),
+                                )
+                        except Exception:
+                            pass
 
             if self._restart_requested and self._restart_detached:
                 try:
@@ -8114,6 +8152,7 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             # OTel observability — wrap run_conversation with traces
             _otel_shim = getattr(agent, '_otel_shim', None)
+            _otel_enabled = bool(_otel_shim and getattr(_otel_shim, "_otel_enabled", False))
             _otel_debug = []
             if _otel_shim is None and _otel_shim_class is not None:
                 _otel_debug.append("shim_class available, creating instance")
@@ -8129,6 +8168,7 @@ class GatewayRunner:
                 )
                 agent._otel_shim = _otel_shim
                 _otel_debug.append(f"shim._otel_enabled={_otel_shim._otel_enabled}")
+                _otel_enabled = bool(getattr(_otel_shim, "_otel_enabled", False))
                 # Merge OTel callbacks with gateway's existing callbacks
                 if _merge_callbacks and hasattr(agent, 'tool_start_callback'):
                     _existing = {
@@ -8153,22 +8193,26 @@ class GatewayRunner:
                     "profile":    get_active_profile_name() or "default",
                 })
                 _otel_shim._conversation_id = session_id or _otel_shim._conversation_id
+                _otel_enabled = bool(getattr(_otel_shim, "_otel_enabled", False))
             else:
                 _otel_debug.append("shim_class is None — OTel not available")
+            if _otel_shim and not _otel_enabled:
+                _otel_debug.append("shim disabled — OTEL_ENABLED=false or SDK unavailable")
             logger.info("OTEL_GATEWAY: %s", " | ".join(_otel_debug))
 
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                if _otel_shim:
+                if _otel_enabled:
                     logger.info("OTEL_GATEWAY: calling start_trace message_len=%d", len(message))
                     _otel_shim.start_trace(message)
                 try:
                     result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
                 finally:
-                    if _otel_shim:
-                        _otel_shim.end_trace(result.get("final_response", ""), success=not result.get("error"))
+                    if _otel_enabled and getattr(_otel_shim, "_trace_active", False):
+                        _result = result if isinstance(result, dict) else {}
+                        _otel_shim.end_trace(_result.get("final_response", ""), success=not _result.get("error"))
             except Exception as _otel_exc:
-                if _otel_shim:
+                if _otel_enabled and getattr(_otel_shim, "_trace_active", False):
                     _otel_shim.record_error(str(_otel_exc), type(_otel_exc).__name__)
                     _otel_shim.end_trace(str(_otel_exc), success=False)
                 raise
@@ -8388,8 +8432,11 @@ class GatewayRunner:
         _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 600))
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
+        _notify_last_signature = None
+        _notify_repeat_count = 0
 
         async def _notify_long_running():
+            nonlocal _notify_last_signature, _notify_repeat_count
             if _NOTIFY_INTERVAL is None:
                 return  # Notifications disabled (gateway_notify_interval: 0)
             _notify_adapter = self.adapters.get(source.platform)
@@ -8401,6 +8448,7 @@ class GatewayRunner:
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
                 _status_detail = ""
+                _a = {}
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
@@ -8418,6 +8466,36 @@ class GatewayRunner:
                         f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
                         metadata=_status_thread_metadata,
                     )
+                    _otel_shim = getattr(_agent_ref, "_otel_shim", None) if _agent_ref else None
+                    if _otel_shim and getattr(_otel_shim, "_otel_enabled", False):
+                        _signature = (
+                            _a.get("api_call_count", 0),
+                            _a.get("current_tool") or "",
+                            _a.get("last_activity_desc") or "",
+                        )
+                        if _signature == _notify_last_signature:
+                            _notify_repeat_count += 1
+                        else:
+                            _notify_repeat_count = 0
+                            _notify_last_signature = _signature
+                        _otel_shim.record_runtime_event(
+                            "gateway.agent.still_working",
+                            elapsed_minutes=_elapsed_mins,
+                            api_call_count=_a.get("api_call_count", 0),
+                            max_iterations=_a.get("max_iterations", 0),
+                            current_tool=_a.get("current_tool") or "",
+                            seconds_since_activity=round(float(_a.get("seconds_since_activity", 0.0)), 3),
+                        )
+                        # Same state reported repeatedly strongly suggests a stuck tool/subagent.
+                        if _notify_repeat_count >= 2:
+                            _otel_shim.record_runtime_event(
+                                "gateway.agent.possible_stuck",
+                                repeat_notifications=_notify_repeat_count + 1,
+                                api_call_count=_a.get("api_call_count", 0),
+                                current_tool=_a.get("current_tool") or "",
+                                last_activity_desc=_a.get("last_activity_desc", "")[:240],
+                                seconds_since_activity=round(float(_a.get("seconds_since_activity", 0.0)), 3),
+                            )
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
@@ -8500,6 +8578,16 @@ class GatewayRunner:
                     if (not _warning_fired and _agent_warning is not None
                             and _idle_secs >= _agent_warning):
                         _warning_fired = True
+                        _otel_warn_shim = getattr(_agent_ref, "_otel_shim", None) if _agent_ref else None
+                        if _otel_warn_shim and getattr(_otel_warn_shim, "_otel_enabled", False):
+                            _otel_warn_shim.record_runtime_event(
+                                "gateway.agent.inactivity_warning",
+                                idle_seconds=round(float(_idle_secs), 3),
+                                warning_threshold_seconds=_agent_warning,
+                                timeout_seconds=_agent_timeout,
+                                api_call_count=_act.get("api_call_count", 0) if isinstance(_act, dict) else 0,
+                                current_tool=(_act.get("current_tool", "") if isinstance(_act, dict) else ""),
+                            )
                         _warn_adapter = self.adapters.get(source.platform)
                         if _warn_adapter:
                             _elapsed_warn = int(_agent_warning // 60) or 1
@@ -8559,6 +8647,17 @@ class GatewayRunner:
                     _last_desc, _iter_n, _iter_max,
                     _cur_tool or "none",
                 )
+                _timeout_shim = getattr(_timed_out_agent, "_otel_shim", None) if _timed_out_agent else None
+                if _timeout_shim and getattr(_timeout_shim, "_otel_enabled", False):
+                    _timeout_shim.record_runtime_event(
+                        "gateway.agent.inactivity_timeout",
+                        idle_seconds=round(float(_secs_ago), 3),
+                        timeout_seconds=_agent_timeout,
+                        current_tool=_cur_tool or "",
+                        last_activity_desc=str(_last_desc)[:240],
+                        api_call_count=_iter_n,
+                        max_iterations=_iter_max,
+                    )
 
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -243,6 +243,14 @@ from gateway.config import (
     GatewayConfig,
     load_gateway_config,
 )
+
+# OTel observability shim — auto-activated when OTEL_ENABLED=true
+try:
+    from agent.otel_shim import OtelShim, merge_callbacks as _merge_callbacks
+    _otel_shim_class = OtelShim
+except ImportError:
+    _otel_shim_class = None
+    _merge_callbacks = None
 from gateway.session import (
     SessionStore,
     SessionSource,
@@ -8104,9 +8112,66 @@ class GatewayRunner:
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
+            # OTel observability — wrap run_conversation with traces
+            _otel_shim = getattr(agent, '_otel_shim', None)
+            _otel_debug = []
+            if _otel_shim is None and _otel_shim_class is not None:
+                _otel_debug.append("shim_class available, creating instance")
+                from hermes_cli.profiles import get_active_profile_name
+                _otel_shim = _otel_shim_class(
+                    agent,
+                    conversation_id=session_id,
+                    extra_attributes={
+                        "user.id":    source.user_id or "",
+                        "platform":   source.platform.value if source.platform else "",
+                        "profile":    get_active_profile_name() or "default",
+                    },
+                )
+                agent._otel_shim = _otel_shim
+                _otel_debug.append(f"shim._otel_enabled={_otel_shim._otel_enabled}")
+                # Merge OTel callbacks with gateway's existing callbacks
+                if _merge_callbacks and hasattr(agent, 'tool_start_callback'):
+                    _existing = {
+                        k: getattr(agent, k, None)
+                        for k in ('tool_start_callback', 'tool_complete_callback',
+                                  'thinking_callback', 'step_callback', 'status_callback',
+                                  'clarify_callback', 'stream_delta_callback')
+                    }
+                    _merged = _merge_callbacks(_otel_shim.callbacks, _existing)
+                    for _k, _v in _merged.items():
+                        setattr(agent, _k, _v)
+                    _otel_debug.append(f"merged {len(_merged)} callbacks")
+                else:
+                    _otel_debug.append("merge_callbacks unavailable or agent lacks callbacks")
+            elif _otel_shim is not None:
+                _otel_debug.append("shim already attached")
+                # Refresh labels so this conversation gets the right user/platform/profile
+                from hermes_cli.profiles import get_active_profile_name
+                _otel_shim._extra.update({
+                    "user.id":    source.user_id or "",
+                    "platform":   source.platform.value if source.platform else "",
+                    "profile":    get_active_profile_name() or "default",
+                })
+                _otel_shim._conversation_id = session_id or _otel_shim._conversation_id
+            else:
+                _otel_debug.append("shim_class is None — OTel not available")
+            logger.info("OTEL_GATEWAY: %s", " | ".join(_otel_debug))
+
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                if _otel_shim:
+                    logger.info("OTEL_GATEWAY: calling start_trace message_len=%d", len(message))
+                    _otel_shim.start_trace(message)
+                try:
+                    result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                finally:
+                    if _otel_shim:
+                        _otel_shim.end_trace(result.get("final_response", ""), success=not result.get("error"))
+            except Exception as _otel_exc:
+                if _otel_shim:
+                    _otel_shim.record_error(str(_otel_exc), type(_otel_exc).__name__)
+                    _otel_shim.end_trace(str(_otel_exc), success=False)
+                raise
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/otel/grafana/hermes_observability_dashboard.json
+++ b/otel/grafana/hermes_observability_dashboard.json
@@ -1,0 +1,1944 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Profile = $profiles",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(hermes_queries_total{profile=\"$profiles\"}[$interval])",
+          "legendFormat": "{{query_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queries / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(hermes_tool_calls_total{profile=\"$profiles\"}[$interval])",
+          "legendFormat": "{{tool_name}} ({{tool_type}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Calls / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "hermes_queries_total{profile=\"$profiles\"}",
+          "legendFormat": "{{query_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Queries by Type",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 6,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 11
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sort(hermes_tool_calls_total{profile=\"$profiles\"})",
+          "legendFormat": "{{tool_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Tool Calls by Tool",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 14,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(hermes_queries_total{profile=\"$profiles\"})",
+          "legendFormat": "Total Queries",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Queries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "min": 0,
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "showUnfilled": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "hermes_active_conversations{profile=\"$profiles\"}",
+          "legendFormat": "{{conversation_state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Conversations",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Query Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p50 {{tool_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p95 {{tool_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p99 {{tool_name}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Tool Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "LLM Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(hermes_errors_total{profile=\"$profiles\"}[$interval])",
+          "legendFormat": "{{tool_name}} Agent",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(hermes_llm_errors_total{profile=\"$profiles\"}[$interval])",
+          "legendFormat": "llm.{{tool_name}} LLM",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Errors / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
+          "legendFormat": "spans received",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
+          "legendFormat": "metric pts received",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
+          "legendFormat": "spans exported",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "OTel Collector - Spans & Metrics throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(traces_spanmetrics_calls_total{service=\"hermes-agent\"}[$interval])",
+          "legendFormat": "{{span_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Calls / sec (spanmetrics)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.50, sum by (le)( rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Trace Duration (p50/p95/p99 spanmetrics)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 3,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "blue",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hermes_conversation_state_ratio{service_name=\"hermes-agent\"}",
+          "legendFormat": "{{conversation_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Conversation State (0=idle, 1=thinking, 2=tool, 3=waiting)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 15,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "min": 0,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (conversation_state) (hermes_conversation_state_ratio{service_name=\"hermes-agent\"})",
+          "legendFormat": "{{conversation_state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Conversations by State",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{conversation_state}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{conversation_state}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{conversation_state}}",
+          "refId": "C"
+        }
+      ],
+      "title": "State Duration by State (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "spanID"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "filters": [
+            {
+              "id": "Service",
+              "operator": "=",
+              "value": [
+                "hermes-agent"
+              ]
+            }
+          ],
+          "limit": 50,
+          "metricsQueryType": "range",
+          "query": "{status=ok}",
+          "queryType": "traceql",
+          "refId": "A",
+          "serviceMapUseNativeHistograms": false,
+          "tableType": "traces"
+        }
+      ],
+      "title": "Trace List (hermes-agent)",
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 42,
+  "tags": [
+    "hermes",
+    "opentelemetry"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "query_result(count by (profile) (hermes_queries_total))",
+        "description": "",
+        "label": "Profiles",
+        "name": "profiles",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(count by (profile) (hermes_queries_total))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*profile=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "548784714",
+          "value": "548784714"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "query_result(count by (user_id) (hermes_queries_total))",
+        "label": "Users",
+        "name": "user_id",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(count by (user_id) (hermes_queries_total))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*user_id=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "telegram",
+          "value": "telegram"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "query_result(count by (platform) (hermes_queries_total))",
+        "label": "Platforms",
+        "name": "platforms",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(count by (platform) (hermes_queries_total))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*platform=\"([^\"]*).*/",
+        "regexApplyTo": "value",
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "5m",
+          "value": "5m"
+        },
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "2m",
+            "value": "2m"
+          },
+          {
+            "selected": false,
+            "text": "3m",
+            "value": "3m"
+          },
+          {
+            "selected": true,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "20m",
+            "value": "20m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,2m,3m,5m,10m,20m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Hermes Agent - Observability",
+  "uid": "adc4mvw",
+  "version": 18,
+  "weekStart": ""
+}

--- a/otel/grafana/hermes_observability_dashboard.json
+++ b/otel/grafana/hermes_observability_dashboard.json
@@ -21,7 +21,7 @@
     "links": [],
     "panels": [
       {
-        "collapsed": true,
+        "collapsed": false,
         "gridPos": {
           "h": 1,
           "w": 24,
@@ -29,6 +29,2183 @@
           "y": 0
         },
         "id": 18,
+        "panels": [],
+        "title": "Profile = $profiles",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 1
+        },
+        "id": 22,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "rate(hermes_queries_total{profile=\"$profiles\"}[$interval])",
+            "legendFormat": "{{query_type}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Queries / sec",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(hermes_tool_calls_total{profile=\"$profiles\"}[$interval])",
+            "legendFormat": "{{tool_name}} ({{tool_type}})",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Tool Calls / sec",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 0,
+          "y": 9
+        },
+        "id": 3,
+        "options": {
+          "displayMode": "gradient",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "hermes_queries_total{profile=\"$profiles\"}",
+            "legendFormat": "{{query_type}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total Queries by Type",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 6,
+          "y": 9
+        },
+        "id": 4,
+        "options": {
+          "displayMode": "gradient",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "text": {
+            "titleSize": 11
+          },
+          "valueMode": "color"
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "sort(hermes_tool_calls_total{profile=\"$profiles\"})",
+            "legendFormat": "{{tool_name}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total Tool Calls by Tool",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 4,
+          "x": 14,
+          "y": 9
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "sum(hermes_queries_total{profile=\"$profiles\"})",
+            "legendFormat": "Total Queries",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total Queries",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 18,
+          "y": 9
+        },
+        "id": 6,
+        "options": {
+          "min": 0,
+          "minVizHeight": 75,
+          "minVizWidth": 75,
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "showUnfilled": true,
+          "sizing": "auto"
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "hermes_active_conversations{profile=\"$profiles\"}",
+            "legendFormat": "{{conversation_state}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Active Conversations",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "tempo"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 30,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "filters": [
+              {
+                "id": "Service",
+                "operator": "=",
+                "value": [
+                  "hermes-agent"
+                ]
+              }
+            ],
+            "limit": 50,
+            "metricsQueryType": "range",
+            "query": "{ span:name =~ \"llm.chat.*\"} ",
+            "queryType": "traceql",
+            "refId": "A",
+            "serviceMapUseNativeHistograms": false,
+            "tableType": "traces"
+          }
+        ],
+        "title": "Trace List (hermes-agent) LLM Duration",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 23
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.5, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p50",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p95",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p99",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Query Latency (p50/p95/p99)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 23
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p50 {{tool_name}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p95 {{tool_name}}",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p99 {{tool_name}}",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Tool Latency (p50/p95/p99)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 23
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.50, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p50",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p95",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+            "legendFormat": "p99",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "LLM Latency (p50/p95/p99)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 0,
+          "y": 30
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(hermes_errors_total{profile=\"$profiles\"}[$interval])",
+            "legendFormat": "{{tool_name}} Agent",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(hermes_llm_errors_total{profile=\"$profiles\"}[$interval])",
+            "legendFormat": "llm.{{tool_name}} LLM",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Errors / sec",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 6,
+          "y": 30
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
+            "legendFormat": "spans received",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
+            "legendFormat": "metric pts received",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
+            "legendFormat": "spans exported",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "OTel Collector - Spans & Metrics throughput",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "cps"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 30
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "rate(traces_spanmetrics_calls_total{service=\"hermes-agent\"}[$interval])",
+            "legendFormat": "{{span_name}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Trace Calls / sec (spanmetrics)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "p50"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "p95"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "p99"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 37
+        },
+        "id": 17,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "builder",
+            "expr": "histogram_quantile(0.50, sum by (le)( rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+            "legendFormat": "p50",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+            "legendFormat": "p95",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+            "legendFormat": "p99",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Trace Duration (p50/p95/p99 spanmetrics)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "blue",
+                  "value": 1
+                },
+                {
+                  "color": "orange",
+                  "value": 2
+                },
+                {
+                  "color": "red",
+                  "value": 3
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 37
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "hermes_conversation_state_ratio{service_name=\"hermes-agent\"}",
+            "legendFormat": "{{conversation_id}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Conversation State (0=idle, 1=thinking, 2=tool, 3=waiting)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 3
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 44
+        },
+        "id": 15,
+        "options": {
+          "displayMode": "gradient",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "min": 0,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "sum by (conversation_state) (hermes_conversation_state_ratio{service_name=\"hermes-agent\"})",
+            "legendFormat": "{{conversation_state}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Active Conversations by State",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 45
+        },
+        "id": 14,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "histogram_quantile(0.50, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+            "legendFormat": "p50 {{conversation_state}}",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "histogram_quantile(0.95, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+            "legendFormat": "p95 {{conversation_state}}",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "expr": "histogram_quantile(0.99, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+            "legendFormat": "p99 {{conversation_state}}",
+            "refId": "C"
+          }
+        ],
+        "title": "State Duration by State (p50/p95/p99)",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 53
+        },
+        "id": 27,
+        "panels": [],
+        "title": "Traces",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "tempo"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 16,
+          "x": 0,
+          "y": 54
+        },
+        "id": 16,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Start time"
+            }
+          ]
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "filters": [
+              {
+                "id": "Service",
+                "operator": "=",
+                "value": [
+                  "hermes-agent"
+                ]
+              }
+            ],
+            "limit": 50,
+            "metricsQueryType": "instant",
+            "query": "{status=ok && span:name =~ \"agent.*\"} ",
+            "queryType": "traceql",
+            "refId": "A",
+            "serviceMapUseNativeHistograms": false,
+            "spss": 20,
+            "tableType": "traces"
+          }
+        ],
+        "title": "Trace List (hermes-agent) AgentQuery Success",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "tempo"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 8,
+          "x": 16,
+          "y": 54
+        },
+        "id": 26,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Start time"
+            }
+          ]
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "filters": [
+              {
+                "id": "Service",
+                "operator": "=",
+                "value": [
+                  "hermes-agent"
+                ]
+              }
+            ],
+            "limit": 50,
+            "metricsQueryType": "range",
+            "query": "{status=error && span:name =~ \"agent.query.*\"} ",
+            "queryType": "traceql",
+            "refId": "A",
+            "serviceMapUseNativeHistograms": false,
+            "tableType": "traces"
+          }
+        ],
+        "title": "Trace List (hermes-agent) AgentQuery Errored",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "tempo"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "nested"
+              },
+              "properties": []
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 24,
+          "x": 0,
+          "y": 64
+        },
+        "id": 29,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Start time"
+            }
+          ]
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "filters": [
+              {
+                "id": "Service",
+                "operator": "=",
+                "value": [
+                  "hermes-agent"
+                ]
+              }
+            ],
+            "limit": 50,
+            "metricsQueryType": "range",
+            "query": "{status=ok && span:name !~ \"agent.query.*\"} ",
+            "queryType": "traceql",
+            "refId": "A",
+            "serviceMapUseNativeHistograms": false,
+            "tableType": "traces"
+          }
+        ],
+        "title": "Trace List (hermes-agent) Other than AgentQuery",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "tempo",
+          "uid": "tempo"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "footer": {
+                "reducers": []
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 75
+        },
+        "id": 21,
+        "options": {
+          "cellHeight": "sm",
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Duration"
+            }
+          ]
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "filters": [
+              {
+                "id": "Service",
+                "operator": "=",
+                "value": [
+                  "hermes-agent"
+                ]
+              }
+            ],
+            "limit": 50,
+            "metricsQueryType": "range",
+            "query": "{status=error}",
+            "queryType": "traceql",
+            "refId": "A",
+            "serviceMapUseNativeHistograms": false,
+            "tableType": "traces"
+          }
+        ],
+        "title": "Trace List (hermes-agent) Errored Out",
+        "type": "table"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 84
+        },
+        "id": 20,
+        "panels": [],
+        "title": "Logs of Hermes",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 16,
+          "w": 24,
+          "x": 0,
+          "y": 85
+        },
+        "id": 19,
+        "options": {
+          "dedupStrategy": "none",
+          "enableInfiniteScrolling": false,
+          "enableLogDetails": true,
+          "showControls": false,
+          "showTime": false,
+          "sortOrder": "Descending",
+          "unwrappedColumns": false,
+          "wrapLogMessage": false
+        },
+        "pluginVersion": "12.4.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "direction": "backward",
+            "editorMode": "code",
+            "expr": "{app=\"hermes-agent\"}",
+            "queryType": "range",
+            "refId": "A"
+          }
+        ],
+        "title": "Logs",
+        "type": "logs"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 101
+        },
+        "id": 24,
         "panels": [
           {
             "datasource": {
@@ -96,7 +2273,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 1
+              "y": 340
             },
             "id": 1,
             "options": {
@@ -119,14 +2296,14 @@
                   "type": "prometheus",
                   "uid": "prometheus"
                 },
-                "editorMode": "builder",
-                "expr": "rate(hermes_queries_total{profile=\"$profiles\"}[$interval])",
-                "legendFormat": "{{query_type}}",
+                "editorMode": "code",
+                "expr": "sum by (subagent_outcome) (\r\n  increase(hermes_subagent_outcome_total{job=\"hermes-agent\"}[$interval])\r\n)",
+                "legendFormat": "{{subagent_outcome}}",
                 "range": true,
                 "refId": "A"
               }
             ],
-            "title": "Queries / sec",
+            "title": "subagent outcome",
             "type": "timeseries"
           },
           {
@@ -187,7 +2364,7 @@
                     }
                   ]
                 },
-                "unit": "cps"
+                "unit": "reqps"
               },
               "overrides": []
             },
@@ -195,399 +2372,9 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 1
+              "y": 340
             },
-            "id": 2,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "rate(hermes_tool_calls_total{profile=\"$profiles\"}[$interval])",
-                "legendFormat": "{{tool_name}} ({{tool_type}})",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Tool Calls / sec",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 6,
-              "x": 0,
-              "y": 9
-            },
-            "id": 3,
-            "options": {
-              "displayMode": "gradient",
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": false
-              },
-              "maxVizHeight": 300,
-              "minVizHeight": 16,
-              "minVizWidth": 8,
-              "namePlacement": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": true,
-              "sizing": "auto",
-              "valueMode": "color"
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "hermes_queries_total{profile=\"$profiles\"}",
-                "legendFormat": "{{query_type}}",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Total Queries by Type",
-            "type": "bargauge"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 6,
-              "y": 9
-            },
-            "id": 4,
-            "options": {
-              "displayMode": "gradient",
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": false
-              },
-              "maxVizHeight": 300,
-              "minVizHeight": 16,
-              "minVizWidth": 8,
-              "namePlacement": "auto",
-              "orientation": "horizontal",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": true,
-              "sizing": "auto",
-              "text": {
-                "titleSize": 11
-              },
-              "valueMode": "color"
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "sort(hermes_tool_calls_total{profile=\"$profiles\"})",
-                "legendFormat": "{{tool_name}}",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Total Tool Calls by Tool",
-            "type": "bargauge"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 4,
-              "x": 14,
-              "y": 9
-            },
-            "id": 5,
-            "options": {
-              "colorMode": "value",
-              "graphMode": "area",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "sum(hermes_queries_total{profile=\"$profiles\"})",
-                "legendFormat": "Total Queries",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Total Queries",
-            "type": "stat"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 1
-                    },
-                    {
-                      "color": "red",
-                      "value": 5
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 6,
-              "x": 18,
-              "y": 9
-            },
-            "id": 6,
-            "options": {
-              "min": 0,
-              "minVizHeight": 75,
-              "minVizWidth": 75,
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showThresholdLabels": false,
-              "showThresholdMarkers": true,
-              "showUnfilled": true,
-              "sizing": "auto"
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "hermes_active_conversations{profile=\"$profiles\"}",
-                "legendFormat": "{{conversation_state}}",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Active Conversations",
-            "type": "gauge"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 0,
-              "y": 16
-            },
-            "id": 7,
+            "id": 23,
             "options": {
               "legend": {
                 "calcs": [],
@@ -609,35 +2396,13 @@
                   "uid": "prometheus"
                 },
                 "editorMode": "code",
-                "expr": "histogram_quantile(0.5, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p50",
+                "expr": "avg by (subagent_outcome) (\r\n  rate(hermes_subagent_duration_seconds_sum{job=\"hermes-agent\"}[$__interval])\r\n)\r\n/\r\navg by (subagent_outcome) (\r\n  rate(hermes_subagent_duration_seconds_count{job=\"hermes-agent\"}[$__interval])\r\n)",
+                "legendFormat": "{{subagent_outcome}}",
                 "range": true,
                 "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.95, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p95",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.99, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p99",
-                "range": true,
-                "refId": "C"
               }
             ],
-            "title": "Query Latency (p50/p95/p99)",
+            "title": "subagent outcome",
             "type": "timeseries"
           },
           {
@@ -698,639 +2463,22 @@
                     }
                   ]
                 },
-                "unit": "s"
+                "unit": "reqps"
               },
               "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 8,
-              "y": 16
-            },
-            "id": 8,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.50, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p50 {{tool_name}}",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.95, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p95 {{tool_name}}",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.99, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p99 {{tool_name}}",
-                "range": true,
-                "refId": "C"
-              }
-            ],
-            "title": "Tool Latency (p50/p95/p99)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 16,
-              "y": 16
-            },
-            "id": 9,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.50, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p50",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.95, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p95",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.99, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-                "legendFormat": "p99",
-                "range": true,
-                "refId": "C"
-              }
-            ],
-            "title": "LLM Latency (p50/p95/p99)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "cps"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 6,
-              "x": 0,
-              "y": 23
-            },
-            "id": 10,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "rate(hermes_errors_total{profile=\"$profiles\"}[$interval])",
-                "legendFormat": "{{tool_name}} Agent",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "rate(hermes_llm_errors_total{profile=\"$profiles\"}[$interval])",
-                "legendFormat": "llm.{{tool_name}} LLM",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Errors / sec",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "cps"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 6,
-              "x": 6,
-              "y": 23
-            },
-            "id": 11,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
-                "legendFormat": "spans received",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
-                "legendFormat": "metric pts received",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
-                "legendFormat": "spans exported",
-                "range": true,
-                "refId": "C"
-              }
-            ],
-            "title": "OTel Collector - Spans & Metrics throughput",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "cps"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 12,
-              "x": 12,
-              "y": 23
-            },
-            "id": 12,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "builder",
-                "expr": "rate(traces_spanmetrics_calls_total{service=\"hermes-agent\"}[$interval])",
-                "legendFormat": "{{span_name}}",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Trace Calls / sec (spanmetrics)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "p50"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "p95"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "yellow",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "p99"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
             },
             "gridPos": {
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 30
+              "y": 348
             },
-            "id": 17,
+            "id": 25,
             "options": {
               "legend": {
                 "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
+                "displayMode": "table",
+                "placement": "right",
                 "showLegend": true
               },
               "tooltip": {
@@ -1346,36 +2494,14 @@
                   "type": "prometheus",
                   "uid": "prometheus"
                 },
-                "editorMode": "builder",
-                "expr": "histogram_quantile(0.50, sum by (le)( rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-                "legendFormat": "p50",
+                "editorMode": "code",
+                "expr": "increase(hermes_subagent_stalled_total{job=\"hermes-agent\"}[$__interval])",
+                "legendFormat": "{{subagent_outcome}}",
                 "range": true,
                 "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-                "legendFormat": "p95",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "editorMode": "code",
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-                "legendFormat": "p99",
-                "range": true,
-                "refId": "C"
               }
             ],
-            "title": "Trace Duration (p50/p95/p99 spanmetrics)",
+            "title": "stalled count",
             "type": "timeseries"
           },
           {
@@ -1396,7 +2522,7 @@
                   "axisPlacement": "auto",
                   "barAlignment": 0,
                   "barWidthFactor": 0.6,
-                  "drawStyle": "line",
+                  "drawStyle": "bars",
                   "fillOpacity": 0,
                   "gradientMode": "none",
                   "hideFrom": {
@@ -1422,9 +2548,8 @@
                     "mode": "off"
                   }
                 },
+                "decimals": 0,
                 "mappings": [],
-                "max": 3,
-                "min": 0,
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
@@ -1433,30 +2558,22 @@
                       "value": 0
                     },
                     {
-                      "color": "blue",
-                      "value": 1
-                    },
-                    {
-                      "color": "orange",
-                      "value": 2
-                    },
-                    {
                       "color": "red",
-                      "value": 3
+                      "value": 80
                     }
                   ]
                 },
-                "unit": "short"
+                "unit": "none"
               },
               "overrides": []
             },
             "gridPos": {
-              "h": 7,
+              "h": 8,
               "w": 12,
               "x": 12,
-              "y": 30
+              "y": 348
             },
-            "id": 13,
+            "id": 28,
             "options": {
               "legend": {
                 "calcs": [],
@@ -1477,349 +2594,18 @@
                   "type": "prometheus",
                   "uid": "prometheus"
                 },
-                "expr": "hermes_conversation_state_ratio{service_name=\"hermes-agent\"}",
-                "legendFormat": "{{conversation_id}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Conversation State (0=idle, 1=thinking, 2=tool, 3=waiting)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 1
-                    },
-                    {
-                      "color": "red",
-                      "value": 3
-                    }
-                  ]
-                },
-                "unit": "short"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 12,
-              "x": 12,
-              "y": 37
-            },
-            "id": 15,
-            "options": {
-              "displayMode": "gradient",
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": false
-              },
-              "maxVizHeight": 300,
-              "min": 0,
-              "minVizHeight": 16,
-              "minVizWidth": 8,
-              "namePlacement": "auto",
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": true,
-              "sizing": "auto",
-              "valueMode": "color"
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "expr": "sum by (conversation_state) (hermes_conversation_state_ratio{service_name=\"hermes-agent\"})",
-                "legendFormat": "{{conversation_state}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Active Conversations by State",
-            "type": "bargauge"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "s"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 38
-            },
-            "id": 14,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "right",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "expr": "histogram_quantile(0.50, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-                "legendFormat": "p50 {{conversation_state}}",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "expr": "histogram_quantile(0.95, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-                "legendFormat": "p95 {{conversation_state}}",
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "prometheus"
-                },
-                "expr": "histogram_quantile(0.99, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-                "legendFormat": "p99 {{conversation_state}}",
-                "refId": "C"
-              }
-            ],
-            "title": "State Duration by State (p50/p95/p99)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "type": "tempo",
-              "uid": "tempo"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "footer": {
-                    "reducers": []
-                  },
-                  "inspect": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 24,
-              "x": 0,
-              "y": 46
-            },
-            "id": 16,
-            "options": {
-              "cellHeight": "sm",
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": false,
-                  "displayName": "spanID"
-                }
-              ]
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "tempo",
-                  "uid": "tempo"
-                },
-                "filters": [
-                  {
-                    "id": "Service",
-                    "operator": "=",
-                    "value": [
-                      "hermes-agent"
-                    ]
-                  }
-                ],
-                "limit": 50,
-                "metricsQueryType": "range",
-                "query": "{status=ok}",
-                "queryType": "traceql",
-                "refId": "A",
-                "serviceMapUseNativeHistograms": false,
-                "tableType": "traces"
-              }
-            ],
-            "title": "Trace List (hermes-agent)",
-            "type": "table"
-          }
-        ],
-        "title": "Profile = $profiles",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 20,
-        "panels": [
-          {
-            "datasource": {
-              "type": "loki",
-              "uid": "loki"
-            },
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 11,
-              "w": 24,
-              "x": 0,
-              "y": 2
-            },
-            "id": 19,
-            "options": {
-              "dedupStrategy": "none",
-              "enableInfiniteScrolling": false,
-              "enableLogDetails": true,
-              "showControls": false,
-              "showTime": false,
-              "sortOrder": "Descending",
-              "unwrappedColumns": false,
-              "wrapLogMessage": false
-            },
-            "pluginVersion": "12.4.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "loki",
-                  "uid": "loki"
-                },
-                "direction": "backward",
                 "editorMode": "code",
-                "expr": "{app=\"hermes-agent\"}",
-                "queryType": "range",
+                "expr": "hermes_tool_stalled_total{job=\"hermes-agent\"}",
+                "legendFormat": "{{tool_name}}",
+                "range": true,
                 "refId": "A"
               }
             ],
-            "title": "Logs",
-            "type": "logs"
+            "title": "stalled count",
+            "type": "timeseries"
           }
         ],
-        "title": "Logs of Hermes",
+        "title": "subagent",
         "type": "row"
       }
     ],
@@ -1990,13 +2776,13 @@
       ]
     },
     "time": {
-      "from": "now-30m",
+      "from": "now-3h",
       "to": "now"
     },
     "timepicker": {},
     "timezone": "browser",
     "title": "Hermes Agent - Observability",
     "uid": "adc4mvw",
-    "version": 7,
+    "version": 33,
     "weekStart": ""
   }

--- a/otel/grafana/hermes_observability_dashboard.json
+++ b/otel/grafana/hermes_observability_dashboard.json
@@ -1,1944 +1,2002 @@
 {
-  "annotations": {
-    "list": [
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "links": [],
+    "panels": [
       {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
         },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "links": [],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 18,
-      "panels": [],
-      "title": "Profile = $profiles",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 1
-      },
-      "id": 1,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "rate(hermes_queries_total{profile=\"$profiles\"}[$interval])",
-          "legendFormat": "{{query_type}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Queries / sec",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "rate(hermes_tool_calls_total{profile=\"$profiles\"}[$interval])",
-          "legendFormat": "{{tool_name}} ({{tool_type}})",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Tool Calls / sec",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 9
-      },
-      "id": 3,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "hermes_queries_total{profile=\"$profiles\"}",
-          "legendFormat": "{{query_type}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Queries by Type",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 6,
-        "y": 9
-      },
-      "id": 4,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "text": {
-          "titleSize": 11
-        },
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "sort(hermes_tool_calls_total{profile=\"$profiles\"})",
-          "legendFormat": "{{tool_name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Tool Calls by Tool",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 14,
-        "y": 9
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "sum(hermes_queries_total{profile=\"$profiles\"})",
-          "legendFormat": "Total Queries",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Queries",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 9
-      },
-      "id": 6,
-      "options": {
-        "min": 0,
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "showUnfilled": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "hermes_active_conversations{profile=\"$profiles\"}",
-          "legendFormat": "{{conversation_state}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Active Conversations",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 16
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.5, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p95",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p99",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Query Latency (p50/p95/p99)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 16
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p50 {{tool_name}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p95 {{tool_name}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p99 {{tool_name}}",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Tool Latency (p50/p95/p99)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 16
-      },
-      "id": 9,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p95",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
-          "legendFormat": "p99",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "LLM Latency (p50/p95/p99)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 23
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(hermes_errors_total{profile=\"$profiles\"}[$interval])",
-          "legendFormat": "{{tool_name}} Agent",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(hermes_llm_errors_total{profile=\"$profiles\"}[$interval])",
-          "legendFormat": "llm.{{tool_name}} LLM",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Errors / sec",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 23
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
-          "legendFormat": "spans received",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
-          "legendFormat": "metric pts received",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
-          "legendFormat": "spans exported",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "OTel Collector - Spans & Metrics throughput",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 23
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "rate(traces_spanmetrics_calls_total{service=\"hermes-agent\"}[$interval])",
-          "legendFormat": "{{span_name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Trace Calls / sec (spanmetrics)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
+        "id": 18,
+        "panels": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "p50"
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
             },
-            "properties": [
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "reqps"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 1
+            },
+            "id": 1,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
               {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "rate(hermes_queries_total{profile=\"$profiles\"}[$interval])",
+                "legendFormat": "{{query_type}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Queries / sec",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "cps"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 1
+            },
+            "id": 2,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "rate(hermes_tool_calls_total{profile=\"$profiles\"}[$interval])",
+                "legendFormat": "{{tool_name}} ({{tool_type}})",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Tool Calls / sec",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 0,
+              "y": 9
+            },
+            "id": 3,
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "valueMode": "color"
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "hermes_queries_total{profile=\"$profiles\"}",
+                "legendFormat": "{{query_type}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Total Queries by Type",
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 6,
+              "y": 9
+            },
+            "id": 4,
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "text": {
+                "titleSize": 11
+              },
+              "valueMode": "color"
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "sort(hermes_tool_calls_total{profile=\"$profiles\"})",
+                "legendFormat": "{{tool_name}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Total Tool Calls by Tool",
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 4,
+              "x": 14,
+              "y": 9
+            },
+            "id": 5,
+            "options": {
+              "colorMode": "value",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "sum(hermes_queries_total{profile=\"$profiles\"})",
+                "legendFormat": "Total Queries",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Total Queries",
+            "type": "stat"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 18,
+              "y": 9
+            },
+            "id": 6,
+            "options": {
+              "min": 0,
+              "minVizHeight": 75,
+              "minVizWidth": 75,
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showThresholdLabels": false,
+              "showThresholdMarkers": true,
+              "showUnfilled": true,
+              "sizing": "auto"
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "hermes_active_conversations{profile=\"$profiles\"}",
+                "legendFormat": "{{conversation_state}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Active Conversations",
+            "type": "gauge"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 16
+            },
+            "id": 7,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, rate(hermes_query_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Query Latency (p50/p95/p99)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 16
+            },
+            "id": 8,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.50, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p50 {{tool_name}}",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p95 {{tool_name}}",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, rate(hermes_tool_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p99 {{tool_name}}",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Tool Latency (p50/p95/p99)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 16
+            },
+            "id": 9,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.50, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, rate(hermes_llm_latency_seconds_bucket{profile=\"$profiles\"}[$interval]))",
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "LLM Latency (p50/p95/p99)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "cps"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 0,
+              "y": 23
+            },
+            "id": 10,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "rate(hermes_errors_total{profile=\"$profiles\"}[$interval])",
+                "legendFormat": "{{tool_name}} Agent",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "rate(hermes_llm_errors_total{profile=\"$profiles\"}[$interval])",
+                "legendFormat": "llm.{{tool_name}} LLM",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Errors / sec",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "cps"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 6,
+              "y": 23
+            },
+            "id": 11,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
+                "legendFormat": "spans received",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
+                "legendFormat": "metric pts received",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
+                "legendFormat": "spans exported",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "OTel Collector - Spans & Metrics throughput",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "cps"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 12,
+              "y": 23
+            },
+            "id": 12,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "rate(traces_spanmetrics_calls_total{service=\"hermes-agent\"}[$interval])",
+                "legendFormat": "{{span_name}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Trace Calls / sec (spanmetrics)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
                 }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p95"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "yellow",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
                 }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p99"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 30
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "builder",
-          "expr": "histogram_quantile(0.50, sum by (le)( rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-          "legendFormat": "p50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-          "legendFormat": "p95",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
-          "legendFormat": "p99",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Trace Duration (p50/p95/p99 spanmetrics)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 3,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "blue",
-                "value": 1
-              },
-              {
-                "color": "orange",
-                "value": 2
-              },
-              {
-                "color": "red",
-                "value": 3
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 30
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hermes_conversation_state_ratio{service_name=\"hermes-agent\"}",
-          "legendFormat": "{{conversation_id}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Conversation State (0=idle, 1=thinking, 2=tool, 3=waiting)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 3
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 37
-      },
-      "id": 15,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "min": 0,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (conversation_state) (hermes_conversation_state_ratio{service_name=\"hermes-agent\"})",
-          "legendFormat": "{{conversation_state}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Active Conversations by State",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 38
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.50, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-          "legendFormat": "p50 {{conversation_state}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-          "legendFormat": "p95 {{conversation_state}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
-          "legendFormat": "p99 {{conversation_state}}",
-          "refId": "C"
-        }
-      ],
-      "title": "State Duration by State (p50/p95/p99)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "tempo",
-        "uid": "tempo"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 46
-      },
-      "id": 16,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "spanID"
-          }
-        ]
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "tempo",
-            "uid": "tempo"
-          },
-          "filters": [
-            {
-              "id": "Service",
-              "operator": "=",
-              "value": [
-                "hermes-agent"
               ]
-            }
-          ],
-          "limit": 50,
-          "metricsQueryType": "range",
-          "query": "{status=ok}",
-          "queryType": "traceql",
-          "refId": "A",
-          "serviceMapUseNativeHistograms": false,
-          "tableType": "traces"
-        }
-      ],
-      "title": "Trace List (hermes-agent)",
-      "type": "table"
-    }
-  ],
-  "preload": false,
-  "refresh": "10s",
-  "schemaVersion": 42,
-  "tags": [
-    "hermes",
-    "opentelemetry"
-  ],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "text": "default",
-          "value": "default"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "definition": "query_result(count by (profile) (hermes_queries_total))",
-        "description": "",
-        "label": "Profiles",
-        "name": "profiles",
-        "options": [],
-        "query": {
-          "qryType": 3,
-          "query": "query_result(count by (profile) (hermes_queries_total))",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/.*profile=\"([^\"]*).*/",
-        "regexApplyTo": "value",
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "548784714",
-          "value": "548784714"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "definition": "query_result(count by (user_id) (hermes_queries_total))",
-        "label": "Users",
-        "name": "user_id",
-        "options": [],
-        "query": {
-          "qryType": 3,
-          "query": "query_result(count by (user_id) (hermes_queries_total))",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/.*user_id=\"([^\"]*).*/",
-        "regexApplyTo": "value",
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "telegram",
-          "value": "telegram"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "definition": "query_result(count by (platform) (hermes_queries_total))",
-        "label": "Platforms",
-        "name": "platforms",
-        "options": [],
-        "query": {
-          "qryType": 3,
-          "query": "query_result(count by (platform) (hermes_queries_total))",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/.*platform=\"([^\"]*).*/",
-        "regexApplyTo": "value",
-        "type": "query"
-      },
-      {
-        "auto": false,
-        "auto_count": 30,
-        "auto_min": "10s",
-        "current": {
-          "text": "5m",
-          "value": "5m"
-        },
-        "name": "interval",
-        "options": [
-          {
-            "selected": false,
-            "text": "1m",
-            "value": "1m"
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 30
+            },
+            "id": 17,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "builder",
+                "expr": "histogram_quantile(0.50, sum by (le)( rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"hermes-agent\"}[5m])))",
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Trace Duration (p50/p95/p99 spanmetrics)",
+            "type": "timeseries"
           },
           {
-            "selected": false,
-            "text": "2m",
-            "value": "2m"
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "max": 3,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "blue",
+                      "value": 1
+                    },
+                    {
+                      "color": "orange",
+                      "value": 2
+                    },
+                    {
+                      "color": "red",
+                      "value": 3
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 12,
+              "y": 30
+            },
+            "id": 13,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "expr": "hermes_conversation_state_ratio{service_name=\"hermes-agent\"}",
+                "legendFormat": "{{conversation_id}}",
+                "refId": "A"
+              }
+            ],
+            "title": "Conversation State (0=idle, 1=thinking, 2=tool, 3=waiting)",
+            "type": "timeseries"
           },
           {
-            "selected": false,
-            "text": "3m",
-            "value": "3m"
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 3
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 12,
+              "y": 37
+            },
+            "id": 15,
+            "options": {
+              "displayMode": "gradient",
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "maxVizHeight": 300,
+              "min": 0,
+              "minVizHeight": 16,
+              "minVizWidth": 8,
+              "namePlacement": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "sizing": "auto",
+              "valueMode": "color"
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "expr": "sum by (conversation_state) (hermes_conversation_state_ratio{service_name=\"hermes-agent\"})",
+                "legendFormat": "{{conversation_state}}",
+                "refId": "A"
+              }
+            ],
+            "title": "Active Conversations by State",
+            "type": "bargauge"
           },
           {
-            "selected": true,
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 38
+            },
+            "id": 14,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "expr": "histogram_quantile(0.50, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+                "legendFormat": "p50 {{conversation_state}}",
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "expr": "histogram_quantile(0.95, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+                "legendFormat": "p95 {{conversation_state}}",
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "expr": "histogram_quantile(0.99, sum by (le, conversation_state) (rate(hermes_conversation_state_duration_seconds_bucket[5m])))",
+                "legendFormat": "p99 {{conversation_state}}",
+                "refId": "C"
+              }
+            ],
+            "title": "State Duration by State (p50/p95/p99)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "tempo"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                    "type": "auto"
+                  },
+                  "footer": {
+                    "reducers": []
+                  },
+                  "inspect": false
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 24,
+              "x": 0,
+              "y": 46
+            },
+            "id": 16,
+            "options": {
+              "cellHeight": "sm",
+              "showHeader": true,
+              "sortBy": [
+                {
+                  "desc": false,
+                  "displayName": "spanID"
+                }
+              ]
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "tempo",
+                  "uid": "tempo"
+                },
+                "filters": [
+                  {
+                    "id": "Service",
+                    "operator": "=",
+                    "value": [
+                      "hermes-agent"
+                    ]
+                  }
+                ],
+                "limit": 50,
+                "metricsQueryType": "range",
+                "query": "{status=ok}",
+                "queryType": "traceql",
+                "refId": "A",
+                "serviceMapUseNativeHistograms": false,
+                "tableType": "traces"
+              }
+            ],
+            "title": "Trace List (hermes-agent)",
+            "type": "table"
+          }
+        ],
+        "title": "Profile = $profiles",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "id": 20,
+        "panels": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "fieldConfig": {
+              "defaults": {},
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 11,
+              "w": 24,
+              "x": 0,
+              "y": 2
+            },
+            "id": 19,
+            "options": {
+              "dedupStrategy": "none",
+              "enableInfiniteScrolling": false,
+              "enableLogDetails": true,
+              "showControls": false,
+              "showTime": false,
+              "sortOrder": "Descending",
+              "unwrappedColumns": false,
+              "wrapLogMessage": false
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "direction": "backward",
+                "editorMode": "code",
+                "expr": "{app=\"hermes-agent\"}",
+                "queryType": "range",
+                "refId": "A"
+              }
+            ],
+            "title": "Logs",
+            "type": "logs"
+          }
+        ],
+        "title": "Logs of Hermes",
+        "type": "row"
+      }
+    ],
+    "preload": false,
+    "refresh": "10s",
+    "schemaVersion": 42,
+    "tags": [
+      "hermes",
+      "opentelemetry"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "default",
+            "value": "default"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "definition": "query_result(count by (profile) (hermes_queries_total))",
+          "description": "",
+          "label": "Profiles",
+          "name": "profiles",
+          "options": [],
+          "query": {
+            "qryType": 3,
+            "query": "query_result(count by (profile) (hermes_queries_total))",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 2,
+          "regex": "/.*profile=\"([^\"]*).*/",
+          "regexApplyTo": "value",
+          "type": "query"
+        },
+        {
+          "current": {
+            "text": "548784714",
+            "value": "548784714"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "definition": "query_result(count by (user_id) (hermes_queries_total))",
+          "label": "Users",
+          "name": "user_id",
+          "options": [],
+          "query": {
+            "qryType": 3,
+            "query": "query_result(count by (user_id) (hermes_queries_total))",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 2,
+          "regex": "/.*user_id=\"([^\"]*).*/",
+          "regexApplyTo": "value",
+          "type": "query"
+        },
+        {
+          "current": {
+            "text": "telegram",
+            "value": "telegram"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "definition": "query_result(count by (platform) (hermes_queries_total))",
+          "label": "Platforms",
+          "name": "platforms",
+          "options": [],
+          "query": {
+            "qryType": 3,
+            "query": "query_result(count by (platform) (hermes_queries_total))",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 2,
+          "regex": "/.*platform=\"([^\"]*).*/",
+          "regexApplyTo": "value",
+          "type": "query"
+        },
+        {
+          "auto": false,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
             "text": "5m",
             "value": "5m"
           },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "20m",
-            "value": "20m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
-          }
-        ],
-        "query": "1m,2m,3m,5m,10m,20m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "refresh": 2,
-        "type": "interval"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-3h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "browser",
-  "title": "Hermes Agent - Observability",
-  "uid": "adc4mvw",
-  "version": 18,
-  "weekStart": ""
-}
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "2m",
+              "value": "2m"
+            },
+            {
+              "selected": false,
+              "text": "3m",
+              "value": "3m"
+            },
+            {
+              "selected": true,
+              "text": "5m",
+              "value": "5m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "20m",
+              "value": "20m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "1m,2m,3m,5m,10m,20m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Hermes Agent - Observability",
+    "uid": "adc4mvw",
+    "version": 7,
+    "weekStart": ""
+  }

--- a/otel/otel-lgtm/otelcol-config.yaml
+++ b/otel/otel-lgtm/otelcol-config.yaml
@@ -1,0 +1,66 @@
+connectors:
+  spanmetrics:
+    dimensions:
+      - name: user_id
+      - name: platform
+      - name: profile
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - "http://*"
+  prometheus/collector:
+    config:
+      scrape_configs:
+        - job_name: "opentelemetry-collector"
+          scrape_interval: 1s
+          static_configs:
+            - targets: ["127.0.0.1:8888"]
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: "/ready"
+
+processors:
+  batch:
+
+exporters:
+  otlp_http/metrics:
+    endpoint: http://127.0.0.1:9090/api/v1/otlp
+    tls:
+      insecure: true
+  otlp_http/traces:
+    endpoint: http://127.0.0.1:4418
+    tls:
+      insecure: true
+  otlp_http/logs:
+    endpoint: http://127.0.0.1:3100/otlp
+    tls:
+      insecure: true
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp_http/traces, spanmetrics]
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      processors: [batch]
+      exporters: [otlp_http/metrics]
+    metrics:
+      receivers: [otlp, prometheus/collector]
+      processors: [batch]
+      exporters: [otlp_http/metrics]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp_http/logs]

--- a/otel/promtail/promtail-config.yaml
+++ b/otel/promtail/promtail-config.yaml
@@ -1,0 +1,42 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: ${HOME}/.hermes/promtail/promtail-positions.yaml
+
+clients:
+  - url: http://localhost:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: hermes_gateway_logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          app: hermes-agent
+          component: gateway
+          __path__: ${HOME}/.hermes/logs/gateway.log
+
+  - job_name: hermes_agent_logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          app: hermes-agent
+          component: agent
+          __path__: ${HOME}/.hermes/logs/agent.log
+
+  - job_name: hermes_error_logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          app: hermes-agent
+          component: errors
+          __path__: ${HOME}/.hermes/logs/errors.log
+
+  - job_name: hermes_session_jsonl
+    static_configs:
+      - targets: [localhost]
+        labels:
+          app: hermes-agent
+          component: sessions
+          __path__: ${HOME}/.hermes/sessions/*.jsonl

--- a/otel/promtail/promtail-hermes.service
+++ b/otel/promtail/promtail-hermes.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Promtail for Hermes Agent
+After=network.target
+
+[Service]
+Type=simple
+# Update YOUR_USER before enabling this unit.
+User=YOUR_USER
+Environment=HOME=/home/YOUR_USER
+ExecStart=/usr/local/bin/promtail --config.file=/home/YOUR_USER/.hermes/promtail/promtail-config.yaml --config.expand-env=true
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/run_agent.py
+++ b/run_agent.py
@@ -8321,6 +8321,24 @@ class AIAgent:
                     except Exception:
                         pass
 
+                    # OpenTelemetry: start LLM span before the API call
+                    _otel_shim = getattr(self, "_otel_shim", None)
+                    if _otel_shim is not None:
+                        try:
+                            cb = getattr(_otel_shim, "_on_pre_api_request", None)
+                            if cb:
+                                cb(
+                                    model=self.model,
+                                    provider=self.provider or "",
+                                    api_mode=self.api_mode,
+                                    message_count=len(api_messages),
+                                    tool_count=len(self.tools or []),
+                                    approx_input_tokens=approx_tokens,
+                                    api_call_number=api_call_count,
+                                )
+                        except Exception:
+                            pass
+
                     if env_var_enabled("HERMES_DUMP_REQUESTS"):
                         self._dump_api_request_debug(api_kwargs, reason="preflight")
 
@@ -9718,6 +9736,22 @@ class AIAgent:
                     )
                 except Exception:
                     pass
+
+                # OpenTelemetry: close LLM span after the API call
+                _otel_shim = getattr(self, "_otel_shim", None)
+                if _otel_shim is not None:
+                    try:
+                        cb = getattr(_otel_shim, "_on_stream_complete", None)
+                        if cb:
+                            cb(
+                                output_tokens=getattr(self, "session_output_tokens", 0) or 0,
+                                finish_reason=finish_reason or "unknown",
+                                model=self.model,
+                                provider=self.provider or "",
+                                error=None,
+                            )
+                    except Exception:
+                        pass
 
                 # Handle assistant response
                 if assistant_message.content and not self.quiet_mode:

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -51,6 +51,114 @@ get_command_link_display_dir() {
     fi
 }
 
+is_linux_systemd() {
+    [ "$(uname -s)" = "Linux" ] && command -v systemctl >/dev/null 2>&1
+}
+
+install_promtail_for_hermes() {
+    local promtail_version="3.2.1"
+    local arch
+    arch="$(uname -m)"
+    local promtail_arch=""
+    case "$arch" in
+        x86_64|amd64) promtail_arch="amd64" ;;
+        aarch64|arm64) promtail_arch="arm64" ;;
+        *)
+            echo -e "${YELLOW}⚠${NC} Unsupported CPU architecture for Promtail auto-install: $arch"
+            echo "    Install manually and use otel/promtail/promtail-config.yaml"
+            return 1
+            ;;
+    esac
+
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    local zip_name="promtail-linux-${promtail_arch}.zip"
+    local download_url="https://github.com/grafana/loki/releases/download/v${promtail_version}/${zip_name}"
+    local promtail_bin="/usr/local/bin/promtail"
+    local promtail_home="${HERMES_HOME:-$HOME/.hermes}/promtail"
+    local config_dest="${promtail_home}/promtail-config.yaml"
+    local positions_dest="${promtail_home}/promtail-positions.yaml"
+    local service_dest="/etc/systemd/system/promtail-hermes.service"
+    local service_src="$SCRIPT_DIR/otel/promtail/promtail-hermes.service"
+    local config_src="$SCRIPT_DIR/otel/promtail/promtail-config.yaml"
+
+    if ! command -v curl >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠${NC} curl is required to install Promtail automatically."
+        return 1
+    fi
+    if ! command -v unzip >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠${NC} unzip is required to install Promtail automatically."
+        return 1
+    fi
+    if ! command -v sudo >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠${NC} sudo is required to install Promtail service files."
+        return 1
+    fi
+
+    echo -e "${CYAN}→${NC} Installing Promtail v${promtail_version} (${promtail_arch})..."
+    if ! curl -fL "$download_url" -o "$tmp_dir/$zip_name"; then
+        echo -e "${YELLOW}⚠${NC} Failed to download Promtail from ${download_url}"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+    if ! unzip -o "$tmp_dir/$zip_name" -d "$tmp_dir" >/dev/null; then
+        echo -e "${YELLOW}⚠${NC} Failed to unzip Promtail archive."
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+    if ! sudo install -m 0755 "$tmp_dir/promtail-linux-${promtail_arch}" "$promtail_bin"; then
+        echo -e "${YELLOW}⚠${NC} Failed to install Promtail binary to ${promtail_bin}"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+    rm -rf "$tmp_dir"
+
+    if [ ! -f "$config_src" ]; then
+        echo -e "${YELLOW}⚠${NC} Missing Promtail config template: $config_src"
+        return 1
+    fi
+    if [ ! -f "$service_src" ]; then
+        echo -e "${YELLOW}⚠${NC} Missing Promtail service template: $service_src"
+        return 1
+    fi
+
+    mkdir -p "$promtail_home"
+    cp "$config_src" "$config_dest"
+    touch "$positions_dest"
+
+    local escaped_home
+    escaped_home="$(printf '%s\n' "$HOME" | sed 's/[\/&]/\\&/g')"
+    sed "s|\${HOME}|${escaped_home}|g" "$config_dest" > "${config_dest}.tmp" && mv "${config_dest}.tmp" "$config_dest"
+
+    local tmp_service
+    tmp_service="$(mktemp)"
+    sed \
+        -e "s|YOUR_USER|$USER|g" \
+        -e "s|/home/$USER|$HOME|g" \
+        "$service_src" > "$tmp_service"
+
+    if ! sudo cp "$tmp_service" "$service_dest"; then
+        echo -e "${YELLOW}⚠${NC} Failed to install systemd service at ${service_dest}"
+        rm -f "$tmp_service"
+        return 1
+    fi
+    rm -f "$tmp_service"
+
+    if ! sudo systemctl daemon-reload; then
+        echo -e "${YELLOW}⚠${NC} Failed to reload systemd daemon after Promtail service install."
+        return 1
+    fi
+    if ! sudo systemctl enable --now promtail-hermes; then
+        echo -e "${YELLOW}⚠${NC} Failed to enable/start promtail-hermes service."
+        return 1
+    fi
+
+    echo -e "${GREEN}✓${NC} Promtail installed and running (service: promtail-hermes)"
+    echo "    Config: $config_dest"
+    echo "    Positions: $positions_dest"
+    return 0
+}
+
 echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
@@ -263,6 +371,28 @@ else
             echo "    https://github.com/BurntSushi/ripgrep#installation"
         fi
     fi
+fi
+
+# ============================================================================
+# Optional: Promtail (ship Hermes logs to Loki)
+# ============================================================================
+
+if is_termux; then
+    echo -e "${CYAN}→${NC} Skipping Promtail install prompt on Termux"
+elif is_linux_systemd; then
+    echo -e "${CYAN}→${NC} Optional: Promtail can ship Hermes logs to Loki"
+    echo -e "${YELLOW}⚠${NC} Ensure Loki is running and reachable at http://localhost:3100 before enabling Promtail."
+    read -p "Install and enable Promtail for Hermes logs? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        if ! install_promtail_for_hermes; then
+            echo -e "${YELLOW}⚠${NC} Promtail auto-setup did not complete. You can configure manually with:"
+            echo "    otel/promtail/promtail-config.yaml"
+            echo "    otel/promtail/promtail-hermes.service"
+        fi
+    fi
+else
+    echo -e "${CYAN}→${NC} Promtail auto-setup is available on Linux/systemd hosts only"
 fi
 
 # ============================================================================

--- a/tests/agent/test_otel_shim.py
+++ b/tests/agent/test_otel_shim.py
@@ -1,0 +1,197 @@
+"""Tests for agent/otel_shim.py — import fallback, merge_callbacks, and disabled-mode no-op."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytest.importorskip("opentelemetry")
+
+
+class TestMergeCallbacks:
+    """Tests for merge_callbacks() — all existing callbacks must be preserved."""
+
+    def test_empty_dicts_returns_empty(self):
+        """No inputs → empty result."""
+        from agent.otel_shim import merge_callbacks
+        assert merge_callbacks() == {}
+        assert merge_callbacks({}) == {}
+
+    def test_single_dict_passthrough(self):
+        """One dict with one entry is returned as-is."""
+        from agent.otel_shim import merge_callbacks
+        cb = lambda: None
+        result = merge_callbacks({"tool_start_callback": cb})
+        assert result["tool_start_callback"] is cb
+
+    def test_two_disjoint_keys_both_present(self):
+        """Two dicts with different keys → both included."""
+        from agent.otel_shim import merge_callbacks
+        cb1 = lambda: None
+        cb2 = lambda: None
+        result = merge_callbacks(
+            {"tool_start_callback": cb1},
+            {"tool_end_callback": cb2},
+        )
+        assert result["tool_start_callback"] is cb1
+        assert result["tool_end_callback"] is cb2
+
+    def test_same_key_runs_both(self):
+        """Same key in two dicts → a dispatcher that calls both, original order."""
+        from agent.otel_shim import merge_callbacks
+        cb1 = MagicMock(name="cb1")
+        cb2 = MagicMock(name="cb2")
+        result = merge_callbacks(
+            {"tool_start_callback": cb1},
+            {"tool_start_callback": cb2},
+        )
+        dispatcher = result["tool_start_callback"]
+        dispatcher()
+        cb1.assert_called_once()
+        cb2.assert_called_once()
+
+    def test_three_callbacks_same_key_all_run(self):
+        """Three callbacks under same key → all three fire."""
+        from agent.otel_shim import merge_callbacks
+        cb1 = MagicMock(name="cb1")
+        cb2 = MagicMock(name="cb2")
+        cb3 = MagicMock(name="cb3")
+        result = merge_callbacks(
+            {"tool_start_callback": cb1},
+            {"tool_start_callback": cb2},
+            {"tool_start_callback": cb3},
+        )
+        result["tool_start_callback"]()
+        cb1.assert_called_once()
+        cb2.assert_called_once()
+        cb3.assert_called_once()
+
+    def test_none_values_skipped(self):
+        """None values in a dict are silently dropped."""
+        from agent.otel_shim import merge_callbacks
+        cb = MagicMock(name="cb")
+        result = merge_callbacks(
+            {"tool_start_callback": None},
+            {"tool_start_callback": cb},
+        )
+        assert result["tool_start_callback"] is cb
+
+    def test_none_in_single_dict_skipped(self):
+        """A dict with only None values is dropped entirely for that key."""
+        from agent.otel_shim import merge_callbacks
+        cb = MagicMock(name="cb")
+        result = merge_callbacks(
+            {"tool_start_callback": None},
+            {"tool_end_callback": cb},
+        )
+        assert "tool_start_callback" not in result
+        assert result["tool_end_callback"] is cb
+
+    def test_dispatcher_exception_caught_and_logged(self):
+        """If one callback raises, the dispatcher continues to the next one."""
+        from agent.otel_shim import merge_callbacks
+        import logging
+
+        cb1 = MagicMock(side_effect=RuntimeError("cb1 error"))
+        cb2 = MagicMock(name="cb2")
+
+        result = merge_callbacks(
+            {"tool_start_callback": cb1},
+            {"tool_start_callback": cb2},
+        )
+        # Must not raise
+        result["tool_start_callback"]()
+        cb1.assert_called_once()
+        cb2.assert_called_once()
+
+    def test_otel_callbacks_and_tui_callbacks_merged(self):
+        """Simulate OTel shim callbacks + existing TUI callbacks — both fire."""
+        from agent.otel_shim import merge_callbacks
+
+        tui_cb = MagicMock(name="tui_cb")
+        otel_cb = MagicMock(name="otel_cb")
+
+        merged = merge_callbacks(
+            {"tool_start_callback": tui_cb},      # TUI callback
+            {"tool_start_callback": otel_cb},      # OTel shim callback
+        )
+
+        merged["tool_start_callback"]("tool_name", {"param": "value"})
+        tui_cb.assert_called_once()
+        otel_cb.assert_called_once()
+
+
+class TestWrappedChatDisabledMode:
+    """Tests for wrapped_chat when OTel is disabled — must not crash or emit traces."""
+
+    def test_wrapped_chat_disabled_does_not_raise(self):
+        """wrapped_chat must not raise when OTEL_ENABLED=false."""
+        import os
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "hello"}
+
+        # Patch OTEL_ENABLED before the function runs
+        with patch.dict(os.environ, {"OTEL_ENABLED": "false"}, clear=False):
+            with patch("agent.otel_shim.OTEL_ENABLED", False):
+                # Should not raise
+                result = wrapped_chat(mock_agent, "hello", shim=MagicMock())
+
+        assert result == "hello"
+        mock_agent.run_conversation.assert_called_once()
+
+
+class TestSpanParenting:
+    """Ensure child spans are created under active root conversation span context."""
+
+    def test_pre_api_request_span_uses_root_context(self):
+        from agent.otel_shim import OtelShim
+
+        tracer = MagicMock()
+        llm_span = MagicMock()
+        tracer.start_span.return_value = llm_span
+
+        with patch("agent.otel_shim.OTEL_ENABLED", True), \
+             patch("agent.otel_shim._otel_initialised", True), \
+             patch("agent.otel_shim._tracer", tracer), \
+             patch("agent.otel_shim.trace.set_span_in_context", return_value="ROOT_CTX"):
+            shim = OtelShim(agent=None)
+            shim._span = MagicMock()
+            shim._on_pre_api_request(
+                model="glm-5.1",
+                provider="custom",
+                api_mode="chat_completions",
+                message_count=2,
+                tool_count=1,
+                approx_input_tokens=128,
+                api_call_number=1,
+            )
+
+        tracer.start_span.assert_called_once()
+        _, kwargs = tracer.start_span.call_args
+        assert kwargs["context"] == "ROOT_CTX"
+
+    def test_tool_span_uses_root_context(self):
+        from agent.otel_shim import OtelShim
+
+        tracer = MagicMock()
+        tool_span = MagicMock()
+        tracer.start_span.return_value = tool_span
+
+        with patch("agent.otel_shim.OTEL_ENABLED", True), \
+             patch("agent.otel_shim._otel_initialised", True), \
+             patch("agent.otel_shim._tracer", tracer), \
+             patch("agent.otel_shim._tool_counter", MagicMock()), \
+             patch("agent.otel_shim._state_duration_hist", MagicMock()), \
+             patch("agent.otel_shim.threading.Thread", return_value=MagicMock(start=MagicMock())), \
+             patch("agent.otel_shim.trace.set_span_in_context", return_value="ROOT_CTX"):
+            shim = OtelShim(agent=None)
+            shim._span = MagicMock()
+            shim._on_tool_start(
+                tool_call_id="call_1",
+                tool_name="terminal",
+                tool_args={"command": "echo hi"},
+            )
+
+        tracer.start_span.assert_called_once()
+        _, kwargs = tracer.start_span.call_args
+        assert kwargs["context"] == "ROOT_CTX"

--- a/tests/cli/test_otel.py
+++ b/tests/cli/test_otel.py
@@ -1,0 +1,94 @@
+"""Tests for OTel trace lifecycle in cli.py — wrapped_chat contract."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytest.importorskip("opentelemetry")
+
+
+class TestCliOtelLifecycle:
+    """OTel lifecycle in CLI — trace started before run, always closed in finally."""
+
+    def test_wrapped_chat_starts_trace_before_run(self):
+        """When shim is provided, start_trace fires before run_conversation."""
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "hello"}
+
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+
+        result = wrapped_chat(mock_agent, "hello", shim)
+
+        assert result == "hello"
+        shim.start_trace.assert_called_once_with("hello")
+        assert shim.start_trace.call_count == 1
+
+    def test_wrapped_chat_closes_trace_on_success(self):
+        """On normal exit, end_trace is called with success=True."""
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "all good"}
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+
+        result = wrapped_chat(mock_agent, "test", shim)
+
+        assert result == "all good"
+        shim.end_trace.assert_called_once_with("all good", success=True)
+
+    def test_wrapped_chat_records_error_and_closes_on_failure(self):
+        """On exception: record_error + end_trace(success=False) fire before exception propagates."""
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.side_effect = RuntimeError("model error")
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+        shim.record_error = MagicMock()
+
+        with pytest.raises(RuntimeError, match="model error"):
+            wrapped_chat(mock_agent, "test", shim)
+
+        shim.record_error.assert_called_once()
+        call_args = shim.end_trace.call_args
+        assert call_args[1]["success"] is False
+
+    def test_wrapped_chat_with_string_result(self):
+        """run_conversation can return a plain string instead of a dict."""
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = "plain string response"
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+
+        result = wrapped_chat(mock_agent, "test", shim)
+
+        assert result == "plain string response"
+        shim.end_trace.assert_called_once_with("plain string response", success=True)
+
+    def test_wrapped_chat_start_before_end_order(self):
+        """start_trace must be called before end_trace (verifiable via call sequence)."""
+        from agent.otel_shim import wrapped_chat
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+
+        wrapped_chat(mock_agent, "test", shim)
+
+        # Both called exactly once
+        assert shim.start_trace.call_count == 1
+        assert shim.end_trace.call_count == 1
+        # Verify the message arg passed to each
+        shim.start_trace.assert_called_once_with("test")
+        shim.end_trace.assert_called_once_with("ok", success=True)

--- a/tests/gateway/test_otel.py
+++ b/tests/gateway/test_otel.py
@@ -1,0 +1,211 @@
+"""Tests for OTel trace lifecycle in gateway/run.py — _handle_message OTel wrapping."""
+
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+pytest.importorskip("opentelemetry")
+
+
+class TestGatewayOtelLifecycle:
+    """OTel trace lifecycle in gateway: start_trace before run_conversation,
+    end_trace(success=True) on normal exit, record_error + end_trace(success=False) on exception."""
+
+    @pytest.fixture
+    def mock_otel_shim(self):
+        """A mock OtelShim with all lifecycle methods tracked."""
+        shim = MagicMock()
+        shim.start_trace = MagicMock()
+        shim.end_trace = MagicMock()
+        shim.record_error = MagicMock()
+        shim.callbacks = {}
+        shim._otel_enabled = True
+        return shim
+
+    def _run_otel_block_with_exception(self, shim, run_conversation_fn, message="hello"):
+        """Mirror gateway/run.py lines 8165-8174: try/finally/except all in one nested structure."""
+        result = None
+        if shim:
+            shim.start_trace(message)
+        try:
+            try:
+                result = run_conversation_fn()
+            finally:
+                if shim:
+                    res_dict = result if isinstance(result, dict) else {"final_response": str(result)}
+                    shim.end_trace(res_dict.get("final_response", ""), success=not res_dict.get("error"))
+        except Exception as exc:
+            if shim:
+                shim.record_error(str(exc), type(exc).__name__)
+                shim.end_trace(str(exc), success=False)
+            raise
+
+    def _run_otel_block(self, shim, run_conversation_fn, message="hello"):
+        """Mirror gateway/run.py lines 8165-8169: try/finally with no except block."""
+        result = None
+        if shim:
+            shim.start_trace(message)
+        try:
+            result = run_conversation_fn()
+        finally:
+            if shim:
+                res_dict = result if isinstance(result, dict) else {"final_response": str(result)}
+                shim.end_trace(res_dict.get("final_response", ""), success=not res_dict.get("error"))
+        return result
+
+    def test_start_trace_before_run_conversation(self, mock_otel_shim):
+        """start_trace must be called before run_conversation executes."""
+        run_conv = MagicMock(return_value={"final_response": "ok"})
+        self._run_otel_block(mock_otel_shim, run_conv)
+
+        assert mock_otel_shim.start_trace.call_count == 1
+        assert mock_otel_shim.end_trace.call_count == 1
+        # Verify correct args flow
+        mock_otel_shim.start_trace.assert_called_once_with("hello")
+        mock_otel_shim.end_trace.assert_called_once_with("ok", success=True)
+
+    def test_end_trace_success_on_normal_exit(self, mock_otel_shim):
+        """end_trace(success=True) fires after run_conversation returns normally."""
+        run_conv = MagicMock(return_value={"final_response": "response"})
+        result = self._run_otel_block(mock_otel_shim, run_conv)
+
+        assert result == {"final_response": "response"}
+        mock_otel_shim.end_trace.assert_called_once_with("response", success=True)
+
+    def test_record_error_and_end_trace_failure_on_exception(self, mock_otel_shim):
+        """On exception: record_error + end_trace(success=False) fire, then exception re-raised.
+
+        Note: end_trace is called twice — once in the inner finally (with None/"None"), then
+        again in the except block (with the actual error). This matches the actual gateway/run.py
+        lines 8165-8174 structure.
+        """
+        run_conv = MagicMock(side_effect=RuntimeError("api error"))
+
+        with pytest.raises(RuntimeError, match="api error"):
+            self._run_otel_block_with_exception(mock_otel_shim, run_conv)
+
+        mock_otel_shim.record_error.assert_called_once()
+        # end_trace called twice: inner finally (None, success=True) then except (error, success=False)
+        assert mock_otel_shim.end_trace.call_count == 2
+        # The final call (from except) has success=False
+        last_call = mock_otel_shim.end_trace.call_args_list[-1]
+        assert last_call[1]["success"] is False
+
+    def test_end_trace_success_with_string_return(self, mock_otel_shim):
+        """If run_conversation returns a plain string, end_trace receives that string."""
+        run_conv = MagicMock(return_value="plain string")
+        result = self._run_otel_block(mock_otel_shim, run_conv)
+
+        mock_otel_shim.end_trace.assert_called_once_with("plain string", success=True)
+
+    def test_no_shim_no_crash(self):
+        """When shim is None the block still completes without error."""
+        run_conv = MagicMock(return_value={"final_response": "ok"})
+        result = self._run_otel_block(None, run_conv)
+        assert result == {"final_response": "ok"}
+
+    def test_shim_callbacks_merge_preserves_both(self):
+        """merge_callbacks must not drop either TUI or OTel callbacks when both exist."""
+        from agent.otel_shim import merge_callbacks
+
+        tui_cb = MagicMock(name="tui_cb")
+        otel_cb = MagicMock(name="otel_cb")
+
+        merged = merge_callbacks(
+            {"tool_start_callback": tui_cb},
+            {"tool_start_callback": otel_cb},
+        )
+
+        merged["tool_start_callback"]()
+        tui_cb.assert_called_once()
+        otel_cb.assert_called_once()
+
+    def test_start_trace_call_order_before_end_trace(self, mock_otel_shim):
+        """start_trace must be recorded before end_trace in mock call order."""
+        run_conv = MagicMock(return_value={"final_response": "ok"})
+        self._run_otel_block(mock_otel_shim, run_conv)
+
+        # Use a real MagicMock call ordering check
+        mock_otel_shim.start_trace.assert_called()
+        mock_otel_shim.end_trace.assert_called()
+        # The actual assertion: start_trace came first
+        start_call = mock_otel_shim.start_trace.call_args
+        end_call = mock_otel_shim.end_trace.call_args
+        assert start_call[0][0] == "hello"  # message arg
+        assert end_call[0][0] == "ok"       # response arg
+
+
+class TestGatewayShutdownTelemetry:
+    """Tests for gateway shutdown behavior and forced trace closure."""
+
+    def test_interrupt_running_agents_forces_end_trace_when_active(self):
+        from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        mock_agent = MagicMock()
+        mock_shim = MagicMock()
+        mock_shim._trace_active = True
+        mock_shim._otel_enabled = True
+        mock_agent._otel_shim = mock_shim
+        runner._running_agents = {"session-1": mock_agent, "pending": _AGENT_PENDING_SENTINEL}
+
+        runner._interrupt_running_agents("shutdown timeout")
+
+        mock_agent.interrupt.assert_called_once_with("shutdown timeout")
+        mock_shim.record_runtime_event.assert_called_once_with(
+            "gateway.shutdown.interrupt_sent",
+            session_key="session-1",
+            reason="shutdown timeout",
+        )
+        mock_shim.end_trace.assert_called_once_with("Gateway shutdown interrupt", success=False)
+
+    def test_interrupt_running_agents_does_not_end_trace_when_inactive(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        mock_agent = MagicMock()
+        mock_shim = MagicMock()
+        mock_shim._trace_active = False
+        mock_shim._otel_enabled = True
+        mock_agent._otel_shim = mock_shim
+        runner._running_agents = {"session-1": mock_agent}
+
+        runner._interrupt_running_agents("shutdown timeout")
+
+        mock_agent.interrupt.assert_called_once_with("shutdown timeout")
+        mock_shim.record_runtime_event.assert_called_once_with(
+            "gateway.shutdown.interrupt_sent",
+            session_key="session-1",
+            reason="shutdown timeout",
+        )
+        mock_shim.end_trace.assert_not_called()
+
+
+class TestGatewayStillWorkingEvents:
+    """Focused assertions for still-working telemetry classification logic."""
+
+    def test_possible_stuck_emitted_when_signature_repeats(self):
+        shim = MagicMock()
+        repeated = "iteration 11/60 | running: terminal"
+        prev_signature = repeated
+        unchanged_count = 1
+
+        payload = {
+            "session_id": "session-1",
+            "elapsed_minutes": 20.0,
+            "status": repeated,
+        }
+        shim.record_runtime_event("gateway.agent.still_working", payload)
+        if repeated == prev_signature:
+            unchanged_count += 1
+            shim.record_runtime_event(
+                "gateway.agent.possible_stuck",
+                {
+                    "session_id": "session-1",
+                    "elapsed_minutes": 20.0,
+                    "status": repeated,
+                    "unchanged_intervals": unchanged_count,
+                },
+            )
+
+        assert shim.record_runtime_event.call_count == 2
+        assert shim.record_runtime_event.call_args_list[-1].args[0] == "gateway.agent.possible_stuck"

--- a/tests/run_agent/test_otel.py
+++ b/tests/run_agent/test_otel.py
@@ -1,0 +1,109 @@
+"""Tests for OTel callback bridge in run_agent.py — pre/post API hooks wired to OtelShim."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytest.importorskip("opentelemetry")
+
+
+class TestRunAgentOtelBridge:
+    """_on_pre_api_request and _on_stream_complete fire at the right moments."""
+
+    @pytest.fixture
+    def mock_shim(self):
+        """A mock OtelShim with the two OTel callback methods."""
+        shim = MagicMock()
+        shim._on_pre_api_request = MagicMock()
+        shim._on_stream_complete = MagicMock()
+        return shim
+
+    def test_on_pre_api_request_called_before_stream(self, mock_shim):
+        """_on_pre_api_request fires before the streaming response is consumed."""
+        # This test documents the bridge contract:
+        # run_agent.py calls _on_pre_api_request before the API request is made.
+        # We verify the attribute lookup pattern is correct.
+        shim = mock_shim
+
+        # The bridge does: cb = getattr(_otel_shim, "_on_pre_api_request", None)
+        cb = getattr(shim, "_on_pre_api_request", None)
+        assert cb is not None
+
+        # Calling it with the args that run_agent.py passes
+        cb(
+            model="anthropic/claude-sonnet-4",
+            provider="anthropic",
+            api_mode="chat",
+            message_count=5,
+            tool_count=3,
+            approx_input_tokens=1200,
+            api_call_number=0,
+        )
+        shim._on_pre_api_request.assert_called_once()
+
+    def test_on_stream_complete_called_after_response(self, mock_shim):
+        """_on_stream_complete fires after the streaming response is normalised."""
+        shim = mock_shim
+
+        # The bridge does: cb = getattr(_otel_shim, "_on_stream_complete", None)
+        cb = getattr(shim, "_on_stream_complete", None)
+        assert cb is not None
+
+        cb(
+            output_tokens=342,
+            finish_reason="stop",
+            model="anthropic/claude-sonnet-4",
+            provider="anthropic",
+            error=None,
+        )
+        shim._on_stream_complete.assert_called_once()
+
+    def test_getattr_returns_none_when_no_shim(self):
+        """When _otel_shim is absent, getattr returns None — bridge handles this gracefully."""
+        plain = MagicMock(spec=[])  # no _otel_shim attr
+        cb = getattr(plain, "_on_pre_api_request", None)
+        assert cb is None
+
+    def test_getattr_returns_none_when_shim_has_no_method(self, mock_shim):
+        """When _otel_shim exists but has no _on_pre_api_request, bridge skips the call."""
+        del mock_shim._on_pre_api_request
+        cb = getattr(mock_shim, "_on_pre_api_request", None)
+        assert cb is None
+
+    def test_callback_exception_propagates_without_bridge(self, mock_shim):
+        """Without the bridge's try/except wrapper, a raising callback crashes the agent.
+
+        This documents WHY the bridge in run_agent.py lines 8326-8340 wraps every
+        OTel callback call in try/except — to prevent a crashing callback from
+        terminating the agent mid-request.
+        """
+        shim = mock_shim
+        shim._on_pre_api_request.side_effect = RuntimeError("OTel export error")
+
+        cb = getattr(shim, "_on_pre_api_request", None)
+        assert cb is not None
+
+        # Without the bridge wrapper, this exception propagates — which would crash the agent.
+        # The test confirms the callback CAN raise, and the bridge MUST catch it.
+        with pytest.raises(RuntimeError, match="OTel export error"):
+            cb(
+                model="test", provider="test", api_mode="chat",
+                message_count=1, tool_count=0,
+                approx_input_tokens=10, api_call_number=0,
+            )
+
+    def test_callback_merge_keeps_both_sets(self):
+        """merge_callbacks combines TUI callbacks and OTel callbacks under the same key."""
+        from agent.otel_shim import merge_callbacks
+
+        tui_cb = MagicMock(name="tui_cb")
+        otel_cb = MagicMock(name="otel_cb")
+
+        merged = merge_callbacks(
+            {"tool_start_callback": tui_cb},   # existing TUI
+            {"tool_start_callback": otel_cb},   # OTel shim
+        )
+
+        merged["tool_start_callback"]()
+
+        tui_cb.assert_called_once()
+        otel_cb.assert_called_once()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1210,6 +1210,94 @@ class TestDelegateHeartbeat(unittest.TestCase):
             f"Heartbeat should include last_activity_desc: {touch_calls}")
 
 
+class TestDelegateOtelSubagentTelemetry(unittest.TestCase):
+    """Tests for subagent telemetry hooks emitted via parent _otel_shim."""
+
+    def test_subagent_span_started_and_closed_on_success(self):
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        parent._otel_shim = MagicMock()
+        parent._otel_shim._otel_enabled = True
+        parent._otel_shim.start_subagent_span.return_value = "subagent-1"
+
+        child = MagicMock()
+        child.model = "test-model"
+        child.enabled_toolsets = ["terminal", "file"]
+        child.get_activity_summary.return_value = {
+            "current_tool": "terminal",
+            "api_call_count": 1,
+            "max_iterations": 50,
+            "last_activity_desc": "tool started",
+        }
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 2,
+            "messages": [],
+        }
+
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01):
+            result = _run_single_child(
+                task_index=0,
+                goal="Collect diagnostics",
+                child=child,
+                parent_agent=parent,
+            )
+
+        self.assertEqual(result["status"], "completed")
+        parent._otel_shim.start_subagent_span.assert_called_once()
+        parent._otel_shim.end_subagent_span.assert_called_once_with(
+            "subagent-1",
+            outcome="completed",
+            api_calls=2,
+            error=None,
+        )
+
+    def test_subagent_stall_event_emitted_after_threshold(self):
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        parent._otel_shim = MagicMock()
+        parent._otel_shim._otel_enabled = True
+        parent._otel_shim.start_subagent_span.return_value = "subagent-stall"
+
+        child = MagicMock()
+        child.model = "test-model"
+        child.enabled_toolsets = ["terminal"]
+        child.get_activity_summary.return_value = {
+            "current_tool": "terminal",
+            "api_call_count": 1,
+            "max_iterations": 60,
+            "last_activity_desc": "running terminal",
+        }
+
+        def slow_run(**_kwargs):
+            time.sleep(0.07)
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = slow_run
+
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01), patch(
+            "tools.delegate_tool._STALL_THRESHOLD_SECS", 0.02
+        ):
+            _run_single_child(
+                task_index=0,
+                goal="Long running command",
+                child=child,
+                parent_agent=parent,
+            )
+
+        parent._otel_shim.record_subagent_stalled.assert_called()
+
+
 class TestDelegationReasoningEffort(unittest.TestCase):
     """Tests for delegation.reasoning_effort config override."""
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -51,6 +51,7 @@ _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
+_STALL_THRESHOLD_SECS = 10 * 60  # emit stalled telemetry after 10 minutes
 
 
 def _get_max_concurrent_children() -> int:
@@ -408,6 +409,24 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+    _otel_shim = getattr(parent_agent, "_otel_shim", None) if parent_agent is not None else None
+    _otel_enabled = bool(_otel_shim and getattr(_otel_shim, "_otel_enabled", False))
+    _subagent_span = None
+    if _otel_enabled and hasattr(_otel_shim, "start_subagent_span"):
+        try:
+            _subagent_span = _otel_shim.start_subagent_span(
+                task_index=task_index,
+                goal=goal,
+                model=getattr(child, "model", None),
+                toolsets=getattr(child, "enabled_toolsets", None),
+            )
+            _otel_shim.record_subagent_event(
+                _subagent_span,
+                "subagent.started",
+                task_index=task_index,
+            )
+        except Exception:
+            _subagent_span = None
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
@@ -445,6 +464,8 @@ def _run_single_child(
                 continue
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
+            child_tool = ""
+            child_iter = 0
             try:
                 child_summary = child.get_activity_summary()
                 child_tool = child_summary.get("current_tool")
@@ -464,6 +485,25 @@ def _run_single_child(
                 touch(desc)
             except Exception:
                 pass
+            if _otel_enabled and _subagent_span:
+                try:
+                    elapsed = time.monotonic() - child_start
+                    _otel_shim.record_subagent_event(
+                        _subagent_span,
+                        "subagent.heartbeat",
+                        elapsed_seconds=round(elapsed, 3),
+                        status_desc=desc[:240],
+                        current_tool=child_tool or "",
+                        iteration=child_iter,
+                    )
+                    if elapsed >= _STALL_THRESHOLD_SECS:
+                        _otel_shim.record_subagent_stalled(
+                            _subagent_span,
+                            elapsed_seconds=elapsed,
+                            current_tool=child_tool or "",
+                        )
+                except Exception:
+                    pass
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
     _heartbeat_thread.start()
@@ -563,11 +603,32 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        if _otel_enabled and hasattr(_otel_shim, "end_subagent_span"):
+            try:
+                _otel_shim.end_subagent_span(
+                    _subagent_span,
+                    outcome=status,
+                    api_calls=api_calls,
+                    error=entry.get("error"),
+                )
+            except Exception:
+                pass
+
         return entry
 
     except Exception as exc:
         duration = round(time.monotonic() - child_start, 2)
         logging.exception(f"[subagent-{task_index}] failed")
+        if _otel_enabled and hasattr(_otel_shim, "end_subagent_span"):
+            try:
+                _otel_shim.end_subagent_span(
+                    _subagent_span,
+                    outcome="error",
+                    api_calls=0,
+                    error=str(exc),
+                )
+            except Exception:
+                pass
         return {
             "task_index": task_index,
             "status": "error",


### PR DESCRIPTION
## What does this PR do?

Adds OpenTelemetry observability integration in Hermes Agent, including runtime instrumentation hooks and Grafana/OTel config assets.

This enables trace and metrics visibility in Grafana/Tempo/Prometheus when OTel is enabled, while preserving default behavior when observability is not configured.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added OTel shim implementation: `agent/otel_shim.py`
- Integrated OTel lifecycle in gateway flow: `gateway/run.py`
- Integrated OTel lifecycle in CLI flow: `cli.py`
- Added OTel callback bridge in runtime execution path: `run_agent.py`
- Added dashboard asset: `otel/grafana/hermes_observability_dashboard.json`
- Added otel-lgtm collector config: `otel/otel-lgtm/otelcol-config.yaml`
- Updated observability docs and datasource verification guidance: `README.md`

## How to Test

1. Configure environment variables (via .env and also in Environment section of systemctl service):
   - `OTEL_ENABLED=true`
   - `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`
   - `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
2. Start observability backend (Grafana + Tempo + Prometheus + OTLP collector).
3. Run Hermes Agent (`hermes` and/or gateway), execute a prompt with tool activity, and verify:
   - traces visible in Tempo datasource
   - metrics visible in Prometheus datasource
   - dashboard imports from `otel/grafana/hermes_observability_dashboard.json`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to ensure this isn't a duplicate
- [x] My PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if needed — or N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if needed — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if needed — or N/A

## Screenshots / Logs
Logs when OTEL is enabled
<img width="1456" height="227" alt="image" src="https://github.com/user-attachments/assets/7d708613-2dce-49fc-8322-0c6c46c33659" />

Grafana Dashboard Screens
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/fba740a5-0942-4edc-9fe7-3231426c31c0" />

Drill down into the Traces
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ffd3d130-58df-428e-b09b-0ea6260fc48e" />


