### PR TITLE
fix(cli): prevent custom_providers.model from overwriting manual model switches

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2735,7 +2735,10 @@ class HermesCLI:
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
         runtime_model = runtime.get("model")
         if runtime_model and isinstance(runtime_model, str):
-            self.model = runtime_model
+            requested = runtime.get("requested_provider", "")
+            requested_name = requested.split(":", 1)[1] if ":" in requested else requested
+            if not self.model or self.model == requested or self.model == requested_name:
+                self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
         # without `hermes model`), fall back to the provider's first catalog


### PR DESCRIPTION
## Summary

Fixes a bug where `custom_providers.model` unconditionally overwrote manually switched models on every turn in the CLI.

## Problem

`_ensure_runtime_credentials()` always assigned `runtime.get(\"model\")` to `self.model`. When a user manually switched models via `/model`, the next message would revert to the `custom_providers` default model.

## Fix

Only apply the `custom_providers.model` fallback when `self.model` is either:
- Empty (no model configured), or
- Still set to the provider name/slug (preserving the #7828 fix for `hermes chat --model <provider-name>`)

## Changes

- `cli.py` (`_ensure_runtime_credentials`): add guard before applying `runtime_model`

## Related Issue

Fixes #9679