### PR TITLE
fix(telegram): escape Markdown special chars in send_exec_approval

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1067,10 +1067,13 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            # Escape backticks that would break Markdown v1 inline code parsing
+            safe_cmd = cmd_preview.replace("`", "'")
+            safe_desc = description.replace("`", "'").replace("*", "∗")
             text = (
                 f"⚠️ *Command Approval Required*\n\n"
-                f"`{cmd_preview}`\n\n"
-                f"Reason: {description}"
+                f"`{safe_cmd}`\n\n"
+                f"Reason: {safe_desc}"
             )
 
             # Resolve thread context for thread replies


### PR DESCRIPTION
## Problem

`send_exec_approval` in `telegram.py` wraps the command preview in Markdown v1 inline code (backticks) without escaping. When the command or description contains backticks (`) or asterisks (\*), Telegram's Markdown parser fails with:

```
Can't parse entities: can't find end of the entity starting at byte offset NNNN
```

This causes the approval message to silently fail to send, leaving the agent stuck waiting for approval that never arrives.

## Fix

Escape backticks in `cmd_preview` (replace with single quotes) and backticks + asterisks in `description` before inserting into the Markdown template. This prevents the Markdown v1 parser from choking on nested special characters.

## Steps to Reproduce

1. Ask the agent to run a command containing backticks (e.g., a `gh issue create` with code blocks)
2. Agent triggers `send_exec_approval`
3. Telegram API rejects the message
4. Agent hangs indefinitely