### PR TITLE
feat(api_server): 为 API 会话自动生成标题 / Auto-title API sessions

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,18 +5,76 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "Return ONLY the title text, nothing else. Use the same language as the user when possible. "
+    "Do not mention 'user' or 'assistant'. Do not return reasoning, analysis, or prefixes like "
+    "'The user is asking'. No quotes, no punctuation at the end, no prefixes."
 )
+
+_META_TITLE_PREFIXES = (
+    "the user is asking",
+    "the user wants",
+    "the assistant is",
+    "the conversation is about",
+)
+
+
+def _strip_wrapping_quotes(text: str) -> str:
+    stripped = (text or "").strip()
+    pairs = {
+        ('"', '"'),
+        ("'", "'"),
+        ("“", "”"),
+        ("‘", "’"),
+    }
+    while len(stripped) >= 2 and (stripped[0], stripped[-1]) in pairs:
+        stripped = stripped[1:-1].strip()
+    return stripped
+
+
+def _clean_generated_title(raw_title: str) -> Optional[str]:
+    if not raw_title:
+        return None
+
+    title = re.sub(r"<[^>]+>", " ", raw_title)
+    title = re.sub(r"\s+", " ", title).strip()
+    title = _strip_wrapping_quotes(title)
+
+    if title.lower().startswith("title:"):
+        title = _strip_wrapping_quotes(title[6:].strip())
+
+    lowered = title.lower()
+    if lowered.startswith(_META_TITLE_PREFIXES):
+        quoted = re.search(r'["“\'‘](.+?)["”\'’]', title)
+        if quoted:
+            title = quoted.group(1).strip()
+        else:
+            for prefix in _META_TITLE_PREFIXES:
+                if lowered.startswith(prefix):
+                    title = title[len(prefix):].strip(" :.-")
+                    break
+
+    title = _strip_wrapping_quotes(title)
+    if not title:
+        return None
+
+    if len(title.split()) > 12:
+        return None
+
+    if len(title) > 80:
+        title = title[:77] + "..."
+
+    return title or None
 
 
 def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
@@ -42,15 +100,8 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             temperature=0.3,
             timeout=timeout,
         )
-        title = (response.choices[0].message.content or "").strip()
-        # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
-        title = title.strip('"\'')
-        if title.lower().startswith("title:"):
-            title = title[6:].strip()
-        # Enforce reasonable length
-        if len(title) > 80:
-            title = title[:77] + "..."
-        return title if title else None
+        title = extract_content_or_reasoning(response).strip()
+        return _clean_generated_title(title)
     except Exception as e:
         logger.debug("Title generation failed: %s", e)
         return None

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1493,6 +1493,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 task_id="default",
             )
+            final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+            if (
+                final_response
+                and isinstance(result, dict)
+                and not result.get("failed")
+                and not result.get("partial")
+            ):
+                try:
+                    from agent.title_generator import maybe_auto_title
+                    maybe_auto_title(
+                        self._ensure_session_db(),
+                        getattr(agent, "session_id", session_id) or session_id,
+                        user_message,
+                        final_response,
+                        result.get("messages", conversation_history) if isinstance(result, dict) else conversation_history,
+                    )
+                except Exception:
+                    pass
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -64,6 +64,36 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("no provider")):
             assert generate_title("question", "answer") is None
 
+    def test_salvages_unquoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "The conversation is about Kubernetes pod debugging"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
+
+    def test_extracts_quoted_meta_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'The conversation is about "Kubernetes pod debugging"'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("my pod keeps crashing", "Let me look...")
+            assert title == "Kubernetes pod debugging"
+
+    def test_uses_reasoning_when_content_is_empty(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+        mock_response.choices[0].message.reasoning = "Redis deployment troubleshooting"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("redis won't start", "Let's debug it")
+            assert title == "Redis deployment troubleshooting"
+
     def test_truncates_long_messages(self):
         """Long user/assistant messages should be truncated in the LLM request."""
         captured_kwargs = {}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1210,6 +1210,82 @@ class TestSendMethod:
 
 
 # ---------------------------------------------------------------------------
+# _run_agent auto-title behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentAutoTitle:
+    @pytest.mark.asyncio
+    async def test_triggers_auto_title_on_success(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-1"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent.run_conversation.return_value = {
+            "final_response": "Hello there",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result["final_response"] == "Hello there"
+        assert usage["total_tokens"] == 18
+        maybe_auto_title.assert_called_once_with(
+            "db",
+            "sess-1",
+            "Hello",
+            "Hello there",
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hello there"},
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_auto_title_for_partial_or_failed_results(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = "sess-2"
+        agent.session_prompt_tokens = 11
+        agent.session_completion_tokens = 7
+        agent.session_total_tokens = 18
+        agent.run_conversation.return_value = {
+            "final_response": "Partial answer",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Partial answer"},
+            ],
+            "partial": True,
+        }
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=agent),
+            patch.object(adapter, "_ensure_session_db", return_value="db"),
+            patch("agent.title_generator.maybe_auto_title") as maybe_auto_title,
+        ):
+            result, _usage = await adapter._run_agent(
+                user_message="Hello",
+                conversation_history=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result["final_response"] == "Partial answer"
+        maybe_auto_title.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/responses/{response_id}
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 摘要 / Summary
- 中文：让 API Server 在首轮成功回复后，沿用 CLI 和 gateway 的 fire-and-forget 路径为会话自动生成标题。
- English: Let the API Server auto-generate a session title after the first successful reply, reusing the same fire-and-forget path as the CLI and gateway.
- 中文：增强 `agent/title_generator.py` 的标题清洗逻辑，能处理 meta 风格输出、带引号标题，以及 `content` 为空但 reasoning 字段里有内容的辅助模型响应。
- English: Harden `agent/title_generator.py` title cleanup so it can recover usable titles from meta-style outputs, quoted titles, and auxiliary-model responses where `content` is empty but reasoning fields are populated.
- 中文：只在成功完成的 API 会话上触发自动标题，避免对 `partial` 或 `failed` 响应误生成标题。
- English: Only trigger auto-titling for successful API runs, avoiding false titles on `partial` or `failed` responses.

## 测试 / Testing
- `uv run --extra dev pytest tests/agent/test_title_generator.py tests/gateway/test_api_server.py -k "title or auto_title"`