### PR TITLE
feat(feishu): upgrade askQuestion to interactive Card V2 forms

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7183,7 +7183,7 @@ class HermesCLI:
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
 
-    def _clarify_callback(self, question, choices):
+    def _clarify_callback(self, question, choices=None, **kwargs):
         """
         Platform callback for the clarify tool. Called from the agent thread.
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -988,6 +988,24 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list[str]] = None,
+        prompt_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        questions: Optional[list[dict]] = None,
+    ) -> SendResult:
+        """Send an interactive clarify prompt when the platform supports it.
+
+        When *questions* is provided (advanced form mode), platforms that support
+        Card V2 forms should render a structured form with dropdowns, text inputs,
+        and multi-select. Platforms without form support return ``success=False``
+        so callers can fall back to plain text.
+        """
+        return SendResult(success=False, error="Not supported")
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
         Send a typing indicator.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -74,6 +74,7 @@ try:
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
     from lark_oapi.event.callback.model.p2_card_action_trigger import (
         CallBackCard,
+        CallBackToast,
         P2CardActionTriggerResponse,
     )
     from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
@@ -83,8 +84,9 @@ try:
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None  # type: ignore[assignment]
-    CallBackCard = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
+    CallBackCard = None  # type: ignore[assignment]
+    CallBackToast = None  # type: ignore[assignment]
     EventDispatcherHandler = None  # type: ignore[assignment]
     FeishuWSClient = None  # type: ignore[assignment]
     FEISHU_DOMAIN = None  # type: ignore[assignment]
@@ -173,19 +175,6 @@ _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
-
-_APPROVAL_CHOICE_MAP: Dict[str, str] = {
-    "approve_once": "once",
-    "approve_session": "session",
-    "approve_always": "always",
-    "deny": "deny",
-}
-_APPROVAL_LABEL_MAP: Dict[str, str] = {
-    "once": "Approved once",
-    "session": "Approved for session",
-    "always": "Approved permanently",
-    "deny": "Denied",
-}
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 _FEISHU_ACK_EMOJI = "OK"
@@ -1073,6 +1062,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
+        self._card_action_responses: Dict[str, Any] = {}  # token → cached inline response
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
@@ -1089,6 +1079,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
+        # Clarify prompt state (prompt_id → {event, response, question, message_id})
+        self._clarify_state: Dict[str, Dict[str, Any]] = {}
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1507,24 +1499,265 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
-    @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
-        """Build raw card JSON for a resolved approval action."""
-        icon = "❌" if choice == "deny" else "✅"
-        label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list[str]] = None,
+        prompt_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        questions: Optional[list[dict]] = None,
+    ) -> SendResult:
+        """Send a Feishu interactive card for clarify prompts.
+
+        When *questions* is provided, sends a Card V2 form. Otherwise
+        sends the classic V1 button card.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        prompt_id = str(prompt_id or uuid.uuid4())
+
+        if questions:
+            return await self._send_ask_form(chat_id, questions, prompt_id, metadata)
+
+        try:
+            card = self._build_clarify_card(question, choices or [], prompt_id)
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "send_clarify_prompt failed")
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify_prompt failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def _send_ask_form(
+        self,
+        chat_id: str,
+        questions: list[dict],
+        prompt_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Card V2 form for multi-question input."""
+        try:
+            card = self._build_ask_form_card(questions, prompt_id)
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "_send_ask_form failed")
+        except Exception as exc:
+            logger.warning("[Feishu] _send_ask_form failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _build_clarify_card(self, question: str, choices: list[str], prompt_id: str) -> dict:
+        """Build a Feishu interactive card for clarify prompts."""
+        normalized_question = (question or "").strip()
+        normalized_choices = [str(c).strip() for c in (choices or []) if str(c).strip()][:4]
+        actions = []
+        for idx, choice in enumerate(normalized_choices, start=1):
+            actions.append(
+                {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": choice[:40]},
+                    "type": "primary" if idx == 1 else "default",
+                    "value": {
+                        "hermes_clarify": True,
+                        "prompt_id": prompt_id,
+                        "choice_index": idx,
+                        "choice_text": choice,
+                    },
+                }
+            )
+        if normalized_choices:
+            actions.append(
+                {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": "其他 / 手动输入"},
+                    "type": "default",
+                    "value": {
+                        "hermes_clarify": True,
+                        "prompt_id": prompt_id,
+                        "choice_index": 0,
+                        "choice_text": "Other",
+                    },
+                }
+            )
+        elements = []
+        if actions:
+            # Adaptive columns: ≤3 buttons → 1 row; otherwise 3 per row.
+            cols = len(actions) if len(actions) <= 3 else 3
+            for i in range(0, len(actions), cols):
+                elements.append({"tag": "action", "actions": actions[i:i + cols]})
+        else:
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "content": "请直接回复这条消息，输入你的答案。",
+                }
+            )
         return {
             "config": {"wide_screen_mode": True},
             "header": {
-                "title": {"content": f"{icon} {label}", "tag": "plain_text"},
-                "template": "red" if choice == "deny" else "green",
+                "title": {"content": normalized_question or "❓ 请选择", "tag": "plain_text"},
+                "template": "blue",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": elements,
         }
+
+    def _build_ask_form_card(self, questions: list[dict], prompt_id: str) -> dict:
+        """Build a Feishu Card V2 form for structured multi-question input."""
+        form_elements: list[dict] = []
+
+        for idx, q in enumerate(questions):
+            header = str(q.get("header", "")).strip()
+            question_text = str(q.get("question", "")).strip()
+            options = q.get("options") or []
+            multi_select = bool(q.get("multiSelect", False))
+            allow_freeform = bool(q.get("allowFreeformInput", False))
+
+            if idx > 0:
+                form_elements.append({"tag": "hr"})
+
+            if options:
+                rendered_options = []
+                initial_option = None
+                for opt in options:
+                    label = str(opt.get("label", "")).strip()
+                    desc = str(opt.get("description", "")).strip()
+                    recommended = bool(opt.get("recommended", False))
+                    display = f"⭐ {label}" if recommended else label
+                    if desc:
+                        display = f"{display} — {desc}"
+                    rendered_options.append({
+                        "text": {"tag": "plain_text", "content": display},
+                        "value": label,
+                    })
+                    if recommended and initial_option is None:
+                        initial_option = label
+
+                if multi_select:
+                    component: dict = {
+                        "tag": "multi_select_static",
+                        "name": header,
+                        "required": False,
+                        "width": "fill",
+                        "placeholder": {"tag": "plain_text", "content": "请选择（可多选）"},
+                        "options": rendered_options,
+                    }
+                    if initial_option:
+                        component["selected_values"] = [initial_option]
+                    form_elements.append({
+                        "tag": "markdown",
+                        "content": f"**{question_text}**",
+                    })
+                    form_elements.append(component)
+                else:
+                    component = {
+                        "tag": "select_static",
+                        "name": header,
+                        "required": False,
+                        "width": "fill",
+                        "placeholder": {"tag": "plain_text", "content": "请选择"},
+                        "options": rendered_options,
+                    }
+                    if initial_option:
+                        component["initial_option"] = initial_option
+                    form_elements.append({
+                        "tag": "markdown",
+                        "content": f"**{question_text}**",
+                    })
+                    form_elements.append(component)
+
+                if allow_freeform:
+                    form_elements.append({
+                        "tag": "input",
+                        "name": f"{header}_freeform",
+                        "required": False,
+                        "input_type": "text",
+                        "max_length": 500,
+                        "width": "fill",
+                        "placeholder": {"tag": "plain_text", "content": "或输入自定义内容"},
+                        "label": {"tag": "plain_text", "content": "自定义输入"},
+                        "label_position": "top",
+                    })
+            else:
+                form_elements.append({
+                    "tag": "input",
+                    "name": header,
+                    "required": False,
+                    "input_type": "multiline_text",
+                    "rows": 3,
+                    "max_length": 1000,
+                    "width": "fill",
+                    "placeholder": {"tag": "plain_text", "content": "请输入你的回答"},
+                    "label": {"tag": "plain_text", "content": question_text},
+                    "label_position": "top",
+                })
+
+        form_elements.append({
+            "tag": "button",
+            "name": "hermes_ask_submit",
+            "form_action_type": "submit",
+            "type": "primary",
+            "text": {"tag": "plain_text", "content": "提交"},
+            "behaviors": [
+                {"type": "callback", "value": {"hermes_ask_form": True, "prompt_id": prompt_id}}
+            ],
+        })
+
+        first_question = str(questions[0].get("question", "")).strip() if questions else ""
+        card_title = first_question[:50] if len(questions) == 1 else "📋 请回答以下问题"
+
+        return {
+            "schema": "2.0",
+            "header": {
+                "title": {"tag": "plain_text", "content": card_title},
+                "template": "blue",
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "form",
+                        "name": "hermes_ask_form",
+                        "elements": form_elements,
+                    }
+                ]
+            },
+        }
+
+    def _parse_form_value(self, form_value: dict, questions: list[dict]) -> dict:
+        """Parse a Feishu Card V2 form_value into structured responses."""
+        result = {}
+        for q in questions:
+            header = str(q.get("header", "")).strip()
+            allow_freeform = bool(q.get("allowFreeformInput", False))
+
+            raw = form_value.get(header)
+            freeform_key = f"{header}_freeform"
+            freeform_val = str(form_value.get(freeform_key, "") or "").strip() or None
+
+            if isinstance(raw, list):
+                selected = [str(v) for v in raw]
+            elif raw is not None:
+                selected = [str(raw)]
+            else:
+                selected = []
+
+            result[header] = {
+                "selected": selected,
+                "freeform": freeform_val if allow_freeform else None,
+            }
+        return result
 
     async def send_voice(
         self,
@@ -1853,81 +2086,34 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
 
     def _on_card_action_trigger(self, data: Any) -> Any:
-        """Handle card-action callback from the Feishu SDK (synchronous).
+        """Handle Feishu card action and return inline card update.
 
-        For approval actions: parses the event once, returns the resolved card
-        inline (the only reliable way to sync all clients), and schedules a
-        lightweight async method to actually unblock the agent.
-
-        For other card actions: delegates to ``_handle_card_action_event``.
+        Waits for the async handler to complete so the updated card can be
+        returned directly in the callback response — this is the reliable
+        way to update a card on button/form interaction.
         """
         loop = self._loop
-        if not self._loop_accepts_callbacks(loop):
+        if loop is None or bool(getattr(loop, "is_closed", lambda: False)()):
             logger.warning("[Feishu] Dropping card action before adapter loop is ready")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
         event = getattr(data, "event", None)
-        action = getattr(event, "action", None)
-        action_value = getattr(action, "value", {}) or {}
-        hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
+        token = str(getattr(event, "token", "") or "")
 
-        if hermes_action:
-            return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
-
-        self._submit_on_loop(loop, self._handle_card_action_event(data))
-        if P2CardActionTriggerResponse is None:
-            return None
-        return P2CardActionTriggerResponse()
-
-    @staticmethod
-    def _loop_accepts_callbacks(loop: Any) -> bool:
-        """Return True when the adapter loop can accept thread-safe submissions."""
-        return loop is not None and not bool(getattr(loop, "is_closed", lambda: False)())
-
-    def _submit_on_loop(self, loop: Any, coro: Any) -> None:
-        """Schedule background work on the adapter loop with shared failure logging."""
-        future = asyncio.run_coroutine_threadsafe(coro, loop)
-        future.add_done_callback(self._log_background_failure)
-
-    def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
-        """Schedule approval resolution and build the synchronous callback response."""
-        approval_id = action_value.get("approval_id")
-        if approval_id is None:
-            logger.debug("[Feishu] Card action missing approval_id, ignoring")
-            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
-        choice = _APPROVAL_CHOICE_MAP.get(action_value.get("hermes_action"), "deny")
-
-        operator = getattr(event, "operator", None)
-        open_id = str(getattr(operator, "open_id", "") or "")
-        user_name = self._get_cached_sender_name(open_id) or open_id
-
-        self._submit_on_loop(loop, self._resolve_approval(approval_id, choice, user_name))
-
-        if P2CardActionTriggerResponse is None:
-            return None
-        response = P2CardActionTriggerResponse()
-        if CallBackCard is not None:
-            card = CallBackCard()
-            card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
-            response.card = card
-        return response
-
-    async def _resolve_approval(self, approval_id: Any, choice: str, user_name: str) -> None:
-        """Pop approval state and unblock the waiting agent thread."""
-        state = self._approval_state.pop(approval_id, None)
-        if not state:
-            logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
-            return
+        future = asyncio.run_coroutine_threadsafe(
+            self._handle_card_action_event(data),
+            loop,
+        )
         try:
-            from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
-            logger.info(
-                "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                count, state["session_key"], choice, user_name,
-            )
+            result = future.result(timeout=10)
+            if isinstance(result, P2CardActionTriggerResponse):
+                if token:
+                    self._card_action_responses[token] = result
+                return result
         except Exception as exc:
-            logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+            logger.warning("[Feishu] Card action handler failed or timed out: %s", exc)
+
+        return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -1966,7 +2152,7 @@ class FeishuAdapter(BasePlatformAdapter):
         action = "added" if "created" in event_type else "removed"
         synthetic_text = f"reaction:{action}:{emoji_type}"
 
-        sender_profile = await self._resolve_sender_profile(user_id_obj)
+        sender_profile = await self._resolve_sender_profile(user_id_obj, chat_id=chat_id)
         chat_info = await self.get_chat_info(chat_id)
         source = self.build_source(
             chat_id=chat_id,
@@ -1991,22 +2177,49 @@ class FeishuAdapter(BasePlatformAdapter):
     def _is_card_action_duplicate(self, token: str) -> bool:
         """Return True if this card action token was already processed within the dedup window."""
         now = time.time()
-        # Prune expired tokens lazily each call.
+        # Prune expired tokens and their cached responses lazily each call.
         expired = [t for t, ts in self._card_action_tokens.items() if now - ts > _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS]
         for t in expired:
             del self._card_action_tokens[t]
+            self._card_action_responses.pop(t, None)
         if token in self._card_action_tokens:
             return True
         self._card_action_tokens[token] = now
         return False
 
-    async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
+    def _build_inline_card_response(self, card: dict, toast_content: Optional[str] = None) -> Any:
+        """Build a P2CardActionTriggerResponse with an inline card update."""
+        if P2CardActionTriggerResponse is None:
+            return None
+        resp = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            cb_card = CallBackCard()
+            cb_card.type = "raw"
+            cb_card.data = card
+            resp.card = cb_card
+        if toast_content and CallBackToast is not None:
+            toast = CallBackToast()
+            toast.type = "info"
+            toast.content = toast_content
+            resp.toast = toast
+        return resp
+
+    async def _handle_card_action_event(self, data: Any) -> Any:
+        """Route Feishu interactive card button clicks as synthetic COMMAND events.
+
+        Returns a ``P2CardActionTriggerResponse`` when the card should be
+        updated inline (approval / clarify / form actions), or ``None``
+        for generic card actions routed as synthetic commands.
+        """
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
         if token and self._is_card_action_duplicate(token):
-            logger.debug("[Feishu] Dropping duplicate card action token: %s", token)
-            return
+            cached = self._card_action_responses.get(token)
+            if cached is not None:
+                logger.debug("[Feishu] Returning cached response for duplicate card action token: %s", token)
+                return cached
+            logger.debug("[Feishu] Dropping duplicate card action token (no cached response): %s", token)
+            return None
 
         context = getattr(event, "context", None)
         chat_id = str(getattr(context, "open_chat_id", "") or "")
@@ -2014,11 +2227,145 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = str(getattr(operator, "open_id", "") or "")
         if not chat_id or not open_id:
             logger.debug("[Feishu] Card action missing chat_id or operator open_id, dropping")
-            return
+            return None
 
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
+
+        # --- Exec approval button intercept ---
+        hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
+        if hermes_action:
+            approval_id = action_value.get("approval_id")
+            state = self._approval_state.pop(approval_id, None)
+            if not state:
+                logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
+                return None
+
+            choice_map = {
+                "approve_once": "once",
+                "approve_session": "session",
+                "approve_always": "always",
+                "deny": "deny",
+            }
+            choice = choice_map.get(hermes_action, "deny")
+
+            label_map = {
+                "once": "Approved once",
+                "session": "Approved for session",
+                "always": "Approved permanently",
+                "deny": "Denied",
+            }
+            label = label_map.get(choice, "Resolved")
+
+            # Resolve sender name for the status card
+            sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+            sender_profile = await self._resolve_sender_profile(sender_id, chat_id=chat_id)
+            user_name = sender_profile.get("user_name") or "用户"
+
+            # Resolve the approval — unblocks the agent thread
+            try:
+                from tools.approval import resolve_gateway_approval
+                count = resolve_gateway_approval(state["session_key"], choice)
+                logger.info(
+                    "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                    count, state["session_key"], choice, user_name,
+                )
+            except Exception as exc:
+                logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+
+            # Return inline card update
+            icon = "❌" if choice == "deny" else "✅"
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": f"{icon} {label}", "tag": "plain_text"},
+                    "template": "red" if choice == "deny" else "green",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": f"{icon} **{label}** by {user_name}"},
+                ],
+            }
+            return self._build_inline_card_response(card, toast_content=label)
+
+        # --- Clarify button intercept ---
+        if isinstance(action_value, dict) and action_value.get("hermes_clarify"):
+            prompt_id = str(action_value.get("prompt_id", "") or "")
+            state = self._clarify_state.get(prompt_id)
+            if not state:
+                logger.debug("[Feishu] Clarify prompt %s already resolved or unknown", prompt_id)
+                return None
+            response_text = str(action_value.get("choice_text") or "").strip() or "Other"
+            sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+            sender_profile = await self._resolve_sender_profile(sender_id, chat_id=chat_id)
+            user_name = sender_profile.get("user_name") or "用户"
+            state["response"] = response_text
+            state["resolved_by"] = user_name
+            state["event"].set()
+
+            question = state.get("question", "")
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "✅ 已选择", "tag": "plain_text"},
+                    "template": "green",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": f"**问题：** {question}"},
+                    {"tag": "markdown", "content": f"**回答：** {response_text}"},
+                    {"tag": "markdown", "content": f"由 {user_name} 选择"},
+                ],
+            }
+            return self._build_inline_card_response(card, toast_content="已选择")
+
+        form_value = getattr(action, "form_value", None)
+        if isinstance(form_value, dict) and isinstance(action_value, dict) and action_value.get("hermes_ask_form"):
+            prompt_id = str(action_value.get("prompt_id", "") or "")
+            state = self._clarify_state.get(prompt_id)
+            if not state:
+                logger.debug("[Feishu] Ask form prompt %s already resolved or unknown", prompt_id)
+                return None
+
+            questions = state.get("questions") or []
+            parsed = self._parse_form_value(form_value, questions)
+
+            sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+            sender_profile = await self._resolve_sender_profile(sender_id, chat_id=chat_id)
+            user_name = sender_profile.get("user_name") or "用户"
+
+            state["response"] = parsed
+            state["resolved_by"] = user_name
+            state["event"].set()
+
+            # Build summary for inline card update
+            summary_lines = []
+            for q in questions:
+                header = str(q.get("header", "")).strip()
+                resp = parsed.get(header, {})
+                selected = resp.get("selected", [])
+                freeform = resp.get("freeform")
+                parts = []
+                if selected:
+                    parts.append("\u3001".join(selected))
+                if freeform:
+                    parts.append(freeform)
+                answer = " | ".join(parts) if parts else "（未填写）"
+                summary_lines.append(f"**{header}:** {answer}")
+
+            card = {
+                "schema": "2.0",
+                "header": {
+                    "title": {"tag": "plain_text", "content": "✅ 已提交"},
+                    "template": "green",
+                },
+                "body": {
+                    "elements": [
+                        {"tag": "markdown", "content": "\n".join(summary_lines)},
+                        {"tag": "markdown", "content": f"由 {user_name} 提交"},
+                    ],
+                },
+            }
+            return self._build_inline_card_response(card, toast_content="已提交")
 
         synthetic_text = f"/card {action_tag}"
         if action_value:
