### PR TITLE
fix(dingtalk): accept oapi.dingtalk.com webhook domain for stream mode reply routing

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
-_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
+_DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 
 
 def check_dingtalk_requirements() -> bool:

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -219,6 +219,6 @@ docker restart hermes
 
 ```sh
 docker logs --tail 50 hermes          # Recent logs
-docker run -it --rm nousresearch/hermes-agent:latest version     # Verify version
+docker exec hermes hermes version     # Verify version
 docker stats hermes                    # Resource usage
 ```


### PR DESCRIPTION
## Summary

DingTalk Stream SDK returns `sessionWebhook` URLs using the `oapi.dingtalk.com` domain, but the current SSRF validation regex (`_DINGTALK_WEBHOOK_RE`) only accepts `api.dingtalk.com`. This causes **all reply routing via session webhooks to silently fail** when running in stream mode — messages are received but replies never reach the user.

### Root Cause

The webhook validation regex at `gateway/platforms/dingtalk.py:57` was:
```python
_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
```

DingTalk's Stream SDK actually returns webhooks like:
```
https://oapi.dingtalk.com/robot/sendBySession?session=xxx
```

The `oapi.dingtalk.com` domain is the **legacy but still actively used** Open API endpoint, while `api.dingtalk.com` is the newer endpoint. Both are legitimate DingTalk domains.

### Fix

Updated the regex to accept **both** domains:
```python
_DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
```

This is a minimal, targeted fix — no behavioral change for `api.dingtalk.com` webhooks; only `oapi.dingtalk.com` is additionally accepted.

### Additional Fix

Fixed the Docker troubleshooting docs (`website/docs/user-guide/docker.md`): the version check command used `docker run` which spins up a **new** container instead of checking the running one. Corrected to `docker exec hermes hermes version`.

## Commits

| Commit | Scope |
|--------|-------|
| `fix(dingtalk): accept oapi.dingtalk.com webhook domain alongside api.dingtalk.com` | `gateway/platforms/dingtalk.py`, `website/docs/user-guide/docker.md` |

## Test Plan

- [x] Verified regex matches both `https://api.dingtalk.com/...` and `https://oapi.dingtalk.com/...`
- [x] Verified regex rejects non-DingTalk domains (SSRF protection intact)
- [x] Tested DingTalk stream mode end-to-end: bot receives messages and replies successfully via `oapi.dingtalk.com` session webhooks
- [x] Docker docs command verified: `docker exec` correctly queries the running container

## Risk Assessment

**Low risk** — single regex change expanding the allowlist to include a legitimate DingTalk domain. No new dependencies, no architectural changes, no breaking changes.