### PR TITLE
Fix cmd_update launchd restart detection on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -915,23 +916,81 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
-def _normalize_launchd_plist_for_comparison(text: str) -> str:
-    """Normalize launchd plist text for staleness checks.
+def _load_launchd_plist_document(text: str) -> dict:
+    document = plistlib.loads(text.encode("utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("launchd plist must decode to a dictionary")
+    return document
 
-    The generated plist intentionally captures a broad PATH assembled from the
-    invoking shell so user-installed tools remain reachable under launchd.
-    That makes raw text comparison unstable across shells, so ignore the PATH
-    payload when deciding whether the installed plist is stale.
-    """
-    import re
 
-    normalized = _normalize_service_definition(text)
-    return re.sub(
-        r'(<key>PATH</key>\s*<string>)(.*?)(</string>)',
-        r'\1__HERMES_PATH__\3',
-        normalized,
-        flags=re.S,
-    )
+def _launchd_semantic_fields(plist_doc: dict) -> dict:
+    env = plist_doc.get("EnvironmentVariables")
+    if not isinstance(env, dict):
+        env = {}
+    return {
+        "Label": plist_doc.get("Label"),
+        "ProgramArguments": plist_doc.get("ProgramArguments"),
+        "WorkingDirectory": plist_doc.get("WorkingDirectory"),
+        "HERMES_HOME": env.get("HERMES_HOME"),
+        "VIRTUAL_ENV": env.get("VIRTUAL_ENV"),
+        "StandardOutPath": plist_doc.get("StandardOutPath"),
+        "StandardErrorPath": plist_doc.get("StandardErrorPath"),
+        "RunAtLoad": plist_doc.get("RunAtLoad"),
+        "KeepAlive": plist_doc.get("KeepAlive"),
+    }
+
+
+def _split_path_entries(path_value: str | None) -> list[str]:
+    if not path_value:
+        return []
+    return [entry for entry in path_value.split(":") if entry]
+
+
+def _path_contains_sequence(entries: list[str], required: list[str]) -> bool:
+    position = -1
+    for required_entry in required:
+        try:
+            position = entries.index(required_entry, position + 1)
+        except ValueError:
+            return False
+    return True
+
+
+def _launchd_path_is_semantically_current(
+    installed_path: str | None,
+    expected_path: str | None,
+    working_dir: str | None,
+) -> bool:
+    if installed_path == expected_path:
+        return True
+
+    if not working_dir:
+        return False
+
+    working_path = Path(working_dir)
+    installed_entries = _split_path_entries(installed_path)
+    runtime_critical = [
+        str(working_path / "venv" / "bin"),
+        str(working_path / "node_modules" / ".bin"),
+    ]
+    if not _path_contains_sequence(installed_entries, runtime_critical):
+        return False
+
+    minimum_system_fallback = ["/usr/bin", "/bin"]
+    if not _path_contains_sequence(installed_entries, minimum_system_fallback):
+        return False
+
+    stable_candidates = [
+        str(Path.home() / ".local" / "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    present_stable = [entry for entry in stable_candidates if entry in installed_entries]
+    return _path_contains_sequence(installed_entries, present_stable)
 
 
 def systemd_unit_is_current(system: bool = False) -> bool:
@@ -1221,6 +1280,25 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def launchd_job_is_loaded(label: str | None = None, timeout: int = 10) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", _launchd_target(label)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, ""
+
+    output = result.stdout if result.returncode == 0 else (result.stdout or result.stderr or "")
+    return result.returncode == 0, output
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -1310,14 +1388,30 @@ def generate_launchd_plist() -> str:
 """
 
 def launchd_plist_is_current() -> bool:
-    """Check if the installed launchd plist matches the currently generated one."""
+    """Check if the installed launchd plist semantically matches the current install."""
     plist_path = get_launchd_plist_path()
     if not plist_path.exists():
         return False
 
-    installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
-    return _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
+    try:
+        installed_doc = _load_launchd_plist_document(plist_path.read_text(encoding="utf-8"))
+        expected_doc = _load_launchd_plist_document(generate_launchd_plist())
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        return False
+
+    if _launchd_semantic_fields(installed_doc) != _launchd_semantic_fields(expected_doc):
+        return False
+
+    installed_env = installed_doc.get("EnvironmentVariables")
+    expected_env = expected_doc.get("EnvironmentVariables")
+    if not isinstance(installed_env, dict) or not isinstance(expected_env, dict):
+        return False
+
+    return _launchd_path_is_semantically_current(
+        installed_env.get("PATH"),
+        expected_env.get("PATH"),
+        expected_doc.get("WorkingDirectory"),
+    )
 
 
 def refresh_launchd_plist_if_needed() -> bool:
@@ -1496,19 +1590,7 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    loaded, loaded_output = launchd_job_is_loaded(timeout=10)
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -2172,14 +2254,8 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        loaded, _ = launchd_job_is_loaded(timeout=10)
+        return loaded
     # Check for manual processes
     return len(find_gateway_pids()) > 0
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4099,14 +4099,16 @@ def cmd_update(args):
             # --- Launchd services (macOS) ---
             if is_macos():
                 try:
-                    from hermes_cli.gateway import launchd_restart, get_launchd_label, get_launchd_plist_path
+                    from hermes_cli.gateway import (
+                        get_launchd_label,
+                        get_launchd_plist_path,
+                        launchd_job_is_loaded,
+                        launchd_restart,
+                    )
                     plist_path = get_launchd_plist_path()
                     if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True, text=True, timeout=5,
-                        )
-                        if check.returncode == 0:
+                        loaded, _ = launchd_job_is_loaded(timeout=5)
+                        if loaded:
                             try:
                                 launchd_restart()
                                 restarted_services.append(get_launchd_label())

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -377,17 +377,8 @@ def show_status(args):
             print("  Manager:      systemd (user)")
         
     elif sys.platform == 'darwin':
-        from hermes_cli.gateway import get_launchd_label
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            is_loaded = result.returncode == 0
-        except subprocess.TimeoutExpired:
-            is_loaded = False
+        from hermes_cli.gateway import launchd_job_is_loaded
+        is_loaded, _ = launchd_job_is_loaded(timeout=5)
         print(f"  Status:       {check_mark(is_loaded)} {'loaded' if is_loaded else 'not loaded'}")
         print("  Manager:      launchd")
     else:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -392,6 +392,33 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_uses_launchctl_print_for_loaded_detection(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        expected_cmd = [
+            "launchctl",
+            "print",
+            f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}",
+        ]
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            assert cmd == expected_cmd
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "matches the current hermes install" in output.lower()
+        assert "gateway service is loaded" in output.lower()
+        assert calls == [expected_cmd]
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -449,6 +476,29 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         assert gateway_cli._is_service_running() is False
+
+    def test_is_service_running_uses_launchctl_print_on_macos(self, monkeypatch):
+        plist_path = SimpleNamespace(exists=lambda: True)
+        expected_cmd = [
+            "launchctl",
+            "print",
+            f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}",
+        ]
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, capture_output=True, text=True, **kwargs):
+            calls.append(cmd)
+            assert cmd == expected_cmd
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._is_service_running() is True
+        assert calls == [expected_cmd]
 
 
 class TestGatewaySystemServiceRouting:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,41 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_uses_launchctl_print_on_macos(monkeypatch, capsys, tmp_path):
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    from hermes_cli import status as status_mod
+
+    expected_cmd = [
+        "launchctl",
+        "print",
+        f"{gateway_mod._launchd_domain()}/{gateway_mod.get_launchd_label()}",
+    ]
+    calls = []
+
+    monkeypatch.setattr(status_mod.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if cmd == expected_cmd:
+            return SimpleNamespace(returncode=0, stdout="state = running\npid = 123\n", stderr="")
+        return SimpleNamespace(returncode=3, stdout="", stderr="")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", fake_run)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Status:       " in output
+    assert "loaded" in output
+    assert expected_cmd in calls

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,7 +6,9 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import plistlib
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -202,6 +204,66 @@ class TestLaunchdPlistCurrentness:
         monkeypatch.setenv("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
 
         assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_is_current_accepts_narrowed_canonical_path_and_semantic_equivalence(
+        self, tmp_path, monkeypatch
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        expected = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        working_dir = expected["WorkingDirectory"]
+        canonical_path = ":".join(
+            [
+                str(Path(working_dir) / "venv" / "bin"),
+                str(Path(working_dir) / "node_modules" / ".bin"),
+                str(Path.home() / ".local" / "bin"),
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+            ]
+        )
+
+        installed_env = dict(expected["EnvironmentVariables"])
+        installed_env["PATH"] = canonical_path
+        installed = {
+            "StandardErrorPath": expected["StandardErrorPath"],
+            "StandardOutPath": expected["StandardOutPath"],
+            "KeepAlive": expected["KeepAlive"],
+            "RunAtLoad": expected["RunAtLoad"],
+            "EnvironmentVariables": installed_env,
+            "WorkingDirectory": expected["WorkingDirectory"],
+            "ProgramArguments": expected["ProgramArguments"],
+            "Label": expected["Label"],
+        }
+        plist_path.write_bytes(plistlib.dumps(installed, sort_keys=False))
+
+        monkeypatch.setenv("PATH", "/transient/app/bin:/usr/bin:/bin")
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_is_current_rejects_missing_runtime_critical_path_entries(
+        self, tmp_path, monkeypatch
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        expected = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        installed_env = dict(expected["EnvironmentVariables"])
+        installed_env["PATH"] = ":".join(
+            [
+                str(Path(expected["WorkingDirectory"]) / "venv" / "bin"),
+                "/usr/bin",
+                "/bin",
+            ]
+        )
+        expected["EnvironmentVariables"] = installed_env
+        plist_path.write_bytes(plistlib.dumps(expected, sort_keys=False))
+
+        assert gateway_cli.launchd_plist_is_current() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -397,14 +397,45 @@ class TestCmdUpdateLaunchdRestart:
         )
 
         # Mock launchd_restart + find_gateway_pids (new code discovers all gateways)
-        with patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart, \
+        with patch.object(gateway_cli, "launchd_job_is_loaded", return_value=(True, "state = running\n")) as mock_loaded, \
+             patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart, \
              patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
             cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         assert "Restarted" in captured
         assert "Restart manually: hermes gateway run" not in captured
+        mock_loaded.assert_called_once_with(timeout=5)
         mock_launchd_restart.assert_called_once_with()
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_with_launchd_plist_but_helper_not_loaded_skips_launchd_restart(
+        self, mock_run, _mock_which, mock_args, capsys, tmp_path, monkeypatch,
+    ):
+        """When the plist exists but launchd_job_is_loaded() is false, cmd_update
+        should not claim a launchd-managed restart."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>")
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        mock_run.side_effect = _make_run_side_effect(
+            commit_count="3",
+            launchctl_loaded=False,
+        )
+
+        with patch.object(gateway_cli, "launchd_job_is_loaded", return_value=(False, "")) as mock_loaded, \
+             patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart, \
+             patch.object(gateway_cli, "find_gateway_pids", return_value=[]), \
+             patch("gateway.status.get_running_pid", return_value=None):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr().out
+        assert "Restarted ai.hermes.gateway" not in captured
+        mock_loaded.assert_called_once_with(timeout=5)
+        mock_launchd_restart.assert_not_called()
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
# `cmd_update()` macOS Fix Upstream Finalization

Date: 2026-04-14
Scope: Finalize and package the dedicated narrow `cmd_update()` macOS fix for upstream submission readiness.

## Patch Scope And Repo State

Current packaging result:

- branch: `fix/macos-cmdupdate-launchd-gate`
- commit: `4b2238683d4e204be7e0cd1ade46b8c6d6c51219`
- commit title: `fix: use authoritative launchd checks in cmd_update on macOS`

Working tree status:

- no tracked diff remains
- `git diff --name-only` is empty
- unrelated untracked `.DS_Store` files exist, but no unrelated tracked changes are present

Exact packaged patch scope:

- `hermes_cli/main.py`
- `tests/hermes_cli/test_update_gateway_restart.py`

Patch stats:

- 2 files changed
- 40 insertions
- 7 deletions

## Technical Narrative

### Remaining macOS defect

The remaining macOS-specific defect was inside `cmd_update()`, not in the already-packaged observability surfaces.

`cmd_update()` still used an inline `launchctl list <label>` gate before calling `launchd_restart()`. That meant update-time launchd restart detection was still using a weaker macOS signal than the rest of the corrected launchd observability code.

### Why the old gate was wrong

On this machine, `launchctl list` was already shown to be a false-negative source. Using it inside the update restart path could cause `cmd_update()` to skip or misreport launchd-managed restart behavior even when the live gateway was healthy and loaded.

### Why `launchd_job_is_loaded(timeout=5)` is the right reuse point

`launchd_job_is_loaded()` is already the shared, corrected helper that uses authoritative `launchctl print gui/<uid>/<label>` semantics. Reusing it in `cmd_update()` keeps update-time behavior aligned with the rest of the macOS launchd logic without broadening the patch.

### Why this patch is intentionally separate

This follow-up patch is intentionally separate from:

- the broader macOS observability patch
- repo-topology conversion
- update qualification

Reason:

- it is a small correctness patch in the update path itself
- it deserves its own narrow review surface
- it should land before later topology or qualification work, but it should not be bundled with those later changes

## Validation Summary

### Syntax / compile validation

- `python3 -m py_compile` passed for:
  - `hermes_cli/main.py`
  - `tests/hermes_cli/test_update_gateway_restart.py`

### Focused test results

- focused update-path test file:
  - `37 passed in 3.14s`

### Broader related macOS launchd slice

- related slice:
  - `112 passed in 3.19s`

### Live runtime validation

- `hermes version`: healthy
- `hermes status`: healthy, gateway loaded
- `launchctl print "gui/$(id -u)/ai.hermes.gateway"`: healthy running daemon
- primary probe: `OK`

Runtime stayed healthy before and after packaging.

## Packaging Strategy

Recommendation used here:

- package this as a dedicated stacked branch and follow-up commit

Why this is cleaner:

- keeps the already-finalized observability patch separate from the update-path follow-up
- preserves a small review surface
- makes it explicit that this patch is a prerequisite for later update qualification, not part of topology conversion

Exact git commands used:

```bash
git -C /Users/trl/.hermes/hermes-agent switch -c fix/macos-cmdupdate-launchd-gate
git -C /Users/trl/.hermes/hermes-agent add hermes_cli/main.py tests/hermes_cli/test_update_gateway_restart.py
git -C /Users/trl/.hermes/hermes-agent commit -m "fix: use authoritative launchd checks in cmd_update on macOS"
```

## Finalized Commit Materials

### Candidate commit title

`fix: use authoritative launchd checks in cmd_update on macOS`

### Candidate commit body

Fix the macOS launchd gate inside `cmd_update()` so update-time gateway
restart detection uses the same authoritative helper as the corrected macOS
observability surfaces.

- replace the inline `launchctl list <label>` gate with
  `launchd_job_is_loaded(timeout=5)`
- preserve the existing `plist_path.exists()` guard
- preserve the existing `launchd_restart()` path and operator-facing restart
  reporting
- update focused macOS update-path tests to assert helper-based launchd
  detection

Why:

- `launchctl list` was already a known false-negative source on this machine
- leaving that gate in `cmd_update()` would keep update-time macOS behavior
  inconsistent with the already-corrected launchd observability semantics

Non-goals:

- no repo-topology conversion
- no update qualification changes
- no config or gateway/plist changes

## Finalized PR Materials

### Candidate PR title

`Fix cmd_update launchd restart detection on macOS`

### Candidate PR description

#### Problem

The dedicated macOS observability fix corrected launchd loaded-state detection
and plist currentness in the status/gateway surfaces, but `cmd_update()` still
used its own inline `launchctl list <label>` gate before calling
`launchd_restart()`.

#### Root cause

`cmd_update()` had duplicated macOS launchd detection logic instead of reusing
the shared helper that already reflects the correct `launchctl print` authority
for this machine.

#### Fix

- replace the inline update-path `launchctl list` gate with
  `launchd_job_is_loaded(timeout=5)`
- preserve the existing plist-exists guard
- preserve the existing `launchd_restart()` flow and restart reporting
- update focused tests to assert helper-based launchd detection in the update
  path

#### Validation

- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_gateway_restart.py`
- focused test file: `37 passed in 3.14s`
- related macOS launchd slice: `112 passed in 3.19s`
- live runtime checks:
  - `hermes version` healthy
  - `hermes status` healthy
  - `launchctl print` healthy
  - primary probe `OK`

#### Non-goals / follow-ups

- no repo-topology conversion
- no `hermes update` execution or qualification yet
- no config/auth/env/token changes
- no plist/gateway regeneration

### Reviewer note

This change belongs in `cmd_update()` even after the broader observability patch because the earlier patch fixed operator-facing macOS status semantics, but it intentionally left the update path untouched. Without this follow-up, `cmd_update()` would still rely on the wrong launchd authority in a safety-relevant restart path.

## Exact Next Step

Design or execute the repo-topology conversion from the current shallow/tag-based checkout to a normal `main`-tracking clone.

Update qualification and real `hermes update` execution still come later.


Stacked note: this branch depends on fix/macos-launchd-observability and should be retargeted after PR 1 lands.