### PR TITLE
fix(streaming): pass reply_to to stream consumer for message quoting

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7843,6 +7843,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -82,11 +82,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -714,10 +716,11 @@ class GatewayStreamConsumer:
                     # The final response will be sent by the fallback path.
                     return False
             else:
-                # First message — send new
+                # First message — send new (with reply_to to quote the user's message)
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:


### PR DESCRIPTION
## Problem

The `GatewayStreamConsumer` does not pass `reply_to` when sending the first streamed message. This means platform adapters that support reply/quoting (e.g. Feishu, Telegram) cannot reference the user's original message when streaming is enabled.

Non-streaming path works correctly — `base.py _process_message_background` passes `reply_to=event.message_id` to `_send_with_retry`. But the streaming path in `_send_or_edit()` sends the first message without `reply_to`.

## Changes

1. **gateway/stream_consumer.py** — Add `reply_to` parameter to `GatewayStreamConsumer.__init__`, store as `self.reply_to`
2. **gateway/stream_consumer.py** — Pass `reply_to=self.reply_to` when sending the first message in `_send_or_edit()`
3. **gateway/run.py** — Pass `event_message_id` as `reply_to` when creating `GatewayStreamConsumer`

## Testing

Verified that the `reply_to` parameter flows correctly:
- `_run_agent` receives `event_message_id` from the inbound event
- Creates `GatewayStreamConsumer(reply_to=event_message_id)`
- First streamed message calls `adapter.send(reply_to=self.reply_to, ...)`
- Adapter (e.g. Feishu) uses `reply_to` to call the platform's reply API