### PR TITLE
fix(cli): honor root-level personalities from config.yaml

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -380,6 +380,21 @@ def load_cli_config() -> Dict[str, Any]:
                 and agent_file_config.get("max_turns") is not None
             ):
                 defaults["agent"]["max_turns"] = file_config["max_turns"]
+
+            # Handle root-level personalities (backwards compat).
+            # Canonical config schema exposes it at root level, but CLI reads
+            # agent.personalities.  Merge root-level personalities into agent
+            # when the nested section is empty or missing.
+            root_personalities = file_config.get("personalities")
+            if root_personalities and isinstance(root_personalities, dict):
+                existing = defaults["agent"].get("personalities", {})
+                if not existing:
+                    defaults["agent"]["personalities"] = root_personalities
+                elif isinstance(existing, dict):
+                    # Merge: root-level entries fill in gaps but don't
+                    # overwrite explicit agent.personalities entries.
+                    merged = {**root_personalities, **existing}
+                    defaults["agent"]["personalities"] = merged
         except Exception as e:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 


### PR DESCRIPTION
## Summary

CLI silently ignores root-level `personalities` from `config.yaml`, even though the canonical config schema defines it there.

## Problem

The config schema (`hermes_cli/config.py:667`) exposes `personalities` at the config root. The gateway personality command reads it from there. But the CLI (`cli.py:1746`) only checks `agent.personalities` — root-level custom personalities are invisible to `/personality`.

A user defining custom personalities at the config root (following the schema) will never see them listed.

## Fix

Merge root-level `personalities` into `agent.personalities` during `load_cli_config()`. Explicit `agent.personalities` entries take precedence; root-level entries fill gaps. Same fallback pattern as the existing `max_turns` normalization.

Closes #9636