### PR TITLE
fix(cli): honor direct model aliases before codex normalization

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1660,6 +1660,27 @@ class HermesCLI:
                 _detected = _auto_detect_local_model(_base_url)
                 if _detected:
                     self.model = _detected
+
+        # Expand direct model aliases from config.yaml early in CLI startup.
+        # This ensures commands like `hermes chat -m example/gpt-5.4` pick up
+        # the aliased provider/base_url before lazy runtime resolution and
+        # provider-specific normalization run.
+        try:
+            from hermes_cli.model_switch import DIRECT_ALIASES, _ensure_direct_aliases
+
+            alias_key = (self.model or "").strip().lower()
+            if alias_key:
+                _ensure_direct_aliases()
+                direct_alias = DIRECT_ALIASES.get(alias_key)
+                if direct_alias is not None:
+                    self.model = direct_alias.model
+                    if provider is None and direct_alias.provider:
+                        provider = direct_alias.provider
+                    if base_url is None and direct_alias.base_url:
+                        base_url = direct_alias.base_url
+        except Exception:
+            pass
+
         # Track whether model was explicitly chosen by the user or fell back
         # to the global default.  Provider-specific normalisation may override
         # the default silently but should warn when overriding an explicit choice.
@@ -2200,17 +2221,20 @@ class HermesCLI:
         if resolved_provider != "openai-codex":
             return changed
 
-        # 1. Strip provider prefix ("openai/gpt-5.4" → "gpt-5.4")
+        # 1. Strip only known Codex-facing provider prefixes
+        #    ("openai/gpt-5.4" → "gpt-5.4"). Do not strip unrelated custom
+        #    aliases like "example/gpt-5.4".
         if "/" in current_model:
-            slug = current_model.split("/", 1)[1]
-            if not self._model_is_default:
-                self.console.print(
-                    f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; "
-                    f"using '{slug}' for OpenAI Codex.[/]"
-                )
-            self.model = slug
-            current_model = slug
-            changed = True
+            vendor, _, slug = current_model.partition("/")
+            if vendor.strip().lower() in {"openai", "openai-codex", "official"} and slug:
+                if not self._model_is_default:
+                    self.console.print(
+                        f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; "
+                        f"using '{slug}' for OpenAI Codex.[/]"
+                    )
+                self.model = slug
+                current_model = slug
+                changed = True
 
         # 2. Replace untouched default with a Codex model
         if self._model_is_default:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,56 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_cli_startup_expands_direct_model_alias_before_runtime_resolution(monkeypatch):
+    cli = _import_cli()
+    from hermes_cli import model_switch
+
+    monkeypatch.setattr(
+        cli,
+        "CLI_CONFIG",
+        {
+            "model": {
+                "default": "gpt-5.4",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            },
+            "display": {"compact": False, "tool_progress": "all", "resume_display": "full"},
+            "agent": {},
+            "terminal": {"env_type": "local"},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        model_switch,
+        "DIRECT_ALIASES",
+        {
+            "example/gpt-5.4": model_switch.DirectAlias(
+                model="gpt-5.4",
+                provider="custom-endpoint",
+                base_url="https://example.invalid/v1",
+            )
+        },
+    )
+
+    shell = cli.HermesCLI(model="example/gpt-5.4", compact=True, max_turns=1)
+
+    assert shell.model == "gpt-5.4"
+    assert shell.requested_provider == "custom-endpoint"
+    assert shell.provider == "custom-endpoint"
+    assert shell.base_url == "https://example.invalid/v1"
+    assert shell._explicit_base_url == "https://example.invalid/v1"
+
+
+def test_openai_codex_normalization_does_not_strip_unrelated_provider_prefix():
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="example/gpt-5.4", provider="openai-codex", compact=True, max_turns=1)
+
+    changed = shell._normalize_model_for_provider("openai-codex")
+
+    assert changed is False
+    assert shell.model == "example/gpt-5.4"
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -184,13 +184,13 @@ class TestNormalizeModelForProvider:
         assert changed is True
         assert cli.model == "gpt-5.4"
 
