### PR TITLE
fix: remove @staticmethod from _context_completions — crashes on @ mention

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Problem

After v0.9.0 (commit eb44abd6, PR #9467), every `@` mention in the CLI input triggers:

```
Unhandled exception in event loop:
  File ".../prompt_toolkit/buffer.py", line 1923, in new_coroutine
  ...
  File ".../hermes_cli/commands.py", line 806, in _context_completions
    yield from self._fuzzy_file_completions(word, query, limit)
Exception name 'self' is not defined
```

The error fires on every keystroke after typing `@`, making @ context references unusable. Reported by multiple users on Fedora 43 and Ubuntu 22.04 (users had to roll back to the 2026.4.8 tag).

## Root cause

PR #9467 added fuzzy project-wide file search to `_context_completions()`, calling `self._fuzzy_file_completions()`. But the method was still decorated with `@staticmethod` from its original implementation (which only did static ref matching and didn't need instance state). The `@staticmethod` decorator strips the implicit `self` parameter, so the call to `self._fuzzy_file_completions()` fails with `name 'self' is not defined`.

## Fix

One-line fix: remove the `@staticmethod` decorator and add `self` as the first parameter. The method now correctly receives the instance and can call `self._fuzzy_file_completions()` and the rest of the instance method chain (`_get_project_files`, `_score_path`, etc.).

## Verified
- `python -m pytest tests/hermes_cli/test_commands.py -n0 -q` — 104 passed
- E2E: `SlashCommandCompleter().get_completions()` with `@` and `@test` inputs — no crash, correct results