### PR TITLE
feat(mattermost): add sticky thread routing

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -23,12 +23,14 @@ from typing import Any, Dict, List, Optional
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.mattermost_thread_state import MattermostThreadStateStore
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     SendResult,
 )
+from hermes_cli.profiles import get_active_profile_name
 
 logger = logging.getLogger(__name__)
 
@@ -95,9 +97,117 @@ class MattermostAdapter(BasePlatformAdapter):
             config.extra.get("reply_mode", "")
             or os.getenv("MATTERMOST_REPLY_MODE", "off")
         ).lower()
+        self._profile_name = get_active_profile_name()
+        self._thread_state = MattermostThreadStateStore()
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+    def _mention_patterns(self) -> List[str]:
+        return [
+            f"@{self._bot_username}",
+            f"@{self._bot_user_id}",
+        ]
+
+    def _is_thread_sticky_enabled(self) -> bool:
+        return (
+            os.getenv("MATTERMOST_THREAD_STICKY", "true").lower()
+            not in ("false", "0", "no")
+        )
+
+    def _has_mention(self, message_text: str) -> bool:
+        if not message_text:
+            return False
+        return any(
+            pattern.lower() in message_text.lower()
+            for pattern in self._mention_patterns()
+        )
+
+    def _strip_mentions(self, message_text: str) -> str:
+        cleaned = message_text
+        for pattern in self._mention_patterns():
+            cleaned = re.sub(
+                re.escape(pattern), "", cleaned, flags=re.IGNORECASE
+            ).strip()
+        return cleaned
+
+    def _thread_is_claimed_for_me(self, channel_id: str, thread_id: Optional[str]) -> bool:
+        if not self._is_thread_sticky_enabled() or not thread_id:
+            return False
+        active_agent = self._thread_state.get_active_agent(channel_id, thread_id)
+        return active_agent == self._profile_name
+
+    async def _build_thread_transcript(self, thread_root_id: str, exclude_post_id: Optional[str] = None) -> str:
+        if self._session is None:
+            return ""
+        thread_data = await self._api_get(f"posts/{thread_root_id}/thread")
+        if not thread_data:
+            return ""
+
+        posts = thread_data.get("posts") or {}
+        order = thread_data.get("order") or []
+        if not posts:
+            return ""
+
+        if not order:
+            order = [
+                post_id
+                for post_id, _ in sorted(
+                    posts.items(),
+                    key=lambda item: item[1].get("create_at", 0),
+                )
+            ]
+
+        visible_lines: List[str] = []
+        total_chars = 0
+        truncated = False
+        max_posts = 50
+        max_chars = 24000
+
+        if len(order) > max_posts:
+            truncated = True
+
+        for post_id in order[-max_posts:]:
+            if exclude_post_id and post_id == exclude_post_id:
+                continue
+            post = posts.get(post_id) or {}
+            if post.get("type"):
+                continue
+            message = (post.get("message") or "").strip()
+            if not message:
+                continue
+            author = post.get("user_id") or "unknown"
+            line = f"{author}: {message}"
+            total_chars += len(line)
+            visible_lines.append(line)
+
+        while visible_lines and total_chars > max_chars:
+            removed = visible_lines.pop(0)
+            total_chars -= len(removed)
+            truncated = True
+
+        if not visible_lines:
+            return ""
+
+        if truncated:
+            visible_lines.insert(0, "[Earlier thread messages truncated]")
+
+        return "\n".join(visible_lines)
+
+    def _prepend_thread_context(self, transcript: str, message_text: str) -> str:
+        if not transcript:
+            return message_text
+        if not message_text:
+            return (
+                "[Mattermost thread context]\n"
+                f"{transcript}"
+            )
+        return (
+            "[Mattermost thread context]\n"
+            f"{transcript}\n\n"
+            "[New message]\n"
+            f"{message_text}"
+        )
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -262,6 +372,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
+        thread_root_id = metadata.get("thread_id") if metadata else None
 
         last_id = None
         for chunk in chunks:
