### PR TITLE
fix(tools): handle UnicodeDecodeError in read_file to prevent silent …

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -358,8 +358,20 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
-        result_dict = result.to_dict()
+        try:
+            result = file_ops.read_file(path, offset, limit)
+            result_dict = result.to_dict()
+        except UnicodeDecodeError as e:
+            # Fallback for Windows (cp1252/ANSI) files that fail strict UTF-8 decoding.
+            # We catch the error, log it softly, and instruct the user to check encoding.
+            logger.debug("UTF-8 decode failed for %s: %s", path, e)
+            return json.dumps({
+                "error": (
+                    f"Encoding Error: Cannot read '{path}' as UTF-8. "
+                    "This is common on Windows with ANSI-saved files. "
+                    "Please save the file with UTF-8 encoding and try again."
+                ),
+            })
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are


### PR DESCRIPTION
…crashes (#9633)

## What does this PR do?

Fixes  #9633


### Root Cause Analysis
The `read_file` tool in `tools/file_tools.py` delegates execution to `ShellFileOperations`, which enforces strict UTF-8 decoding. On Windows environments, user-created text files are frequently saved using legacy code pages (e.g., ANSI/cp1252). Encountering non-UTF-8 byte sequences raised an unhandled `UnicodeDecodeError`, resulting in a silent CLI crash and terminating the agent's tool execution loop with a generic `[error]` output.

### Implementation Details
* Wrapped the `file_ops.read_file(path, offset, limit)` invocation in a `try/except` block specifically targeting `UnicodeDecodeError`.
* Implemented a graceful error degradation mechanism: instead of propagating the exception, the handler now catches it and returns a JSON-formatted error string.
* Added a `logger.debug` trace for internal diagnostics without polluting the standard output.

### System Impact
* Eliminates the silent process termination associated with encoding mismatches.
* Provides the LLM (and subsequently the end-user) with an actionable, deterministic error message explaining the encoding requirement, thereby improving overall fault tolerance on Windows environments.



