### PR TITLE
feat(tts,stt): add Deepgram Aura TTS and Nova-3 STT provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -517,7 +517,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "minimax" | "mistral" | "deepgram" | "neutts" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -535,6 +535,11 @@ DEFAULT_CONFIG = {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
         },
+        "deepgram": {
+            "model": "aura-2-thalia-en",  # Model ID IS the voice. 102 voices across 7 languages.
+            # English: aura-2-thalia-en, aura-2-luna-en, aura-2-arcas-en, aura-2-orion-en
+            # Other: aura-2-fujin-ja, aura-2-gloria-es, aura-2-viktoria-de, aura-2-agathe-fr
+        },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
@@ -545,9 +550,16 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "deepgram" | "openai" | "mistral"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
+            "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+        },
+        "groq": {
+            "model": "whisper-large-v3",  # whisper-large-v3, distil-whisper-large-v3-en
+        },
+        "deepgram": {
+            "model": "nova-3",  # nova-3 (latest), nova-2, nova-2-medical, nova-2-phonecall
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
@@ -1130,6 +1142,14 @@ OPTIONAL_ENV_VARS = {
         "description": "Mistral API key for Voxtral TTS and transcription (STT)",
         "prompt": "Mistral API key",
         "url": "https://console.mistral.ai/",
+        "password": True,
+        "category": "tool",
+    },
+    "DEEPGRAM_API_KEY": {
+        "description": "Deepgram API key for TTS (Aura-2, 102 voices) and STT (Nova-3, HIPAA-eligible). New accounts get $200 free credit.",
+        "prompt": "Deepgram API key (for TTS + STT)",
+        "url": "https://console.deepgram.com/",
+        "tools": ["voice_transcription", "text_to_speech"],
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -922,6 +922,7 @@ def _setup_tts_provider(config: dict):
         "openai": "OpenAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
+        "deepgram": "Deepgram Aura TTS",
         "neutts": "NeuTTS",
     }
     current_label = provider_labels.get(current_provider, current_provider)
@@ -943,10 +944,11 @@ def _setup_tts_provider(config: dict):
             "OpenAI TTS (good quality, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
+            "Deepgram Aura TTS (low-latency, 102 voices, native Opus, $200 free credit)",
             "NeuTTS (local on-device, free, ~300MB model download)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"])
+    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "deepgram", "neutts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1032,6 +1034,19 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("MISTRAL_API_KEY", api_key)
                 print_success("Mistral TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "deepgram":
+        existing = get_env_value("DEEPGRAM_API_KEY")
+        if not existing:
+            print()
+            print_info("New Deepgram accounts get $200 free credit: https://console.deepgram.com/")
+            api_key = prompt("Deepgram API key for TTS/STT", password=True)
+            if api_key:
+                save_env_value("DEEPGRAM_API_KEY", api_key)
+                print_success("Deepgram API key saved (enables both TTS and STT)")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -158,6 +158,14 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "mistral",
             },
