### PR TITLE
fix(gateway): close active sessions on shutdown

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1862,18 +1862,27 @@ class BasePlatformAdapter(ABC):
             if session_key in self._active_sessions:
                 del self._active_sessions[session_key]
     
-    async def cancel_background_tasks(self) -> None:
+    async def cancel_background_tasks(self, *, end_reason: str = "gateway_shutdown") -> None:
         """Cancel any in-flight background message-processing tasks.
 
         Used during gateway shutdown/replacement so active sessions from the old
         process do not keep running after adapters are being torn down.
         """
+        active_session_keys = list(self._active_sessions)
         tasks = [task for task in self._background_tasks if not task.done()]
         for task in tasks:
             self._expected_cancelled_tasks.add(task)
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        if active_session_keys:
+            session_store = getattr(self, "_session_store", None)
+            close_sessions = getattr(session_store, "close_sessions", None)
+            if close_sessions is not None:
+                try:
+                    close_sessions(active_session_keys, end_reason=end_reason)
+                except Exception as e:
+                    logger.debug("[%s] Session close during shutdown failed: %s", self.name, e)
         self._background_tasks.clear()
         self._expected_cancelled_tasks.clear()
         self._pending_messages.clear()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2042,9 +2042,10 @@ class GatewayRunner:
 
             self._finalize_shutdown_agents(active_agents)
 
+            adapter_task_end_reason = "gateway_restart" if self._restart_requested else "gateway_shutdown"
             for platform, adapter in list(self.adapters.items()):
                 try:
-                    await adapter.cancel_background_tasks()
+                    await adapter.cancel_background_tasks(end_reason=adapter_task_end_reason)
                 except Exception as e:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
                 try:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
+from typing import Dict, Iterable, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -819,6 +819,39 @@ class SessionStore:
             if count:
                 self._save()
         return count
+
+    def close_sessions(self, session_keys: Iterable[str], end_reason: str) -> int:
+        """Close active sessions in the SQLite DB and suspend them for reset.
+
+        Used by gateway shutdown when in-flight adapter tasks are cancelled.
+        The in-memory entry remains as the session key mapping, but is marked
+        suspended so the next incoming message starts a fresh session instead
+        of appending to a DB record that has been ended.
+        """
+        session_ids: List[str] = []
+        seen: set[str] = set()
+        with self._lock:
+            self._ensure_loaded_locked()
+            for session_key in session_keys:
+                if session_key in seen:
+                    continue
+                seen.add(session_key)
+                entry = self._entries.get(session_key)
+                if entry is None:
+                    continue
+                entry.suspended = True
+                entry.updated_at = _now()
+                session_ids.append(entry.session_id)
+            if session_ids:
+                self._save()
+
+        if self._db:
+            for session_id in session_ids:
+                try:
+                    self._db.end_session(session_id, end_reason)
+                except Exception as e:
+                    logger.debug("Session DB end_session failed: %s", e)
+        return len(session_ids)
 
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -36,6 +36,22 @@ async def test_cancel_background_tasks_cancels_inflight_message_processing():
 
 
 @pytest.mark.asyncio
+async def test_cancel_background_tasks_closes_session_store_entries():
+    _runner, adapter = make_restart_runner()
+    session_key = build_session_key(make_restart_source())
+    adapter._session_store = MagicMock()
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter.cancel_background_tasks(end_reason="gateway_restart")
+
+    adapter._session_store.close_sessions.assert_called_once_with(
+        [session_key],
+        end_reason="gateway_restart",
+    )
+    assert adapter._active_sessions == {}
+
+
+@pytest.mark.asyncio
 async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks():
     runner, adapter = make_restart_runner()
     runner._pending_messages = {"session": "pending text"}
@@ -54,7 +70,9 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     await asyncio.sleep(0)
 
     disconnect_mock = AsyncMock()
+    cancel_mock = AsyncMock()
     adapter.disconnect = disconnect_mock
+    adapter.cancel_background_tasks = cancel_mock
 
     session_key = build_session_key(event.source)
     running_agent = MagicMock()
@@ -64,6 +82,7 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
         await runner.stop()
 
     running_agent.interrupt.assert_called_once_with("Gateway shutting down")
+    cancel_mock.assert_awaited_once_with(end_reason="gateway_shutdown")
     disconnect_mock.assert_awaited_once()
     assert runner.adapters == {}
     assert runner._running_agents == {}
@@ -118,11 +137,13 @@ async def test_gateway_stop_interrupts_after_drain_timeout():
 async def test_gateway_stop_service_restart_sets_named_exit_code():
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
+    adapter.cancel_background_tasks = AsyncMock()
 
     with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    adapter.cancel_background_tasks.assert_awaited_once_with(end_reason="gateway_restart")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -591,6 +591,38 @@ class TestSessionStoreSwitchSession:
         db.close()
 
 
+class TestSessionStoreCloseSessions:
+    """Regression coverage for shutdown-time session DB cleanup."""
+
+    def test_close_sessions_ends_db_record_and_marks_suspended(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store._db = db
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="tester",
+        )
+        entry = store.get_or_create_session(source)
+
+        closed = store.close_sessions([entry.session_key], "gateway_restart")
+
+        assert closed == 1
+        assert store._entries[entry.session_key].suspended is True
+        db_entry = db.get_session(entry.session_id)
+        assert db_entry["ended_at"] is not None
+        assert db_entry["end_reason"] == "gateway_restart"
+        db.close()
+
+
 class TestWhatsAppDMSessionKeyConsistency:
     """Regression: all session-key construction must go through build_session_key
     so DMs are isolated by chat_id across platforms."""


### PR DESCRIPTION
## Summary
- close adapter active sessions in the session store when shutdown cancels in-flight background tasks
- use `gateway_restart` vs `gateway_shutdown` as the session DB end reason
- mark closed session entries suspended so the next message starts fresh instead of appending to an ended DB session
- add regression coverage for adapter shutdown and SessionStore DB end behavior

## Root cause
Gateway shutdown cancelled adapter background tasks and cleared `_active_sessions`, but it did not propagate those in-flight session IDs to the session store. For Feishu WebSocket restarts this left active SQLite sessions without `ended_at` / `end_reason`.

## Test plan
- `python -m pytest -o addopts='' tests/gateway/test_gateway_shutdown.py tests/gateway/test_session.py::TestSessionStoreCloseSessions -q`
- `python -m py_compile gateway/platforms/base.py gateway/run.py gateway/session.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_session.py`
- `python -m pytest -o addopts='' tests/gateway/test_base_topic_sessions.py::TestBasePlatformTopicSessions::test_cancel_background_tasks_marks_expected_cancellation_cancelled -q`
- `git diff --check`

Related: #9090