-    def test_any_provider_prefix_stripped(self):
-        """anthropic/claude-opus-4.6 → claude-opus-4.6 (strip prefix only).
-        User explicitly chose this — let the API decide if it works."""
+    def test_unrelated_provider_prefix_not_stripped_for_openai_codex(self):
+        """anthropic/claude-opus-4.6 should not be rewritten by Codex-specific normalization.
+        Only known Codex-facing prefixes are stripped."""
         cli = _make_cli(model="anthropic/claude-opus-4.6")
         changed = cli._normalize_model_for_provider("openai-codex")
-        assert changed is True
-        assert cli.model == "claude-opus-4.6"
+        assert changed is False
+        assert cli.model == "anthropic/claude-opus-4.6"
 
     def test_opencode_go_prefix_stripped(self):
         cli = _make_cli(model="opencode-go/kimi-k2.5")


### PR DESCRIPTION
Title: fix(cli): honor direct model aliases before codex normalization

## What changed
This PR fixes a CLI routing bug where direct model aliases for custom endpoints (for example `example/gpt-5.4`) could be interpreted using the persisted `openai-codex` provider before the alias was expanded.

It makes three focused changes:
- expand exact direct aliases from `model_aliases` / `DIRECT_ALIASES` early in `HermesCLI.__init__`
- narrow OpenAI Codex prefix stripping so it only applies to known Codex-facing prefixes (`openai`, `openai-codex`, `official`)
- update/add regression tests to match the corrected normalization behavior

## Why
Without early alias expansion, a command like `hermes chat -m example/gpt-5.4` could inherit the persisted provider configuration and later be normalized as if it were an OpenAI Codex model selector. That incorrectly strips the custom alias prefix and routes the request to the wrong backend.

Although this was discovered with one specific personal custom provider alias, the bug is not specific to that setup. It can affect any direct alias that maps a custom endpoint/model pair before provider-specific normalization runs.

## How to test
1. Configure a direct alias such as `example/gpt-5.4` in `model_aliases`.
2. Run `hermes chat -m example/gpt-5.4 -q "Reply with OK only." -Q`.
3. Confirm the request succeeds without being normalized onto `openai-codex`.
4. Run `hermes chat -m openai-codex/gpt-5.4 -q "Reply with OK only." -Q`.
5. Confirm the expected Codex normalization behavior still works.

## Platforms tested
- macOS

## Test coverage
Targeted tests that pass on this branch:
- `python -m pytest tests/cli/test_cli_provider_resolution.py -q -o addopts=''`
- `python -m pytest tests/cli/test_cli_init.py -q -o addopts=''`

Manual verification that passes on this branch:
- verified with a local custom direct alias mapped to a custom endpoint
- `hermes chat -m openai-codex/gpt-5.4 -q 'Reply with OK only.' -Q`

## Full suite note
I also rebased this branch onto the current upstream `main` and ran `pytest tests/ -v`.

On this machine, the full suite still reports failures that appear to be unrelated to this PR. I verified representative examples directly against a separate `origin/main` worktree, including failures in:
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
- `tests/hermes_cli/test_claw.py::TestCmdCleanup::test_dry_run_lists_dirs`
- `tests/tools/test_file_staleness.py::TestStalenessCheck::test_warning_when_file_modified_externally`

Because of that baseline instability, the strongest signal for this PR is the targeted regression coverage plus direct CLI verification above.

## Notes
- This PR is intentionally focused on one bugfix and its regression tests.
- No related issue number to reference for this fix.

## Risk assessment
Low. The behavior change is limited to exact direct alias handling during CLI startup and to narrowing an over-broad Codex normalization rule. Existing `openai-codex/...` normalization behavior is preserved.
