### PR TITLE
fix(discord): implement smart auto-thread mode, free-response channels skip threading

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2466,20 +2466,33 @@ class DiscordAdapter(BasePlatformAdapter):
                 if self._client.user not in message.mentions:
                     return
 
-            if self._client.user and self._client.user in message.mentions:
+            was_mentioned = self._client.user and self._client.user in message.mentions
+            if was_mentioned:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+        else:
+            was_mentioned = False
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        #
+        # auto_thread values:
+        #   true/1/yes — thread on every message that passes the mention gate
+        #   false/0/no — never thread (respond inline)
+        #   smart      — thread only on explicit @mention; free-response channels
+        #                always skip threading regardless
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels)
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            auto_thread_mode = os.getenv("DISCORD_AUTO_THREAD", "true").lower()
+            if auto_thread_mode == "smart":
+                auto_thread = was_mentioned
+            else:
+                auto_thread = auto_thread_mode in ("true", "1", "yes")
             if auto_thread and not skip_thread and not is_voice_linked_channel:
                 thread = await self._auto_create_thread(message)
                 if thread:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -386,6 +386,96 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
+async def test_discord_free_channel_skips_auto_thread(adapter, monkeypatch):
+    """Free-response channels must NOT auto-create threads — bot replies directly."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="free chat message",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_smart_thread_creates_thread_on_mention(adapter, monkeypatch):
+    """smart mode: @mention in a normal channel creates a thread."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "smart")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    fake_thread = FakeThread(channel_id=888, name="smart-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123),
+        content=f"<@{bot_user.id}> help",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_smart_thread_no_thread_without_mention(adapter, monkeypatch):
+    """smart mode: message without @mention in free channel does NOT create thread."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "smart")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123),
+        content="just chatting",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_smart_thread_free_channel_skips_thread_even_on_mention(adapter, monkeypatch):
+    """smart mode: free-response channels never thread, even if bot is @mentioned."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "smart")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+
+    bot_user = adapter._client.user
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content=f"<@{bot_user.id}> hey",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
 async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter, monkeypatch):
     """Threads under a voice-linked channel should still require @mention."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")


### PR DESCRIPTION
## Problem

Two related threading bugs in the Discord gateway:

**1. Free-response channels were creating auto-threads**
Channels listed in `DISCORD_FREE_RESPONSE_CHANNELS` (or `discord.free_response_channels` in config.yaml) bypassed the `@mention` requirement correctly, but still triggered auto-thread creation. The intent of a free-response channel is lightweight inline replies — threading overhead is equally unwanted.

**2. `auto_thread: smart` was silently treated as `false`**
The config supports `auto_thread: smart` but the parser only checked for `("true", "1", "yes")`, so `"smart"` fell through to `False` — disabling threading entirely rather than enabling the intended smart behaviour.

The original `smart` mode implementation existed in `gateway/run.py` and `run_agent.py` (old architecture) but was never ported after the platform refactor to `gateway/platforms/discord.py`.

## Fix

**`discord.py` line 2301** — extend `skip_thread` to include `is_free_channel`:
```python
# before
skip_thread = bool(channel_ids & no_thread_channels)

# after
skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
```

**`discord.py` lines 2311-2315** — implement the three-value `auto_thread` parser:
```python
auto_thread_mode = os.getenv("DISCORD_AUTO_THREAD", "true").lower()
if auto_thread_mode == "smart":
    auto_thread = was_mentioned   # thread only on explicit @mention
else:
    auto_thread = auto_thread_mode in ("true", "1", "yes")
```

## Behaviour after fix

| Channel type | `auto_thread` | Bot mentioned | Creates thread? |
|---|---|---|---|
| Normal | `true` | yes | ✅ yes |
| Normal | `smart` | yes | ✅ yes |
| Normal | `smart` | no | ❌ no |
| Free-response | `true` / `smart` | any | ❌ no |
| `no_thread_channels` | any | any | ❌ no |
| Voice-linked | any | any | ❌ no |

## Tests

4 new tests added to `tests/gateway/test_discord_free_response.py`:
- `test_discord_free_channel_skips_auto_thread`
- `test_discord_smart_thread_creates_thread_on_mention`
- `test_discord_smart_thread_no_thread_without_mention`
- `test_discord_smart_thread_free_channel_skips_thread_even_on_mention`

All 21 tests in the file pass.