### PR TITLE
fix(cli): trigger path autocomplete for Windows-style paths

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -652,7 +652,8 @@ class SlashCommandCompleter(Completer):
         Returns the path-like token under the cursor, or None if the
         current word doesn't look like a path.  A word is path-like when
         it starts with ``./``, ``../``, ``~/``, ``/``, or contains a
-        ``/`` separator (e.g. ``src/main.py``).
+        ``/`` or ``\\`` separator (e.g. ``src/main.py`` or
+        ``src\\main.py``).
         """
         if not text:
             return None
@@ -665,7 +666,11 @@ class SlashCommandCompleter(Completer):
         if not word:
             return None
         # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
+        if (
+            word.startswith(("./", "../", "~/", "/", ".\\", "..\\", "~\\", "\\"))
+            or "/" in word
+            or "\\" in word
+        ):
             return word
         return None
 

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -35,6 +35,12 @@ class TestExtractPathWord:
     def test_absolute_path(self):
         assert SlashCommandCompleter._extract_path_word("read /etc/hosts") == "/etc/hosts"
 
+    def test_windows_absolute_path(self):
+        assert SlashCommandCompleter._extract_path_word(r"read C:\Users\Simba\notes.txt") == r"C:\Users\Simba\notes.txt"
+
+    def test_windows_relative_path(self):
+        assert SlashCommandCompleter._extract_path_word(r"edit .\src\main.py") == r".\src\main.py"
+
     def test_parent_path(self):
         assert SlashCommandCompleter._extract_path_word("check ../config.yaml") == "../config.yaml"
 
@@ -101,6 +107,7 @@ class TestPathCompletions:
 
     def test_home_expansion(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         (tmp_path / "testfile.md").touch()
 
         completions = list(SlashCommandCompleter._path_completions("~/test"))
@@ -149,19 +156,39 @@ class TestIntegration:
         finally:
             os.chdir(old_cwd)
 
+    def test_path_completion_triggers_on_windows_style_path(self, completer, monkeypatch):
+        seen = {}
+
+        def fake_path_completions(word, limit=30):
+            seen["word"] = word
+            return iter(())
+
+        monkeypatch.setattr(SlashCommandCompleter, "_path_completions", staticmethod(fake_path_completions))
+
+        doc = Document(r"edit .\te", cursor_position=len(r"edit .\te"))
+        event = MagicMock()
+
+        list(completer.get_completions(doc, event))
+
+        assert seen["word"] == r".\te"
+
     def test_no_completion_for_plain_words(self, completer):
         doc = Document("hello world", cursor_position=11)
         event = MagicMock()
         completions = list(completer.get_completions(doc, event))
         assert completions == []
 
-    def test_absolute_path_triggers_completion(self, completer):
-        doc = Document("check /etc/hos", cursor_position=14)
+    def test_absolute_path_triggers_completion(self, completer, tmp_path):
+        (tmp_path / "host_test.txt").touch()
+        abs_path = str(tmp_path / "hos")
+        # Replace backslashes with forward slashes for the test if it's Windows, or leave as native
+        # The user's fix allows backslashes too. Let's test native absolute path.
+        doc_text = f"check {abs_path}"
+        doc = Document(doc_text, cursor_position=len(doc_text))
         event = MagicMock()
         completions = list(completer.get_completions(doc, event))
         names = _display_names(completions)
-        # /etc/hosts should exist on Linux
-        assert any("host" in n.lower() for n in names)
+        assert any("host_test" in n.lower() for n in names)
 
 
 class TestFileSizeLabel:


### PR DESCRIPTION
## Summary

Fix CLI path autocomplete for Windows-style paths such as `C:\...`, `.\...`, `..\...`, and `~\...`.

## Repro

1. Start the Hermes CLI on Windows.
2. Type a command containing a native Windows path, for example:
   - `edit .\te`
   - `edit C:\Users\<user>\Doc`
3. Trigger autocomplete.

Before this change, no path completions appeared, while equivalent POSIX-style inputs like `./te` did trigger completion.

## Root Cause

`SlashCommandCompleter._extract_path_word()` only recognized `/`-based paths (`./`, `../`, `~/`, `/`, or tokens containing `/`).

Windows-native paths use `\`, so those tokens were treated as plain words and `_path_completions()` was never called.

## Fix

Treat backslash-separated Windows path tokens as path-like too.

This change is intentionally small and limited to path detection only:
- no refactor
- no new abstraction
- no architecture change

## Tests

Added regression coverage for:
- Windows absolute path extraction
- Windows relative path extraction
- integration-level verification that Windows-style tokens trigger `_path_completions()`

## Test Evidence

Validated with:

```bash
uv run pytest tests/hermes_cli/test_path_completion.py -v

Result:

29 passed