### PR TITLE
fix: restore @ context completions in CLI

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -155,6 +155,22 @@ class TestIntegration:
         completions = list(completer.get_completions(doc, event))
         assert completions == []
 
+    def test_at_completion_shows_static_refs_and_files(self, completer, monkeypatch):
+        monkeypatch.setattr(
+            completer,
+            "_get_project_files",
+            lambda: ["README.md", "docs/guide.md"],
+        )
+
+        doc = Document("@", cursor_position=1)
+        event = MagicMock()
+        completions = list(completer.get_completions(doc, event))
+        texts = [c.text for c in completions]
+
+        assert "@diff" in texts
+        assert "@file:" in texts
+        assert "@file:README.md" in texts
+
     def test_absolute_path_triggers_completion(self, completer):
         doc = Document("check /etc/hos", cursor_position=14)
         event = MagicMock()


### PR DESCRIPTION
## Summary
- Fixes a crash when typing `@` in the Hermes CLI completion buffer.
- `SlashCommandCompleter._context_completions` was incorrectly declared as `@staticmethod` while calling `self._fuzzy_file_completions(...)`, causing `NameError: self is not defined`.
- Added a regression test for bare `@` completion results.

## Verification
- `pytest tests/hermes_cli/test_path_completion.py -q`
- `pytest tests/hermes_cli/test_path_completion.py tests/gateway/test_background_command.py -q`
- Manual smoke test: `@` now yields static refs and file completions.
