### PR TITLE
fix: add truncation continuation support for anthropic_messages API mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9220,14 +9220,26 @@ class AIAgent:
                                 "error": _exhaust_error,
                             }
 
-                        if self.api_mode in ("chat_completions", "bedrock_converse"):
-                            assistant_message = response.choices[0].message
-                            if not assistant_message.tool_calls:
+                        if self.api_mode in ("chat_completions", "bedrock_converse", "anthropic_messages"):
+                            # Normalize the truncated response into _trunc_assistant
+                            # so all API modes share the same continuation logic.
+                            if self.api_mode in ("chat_completions", "bedrock_converse"):
+                                _trunc_assistant = response.choices[0].message
+                            else:
+                                # Anthropic: build a lightweight SimpleNamespace from
+                                # the raw response so the rest of the code works
+                                # identically to chat_completions.
+                                from agent.anthropic_adapter import normalize_anthropic_response as _nar_trunc
+                                _trunc_assistant, _ = _nar_trunc(
+                                    response, strip_tool_prefix=self._is_anthropic_oauth
+                                )
+
+                            if not _trunc_assistant.tool_calls:
                                 length_continue_retries += 1
-                                interim_msg = self._build_assistant_message(assistant_message, finish_reason)
+                                interim_msg = self._build_assistant_message(_trunc_assistant, finish_reason)
                                 messages.append(interim_msg)
-                                if assistant_message.content:
-                                    truncated_response_prefix += assistant_message.content
+                                if _trunc_assistant.content:
+                                    truncated_response_prefix += _trunc_assistant.content
 
                                 if length_continue_retries < 3:
                                     self._vprint(
@@ -9260,9 +9272,16 @@ class AIAgent:
                                     "error": "Response remained truncated after 3 continuation attempts",
                                 }
 
-                        if self.api_mode in ("chat_completions", "bedrock_converse"):
-                            assistant_message = response.choices[0].message
-                            if assistant_message.tool_calls:
+                        if self.api_mode in ("chat_completions", "bedrock_converse", "anthropic_messages"):
+                            if self.api_mode in ("chat_completions", "bedrock_converse"):
+                                _trunc_assistant2 = response.choices[0].message
+                            else:
+                                from agent.anthropic_adapter import normalize_anthropic_response as _nar_trunc2
+                                _trunc_assistant2, _ = _nar_trunc2(
+                                    response, strip_tool_prefix=self._is_anthropic_oauth
+                                )
+
+                            if _trunc_assistant2.tool_calls:
                                 if truncated_tool_call_retries < 1:
                                     truncated_tool_call_retries += 1
                                     self._vprint(


### PR DESCRIPTION
## Problem

When using `api_mode: anthropic_messages` (Anthropic native protocol), if the model hits `max_tokens` and returns `stop_reason: max_tokens`, the response is truncated with no continuation attempt. The user sees:

```
⚠️  Response truncated (finish_reason='length') - model hit max output tokens
Error: Response truncated due to output length limit
```

This happens because the continuation retry logic (up to 3 retries with "continue where you left off" prompts) and the truncated tool call retry logic only handled `chat_completions` mode. For `anthropic_messages`, the code fell through directly to a rollback path that returned an error.

## Fix

Extend both truncation handling paths to also cover `anthropic_messages` by:
1. Normalizing the raw Anthropic response via `normalize_anthropic_response()` into the same `SimpleNamespace` format used by `chat_completions`
2. Reusing the existing continuation logic for both API modes

This covers:
- **Text continuation**: when the model output is truncated mid-text, automatically request up to 3 continuations
- **Truncated tool call retry**: when a tool call is truncated, retry the API call once before giving up

## Testing

All 5 existing truncation-related tests pass:
```
tests/run_agent/test_run_agent.py — 5 passed
```