@@ -2028,7 +2375,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 pass
 
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
-        sender_profile = await self._resolve_sender_profile(sender_id)
+        sender_profile = await self._resolve_sender_profile(sender_id, chat_id=chat_id)
         chat_info = await self.get_chat_info(chat_id)
         source = self.build_source(
             chat_id=chat_id,
@@ -2187,7 +2534,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
-        sender_profile = await self._resolve_sender_profile(sender_id)
+        sender_profile = await self._resolve_sender_profile(sender_id, chat_id=chat_id)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -2910,35 +3257,23 @@ class FeishuAdapter(BasePlatformAdapter):
             return "dm"
         return "group"
 
-    async def _resolve_sender_profile(self, sender_id: Any) -> Dict[str, Optional[str]]:
+    async def _resolve_sender_profile(self, sender_id: Any, chat_id: str = "") -> Dict[str, Optional[str]]:
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
         primary_id = open_id or user_id
-        display_name = await self._resolve_sender_name_from_api(primary_id or union_id)
+        display_name = await self._resolve_sender_name_from_api(primary_id or union_id, chat_id=chat_id)
         return {
             "user_id": primary_id,
             "user_name": display_name,
             "user_id_alt": union_id,
         }
 
-    def _get_cached_sender_name(self, sender_id: Optional[str]) -> Optional[str]:
-        """Return a cached sender name only while its TTL is still valid."""
-        if not sender_id:
-            return None
-        cached = self._sender_name_cache.get(sender_id)
-        if cached is None:
-            return None
-        name, expire_at = cached
-        if time.time() < expire_at:
-            return name
-        self._sender_name_cache.pop(sender_id, None)
-        return None
-
-    async def _resolve_sender_name_from_api(self, sender_id: Optional[str]) -> Optional[str]:
+    async def _resolve_sender_name_from_api(self, sender_id: Optional[str], *, chat_id: str = "") -> Optional[str]:
         """Fetch the sender's display name from the Feishu contact API with a 10-minute cache.
 
         ID-type detection mirrors openclaw: ou_ → open_id, on_ → union_id, else user_id.
+        Falls back to the IM chat-members API when contact scope is insufficient.
         Failures are silently suppressed; the message pipeline must not block on name resolution.
         """
         if not sender_id or not self._client:
@@ -2947,9 +3282,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not trimmed:
             return None
         now = time.time()
-        cached_name = self._get_cached_sender_name(trimmed)
-        if cached_name is not None:
-            return cached_name
+        cached = self._sender_name_cache.get(trimmed)
+        if cached is not None:
+            name, expire_at = cached
+            if now < expire_at:
+                return name
         try:
             from lark_oapi.api.contact.v3 import GetUserRequest  # lazy import
             if trimmed.startswith("ou_"):
@@ -2961,7 +3298,12 @@ class FeishuAdapter(BasePlatformAdapter):
             request = GetUserRequest.builder().user_id(trimmed).user_id_type(id_type).build()
             response = await asyncio.to_thread(self._client.contact.v3.user.get, request)
             if not response or not response.success():
-                return None
+                logger.debug(
+                    "[Feishu] Contact API failed for %s (code=%s), trying chat-members fallback.",
+                    sender_id,
+                    getattr(response, "code", "?"),
+                )
+                return await self._resolve_name_from_chat_members(trimmed, chat_id)
             user = getattr(getattr(response, "data", None), "user", None)
             name = (
                 getattr(user, "name", None)
@@ -2976,6 +3318,38 @@ class FeishuAdapter(BasePlatformAdapter):
                     return name
         except Exception:
             logger.debug("[Feishu] Failed to resolve sender name for %s", sender_id, exc_info=True)
+        return await self._resolve_name_from_chat_members(trimmed, chat_id)
+
+    async def _resolve_name_from_chat_members(self, open_id: str, chat_id: str) -> Optional[str]:
+        """Fallback: look up a user's name via the IM chat-members API.
+
+        This avoids the 'contact:user.base:readonly' scope / visibility-range
+        requirement by using im:chat permissions the bot already has.
+        """
+        if not chat_id or not self._client:
+            return None
+        try:
+            from lark_oapi.api.im.v1 import GetChatMembersRequest  # lazy import
+            request = (
+                GetChatMembersRequest.builder()
+                .chat_id(chat_id)
+                .member_id_type("open_id")
+                .build()
+            )
+            response = await asyncio.to_thread(self._client.im.v1.chat_members.get, request)
+            if not response or not getattr(response, "success", lambda: False)():
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            for member in items:
+                if getattr(member, "member_id", None) == open_id:
+                    name = getattr(member, "name", None)
+                    if name and isinstance(name, str) and name.strip():
+                        name = name.strip()
+                        now = time.time()
+                        self._sender_name_cache[open_id] = (name, now + _FEISHU_SENDER_NAME_TTL_SECONDS)
+                        return name
+        except Exception:
+            logger.debug("[Feishu] chat-members fallback failed for %s in %s", open_id, chat_id, exc_info=True)
         return None
 
     async def _fetch_message_text(self, message_id: str) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+import uuid
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
@@ -8057,6 +8058,10 @@ class GatewayRunner:
             if event_type not in ("tool.started",):
                 return
 
+            # Skip tools that have their own interactive UI (e.g. cards).
+            if tool_name in ("clarify",):
+                return
+
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
@@ -8504,6 +8509,83 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            def _clarify_callback_sync(question: str, choices=None, questions=None):
+                prompt_id = str(uuid.uuid4())
+                state = {
+                    "event": threading.Event(),
+                    "response": None,
+                    "question": question,
+                    "choices": list(choices or []),
+                    "questions": questions,
+                    "message_id": "",
+                }
+                adapter_state = getattr(_status_adapter, "_clarify_state", None)
+                if not isinstance(adapter_state, dict):
+                    raise RuntimeError("Adapter does not support clarify state")
+                adapter_state[prompt_id] = state
+
+                sent = False
+                if getattr(type(_status_adapter), "send_clarify_prompt", None) is not None:
+                    try:
+                        result = asyncio.run_coroutine_threadsafe(
+                            _status_adapter.send_clarify_prompt(
+                                chat_id=_status_chat_id,
+                                question=question or "",
+                                choices=list(choices or []),
+                                prompt_id=prompt_id,
+                                metadata=_status_thread_metadata,
+                                questions=questions,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=20)
+                        if result and getattr(result, "success", False):
+                            state["message_id"] = getattr(result, "message_id", "") or ""
+                            sent = True
+                    except Exception as _e:
+                        logger.warning("Clarify card prompt failed, falling back to text: %s", _e)
+
+                if not sent:
+                    if questions:
+                        lines = ["📋 请回答以下问题：", ""]
+                        for idx, q in enumerate(questions, 1):
+                            lines.append(f"**{idx}. {q.get('header', '')}** — {q.get('question', '')}")
+                            opts = q.get("options") or []
+                            for oi, opt in enumerate(opts, 1):
+                                label = opt.get("label", "")
+                                desc = opt.get("description", "")
+                                rec = " ⭐" if opt.get("recommended") else ""
+                                lines.append(f"   {oi}. {label}{rec}" + (f" — {desc}" if desc else ""))
+                            if q.get("allowFreeformInput"):
+                                lines.append("   (也可直接输入自定义内容)")
+                            lines.append("")
+                        msg = "\n".join(lines)
+                    else:
+                        choices_text = ""
+                        if choices:
+                            rendered = [f"{idx + 1}. {choice}" for idx, choice in enumerate(choices)]
+                            rendered.append(f"{len(rendered) + 1}. 其他（直接回复）")
+                            choices_text = "\n" + "\n".join(rendered)
+                        msg = f"❓ {question}{choices_text}"
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send(
+                            _status_chat_id,
+                            msg,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+
+                if not state["event"].wait(timeout=1800):
+                    adapter_state.pop(prompt_id, None)
+                    raise TimeoutError("Timed out waiting for user clarification")
+                response = state.get("response")
+                adapter_state.pop(prompt_id, None)
+
+                if questions and isinstance(response, dict):
+                    return json.dumps(response, ensure_ascii=False)
+                return str(response or "").strip()
+
+            agent.clarify_callback = _clarify_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -635,6 +635,9 @@ class GatewayStreamConsumer:
         _visible_stripped = visible_without_cursor.strip()
         if not _visible_stripped:
             return True  # cursor-only / whitespace-only update
+        # Strip leading newlines — the non-streaming path does this via
+        # format_message().strip(), but edit_message() skips formatting.
+        text = text.lstrip('\n')
         if not text.strip():
             return True  # nothing to send is "success"
         # Guard: do not create a brand-new standalone message when the only

--- a/run_agent.py
+++ b/run_agent.py
@@ -6980,6 +6980,7 @@ class AIAgent:
             return _clarify_tool(
                 question=function_args.get("question", ""),
                 choices=function_args.get("choices"),
+                questions=function_args.get("questions"),
                 callback=self.clarify_callback,
             )
         elif function_name == "delegate_task":
@@ -7392,6 +7393,7 @@ class AIAgent:
                 function_result = _clarify_tool(
                     question=function_args.get("question", ""),
                     choices=function_args.get("choices"),
+                    questions=function_args.get("questions"),
                     callback=self.clarify_callback,
                 )
                 tool_duration = time.time() - tool_start_time

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -24,6 +24,8 @@ def _mock_event_dispatcher_builder(mock_handler_class):
     mock_builder.register_p2_im_message_reaction_created_v1 = Mock(return_value=mock_builder)
     mock_builder.register_p2_im_message_reaction_deleted_v1 = Mock(return_value=mock_builder)
     mock_builder.register_p2_card_action_trigger = Mock(return_value=mock_builder)
+    mock_builder.register_p2_im_chat_member_bot_added_v1 = Mock(return_value=mock_builder)
+    mock_builder.register_p2_im_chat_member_bot_deleted_v1 = Mock(return_value=mock_builder)
     mock_builder.build = Mock(return_value=object())
     mock_handler_class.builder = Mock(return_value=mock_builder)
     return mock_builder

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -1,11 +1,13 @@
 """Tests for Feishu interactive card approval buttons."""
 
-import importlib.util
+import asyncio
 import json
+import os
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -22,14 +24,29 @@ if _repo not in sys.path:
 # ---------------------------------------------------------------------------
 def _ensure_feishu_mocks():
     """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
-    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+    if "lark_oapi" not in sys.modules:
         mod = MagicMock()
+        # Must cover every submodule path imported by feishu.py's top-level
+        # try/except block, otherwise the whole block falls to ImportError
+        # and sets P2CardActionTriggerResponse etc. to None.
         for name in (
-            "lark_oapi", "lark_oapi.api.im.v1",
-            "lark_oapi.event", "lark_oapi.event.callback_type",
+            "lark_oapi",
+            "lark_oapi.api",
+            "lark_oapi.api.application",
+            "lark_oapi.api.application.v6",
+            "lark_oapi.api.im",
+            "lark_oapi.api.im.v1",
+            "lark_oapi.core",
+            "lark_oapi.core.const",
+            "lark_oapi.event",
+            "lark_oapi.event.callback",
+            "lark_oapi.event.callback.model",
+            "lark_oapi.event.callback.model.p2_card_action_trigger",
+            "lark_oapi.event.dispatcher_handler",
+            "lark_oapi.ws",
         ):
             sys.modules.setdefault(name, mod)
-    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+    if "aiohttp" not in sys.modules:
         aio = MagicMock()
         sys.modules.setdefault("aiohttp", aio)
         sys.modules.setdefault("aiohttp.web", aio.web)
@@ -38,7 +55,6 @@ def _ensure_feishu_mocks():
 _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
-import gateway.platforms.feishu as feishu_module
 from gateway.platforms.feishu import FeishuAdapter
 
 
@@ -59,6 +75,8 @@ def _make_card_action_data(
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
     token: str = "tok_abc",
+    form_value: dict = None,
+    action_name: str = None,
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
     return SimpleNamespace(
@@ -69,15 +87,11 @@ def _make_card_action_data(
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
+                form_value=form_value,
+                name=action_name,
             ),
         ),
     )
-
-
-def _close_submitted_coro(coro, _loop):
-    """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
-    coro.close()
-    return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
 
 
 # ===========================================================================
@@ -209,14 +223,14 @@ class TestFeishuExecApproval:
 
 
 # ===========================================================================
-# _resolve_approval — approval state pop + gateway resolution
+# _handle_card_action_event — approval button clicks
 # ===========================================================================
 
-class TestResolveApproval:
-    """Test _resolve_approval pops state and calls resolve_gateway_approval."""
+class TestFeishuApprovalCallback:
+    """Test the approval intercept in _handle_card_action_event."""
 
     @pytest.mark.asyncio
-    async def test_resolves_once(self):
+    async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
         adapter._approval_state[1] = {
             "session_key": "agent:main:feishu:group:oc_12345",
@@ -224,14 +238,29 @@ class TestResolveApproval:
             "chat_id": "oc_12345",
         }
 
-        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(1, "once", "Norbert")
+        data = _make_card_action_data(
+            action_value={"hermes_action": "approve_once", "approval_id": 1},
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_user1", "user_name": "Norbert", "user_id_alt": None},
+            ),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            result = await adapter._handle_card_action_event(data)
 
         mock_resolve.assert_called_once_with("agent:main:feishu:group:oc_12345", "once")
+        # Inline card response returned (no separate _update_approval_card call)
+        assert result is not None
+        assert getattr(result, "card", None) is not None
+
+        # State should be cleaned up
         assert 1 not in adapter._approval_state
 
     @pytest.mark.asyncio
-    async def test_resolves_deny(self):
+    async def test_deny_button(self):
         adapter = _make_adapter()
         adapter._approval_state[2] = {
             "session_key": "some-session",
@@ -239,13 +268,26 @@ class TestResolveApproval:
             "chat_id": "oc_12345",
         }
 
-        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(2, "deny", "Alice")
+        data = _make_card_action_data(
+            action_value={"hermes_action": "deny", "approval_id": 2},
+            token="tok_deny",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_alice", "user_name": "Alice", "user_id_alt": None},
+            ),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            result = await adapter._handle_card_action_event(data)
 
         mock_resolve.assert_called_once_with("some-session", "deny")
+        assert result is not None
+        assert getattr(result, "card", None) is not None
 
     @pytest.mark.asyncio
-    async def test_resolves_session(self):
+    async def test_session_approval(self):
         adapter = _make_adapter()
         adapter._approval_state[3] = {
             "session_key": "sess-3",
@@ -253,13 +295,26 @@ class TestResolveApproval:
             "chat_id": "oc_99",
         }
 
-        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(3, "session", "Bob")
+        data = _make_card_action_data(
+            action_value={"hermes_action": "approve_session", "approval_id": 3},
+            token="tok_ses",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Bob", "user_id_alt": None},
+            ),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            result = await adapter._handle_card_action_event(data)
 
         mock_resolve.assert_called_once_with("sess-3", "session")
+        assert result is not None
+        assert getattr(result, "card", None) is not None
 
     @pytest.mark.asyncio
-    async def test_resolves_always(self):
+    async def test_always_approval(self):
         adapter = _make_adapter()
         adapter._approval_state[4] = {
             "session_key": "sess-4",
@@ -267,29 +322,41 @@ class TestResolveApproval:
             "chat_id": "oc_55",
         }
 
-        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
-            await adapter._resolve_approval(4, "always", "Carol")
+        data = _make_card_action_data(
+            action_value={"hermes_action": "approve_always", "approval_id": 4},
+            token="tok_alw",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Carol", "user_id_alt": None},
+            ),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            await adapter._handle_card_action_event(data)
 
         mock_resolve.assert_called_once_with("sess-4", "always")
 
     @pytest.mark.asyncio
     async def test_already_resolved_drops_silently(self):
         adapter = _make_adapter()
+        # No state for approval_id 99 — already resolved
+
+        data = _make_card_action_data(
+            action_value={"hermes_action": "approve_once", "approval_id": 99},
+            token="tok_gone",
+        )
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
-            await adapter._resolve_approval(99, "once", "Nobody")
+            await adapter._handle_card_action_event(data)
 
+        # Should NOT resolve — already handled
         mock_resolve.assert_not_called()
 
-# ===========================================================================
-# _handle_card_action_event — non-approval card actions
-# ===========================================================================
-
-class TestNonApprovalCardAction:
-    """Non-approval card actions should still route as synthetic commands."""
-
     @pytest.mark.asyncio
-    async def test_routes_as_synthetic_command(self):
+    async def test_non_approval_actions_route_normally(self):
+        """Non-approval card actions should still become synthetic commands."""
         adapter = _make_adapter()
 
         data = _make_card_action_data(
@@ -304,141 +371,557 @@ class TestNonApprovalCardAction:
             ),
             patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
             patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+            patch("tools.approval.resolve_gateway_approval") as mock_resolve,
         ):
             await adapter._handle_card_action_event(data)
 
+        # Should NOT resolve any approval
+        mock_resolve.assert_not_called()
+        # Should have routed as synthetic command
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
 
 
 # ===========================================================================
-# _on_card_action_trigger — inline card response for approval actions
+# _update_approval_card — card replacement after resolution
 # ===========================================================================
 
-class _FakeCallBackCard:
-    def __init__(self):
-        self.type = None
-        self.data = None
-
-
-class _FakeP2Response:
-    def __init__(self):
-        self.card = None
-
-
-@pytest.fixture(autouse=False)
-def _patch_callback_card_types(monkeypatch):
-    """Provide real-ish P2CardActionTriggerResponse / CallBackCard for tests."""
-    monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeP2Response)
-    monkeypatch.setattr(feishu_module, "CallBackCard", _FakeCallBackCard)
-
-
-class TestCardActionCallbackResponse:
-    """Test that _on_card_action_trigger returns updated card inline."""
-
-    def test_drops_action_when_loop_not_ready(self, _patch_callback_card_types):
+class TestFeishuClarifyButtons:
+    @pytest.mark.asyncio
+    async def test_send_clarify_prompt_sends_interactive_card(self):
         adapter = _make_adapter()
-        adapter._loop = None
-        data = _make_card_action_data({"hermes_action": "approve_once", "approval_id": 1})
-
-        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
-            response = adapter._on_card_action_trigger(data)
-
-        assert response is not None
-        assert response.card is None
-        mock_submit.assert_not_called()
-
-    def test_returns_card_for_approve_action(self, _patch_callback_card_types):
-        adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
-        data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 1},
-            open_id="ou_bob",
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clarify_1"),
         )
