### PR TITLE
fix(gateway): detect Windows local media paths for native delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1235,10 +1235,10 @@ class BasePlatformAdapter(ABC):
         """
         Detect bare local file paths in response text for native media delivery.
 
-        Matches absolute paths (/...) and tilde paths (~/) ending in common
-        image or video extensions.  Validates each candidate with
-        ``os.path.isfile()`` to avoid false positives from URLs or
-        non-existent paths.
+        Matches Unix absolute paths (/...), tilde paths (~/), and Windows
+        drive-letter absolute paths (C:\\... / C:/...) ending in common image
+        or video extensions.  Validates each candidate with ``os.path.isfile()``
+        to avoid false positives from URLs or non-existent paths.
 
         Paths inside fenced code blocks (``` ... ```) and inline code
         (`...`) are ignored so that code samples are never mutilated.
@@ -1255,9 +1255,12 @@ class BasePlatformAdapter(ABC):
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
-        # (?:~/|/)    anchors to absolute or home-relative paths
+        # The path body supports Unix absolute/home-relative paths and
+        # Windows drive-letter absolute paths.
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:(?:~/|/)(?:[\w.\-]+/)*|[A-Za-z]:(?:\\|/)(?:[\w.\-]+(?:\\|/))*)[\w.\-]+\.(?:'
+            + ext_part
+            + r')\b',
             re.IGNORECASE,
         )
 

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -278,10 +278,19 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
-        assert paths == []
+    def test_windows_backslash_path_matched(self):
+        """Windows absolute paths should be extracted for native delivery."""
+        text = r"See C:\Users\test\image.png"
+        paths, cleaned = _extract(text)
+        assert paths == [r"C:\Users\test\image.png"]
+        assert r"C:\Users\test\image.png" not in cleaned
+
+    def test_windows_forward_slash_path_matched(self):
+        """Windows absolute paths using forward slashes should also match."""
+        text = "See C:/Users/test/image.png"
+        paths, cleaned = _extract(text)
+        assert paths == ["C:/Users/test/image.png"]
+        assert "C:/Users/test/image.png" not in cleaned
 
     def test_relative_path_not_matched(self):
         """Relative paths like ./image.png should not match."""


### PR DESCRIPTION
## Summary

Fix gateway local media extraction so drive-letter absolute paths are detected as local files and sent via native attachment delivery instead of being left as raw text in the response.

## Root Cause

`BasePlatformAdapter.extract_local_files()` only recognized Unix-style absolute or home-relative paths, so drive-letter absolute paths were never matched.

## Fix

Extend the existing local-path detection regex to recognize drive-letter absolute paths while preserving the current safeguards:

- ignore relative paths
- ignore inline/fenced code
- keep `os.path.isfile()` validation
- no refactor or architecture change

## Tests

Added regression coverage for drive-letter absolute path extraction in both backslash and forward-slash forms.

Validation:
- `python -m pytest -o addopts='' tests/gateway/test_extract_local_files.py -q`

Result:
- `38 passed`