### PR TITLE
fix(agent): increase max_tokens for title generation to support reasoning models #9571

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -38,7 +38,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
         response = call_llm(
             task="title_generation",
             messages=messages,
-            max_tokens=30,
+            max_tokens=500, #
             temperature=0.3,
             timeout=timeout,
         )


### PR DESCRIPTION
### Description
This PR fixes the issue where title generation fails when using reasoning-heavy models like **GLM 5.1**.

### The Problem
Models with a "thinking" (reasoning) phase often consume the entire 30-token budget before producing the actual title. This results in a `finish_reason: length` error and an empty title field.

### The Solution
- Increased `max_tokens` from **30** to **500** in `agent/title_generator.py`.
- This provides sufficient headroom for the model's reasoning process while keeping the final output concise as per the system instructions.

### Related Issue
Fixes #9571