### PR TITLE
fix(cli): honor root-level prefill_messages_file from config.yaml

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -380,6 +380,16 @@ def load_cli_config() -> Dict[str, Any]:
                 and agent_file_config.get("max_turns") is not None
             ):
                 defaults["agent"]["max_turns"] = file_config["max_turns"]
+
+            # Handle legacy root-level prefill_messages_file (backwards compat).
+            # Canonical config schema exposes it at root level, but CLI reads
+            # agent.prefill_messages_file.  Mirror root-level value to agent
+            # when the nested key is not set — same pattern as max_turns above.
+            if "prefill_messages_file" in file_config and not (
+                isinstance(agent_file_config, dict)
+                and agent_file_config.get("prefill_messages_file")
+            ):
+                defaults["agent"]["prefill_messages_file"] = file_config["prefill_messages_file"]
         except Exception as e:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 


### PR DESCRIPTION
## Summary

CLI silently ignores root-level `prefill_messages_file` from `config.yaml`, even though the canonical config schema and gateway/cron loaders use it at the root level.

## Problem

The config schema (`hermes_cli/config.py:616`) defines `prefill_messages_file` at the config root. Gateway (`gateway/run.py:1084`) and cron (`cron/scheduler.py:662`) both read it from there. But the CLI (`cli.py:1740`) only checks `agent.prefill_messages_file` — a root-level key is silently dropped.

A user with a valid `config.yaml` loses few-shot prefill behavior in the CLI with no error or warning.

## Fix

Mirror root-level `prefill_messages_file` into `agent.prefill_messages_file` during `load_cli_config()`, same fallback pattern already used for root-level `max_turns` (lines 375-382).

Only applies when the nested key is not already set, so existing `agent.prefill_messages_file` configs are unaffected.

Closes #9635