-        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_prompt(
+                chat_id="oc_12345",
+                question="你想测试哪一种？",
+                choices=["多选按钮", "开放输入"],
+                prompt_id="prompt-1",
+            )
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "blue"
+        actions = []
+        for element in card["elements"]:
+            if element.get("tag") == "action":
+                actions.extend(element["actions"])
+        assert any(a["value"].get("hermes_clarify") for a in actions)
+        assert any(a["value"].get("choice_text") == "多选按钮" for a in actions)
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
-            response = adapter._on_card_action_trigger(data)
-
-        assert response is not None
-        assert response.card is not None
-        assert response.card.type == "raw"
-        card = response.card.data
-        assert card["header"]["template"] == "green"
-        assert "Approved once" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
-
-    def test_returns_card_for_deny_action(self, _patch_callback_card_types):
+    @pytest.mark.asyncio
+    async def test_clarify_button_resolves_waiter_and_updates_card(self):
         adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
+        evt = threading.Event()
+        adapter._clarify_state["prompt-42"] = {
+            "event": evt,
+            "response": None,
+            "question": "继续做什么？",
+            "message_id": "msg_clarify_42",
+        }
         data = _make_card_action_data(
-            {"hermes_action": "deny", "approval_id": 2},
+            action_value={
+                "hermes_clarify": True,
+                "prompt_id": "prompt-42",
+                "choice_index": 1,
+                "choice_text": "检查配置",
+            },
+            token="tok_clarify",
         )
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Alice", "user_id_alt": None},
+            ),
+        ):
+            result = await adapter._handle_card_action_event(data)
+        assert evt.is_set()
+        assert adapter._clarify_state["prompt-42"]["response"] == "检查配置"
+        # Verify inline card response is returned
+        assert result is not None
+        assert getattr(result, "card", None) is not None
+        assert result.card.data["header"]["template"] == "green"
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
-            response = adapter._on_card_action_trigger(data)
 
