### PR TITLE
feat(compressor): implement preflight compression check

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -179,6 +179,16 @@ class ContextCompressor(ContextEngine):
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         return tokens >= self.threshold_tokens
 
+    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+        """Quick rough check before the API call (no real token count yet).
+
+        Uses the same rough char-based estimate as the pruning pass to
+        decide whether compression should fire before paying for a full
+        API call at the current (over-limit) token count.
+        """
+        rough = estimate_messages_tokens_rough(messages)
+        return rough >= self.threshold_tokens
+
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Override `should_compress_preflight()` on `ContextCompressor` to enable pre-API-call compression detection.

## Problem

The `ContextEngine` ABC defines `should_compress_preflight()` but the default `ContextCompressor` inherits the base `return False`. This means preflight compression never fires — a conversation that's already over the limit still makes a full API call (paying for all those tokens) before compression triggers.

The preflight path exists in `run_agent.py:7941-7997` and calls `estimate_request_tokens_rough()`, but the compressor itself never reports "yes, compress now" via its own preflight method.

## Fix

3-line override that uses the existing `estimate_messages_tokens_rough()` (already imported) to do a cheap O(n) estimate and compare against `threshold_tokens`.

False negatives (under-estimate) just delay compression by one turn — current behavior. False positives (over-estimate) trigger an early compress that's harmless.

## Test plan

- All 63 existing compressor/engine tests pass
- The ABC tests already verify the interface contract

Part of #9666.
