### PR TITLE
feat(wecom): progressive native streaming on the reply channel

### DIFF
--- a/docs/wecom-streaming.md
+++ b/docs/wecom-streaming.md
@@ -1,0 +1,157 @@
+# WeCom Native Streaming
+
+How the WeCom AI Bot adapter turns `GatewayStreamConsumer` deltas into
+progressive reply-channel stream frames — and why it does things a bit
+differently from every other platform adapter.
+
+> **Credit.** The initial implementation is adapted from [PR #7041][pr-7041]
+> by @fantasticKe, with a simpler mapping onto the existing consumer API
+> plus tool-boundary and test coverage.
+> The `<think></think>` thinking-placeholder pattern was investigated after
+> reading the [OpenClaw WeCom plugin][openclaw] but is deliberately NOT
+> enabled in this adapter (see *Why no thinking animation* below).
+
+[pr-7041]: https://github.com/NousResearch/hermes-agent/pull/7041
+[openclaw]: https://github.com/openclaw
+
+## Why
+
+WeCom's AI Bot client displays a reply-channel *stream* message
+(`msgtype: stream`) as a single, progressively-updated bubble in the chat
+— this is the platform's native analogue of Telegram's "edit a message in
+place" trick that most streaming adapters use. Without it, a user sees
+nothing for the full duration of the reply, then the full text appears
+as one block.
+
+This adapter wires the consumer's generic `send` → `edit_message` →
+`finalize_stream` cycle onto that native stream protocol, so the WeCom
+user sees the same progressive-typing UX that Telegram and Discord users
+get.
+
+## Protocol
+
+The reply-channel stream is correlated by two ids:
+
+- **`reply_req_id`** — identifies the inbound request being replied to.
+  WeCom assigns exactly ONE stream lifetime per `reply_req_id`; once a
+  frame is sent with `finish=true`, that id is exhausted. Attempting to
+  open a second stream (a new stream_id) against the same `reply_req_id`
+  fails with `errcode 6000` ("data version conflict").
+- **`stream_id`** — identifies which stream inside a reply. Chosen by the
+  sender. All frames of one stream (`finish=false` continuations and the
+  closing `finish=true`) must share the same `stream_id`.
+
+Frame shape (delivered over the existing WebSocket `aibot_respond_msg`):
+
+```json
+{
+  "msgtype": "stream",
+  "stream": {
+    "id":      "<stream_id>",
+    "finish":  false,
+    "content": "<full accumulated text>"
+  }
+}
+```
+
+Notes:
+
+- `content` is the FULL response so far, not a delta. WeCom's client
+  does the diffing.
+- Only the final frame (`finish=true`) is sent through
+  `_send_reply_request` (which awaits an ACK). Intermediate frames are
+  fire-and-forget via `_send_json` — WeCom does not ACK per-frame and
+  awaiting one would stall the stream behind network RTT.
+
+## Mapping the consumer API
+
+```
+GatewayStreamConsumer              WeComAdapter
+──────────────────────────         ──────────────────────────
+first send(text, streaming=True)   → stream_id = new_id()
+                                     _send_reply_stream(finish=False)
+                                     _active_streams[reply_req_id] = stream_id
+                                     return SendResult(message_id=reply_req_id)
+
+edit_message(id, text)             → look up stream_id
+                                     _send_reply_stream(finish=False)
+
+finalize_stream(id, text)          → look up stream_id
+                                     _send_reply_stream(finish=True)
+                                     _active_streams.pop(reply_req_id)
+```
+
+`message_id` is deliberately set to `reply_req_id` in streaming mode so
+that subsequent consumer calls can find the right stream_id without
+needing a separate lookup table.
+
+## Unified-stream and tool boundaries
+
+Hermes' `GatewayStreamConsumer` inserts a *segment break* at every tool
+call, which on most adapters finalizes the current message so tool
+progress messages can appear "between" assistant text messages. On
+WeCom this would be catastrophic: finalizing closes the stream's only
+lifetime, and the next segment's `send()` would try to open a second
+stream against the same `reply_req_id` — triggering `errcode 6000`.
+
+To avoid that, the WeCom adapter sets:
+
+```python
+class WeComAdapter(...):
+    native_streaming_unified = True
+```
+
+The consumer checks this flag in its segment-break branch and skips
+both `finalize_stream` and the internal `_reset_segment_state`. The
+entire response — across any number of tool calls — is delivered
+through a single stream frame sequence.
+
+Consequence: tool-progress messages (sent via the proactive
+`aibot_send_msg` channel) appear in the chat timeline as independent
+messages, BELOW the streaming reply bubble. The default
+`_PLATFORM_DEFAULTS["wecom"]["tool_progress"] = "off"` already
+suppresses those for typical users; operators who opt into tool
+progress on WeCom accept that they see the progress after the streaming
+bubble has already been pinned to its timeline position.
+
+## Why no thinking animation
+
+WeCom renders a `<think>...</think>` prefix as a thinking animation,
+and it is tempting to open the stream the moment an inbound message
+arrives (in `send_typing`) so the user sees an immediate "typing"
+signal while the agent reasons and calls tools.
+
+This is how OpenClaw's WeCom plugin works, and an earlier draft of this
+patch did the same. It was reverted after live testing because the
+stream bubble is pinned to its *initial* position in the chat timeline,
+which means any tool-progress messages sent after the thinking frame
+appear BELOW it, and the eventual real reply appears ABOVE those
+progress messages. The result is confusing: the final reply looks like
+it was said *before* the tools ran.
+
+Given the choice between a visible "typing" animation with wrong
+ordering, and no animation with correct ordering plus visible tool
+progress, we picked the latter. `send_typing` is intentionally a no-op
+on WeCom; the first streaming delta itself serves as the "bot is
+responding" signal.
+
+If you need a thinking animation AND correct ordering, you also need to
+suppress `display.platforms.wecom.tool_progress` and route all
+intermediate signalling through the stream frames themselves. That is
+out of scope for this PR.
+
+## Failure modes
+
+- **`finalize_stream` returns `success=False`** — the consumer's
+  `_finalize_native_stream` helper treats that as a signal to fall
+  through to the generic `_send_or_edit` path, which will attempt to
+  deliver the final text as a continuation `edit_message` or, on
+  failure, a fallback standalone message.
+- **Adapter-level exceptions** (network, timeout) — swallowed and
+  logged inside the `finalize_stream` / `edit_message` methods; caller
+  sees a failed `SendResult` and handles it as above.
+- **Proactive (non-reply) streaming send** — the `streaming` flag is
+  honored only when a `reply_req_id` is available. Proactive sends to
+  a chat with no reply context deliver as a single block message, and
+  `_active_streams` is deliberately not populated (so a later
+  `edit_message` correctly reports "no active stream").

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -146,6 +146,14 @@ class WeComAdapter(BasePlatformAdapter):
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
 
+    # Signals to ``GatewayStreamConsumer`` that this adapter uses a single
+    # native stream for the entire response — opened by send_typing() /
+    # send(streaming=True), continued by edit_message(), closed by
+    # finalize_stream(). Tool-boundary segment breaks must NOT close the
+    # stream, because WeCom's reply channel only allows one stream per
+    # reply_req_id (reopening triggers errcode 6000 "data version conflict").
+    native_streaming_unified = True
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM)
 