-        assert response.card is not None
-        card = response.card.data
-        assert card["header"]["template"] == "red"
-        assert "Denied" in card["header"]["title"]["content"]
+# ===========================================================================
+# Card V2 form building (ask-form)
+# ===========================================================================
 
-    def test_ignores_missing_approval_id(self, _patch_callback_card_types):
+class TestFeishuAskFormCard:
+
+    def test_build_ask_form_card_basic_structure(self):
         adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
-        data = _make_card_action_data({"hermes_action": "approve_once"})
+        questions = [
+            {
+                "header": "env",
+                "question": "Which environment?",
+                "options": [
+                    {"label": "staging", "description": "Test env"},
+                    {"label": "production"},
+                ],
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "prompt-123")
+        assert card["schema"] == "2.0"
+        assert "body" in card
+        assert "elements" in card["body"]
+        assert card["header"]["template"] == "blue"
 
-        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
-            response = adapter._on_card_action_trigger(data)
-
-        assert response is not None
-        assert response.card is None
-        mock_submit.assert_not_called()
-
-    def test_no_card_for_non_approval_action(self, _patch_callback_card_types):
+    def test_build_ask_form_card_has_form_container(self):
         adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
-        data = _make_card_action_data({"some_other": "value"})
+        questions = [{"header": "q1", "question": "What?"}]
+        card = adapter._build_ask_form_card(questions, "prompt-1")
+        forms = [e for e in card["body"]["elements"] if e.get("tag") == "form"]
+        assert len(forms) == 1
+        assert forms[0]["name"] == "hermes_ask_form"
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
-            response = adapter._on_card_action_trigger(data)
-
-        assert response is not None
-        assert response.card is None
-
-    def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
+    def test_build_ask_form_card_single_select_option(self):
         adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
+        questions = [
+            {
+                "header": "deploy_env",
+                "question": "Deploy where?",
+                "options": [
+                    {"label": "staging", "recommended": True},
+                    {"label": "production"},
+                ],
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        selects = [e for e in form["elements"] if e.get("tag") == "select_static"]
+        assert len(selects) == 1
+        assert selects[0]["name"] == "deploy_env"
+        assert selects[0]["initial_option"] == "staging"
+        assert len(selects[0]["options"]) == 2
+
+    def test_build_ask_form_card_multi_select_option(self):
+        adapter = _make_adapter()
+        questions = [
+            {
+                "header": "tags",
+                "question": "Select tags",
+                "multiSelect": True,
+                "options": [
+                    {"label": "bug"},
+                    {"label": "feature"},
+                ],
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        multi = [e for e in form["elements"] if e.get("tag") == "multi_select_static"]
+        assert len(multi) == 1
+        assert multi[0]["name"] == "tags"
+
+    def test_build_ask_form_card_freeform_input(self):
+        adapter = _make_adapter()
+        questions = [
+            {
+                "header": "notes",
+                "question": "Any notes?",
+                "allowFreeformInput": True,
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        inputs = [e for e in form["elements"] if e.get("tag") == "input"]
+        assert len(inputs) == 1
+        assert inputs[0]["name"] == "notes"
+
+    def test_build_ask_form_card_options_plus_freeform(self):
+        adapter = _make_adapter()
+        questions = [
+            {
+                "header": "choice",
+                "question": "Pick or type",
+                "options": [{"label": "A"}, {"label": "B"}],
+                "allowFreeformInput": True,
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        selects = [e for e in form["elements"] if e.get("tag") == "select_static"]
+        inputs = [e for e in form["elements"] if e.get("tag") == "input"]
+        assert len(selects) == 1
+        assert selects[0]["name"] == "choice"
+        assert len(inputs) == 1
+        assert inputs[0]["name"] == "choice_freeform"
+
+    def test_build_ask_form_card_has_submit_button(self):
+        adapter = _make_adapter()
+        questions = [{"header": "q1", "question": "Q?"}]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        buttons = [e for e in form["elements"] if e.get("tag") == "button"]
+        submit_buttons = [b for b in buttons if b.get("form_action_type") == "submit"]
+        assert len(submit_buttons) >= 1
+        assert submit_buttons[0]["behaviors"][0]["value"]["hermes_ask_form"] is True
+
+    def test_build_ask_form_card_recommended_marker_in_label(self):
+        adapter = _make_adapter()
+        questions = [
+            {
+                "header": "env",
+                "question": "Env?",
+                "options": [
+                    {"label": "staging", "recommended": True},
+                    {"label": "prod"},
+                ],
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        select = [e for e in form["elements"] if e.get("tag") == "select_static"][0]
+        recommended_opt = select["options"][0]
+        assert "⭐" in recommended_opt["text"]["content"]
+
+    def test_build_ask_form_card_multiple_questions(self):
+        adapter = _make_adapter()
+        questions = [
+            {"header": "q1", "question": "First?", "allowFreeformInput": True},
+            {"header": "q2", "question": "Second?", "options": [{"label": "A"}]},
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        hrs = [e for e in form["elements"] if e.get("tag") == "hr"]
+        assert len(hrs) >= 1
+
+    def test_build_ask_form_card_option_description(self):
+        adapter = _make_adapter()
+        questions = [
+            {
+                "header": "env",
+                "question": "Env?",
+                "options": [
+                    {"label": "staging", "description": "For testing"},
+                ],
+            }
+        ]
+        card = adapter._build_ask_form_card(questions, "p1")
+        form = [e for e in card["body"]["elements"] if e.get("tag") == "form"][0]
+        select = [e for e in form["elements"] if e.get("tag") == "select_static"][0]
+        assert "For testing" in select["options"][0]["text"]["content"]
+
+
+# ===========================================================================
+# send_clarify_prompt dispatch (V1 vs V2)
+# ===========================================================================
+
+class TestFeishuAskFormSend:
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_prompt_with_questions_sends_v2_card(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_form_1"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_prompt(
+                chat_id="oc_12345",
+                question="",
+                choices=None,
+                prompt_id="prompt-form-1",
+                questions=[
+                    {"header": "env", "question": "Which env?", "options": [{"label": "staging"}]}
+                ],
+            )
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+        card = json.loads(kwargs["payload"])
+        assert card.get("schema") == "2.0"
+        assert "body" in card
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_prompt_without_questions_uses_v1(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_v1"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_prompt(
+                chat_id="oc_12345",
+                question="Pick one",
+                choices=["A", "B"],
+                prompt_id="prompt-v1",
+            )
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        card = json.loads(kwargs["payload"])
+        assert "schema" not in card
+        assert "elements" in card
+
+
+# ===========================================================================
+# Card V2 form submit callback handling
+# ===========================================================================
+
+class TestFeishuAskFormCallback:
+
+    @pytest.mark.asyncio
+    async def test_form_submit_resolves_clarify_state(self):
+        adapter = _make_adapter()
+        evt = threading.Event()
+        adapter._clarify_state["prompt-form-1"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [
+                {"header": "env", "question": "Which env?"},
+            ],
+            "message_id": "msg_form_1",
+        }
         data = _make_card_action_data(
-            {"hermes_action": "approve_session", "approval_id": 3},
-            open_id="ou_unknown",
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-form-1"},
+            form_value={
+                "env": "staging",
+                "hermes_ask_submit": None,
+            },
+            action_name="hermes_ask_submit",
+            token="tok_form_1",
         )
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Alice", "user_id_alt": None},
+            ),
+        ):
+            result = await adapter._handle_card_action_event(data)
+        assert evt.is_set()
+        response = adapter._clarify_state["prompt-form-1"]["response"]
+        assert isinstance(response, dict)
+        assert response["env"] == {"selected": ["staging"], "freeform": None}
+        # Verify inline card response is returned
+        assert result is not None
+        assert getattr(result, "card", None) is not None
+        assert result.card.data["header"]["template"] == "green"
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
-            response = adapter._on_card_action_trigger(data)
-
-        card = response.card.data
-        assert "ou_unknown" in card["elements"][0]["content"]
-
-    def test_ignores_expired_cached_name(self, _patch_callback_card_types):
+    @pytest.mark.asyncio
+    async def test_form_submit_with_multi_select(self):
         adapter = _make_adapter()
-        adapter._loop = MagicMock()
-        adapter._loop.is_closed = MagicMock(return_value=False)
+        evt = threading.Event()
+        adapter._clarify_state["prompt-ms"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [
+                {"header": "tags", "question": "Tags?", "multiSelect": True},
+            ],
+            "message_id": "msg_ms",
+        }
         data = _make_card_action_data(
-            {"hermes_action": "approve_once", "approval_id": 4},
-            open_id="ou_expired",
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-ms"},
+            form_value={"tags": ["bug", "feature"]},
+            token="tok_ms",
         )
-        adapter._sender_name_cache["ou_expired"] = ("Old Name", 1)
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Bob", "user_id_alt": None},
+            ),
+        ):
+            await adapter._handle_card_action_event(data)
+        assert evt.is_set()
+        response = adapter._clarify_state["prompt-ms"]["response"]
+        assert response["tags"] == {"selected": ["bug", "feature"], "freeform": None}
 
-        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
-            response = adapter._on_card_action_trigger(data)
+    @pytest.mark.asyncio
+    async def test_form_submit_with_freeform(self):
+        adapter = _make_adapter()
+        evt = threading.Event()
+        adapter._clarify_state["prompt-ff"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [
+                {
+                    "header": "choice",
+                    "question": "Pick or type",
+                    "options": [{"label": "A"}],
+                    "allowFreeformInput": True,
+                },
+            ],
+            "message_id": "msg_ff",
+        }
+        data = _make_card_action_data(
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-ff"},
+            form_value={"choice": "A", "choice_freeform": "custom answer"},
+            token="tok_ff",
+        )
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Carol", "user_id_alt": None},
+            ),
+        ):
+            await adapter._handle_card_action_event(data)
+        assert evt.is_set()
+        response = adapter._clarify_state["prompt-ff"]["response"]
+        assert response["choice"] == {"selected": ["A"], "freeform": "custom answer"}
 
-        card = response.card.data
-        assert "Old Name" not in card["elements"][0]["content"]
-        assert "ou_expired" in card["elements"][0]["content"]
+    @pytest.mark.asyncio
+    async def test_form_submit_unknown_prompt_id_ignored(self):
+        adapter = _make_adapter()
+        data = _make_card_action_data(
+            action_value={"hermes_ask_form": True, "prompt_id": "nonexistent"},
+            form_value={"q": "val"},
+            token="tok_unknown",
+        )
+        await adapter._handle_card_action_event(data)
+
+    @pytest.mark.asyncio
+    async def test_form_submit_inline_card_uses_v2_schema(self):
+        """Ask form submit inline response must use Card V2 schema (schema: '2.0', body.elements)."""
+        adapter = _make_adapter()
+        evt = threading.Event()
+        adapter._clarify_state["prompt-v2"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [
+                {"header": "env", "question": "Which env?"},
+            ],
+            "message_id": "msg_v2",
+        }
+        data = _make_card_action_data(
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-v2"},
+            form_value={"env": "prod", "hermes_ask_submit": None},
+            action_name="hermes_ask_submit",
+            token="tok_v2_schema",
+        )
+        with patch.object(
+            adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+            return_value={"user_id": "ou_u", "user_name": "Alice", "user_id_alt": None},
+        ):
+            result = await adapter._handle_card_action_event(data)
+        card_data = result.card.data
+        assert card_data.get("schema") == "2.0", "Ask form submit card must use V2 schema"
+        assert "body" in card_data, "V2 card must have 'body' key"
+        assert "elements" in card_data["body"], "V2 card body must have 'elements'"
+        assert "config" not in card_data, "V2 card should not have 'config' (V1 field)"
+
+
+class TestDuplicateTokenIdempotency:
+    """Card action duplicate token returns cached inline response."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_token_returns_cached_response(self):
+        adapter = _make_adapter()
+        evt = threading.Event()
+        adapter._clarify_state["prompt-dup"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [{"header": "q1", "question": "Q?"}],
+            "message_id": "msg_dup",
+        }
+        data = _make_card_action_data(
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-dup"},
+            form_value={"q1": "answer"},
+            action_name="hermes_ask_submit",
+            token="tok_dup_test",
+        )
+        with patch.object(
+            adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+            return_value={"user_id": "ou_u", "user_name": "User", "user_id_alt": None},
+        ):
+            first_result = await adapter._handle_card_action_event(data)
+        assert first_result is not None
+
+        # Simulate _on_card_action_trigger caching the response
+        adapter._card_action_responses["tok_dup_test"] = first_result
+
+        # Second call with same token should return cached response
+        second_result = await adapter._handle_card_action_event(data)
+        assert second_result is first_result
+
+    @pytest.mark.asyncio
+    async def test_response_cached_after_first_handling(self):
+        """After handler returns a response, caching it keyed by token enables idempotent replay."""
+        adapter = _make_adapter()
+        evt = threading.Event()
+        adapter._clarify_state["prompt-cache"] = {
+            "event": evt,
+            "response": None,
+            "question": "",
+            "questions": [{"header": "q", "question": "Q?"}],
+            "message_id": "msg_cache",
+        }
+        data = _make_card_action_data(
+            action_value={"hermes_ask_form": True, "prompt_id": "prompt-cache"},
+            form_value={"q": "val"},
+            action_name="hermes_ask_submit",
+            token="tok_cache_test",
+        )
+        with patch.object(
+            adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+            return_value={"user_id": "ou_u", "user_name": "User", "user_id_alt": None},
+        ):
+            result = await adapter._handle_card_action_event(data)
+        assert result is not None
+        # Simulate _on_card_action_trigger caching
+        adapter._card_action_responses["tok_cache_test"] = result
+        assert adapter._card_action_responses["tok_cache_test"] is result
+
+    def test_dedup_prunes_expired_responses(self):
+        """Expired tokens should also clean up cached responses."""
+        import time
+        adapter = _make_adapter()
+        adapter._card_action_tokens["old_tok"] = time.time() - 999
+        adapter._card_action_responses["old_tok"] = MagicMock()
+        # Calling _is_card_action_duplicate should prune the expired entry
+        adapter._is_card_action_duplicate("new_tok")
+        assert "old_tok" not in adapter._card_action_tokens
+        assert "old_tok" not in adapter._card_action_responses
+
+
+class TestChatMembersFallback:
+    """Test _resolve_name_from_chat_members fallback."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_name_from_chat_members(self):
+        adapter = _make_adapter()
+        member = SimpleNamespace(member_id="ou_target", name="张三")
+        mock_resp = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(items=[member]),
+        )
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp):
+            name = await adapter._resolve_name_from_chat_members("ou_target", "oc_chat1")
+        assert name == "张三"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self):
+        adapter = _make_adapter()
+        other = SimpleNamespace(member_id="ou_other", name="李四")
+        mock_resp = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(items=[other]),
+        )
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp):
+            name = await adapter._resolve_name_from_chat_members("ou_target", "oc_chat1")
+        assert name is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self):
+        adapter = _make_adapter()
+        with patch("asyncio.to_thread", new_callable=AsyncMock, side_effect=Exception("API fail")):
+            name = await adapter._resolve_name_from_chat_members("ou_target", "oc_chat1")
+        assert name is None

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -24,8 +24,6 @@ class TestClarifyToolBasics:
             return "blue"
 
         result = json.loads(clarify_tool("What color?", callback=mock_callback))
