### PR TITLE
fix(cron): expand api_key env vars in job runtime kwargs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -692,6 +692,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
+            if job.get("api_key"):
+                runtime_kwargs["explicit_api_key"] = os.path.expandvars(job.get("api_key", ""))
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,6 +1055,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3909,6 +3910,7 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -3927,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },


### PR DESCRIPTION
Fixes cron jobs that use custom providers with API keys stored in environment variables. The `api_key` field in cron job definitions is now expanded via `os.path.expandvars()` before being passed to the runtime provider, allowing `\$MY_API_KEY` style references in `jobs.json`.