### PR TITLE
fix: inherit max_api_retries and max_stream_retries in subagents

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -354,6 +354,8 @@ def _build_child_agent(
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,
         max_iterations=max_iterations,
+        max_api_retries=getattr(parent_agent, "max_api_retries", 3),
+        max_stream_retries=getattr(parent_agent, "max_stream_retries", 1),
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),


### PR DESCRIPTION
## Summary

Subagents spawned via `delegate_task` and `delegate_task_async` always use the hardcoded defaults `max_api_retries=3` and `max_stream_retries=1`, ignoring the user's config.yaml.

## Root Cause

`_build_child_agent()` constructs the child `AIAgent` with ~25 explicit kwargs but omits `max_api_retries` and `max_stream_retries`. The constructor defaults fire instead.

## Fix

Inherit both values from the parent:

```python
    max_iterations=max_iterations,\n    max_api_retries=getattr(parent_agent, "max_api_retries", 3),\n    max_stream_retries=getattr(parent_agent, "max_stream_retries", 1),\n```

Closes #9647