### PR TITLE
fix(alibaba): accept ALIBABA_API_KEY alias and correct missing-key hints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2340,9 +2340,11 @@ def call_llm(
             # through OpenRouter (which causes confusing 404s).
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                from hermes_cli.auth import format_api_key_env_var_hint
+                _env_hint = format_api_key_env_var_hint(_explicit)
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             # For auto/custom with no credentials, try the full auto chain
@@ -2545,9 +2547,11 @@ async def async_call_llm(
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                from hermes_cli.auth import format_api_key_env_var_hint
+                _env_hint = format_api_key_env_var_hint(_explicit)
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             if not resolved_base_url:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -195,7 +195,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
         inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        api_key_env_vars=("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(
@@ -374,6 +374,24 @@ def _resolve_api_key_provider_secret(
             return val, env_var
 
     return "", ""
+
+
+def format_api_key_env_var_hint(provider_id: str) -> str:
+    """Return a user-facing env-var hint for a provider's API key."""
+    pconfig = PROVIDER_REGISTRY.get((provider_id or "").strip().lower())
+    if not pconfig or not pconfig.api_key_env_vars:
+        normalized = (provider_id or "").strip().upper()
+        return f"{normalized}_API_KEY" if normalized else "API_KEY"
+
+    env_vars = tuple(ev for ev in pconfig.api_key_env_vars if ev)
+    if not env_vars:
+        normalized = (provider_id or "").strip().upper()
+        return f"{normalized}_API_KEY" if normalized else "API_KEY"
+    if len(env_vars) == 1:
+        return env_vars[0]
+    if len(env_vars) == 2:
+        return f"{env_vars[0]} (or {env_vars[1]})"
+    return f"{', '.join(env_vars[:-1])}, or {env_vars[-1]}"
 
 
 # =============================================================================

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -725,7 +725,7 @@ def run_doctor(args):
         ("Arcee AI",         ("ARCEEAI_API_KEY",),                            "https://api.arcee.ai/api/v1/models",  "ARCEE_BASE_URL", True),
         ("DeepSeek",         ("DEEPSEEK_API_KEY",),                           "https://api.deepseek.com/v1/models",  "DEEPSEEK_BASE_URL", True),
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
-        ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
+        ("Alibaba/DashScope", ("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
         # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
         ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),

--- a/run_agent.py
+++ b/run_agent.py
@@ -937,9 +937,11 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        from hermes_cli.auth import format_api_key_env_var_hint
+                        _env_hint = format_api_key_env_var_hint(_explicit)
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -15,6 +15,7 @@ if "dotenv" not in sys.modules:
 from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     ProviderConfig,
+    format_api_key_env_var_hint,
     resolve_provider,
     get_api_key_provider_status,
     resolve_api_key_provider_credentials,
@@ -100,6 +101,14 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("HF_TOKEN",)
         assert pconfig.base_url_env_var == "HF_BASE_URL"
 
+    def test_alibaba_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["alibaba"]
+        assert pconfig.api_key_env_vars == ("DASHSCOPE_API_KEY", "ALIBABA_API_KEY")
+        assert pconfig.base_url_env_var == "DASHSCOPE_BASE_URL"
+
+    def test_alibaba_env_hint(self):
+        assert format_api_key_env_var_hint("alibaba") == "DASHSCOPE_API_KEY (or ALIBABA_API_KEY)"
+
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
@@ -130,7 +139,7 @@ PROVIDER_ENV_VARS = (
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
-    "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
+    "DASHSCOPE_API_KEY", "ALIBABA_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
@@ -215,6 +224,9 @@ class TestResolveProvider:
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
+
+    def test_explicit_alibaba(self):
+        assert resolve_provider("alibaba") == "alibaba"
 
     def test_alias_hf(self):
         assert resolve_provider("hf") == "huggingface"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1047,6 +1047,21 @@ def test_alibaba_anthropic_endpoint_override_uses_anthropic_messages(monkeypatch
     assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic"
 
 
+def test_alibaba_alias_key_env_is_accepted(monkeypatch):
+    """Alibaba should accept ALIBABA_API_KEY as a compatibility alias."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.setenv("ALIBABA_API_KEY", "test-alibaba-key")
+
+    resolved = rp.resolve_runtime_provider(requested="alibaba")
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["api_key"] == "test-alibaba-key"
+    assert resolved["source"] == "env:ALIBABA_API_KEY"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+
 def test_opencode_zen_gpt_defaults_to_responses(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "gpt-5.4"})


### PR DESCRIPTION
## Summary

- accept `ALIBABA_API_KEY` as a compatibility alias for the `alibaba` provider
- keep `DASHSCOPE_API_KEY` as the primary env var
- generate missing-key hints from the provider registry instead of constructing the wrong env var name dynamically
- align doctor/runtime behavior with the same alias support

## Why

The `alibaba` provider is registered around `DASHSCOPE_API_KEY`, and the rest of the config/docs flow already points users to that env var.

However, the runtime missing-key path was dynamically constructing `ALIBABA_API_KEY` from the provider name, which did not match the actual provider registry and could mislead users.

This PR keeps the fix intentionally narrow:
- preserve `DASHSCOPE_API_KEY` as the canonical env var
- accept `ALIBABA_API_KEY` as a compatibility alias
- make runtime and doctor hints reflect the provider registry consistently

Fixes #9506

## Changes

- add `ALIBABA_API_KEY` as a secondary alias for the `alibaba` provider in `hermes_cli/auth.py`
- update missing-key hint generation in `run_agent.py` and `agent/auxiliary_client.py`
- align `hermes_cli/doctor.py` with the same alias handling
- add regression coverage in:
  - `tests/hermes_cli/test_api_key_providers.py`
  - `tests/hermes_cli/test_runtime_provider_resolution.py`

## Testing

- `pytest tests/hermes_cli/test_api_key_providers.py`
- `pytest tests/hermes_cli/test_runtime_provider_resolution.py`

Local result: `198 passed`
