### PR TITLE
fix(tools): keep memory tool available when fcntl is unavailable

### DIFF
--- a/tests/tools/test_memory_tool_import_fallback.py
+++ b/tests/tools/test_memory_tool_import_fallback.py
@@ -1,0 +1,31 @@
+"""Regression tests for memory-tool import fallbacks."""
+
+import builtins
+import importlib
+import sys
+
+from tools.registry import registry
+
+
+def test_memory_tool_imports_without_fcntl(monkeypatch, tmp_path):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "fcntl":
+            raise ImportError("simulated missing fcntl")
+        return original_import(name, globals, locals, fromlist, level)
+
+    registry.deregister("memory")
+    monkeypatch.delitem(sys.modules, "tools.memory_tool", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    memory_tool = importlib.import_module("tools.memory_tool")
+    monkeypatch.setattr(memory_tool, "get_memory_dir", lambda: tmp_path)
+
+    store = memory_tool.MemoryStore(memory_char_limit=200, user_char_limit=200)
+    store.load_from_disk()
+    result = store.add("memory", "fact learned during import fallback test")
+
+    assert memory_tool.fcntl is None
+    assert registry.get_entry("memory") is not None
+    assert result["success"] is True

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -33,6 +32,16 @@ from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 logger = logging.getLogger(__name__)
 
@@ -139,12 +148,31 @@ class MemoryStore:
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
+
+        if fcntl is None and msvcrt is None:
+            yield
+            return
+
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+
+        fd = open(lock_path, "r+" if msvcrt else "a+")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            else:
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            elif msvcrt:
+                try:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
             fd.close()
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fix the `memory` tool disappearing on platforms where `fcntl` is unavailable.

## Root Cause

`tools/memory_tool.py` imported Unix-only `fcntl` at module import time. On platforms without `fcntl`, importing the module raised `ImportError`. `model_tools._discover_tools()` swallows tool import failures, so Hermes stayed up, but the `memory` tool was never registered.

## Repro

Before this change, simulating a missing `fcntl` import produced:

- `memory_tool import: ImportError simulated missing fcntl`
- `memory registered: False`

That confirmed the tool was silently dropped from discovery.

## Fix

Keep the change local to `tools/memory_tool.py`:

- make `fcntl` optional
- use `msvcrt` for lock files on Windows
- fall back to a no-op lock if neither backend exists

No refactor or new abstraction was introduced; the patch only touches the module’s import and file-lock path.

## Test Evidence

Added a regression test that simulates `fcntl` being unavailable, re-imports `tools.memory_tool`, verifies the tool still registers, and exercises `MemoryStore.add()` through the fallback path.

Commands run:

- `python -m pytest -o addopts= tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py -q`
  - Result: `33 passed, 1 failed`
  - Existing unrelated failure: `tests/tools/test_memory_tool.py::TestMemoryStorePersistence::test_deduplication_on_load`
- `python -m pytest -o addopts= tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py -k "not deduplication_on_load" -q`
  - Result: `33 passed, 1 deselected in 0.18s`