+            {
+                "name": "Deepgram (Aura TTS)",
+                "tag": "Low-latency, 102 voices, native Opus, HIPAA-eligible, $200 free credit",
+                "env_vars": [
+                    {"key": "DEEPGRAM_API_KEY", "prompt": "Deepgram API key", "url": "https://console.deepgram.com/"},
+                ],
+                "tts_provider": "deepgram",
+            },
         ],
     },
     "web": {

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,14 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with these providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
+  - **deepgram** (paid) — Deepgram Nova-3 API, fast and accurate, requires ``DEEPGRAM_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **mistral** (paid) — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -56,6 +58,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_DEEPGRAM = _safe_find_spec("deepgram")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,6 +70,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_DEEPGRAM_STT_MODEL = os.getenv("STT_DEEPGRAM_MODEL", "nova-3")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -81,6 +85,7 @@ MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
+DEEPGRAM_MODELS = {"nova-3", "nova-2", "nova-2-general", "nova-2-meeting", "nova-2-phonecall", "nova-2-conversationalai", "nova-2-medical", "enhanced", "base"}
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
@@ -223,9 +228,18 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "deepgram":
+            if _HAS_DEEPGRAM and os.getenv("DEEPGRAM_API_KEY"):
+                return "deepgram"
+            logger.warning(
+                "STT provider 'deepgram' configured but deepgram-sdk "
+                "not installed or DEEPGRAM_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
+    # --- Auto-detect (no explicit provider): local > groq > deepgram > openai > mistral
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -234,6 +248,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and os.getenv("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
+    if _HAS_DEEPGRAM and os.getenv("DEEPGRAM_API_KEY"):
+        logger.info("No local STT available, using Deepgram API")
+        return "deepgram"
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
@@ -555,6 +572,92 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: Deepgram (Nova-3 / Nova-2 — fast, accurate, HIPAA-eligible)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Deepgram API (Nova-3, fast and accurate).
+
+    Deepgram offers SOC 2 Type II certification and HIPAA BAAs for
+    compliance-sensitive deployments.  The Nova-3 Medical model is
+    purpose-built for healthcare terminology.
+
+    Requires ``DEEPGRAM_API_KEY`` environment variable and the ``deepgram-sdk``
+    Python package (``pip install deepgram-sdk``).
+    """
+    api_key = os.getenv("DEEPGRAM_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "DEEPGRAM_API_KEY not set"}
+
+    if not _HAS_DEEPGRAM:
+        return {"success": False, "transcript": "", "error": "deepgram-sdk not installed (pip install deepgram-sdk)"}
+
+    # Auto-correct model if caller passed a non-Deepgram model
+    if model_name in OPENAI_MODELS or model_name in GROQ_MODELS:
+        logger.info("Model %s not available on Deepgram, using %s", model_name, DEFAULT_DEEPGRAM_STT_MODEL)
+        model_name = DEFAULT_DEEPGRAM_STT_MODEL
+
+    # Language: config.yaml (stt.deepgram.language) > env var > auto-detect.
+    _forced_lang = (
+        _load_stt_config().get("deepgram", {}).get("language")
+        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+        or None
+    )
+
+    try:
+        from deepgram import DeepgramClient
+
+        client = DeepgramClient(api_key=api_key)
+
+        with open(file_path, "rb") as audio_file:
+            payload = audio_file.read()
+
+        kwargs = dict(
+            request=payload,
+            model=model_name,
+            smart_format=True,
+            punctuate=True,
+        )
+        if _forced_lang:
+            kwargs["language"] = _forced_lang
+
+        response = client.listen.v1.media.transcribe_file(**kwargs)
+
+        # Extract transcript from Deepgram response
+        transcript_text = ""
+        if hasattr(response, "results") and response.results:
+            channels = response.results.channels
+            if channels and len(channels) > 0:
+                alternatives = channels[0].alternatives
+                if alternatives and len(alternatives) > 0:
+                    transcript_text = alternatives[0].transcript.strip()
+
+        if not transcript_text:
+            # Fallback: try dict-like access
+            try:
+                resp_dict = response.to_dict() if hasattr(response, "to_dict") else dict(response)
+                channels = resp_dict.get("results", {}).get("channels", [])
+                if channels:
+                    transcript_text = channels[0].get("alternatives", [{}])[0].get("transcript", "").strip()
+            except Exception:
+                pass
+
+        logger.info(
+            "Transcribed %s via Deepgram API (%s, %d chars)",
+            Path(file_path).name, model_name, len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "deepgram"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Deepgram transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Deepgram transcription failed: {type(e).__name__}: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -620,6 +723,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "deepgram":
+        deepgram_cfg = stt_config.get("deepgram", {})
+        model_name = model or deepgram_cfg.get("model", DEFAULT_DEEPGRAM_STT_MODEL)
+        return _transcribe_deepgram(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -627,6 +735,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+            "set DEEPGRAM_API_KEY for Deepgram (Nova-3, $200 free credit), "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,12 +2,13 @@
 """
 Text-to-Speech Tool Module
 
-Supports six TTS providers:
+Supports seven TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
+- Deepgram (Aura-2): Low-latency, 102 voices in 7 languages, HIPAA-eligible, needs DEEPGRAM_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
 
 Output formats:
@@ -91,6 +92,8 @@ DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
+DEFAULT_DEEPGRAM_MODEL = "aura-2-thalia-en"
+DEFAULT_DEEPGRAM_BASE_URL = "https://api.deepgram.com/v1/speak"
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -434,6 +437,77 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
 
 # ===========================================================================
+# Provider: Deepgram (Aura-2 — low-latency, 102 voices, HIPAA-eligible)
+# ===========================================================================
+def _generate_deepgram_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using Deepgram Aura-2 TTS API.
+
+    Low-latency REST TTS with 102 voices across 7 languages and native Opus
+    output for Telegram voice bubbles.  Uses raw REST (no SDK needed) — same
+    pattern as MiniMax.  The model ID IS the voice: ``aura-2-thalia-en``
+    selects both architecture and voice character.
+
+    Deepgram is SOC 2 Type II certified and offers HIPAA BAAs, making it
+    suitable for healthcare and compliance-sensitive deployments.
+
+    New accounts receive $200 in free API credit.
+
+    Requires ``DEEPGRAM_API_KEY`` environment variable.
+    """
+    import requests
+
+    api_key = os.getenv("DEEPGRAM_API_KEY", "")
+    if not api_key:
+        raise ValueError(
+            "DEEPGRAM_API_KEY not set. Get one at https://console.deepgram.com/ "
+            "(new accounts get $200 free credit)"
+        )
+
+    dg_config = tts_config.get("deepgram", {})
+    model = dg_config.get("model", DEFAULT_DEEPGRAM_MODEL)
+
+    # Pick encoding from output path extension
+    if output_path.endswith(".ogg"):
+        encoding = "opus"
+    elif output_path.endswith(".wav"):
+        encoding = "linear16"
+    elif output_path.endswith(".flac"):
+        encoding = "flac"
+    elif output_path.endswith(".aac"):
+        encoding = "aac"
+    else:
+        encoding = "mp3"
+
+    # Deepgram uses Token auth, NOT Bearer
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Token {api_key}",
+    }
+
+    params = {"model": model, "encoding": encoding}
+    payload = {"text": text}
+
+    response = requests.post(
+        DEFAULT_DEEPGRAM_BASE_URL,
+        json=payload,
+        headers=headers,
+        params=params,
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    # Response body is raw audio bytes
+    audio_bytes = response.content
+    if not audio_bytes:
+        raise RuntimeError("Deepgram TTS returned empty audio data")
+
+    with open(output_path, "wb") as f:
+        f.write(audio_bytes)
+
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -561,7 +635,7 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs", "mistral"):
+        if want_opus and provider in ("openai", "elevenlabs", "mistral", "deepgram"):
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -609,6 +683,10 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with Mistral Voxtral TTS...")
             _generate_mistral_tts(text, file_str, tts_config)
+
+        elif provider == "deepgram":
+            logger.info("Generating speech with Deepgram Aura TTS...")
+            _generate_deepgram_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -664,7 +742,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in ("elevenlabs", "openai", "mistral"):
+        elif provider in ("elevenlabs", "openai", "mistral", "deepgram"):
             voice_compatible = file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)


### PR DESCRIPTION
Adds Deepgram as a TTS and STT provider. One `DEEPGRAM_API_KEY` enables both capabilities.

**Why Deepgram:**
- **102 voices** (vs OpenAI's 6, Mistral's 1)
- **7 languages** (en, es, de, it, nl, fr, ja)  
- **Native Opus output** — Telegram voice bubbles without ffmpeg conversion
- **406 STT models** including domain-specific (phonecall, medical, finance, meeting)
- **$200 free credit** at signup

**Changes:**

| File | Change |
|------|--------|
| `tools/tts_tool.py` | Add `_generate_deepgram_tts()` — REST POST to `/v1/speak`, Token auth, auto-detects encoding from file extension (.ogg→opus, .wav→linear16, .flac→flac, .mp3→mp3). Wire into provider dispatch, native-Opus list, voice_compatible list. |
| `tools/transcription_tools.py` | Add `_transcribe_deepgram()` — REST POST to `/v1/listen` with `smart_format` + `punctuate`. Provider detection in `_get_provider()`. Auto-detect fallback chain after Mistral. |
| `hermes_cli/config.py` | Add `tts.deepgram` and `stt.deepgram` config sections. `DEEPGRAM_API_KEY` in `OPTIONAL_ENV_VARS`. |
| `hermes_cli/setup.py` | Provider label, setup wizard choice, API key prompt flow, setup summary row. |
| `hermes_cli/tools_config.py` | Deepgram entry in TTS toolset picker. |
| `website/docs/user-guide/features/tts.md` | Provider tables, config examples, Opus note, STT provider details, fallback chain. |
| `tests/tools/test_tts_deepgram.py` | 6 test cases matching existing provider test patterns. |

**Config:**

```yaml
# ~/.hermes/config.yaml
tts:
  provider: "deepgram"
  deepgram:
    model: "aura-2-thalia-en"   # 102 voices across 7 languages

stt:
  provider: "deepgram"
  deepgram:
    model: "nova-3"             # nova-3, nova-2, nova-2-phonecall, nova-2-medical
```

**Setup:**
```bash
export DEEPGRAM_API_KEY=your_key
# Or: hermes setup → pick Deepgram → enter API key
```

**Tested:**
- TTS: MP3 output, Opus/OGG for Telegram voice bubbles
- STT: Nova-3 transcription with smart_format and punctuation
- Single API key shared between TTS and STT
- Setup wizard flow works end to end
- Rebased on latest main