### PR TITLE
fix(packaging): expose web extra in uv lock

### DIFF
--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,6 +11,11 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
+def _load_uv_lock_text():
+    uv_lock_path = Path(__file__).resolve().parents[1] / "uv.lock"
+    return uv_lock_path.read_text(encoding="utf-8")
+
+
 def test_matrix_extra_linux_only_in_all():
     """mautrix[encryption] depends on python-olm which is upstream-broken on
     modern macOS (archived libolm, C++ errors with Clang 21+).  The [matrix]
@@ -27,3 +32,16 @@ def test_matrix_extra_linux_only_in_all():
         if "matrix" in dep and "linux" in dep
     ]
     assert linux_gated, "expected hermes-agent[matrix] with sys_platform=='linux' marker in [all]"
+
+
+def test_web_extra_is_exposed_in_uv_lock():
+    uv_lock = _load_uv_lock_text()
+
+    assert 'provides-extras = ["' in uv_lock
+    provides_extras = next(
+        line for line in uv_lock.splitlines()
+        if line.startswith("provides-extras = ")
+    )
+    assert '"web"' in provides_extras
+    assert '{ name = "fastapi", marker = "extra == \'rl\' or extra == \'web\'"' in uv_lock
+    assert '{ name = "uvicorn", extras = ["standard"], marker = "extra == \'rl\' or extra == \'web\'"' in uv_lock

--- a/uv.lock
+++ b/uv.lock
@@ -1865,7 +1865,7 @@ requires-dist = [
     { name = "elevenlabs", marker = "extra == 'tts-premium'", specifier = ">=1.0,<2" },
     { name = "exa-py", specifier = ">=2.9.0,<3" },
     { name = "fal-client", specifier = ">=0.13.1,<1" },
-    { name = "fastapi", marker = "extra == 'rl'", specifier = ">=0.104.0,<1" },
+    { name = "fastapi", marker = "extra == 'rl' or extra == 'web'", specifier = ">=0.104.0,<1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
@@ -1928,11 +1928,11 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
     { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl' or extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"


### PR DESCRIPTION
## Summary
- expose the `web` extra in `uv.lock` `provides-extras`
- mark `fastapi` and `uvicorn[standard]` dependencies for both `rl` and `web`
- add metadata coverage so the lockfile cannot drop the web extra silently again

## Root cause
`pyproject.toml` defines a `web` extra and includes it in `all`, but the lockfile metadata only exposed the web server dependencies through the `rl` extra.

## Test plan
- `python -m pytest -o addopts='' tests/test_project_metadata.py tests/test_packaging_metadata.py -q`
- `python -m py_compile tests/test_project_metadata.py`
- `git diff --check`

Related: #9569