### PR TITLE
Fix macOS launchd observability for healthy narrowed-PATH installs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -915,23 +916,81 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
-def _normalize_launchd_plist_for_comparison(text: str) -> str:
-    """Normalize launchd plist text for staleness checks.
+def _load_launchd_plist_document(text: str) -> dict:
+    document = plistlib.loads(text.encode("utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("launchd plist must decode to a dictionary")
+    return document
 
-    The generated plist intentionally captures a broad PATH assembled from the
-    invoking shell so user-installed tools remain reachable under launchd.
-    That makes raw text comparison unstable across shells, so ignore the PATH
-    payload when deciding whether the installed plist is stale.
-    """
-    import re
 
-    normalized = _normalize_service_definition(text)
-    return re.sub(
-        r'(<key>PATH</key>\s*<string>)(.*?)(</string>)',
-        r'\1__HERMES_PATH__\3',
-        normalized,
-        flags=re.S,
-    )
+def _launchd_semantic_fields(plist_doc: dict) -> dict:
+    env = plist_doc.get("EnvironmentVariables")
+    if not isinstance(env, dict):
+        env = {}
+    return {
+        "Label": plist_doc.get("Label"),
+        "ProgramArguments": plist_doc.get("ProgramArguments"),
+        "WorkingDirectory": plist_doc.get("WorkingDirectory"),
+        "HERMES_HOME": env.get("HERMES_HOME"),
+        "VIRTUAL_ENV": env.get("VIRTUAL_ENV"),
+        "StandardOutPath": plist_doc.get("StandardOutPath"),
+        "StandardErrorPath": plist_doc.get("StandardErrorPath"),
+        "RunAtLoad": plist_doc.get("RunAtLoad"),
+        "KeepAlive": plist_doc.get("KeepAlive"),
+    }
+
+
+def _split_path_entries(path_value: str | None) -> list[str]:
+    if not path_value:
+        return []
+    return [entry for entry in path_value.split(":") if entry]
+
+
+def _path_contains_sequence(entries: list[str], required: list[str]) -> bool:
+    position = -1
+    for required_entry in required:
+        try:
+            position = entries.index(required_entry, position + 1)
+        except ValueError:
+            return False
+    return True
+
+
+def _launchd_path_is_semantically_current(
+    installed_path: str | None,
+    expected_path: str | None,
+    working_dir: str | None,
+) -> bool:
+    if installed_path == expected_path:
+        return True
+
+    if not working_dir:
+        return False
+
+    working_path = Path(working_dir)
+    installed_entries = _split_path_entries(installed_path)
+    runtime_critical = [
+        str(working_path / "venv" / "bin"),
+        str(working_path / "node_modules" / ".bin"),
+    ]
+    if not _path_contains_sequence(installed_entries, runtime_critical):
+        return False
+
+    minimum_system_fallback = ["/usr/bin", "/bin"]
+    if not _path_contains_sequence(installed_entries, minimum_system_fallback):
+        return False
+
+    stable_candidates = [
+        str(Path.home() / ".local" / "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    present_stable = [entry for entry in stable_candidates if entry in installed_entries]
+    return _path_contains_sequence(installed_entries, present_stable)
 
 
 def systemd_unit_is_current(system: bool = False) -> bool:
@@ -1221,6 +1280,25 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def launchd_job_is_loaded(label: str | None = None, timeout: int = 10) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", _launchd_target(label)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, ""
+
+    output = result.stdout if result.returncode == 0 else (result.stdout or result.stderr or "")
+    return result.returncode == 0, output
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -1310,14 +1388,30 @@ def generate_launchd_plist() -> str:
 """
 
 def launchd_plist_is_current() -> bool:
-    """Check if the installed launchd plist matches the currently generated one."""
+    """Check if the installed launchd plist semantically matches the current install."""
     plist_path = get_launchd_plist_path()
     if not plist_path.exists():
         return False
 
-    installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
-    return _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
+    try:
+        installed_doc = _load_launchd_plist_document(plist_path.read_text(encoding="utf-8"))
+        expected_doc = _load_launchd_plist_document(generate_launchd_plist())
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        return False
+
+    if _launchd_semantic_fields(installed_doc) != _launchd_semantic_fields(expected_doc):
+        return False
+
+    installed_env = installed_doc.get("EnvironmentVariables")
+    expected_env = expected_doc.get("EnvironmentVariables")
+    if not isinstance(installed_env, dict) or not isinstance(expected_env, dict):
+        return False
+
+    return _launchd_path_is_semantically_current(
+        installed_env.get("PATH"),
+        expected_env.get("PATH"),
+        expected_doc.get("WorkingDirectory"),
+    )
 
 
 def refresh_launchd_plist_if_needed() -> bool:
@@ -1496,19 +1590,7 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    loaded, loaded_output = launchd_job_is_loaded(timeout=10)
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -2172,14 +2254,8 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        loaded, _ = launchd_job_is_loaded(timeout=10)
+        return loaded
     # Check for manual processes
     return len(find_gateway_pids()) > 0
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -377,17 +377,8 @@ def show_status(args):
             print("  Manager:      systemd (user)")
         
     elif sys.platform == 'darwin':
-        from hermes_cli.gateway import get_launchd_label
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            is_loaded = result.returncode == 0
-        except subprocess.TimeoutExpired:
-            is_loaded = False
+        from hermes_cli.gateway import launchd_job_is_loaded
+        is_loaded, _ = launchd_job_is_loaded(timeout=5)
         print(f"  Status:       {check_mark(is_loaded)} {'loaded' if is_loaded else 'not loaded'}")
         print("  Manager:      launchd")
     else:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -392,6 +392,33 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_uses_launchctl_print_for_loaded_detection(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        expected_cmd = [
+            "launchctl",
+            "print",
+            f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}",
+        ]
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            assert cmd == expected_cmd
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "matches the current hermes install" in output.lower()
+        assert "gateway service is loaded" in output.lower()
+        assert calls == [expected_cmd]
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -449,6 +476,29 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         assert gateway_cli._is_service_running() is False
+
+    def test_is_service_running_uses_launchctl_print_on_macos(self, monkeypatch):
+        plist_path = SimpleNamespace(exists=lambda: True)
+        expected_cmd = [
+            "launchctl",
+            "print",
+            f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}",
+        ]
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, capture_output=True, text=True, **kwargs):
+            calls.append(cmd)
+            assert cmd == expected_cmd
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._is_service_running() is True
+        assert calls == [expected_cmd]
 
 
 class TestGatewaySystemServiceRouting:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,41 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_uses_launchctl_print_on_macos(monkeypatch, capsys, tmp_path):
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import status as status_mod
+
+    expected_cmd = [
+        "launchctl",
+        "print",
+        f"{gateway_mod._launchd_domain()}/{gateway_mod.get_launchd_label()}",
+    ]
+    calls = []
+
+    monkeypatch.setattr(status_mod.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if cmd == expected_cmd:
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+        return SimpleNamespace(returncode=3, stdout="", stderr="")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", fake_run)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Status:       " in output
+    assert "loaded" in output
+    assert expected_cmd in calls

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,7 +6,9 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import plistlib
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -202,6 +204,66 @@ class TestLaunchdPlistCurrentness:
         monkeypatch.setenv("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
 
         assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_is_current_accepts_narrowed_canonical_path_and_semantic_equivalence(
+        self, tmp_path, monkeypatch
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        expected = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        working_dir = expected["WorkingDirectory"]
+        canonical_path = ":".join(
+            [
+                str(Path(working_dir) / "venv" / "bin"),
+                str(Path(working_dir) / "node_modules" / ".bin"),
+                str(Path.home() / ".local" / "bin"),
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+            ]
+        )
+
+        installed_env = dict(expected["EnvironmentVariables"])
+        installed_env["PATH"] = canonical_path
+        installed = {
+            "StandardErrorPath": expected["StandardErrorPath"],
+            "StandardOutPath": expected["StandardOutPath"],
+            "KeepAlive": expected["KeepAlive"],
+            "RunAtLoad": expected["RunAtLoad"],
+            "EnvironmentVariables": installed_env,
+            "WorkingDirectory": expected["WorkingDirectory"],
+            "ProgramArguments": expected["ProgramArguments"],
+            "Label": expected["Label"],
+        }
+        plist_path.write_bytes(plistlib.dumps(installed, sort_keys=False))
+
+        monkeypatch.setenv("PATH", "/transient/app/bin:/usr/bin:/bin")
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_is_current_rejects_missing_runtime_critical_path_entries(
+        self, tmp_path, monkeypatch
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        expected = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        installed_env = dict(expected["EnvironmentVariables"])
+        installed_env["PATH"] = ":".join(
+            [
+                str(Path(expected["WorkingDirectory"]) / "venv" / "bin"),
+                "/usr/bin",
+                "/bin",
+            ]
+        )
+        expected["EnvironmentVariables"] = installed_env
+        plist_path.write_bytes(plistlib.dumps(expected, sort_keys=False))
+
+        assert gateway_cli.launchd_plist_is_current() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Observability Upstream Finalization

Date: 2026-04-14
Scope: Finalize the already-packaged macOS observability patch for upstream submission readiness.

## Patch Scope And Branch State

Current git state:

- branch: `fix/macos-launchd-observability`
- HEAD: `7d7c5bb68b60ffee43d0e7f45fb0b6dbb9dddf76`
- commit subject: `fix: use semantic launchd checks on macOS`

Working tree status:

- no tracked file diffs remain
- `git diff --name-only` is empty
- unrelated untracked `.DS_Store` files exist in the repo tree, but no unrelated tracked changes are present

The observability patch is already:

- committed on a dedicated branch
- limited to the intended five files

Exact committed patch scope:

- `hermes_cli/gateway.py`
- `hermes_cli/status.py`
- `tests/hermes_cli/test_gateway_service.py`
- `tests/hermes_cli/test_update_gateway_restart.py`
- `tests/hermes_cli/test_status.py`

Commit stats:

- 5 files changed
- 268 insertions
- 51 deletions

## Technical Narrative

### Problem 1: macOS loaded-state false negatives

The old macOS observability path used `launchctl list <label>` to decide whether the launchd gateway was loaded. On this machine, that was not the authoritative signal, so a healthy gateway could be reported as not loaded.

### Problem 2: stale-definition false positives

The old launchd currentness check treated plist freshness too literally by comparing normalized text rather than comparing semantic fields. That caused healthy launchd plists to look stale when:

- plist key ordering or formatting differed
- the PATH had been intentionally narrowed to the runtime-safe canonical form instead of matching a broader shell-captured string exactly

### Why `launchctl print` is authoritative here

This machine’s live launchd state is accurately reflected by `launchctl print "gui/<uid>/ai.hermes.gateway"`. That command reports the actual running daemon, working directory, environment, and paths in the live job definition. The earlier false negatives came from relying on a weaker signal than the one the OS is already exposing correctly.

### Why semantic plist comparison is the right fix

The launchd service definition should be judged on fields that affect runtime correctness, not on plist serialization details or transient PATH capture artifacts. Semantic comparison fixes the real operator problem:

- it accepts the healthy narrowed canonical PATH
- it ignores irrelevant plist formatting/key-order drift
- it still detects meaningful service-definition mismatch

### Why Linux/systemd behavior remains untouched

The patch is scoped to macOS launchd observability. Linux/systemd service management semantics are different and were already outside the demonstrated defect. Leaving them untouched keeps regression risk low and makes the patch easier to review upstream.

## Validation Summary

### Syntax / compile validation

- `python3 -m py_compile` passed for the touched source and test files

### Targeted tests

- focused test slice re-run in the Hermes venv:
  - `111 passed in 1.37s`

### Live runtime validation

- `launchctl print "gui/$(id -u)/ai.hermes.gateway"`: healthy running daemon from `/Users/trl/.hermes/hermes-agent`
- primary probe: `OK`
- `hermes status`: gateway reports loaded
- `hermes gateway status`: service definition matches current install and service reports loaded

Fallback health is intentionally non-authoritative and out of scope for this upstream-finalization pass.

## Residual Risks Left Out Of Scope

This patch intentionally does not address:

- `cmd_update()` macOS restart gating
- repo-topology conversion from shallow tag-based checkout to normal `main`-tracking clone
- broad PATH generation policy in launchd plist generation
- config migration or update policy
- unrelated runtime/log noise

## Finalized Commit Materials

### Candidate commit title

`fix: use semantic launchd checks on macOS`

### Candidate commit body

Fix macOS launchd observability so Hermes reports healthy launchd state
correctly on installations that use a narrowed canonical PATH.

- use `launchctl print gui/<uid>/<label>` for macOS loaded/running checks in
  the touched gateway/status surfaces
- replace text-based launchd plist equality with semantic comparison
- accept a narrowed canonical PATH when the runtime-critical entries remain
  present in the correct precedence order
- add focused regression coverage for macOS loaded-state detection, launchd
  plist currentness, and status output

Why:

- `launchctl list` produced false negatives on this machine
- text-based plist equality produced false stale-definition reports for healthy
  launchd plists whose PATH had been intentionally normalized

Non-goals:

- no Linux/systemd behavior changes
- no update-path changes
- no launchd PATH generation policy changes

## Finalized PR Materials

### Candidate PR title

`Fix macOS launchd observability for healthy narrowed-PATH installs`

### Candidate PR description

#### Problem

On macOS, Hermes could misreport a healthy launchd gateway as not loaded, and
could mark a healthy launchd plist as stale after the PATH was intentionally
narrowed to a canonical runtime-safe form.

#### Root cause

There were two issues:

1. The touched macOS observability surfaces used `launchctl list <label>` for
   loaded-state detection, which was not the authoritative signal on this
   machine.
2. Launchd plist currentness was based on normalized text equality, which was
   too strict for macOS because plist formatting/key order can drift and PATH
   can be semantically correct without matching a broader shell-captured string
   exactly.

#### Fix

- switch the touched macOS loaded/running checks to
  `launchctl print gui/<uid>/<label>`
- compare launchd plists semantically rather than by normalized text
- require semantic agreement on the runtime-relevant launchd fields
- treat PATH semantically by requiring the runtime-critical canonical entries in
  the correct precedence order instead of requiring exact string equality

#### Validation

- `python3 -m py_compile` on touched source/test files
- focused test slice in the Hermes venv: `111 passed in 1.37s`
- live runtime checks on macOS:
  - `launchctl print` healthy
  - primary probe `OK`
  - `hermes status` improved
  - `hermes gateway status` improved

#### Non-goals / follow-ups

- no Linux/systemd changes
- no `cmd_update()` changes
- no launchd PATH generation policy changes
- no repo-topology conversion work

### Reviewer note: why semantic PATH comparison is better

Exact PATH equality is too brittle on macOS because launchd plists can carry shell-derived or formatting-specific differences that do not affect runtime correctness. Semantic comparison is the better contract: it preserves detection of meaningful drift while treating a narrowed canonical PATH as current when the required runtime entries are present in the correct order.

## Exact Next Step

Design the dedicated narrow `cmd_update()` macOS fix.

Repo-topology conversion and real update qualification should happen later, after that dedicated update-path work is defined.
