### PR TITLE
fix: propagate model_aliases context_length to display and compression checks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4457,6 +4457,7 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    context_length=result.context_length,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -4488,6 +4489,7 @@ class HermesCLI:
                     base_url=result.base_url or self.base_url,
                     api_key=result.api_key or self.api_key,
                     provider=result.target_provider,
+                    config_context_length=result.context_length,
                 )
                 _cprint(f"    Context: {ctx:,} tokens")
             except Exception:
@@ -4675,6 +4677,7 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    context_length=result.context_length,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -4712,6 +4715,7 @@ class HermesCLI:
                     base_url=result.base_url or self.base_url,
                     api_key=result.api_key or self.api_key,
                     provider=result.target_provider,
+                    config_context_length=result.context_length,
                 )
                 _cprint(f"    Context: {ctx:,} tokens")
             except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4340,6 +4340,7 @@ class GatewayRunner:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    context_length=result.context_length,
                                 )
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
@@ -4455,6 +4456,7 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    context_length=result.context_length,
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
@@ -4523,6 +4525,7 @@ class GatewayRunner:
                     base_url=result.base_url or current_base_url,
                     api_key=result.api_key or current_api_key,
                     provider=result.target_provider,
+                    config_context_length=result.context_length,
                 )
                 lines.append(f"Context: {ctx:,} tokens")
             except Exception:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -141,6 +141,7 @@ class DirectAlias(NamedTuple):
     model: str
     provider: str
     base_url: str
+    context_length: int | None = None
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
@@ -177,9 +178,16 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 model = entry.get("model", "")
                 provider = entry.get("provider", "custom")
                 base_url = entry.get("base_url", "")
+                context_length = entry.get("context_length")
+                if context_length is not None:
+                    try:
+                        context_length = int(context_length)
+                    except (TypeError, ValueError):
+                        context_length = None
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                        context_length=context_length,
                     )
     except Exception:
         pass
@@ -215,6 +223,7 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    context_length: int | None = None
 
 
 @dataclass
@@ -276,7 +285,7 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool]:
 def resolve_alias(
     raw_input: str,
     current_provider: str,
-) -> Optional[tuple[str, str, str]]:
+) -> Optional[tuple[str, str, str, int | None]]:
     """Resolve a short alias against the current provider's catalog.
 
     Looks up *raw_input* in :data:`MODEL_ALIASES`, then searches the
@@ -285,9 +294,9 @@ def resolve_alias(
     providers).
 
     Returns:
-        ``(provider, resolved_model_id, alias_name)`` if a match is
-        found on the current provider, or ``None`` if the alias doesn't
-        exist or no matching model is available.
+        ``(provider, resolved_model_id, alias_name, context_length_or_None)``
+        if a match is found on the current provider, or ``None`` if the
+        alias doesn't exist or no matching model is available.
     """
     key = raw_input.strip().lower()
 
