### PR TITLE
fix(doctor): restore FAL_KEY metadata for image_gen

### DIFF
--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -210,6 +210,22 @@ def test_managed_fal_submit_reuses_cached_sync_client(monkeypatch):
     assert captured["http_client"] is first_client
 
 
+def test_image_generation_registry_requires_fal_key(monkeypatch):
+    _install_fake_tools_package()
+    _install_fake_fal_client({})
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setenv("HERMES_ENABLE_NOUS_MANAGED_TOOLS", "1")
+
+    image_generation_tool = _load_tool_module(
+        "tools.image_generation_tool",
+        "image_generation_tool.py",
+    )
+
+    entry = image_generation_tool.registry.get_entry("image_generate")
+    assert entry is not None
+    assert entry.requires_env == ["FAL_KEY"]
+
+
 def test_openai_tts_uses_managed_audio_gateway_when_direct_key_absent(monkeypatch, tmp_path):
     captured = {}
     _install_fake_tools_package()

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -687,7 +687,7 @@ registry.register(
     schema=IMAGE_GENERATE_SCHEMA,
     handler=_handle_image_generate,
     check_fn=check_image_generation_requirements,
-    requires_env=[],
+    requires_env=["FAL_KEY"],
     is_async=False,  # Switched to sync fal_client API to fix "Event loop is closed" in gateway
     emoji="🎨",
 )


### PR DESCRIPTION
## Summary

Restore `FAL_KEY` metadata for `image_generate` so `hermes doctor` reports a missing credential instead of the generic `system dependency not met` bucket.

## Why

`image_generate` can run either with direct FAL credentials or with managed Nous image-generation access. The runtime check already understands that split, but the registry metadata was changed to `requires_env=[]`, which left `doctor` with no actionable env-var hint when the tool was unavailable.

This change keeps the fix intentionally narrow:
- restore the `FAL_KEY` requirement metadata for `image_generate`
- keep the existing runtime availability check unchanged
- add a regression test that the registry still advertises `FAL_KEY`

Fixes #9516

## Changes

- restore `requires_env=["FAL_KEY"]` on `image_generate`
- add a regression test for the tool registry metadata

## Testing

- `pytest -q -o addopts='' tests/tools/test_managed_media_gateways.py`

Local result: `6 passed`
