### PR TITLE
feat: Add Astraflow (UCloud ModelVerse) provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,21 @@
 # HERMES_QWEN_BASE_URL=https://portal.qwen.ai/v1
 
 # =============================================================================
+# LLM PROVIDER (Astraflow / UCloud ModelVerse)
+# =============================================================================
+# Astraflow provides access to DeepSeek and Llama models via UCloud ModelVerse.
+# Supports deepseek-r1, deepseek-v3, llama-3.3-70b-instruct.
+# Get your key at: https://www.ucloud.cn/site/product/umodelverse.html
+
+# Global endpoint (recommended for non-China users)
+# ASTRAFLOW_API_KEY=
+# ASTRAFLOW_BASE_URL=https://api-us-ca.umodelverse.ai/v1  # Override default base URL
+
+# China endpoint (for users in mainland China)
+# ASTRAFLOW_CN_API_KEY=
+# ASTRAFLOW_CN_BASE_URL=https://api.umodelverse.ai/v1     # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Xiaomi MiMo)
 # =============================================================================
 # Xiaomi MiMo models (mimo-v2-pro, mimo-v2-omni, mimo-v2-flash).

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -274,6 +274,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "astraflow": ProviderConfig(
+        id="astraflow",
+        name="Astraflow (ModelVerse)",
+        auth_type="api_key",
+        inference_base_url="https://api-us-ca.umodelverse.ai/v1",
+        api_key_env_vars=("ASTRAFLOW_API_KEY",),
+        base_url_env_var="ASTRAFLOW_BASE_URL",
+    ),
+    "astraflow-cn": ProviderConfig(
+        id="astraflow-cn",
+        name="Astraflow China (ModelVerse CN)",
+        auth_type="api_key",
+        inference_base_url="https://api.umodelverse.ai/v1",
+        api_key_env_vars=("ASTRAFLOW_CN_API_KEY",),
+        base_url_env_var="ASTRAFLOW_CN_BASE_URL",
+    ),
 }
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -300,6 +300,16 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
     ],
+    "astraflow": [
+        "deepseek-r1",
+        "deepseek-v3",
+        "llama-3.3-70b-instruct",
+    ],
+    "astraflow-cn": [
+        "deepseek-r1",
+        "deepseek-v3",
+        "llama-3.3-70b-instruct",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -533,6 +543,8 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (200+ models, pay-per-use)"),
+    ProviderEntry("astraflow",      "Astraflow (ModelVerse)",    "Astraflow / UCloud ModelVerse (global endpoint — DeepSeek, Llama)"),
+    ProviderEntry("astraflow-cn",   "Astraflow China",          "Astraflow / UCloud ModelVerse China (domestic endpoint — DeepSeek, Llama)"),
 ]
 
 # Derived dicts — used throughout the codebase
@@ -564,6 +576,13 @@ _PROVIDER_ALIASES = {
     "claude": "anthropic",
     "claude-code": "anthropic",
     "deep-seek": "deepseek",
+    # astraflow (global)
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+    # astraflow-cn (China)
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
     "go": "opencode-go",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -141,6 +141,16 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.arcee.ai/api/v1",
         base_url_env_var="ARCEE_BASE_URL",
     ),
+    "astraflow": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://api-us-ca.umodelverse.ai/v1",
+        base_url_env_var="ASTRAFLOW_BASE_URL",
+    ),
+    "astraflow-cn": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://api.umodelverse.ai/v1",
+        base_url_env_var="ASTRAFLOW_CN_BASE_URL",
+    ),
 }
 
 
@@ -239,6 +249,15 @@ ALIASES: Dict[str, str] = {
     # arcee
     "arcee-ai": "arcee",
     "arceeai": "arcee",
+
+    # astraflow (global)
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+
+    # astraflow-cn (China)
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",


### PR DESCRIPTION
## Summary

Adds **Astraflow** (UCloud ModelVerse) as a first-class LLM provider to Hermes Agent, with both global and China endpoints.

### Providers added

| Slug | Display Name | Base URL | Env Var |
|---|---|---|---|
| `astraflow` | Astraflow (ModelVerse) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `astraflow-cn` | Astraflow (China) | `https://api.umodelverse.ai/v1` | `ASTRAFLOW_CN_API_KEY` |

### Aliases registered

| Alias | Resolves to |
|---|---|
| `astra-flow`, `astra_flow`, `modelverse` | `astraflow` |
| `astraflow-china`, `astraflow_cn` | `astraflow-cn` |

### Files changed

- **`hermes_cli/providers.py`** — `HERMES_OVERLAYS` entries + `ALIASES`
- **`hermes_cli/auth.py`** — `PROVIDER_REGISTRY` entries (inference base URLs, API key env vars, base URL env vars)
- **`hermes_cli/models.py`** — `_PROVIDER_MODELS`, `CANONICAL_PROVIDERS` entries, `_PROVIDER_ALIASES`
- **`.env.example`** — Documentation section for both global and China keys

### Notes

- Both providers use `openai_chat` transport (OpenAI-compatible API)
- Models listed: `deepseek-r1`, `deepseek-v3`, `llama-3.3-70b-instruct`
- Base URL env var overrides: `ASTRAFLOW_BASE_URL` / `ASTRAFLOW_CN_BASE_URL`
- `modelverse` is registered as an alias only, never a primary key