-        assert result["question"] == "What color?"
-        assert result["choices_offered"] is None
         assert result["user_response"] == "blue"
 
     def test_question_with_choices(self):
@@ -40,8 +38,6 @@ class TestClarifyToolBasics:
             choices=["1", "2", "3"],
             callback=mock_callback
         ))
-        assert result["question"] == "Pick a number"
-        assert result["choices_offered"] == ["1", "2", "3"]
         assert result["user_response"] == "2"
 
     def test_empty_question_returns_error(self):
@@ -193,3 +189,97 @@ class TestClarifySchema:
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
+
+
+class TestClarifyToolQuestionsMode:
+    """Tests for the advanced multi-question mode."""
+
+    def test_questions_mode_routes_to_callback(self):
+        received = {}
+        def mock_callback(question, choices=None, questions=None):
+            received["questions"] = questions
+            return json.dumps({"deploy_target": {"selected": ["staging"], "freeform": None}})
+
+        questions = [
+            {
+                "header": "deploy_target",
+                "question": "Deploy to which env?",
+                "options": [
+                    {"label": "staging", "description": "Test env", "recommended": True},
+                    {"label": "production", "description": "Prod env"},
+                ],
+            }
+        ]
+        result = json.loads(clarify_tool(questions=questions, callback=mock_callback))
+        assert "responses" in result
+        assert received["questions"] == questions
+
+    def test_questions_mode_ignores_question_and_choices(self):
+        received = {}
+        def mock_callback(question, choices=None, questions=None):
+            received["questions"] = questions
+            received["question"] = question
+            return json.dumps({"q1": {"selected": [], "freeform": "hi"}})
+
+        questions = [{"header": "q1", "question": "What?", "allowFreeformInput": True}]
+        clarify_tool(
+            question="ignored question",
+            choices=["ignored"],
+            questions=questions,
+            callback=mock_callback,
+        )
+        assert received["questions"] is not None
+        assert received["question"] is None
+
+    def test_questions_empty_list_returns_error(self):
+        result = json.loads(clarify_tool(questions=[], callback=lambda *a, **kw: ""))
+        assert "error" in result
+
+    def test_questions_missing_header_returns_error(self):
+        result = json.loads(clarify_tool(
+            questions=[{"question": "No header"}],
+            callback=lambda *a, **kw: "",
+        ))
+        assert "error" in result
+
+    def test_questions_missing_question_text_returns_error(self):
+        result = json.loads(clarify_tool(
+            questions=[{"header": "h1"}],
+            callback=lambda *a, **kw: "",
+        ))
+        assert "error" in result
+
+    def test_questions_duplicate_headers_returns_error(self):
+        result = json.loads(clarify_tool(
+            questions=[
+                {"header": "dup", "question": "Q1"},
+                {"header": "dup", "question": "Q2"},
+            ],
+            callback=lambda *a, **kw: "",
+        ))
+        assert "error" in result
+
+    def test_questions_header_max_length_enforced(self):
+        result = json.loads(clarify_tool(
+            questions=[{"header": "x" * 51, "question": "Q?"}],
+            callback=lambda *a, **kw: "",
+        ))
+        assert "error" in result
+
+
+class TestClarifySchemaQuestionsMode:
+    def test_schema_has_questions_property(self):
+        assert "questions" in CLARIFY_SCHEMA["parameters"]["properties"]
+
+    def test_schema_questions_is_array(self):
+        q = CLARIFY_SCHEMA["parameters"]["properties"]["questions"]
+        assert q["type"] == "array"
+
+    def test_schema_questions_items_have_header_and_question(self):
+        items = CLARIFY_SCHEMA["parameters"]["properties"]["questions"]["items"]
+        assert "header" in items["properties"]
+        assert "question" in items["properties"]
+        assert set(items["required"]) == {"header", "question"}
+
+    def test_schema_questions_not_required(self):
+        assert "questions" not in CLARIFY_SCHEMA["parameters"]["required"]

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -19,10 +19,37 @@ from typing import List, Optional, Callable
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
 
