### PR TITLE
feat(agent): add ssl_verify support for custom provider endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1406,6 +1406,21 @@ class AIAgent:
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
+            # Read ssl_verify once at init for custom provider endpoints.
+            # Stored on self so _create_openai_client can use it without
+            # re-reading config on every API call.
+            self._ssl_verify = True
+            _burl = (client_kwargs.get("base_url") or "").rstrip("/")
+            if _burl:
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers as _gcp_ssl
+                    for _cp in _gcp_ssl():
+                        if ((_cp.get("base_url") or "").rstrip("/") == _burl):
+                            self._ssl_verify = bool(_cp.get("ssl_verify", True))
+                            break
+                except Exception:
+                    pass
+
             # Enable fine-grained tool streaming for Claude on OpenRouter.
             # Without this, Anthropic buffers the entire tool call and goes
             # silent for minutes while thinking — OpenRouter's upstream proxy
@@ -5027,6 +5042,10 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
+        if not getattr(self, "_ssl_verify", True) and "http_client" not in client_kwargs:
+            import httpx as _httpx_ssl
+            client_kwargs["http_client"] = _httpx_ssl.Client(verify=False)
+            logger.warning("SSL verification disabled for %s", client_kwargs.get("base_url", ""))
         if "http_client" not in client_kwargs:
             keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
             if keepalive_http is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -955,6 +955,21 @@ class AIAgent:
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
+            # Read ssl_verify once at init for custom provider endpoints.
+            # Stored on self so _create_openai_client can use it without
+            # re-reading config on every API call.
+            self._ssl_verify = True
+            _burl = (client_kwargs.get("base_url") or "").rstrip("/")
+            if _burl:
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers as _gcp_ssl
+                    for _cp in _gcp_ssl():
+                        if ((_cp.get("base_url") or "").rstrip("/") == _burl):
+                            self._ssl_verify = bool(_cp.get("ssl_verify", True))
+                            break
+                except Exception:
+                    pass
+
             # Enable fine-grained tool streaming for Claude on OpenRouter.
             # Without this, Anthropic buffers the entire tool call and goes
             # silent for minutes while thinking — OpenRouter's upstream proxy
@@ -4117,7 +4132,12 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
-        client = OpenAI(**client_kwargs)
+        effective_kwargs = client_kwargs
+        if not getattr(self, "_ssl_verify", True):
+            import httpx as _httpx_ssl
+            effective_kwargs = {**client_kwargs, "http_client": _httpx_ssl.Client(verify=False)}
+            logger.warning("SSL verification disabled for %s", client_kwargs.get("base_url", ""))
+        client = OpenAI(**effective_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",
             reason,


### PR DESCRIPTION
## Summary

Custom provider endpoints using self-signed or private CA certificates
(e.g. Ollama behind a local Caddy reverse proxy with HTTPS) fail with
SSL verification errors. There was no way to disable certificate
verification per-provider in config.yaml.

**Fix:** Add an `ssl_verify` boolean field to `custom_providers` entries.
When `ssl_verify: false` is set, an `httpx.Client(verify=False)` is
passed via the `http_client` parameter of the OpenAI SDK client,
disabling certificate verification for that provider only. A warning is
logged when verification is disabled.

The value is read once at `AIAgent.__init__` time by matching
`base_url` against `custom_providers` entries via
`get_compatible_custom_providers()` (covering both the legacy list format
and the newer `providers: dict` format). It is cached as `self._ssl_verify`
so `_create_openai_client()` can use it without re-reading config on
every API call.

## Changes

- `run_agent.py` — `AIAgent.__init__`: read and cache `ssl_verify` from
  config for the active `base_url`
- `run_agent.py` — `_create_openai_client()`: inject
  `httpx.Client(verify=False)` when `self._ssl_verify` is False; logs a
  warning at the provider URL

## Usage

```yaml
custom_providers:
  - name: local-ollama
    base_url: https://ollama.internal
    api_key: ""
    ssl_verify: false
```

## Test plan

- Manually verified against a local Ollama instance behind Caddy with a
  self-signed certificate; requests succeed where they previously failed
  with `SSLCertVerificationError`
- No automated tests added (existing suite requires dependencies not
  available in this environment)