### PR TITLE
feat(whatsapp): send read receipts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -286,6 +286,7 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # WhatsApp (built-in Baileys bridge — run `hermes whatsapp` to pair)
 # WHATSAPP_ENABLED=false
 # WHATSAPP_ALLOWED_USERS=15551234567
+# WHATSAPP_SEND_READ_RECEIPTS=true          # Auto-mark incoming messages as read (default: true)
 
 # Email (IMAP/SMTP — send and receive emails as Hermes)
 # For Gmail: enable 2FA → create App Password at https://myaccount.google.com/apppasswords

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -644,6 +644,8 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
+                if "send_read_receipts" in whatsapp_cfg and not os.getenv("WHATSAPP_SEND_READ_RECEIPTS"):
+                    os.environ["WHATSAPP_SEND_READ_RECEIPTS"] = str(whatsapp_cfg["send_read_receipts"]).lower()
 
             # Matrix settings → env vars (env vars take precedence)
             matrix_cfg = yaml_cfg.get("matrix", {})

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -27,6 +27,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { shouldSendReadReceipt } from './read_receipts.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -40,6 +41,10 @@ const WHATSAPP_DEBUG =
   process.env &&
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
+
+const WHATSAPP_SEND_READ_RECEIPTS = !['0', 'false', 'no', 'off'].includes(
+  String(process.env.WHATSAPP_SEND_READ_RECEIPTS || '').toLowerCase()
+);
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -230,6 +235,14 @@ async function startSocket() {
       // Check allowlist for messages from others (resolve LID ↔ phone aliases)
       if (!msg.key.fromMe && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
         continue;
+      }
+
+      if (shouldSendReadReceipt(msg, { enabled: WHATSAPP_SEND_READ_RECEIPTS })) {
+        sock.readMessages([msg.key]).catch((err) => {
+          if (WHATSAPP_DEBUG) {
+            console.error('[bridge] readMessages failed:', err?.message || err);
+          }
+        });
       }
 
       const messageContent = getMessageContent(msg);

--- a/scripts/whatsapp-bridge/read_receipts.js
+++ b/scripts/whatsapp-bridge/read_receipts.js
@@ -1,0 +1,6 @@
+export function shouldSendReadReceipt(msg, { enabled }) {
+  if (!enabled) return false;
+  if (!msg?.key) return false;
+  if (msg.key.fromMe) return false;
+  return true;
+}

--- a/scripts/whatsapp-bridge/read_receipts.test.mjs
+++ b/scripts/whatsapp-bridge/read_receipts.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldSendReadReceipt } from './read_receipts.js';
+
+const inboundMsg = { key: { id: 'abc', remoteJid: '19175395595@s.whatsapp.net', fromMe: false } };
+const outboundMsg = { key: { id: 'xyz', remoteJid: '19175395595@s.whatsapp.net', fromMe: true } };
+
+test('shouldSendReadReceipt returns true for inbound messages when enabled', () => {
+  assert.equal(shouldSendReadReceipt(inboundMsg, { enabled: true }), true);
+});
+
+test('shouldSendReadReceipt returns false when feature is disabled', () => {
+  assert.equal(shouldSendReadReceipt(inboundMsg, { enabled: false }), false);
+});
+
+test('shouldSendReadReceipt returns false for fromMe messages regardless of enabled flag', () => {
+  assert.equal(shouldSendReadReceipt(outboundMsg, { enabled: true }), false);
+});
+
+test('shouldSendReadReceipt returns false for malformed messages without a key', () => {
+  assert.equal(shouldSendReadReceipt({}, { enabled: true }), false);
+  assert.equal(shouldSendReadReceipt(null, { enabled: true }), false);
+});

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -190,6 +190,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
 | `WHATSAPP_DEBUG` | Log raw message events in the bridge for troubleshooting (`true`/`false`) |
