### PR TITLE
fix(mcp): coerce JSON-string arrays and objects for tool args

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -334,14 +334,16 @@ _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     """Coerce tool call arguments to match their JSON Schema types.
 
-    LLMs frequently return numbers as strings (``"42"`` instead of ``42``)
-    and booleans as strings (``"true"`` instead of ``true``).  This compares
-    each argument value against the tool's registered JSON Schema and attempts
-    safe coercion when the value is a string but the schema expects a different
-    type.  Original values are preserved when coercion fails.
+    LLMs frequently serialize tool arguments incorrectly:
+    - numbers as strings (``"42"`` instead of ``42``)
+    - booleans as strings (``"true"`` instead of ``true``)
+    - arrays/objects as JSON strings (``"[\"a\"]"`` / ``"{...}"``)
 
-    Handles ``"type": "integer"``, ``"type": "number"``, ``"type": "boolean"``,
-    and union types (``"type": ["integer", "string"]``).
+    This compares each argument value against the tool's registered JSON Schema
+    and attempts safe coercion before dispatch. Nested arrays/objects are
+    recursively normalized using the schema's ``items`` / ``properties``
+    definitions when available. Original values are preserved when coercion
+    fails or is not applicable.
     """
     if not args or not isinstance(args, dict):
         return args
@@ -360,14 +362,43 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         prop_schema = properties.get(key)
         if not prop_schema:
             continue
-        expected = prop_schema.get("type")
-        if not expected:
-            continue
-        coerced = _coerce_value(value, expected)
+        coerced = _coerce_by_schema(value, prop_schema)
         if coerced is not value:
             args[key] = coerced
 
     return args
+
+
+def _coerce_by_schema(value: Any, schema: Dict[str, Any] | None):
+    """Coerce *value* according to a JSON Schema fragment.
+
+    Handles top-level scalar coercion plus recursive normalization for arrays
+    and objects when nested schemas are present.
+    """
+    if not schema:
+        return value
+
+    expected_type = schema.get("type")
+    coerced = _coerce_value(value, expected_type)
+
+    if isinstance(coerced, list):
+        item_schema = schema.get("items")
+        if item_schema:
+            return [_coerce_by_schema(item, item_schema) for item in coerced]
+        return coerced
+
+    if isinstance(coerced, dict):
+        properties = schema.get("properties") or {}
+        additional = schema.get("additionalProperties")
+        normalized = {}
+        for key, item in coerced.items():
+            child_schema = properties.get(key)
+            if child_schema is None and isinstance(additional, dict):
+                child_schema = additional
+            normalized[key] = _coerce_by_schema(item, child_schema) if child_schema else item
+        return normalized
+
+    return coerced
 
 
 def _coerce_value(value: str, expected_type):
@@ -387,6 +418,10 @@ def _coerce_value(value: str, expected_type):
         return _coerce_number(value, integer_only=(expected_type == "integer"))
     if expected_type == "boolean":
         return _coerce_boolean(value)
+    if expected_type == "array":
+        return _coerce_json_container(value, list)
+    if expected_type == "object":
+        return _coerce_json_container(value, dict)
     return value
 
 
@@ -416,6 +451,25 @@ def _coerce_boolean(value: str):
     if low == "false":
         return False
     return value
