### PR TITLE
fix: load trajectory compressor credentials from HERMES_HOME/.env

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -1,6 +1,9 @@
 """Tests for trajectory_compressor.py — config, metrics, and compression logic."""
 
+import importlib
 import json
+import os
+import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, MagicMock
 
@@ -12,6 +15,20 @@ from trajectory_compressor import (
     AggregateMetrics,
     TrajectoryCompressor,
 )
+
+
+def test_import_loads_env_from_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("OPENROUTER_API_KEY=from-hermes-home\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    sys.modules.pop("trajectory_compressor", None)
+    importlib.import_module("trajectory_compressor")
+
+    assert os.getenv("OPENROUTER_API_KEY") == "from-hermes-home"
 
 
 # ---------------------------------------------------------------------------

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -43,12 +43,15 @@ from datetime import datetime
 import fire
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.console import Console
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, get_hermes_home
 from agent.retry_utils import jittered_backoff
 
-# Load environment variables
-from dotenv import load_dotenv
-load_dotenv()
+# Load .env from HERMES_HOME first, then project root as a dev fallback.
+from hermes_cli.env_loader import load_hermes_dotenv
+
+_hermes_home = get_hermes_home()
+_project_env = Path(__file__).parent / ".env"
+load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Fix `trajectory_compressor.py` so it loads credentials from the standard Hermes user config location: `HERMES_HOME/.env`.

Before this change, trajectory compression could fail when `OPENROUTER_API_KEY` was defined only in `HERMES_HOME/.env`, because the module relied on plain `load_dotenv()` during import instead of Hermes' shared env-loading behavior.

## Root Cause

`trajectory_compressor.py` called raw `load_dotenv()` at import time.

That only searches for `.env` using normal dotenv discovery rules (for example, the current working directory chain). It does **not** reliably load the standard Hermes config location at `HERMES_HOME/.env`.

As a result, users following the normal Hermes setup pattern could have a valid API key in `HERMES_HOME/.env`, while trajectory compression still behaved as if the key was missing.

## Repro

1. Create a temporary `HERMES_HOME`
2. Write `OPENROUTER_API_KEY=from-hermes-home` to `HERMES_HOME/.env`
3. Clear `OPENROUTER_API_KEY` from the process environment
4. Import `trajectory_compressor.py`
5. Check `os.getenv("OPENROUTER_API_KEY")`

Before this fix:
- `os.getenv("OPENROUTER_API_KEY")` returned `<missing>`

After this fix:
- `os.getenv("OPENROUTER_API_KEY")` returns `from-hermes-home`

## Fix

Replace the raw dotenv import-time loading with Hermes' shared env loader:

- use `load_hermes_dotenv(...)`
- load from `HERMES_HOME/.env` first
- keep the repo `.env` as a development fallback

This keeps the change local to `trajectory_compressor.py` and aligns it with Hermes' standard configuration behavior without introducing any refactor, new abstraction, or architectural change.

## Test Evidence

Added a regression test:

- `test_import_loads_env_from_hermes_home`

This test verifies that importing the module correctly loads `OPENROUTER_API_KEY` from `HERMES_HOME/.env`.

Command run:

```bash
python -m pytest tests/test_trajectory_compressor.py -q