### PR TITLE
fix: remove @staticmethod from _context_completions to fix @ autocomplete crash

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Summary

`SlashCommandCompleter._context_completions` was decorated with `@staticmethod` but internally calls `self._fuzzy_match()`, causing a `TypeError` when typing `@` in the CLI input.

## Fix

Remove the `@staticmethod` decorator and add `self` as the first parameter.

## Reproduction

1. Start hermes CLI
2. Type `@` in the input box
3. Observe crash / no completions

After fix: `@` autocompletes context references as expected.