### PR TITLE
feat(api_server): add session logging and auto-titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,18 +5,76 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "Return ONLY the title text, nothing else. Use the same language as the user when possible. "
+    "Do not mention 'user' or 'assistant'. Do not return reasoning, analysis, or prefixes like "
+    "'The user is asking'. No quotes, no punctuation at the end, no prefixes."
 )
+
+_META_TITLE_PREFIXES = (
+    "the user is asking",
+    "the user wants",
+    "the assistant is",
+    "the conversation is about",
+)
+
+
+def _strip_wrapping_quotes(text: str) -> str:
+    stripped = (text or "").strip()
+    pairs = {
+        ('"', '"'),
+        ("'", "'"),
+        ("“", "”"),
+        ("‘", "’"),
+    }
+    while len(stripped) >= 2 and (stripped[0], stripped[-1]) in pairs:
+        stripped = stripped[1:-1].strip()
+    return stripped
+
+
+def _clean_generated_title(raw_title: str) -> Optional[str]:
+    if not raw_title:
+        return None
+
+    title = re.sub(r"<[^>]+>", " ", raw_title)
+    title = re.sub(r"\s+", " ", title).strip()
+    title = _strip_wrapping_quotes(title)
+
+    if title.lower().startswith("title:"):
+        title = _strip_wrapping_quotes(title[6:].strip())
+
+    lowered = title.lower()
+    if lowered.startswith(_META_TITLE_PREFIXES):
+        quoted = re.search(r'["“\'‘](.+?)["”\'’]', title)
+        if quoted:
+            title = quoted.group(1).strip()
+        else:
+            for prefix in _META_TITLE_PREFIXES:
+                if lowered.startswith(prefix):
+                    title = title[len(prefix):].strip(" :.-")
+                    break
+
+    title = _strip_wrapping_quotes(title)
+    if not title:
+        return None
+
+    if len(title.split()) > 12:
+        return None
+
+    if len(title) > 80:
+        title = title[:77] + "..."
+
+    return title or None
 
 
 def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
@@ -42,15 +100,8 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             temperature=0.3,
             timeout=timeout,
         )
-        title = (response.choices[0].message.content or "").strip()
-        # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
-        title = title.strip('"\'')
-        if title.lower().startswith("title:"):
-            title = title[6:].strip()
-        # Enforce reasonable length
-        if len(title) > 80:
-            title = title[:77] + "..."
-        return title if title else None
+        title = extract_content_or_reasoning(response).strip()
+        return _clean_generated_title(title)
     except Exception as e:
         logger.debug("Title generation failed: %s", e)
         return None

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -688,6 +688,11 @@ class APIServerAdapter(BasePlatformAdapter):
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
         created = int(time.time())
+        _start = time.time()
+        logger.info(
+            "[api_server] chat session=%s stream=%s msg=%r",
+            session_id, stream, user_message[:80],
+        )
 
         if stream:
             import queue as _q
@@ -751,6 +756,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
+                start_time=_start,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -809,11 +815,17 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
+        logger.info(
+            "[api_server] chat done session=%s tokens=%d/%d elapsed=%.1fs",
+            session_id, usage.get("input_tokens", 0),
+            usage.get("output_tokens", 0), time.time() - _start,
+        )
         return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
 
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
+        start_time: float = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -923,6 +935,12 @@ class APIServerAdapter(BasePlatformAdapter):
             }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
+            _elapsed = f" elapsed={time.time() - start_time:.1f}s" if start_time else ""
+            logger.info(
+                "[api_server] chat done session=%s tokens=%d/%d (stream)%s",
+                session_id, usage.get("input_tokens", 0),
+                usage.get("output_tokens", 0), _elapsed,
+            )
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
             # stops making LLM API calls at the next loop iteration, then
@@ -1037,6 +1055,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Run the agent (with Idempotency-Key support)
         session_id = str(uuid.uuid4())
+        _start = time.time()
+        logger.info(
+            "[api_server] response session=%s msg=%r",
+            session_id, user_message[:80],
+        )
 
         async def _compute_response():
             return await self._run_agent(
@@ -1117,6 +1140,12 @@ class APIServerAdapter(BasePlatformAdapter):
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
+        logger.info(
+            "[api_server] response done session=%s response_id=%s tokens=%d/%d elapsed=%.1fs",
+            session_id, response_id,
+            usage.get("input_tokens", 0), usage.get("output_tokens", 0),
+            time.time() - _start,
+        )
         return web.json_response(response_data)
 
     # ------------------------------------------------------------------
@@ -1480,6 +1509,8 @@ class APIServerAdapter(BasePlatformAdapter):
         loop = asyncio.get_event_loop()
 
         def _run():
+            from hermes_logging import set_session_context
+            set_session_context(session_id)
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -1645,6 +1676,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
+        _start = time.time()
+        logger.info(
+            "[api_server] run started run_id=%s session=%s msg=%r",
+            run_id, session_id, user_message[:80],
+        )
 
         async def _run_and_close():
             try:
@@ -1655,6 +1691,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=event_cb,
                 )
                 def _run_sync():
