### PR TITLE
fix(memory-setup): correct hint for providers with optional API keys

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -162,11 +162,14 @@ def _get_available_providers() -> list:
 
         schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
         has_secrets = any(f.get("secret") for f in schema)
+        required_secrets = any(f.get("secret") and f.get("required") for f in schema)
         has_non_secrets = any(not f.get("secret") for f in schema)
-        if has_secrets and has_non_secrets:
+        if required_secrets:
+            setup_hint = "requires API key"
+        elif has_secrets and has_non_secrets:
             setup_hint = "API key / local"
         elif has_secrets:
-            setup_hint = "requires API key"
+            setup_hint = "API key / local"
         elif not schema:
             setup_hint = "no setup needed"
         else:


### PR DESCRIPTION
## Summary

`hermes memory setup` shows "byterover — requires API key" even though the ByteRover API key is optional (local-only mode works without it).

## Problem

The setup wizard treats any provider with a `secret` config field as "requires API key". ByteRover's schema marks its API key as `secret: true` but doesn't set `required: true` — the key is optional and only needed for cloud sync.

This is misleading for users who want to try ByteRover in local-only mode.

## Fix

Check the `required` flag on config schema fields. Only display "requires API key" when a secret field is explicitly marked `required: true`. Providers with optional secrets (like ByteRover) now show "API key / local" instead.

Closes #9641