### PR TITLE
fix: include -p profile flag in exit resume hint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7979,9 +7979,13 @@ class HermesCLI:
                     pass
 
             print("Resume this session with:")
-            print(f"  hermes --resume {self.session_id}")
+            # Get the active profile so the resume command works across profiles
+            from hermes_cli.profiles import get_active_profile_name
+            profile = get_active_profile_name()
+            profile_flag = "" if profile in ("default", "custom") else f" -p {profile}"
+            print(f"  hermes --resume {self.session_id}{profile_flag}")
             if session_title:
-                print(f"  hermes -c \"{session_title}\"")
+                print(f"  hermes -c \"{session_title}\"{profile_flag}")
             print()
             print(f"Session:        {self.session_id}")
             if session_title:


### PR DESCRIPTION
## Summary

Session IDs are profile-constrained, so the resume hint printed on exit needs to include the active profile for multi-profile users. Without this, copying the hint from a non-default profile fails to resume the correct session.

**Before:**\n```\nhermes --resume 20260414_063228_c1240e\n```

**After:**\n```\nhermes --resume 20260414_063228_c1240e -p dev\n```

Also includes `-p` on the resume-by-title hint. Skipped for `default` and `custom` profiles (no `-p` needed).