+MAX_QUESTIONS = 10
+
+
+def _validate_questions(questions: list) -> Optional[str]:
+    if not questions:
+        return "questions array must not be empty."
+    if len(questions) > MAX_QUESTIONS:
+        return f"questions array exceeds maximum of {MAX_QUESTIONS}."
+    headers_seen: set = set()
+    for i, q in enumerate(questions):
+        if not isinstance(q, dict):
+            return f"questions[{i}] must be an object."
+        header = q.get("header")
+        if not header or not str(header).strip():
+            return f"questions[{i}]: header is required."
+        header = str(header).strip()
+        if len(header) > 50:
+            return f"questions[{i}]: header exceeds 50 characters."
+        if header in headers_seen:
+            return f"Duplicate header '{header}'."
+        headers_seen.add(header)
+        question_text = q.get("question")
+        if not question_text or not str(question_text).strip():
+            return f"questions[{i}]: question text is required."
+    return None
+
 
 def clarify_tool(
-    question: str,
+    question: str = "",
     choices: Optional[List[str]] = None,
+    questions: Optional[List[dict]] = None,
     callback: Optional[Callable] = None,
 ) -> str:
     """
@@ -32,6 +59,8 @@ def clarify_tool(
         question: The question text to present.
         choices:  Up to 4 predefined answer choices. When omitted the
                   question is purely open-ended.
+        questions: Advanced mode — structured multi-question form. When
+                   provided, question and choices are ignored.
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
                   Injected by the agent runner (cli.py / gateway).
@@ -39,6 +68,33 @@ def clarify_tool(
     Returns:
         JSON string with the user's response.
     """
