### PR TITLE
fix(cli): respect explicit /model switch in _ensure_runtime_credentials

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1652,6 +1652,7 @@ class HermesCLI:
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        self._user_model_override = False  # set True when user explicitly switches via /model
         # Auto-detect model from local server if still on default
         if self.model == _DEFAULT_CONFIG_MODEL:
             _base_url = (_model_config.get("base_url") or "") if isinstance(_model_config, dict) else ""
@@ -2733,8 +2734,9 @@ class HermesCLI:
         # `hermes chat --model <provider-name>` sends the provider name
         # (e.g. "my-provider") as the model string to the API instead of
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
+        # Skip if the user explicitly switched models via /model command.
         runtime_model = runtime.get("model")
-        if runtime_model and isinstance(runtime_model, str):
+        if runtime_model and isinstance(runtime_model, str) and not self._user_model_override:
             self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
@@ -4504,6 +4506,7 @@ class HermesCLI:
 
         old_model = self.model
         self.model = result.new_model
+        self._user_model_override = True
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
         if result.api_key:
@@ -4721,6 +4724,7 @@ class HermesCLI:
         # overwrite the switch on the next turn (it re-resolves from this).
         old_model = self.model
         self.model = result.new_model
+        self._user_model_override = True
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
         if result.api_key:


### PR DESCRIPTION
## What changed

`_ensure_runtime_credentials()` unconditionally overwrites `self.model` with the custom_provider's configured `model` field (line 2736-2738). This silently reverts the user's intentional `/model` switch.

## Why

When a user runs `/model sonnet` to switch models mid-session, `_apply_model_switch_result()` sets `self.model` correctly. But the next API call triggers `_ensure_runtime_credentials()` again, which reads the provider's `model` config and overwrites the user's choice. The user's switch is silently discarded.

## How it works

1. Add `_user_model_override = False` flag on init
2. Set it to `True` in `_apply_model_switch_result()` when user explicitly switches
3. Guard the runtime model override with `not self._user_model_override`

## How to test

1. Configure a custom_provider with an explicit `model` field
2. Start a chat session
3. Run `/model <different-model>`
4. Send a message — verify it uses the switched model, not the provider's configured one

## Platforms tested

macOS (code review only — logic change is platform-independent)

Fixes #9679