### PR TITLE
fix(agent): skip snapshot messages when scanning bg review tool results

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2214,10 +2214,13 @@ class AIAgent:
                         conversation_history=messages_snapshot,
                     )
 
-                # Scan the review agent's messages for successful tool actions
-                # and surface a compact summary to the user.
+                # Scan only messages added by the review agent itself — skip the
+                # snapshot (snapshot_len entries) and the review prompt (+1).
+                # Without this slice, old tool results from the main conversation
+                # are included and trigger false 💾 notifications on every cycle.
+                snapshot_len = len(messages_snapshot)
                 actions = []
-                for msg in getattr(review_agent, "_session_messages", []):
+                for msg in getattr(review_agent, "_session_messages", [])[snapshot_len + 1:]:
                     if not isinstance(msg, dict) or msg.get("role") != "tool":
                         continue
                     try:


### PR DESCRIPTION
## Summary

`_spawn_background_review()` forks a review agent seeded with a snapshot
of the current conversation (`messages_snapshot`) plus a review prompt,
then scans `_session_messages` for tool results that indicate saves. The
bug: the scan iterated the *entire* `_session_messages` list, including
the snapshot entries from the main conversation. Tool results in those
old messages (e.g. earlier memory/skill saves from a previous cycle)
were re-scanned and re-triggered the `💾` save notification on every
review cycle, even when the review agent saved nothing new.

**Root cause:** `_spawn_background_review()` in `run_agent.py` passed
the full `_session_messages` to the action scan without accounting for
the `snapshot_len` prefix already present from the forked context.

**Fix:** Slice `_session_messages[snapshot_len + 1:]` so only messages
produced by the review agent itself are scanned — skipping the
`snapshot_len` snapshot entries and the +1 review prompt injected before
the agent ran.

## Changes

- `run_agent.py` — `_spawn_background_review()`: record `snapshot_len =
  len(messages_snapshot)` before forking; slice `_session_messages` by
  `snapshot_len + 1` when collecting actions to notify on

## Test plan

- Manually verified: save notification fires once per genuine save cycle,
  not on repeat cycles when no new saves occurred
- No automated tests added (existing suite requires dependencies not
  available in this environment)