+    # Advanced multi-question mode
+    if questions is not None:
+        err = _validate_questions(questions)
+        if err:
+            return tool_error(err)
+
+        if callback is None:
+            return json.dumps(
+                {"error": "Clarify tool is not available in this execution context."},
+                ensure_ascii=False,
+            )
+
+        try:
+            raw = callback(None, choices=None, questions=questions)
+        except Exception as exc:
+            return json.dumps(
+                {"error": f"Failed to get user input: {exc}"},
+                ensure_ascii=False,
+            )
+
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            parsed = raw
+
+        return json.dumps({"responses": parsed}, ensure_ascii=False)
+
     if not question or not question.strip():
         return tool_error("Question text is required.")
 
@@ -69,9 +125,8 @@ def clarify_tool(
         )
 
     return json.dumps({
-        "question": question,
-        "choices_offered": choices,
         "user_response": str(user_response).strip(),
+        "_note": "The user has made their selection. Continue the conversation based on this choice. Do NOT repeat the question, options, or the user's selection.",
     }, ensure_ascii=False)
 
 
@@ -88,16 +143,24 @@ CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
-        "decision before proceeding. Supports two modes:\n\n"
+        "decision before proceeding. Supports three modes:\n\n"
         "1. **Multiple choice** — provide up to 4 choices. The user picks one "
         "or types their own answer via a 5th 'Other' option.\n"
         "2. **Open-ended** — omit choices entirely. The user types a free-form "
