### PR TITLE
fix(feishu): patch approval card updates

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -68,6 +68,8 @@ try:
         P2ImMessageMessageReadV1,
         ReplyMessageRequest,
         ReplyMessageRequestBody,
+        PatchMessageRequest,
+        PatchMessageRequestBody,
         UpdateMessageRequest,
         UpdateMessageRequestBody,
     )
@@ -1493,8 +1495,12 @@ class FeishuAdapter(BasePlatformAdapter):
     async def _update_approval_card(
         self, message_id: str, label: str, user_name: str, choice: str,
     ) -> None:
-        """Replace the approval card with a resolved status card."""
-        if not self._client or not message_id:
+        """Patch the approval card with a resolved status card."""
+        if not self._client:
+            logger.warning("[Feishu] Cannot update approval card %s: not connected", message_id)
+            return
+        if not message_id:
+            logger.warning("[Feishu] Cannot update approval card: missing message_id")
             return
         icon = "❌" if choice == "deny" else "✅"
         card = {
@@ -1512,9 +1518,9 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         try:
             payload = json.dumps(card, ensure_ascii=False)
-            body = self._build_update_message_body(msg_type="interactive", content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            await asyncio.to_thread(self._client.im.v1.message.update, request)
+            body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            await asyncio.to_thread(self._client.im.v1.message.patch, request)
         except Exception as exc:
             logger.warning("[Feishu] Failed to update approval card %s: %s", message_id, exc)
 
@@ -3523,6 +3529,27 @@ class FeishuAdapter(BasePlatformAdapter):
         if "UpdateMessageRequest" in globals():
             return (
                 UpdateMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        if "PatchMessageRequestBody" in globals():
+            return (
+                PatchMessageRequestBody.builder()
+                .content(content)
+                .build()
+            )
+        return SimpleNamespace(content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        if "PatchMessageRequest" in globals():
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -38,6 +38,7 @@ def _ensure_feishu_mocks():
 
 _ensure_feishu_mocks()
 
+import gateway.platforms.feishu as feishu_module
 from gateway.config import PlatformConfig
 from gateway.platforms.feishu import FeishuAdapter
 
@@ -374,7 +375,7 @@ class TestFeishuUpdateApprovalCard:
     async def test_updates_card_on_approve(self):
         adapter = _make_adapter()
 
-        mock_update = AsyncMock()
+        adapter._client.im.v1.message.patch = MagicMock()
         adapter._client.im.v1.message.update = MagicMock()
 
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
@@ -383,13 +384,15 @@ class TestFeishuUpdateApprovalCard:
             )
 
         mock_thread.assert_called_once()
-        # Verify the update request was built
         call_args = mock_thread.call_args
-        assert call_args[0][0] == adapter._client.im.v1.message.update
+        assert call_args[0][0] == adapter._client.im.v1.message.patch
+        assert call_args[0][0] != adapter._client.im.v1.message.update
 
     @pytest.mark.asyncio
     async def test_updates_card_on_deny(self):
         adapter = _make_adapter()
+        adapter._client.im.v1.message.patch = MagicMock()
+        adapter._client.im.v1.message.update = MagicMock()
 
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
             await adapter._update_approval_card(
@@ -397,6 +400,40 @@ class TestFeishuUpdateApprovalCard:
             )
 
         mock_thread.assert_called_once()
+        call_args = mock_thread.call_args
+        assert call_args[0][0] == adapter._client.im.v1.message.patch
+        assert call_args[0][0] != adapter._client.im.v1.message.update
+
+    def test_patch_body_uses_content_only(self, monkeypatch):
+        class FakePatchMessageRequestBody:
+            @staticmethod
+            def builder():
+                class Builder:
+                    def __init__(self):
+                        self.value = None
+
+                    def msg_type(self, _msg_type):
+                        raise AssertionError("PatchMessageRequestBody must not set msg_type")
+
+                    def content(self, value):
+                        self.value = value
+                        return self
+
+                    def build(self):
+                        return SimpleNamespace(content=self.value)
+
+                return Builder()
+
+        monkeypatch.setattr(
+            feishu_module,
+            "PatchMessageRequestBody",
+            FakePatchMessageRequestBody,
+            raising=False,
+        )
+
+        body = FeishuAdapter._build_patch_message_body(content="{}")
+
+        assert body.content == "{}"
 
     @pytest.mark.asyncio
     async def test_skips_update_when_not_connected(self):


### PR DESCRIPTION
## Summary

Fixes Feishu approval card resolution updates by using the Feishu PATCH message endpoint instead of replacing the interactive card through the update/PUT path.

## Root cause

FeishuAdapter._update_approval_card() used UpdateMessageRequest and message.update for interactive approval cards. Feishu's update path replaces the message payload and can strip or break the interactive card rendering after an approve/deny click.

## Changes

- Import PatchMessageRequest and PatchMessageRequestBody from lark_oapi.api.im.v1.
- Update _update_approval_card() to build a PATCH request body with content only and call self._client.im.v1.message.patch.
- Add PATCH builder helpers with the existing SimpleNamespace fallback pattern for tests without lark-oapi.
- Update Feishu approval button tests to assert approve/deny updates use message.patch, not message.update, and that PATCH bodies do not set msg_type.

## Test plan

- python -m pytest -o addopts='' tests/gateway/test_feishu_approval_buttons.py -q
- python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu_approval_buttons.py
- git diff --check HEAD~1..HEAD

Related: #9533