### PR TITLE
fix(cli): custom provider model switch reverts on every message

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2729,12 +2729,12 @@ class HermesCLI:
         self.base_url = base_url
 
         # When a custom_provider entry carries an explicit `model` field,
-        # use it as the effective model name.  Without this, running
-        # `hermes chat --model <provider-name>` sends the provider name
-        # (e.g. "my-provider") as the model string to the API instead of
-        # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
+        # use it as the effective model name ONLY when the user has not already
+        # explicitly switched models via /model.  Without this check, a user's
+        # `model` switch would be silently overwritten every time
+        # _ensure_runtime_credentials() re-resolves the provider (on every message).
         runtime_model = runtime.get("model")
-        if runtime_model and isinstance(runtime_model, str):
+        if runtime_model and isinstance(runtime_model, str) and not getattr(self, "_model_switched_explicitly", False):
             self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
@@ -4719,6 +4719,7 @@ class HermesCLI:
         # Apply to CLI state.
         # Update requested_provider so _ensure_runtime_credentials() doesn't
         # overwrite the switch on the next turn (it re-resolves from this).
+        self._model_switched_explicitly = True
         old_model = self.model
         self.model = result.new_model
         self.provider = result.target_provider

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1067,6 +1067,13 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
 
+            # Also include all models defined in the models mapping
+            custom_models = entry.get("models")
+            if isinstance(custom_models, dict):
+                for m_id in custom_models:
+                    if m_id not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_id)
+
         for slug, grp in groups.items():
             if slug in seen_slugs:
                 continue

--- a/run_agent.py
+++ b/run_agent.py
@@ -1611,6 +1611,25 @@ class AIAgent:
             or is_native_anthropic
         )
 
+        # Resolve per-model context_length from custom_providers config (step-0 override
+        # in get_model_context_length), so the correct value is used instead of the stale
+        # _config_context_length from the default model.
+        resolved_context_length: int | None = None
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            for entry in cfg.get("custom_providers") or []:
+                entry_base = (entry.get("base_url") or "").rstrip("/")
+                if entry_base and entry_base == (self.base_url or "").rstrip("/"):
+                    models_map = entry.get("models", {})
+                    if isinstance(models_map, dict) and self.model in models_map:
+                        model_entry = models_map[self.model]
+                        if isinstance(model_entry, dict):
+                            resolved_context_length = model_entry.get("context_length")
+                        break
+        except Exception:
+            pass  # Config is optional; fall through to other resolution paths
+
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
@@ -1619,7 +1638,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=resolved_context_length,
             )
             self.context_compressor.update_model(
                 model=self.model,


### PR DESCRIPTION
## Summary

修复 custom provider 模型切换后立即被覆盖回默认值的问题，同时解决 per-model context_length 配置不生效的问题。

### Bug 1: 模型切换回滚

`_ensure_runtime_credentials()` 每次发消息都会从 custom provider 的 `model` 字段取默认值覆盖 `self.model`。用户切换模型后，下一条消息就触发回滚。

**Fix**: 在 `cli.py` 引入 `_model_switched_explicitly` flag，用户通过 `/model` 切换后设置该 flag，后续 credential 解析跳过覆盖。

### Bug 2: Flash 模型不在 TUI picker 中

`list_authenticated_providers` 只收集 custom provider 的 `model` 字段，没有处理 `models` 字典。GPT-Load 的 Flash 模型定义在 `models` dict 里，用户看不到也切换不了。

**Fix**: 在 `model_switch.py` 的 group 遍历中同时收集 `models` 字典的 key。

### Bug 3: per-model context_length 配置不生效

`switch_model` 中使用 `_config_context_length`（旧模型的默认值），而非新模型在 `config.custom_providers[].models[]` 中配置的 context_length。

**Fix**: 在 `run_agent.py` 的 `switch_model` 中，从 `config.custom_providers` 按 `base_url` + `model_id` 查询新模型的 `context_length`，传给 `get_model_context_length` 作为 step-0 override。

## Test Plan

- [x] 切换到 Flash 模型，发消息，模型保持不变
- [x] Flash 模型出现在 TUI picker 中
- [x] context_length 显示正确值（1,046,780）

## Files Changed

- `cli.py` — +8/-4
- `hermes_cli/model_switch.py` — +7
- `run_agent.py` — +21/-1