+| `WHATSAPP_SEND_READ_RECEIPTS` | Auto-mark incoming messages as read after the allowlist filter (`true`/`false`, default `true`) |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |
 | `SIGNAL_ALLOWED_USERS` | Comma-separated E.164 phone numbers or UUIDs |

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -99,6 +99,9 @@ WHATSAPP_MODE=bot                          # "bot" or "self-chat"
 WHATSAPP_ALLOWED_USERS=15551234567         # Comma-separated phone numbers (with country code, no +)
 # WHATSAPP_ALLOWED_USERS=*                 # OR use * to allow everyone
 # WHATSAPP_ALLOW_ALL_USERS=true            # OR set this flag instead (same effect as *)
+
+# Optional
+# WHATSAPP_SEND_READ_RECEIPTS=false        # Disable auto-mark-as-read for allowlisted senders (default: true)
 ```
 
 :::tip Allow-all shorthand
@@ -115,10 +118,12 @@ unauthorized_dm_behavior: pair
 
 whatsapp:
   unauthorized_dm_behavior: ignore
+  send_read_receipts: true
 ```
 
 - `unauthorized_dm_behavior: pair` is the global default. Unknown DM senders get a pairing code.
 - `whatsapp.unauthorized_dm_behavior: ignore` makes WhatsApp stay silent for unauthorized DMs, which is usually the better choice for a private number.
+- `whatsapp.send_read_receipts: false` disables blue-tick read receipts for allowlisted senders (defaults to `true`).
 
 Then start the gateway:
 


### PR DESCRIPTION
## What does this PR do?

Marks inbound allowlisted WhatsApp messages as read via Baileys, so senders see blue ticks and — more importantly in practice — the bot's own WhatsApp account stops piling up unread-message notifications on the host device. Today, running Hermes on a second WhatsApp number means every message I send it generates a lingering system notification on that account's phone/web, even after the bot has processed and replied. Marking the message as read immediately after it clears the allowlist resolves that.

The approach mirrors the existing BlueBubbles read-receipt flag (`BLUEBUBBLES_SEND_READ_RECEIPTS`) so the WhatsApp surface is consistent with the rest of the gateway: env var default-on, overridable via `~/.hermes/config.yaml`, and decoupled from the send path.

## Related Issue

Fixes #6055
Fixes #6539

(A different approach to the same problem is proposed in #8690; this PR adds an opt-out flag, uses fire-and-forget instead of `await` inside the message loop, places the receipt call explicitly after the `fromMe` and allowlist filters to avoid leaking reads to unauthorized senders, and updates the user docs.)

## Type of Change

✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js` — reads `WHATSAPP_SEND_READ_RECEIPTS` (default `true`); calls `sock.readMessages([msg.key])` fire-and-forget after the `fromMe`/allowlist filters; errors logged only when `WHATSAPP_DEBUG=true`
- `scripts/whatsapp-bridge/read_receipts.js` — new pure helper `shouldSendReadReceipt(msg, { enabled })`, same extraction pattern as `allowlist.js`
- `scripts/whatsapp-bridge/read_receipts.test.mjs` — four `node:test` cases covering enabled, disabled, `fromMe`, and malformed inputs
- `gateway/config.py` — YAML key `whatsapp.send_read_receipts` bridged to `WHATSAPP_SEND_READ_RECEIPTS` env var, matching the existing `require_mention` / `mention_patterns` / `free_response_chats` pattern
- `website/docs/reference/environment-variables.md`, `website/docs/user-guide/messaging/whatsapp.md`, `.env.example` — documented env var and YAML option

## How to Test

1. Start the bridge in bot mode against a second WhatsApp number and send a message from an allowlisted sender — the sender sees blue ticks and the bot's account no longer shows the message as unread.
2. Set `WHATSAPP_SEND_READ_RECEIPTS=false` (or `whatsapp.send_read_receipts: false` in `~/.hermes/config.yaml`) and repeat — no blue ticks, message stays unread on the bot side.
3. From a sender **not** on the allowlist, send a message — no blue ticks appear (read confirmation is not leaked to unauthorized senders).
4. Run the bridge unit tests: `node --test scripts/whatsapp-bridge/read_receipts.test.mjs scripts/whatsapp-bridge/allowlist.test.mjs` — all 8 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (CachyOS, kernel 6.19)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — change is a one-way WhatsApp protocol interaction; verification is visual (blue ticks on the sender side + cleared unread state on the bot side).