@@ -295,14 +304,14 @@ def resolve_alias(
     _ensure_direct_aliases()
     direct = DIRECT_ALIASES.get(key)
     if direct is not None:
-        return (direct.provider, direct.model, key)
+        return (direct.provider, direct.model, key, direct.context_length)
 
     # Reverse lookup: match by model ID so full names (e.g. "kimi-k2.5",
     # "glm-4.7") route through direct aliases instead of falling through
     # to the catalog/OpenRouter.
     for alias_name, da in DIRECT_ALIASES.items():
         if da.model.lower() == key:
-            return (da.provider, da.model, alias_name)
+            return (da.provider, da.model, alias_name, da.context_length)
 
     identity = MODEL_ALIASES.get(key)
     if identity is None:
@@ -324,12 +333,12 @@ def resolve_alias(
             # Match vendor/family prefix -- e.g. "anthropic/claude-sonnet"
             prefix = f"{vendor}/{family}".lower()
             if mid_lower.startswith(prefix):
-                return (current_provider, model_id, key)
+                return (current_provider, model_id, key, None)
         else:
             # Non-aggregator: bare names -- e.g. "claude-sonnet-4-6"
             family_lower = family.lower()
             if mid_lower.startswith(family_lower):
-                return (current_provider, model_id, key)
+                return (current_provider, model_id, key, None)
 
     return None
 
@@ -359,7 +368,7 @@ def get_authenticated_provider_slugs(
 def _resolve_alias_fallback(
     raw_input: str,
     authenticated_providers: list[str] = (),
-) -> Optional[tuple[str, str, str]]:
+) -> Optional[tuple[str, str, str, int | None]]:
     """Try to resolve an alias on the user's authenticated providers.
 
     Falls back to ``("openrouter", "nous")`` only when no authenticated
@@ -433,6 +442,7 @@ def switch_model(
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     resolved_alias = ""
+    alias_context_length: int | None = None
     new_model = raw_input.strip()
     target_provider = current_provider
 
@@ -503,7 +513,7 @@ def switch_model(
         # Resolve alias on the TARGET provider
         alias_result = resolve_alias(new_model, target_provider)
         if alias_result is not None:
-            _, new_model, resolved_alias = alias_result
+            _, new_model, resolved_alias, alias_context_length = alias_result
 
     # =================================================================
     # PATH B: No explicit provider — resolve from model input
@@ -513,7 +523,7 @@ def switch_model(
         alias_result = resolve_alias(raw_input, current_provider)
 
         if alias_result is not None:
-            target_provider, new_model, resolved_alias = alias_result
+            target_provider, new_model, resolved_alias, alias_context_length = alias_result
             logger.debug(
                 "Alias '%s' resolved to %s on %s",
                 resolved_alias, new_model, target_provider,
@@ -529,7 +539,7 @@ def switch_model(
                 )
                 fallback_result = _resolve_alias_fallback(raw_input, authed)
                 if fallback_result is not None:
-                    target_provider, new_model, resolved_alias = fallback_result
+                    target_provider, new_model, resolved_alias, alias_context_length = fallback_result
                     logger.debug(
                         "Alias '%s' resolved via fallback to %s on %s",
                         resolved_alias, new_model, target_provider,
@@ -716,6 +726,7 @@ def switch_model(
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,
+        context_length=alias_context_length,
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1231,6 +1231,23 @@ class AIAgent:
         # Store for reuse in switch_model (so config override persists across model switches)
         self._config_context_length = _config_context_length
 
+        # Check model_aliases context_length (for aliases like qwen3.5-local)
+        if _config_context_length is None:
+            _model_aliases = _agent_cfg.get("model_aliases")
+            if isinstance(_model_aliases, dict):
+                for _alias_entry in _model_aliases.values():
+                    if not isinstance(_alias_entry, dict):
+                        continue
+                    if _alias_entry.get("model") == self.model:
+                        _al_ctx = _alias_entry.get("context_length")
+                        if _al_ctx is not None:
+                            try:
+                                _config_context_length = int(_al_ctx)
+                                self._config_context_length = _config_context_length
+                            except (TypeError, ValueError):
+                                pass
+                        break
+
         # Check custom_providers per-model context_length
         if _config_context_length is None:
             _custom_providers = _agent_cfg.get("custom_providers")
@@ -1475,7 +1492,7 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
     
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', context_length=None):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -1551,12 +1568,14 @@ class AIAgent:
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
+            # Use alias-provided context_length if available (overrides config)
+            _effective_ctx = context_length or getattr(self, "_config_context_length", None)
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=_effective_ctx,
             )
             self.context_compressor.update_model(
                 model=self.model,
@@ -1748,10 +1767,17 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            # If aux model is the same as main model, reuse the already-known
+            # context length (avoids re-querying local endpoints that may
+            # report a different default context_length).
+            _config_ctx = None
+            if aux_model == self.model:
+                _config_ctx = getattr(self.context_compressor, "context_length", 0) or None
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
+                config_context_length=_config_ctx,
             )
 
             threshold = self.context_compressor.threshold_tokens


### PR DESCRIPTION
## Problem

When switching to a local model via `model_aliases` (e.g. `/model qwen3.5-local` with `context_length: 131072`), the configured `context_length` was ignored in several places:

1. **Banner display** — After `/model` switch, the context window size shown was wrong (32K instead of 128K)
2. **Compression feasibility check** — False warning: "Compression model context is 32,768 tokens, but the main model's compression threshold is 65,536 tokens" even when the aux model is the same as the main model with 128K context

The root cause: `get_model_context_length()` was called without `config_context_length`, so it queried the local llama.cpp endpoint and received the server's default (32,768) instead of the alias-configured value (131,072).

Additionally, `DirectAlias` and `resolve_alias()` did not carry the `context_length` field at all, so it was lost during alias resolution.

## Changes

- **hermes_cli/model_switch.py** — Add `context_length` to `DirectAlias`, `ModelSwitchResult`, and `resolve_alias()` return tuple
- **cli.py** — Pass `result.context_length` as `config_context_length` in 4 call sites (2 model switch handlers × 2 display paths)
- **gateway/run.py** — Pass `result.context_length` as `config_context_length` in the gateway `/model` display path
- **run_agent.py** — Accept `context_length` param in `switch_model()`; reuse main model's known context_length when aux model matches (avoids re-querying local endpoint with mismatched base_url due to trailing slash)

## Config that triggers the bug

```yaml
model_aliases:
  qwen3.5-local:
    model: "Qwen3.5-35B-...-Q8_0.gguf"
    provider: custom
    base_url: "http://127.0.0.1:8081/v1"
    context_length: 131072  # This value was silently ignored
```