### PR TITLE
fix(gateway): support Telegram MarkdownV2 expandable blockquotes

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1916,9 +1916,20 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
         # 9) Convert blockquotes: > at line start → protect > from escaping
+        #    Handle both regular blockquotes (> text) and expandable blockquotes
+        #    (Telegram MarkdownV2: **> for expandable start, || to end the quote)
+        def _convert_blockquote(m):
+            prefix = m.group(1)  # >, >>, >>>, **>, or **>> etc.
+            content = m.group(2)
+            # Check if content ends with || (expandable blockquote end marker)
+            # In this case, preserve the trailing || unescaped for Telegram
+            if prefix.startswith('**') and content.endswith('||'):
+                return _ph(f'{prefix} {_escape_mdv2(content[:-2])}||')
+            return _ph(f'{prefix} {_escape_mdv2(content)}')
+
         text = re.sub(
-            r'^(>{1,3}) (.+)$',
-            lambda m: _ph(m.group(1) + ' ' + _escape_mdv2(m.group(2))),
+            r'^((?:\*\*)?>{1,3}) (.+)$',
+            _convert_blockquote,
             text,
             flags=re.MULTILINE,
         )

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -408,6 +408,27 @@ class TestFormatMessageBlockquote:
         result = adapter.format_message("5 > 3")
         assert "\\>" in result
 
+    def test_expandable_blockquote(self, adapter):
+        """Expandable blockquote prefix **> and trailing || must NOT be escaped."""
+        result = adapter.format_message("**> Hidden content||")
+        assert "**>" in result
+        assert "||" in result
+        assert "\\*" not in result  # asterisks in prefix must not be escaped
+        assert "\\>" not in result  # > in prefix must not be escaped
+
+    def test_single_asterisk_gt_not_blockquote(self, adapter):
+        """Single asterisk before > should not be treated as blockquote prefix."""
+        result = adapter.format_message("*> not a quote")
+        assert "\\*" in result
+        assert "\\>" in result
+
+    def test_regular_blockquote_with_pipes_escaped(self, adapter):
+        """Regular blockquote ending with || should escape the pipes."""
+        result = adapter.format_message("> not expandable||")
+        assert "> not expandable" in result
+        assert "\\|" in result
+        assert "\\>" not in result
+
 
 # =========================================================================
 # format_message - mixed/complex


### PR DESCRIPTION
## What does this PR do?

Updates the Telegram `format_message()` blockquote conversion to support **MarkdownV2 expandable blockquotes** (`**> ... ||`) while preserving existing behavior for regular blockquotes (`>`, `>>`, `>>>`).

Previously, the `**>` prefix and trailing `||` end marker were escaped by the MarkdownV2 sanitizer, causing expandable blockquotes to render as literal characters instead of Telegram's native expandable quote UI.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No related issue — this is a small, self-contained bug fix.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/platforms/telegram.py`
  - Updated blockquote regex from `^(>{1,3}) (.+)$` to `^((?:\*\*)?>{1,3}) (.+)$` to match both regular and expandable (`**>`) blockquote prefixes.
  - Added `_convert_blockquote()` helper that leaves the prefix unescaped and preserves trailing `||` unescaped **only** for expandable blockquotes (`**>`).
- `tests/gateway/test_telegram_format.py`
  - Added `test_expandable_blockquote` — verifies `**> Hidden content||` is not escaped.
  - Added `test_single_asterisk_gt_not_blockquote` — ensures `*> text` is still escaped (not treated as a blockquote).
  - Added `test_regular_blockquote_with_pipes_escaped` — verifies regular `> text||` still escapes the pipes.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the blockquote-specific tests:
   ```bash
   uv run pytest tests/gateway/test_telegram_format.py -q -k blockquote
   ```
2. Run the full Telegram format test suite:
   ```bash
   uv run pytest tests/gateway/test_telegram_format.py -q
   ```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```text
uv run pytest tests/gateway/test_telegram_format.py -q
bringing up nodes...
...........................................................................                                      [100%]
=================================================== warnings summary ===================================================
tests/gateway/test_telegram_format.py: 10 warnings
  /xxx/xxx/hermes-agent/tests/conftest.py:91: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop_policy().get_event_loop()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
75 passed, 10 warnings in 0.79s
```