### PR TITLE
fix(nix): use python312 for package env

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -2,7 +2,7 @@
 { inputs, ... }: {
   perSystem = { pkgs, ... }:
     let
-      python = pkgs.python311;
+      python = pkgs.python312;
     in {
       devShells.default = pkgs.mkShell {
         packages = with pkgs; [
@@ -18,7 +18,7 @@
 
           # Create venv if missing
           if [ ! -d .venv ]; then
-            echo "Creating Python 3.11 venv..."
+            echo "Creating Python 3.12 venv..."
             uv venv .venv --python ${python}/bin/python3
           fi
 

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -1,6 +1,6 @@
 # nix/python.nix — uv2nix virtual environment builder
 {
-  python311,
+  python312,
   lib,
   callPackage,
   uv2nix,
@@ -37,28 +37,28 @@ let
 
   pythonPackageOverrides = final: _prev:
     if isAarch64Darwin then {
-      numpy = mkPrebuiltOverride final python311.pkgs.numpy { };
+      numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
 
-      av = mkPrebuiltOverride final python311.pkgs.av { };
+      av = mkPrebuiltOverride final python312.pkgs.av { };
 
-      humanfriendly = mkPrebuiltOverride final python311.pkgs.humanfriendly { };
+      humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
 
-      coloredlogs = mkPrebuiltOverride final python311.pkgs.coloredlogs {
+      coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
         humanfriendly = [ ];
       };
 
-      onnxruntime = mkPrebuiltOverride final python311.pkgs.onnxruntime {
+      onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
         coloredlogs = [ ];
         numpy = [ ];
         packaging = [ ];
       };
 
-      ctranslate2 = mkPrebuiltOverride final python311.pkgs.ctranslate2 {
+      ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
         numpy = [ ];
         pyyaml = [ ];
       };
 
-      faster-whisper = mkPrebuiltOverride final python311.pkgs.faster-whisper {
+      faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
         av = [ ];
         ctranslate2 = [ ];
         huggingface-hub = [ ];
@@ -70,7 +70,7 @@ let
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
-      python = python311;
+      python = python312;
     }).overrideScope
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default

--- a/tests/test_nix_metadata.py
+++ b/tests/test_nix_metadata.py
@@ -1,0 +1,22 @@
+"""Regression tests for Nix packaging metadata."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_nix_package_uses_python312():
+    python_nix = (REPO_ROOT / "nix/python.nix").read_text()
+
+    assert "python312" in python_nix
+    assert "python311" not in python_nix
+
+
+def test_nix_devshell_uses_python312():
+    dev_shell_nix = (REPO_ROOT / "nix/devShell.nix").read_text()
+
+    assert "pkgs.python312" in dev_shell_nix
+    assert "Python 3.12 venv" in dev_shell_nix
+    assert "python311" not in dev_shell_nix
+    assert "Python 3.11" not in dev_shell_nix


### PR DESCRIPTION
## Summary
- switch the uv2nix package environment from `python311` to `python312`
- update the dev shell to create Python 3.12 virtual environments
- add static regression tests for the Nix Python version wiring

## Root cause
The current nixpkgs pin includes Sphinx 9.1, which no longer supports Python 3.11. The Nix package builder hardcoded `python311`, so flake evaluation could fail when `pyproject-build-systems` wired the Sphinx hook into the Python 3.11 package set.

## Test plan
- `python -m pytest -o addopts='' tests/test_nix_metadata.py -q`
- `python -m py_compile tests/test_nix_metadata.py`
- `rg -n "python311|Python 3\.11" nix/python.nix nix/devShell.nix` (no matches)
- `git diff --check`

Not run: `nix flake check` / `nix run` because `nix` is not installed in this local environment.

Related: #9526