### PR TITLE
fix(doctor): recognize KIMI_CN_API_KEY and handle kimi-cn probe safely

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -47,6 +47,7 @@ _PROVIDER_ENV_HINTS = (
     "KILOCODE_API_KEY",
     "DEEPSEEK_API_KEY",
     "DASHSCOPE_API_KEY",
+    "KIMI_CN_API_KEY",
     "HF_TOKEN",
     "AI_GATEWAY_API_KEY",
     "OPENCODE_ZEN_API_KEY",
@@ -749,7 +750,7 @@ def run_doctor(args):
             print(f"  Checking {_pname} API...", end="", flush=True)
             try:
                 import httpx
-                _base = os.getenv(_base_env, "")
+                _base = os.getenv(_base_env, "") if _base_env else ""
                 # Auto-detect Kimi Code keys (sk-kimi-) → api.kimi.com
                 if not _base and _key.startswith("sk-kimi-"):
                     _base = "https://api.kimi.com/coding/v1"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -36,6 +36,10 @@ class TestProviderEnvDetection:
         content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"
         assert _has_provider_env_config(content)
 
+    def test_detects_kimi_cn_api_key(self):
+        content = "KIMI_CN_API_KEY=***\n"
+        assert _has_provider_env_config(content)
+
     def test_detects_custom_endpoint_without_openrouter_key(self):
         content = "OPENAI_BASE_URL=http://localhost:8080/v1\n"
         assert _has_provider_env_config(content)
@@ -223,6 +227,44 @@ class TestDoctorMemoryProviderSection:
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
+
+    def test_kimi_cn_probe_does_not_crash_when_base_env_is_none(self, monkeypatch, tmp_path):
+        for key in (
+            "OPENROUTER_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "OPENAI_BASE_URL",
+            "NOUS_API_KEY",
+            "GLM_API_KEY",
+            "ZAI_API_KEY",
+            "Z_AI_API_KEY",
+            "KIMI_API_KEY",
+            "MINIMAX_API_KEY",
+            "MINIMAX_CN_API_KEY",
+            "KILOCODE_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "DASHSCOPE_API_KEY",
+            "KIMI_CN_API_KEY",
+            "HF_TOKEN",
+            "AI_GATEWAY_API_KEY",
+            "OPENCODE_ZEN_API_KEY",
+            "OPENCODE_GO_API_KEY",
+            "XIAOMI_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        monkeypatch.setenv("KIMI_CN_API_KEY", "test-kimi-cn-key")
+        monkeypatch.setitem(
+            sys.modules,
+            "httpx",
+            SimpleNamespace(get=lambda *args, **kwargs: SimpleNamespace(status_code=200)),
+        )
+
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+        assert "Kimi / Moonshot (China)" in out
+        assert "TypeError" not in out
 
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- add `KIMI_CN_API_KEY` to doctor's provider env hints
- make the Kimi / Moonshot (China) doctor probe null-safe when `base_env` is not set
- add regression coverage for both behaviors

## Why

`hermes doctor` appears to have two doctor-only issues for the `kimi-coding-cn` provider:

1. `KIMI_CN_API_KEY` is not included in doctor's provider env hints, so China-only Kimi setups can be misclassified as missing provider credentials
2. the Kimi China probe entry uses `base_env=None`, but the later probe loop still calls `os.getenv(_base_env, "")` unconditionally, which can raise `TypeError: str expected, not NoneType`

This PR keeps the fix intentionally narrow and limits it to the diagnostic layer in `hermes_cli/doctor.py`.

Fixes #9716

## Tests

I added regression coverage in `tests/hermes_cli/test_doctor.py` for:
- recognizing `KIMI_CN_API_KEY` as a configured provider env
- ensuring the Kimi China doctor probe no longer crashes when `base_env` is `None`

Local verification:
- `python -m pytest -o addopts='' tests/hermes_cli/test_doctor.py -q`
- result: `19 passed`

The repository's default pytest configuration includes `-n`, which is not available in this local environment, so I ran the same test file with `addopts` disabled.
