### PR TITLE
fix(whatsapp): send voice replies as native audio attachments

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -781,6 +781,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file natively via bridge."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:
@@ -987,3 +998,4 @@ class WhatsAppAdapter(BasePlatformAdapter):
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")
             return None
+

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -239,6 +239,26 @@ class TestBridgeRuntimeFailure:
         assert adapter._bridge_log_fh is None
 
     @pytest.mark.asyncio
+    async def test_send_voice_routes_to_audio_media_bridge(self):
+        adapter = _make_adapter()
+        expected = MagicMock(success=True, message_id="wamid-123")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected)
+
+        result = await adapter.send_voice(
+            chat_id="chat-123",
+            audio_path="/tmp/reply.ogg",
+            caption="voice reply",
+        )
+
+        assert result is expected
+        adapter._send_media_to_bridge.assert_awaited_once_with(
+            "chat-123",
+            "/tmp/reply.ogg",
+            "audio",
+            "voice reply",
+        )
+
+    @pytest.mark.asyncio
     async def test_poll_messages_marks_retryable_fatal_when_managed_bridge_exits(self):
         adapter = _make_adapter()
         fatal_handler = AsyncMock()
@@ -500,3 +520,4 @@ class TestHttpSessionLifecycle:
 
         mock_task.cancel.assert_not_called()
         assert adapter._poll_task is None
+


### PR DESCRIPTION
## Summary

This PR adds a WhatsApp-specific `send_voice()` override so voice replies are sent through the existing native media path instead of falling back to the base text placeholder behavior.

## Why

The WhatsApp bridge already supports sending `audio` media payloads.

However, the Python WhatsApp adapter did not override `send_voice()`, so voice replies fell back to the base platform implementation, which sends a text placeholder like `🔊 Audio: <path>` instead of a native media attachment.

This change stays intentionally narrow and wires the missing adapter method into the existing WhatsApp media-send path.

## Changes

- add a thin `send_voice()` override to `WhatsAppAdapter`
- route voice replies through `_send_media_to_bridge(chat_id, audio_path, "audio", caption)`
- add regression coverage to verify that `send_voice()` forwards the correct media type and caption

Fixes #9236

## Testing

I added a regression test in `tests/gateway/test_whatsapp_connect.py` covering the adapter behavior directly.

In this local environment, the repository test suite for this file could not be run end-to-end because `pytest-asyncio` and some default `pytest` addopts dependencies are not installed here.

To reduce that risk, I verified the change with:
- a direct Python-level smoke check confirming `send_voice()` forwards to the "audio" media path
- a focused regression test covering the forwarding behavior and caption passthrough