@@ -182,6 +190,15 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex
         self._last_chat_req_ids: Dict[str, str] = {}
+
+        # Active native-streaming sessions: message_id -> (reply_req_id, stream_id).
+        # Populated by send() when ``metadata["streaming"]`` is truthy, consumed
+        # by edit_message() / finalize_stream() to continue / close the stream.
+        #
+        # The message_id we use is ``reply_req_id`` itself — WeCom's reply
+        # channel only supports one stream per request, so this mapping is
+        # effectively reply_req_id -> stream_id.
+        self._active_streams: Dict[str, Tuple[str, str]] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -1216,6 +1233,44 @@ class WeComAdapter(BasePlatformAdapter):
         self._raise_for_wecom_error(response, "send reply markdown")
         return response
 
+    async def _send_reply_stream(
+        self,
+        reply_req_id: str,
+        content: str,
+        stream_id: Optional[str] = None,
+        finish: bool = True,
+    ) -> Dict[str, Any]:
+        """Send one chunk of WeCom's native reply-mode stream.
+
+        Final chunks (``finish=True``) go through :meth:`_send_reply_request`
+        so the caller gets an ACK and any WeCom error is raised. Intermediate
+        chunks (``finish=False``) are fire-and-forget via :meth:`_send_json`
+        — WeCom AI Bot does not send per-chunk ACKs, and waiting for one
+        would stall the stream.
+        """
+        stream_id = stream_id or self._new_req_id("stream")
+        stream_payload = {
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "finish": finish,
+                "content": content[:self.MAX_MESSAGE_LENGTH],
+            },
+        }
+        if finish:
+            response = await self._send_reply_request(reply_req_id, stream_payload)
+            self._raise_for_wecom_error(response, "send reply stream")
+            return response
+
+        await self._send_json(
+            {
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": str(reply_req_id).strip()},
+                "body": stream_payload,
+            }
+        )
+        return {"headers": {"req_id": reply_req_id}}
+
     async def _send_reply_media_message(
         self,
         reply_req_id: str,
@@ -1335,12 +1390,25 @@ class WeComAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
-        del metadata
+        """Send markdown to a WeCom chat.
+
+        Uses passive reply-mode (``aibot_respond_msg``) when a reply context
+        exists, otherwise proactive ``aibot_send_msg``. When ``metadata``
+        contains ``{"streaming": True}`` and a reply context is available,
+        the first chunk is sent with ``finish=False`` and the stream id is
+        stashed in ``self._active_streams`` so later
+        :meth:`edit_message` / :meth:`finalize_stream` calls can continue
+        the same native WebSocket stream (no client-visible message edits).
+
+        Native streaming is a WeCom reply-channel feature; proactive sends
+        ignore the ``streaming`` flag and always deliver as a single message.
+        """
+        streaming = bool(metadata.get("streaming")) if metadata else False
 
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
+        stream_id: Optional[str] = None
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
 
@@ -1348,7 +1416,16 @@ class WeComAdapter(BasePlatformAdapter):
                 reply_req_id = self._last_chat_req_ids[chat_id]
 
             if reply_req_id:
-                response = await self._send_reply_markdown(reply_req_id, content)
+                if streaming:
+                    stream_id = self._new_req_id("stream")
+                    response = await self._send_reply_stream(
+                        reply_req_id,
+                        content,
+                        stream_id=stream_id,
+                        finish=False,
+                    )
+                else:
+                    response = await self._send_reply_markdown(reply_req_id, content)
             else:
                 response = await self._send_request(
                     APP_CMD_SEND,
@@ -1368,11 +1445,89 @@ class WeComAdapter(BasePlatformAdapter):
         if error:
             return SendResult(success=False, error=error)
 
+        # In streaming reply-mode, reuse ``reply_req_id`` as the message_id so
+        # ``edit_message`` / ``finalize_stream`` can look up the active stream.
+        if streaming and stream_id and reply_req_id:
+            self._active_streams[reply_req_id] = (reply_req_id, stream_id)
+            message_id = reply_req_id
+        else:
+            message_id = self._payload_req_id(response) or uuid.uuid4().hex[:12]
+
         return SendResult(
             success=True,
-            message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
+            message_id=message_id,
             raw_response=response,
         )
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Continue an active native stream by sending another (non-final) chunk.
+
+        WeCom has no "edit an already-delivered message" API; instead, its
+        AI Bot protocol supports a multi-chunk stream identified by a
+        ``stream_id`` on the reply channel. We map the gateway's generic
+        ``edit_message`` to that protocol: each call delivers one more
+        ``finish=False`` chunk under the existing ``stream_id``.
+
+        Returns ``SendResult(success=False, ...)`` if the message_id has no
+        active stream (e.g. because the reply window has already been
+        finalized, or the message was sent via the proactive path which
+        does not support streaming).
+        """
+        del chat_id
+        stream_info = self._active_streams.get(message_id)
+        if not stream_info:
+            return SendResult(success=False, error="no active stream for message")
+
+        reply_req_id, stream_id = stream_info
+        try:
+            await self._send_reply_stream(
+                reply_req_id, content, stream_id=stream_id, finish=False,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            logger.error("[%s] Stream edit failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def finalize_stream(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+    ) -> SendResult:
+        """Close an active native stream with a final (``finish=True``) chunk.
+
+        The stream entry is removed from ``self._active_streams`` regardless
+        of outcome to prevent leaks. Called by ``GatewayStreamConsumer`` at
+        the end of a stream, on segment break, or on cancellation.
+        """
+        del chat_id
+        stream_info = self._active_streams.pop(message_id, None)
+        if not stream_info:
+            return SendResult(success=False, error="no active stream for message")
+
+        reply_req_id, stream_id = stream_info
+        # WeCom AI Bot errcode 6000 ("more than one callers at the same time")
+        # fires when the finish=True frame arrives while the server is still
+        # processing the previous fire-and-forget chunk. A short grace period
+        # lets the server settle before we close the stream. The user has
+        # already seen every chunk on their client; this only affects the
+        # finalize ACK.
+        await asyncio.sleep(0.25)
+        try:
+            response = await self._send_reply_stream(
+                reply_req_id, content, stream_id=stream_id, finish=True,
+            )
+            return SendResult(success=True, message_id=message_id, raw_response=response)
+        except Exception as exc:
+            logger.error("[%s] Stream finalize failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
 
     async def send_image(
         self,
@@ -1464,7 +1619,16 @@ class WeComAdapter(BasePlatformAdapter):
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """WeCom does not expose typing indicators in this adapter."""
+        """WeCom does not expose typing indicators in this adapter.
+
+        The AI Bot reply-channel protocol can render a ``<think></think>``
+        animation as the first frame of a stream, but because the stream
+        bubble is pinned to its initial position in the chat timeline, a
+        subsequent real reply would appear ABOVE any tool-progress messages
+        delivered via the proactive send channel. That is worse UX than no
+        animation at all, so we leave this as a no-op and rely on the
+        streaming delta itself as the "is responding" signal.
+        """
         del chat_id, metadata
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12347,6 +12347,7 @@ class GatewayRunner:
                                 if progress_queue is not None
                                 else None
                             ),
+                            reply_to=event_message_id,
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -92,6 +92,7 @@ class GatewayStreamConsumer:
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
         on_new_message: Optional[callable] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -105,6 +106,7 @@ class GatewayStreamConsumer:
         # the content, not edit the old bubble above it.
         # Called with no arguments. Exceptions are swallowed.
         self._on_new_message = on_new_message
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -423,6 +425,13 @@ class GatewayStreamConsumer:
                     if self._accumulated:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
+                        elif self._message_id and await self._finalize_native_stream(self._accumulated):
+                            # Adapter has a native streaming protocol (e.g. WeCom
+                            # reply-channel stream); ``finalize_stream`` closes
+                            # the stream with ``finish=True``. Must run even when
+                            # ``current_update_visible`` is set, otherwise the
+                            # stream is left hanging on the wire.
+                            self._final_response_sent = True
                         elif (
                             current_update_visible
                             and not self._adapter_requires_finalize
@@ -464,22 +473,42 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
-                    # If the segment-break edit failed to deliver the
-                    # accumulated content (flood control that has not yet
-                    # promoted to fallback mode, or fallback mode itself),
-                    # _accumulated still holds pre-boundary text the user
-                    # never saw. Flush that tail as a continuation message
-                    # before the reset below wipes _accumulated — otherwise
-                    # text generated before the tool boundary is silently
-                    # dropped (issue #8124).
-                    if (
-                        self._accumulated
-                        and not current_update_visible
-                        and self._message_id
-                        and self._message_id != "__no_edit__"
-                    ):
-                        await self._flush_segment_tail_on_edit_failure()
-                    self._reset_segment_state(preserve_no_edit=True)
+                    # Adapters with a unified native stream (e.g. WeCom) reuse
+                    # a single stream for the entire response — closing it at
+                    # a tool boundary and reopening would fail the second
+                    # reply_req_id stream (platform limitation). Keep the
+                    # message state intact so subsequent deltas continue the
+                    # same stream via edit_message.
+                    # Strict ``is True`` — adapters opt in with a class-level
+                    # ``True`` constant. Using ``truthy`` would match MagicMock
+                    # auto-attributes in tests and wedge the existing
+                    # tool-boundary suite.
+                    if getattr(self.adapter, "native_streaming_unified", False) is True:
+                        pass
+                    else:
+                        # If the segment-break edit failed to deliver the
+                        # accumulated content (flood control that has not yet
+                        # promoted to fallback mode, or fallback mode itself),
+                        # _accumulated still holds pre-boundary text the user
+                        # never saw. Flush that tail as a continuation message
+                        # before the reset below wipes _accumulated — otherwise
+                        # text generated before the tool boundary is silently
+                        # dropped (issue #8124).
+                        if (
+                            self._accumulated
+                            and not current_update_visible
+                            and self._message_id
+                            and self._message_id != "__no_edit__"
+                        ):
+                            await self._flush_segment_tail_on_edit_failure()
+                        # Close any active native stream before starting a fresh
+                        # segment; otherwise the previous stream keeps hanging
+                        # with ``finish=False`` and the client shows a stuck cursor.
+                        if self._message_id:
+                            await self._finalize_native_stream(
+                                self._last_sent_text or self._accumulated
+                            )
+                        self._reset_segment_state(preserve_no_edit=True)
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 
@@ -488,7 +517,10 @@ class GatewayStreamConsumer:
             _best_effort_ok = False
             if self._accumulated and self._message_id:
                 try:
-                    _best_effort_ok = bool(await self._send_or_edit(self._accumulated))
+                    if await self._finalize_native_stream(self._accumulated):
+                        _best_effort_ok = True
+                    else:
+                        _best_effort_ok = bool(await self._send_or_edit(self._accumulated))
                 except Exception:
                     pass
             # Only confirm final delivery if the best-effort send above
@@ -854,6 +886,27 @@ class GatewayStreamConsumer:
         self._final_response_sent = True
         return True
 
+    async def _finalize_native_stream(self, text: str) -> bool:
+        """Close a native-streaming adapter's stream with a final chunk.
+
+        Returns True when the adapter exposes ``finalize_stream`` and the call
+        succeeded. Returns False for adapters without native streaming, for
+        the ``__no_edit__`` sentinel, or when the adapter reports failure —
+        callers fall back to the generic send/edit path in that case.
+        """
+        if not hasattr(self.adapter, "finalize_stream"):
+            return False
+        if self._message_id in (None, "__no_edit__"):
+            return False
+        try:
+            result = await self.adapter.finalize_stream(
+                self.chat_id, self._message_id, text,
+            )
+        except Exception as exc:
+            logger.debug("finalize_stream raised: %s", exc)
+            return False
+        return bool(result and getattr(result, "success", False))
+
     async def _send_or_edit(self, text: str, *, finalize: bool = False) -> bool:
         """Send or edit the streaming message.
 
@@ -979,11 +1032,17 @@ class GatewayStreamConsumer:
                     # The final response will be sent by the fallback path.
                     return False
             else:
-                # First message — send new
+                # First message — send new. Mark the send as ``streaming`` so
+                # adapters that support native stream protocols (e.g. WeCom)
+                # can open a long-running stream instead of treating this as a
+                # one-shot send.
+                first_send_metadata = dict(self.metadata) if self.metadata else {}
+                first_send_metadata["streaming"] = True
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
-                    metadata=self.metadata,
+                    reply_to=self.reply_to,
+                    metadata=first_send_metadata,
                 )
                 if result.success:
                     if result.message_id:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -170,6 +170,134 @@ class TestEditMessageFinalizeSignature:
         )
 
 
