### PR TITLE
fix: use utf-8 encoding when reading .env file in load_env()

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -111,7 +111,7 @@ def load_env() -> Dict[str, str]:
     if not env_path.exists():
         return env_vars
 
-    with env_path.open() as f:
+    with env_path.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:


### PR DESCRIPTION
On Windows, `Path.open()` defaults to the system ANSI code page (cp1252).
If the `.env` file contains UTF-8 characters (e.g., non-ASCII in API keys or comments),
decoding fails with `'gbk codec can't decode byte 0x94'`.

This is a one-line fix that adds `encoding="utf-8"` to the `open()` call in
`load_env()`, ensuring consistent behavior across Linux, macOS, and Windows.

**Before:** `with env_path.open() as f:`
**After:** `with env_path.open(encoding="utf-8") as f:`

---

### Root cause
`load_env()` in `tools/skills_tool.py` reads `HERMES_HOME/.env` without specifying
an encoding. On Windows, this causes the Python runtime to use the system's default
ANSI code page (cp1252) instead of UTF-8. When the `.env` file contains UTF-8
multi-byte sequences, cp1252 cannot decode byte `0x94`, resulting in:

```
'gbk' codec can't decode byte 0x94 in position 661: illegal multibyte sequence
```

### Fix
Explicitly pass `encoding="utf-8"` to `Path.open()`, matching the encoding
already used elsewhere in the same file (e.g., `tool_error` in `registry.py`).

### Testing
- Verified the fix resolves `skill_view` failures for skills with non-ASCII content
- The `.env` file (18,257 bytes) contains UTF-8 characters that triggered the bug
- Linux/macOS were unaffected since their default encoding is UTF-8