-        "response.\n\n"
+        "response.\n"
+        "3. **Advanced form** — provide a `questions` array for structured "
+        "multi-question forms with options, multi-select, and freeform input.\n\n"
         "Use this tool when:\n"
         "- The task is ambiguous and you need the user to choose an approach\n"
         "- You want post-task feedback ('How did that work out?')\n"
         "- You want to offer to save a skill or update memory\n"
         "- A decision has meaningful trade-offs the user should weigh in on\n\n"
+        "**IMPORTANT — After receiving the result:**\n"
+        "Treat the user's response as equivalent to a new user message. "
+        "Continue the conversation naturally based on their selection or "
+        "answer. Do NOT repeat the question, list of options, or the user's "
+        "choice back to them. Instead, proceed with the task, provide "
+        "relevant follow-up, or act on their decision directly.\n\n"
         "Do NOT use this tool for simple yes/no confirmation of dangerous "
         "commands (the terminal tool handles that). Prefer making a reasonable "
         "default choice yourself when the decision is low-stakes."
@@ -119,6 +182,50 @@ CLARIFY_SCHEMA = {
                     "automatically appends an 'Other (type your answer)' option."
                 ),
             },
+            "questions": {
+                "type": "array",
+                "description": (
+                    "Advanced mode: array of structured questions. Each renders as "
+                    "a form field. When provided, question and choices are ignored."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "header": {
+                            "type": "string",
+                            "maxLength": 50,
+                            "description": "Short unique identifier for this question (used as form field key).",
+                        },
+                        "question": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "The question text displayed to the user.",
+                        },
+                        "multiSelect": {
+                            "type": "boolean",
+                            "description": "Allow multiple selections (default false).",
+                        },
+                        "allowFreeformInput": {
+                            "type": "boolean",
+                            "description": "Show a text input field for custom answers.",
+                        },
+                        "options": {
+                            "type": "array",
+                            "description": "Predefined answer options.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "label": {"type": "string", "description": "Option display text."},
+                                    "description": {"type": "string", "description": "Optional description."},
+                                    "recommended": {"type": "boolean", "description": "Mark as recommended."},
+                                },
+                                "required": ["label"],
+                            },
+                        },
+                    },
+                    "required": ["header", "question"],
+                },
+            },
         },
         "required": ["question"],
     },
@@ -135,6 +242,7 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
+        questions=args.get("questions"),
         callback=kw.get("callback")),
     check_fn=check_clarify_requirements,
     emoji="❓",


### PR DESCRIPTION
## What

Upgrade Feishu's `clarify` / `askQuestion` tool from plain-text messages to **interactive Card V2 forms** with real-time inline response updates.

### Why

The existing plain-text clarify flow on Feishu requires users to type exact option text back — there's no visual structure, and multi-question forms are impossible. Card V2 forms provide native select menus, freeform text inputs, and multi-select checkboxes, matching Feishu's own product UX.

## Changes

| File | What changed |
|------|-------------|
| `tools/clarify_tool.py` | Extended schema with `questions` array — each question supports `header`, `options[]`, `allowFreeformInput`, and `multiSelect` |
| `gateway/platforms/base.py` | Added `send_clarify_prompt(questions=...)` to base adapter interface |
| `gateway/platforms/feishu.py` | Implemented `_build_clarify_card()` (V1 button card), `_build_ask_form_card()` (V2 multi-field form), `_build_inline_card_response()` (inline update), `_handle_card_action_event()` (callback with sender name resolution) |
| `gateway/run.py` | Wired `_clarify_callback_sync` to pass `questions` to platform adapters; text fallback for non-card platforms |
| `gateway/stream_consumer.py` | Strip leading `\n` from streamed edits to avoid blank-looking messages |
| `cli.py` | Updated CLI `_clarify_callback` to accept `**kwargs` for forward compatibility |
| `run_agent.py` | Thread `questions` kwarg through both tool dispatch paths |

## How it works

1. Agent calls `askQuestion` with structured `questions` → adapter builds a Card V2 form (or falls back to V1 button card for single questions without freeform input).
2. User interacts in Feishu (select options / type freeform) → card action callback fires → adapter resolves sender name via Contact API and builds a formatted answer string.
3. The original card is updated **in-place** via `P2CardActionTriggerResponse` (no separate `edit_message` call) → resolved answer is returned to the agent as the tool result.

## How to test

```bash
pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_approval_buttons.py tests/tools/test_clarify_tool.py -v
```

**Manual testing**: Start the gateway (`hermes gateway`), send a message in Feishu that triggers the agent to ask a clarifying question — verify the card renders with selectable options and updates inline after selection.

## Test results

| Suite | Passed |
|-------|--------|
| `tests/gateway/test_feishu.py` | 106 |
| `tests/gateway/test_feishu_approval_buttons.py` | 36 |
| `tests/tools/test_clarify_tool.py` | 31 |
| **Total** | **173** |

## Screenshots
![20260414-192547](https://github.com/user-attachments/assets/40cc4d31-bee5-451c-b024-4a2ed0e5aa24)
![20260414-192552](https://github.com/user-attachments/assets/4306878b-1761-4c20-8e4b-fbe2e4448b4b)


## Platforms tested

- Linux (WSL2 Ubuntu, Python 3.11)
