### PR TITLE
fix: remove @staticmethod from _context_completions causing NameError on bare @

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -164,6 +164,61 @@ class TestIntegration:
         assert any("host" in n.lower() for n in names)
 
 
+class TestContextCompletion:
+    """Tests for @ context reference completion (regression: was @staticmethod)."""
+
+    def test_bare_at_does_not_crash(self, completer, tmp_path, monkeypatch):
+        """Typing bare '@' must not raise NameError (self not defined).
+
+        _context_completions was incorrectly decorated @staticmethod but
+        called self._fuzzy_file_completions on line 806.  This test
+        verifies the fix by ensuring bare '@' yields completions without
+        crashing.
+        """
+        # Provide a predictable file list so the test is deterministic.
+        monkeypatch.setattr(
+            completer,
+            "_file_cache",
+            ["src/main.py", "README.md"],
+        )
+        monkeypatch.setattr(
+            completer,
+            "_file_cache_time",
+            999999.0,
+        )
+        monkeypatch.setattr(
+            completer,
+            "_file_cache_cwd",
+            str(tmp_path),
+        )
+
+        doc = Document("@", cursor_position=1)
+        event = MagicMock()
+        # This used to crash with NameError: name 'self' is not defined
+        completions = list(completer.get_completions(doc, event))
+        # Should produce completions (static refs like @diff, @staged, etc.)
+        texts = [c.text for c in completions]
+        assert any("@diff" in t or "@staged" in t or "@file:" in t for t in texts)
+
+    def test_at_partial_matches_static_refs(self, completer):
+        """'@di' should match @diff but not @staged."""
+        doc = Document("@di", cursor_position=3)
+        event = MagicMock()
+        completions = list(completer.get_completions(doc, event))
+        texts = [c.text for c in completions]
+        assert "@diff" in texts
+        assert not any("@staged" in t for t in texts)
+
+    def test_at_file_prefix_completions(self, completer, tmp_path):
+        """'@file:' should produce path completions."""
+        (tmp_path / "hello.py").touch()
+        doc = Document(f"@file:{tmp_path}/", cursor_position=len(f"@file:{tmp_path}/"))
+        event = MagicMock()
+        completions = list(completer.get_completions(doc, event))
+        texts = [c.text for c in completions]
+        assert any("hello.py" in t for t in texts)
+
+
 class TestFileSizeLabel:
     def test_bytes(self, tmp_path):
         f = tmp_path / "small.txt"


### PR DESCRIPTION
## Bug

Pressing `@` in the CLI (bare `@`, or `@` with a partial filename like `@main`) caused an unhandled exception in prompt_toolkit's event loop, crashing the completer.

## Root Cause

`_context_completions` in `hermes_cli/commands.py` was decorated with `@staticmethod` but called `self._fuzzy_file_completions(word, query, limit)` on line 806. A `@staticmethod` has no `self` parameter, so this raised `NameError`.

The bug only triggered on the **bare `@` / partial filename** code path. The static reference completions (`@diff`, `@staged`, `@file:`, `@folder:`, `@git:`, `@url:`) all worked fine because they never reached the `yield from self._fuzzy_file_completions(...)` call.

## Fix

Removed the `@staticmethod` decorator and added `self` as the first parameter to `_context_completions`.

One-line change (minus the decorator line):

```python
# Before:
@staticmethod
def _context_completions(word: str, limit: int = 30):

# After:
def _context_completions(self, word: str, limit: int = 30):
```

The call site in `get_completions` was already `self._context_completions(ctx_word)` (line 975), so no changes needed there.

## Tests

Added `TestContextCompletion` class with three regression tests:

- **`test_bare_at_does_not_crash`** — verifies that typing `@` produces completions without NameError
- **`test_at_partial_matches_static_refs`** — verifies `@di` matches `@diff`
- **`test_at_file_prefix_completions`** — verifies `@file:/path/` produces path completions

All 29 tests in `test_path_completion.py` pass.