+
+
+def _coerce_json_container(value: Any, container_type):
+    """Parse a JSON string into ``container_type`` (list or dict) when possible."""
+    if isinstance(value, container_type):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    if not stripped:
+        return value
+
+    try:
+        parsed = json.loads(stripped)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return value
+
+    return parsed if isinstance(parsed, container_type) else value
 
 
 def handle_function_call(

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -14,6 +14,7 @@ from model_tools import (
     _coerce_value,
     _coerce_number,
     _coerce_boolean,
+    _coerce_json_container,
 )
 
 
@@ -122,6 +123,12 @@ class TestCoerceValue:
     def test_unknown_type_passthrough(self):
         assert _coerce_value("stuff", "object") == "stuff"
 
+    def test_array_json_string(self):
+        assert _coerce_value('["a", "b"]', "array") == ["a", "b"]
+
+    def test_object_json_string(self):
+        assert _coerce_value('{"enabled": true}', "object") == {"enabled": True}
+
     def test_union_type_prefers_first_match(self):
         """Union types try each in order."""
         assert _coerce_value("42", ["integer", "string"]) == 42
@@ -212,6 +219,57 @@ class TestCoerceToolArgs:
             assert result["items"] == [1, 2, 3]
             assert result["config"] == {"key": "val"}
 
+    def test_coerces_stringified_array_arg(self):
+        schema = self._mock_schema({
+            "messageIds": {"type": "array", "items": {"type": "string"}},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"messageIds": '["a", "b"]'}
+            result = coerce_tool_args("test_tool", args)
+            assert result["messageIds"] == ["a", "b"]
+
+    def test_coerces_stringified_object_arg_and_nested_values(self):
+        schema = self._mock_schema({
+            "criteria": {
+                "type": "object",
+                "properties": {
+                    "hasAttachment": {"type": "boolean"},
+                    "size": {"type": "number"},
+                    "query": {"type": "string"},
+                },
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {
+                "criteria": '{"hasAttachment": "true", "size": "1024", "query": "has:attachment"}',
+            }
+            result = coerce_tool_args("test_tool", args)
+            assert result["criteria"] == {
+                "hasAttachment": True,
+                "size": 1024,
+                "query": "has:attachment",
+            }
+
+    def test_recursively_coerces_nested_array_objects(self):
+        schema = self._mock_schema({
+            "filters": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "threshold": {"type": "integer"},
+                    },
+                },
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {
+                "filters": '[{"enabled": "false", "threshold": "3"}]',
+            }
+            result = coerce_tool_args("test_tool", args)
+            assert result["filters"] == [{"enabled": False, "threshold": 3}]
+
     def test_extra_args_without_schema_left_alone(self):
         """Args not in the schema properties are not touched."""
         schema = self._mock_schema({"limit": {"type": "integer"}})
@@ -260,3 +318,11 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+
+class TestCoerceJsonContainer:
+    def test_invalid_json_passthrough(self):
+        assert _coerce_json_container("not-json", list) == "not-json"
+
+    def test_wrong_container_type_passthrough(self):
+        assert _coerce_json_container('{"a": 1}', list) == '{"a": 1}'

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -74,6 +74,52 @@ class TestHandleFunctionCall:
             ),
         ]
 
+    def test_pre_tool_hook_receives_coerced_args(self):
+        tool_schema = {
+            "name": "test_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "messageIds": {"type": "array", "items": {"type": "string"}},
+                    "criteria": {
+                        "type": "object",
+                        "properties": {
+                            "hasAttachment": {"type": "boolean"},
+                        },
+                    },
+                },
+            },
+        }
+
+        with (
+            patch("model_tools.registry.get_schema", return_value=tool_schema),
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
+        ):
+            result = handle_function_call(
+                "test_tool",
+                {
+                    "messageIds": '["a", "b"]',
+                    "criteria": '{"hasAttachment": "true"}',
+                },
+                task_id="task-1",
+                tool_call_id="call-1",
+                session_id="session-1",
+            )
+
+        assert result == '{"ok":true}'
+        assert mock_invoke_hook.call_args_list[0] == call(
+            "pre_tool_call",
+            tool_name="test_tool",
+            args={
+                "messageIds": ["a", "b"],
+                "criteria": {"hasAttachment": True},
+            },
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+        )
+
 
 # =========================================================================
 # Agent loop tools


### PR DESCRIPTION
Summary
- extend tool argument coercion to handle array and object schemas
- recursively normalize nested array/object values using JSON Schema items/properties
- add regression tests covering stringified non-string MCP arguments
- verify pre-tool hooks observe coerced args

Why
Some MCP tools declare non-string parameter types in inputSchema, but model-produced arguments may still arrive as strings or JSON-encoded strings. This causes validation failures for number, array, and object parameters.

What changed
- add schema-driven coercion for:
  - array
  - object
  - integer / number
  - boolean
- recursively normalize nested structures after parsing
- preserve original values when coercion is not applicable or fails
- add regression coverage for:
  - stringified arrays
  - stringified objects
  - nested object/array coercion
  - mixed argument coercion
  - pre_tool_call hooks receiving coerced args

Validation
- python -m pytest tests/run_agent/test_tool_arg_coercion.py tests/test_model_tools.py -q
- 66 passed

Fixes #3947
