### PR TITLE
fix: resolve @ context completions in CLI

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -361,6 +361,17 @@ class TestSlashCommandCompleter:
     def test_no_completions_for_empty_input(self):
         assert _completions(SlashCommandCompleter(), "") == []
 
+    def test_context_reference_completion_for_bare_at_sign(self, tmp_path, monkeypatch):
+        (tmp_path / "notes.txt").write_text("hello")
+        monkeypatch.chdir(tmp_path)
+
+        completions = _completions(SlashCommandCompleter(), "@")
+        texts = {item.text for item in completions}
+
+        assert "@diff" in texts
+        assert "@file:" in texts
+        assert "@file:notes.txt" in texts
+
     # -- skill commands via provider ------------------------------------
 
     def test_skill_commands_are_completed_from_provider(self):


### PR DESCRIPTION
## Summary
- Fix `@` context completions in `SlashCommandCompleter`
- Make `_context_completions` an instance method so fuzzy file completions can call `self._fuzzy_file_completions(...)`
- Add a regression test for bare `@` completion

## Test Plan
- `pytest tests/hermes_cli/test_commands.py -q`