### PR TITLE
fix(gateway): use unconditional KeepAlive in launchd plist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1086,10 +1086,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -1199,7 +1196,7 @@ def launchd_stop():
     target = f"{_launchd_domain()}/{label}"
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # would immediately restart it because KeepAlive is now unconditional.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)


### PR DESCRIPTION
## Summary

Changes the generated launchd plist's `KeepAlive` from a conditional `SuccessfulExit`-based dictionary to an unconditional `<true/>` boolean.

## Problem

The previous `KeepAlive` config only restarted the gateway after a non-zero exit code. When the gateway exited cleanly (e.g., during restarts, config reloads, or graceful shutdowns), launchd treated it as "job completed successfully" and did not restart it. With multiple profiles, all worker gateways could silently stay down until manually restarted.

## Changes

- `hermes_cli/gateway.py` (`generate_launchd_plist`): use `<true/>` for `KeepAlive`
- `hermes_cli/gateway.py` (`launchd_stop`): updated comment to reflect the new unconditional KeepAlive behavior

## Related Issue

Fixes #9659