### PR TITLE
fix(doctor): detect KIMI_CN_API_KEY and guard null base_env probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -42,6 +42,7 @@ _PROVIDER_ENV_HINTS = (
     "ZAI_API_KEY",
     "Z_AI_API_KEY",
     "KIMI_API_KEY",
+    "KIMI_CN_API_KEY",
     "MINIMAX_API_KEY",
     "MINIMAX_CN_API_KEY",
     "KILOCODE_API_KEY",
@@ -749,7 +750,7 @@ def run_doctor(args):
             print(f"  Checking {_pname} API...", end="", flush=True)
             try:
                 import httpx
-                _base = os.getenv(_base_env, "")
+                _base = os.getenv(_base_env, "") if _base_env else ""
                 # Auto-detect Kimi Code keys (sk-kimi-) → api.kimi.com
                 if not _base and _key.startswith("sk-kimi-"):
                     _base = "https://api.kimi.com/coding/v1"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -44,6 +44,19 @@ class TestProviderEnvDetection:
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
 
+    def test_detects_kimi_cn_api_key(self):
+        content = "KIMI_CN_API_KEY=sk-test\n"
+        assert _has_provider_env_config(content)
+
+
+class TestKimiChinaProbeNullBaseEnv:
+    """The Kimi China provider entry has base_env=None; the probe must not crash."""
+
+    def test_getenv_with_none_base_env_is_guarded(self):
+        _base_env = None
+        _base = os.getenv(_base_env, "") if _base_env else ""
+        assert _base == ""
+
 
 class TestDoctorToolAvailabilityOverrides:
     def test_marks_honcho_available_when_configured(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #9716.

- Add `KIMI_CN_API_KEY` to `_PROVIDER_ENV_HINTS` so `_has_provider_env_config()` recognises China-region Kimi credentials in `.env`.
- Guard the `os.getenv()` call in the provider connectivity probe to skip the lookup when `base_env` is `None` (the `kimi-coding-cn` entry has no base-URL override env var), preventing the `TypeError: str expected, not NoneType` crash.

## Test plan

- Added `test_detects_kimi_cn_api_key` to verify `_has_provider_env_config` returns `True` for `KIMI_CN_API_KEY=...`.
- Added `TestKimiChinaProbeNullBaseEnv` to verify the null `base_env` guard works.
- All existing `test_doctor.py` tests continue to pass.