### PR TITLE
fix(cli): zsh completion fails under `eval` in .zshrc (#6122)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1068,7 +1068,7 @@ _hermes() {
     esac
 }
 
-_hermes "$@"
+compdef _hermes hermes
 '''
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -693,6 +693,17 @@ class TestCompletion:
         script = generate_zsh_completion()
         assert "_hermes" in script
 
+    def test_zsh_completion_registers_via_compdef_not_direct_call(self):
+        # Regression: when the script is loaded via `eval "$(hermes completion zsh)"`
+        # in .zshrc, a trailing `_hermes "$@"` invokes `_arguments` outside a
+        # completion context, raising `_arguments:comparguments: can only be called
+        # from completion function`. The correct pattern registers the function
+        # with `compdef _hermes hermes` so zsh calls it only during completion.
+        # See issue #6122.
+        script = generate_zsh_completion()
+        assert "compdef _hermes hermes" in script
+        assert '_hermes "$@"' not in script
+
 
 # ===================================================================
 # TestGetProfilesRoot / TestGetDefaultHermesHome (internal helpers)


### PR DESCRIPTION
## Summary

Fixes #6122. The generated zsh completion script ends with `_hermes "$@"`, which invokes `_arguments` outside any completion context when the script is loaded the documented way:

```bash
# ~/.zshrc (per docs)
eval "$(hermes completion zsh)"
```

Shell startup then errors:

```
_arguments:comparguments:327: can only be called from completion function
```

Replace the direct call with `compdef _hermes hermes` so zsh registers the function with its completion system and invokes it only during completion.

## Verification

- **Reproduced the original bug** in a clean `zsh -f` by generating the pre-fix script and loading it via `eval` — errors as reported.
- **Verified the fix** by loading the new script the same way — loads cleanly, `hermes <TAB>` works.
- **Added a regression test** (`test_zsh_completion_registers_via_compdef_not_direct_call`) that asserts the generated script uses `compdef _hermes hermes` and does not contain `_hermes "$@"`.

## Test plan

- [x] `pytest tests/hermes_cli/test_profiles.py -k zsh_completion` — 3 passed
- [x] Manual: `eval "$(python -c 'from hermes_cli.profiles import generate_zsh_completion; print(generate_zsh_completion())')"` in `zsh -f` — no error
- [x] Manual: pre-fix script reproduces error in same clean shell

Closes #6122