@@ -269,9 +380,15 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            # Thread support:
+            # - MATTERMOST_REPLY_MODE=thread enables threaded replies.
+            # - When enabled, metadata["thread_id"] is authoritative for an
+            #   existing Mattermost thread.
+            if self._reply_mode == "thread":
+                if thread_root_id:
+                    payload["root_id"] = thread_root_id
+                elif reply_to:
+                    payload["root_id"] = reply_to
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -326,7 +443,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, "image", metadata
         )
 
     async def send_image_file(
@@ -339,7 +456,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -353,7 +470,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata
         )
 
     async def send_voice(
@@ -366,7 +483,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -379,7 +496,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -403,6 +520,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         kind: str = "file",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
         from tools.url_safety import is_safe_url
@@ -452,8 +570,12 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        thread_root_id = metadata.get("thread_id") if metadata else None
+        if self._reply_mode == "thread":
+            if thread_root_id:
+                payload["root_id"] = thread_root_id
+            elif reply_to:
+                payload["root_id"] = reply_to
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -467,6 +589,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -490,8 +613,12 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        thread_root_id = metadata.get("thread_id") if metadata else None
+        if self._reply_mode == "thread":
+            if thread_root_id:
+                payload["root_id"] = thread_root_id
+            elif reply_to:
+                payload["root_id"] = reply_to
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -612,6 +739,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        thread_id = post.get("root_id") or None
 
         # Mention-gating for non-DM channels.
         # Config (env vars):
@@ -626,16 +754,10 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
-            mention_patterns = [
-                f"@{self._bot_username}",
-                f"@{self._bot_user_id}",
-            ]
-            has_mention = any(
-                pattern.lower() in message_text.lower()
-                for pattern in mention_patterns
-            )
+            has_mention = self._has_mention(message_text)
+            thread_claimed_for_me = self._thread_is_claimed_for_me(channel_id, thread_id)
 
-            if require_mention and not is_free_channel and not has_mention:
+            if require_mention and not is_free_channel and not has_mention and not thread_claimed_for_me:
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
                     channel_id,
@@ -644,17 +766,20 @@ class MattermostAdapter(BasePlatformAdapter):
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
-                for pattern in mention_patterns:
-                    message_text = re.sub(
-                        re.escape(pattern), "", message_text, flags=re.IGNORECASE
-                    ).strip()
+                message_text = self._strip_mentions(message_text)
 
         # Resolve sender info.
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
+        if channel_type_raw != "D" and thread_id and self._is_thread_sticky_enabled():
+            active_agent = self._thread_state.get_active_agent(channel_id, thread_id)
+            entering_new_agent = has_mention and active_agent != self._profile_name
+            if has_mention:
+                self._thread_state.claim_thread(channel_id, thread_id, self._profile_name)
+            if entering_new_agent:
+                transcript = await self._build_thread_transcript(thread_id, exclude_post_id=post_id)
+                message_text = self._prepend_thread_context(transcript, message_text)
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -729,5 +854,3 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(msg_event)
-
-

--- a/gateway/platforms/mattermost_thread_state.py
+++ b/gateway/platforms/mattermost_thread_state.py
@@ -1,0 +1,96 @@
+"""Shared thread ownership state for Mattermost profiles.
+
+Each Hermes Mattermost profile runs as an independent process. To support
+"sticky" thread behavior across profiles, active thread ownership must live in
+shared storage rather than in-memory state.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_default_hermes_root
+
+
+class MattermostThreadStateStore:
+    """Persistent shared store for Mattermost thread ownership."""
+
+    def __init__(self, ttl_seconds: int = 7 * 24 * 3600):
+        self._ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+        self._path = self._db_path()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    @staticmethod
+    def _db_path() -> Path:
+        return get_default_hermes_root() / "shared" / "mattermost-thread-state.sqlite3"
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mattermost_thread_state (
+                    platform TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    active_agent_profile TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY (platform, channel_id, thread_id)
+                )
+                """
+            )
+
+    def _purge_expired(self, conn: sqlite3.Connection) -> None:
+        if self._ttl_seconds <= 0:
+            return
+        cutoff = int(time.time()) - self._ttl_seconds
+        conn.execute(
+            """
+            DELETE FROM mattermost_thread_state
+            WHERE platform = 'mattermost' AND updated_at < ?
+            """,
+            (cutoff,),
+        )
+
+    def claim_thread(self, channel_id: str, thread_id: str, active_agent_profile: str) -> None:
+        now = int(time.time())
+        with self._lock:
+            with self._connect() as conn:
+                self._purge_expired(conn)
+                conn.execute(
+                    """
+                    INSERT INTO mattermost_thread_state
+                        (platform, channel_id, thread_id, active_agent_profile, updated_at)
+                    VALUES ('mattermost', ?, ?, ?, ?)
+                    ON CONFLICT(platform, channel_id, thread_id)
+                    DO UPDATE SET
+                        active_agent_profile = excluded.active_agent_profile,
+                        updated_at = excluded.updated_at
+                    """,
+                    (channel_id, thread_id, active_agent_profile, now),
+                )
+
+    def get_active_agent(self, channel_id: str, thread_id: str) -> Optional[str]:
+        with self._lock:
+            with self._connect() as conn:
+                self._purge_expired(conn)
+                row = conn.execute(
+                    """
+                    SELECT active_agent_profile
+                    FROM mattermost_thread_state
+                    WHERE platform = 'mattermost' AND channel_id = ? AND thread_id = ?
+                    """,
+                    (channel_id, thread_id),
+                ).fetchone()
+        return row[0] if row else None
+

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -85,6 +85,18 @@ class TestMattermostConfigLoading:
         assert config.platforms[Platform.MATTERMOST].extra.get("url") == ""
 
 
