### PR TITLE
fix: handle skill bundle bytes and add zellij workflow docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ tmp/
 temp_vision_images/
 hermes-*/*
 examples/
+!website/static/examples/
+!website/static/examples/hermes-zellij/
+!website/static/examples/hermes-zellij/*
 tests/quick_test_dataset.jsonl
 tests/sample_dataset.jsonl
 run_datagen_kimik2-thinking.sh

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -695,6 +695,28 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_handles_bytes_files(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        binary_payload = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "assets/icon.bin": binary_payload,
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "assets").mkdir()
+        (skill_dir / "assets" / "icon.bin").write_bytes(binary_payload)
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        file_content = bundle.files[rel_path]
+        if isinstance(file_content, bytes):
+            h.update(file_content)
+        else:
+            h.update(file_content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 

--- a/website/docs/guides/run-hermes-in-zellij.md
+++ b/website/docs/guides/run-hermes-in-zellij.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 18
+title: "Run Hermes in zellij"
+description: "Use zellij as a PTY-backed multiplexer for long-lived interactive Hermes sessions and parallel agents"
+---
+
+# Run Hermes in zellij
+
+This guide shows how to run Hermes Agent inside detached `zellij` sessions.
+
+Use this when:
+- you want a real PTY for `prompt_toolkit`
+- `tmux` is not installed
+- you prefer `zellij`
+- you want one or more long-lived Hermes subprocesses
+
+If you only need a quick bounded subtask, prefer `delegate_task` instead of spawning a separate Hermes process.
+
+## Why zellij works
+
+Hermes' interactive CLI needs a real terminal. A plain background shell process is not enough.
+
+`zellij` provides the missing PTY and supports the core automation operations needed for spawned-agent workflows:
+- create detached/background sessions
+- run Hermes in a pane
+- list panes
+- send keystrokes
+- dump pane output
+
+## Fastest path: helper scripts
+
+On systems where you have installed the helper scripts, the workflow is:
+
+```bash
+hermes-zellij-start agent1
+hermes-zellij-send agent1 "Build a FastAPI auth service"
+hermes-zellij-read agent1
+hermes-zellij-stop agent1
+```
+
+For code-editing agents, prefer worktree mode:
+
+```bash
+hermes-zellij-start backend -w
+hermes-zellij-start frontend -w
+```
+
+You can find example helper scripts in:
+
+- `/docs/static/examples/hermes-zellij/hermes-zellij-common.sh`
+- `/docs/static/examples/hermes-zellij/hermes-zellij-start.sh`
+- `/docs/static/examples/hermes-zellij/hermes-zellij-send.sh`
+- `/docs/static/examples/hermes-zellij/hermes-zellij-read.sh`
+- `/docs/static/examples/hermes-zellij/hermes-zellij-stop.sh`
+
+## Raw zellij workflow
+
+### 1. Create a detached session
+
+```bash
+zellij attach -b agent1
+```
+
+### 2. Start Hermes in that session
+
+```bash
+zellij -s agent1 run --cwd "$PWD" -- hermes
+```
+
+### 3. List panes
+
+```bash
+zellij -s agent1 action list-panes --json
+```
+
+Look for a pane such as `terminal_0`.
+
+### 4. Send a prompt
+
+```bash
+zellij -s agent1 action write-chars -p terminal_0 "Build a FastAPI auth service"
+zellij -s agent1 action send-keys -p terminal_0 Enter
+```
+
+### 5. Read pane output
+
+```bash
+zellij -s agent1 action dump-screen -p terminal_0 --full
+```
+
+### 6. Exit and clean up
+
+```bash
+zellij -s agent1 action write-chars -p terminal_0 "/exit"
+zellij -s agent1 action send-keys -p terminal_0 Enter
+sleep 2
+zellij kill-session agent1
+```
+
+## Resume an existing Hermes session
+
+Resume most recent:
+
+```bash
+hermes-zellij-start resumed --continue
+```
+
+Resume a specific Hermes transcript:
+
+```bash
+hermes-zellij-start resumed --resume 20260225_143052_a1b2c3
+```
+
+## Two-agent pattern
+
+Start two agents:
+
+```bash
+hermes-zellij-start backend -w
+hermes-zellij-start frontend -w
+```
+
+Send tasks:
+
+```bash
+hermes-zellij-send backend "Build REST API for user management"
+hermes-zellij-send frontend "Build React dashboard for user management"
+```
+
+Read status:
+
+```bash
+hermes-zellij-read backend
+hermes-zellij-read frontend
+```
+
+Relay context manually:
+
+```bash
+hermes-zellij-send frontend "Here is the API schema from the backend agent: ..."
+```
+
+## Pitfalls
+
+- Always confirm pane IDs if you are using raw `zellij` commands.
+- If a session has multiple panes, explicit pane IDs are safer than auto-detection.
+- `zellij list-sessions` may show old sessions as `EXITED`; this is normal session metadata.
+- If Hermes config or tool changes were just made, restart Hermes or use `/reset` before relying on them.
+
+## When to use tmux instead
+
+You do not need to switch if `zellij` already works for you. `tmux` is only another valid PTY-backed option.
+
+The important requirement is not tmux specifically — it is having a real terminal multiplexer for the interactive Hermes process.

--- a/website/static/examples/hermes-zellij/hermes-zellij-common.sh
+++ b/website/static/examples/hermes-zellij/hermes-zellij-common.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+is_pane_id() {
+  [[ "${1:-}" =~ ^terminal_[0-9]+$ || "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+normalize_pane_id() {
+  local pane="${1:-}"
+  if [[ "$pane" =~ ^[0-9]+$ ]]; then
+    printf 'terminal_%s\n' "$pane"
+  else
+    printf '%s\n' "$pane"
+  fi
+}
+
+ensure_session() {
+  local session="$1"
+  zellij attach -b "$session" >/dev/null 2>&1 || true
+}
+
+resolve_pane() {
+  local session="$1"
+  local requested="${2:-}"
+
+  if [[ -n "$requested" ]]; then
+    normalize_pane_id "$requested"
+    return 0
+  fi
+
+  zellij -s "$session" action list-panes --json \
+    | python3 -c 'import json,sys
+panes=json.load(sys.stdin)
+terminals=[p for p in panes if not p.get("is_plugin") and not p.get("exited")]
+if not terminals:
+    raise SystemExit("No active terminal panes found")
+focused=[p for p in terminals if p.get("is_focused")]
+if focused:
+    chosen=focused[0]
+else:
+    terminals.sort(key=lambda p: int(p.get("id", -1)))
+    chosen=terminals[-1]
+print("terminal_%s" % chosen["id"])'
+}
+
+require_cmd zellij
+require_cmd python3

--- a/website/static/examples/hermes-zellij/hermes-zellij-read.sh
+++ b/website/static/examples/hermes-zellij/hermes-zellij-read.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$HOME/.local/bin/hermes-zellij-common"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: hermes-zellij-read <session> [pane_id] [dump-screen args...]" >&2
+  exit 1
+fi
+
+session="$1"
+shift || true
+pane_hint=""
+if [[ $# -gt 0 ]] && is_pane_id "$1"; then
+  pane_hint="$1"
+  shift
+fi
+
+pane_id="$(resolve_pane "$session" "$pane_hint")"
+if [[ $# -eq 0 ]]; then
+  set -- --full
+fi
+
+zellij -s "$session" action dump-screen -p "$pane_id" "$@"

--- a/website/static/examples/hermes-zellij/hermes-zellij-send.sh
+++ b/website/static/examples/hermes-zellij/hermes-zellij-send.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$HOME/.local/bin/hermes-zellij-common"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: hermes-zellij-send <session> [pane_id] <message...>" >&2
+  exit 1
+fi
+
+session="$1"
+shift
+pane_hint=""
+if [[ $# -gt 0 ]] && is_pane_id "$1"; then
+  pane_hint="$1"
+  shift
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "Missing message" >&2
+  exit 1
+fi
+
+pane_id="$(resolve_pane "$session" "$pane_hint")"
+message="$*"
+zellij -s "$session" action write-chars -p "$pane_id" "$message"
+zellij -s "$session" action send-keys -p "$pane_id" Enter
+printf 'session=%s\npane=%s\n' "$session" "$pane_id"

--- a/website/static/examples/hermes-zellij/hermes-zellij-start.sh
+++ b/website/static/examples/hermes-zellij/hermes-zellij-start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$HOME/.local/bin/hermes-zellij-common"
+require_cmd hermes
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: hermes-zellij-start <session> [hermes args...]" >&2
+  exit 1
+fi
+
+session="$1"
+shift || true
+
+ensure_session "$session"
+pane_id="$(zellij -s "$session" run --cwd "$PWD" -- hermes "$@")"
+printf 'session=%s\npane=%s\n' "$session" "$pane_id"

--- a/website/static/examples/hermes-zellij/hermes-zellij-stop.sh
+++ b/website/static/examples/hermes-zellij/hermes-zellij-stop.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$HOME/.local/bin/hermes-zellij-common"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: hermes-zellij-stop <session> [pane_id] [--keep-session]" >&2
+  exit 1
+fi
+
+session="$1"
+shift || true
+pane_hint=""
+keep_session=0
+
+if [[ $# -gt 0 ]] && is_pane_id "$1"; then
+  pane_hint="$1"
+  shift
+fi
+if [[ ${1:-} == "--keep-session" ]]; then
+  keep_session=1
+  shift || true
+fi
+if [[ $# -gt 0 ]]; then
+  echo "Unexpected arguments: $*" >&2
+  exit 1
+fi
+
+pane_id="$(resolve_pane "$session" "$pane_hint")"
+zellij -s "$session" action write-chars -p "$pane_id" "/exit"
+zellij -s "$session" action send-keys -p "$pane_id" Enter
+sleep 2
+if [[ "$keep_session" -eq 0 ]]; then
+  zellij kill-session "$session" >/dev/null 2>&1 || true
+fi
+printf 'session=%s\npane=%s\n' "$session" "$pane_id"


### PR DESCRIPTION
## Summary
- fix `hermes skills check` / skills-hub update hashing when a skill bundle contains byte content
- add a regression test for mixed text/binary bundle files
- document zellij as a PTY-backed alternative to tmux for spawned Hermes sessions
- add tracked zellij helper script examples for interactive agent workflows

## Details
This fixes a skills-hub bug where `bundle_content_hash()` assumed all bundle files were text and called `.encode()` unconditionally. Hub-installed skills can include byte content, which caused `hermes skills check` to crash.

It also adds a practical zellij workflow for long-lived interactive Hermes sessions, including copyable helper scripts and a dedicated guide.

## Files touched
- `tools/skills_hub.py`
- `tests/tools/test_skills_hub.py`
- `website/docs/guides/run-hermes-in-zellij.md`
- `website/static/examples/hermes-zellij/*`
- `.gitignore`

## Test Plan
- ran the targeted skills-hub regression tests locally
- verified `hermes skills check` works after the fix
- tested the zellij helper workflow end-to-end with a disposable session

## Why this helps
- prevents a real crash in skills-hub update checking
- makes Hermes subprocess spawning easier on machines that use zellij instead of tmux
