### PR TITLE
fix(search): default FTS5 multi-keyword queries to OR instead of AND

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -985,6 +985,17 @@ class SessionDB:
         for i, quoted in enumerate(_quoted_parts):
             sanitized = sanitized.replace(f"\x00Q{i}\x00", quoted)
 
+        # Step 7: If no explicit boolean operators, join terms with OR.
+        # FTS5 defaults to AND for space-separated terms, which makes
+        # multi-keyword recall searches (e.g. "特洛伊 海伦") return almost
+        # nothing since few messages contain ALL terms.  For session search
+        # / recall, OR semantics are far more useful.
+        if not re.search(r'(?i)\b(AND|OR|NOT)\b', sanitized):
+            # Split on whitespace but keep quoted phrases as single tokens
+            tokens = re.findall(r'"[^"]*"|\S+', sanitized)
+            if len(tokens) > 1:
+                sanitized = " OR ".join(tokens)
+
         return sanitized.strip()
 
     def search_messages(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -407,7 +407,7 @@ class TestFTS5Search:
         """Unit test for _sanitize_fts5_query static method."""
         from hermes_state import SessionDB
         s = SessionDB._sanitize_fts5_query
-        assert s('hello world') == 'hello world'
+        assert s('hello world') == 'hello OR world'
         assert '+' not in s('C++')
         assert '"' not in s('"unterminated')
         assert '(' not in s('(problem')


### PR DESCRIPTION
## Problem

FTS5 treats space-separated terms as AND by default. This makes multi-keyword session search (e.g. `特洛伊 海伦`, `Trojan war Helen`) return almost nothing, since few individual messages contain ALL search terms simultaneously. Users expect recall-style search to match ANY term, not ALL.

## Root Cause

`_sanitize_fts5_query` in `hermes_state.py` passes queries straight through to FTS5 MATCH, which interprets spaces as implicit AND. A query like `特洛伊 海伦` requires both terms in the same message — only 0-1 results vs. the expected 5+.

## Fix

Added Step 7 to `_sanitize_fts5_query`: when no explicit boolean operators (AND/OR/NOT) are present, automatically join space-separated terms with `OR`. Quoted phrases are preserved as single tokens.

| Before | After |
|--------|-------|
| `特洛伊 海伦` → implicit AND → 0 results | `特洛伊 OR 海伦` → 5+ results |
| `"exact phrase"` → preserved ✅ | `"exact phrase"` → preserved ✅ |
| `python NOT java` → preserved ✅ | `python NOT java` → preserved ✅ |
| `docker OR kubernetes` → preserved ✅ | `docker OR kubernetes` → preserved ✅ |

## Changes

- `hermes_state.py` — Added Step 7 OR conversion in `_sanitize_fts5_query`
- `tests/test_hermes_state.py` — Updated test expectation for `hello world` → `hello OR world`

## Testing

- All 39 related tests pass (sanitize_fts5, session_search, search_messages)
- End-to-end: `session_search('Trojan war Helen 特洛伊 海伦')` now returns 2 sessions instead of 0