### PR TITLE
fix(compressor): hardening — max_tokens cap, multimodal safety, note fix, adaptive cooldown

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -211,7 +211,8 @@ class ContextCompressor(ContextEngine):
             min_protect = min(protect_tail_count, len(result) - 1)
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
-                content_len = len(msg.get("content") or "")
+                raw_content = msg.get("content") or ""
+                content_len = sum(len(p.get("text", "")) for p in raw_content) if isinstance(raw_content, list) else len(raw_content)
                 msg_tokens = content_len // _CHARS_PER_TOKEN + 10
                 for tc in msg.get("tool_calls") or []:
                     if isinstance(tc, dict):
@@ -450,7 +451,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     "api_mode": self.api_mode,
                 },
                 "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": summary_budget * 2,
+                "max_tokens": int(summary_budget * 1.3),
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
             }
             if self.summary_model:
@@ -466,6 +467,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._summary_failure_cooldown_until = 0.0
             return self._with_summary_prefix(summary)
         except RuntimeError:
+            # No provider configured — long cooldown, unlikely to self-resolve
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
             logging.warning("Context compression: no provider available for "
                             "summary. Middle turns will be dropped without summary "
@@ -473,12 +475,14 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                             _SUMMARY_FAILURE_COOLDOWN_SECONDS)
             return None
         except Exception as e:
-            self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
+            # Transient errors (timeout, rate limit, network) — shorter cooldown
+            _transient_cooldown = min(_SUMMARY_FAILURE_COOLDOWN_SECONDS, 60)
+            self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
             logging.warning(
                 "Failed to generate context summary: %s. "
                 "Further summary attempts paused for %d seconds.",
                 e,
-                _SUMMARY_FAILURE_COOLDOWN_SECONDS,
+                _transient_cooldown,
             )
             return None
 
@@ -744,11 +748,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         compressed = []
         for i in range(compress_start):
             msg = messages[i].copy()
-            if i == 0 and msg.get("role") == "system" and self.compression_count == 0:
-                msg["content"] = (
-                    (msg.get("content") or "")
-                    + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
-                )
+            if i == 0 and msg.get("role") == "system":
+                existing = msg.get("content") or ""
+                _compression_note = "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
+                if _compression_note not in existing:
+                    msg["content"] = existing + "\n\n" + _compression_note
             compressed.append(msg)
 
         # If LLM summary failed, insert a static fallback so the model


### PR DESCRIPTION
## Summary

Four small hardening fixes in `context_compressor.py`, each addressing a concrete edge case.

## Fixes

### 1. Summary max_tokens overshoot (line 453)
**Before:** `max_tokens = summary_budget * 2` — the summary model can generate 2x what was requested, wasting time and money on a 12K-token ceiling that becomes 24K.
**After:** `max_tokens = int(summary_budget * 1.3)` — 30% headroom for slight overshoots without doubling the cost.

### 2. Multimodal content safety (line 214)
**Before:** `len(msg.get("content") or "")` — crashes with `TypeError` if content is a list (multimodal messages with image blocks).
**After:** Detects list content and sums text part lengths. Falls back to `len()` for strings.

### 3. Compression note lost after re-compression (line 747)
**Before:** `if self.compression_count == 0` — note only added on first compression. If system prompt is rebuilt between compressions (which `_compress_context` does), the note from #1 is lost and never re-added.
**After:** Check if note already exists in the system prompt content — idempotent, survives rebuilds.

### 4. Adaptive failure cooldown (lines 468-483)
**Before:** Both `RuntimeError` (no provider — permanent) and generic `Exception` (timeout/network — transient) get the same 600s cooldown. A 1-second network blip = 10 minutes of degraded compression.
**After:** `RuntimeError` → 600s (permanent config issue). Generic exceptions → 60s (transient, likely recovers quickly).

## Test plan

- All 44 existing compressor/focus tests pass
- Each fix is independent — they don't interact

Part of #9666.