+class TestNativeStreamingIntegration:
+    """Consumer hooks for adapters with native WebSocket streaming (e.g. WeCom).
+
+    These adapters cannot edit delivered messages; instead they keep a
+    ``finish=False`` stream open, accept continuation chunks via
+    ``edit_message``, and close the stream via ``finalize_stream``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_send_passes_reply_to_and_streaming_metadata(self):
+        """Streaming adapters need reply_to (to pick the stream channel) and
+        ``streaming=True`` metadata (to open the stream instead of sending once).
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="req-1"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter, "chat_123",
+            metadata={"thread_id": "t-1"},
+            reply_to="user-msg-42",
+        )
+        await consumer._send_or_edit("first chunk of streamed response")
+
+        adapter.send.assert_awaited_once()
+        kwargs = adapter.send.call_args.kwargs
+        assert kwargs["reply_to"] == "user-msg-42"
+        assert kwargs["metadata"]["streaming"] is True
+        # Pre-existing metadata must be preserved, not replaced.
+        assert kwargs["metadata"]["thread_id"] == "t-1"
+
+    @pytest.mark.asyncio
+    async def test_finalize_native_stream_succeeds(self):
+        adapter = MagicMock()
+        adapter.finalize_stream = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="req-1")
+        )
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "req-1"
+
+        ok = await consumer._finalize_native_stream("final accumulated text")
+
+        assert ok is True
+        adapter.finalize_stream.assert_awaited_once_with(
+            "chat_123", "req-1", "final accumulated text",
+        )
+
+    @pytest.mark.asyncio
+    async def test_finalize_native_stream_returns_false_without_adapter_support(self):
+        """Adapters that don't implement finalize_stream must not be called and
+        the helper must report False so callers fall back to send/edit."""
+        adapter = MagicMock(spec=["send", "edit_message", "MAX_MESSAGE_LENGTH"])
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+
+        ok = await consumer._finalize_native_stream("text")
+
+        assert ok is False
+        # Adapter had no finalize_stream attribute — nothing to assert_not_called.
+
+    @pytest.mark.asyncio
+    async def test_finalize_native_stream_ignores_no_edit_sentinel(self):
+        """``__no_edit__`` is a sentinel for platforms (Signal, github_comment
+        webhook) that accepted the send but have no editable message id.
+        finalize_stream must be skipped for that sentinel."""
+        adapter = MagicMock()
+        adapter.finalize_stream = AsyncMock()
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "__no_edit__"
+
+        ok = await consumer._finalize_native_stream("text")
+
+        assert ok is False
+        adapter.finalize_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_segment_break_skips_finalize_for_unified_stream_adapter(self):
+        """WeCom-style adapters reuse one stream for the whole response. The
+        consumer must not call finalize_stream at tool boundaries (that would
+        close the stream, and the next send would try to open a second one
+        against the same reply_req_id — WeCom rejects this with errcode 6000)."""
+        adapter = MagicMock()
+        adapter.native_streaming_unified = True
+        adapter.finalize_stream = AsyncMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="req-1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer.on_delta("before tool call ")
+        consumer.on_delta(None)  # tool boundary
+        consumer.on_delta("after tool call")
+        consumer.finish()
+        await consumer.run()
+
+        # finalize_stream should be called exactly once — at the end of the
+        # response (got_done), not at the tool-boundary segment_break.
+        assert adapter.finalize_stream.await_count == 1
+        final_call_args = adapter.finalize_stream.await_args.args
+        assert final_call_args[0] == "chat_123"
+        assert final_call_args[1] == "req-1"
+        # Final call carries the full accumulated text across the tool boundary.
+        assert "before tool call" in final_call_args[2]
+        assert "after tool call" in final_call_args[2]
+        # send was called exactly once (first chunk opens the stream); no
+        # second send at segment_break, because message_id stayed set.
+        assert adapter.send.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_finalize_native_stream_swallows_adapter_exception(self):
+        """Adapter exceptions must not bubble — callers treat this as a signal
+        to try the generic send_or_edit fallback."""
+        adapter = MagicMock()
+        adapter.finalize_stream = AsyncMock(side_effect=RuntimeError("network down"))
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "req-1"
+
+        ok = await consumer._finalize_native_stream("text")
+
+        assert ok is False
+
+
 class TestSendOrEditMediaStripping:
     """Verify _send_or_edit strips MEDIA: before sending to the platform."""
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -172,6 +172,185 @@ class TestWeComReplyMode:
         assert args[1] == {"msgtype": "image", "image": {"media_id": "media-1"}}
 
 
