### PR TITLE
feat(compressor): deduplicate tool results + prune tool_call arguments

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -17,6 +17,7 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import hashlib
 import logging
 import time
 from typing import Any, Dict, List, Optional
@@ -226,6 +227,27 @@ class ContextCompressor(ContextEngine):
         else:
             prune_boundary = len(result) - protect_tail_count
 
+        # Pass 1: Deduplicate identical tool results.
+        # When the same file is read multiple times, keep only the most recent
+        # full copy and replace older duplicates with a back-reference.
+        content_hashes: dict = {}  # hash -> (index, tool_call_id)
+        for i in range(len(result) - 1, -1, -1):
+            msg = result[i]
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content") or ""
+            if len(content) < 200:
+                continue
+            h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+            if h in content_hashes:
+                # This is an older duplicate — replace with back-reference
+                _, ref_id = content_hashes[h]
+                result[i] = {**msg, "content": f"[Duplicate of tool result {ref_id} — same content]"}
+                pruned += 1
+            else:
+                content_hashes[h] = (i, msg.get("tool_call_id", "?"))
+
+        # Pass 2: Prune old tool results outside the protected tail
         for i in range(prune_boundary):
             msg = result[i]
             if msg.get("role") != "tool":
@@ -233,10 +255,32 @@ class ContextCompressor(ContextEngine):
             content = msg.get("content", "")
             if not content or content == _PRUNED_TOOL_PLACEHOLDER:
                 continue
+            # Skip already-deduplicated results
+            if content.startswith("[Duplicate of"):
+                continue
             # Only prune if the content is substantial (>200 chars)
             if len(content) > 200:
                 result[i] = {**msg, "content": _PRUNED_TOOL_PLACEHOLDER}
                 pruned += 1
+
+        # Pass 3: Prune large tool_call arguments in assistant messages
+        # outside the protected tail. write_file with 50KB content, for
+        # example, survives pruning entirely without this.
+        for i in range(prune_boundary):
+            msg = result[i]
+            if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+                continue
+            new_tcs = []
+            modified = False
+            for tc in msg["tool_calls"]:
+                if isinstance(tc, dict):
+                    args = tc.get("function", {}).get("arguments", "")
+                    if len(args) > 500:
+                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                        modified = True
+                new_tcs.append(tc)
+            if modified:
+                result[i] = {**msg, "tool_calls": new_tcs}
 
         return result, pruned
 


### PR DESCRIPTION
## Summary

Two new pruning passes in `_prune_old_tool_results()`:

1. **Duplicate tool result deduplication**: When the same file is read multiple times, replace older copies with `[Duplicate of tool result <id> — same content]`. Keeps only the most recent full copy.

2. **Tool call argument pruning**: Truncate large `arguments` fields in assistant `tool_calls` outside the protected tail. A `write_file` with 50KB `content` in the arguments was never pruned before — only the tool *result* got the placeholder.

## Problem

- Same 10KB file read 5 times = 50KB in context. 3 copies in the protected tail = 30KB of redundant content. Common in debugging workflows. (#499)
- `_prune_old_tool_results` only touches `role="tool"` messages. Assistant messages with huge `tool_calls[].function.arguments` (e.g. `write_file` with large content) survive pruning entirely.

## Fix

- Pass 1 (dedup): MD5-hash tool result content, walk newest-first. Older duplicates → 50-char back-reference stub.
- Pass 2 (existing): Standard placeholder replacement for old results.
- Pass 3 (new): Truncate tool_call arguments > 500 chars to 200-char preview outside the tail.

## Test plan

- All 44 existing compressor/focus tests pass
- Dedup is idempotent (back-reference stubs are <200 chars, skipped on re-prune)

Part of #9666.
