### PR TITLE
fix(weixin): accept image_path kwarg in send_image_file()

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,11 +1542,14 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        path: str = "",
+        image_path: str = "",
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        # Base platform passes image_path=...; accept both names
+        path = image_path or path
         return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
 
     async def send_document(


### PR DESCRIPTION
The base platform adapter (`base.py`) calls `send_image_file()` with `image_path=...` as the keyword argument, but the Weixin adapter's method signature uses `path` instead. This mismatch causes all image deliveries via `MEDIA:` tags to fail silently with:

```
WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
```

**Fix:** Accept both `path` and `image_path` parameter names so the adapter is compatible with the base platform's calling convention.