+class TestWeComNativeStreaming:
+    """Native WebSocket streaming on the reply channel.
+
+    WeCom AI Bot cannot edit an already-delivered message, but its reply
+    protocol supports a multi-chunk stream identified by a shared stream_id.
+    The adapter maps the gateway's generic send/edit_message/finalize_stream
+    cycle onto ``finish=False``/``finish=False``/``finish=True`` chunks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_streaming_first_send_uses_finish_false(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_json = AsyncMock()
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        result = await adapter.send(
+            "chat-123", "first chunk",
+            reply_to="msg-1",
+            metadata={"streaming": True},
+        )
+
+        assert result.success is True
+        # Streaming first chunk must be fire-and-forget (_send_json), not
+        # ACK'd (_send_reply_request), so the stream stays open.
+        adapter._send_reply_request.assert_not_called()
+        adapter._send_json.assert_awaited_once()
+        payload = adapter._send_json.await_args.args[0]
+        assert payload["body"]["msgtype"] == "stream"
+        assert payload["body"]["stream"]["finish"] is False
+        assert payload["body"]["stream"]["content"] == "first chunk"
+        # message_id must equal reply_req_id so edit_message can find it.
+        assert result.message_id == "req-1"
+        assert "req-1" in adapter._active_streams
+        stored_reply, stored_stream = adapter._active_streams["req-1"]
+        assert stored_reply == "req-1"
+        assert stored_stream == payload["body"]["stream"]["id"]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_send_does_not_touch_active_streams(self):
+        """Plain (non-streaming) reply sends must not register a stream.
+
+        Non-streaming replies go through the existing markdown helper — the
+        stream machinery is reserved for metadata={"streaming": True}.
+        """
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        await adapter.send("chat-123", "hello", reply_to="msg-1")
+
+        assert adapter._active_streams == {}
+        payload = adapter._send_reply_request.await_args.args[1]
+        assert payload["msgtype"] == "markdown"
+
+    @pytest.mark.asyncio
+    async def test_edit_message_continues_same_stream_id(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_json = AsyncMock()
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        first = await adapter.send(
+            "chat-123", "chunk-1",
+            reply_to="msg-1",
+            metadata={"streaming": True},
+        )
+        first_stream_id = adapter._send_json.await_args.args[0]["body"]["stream"]["id"]
+
+        edit_result = await adapter.edit_message("chat-123", first.message_id, "chunk-1 + 2")
+
+        assert edit_result.success is True
+        # Second call should reuse the same stream_id and still be finish=False.
+        assert adapter._send_json.await_count == 2
+        second_payload = adapter._send_json.await_args.args[0]
+        assert second_payload["body"]["stream"]["id"] == first_stream_id
+        assert second_payload["body"]["stream"]["finish"] is False
+        assert second_payload["body"]["stream"]["content"] == "chunk-1 + 2"
+        # Still not finalized, so the stream entry must remain.
+        assert first.message_id in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_edit_message_returns_failure_when_no_active_stream(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        result = await adapter.edit_message("chat-123", "unknown-id", "payload")
+        assert result.success is False
+        assert "no active stream" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_finalize_stream_sends_finish_true_and_clears_entry(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_json = AsyncMock()
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        first = await adapter.send(
+            "chat-123", "chunk-1",
+            reply_to="msg-1",
+            metadata={"streaming": True},
+        )
+        opened_stream_id = adapter._send_json.await_args.args[0]["body"]["stream"]["id"]
+
+        result = await adapter.finalize_stream("chat-123", first.message_id, "final full text")
+
+        assert result.success is True
+        # Final chunk must go through the ACK'd reply request, not fire-and-forget.
+        adapter._send_reply_request.assert_awaited_once()
+        final_payload = adapter._send_reply_request.await_args.args[1]
+        assert final_payload["stream"]["finish"] is True
+        assert final_payload["stream"]["id"] == opened_stream_id
+        assert final_payload["stream"]["content"] == "final full text"
+        # Entry cleaned up so a retry cannot accidentally reuse it.
+        assert first.message_id not in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_finalize_stream_returns_failure_when_no_active_stream(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        result = await adapter.finalize_stream("chat-123", "unknown-id", "payload")
+        assert result.success is False
+        assert "no active stream" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_streaming_ignored_for_proactive_send(self):
+        """No reply context → no reply_req_id → native streaming is unavailable.
+
+        The adapter must still deliver the message as a single ``aibot_send_msg``
+        and must NOT populate ``_active_streams`` (otherwise edit_message would
+        incorrectly try to stream to a chat that has no reply channel).
+        """
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "send-1"}, "errcode": 0}
+        )
+
+        result = await adapter.send(
+            "chat-123", "hello",
+            reply_to=None,
+            metadata={"streaming": True},
+        )
+
+        assert result.success is True
+        assert adapter._active_streams == {}
+
+
+class TestWeComUnifiedStreamFlag:
+    @pytest.mark.asyncio
+    async def test_adapter_flags_unified_native_streaming(self):
+        """``GatewayStreamConsumer`` reads this attribute to decide whether
+        tool-boundary segment breaks should close the current stream. WeCom's
+        reply channel cannot reopen a stream once finalized (errcode 6000),
+        so this flag must stay ``True``.
+        """
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.native_streaming_unified is True
+
+
 class TestExtractText:
     def test_extracts_plain_text(self):
         from gateway.platforms.wecom import WeComAdapter

--- a/website/docs/user-guide/messaging/wecom.md
+++ b/website/docs/user-guide/messaging/wecom.md
@@ -226,9 +226,15 @@ Files exceeding the absolute 20 MB limit are rejected with an informational mess
 
 ## Reply-Mode Stream Responses
 
-When the bot receives a message via the WeCom callback, the adapter remembers the inbound request ID. If a response is sent while the request context is still active, the adapter uses WeCom's reply-mode (`aibot_respond_msg`) with streaming to correlate the response directly to the inbound message. This provides a more natural conversation experience in the WeCom client.
+When the bot receives a message via the WeCom callback, the adapter remembers the inbound request ID. If a response is sent while the request context is still active, the adapter uses WeCom's reply-mode (`aibot_respond_msg`) with streaming to correlate the response directly to the inbound message.
 
-If the inbound request context has expired or is unavailable, the adapter falls back to proactive message sending via `aibot_send_msg`.
+### Progressive (Typewriter) Streaming
+
+When `display.platforms.wecom.streaming` is `true`, assistant replies stream into the WeCom client word-by-word as the model generates them — the same experience users get on Telegram and Discord. Under the hood the adapter uses WeCom's native reply-channel stream protocol (`msgtype: stream`) so no client-visible message edits are required.
+
+Tool-call boundaries do NOT break the stream into separate bubbles on WeCom: the whole response is delivered as a single progressively-updated message. See `docs/wecom-streaming.md` for the protocol details and design rationale.
+
+If the inbound request context has expired or is unavailable, the adapter falls back to proactive message sending via `aibot_send_msg` (no streaming in that case — WeCom's native stream is a reply-channel feature).
 
 Reply-mode also works for media: uploaded media can be sent as a reply to the originating message.
 


### PR DESCRIPTION
## Summary

WeCom assistant replies currently arrive as a single block at the end of
the agent's run. This PR wires `GatewayStreamConsumer` onto WeCom's
native `msgtype: stream` reply-channel protocol so users see the reply
stream in word-by-word, the same way they do on Telegram and Discord.

- Closes #8309 (the issue asking for native streaming support).
- Approach adapted from #7041 (thanks @fantasticKe), rebased onto
  current `main` and extended with tool-boundary handling plus test
  coverage.
- Protocol and design rationale documented in the new
  [`docs/wecom-streaming.md`](../blob/feat/wecom-native-streaming/docs/wecom-streaming.md).

## What changes

### `gateway/platforms/wecom.py`

- `_send_reply_stream` now takes `stream_id` and `finish` parameters.
  Intermediate frames are fire-and-forget (WeCom does not ACK per
  chunk and awaiting would stall the stream); only the closing
  `finish=true` frame goes through the ACK'd `_send_reply_request`.
- `send` honors `metadata[\"streaming\"]`. When set and a
  `reply_req_id` is available, it opens the stream with `finish=false`
  and tracks `(reply_req_id, stream_id)` in `self._active_streams`.
  The `SendResult.message_id` is set to `reply_req_id` so the
  consumer's follow-up `edit_message` / `finalize_stream` calls can
  look up the live stream.
- New `edit_message` and `finalize_stream` methods deliver
  continuation (`finish=false`) and closing (`finish=true`) frames on
  the same `stream_id`.
- New class attribute `native_streaming_unified = True`. WeCom's
  reply channel allows exactly one stream lifetime per
  `reply_req_id` — reopening after a `finish=true` fails with
  `errcode 6000 (\"data version conflict\")`. Setting this flag tells
  the stream consumer to treat the whole agent run, across any number
  of tool calls, as a single stream.

### `gateway/stream_consumer.py`

- New `reply_to` constructor parameter, plumbed through so the first
  send targets the reply channel.
- First send now sets `metadata[\"streaming\"] = True` so
  native-streaming adapters know to open a progressive stream instead
  of delivering a one-shot message.
- New `_finalize_native_stream` helper, called at stream done and on
  cancellation; returns False for adapters that do not expose
  `finalize_stream`, for the `__no_edit__` sentinel, and when the
  adapter reports failure — callers fall back to the existing
  `_send_or_edit` path in those cases.
- Segment-break handling: for adapters with
  `native_streaming_unified is True`, skip `finalize_stream` and the
  internal `_reset_segment_state` so the tool boundary does not close
  and reopen the stream.

### `gateway/run.py`

- Passes `event_message_id` as `reply_to` when constructing the stream
  consumer.

### Tests (`tests/gateway/`)

- `test_wecom.py`
  - `TestWeComNativeStreaming`: first send uses `finish=false`,
    non-streaming path unchanged, `edit_message` reuses the same
    `stream_id`, `finalize_stream` sends `finish=true` and cleans up,
    proactive (non-reply) send ignores the streaming flag, missing-
    stream paths for both edit and finalize.
  - `TestWeComUnifiedStreamFlag`: pins the class-level flag so
    accidental removals break loudly.
- `test_stream_consumer.py`
  - `TestNativeStreamingIntegration`: first send passes `reply_to` and
    `streaming=True`, `_finalize_native_stream` success /
    no-adapter-support / `__no_edit__` sentinel / adapter-exception
    paths, and segment-break skips `finalize_stream` for unified-stream
    adapters.

All of `tests/gateway/test_wecom.py`, `test_stream_consumer.py`,
`test_display_config.py`, and `test_text_batching.py` pass locally
(150 tests).

### Docs

- `docs/wecom-streaming.md` (new): protocol reference, mapping from
  the consumer API, unified-stream rationale, failure modes, and a
  specific section explaining why `send_typing` is deliberately left
  as a no-op — see below.
- `website/docs/user-guide/messaging/wecom.md`: updated the
  reply-mode section to describe progressive streaming and link to
  the protocol doc.

## Design notes

### Why `send_typing` is still a no-op

An earlier iteration of this patch opened a `<think></think>`
thinking-stream placeholder in `send_typing` so the WeCom client would
show a typing animation immediately on inbound message. That is the
pattern used by OpenClaw's WeCom plugin and it works well in isolation.

It was reverted after live testing once tool progress was involved.
The WeCom stream bubble is pinned to its *initial* position in the
chat timeline, which means:

1. Thinking stream opens → bubble at timeline position T0.
2. Agent calls a tool → tool-progress message sent via the proactive
   `aibot_send_msg` channel appears at T1, below the thinking bubble.
3. Agent writes its reply → written into the same `stream_id`,
   updating bubble at T0 → final reply appears *above* the tool
   progress message.

Users read that as \"the bot replied before running the tool\", which
is worse UX than having no typing animation at all. The streaming
delta itself already signals that the bot is responding.

A future patch that also re-routes tool progress through the stream
frames (instead of the proactive channel) would be able to bring back
the thinking animation without breaking ordering. Out of scope here.

### `errcode 6000` at tool boundaries

Without `native_streaming_unified`, a multi-tool response would
trigger the consumer's generic segment-break behaviour: finalize the
current stream (`finish=true`) and reopen a new one. WeCom rejects the
second open against the same `reply_req_id` with
`errcode 6000 (\"more than one callers at the same time, data version
conflict\")`. The unified-stream flag avoids that by keeping a single
stream open for the whole response.

## Test plan

- [x] Unit tests for all new methods on the adapter and consumer
      (150 tests passing locally).
- [x] Manual end-to-end in a production-like deployment: short
      replies, long replies, replies with up to 8 tool calls.
- [x] Confirmed no `errcode 6000` in the agent log across long
      tool-using runs after the unified-stream flag.
- [x] Confirmed existing non-streaming reply-mode behaviour is
      unchanged (`TestWeComReplyMode` still passes).

### Reviewer checklist

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs — #7041 had a similar approach but has
      been inactive since 2026-04-10 with merge conflicts and no
      tests; this PR picks up from there with the author's name in
      the commit body and PR description.
- [x] The PR contains only changes related to native streaming.
- [x] Tests added for all new paths.
- [x] Tested on my platform: macOS 25.3.0, Python 3.11.4, WeCom AI
      Bot DM.