+                    from hermes_logging import set_session_context
+                    set_session_context(session_id)
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
@@ -1669,6 +1707,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                logger.info(
+                    "[api_server] run done run_id=%s session=%s tokens=%d/%d elapsed=%.1fs",
+                    run_id, session_id, usage.get("input_tokens", 0),
+                    usage.get("output_tokens", 0), time.time() - _start,
+                )
                 q.put_nowait({
                     "event": "run.completed",
                     "run_id": run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -816,9 +816,10 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
         logger.info(
-            "[api_server] chat done session=%s tokens=%d/%d elapsed=%.1fs",
+            "[api_server] chat done session=%s tokens=%d/%d elapsed=%.1fs response=%d chars",
             session_id, usage.get("input_tokens", 0),
             usage.get("output_tokens", 0), time.time() - _start,
+            len(final_response),
         )
         return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
 
@@ -916,6 +917,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result = {}
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
@@ -936,10 +938,11 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
             _elapsed = f" elapsed={time.time() - start_time:.1f}s" if start_time else ""
+            _resp_len = len(result.get("final_response", "")) if isinstance(result, dict) else 0
             logger.info(
-                "[api_server] chat done session=%s tokens=%d/%d (stream)%s",
+                "[api_server] chat done session=%s tokens=%d/%d (stream) response=%d chars%s",
                 session_id, usage.get("input_tokens", 0),
-                usage.get("output_tokens", 0), _elapsed,
+                usage.get("output_tokens", 0), _resp_len, _elapsed,
             )
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
@@ -1141,10 +1144,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._response_store.set_conversation(conversation, response_id)
 
         logger.info(
-            "[api_server] response done session=%s response_id=%s tokens=%d/%d elapsed=%.1fs",
+            "[api_server] response done session=%s response_id=%s tokens=%d/%d elapsed=%.1fs response=%d chars",
             session_id, response_id,
             usage.get("input_tokens", 0), usage.get("output_tokens", 0),
-            time.time() - _start,
+            time.time() - _start, len(final_response),
         )
         return web.json_response(response_data)
 
@@ -1708,9 +1711,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 logger.info(
-                    "[api_server] run done run_id=%s session=%s tokens=%d/%d elapsed=%.1fs",
+                    "[api_server] run done run_id=%s session=%s tokens=%d/%d elapsed=%.1fs response=%d chars",
                     run_id, session_id, usage.get("input_tokens", 0),
                     usage.get("output_tokens", 0), time.time() - _start,
+                    len(final_response),
                 )
                 q.put_nowait({
                     "event": "run.completed",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1527,6 +1527,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 task_id="default",
             )
+            final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+            if (
+                final_response
+                and isinstance(result, dict)
+                and not result.get("failed")
+                and not result.get("partial")
+            ):
+                try:
+                    from agent.title_generator import maybe_auto_title
+                    maybe_auto_title(
+                        self._ensure_session_db(),
+                        getattr(agent, "session_id", session_id) or session_id,
+                        user_message,
+                        final_response,
+                        result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                    )
+                except Exception:
+                    pass
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -64,6 +64,36 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("no provider")):
             assert generate_title("question", "answer") is None
 
+    def test_salvages_unquoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "The conversation is about Kubernetes pod debugging"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
+
+    def test_extracts_quoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'The conversation is about "Kubernetes pod debugging"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
+
+    def test_uses_reasoning_when_content_is_empty(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+        mock_response.choices[0].message.reasoning = "Redis deployment troubleshooting"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("redis won't start", "Let's debug it")
+            assert title == "Redis deployment troubleshooting"
+
     def test_truncates_long_messages(self):
         """Long user/assistant messages should be truncated in the LLM request."""
         captured_kwargs = {}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1210,6 +1210,82 @@ class TestSendMethod:
 
 
 # ---------------------------------------------------------------------------
+# _run_agent auto-title behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentAutoTitle:
+    @pytest.mark.asyncio
+    async def test_triggers_auto_title_on_success(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-1"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent.run_conversation.return_value = {
+            "final_response": "Hello there",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result["final_response"] == "Hello there"
+        assert usage["total_tokens"] == 18
+        maybe_auto_title.assert_called_once_with(
+            "db",
+            "sess-1",
+            "Hello",
+            "Hello there",
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_partial_or_failed_results(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-2"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent.run_conversation.return_value = {
+            "final_response": "Partial answer",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Partial answer"},
+            ],
+            "partial": True,
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result["final_response"] == "Partial answer"
+        maybe_auto_title.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/responses/{response_id}
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add API-server session-scoped logging for chat, responses, and run flows, including response lengths and token usage
- auto-generate titles for successful API-server sessions using the same fire-and-forget path as CLI/gateway
- harden title cleanup so meta/quoted outputs and reasoning-only auxiliary responses still produce usable titles

## Testing
- uv run --extra dev pytest tests/agent/test_title_generator.py tests/gateway/test_api_server.py