+class TestMattermostThreadStateStore:
+    def test_persists_active_agent_across_instances(self, tmp_path):
+        from gateway.platforms.mattermost_thread_state import MattermostThreadStateStore
+
+        with patch("gateway.platforms.mattermost_thread_state.get_default_hermes_root", return_value=tmp_path):
+            first = MattermostThreadStateStore()
+            first.claim_thread("chan", "thread", "chief")
+
+            second = MattermostThreadStateStore()
+            assert second.get_active_agent("chan", "thread") == "chief"
+
+
 # ---------------------------------------------------------------------------
 # Adapter format / truncate
 # ---------------------------------------------------------------------------
@@ -99,6 +111,17 @@ def _make_adapter():
     )
     adapter = MattermostAdapter(config)
     return adapter
+
+
+class _FakeThreadState:
+    def __init__(self, active=None):
+        self.active = active or {}
+
+    def get_active_agent(self, channel_id, thread_id):
+        return self.active.get((channel_id, thread_id))
+
+    def claim_thread(self, channel_id, thread_id, active_agent_profile):
+        self.active[(channel_id, thread_id)] = active_agent_profile
 
 
 class TestMattermostFormatMessage:
@@ -240,6 +263,81 @@ class TestMattermostSend:
         self.adapter._session.post = MagicMock(return_value=mock_resp)
 
         result = await self.adapter.send("channel_1", "Reply!", reply_to="root_post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_thread_metadata_sets_root_id_when_reply_mode_thread(self):
+        """Existing Mattermost thread replies should honor metadata.thread_id in thread mode."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post790"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="current_post",
+            metadata={"thread_id": "thread_root"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "thread_root"
+
+    @pytest.mark.asyncio
+    async def test_send_thread_metadata_takes_precedence_over_reply_to(self):
+        """The upstream thread root must win over the current event message id."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post791"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="current_post",
+            metadata={"thread_id": "thread_root"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "thread_root"
+
+    @pytest.mark.asyncio
+    async def test_send_thread_metadata_is_ignored_when_reply_mode_off(self):
+        """Off mode should keep sending flat messages even if thread metadata exists."""
+        self.adapter._reply_mode = "off"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post792"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="current_post",
+            metadata={"thread_id": "thread_root"},
+        )
 
         assert result.success is True
         payload = self.adapter._session.post.call_args[1]["json"]
@@ -424,13 +522,15 @@ class TestMattermostMentionBehavior:
         self.adapter._bot_username = "hermes-bot"
         self.adapter.handle_message = AsyncMock()
 
-    def _make_event(self, message, channel_type="O", channel_id="chan_456"):
+    def _make_event(self, message, channel_type="O", channel_id="chan_456", root_id=None):
         post_data = {
             "id": "post_mention",
             "user_id": "user_123",
             "channel_id": channel_id,
             "message": message,
         }
+        if root_id:
+            post_data["root_id"] = root_id
         return {
             "event": "posted",
             "data": {
@@ -492,6 +592,98 @@ class TestMattermostMentionBehavior:
             msg = self.adapter.handle_message.call_args[0][0]
             assert "@hermes-bot" not in msg.text
             assert "2+2" in msg.text
+
+    @pytest.mark.asyncio
+    async def test_thread_sticky_continues_without_repeat_mention(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "true"}, clear=False):
+            self.adapter._thread_state = _FakeThreadState({("chan_456", "root_1"): "chief"})
+            self.adapter._profile_name = "chief"
+            await self.adapter._handle_ws_event(self._make_event("follow up", root_id="root_1"))
+            assert self.adapter.handle_message.called
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert msg.source.thread_id == "root_1"
+            assert msg.text == "follow up"
+
+    @pytest.mark.asyncio
+    async def test_thread_sticky_does_not_leak_to_other_agent(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "true"}, clear=False):
+            self.adapter._thread_state = _FakeThreadState({("chan_456", "root_1"): "chief"})
+            self.adapter._profile_name = "reviewer"
+            await self.adapter._handle_ws_event(self._make_event("follow up", root_id="root_1"))
+            assert not self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_thread_strict_mode_still_requires_mention(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "false"}, clear=False):
+            self.adapter._thread_state = _FakeThreadState({("chan_456", "root_1"): "chief"})
+            self.adapter._profile_name = "chief"
+            await self.adapter._handle_ws_event(self._make_event("follow up", root_id="root_1"))
+            assert not self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_explicit_thread_mention_claims_thread_for_agent(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "true"}, clear=False):
+            store = _FakeThreadState()
+            self.adapter._thread_state = store
+            self.adapter._profile_name = "chief"
+            self.adapter._api_get = AsyncMock(return_value={})
+            self.adapter._bot_username = "chief"
+            await self.adapter._handle_ws_event(
+                self._make_event("@chief please review", root_id="root_1")
+            )
+            assert self.adapter.handle_message.called
+            assert store.get_active_agent("chan_456", "root_1") == "chief"
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert "@chief" not in msg.text
+            assert "please review" in msg.text
+
+    @pytest.mark.asyncio
+    async def test_cross_agent_thread_entry_loads_public_transcript_and_switches_active_agent(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "true"}, clear=False):
+            store = _FakeThreadState({("chan_456", "root_1"): "chief"})
+            self.adapter._thread_state = store
+            self.adapter._profile_name = "reviewer"
+            self.adapter._bot_username = "reviewer"
+            self.adapter._session = object()
+            self.adapter._api_get = AsyncMock(return_value={
+                "order": ["root_1", "p2", "post_mention"],
+                "posts": {
+                    "root_1": {"id": "root_1", "user_id": "alice", "message": "project idea"},
+                    "p2": {"id": "p2", "user_id": "chief_bot", "message": "initial plan"},
+                    "post_mention": {"id": "post_mention", "user_id": "user_123", "message": "@reviewer please review"},
+                },
+            })
+            await self.adapter._handle_ws_event(
+                self._make_event("@reviewer please review", root_id="root_1")
+            )
+            assert self.adapter.handle_message.called
+            assert store.get_active_agent("chan_456", "root_1") == "reviewer"
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert "[Mattermost thread context]" in msg.text
+            assert "project idea" in msg.text
+            assert "initial plan" in msg.text
+            assert "please review" in msg.text
+            assert msg.text.count("please review") == 1
+
+    @pytest.mark.asyncio
+    async def test_remention_same_agent_in_thread_keeps_same_session_without_reloading_transcript(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_STICKY": "true"}, clear=False):
+            store = _FakeThreadState({("chan_456", "root_1"): "chief"})
+            self.adapter._thread_state = store
+            self.adapter._profile_name = "chief"
+            self.adapter._bot_username = "chief"
+            self.adapter._api_get = AsyncMock(return_value={
+                "order": ["root_1"],
+                "posts": {"root_1": {"id": "root_1", "user_id": "alice", "message": "hello"}},
+            })
+            await self.adapter._handle_ws_event(
+                self._make_event("@chief continue", root_id="root_1")
+            )
+            assert self.adapter.handle_message.called
+            self.adapter._api_get.assert_not_called()
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert "[Mattermost thread context]" not in msg.text
+            assert "continue" in msg.text
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -31,9 +31,6 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `GLM_BASE_URL` | Override z.ai base URL (default: `https://api.z.ai/api/paas/v4`) |
 | `KIMI_API_KEY` | Kimi / Moonshot AI API key ([moonshot.ai](https://platform.moonshot.ai)) |
 | `KIMI_BASE_URL` | Override Kimi base URL (default: `https://api.moonshot.ai/v1`) |
-| `KIMI_CN_API_KEY` | Kimi / Moonshot China API key ([moonshot.cn](https://platform.moonshot.cn)) |
-| `ARCEEAI_API_KEY` | Arcee AI API key ([chat.arcee.ai](https://chat.arcee.ai/)) |
-| `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)) |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/v1`) |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)) |
@@ -70,7 +67,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |
@@ -262,20 +259,12 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `BLUEBUBBLES_HOME_CHANNEL` | Phone/email for cron/notification delivery |
 | `BLUEBUBBLES_ALLOWED_USERS` | Comma-separated authorized users |
 | `BLUEBUBBLES_ALLOW_ALL_USERS` | Allow all users (`true`/`false`) |
-| `QQ_APP_ID` | QQ Bot App ID from [q.qq.com](https://q.qq.com) |
-| `QQ_CLIENT_SECRET` | QQ Bot App Secret from [q.qq.com](https://q.qq.com) |
-| `QQ_STT_API_KEY` | API key for external STT fallback provider (optional, used when QQ built-in ASR returns no text) |
-| `QQ_STT_BASE_URL` | Base URL for external STT provider (optional) |
-| `QQ_STT_MODEL` | Model name for external STT provider (optional) |
-| `QQ_ALLOWED_USERS` | Comma-separated QQ user openIDs allowed to message the bot |
-| `QQ_GROUP_ALLOWED_USERS` | Comma-separated QQ group IDs for group @-message access |
-| `QQ_ALLOW_ALL_USERS` | Allow all users (`true`/`false`, overrides `QQ_ALLOWED_USERS`) |
-| `QQ_HOME_CHANNEL` | QQ user/group openID for cron delivery and notifications |
 | `MATTERMOST_URL` | Mattermost server URL (e.g. `https://mm.example.com`) |
 | `MATTERMOST_TOKEN` | Bot token or personal access token for Mattermost |
 | `MATTERMOST_ALLOWED_USERS` | Comma-separated Mattermost user IDs allowed to message the bot |
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
+| `MATTERMOST_THREAD_STICKY` | Keep a thread bound to the most recently `@mentioned` agent so later replies in that thread do not need another `@mention` (default: `true`). Set to `false` to require `@mention` on every thread turn. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
@@ -340,19 +329,16 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 
 ## Context Compression (config.yaml only)
 
-Context compression is configured exclusively through `config.yaml` — there are no environment variables for it. Threshold settings live in the `compression:` block, while the summarization model/provider lives under `auxiliary.compression:`.
+Context compression is configured exclusively through the `compression` section in `config.yaml` — there are no environment variables for it.
 
 ```yaml
 compression:
   enabled: true
   threshold: 0.50
-  target_ratio: 0.20         # fraction of threshold to preserve as recent tail
-  protect_last_n: 20         # minimum recent messages to keep uncompressed
+  summary_model: ""                            # empty = use main configured model
+  summary_provider: auto
+  summary_base_url: null  # Custom OpenAI-compatible endpoint for summaries
 ```
-
-:::info Legacy migration
-Older configs with `compression.summary_model`, `compression.summary_provider`, and `compression.summary_base_url` are automatically migrated to `auxiliary.compression.*` on first load.
-:::
 
 ## Auxiliary Task Overrides
 

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -18,7 +18,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
+| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. With `MATTERMOST_THREAD_STICKY=true` (default), the first `@mention` claims that thread for the agent and later replies in the same thread do not need another `@mention` until a different agent is explicitly mentioned. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -153,6 +153,10 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 # Optional: respond without @mention (default: true = require mention)
 # MATTERMOST_REQUIRE_MENTION=false
 
+# Optional: once a thread is claimed by @mention, later replies in that
+# thread do not need another @mention (default: true)
+# MATTERMOST_THREAD_STICKY=true
+
 # Optional: channels where bot responds without @mention (comma-separated channel IDs)
 # MATTERMOST_FREE_RESPONSE_CHANNELS=channel_id_1,channel_id_2
 ```
@@ -219,11 +223,23 @@ By default, the bot only responds in channels when `@mentioned`. You can change 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
+| `MATTERMOST_THREAD_STICKY` | `true` | When a user first `@mentions` Hermes in a thread, that thread becomes sticky for the agent. Later replies in the same thread do not need another `@mention` unless a different agent is explicitly mentioned. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.
 
 When the bot is `@mentioned`, the mention is automatically stripped from the message before processing.
+
+### Cross-agent threads
+
+If you `@mention` a different Mattermost Hermes agent inside an already-active thread:
+
+- the newly mentioned agent opens its own session scoped to that thread
+- it reads the thread's visible public transcript before responding
+- it becomes the thread's active agent for later unmentioned replies
+
+Only the public thread transcript is shared. Hermes does **not** copy another
+agent's hidden session memory, tool output, or internal reasoning state.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What does this PR do?

Adds thread-aware Mattermost routing with a configurable sticky-thread mode.

This change targets the case where an agent is explicitly `@mentioned` inside a Mattermost thread. After that first explicit mention, the thread can stay bound to the active agent so later replies in the same thread do not need another `@mention`.

It also fixes the thread reply payload to prefer `metadata.thread_id` as the authoritative Mattermost thread root when `MATTERMOST_REPLY_MODE=thread`, while keeping `MATTERMOST_REPLY_MODE=off` as flat-channel behavior.

This PR overlaps with existing Mattermost thread work in #4230 and #6617, but adds two things that are not covered there:

- a configurable `MATTERMOST_THREAD_STICKY` mode
- persistent active-thread ownership shared across gateway processes via a small SQLite state store

It does **not** try to solve the separate scenario where a user opens a brand-new child thread under an agent-authored mainline post and expects that new thread to auto-inherit the agent without a fresh `@mention`.

## Related Issue

Related to #4221
Related to #6617

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 🔒 Security fix
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `gateway/platforms/mattermost_thread_state.py` with a shared SQLite-backed thread ownership store
- update `gateway/platforms/mattermost.py` to:
  - support `MATTERMOST_THREAD_STICKY`
  - allow already-claimed Mattermost threads to bypass repeated mention gating
  - switch thread ownership when another agent is explicitly mentioned
  - load visible Mattermost thread transcript when a different agent first enters the thread
  - prefer `metadata.thread_id` over `reply_to` when sending threaded replies
- add Mattermost gateway tests covering sticky routing, thread ownership persistence, transcript loading, and `root_id` selection
- document `MATTERMOST_THREAD_STICKY` and clarify `MATTERMOST_REPLY_MODE` in:
  - `website/docs/reference/environment-variables.md`
  - `website/docs/user-guide/messaging/mattermost.md`

## How to Test

1. Create a Mattermost thread and `@mention` an agent inside it.
2. Reply again in the same thread without another `@mention` and confirm the same agent continues the conversation.
3. In the same thread, `@mention` a different agent and confirm the new agent replies in the thread and becomes the active agent for later unmentioned replies.
4. Set `MATTERMOST_THREAD_STICKY=false` and confirm unmentioned follow-ups in a thread are ignored.
5. Set `MATTERMOST_REPLY_MODE=thread` and confirm replies in an existing thread use the correct Mattermost `root_id`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (via `uv run --extra dev pytest tests/gateway/test_mattermost.py -q`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run:

```bash
uv run --extra dev pytest tests/gateway/test_mattermost.py -q
56 passed in 1.76s
```
