### PR TITLE
fix(gateway/bluebubbles): fall back to data.chats[0].guid when chatGuid missing

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -835,6 +835,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             payload.get("chat_guid"),
             payload.get("guid"),
         )
+        # Fallback: BlueBubbles v1.9+ webhook payloads omit top-level chatGuid;
+        # the chat GUID is nested under data.chats[0].guid instead.
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
         chat_identifier = self._value(
             record.get("chatIdentifier"),
             record.get("identifier"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -167,6 +167,63 @@ class TestBlueBubblesWebhookParsing:
             chat_identifier = sender
         assert chat_identifier == "user@example.com"
 
+    def test_webhook_extracts_chat_guid_from_chats_array_dm(self, monkeypatch):
+        """BB v1.9+ webhook payloads omit top-level chatGuid; GUID is in chats[0].guid."""
+        adapter = _make_adapter(monkeypatch)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "MESSAGE-GUID",
+                "text": "hello",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chats": [
+                    {"guid": "any;-;+15551234567", "chatIdentifier": "+15551234567"}
+                ],
+            },
+        }
+        record = adapter._extract_payload_record(payload) or {}
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            payload.get("chatGuid"),
+            record.get("chat_guid"),
+            payload.get("chat_guid"),
+            payload.get("guid"),
+        )
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        assert chat_guid == "any;-;+15551234567"
+
+    def test_webhook_extracts_chat_guid_from_chats_array_group(self, monkeypatch):
+        """Group chat GUIDs contain ;+; and must be extracted from chats array."""
+        adapter = _make_adapter(monkeypatch)
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "MESSAGE-GUID",
+                "text": "hello everyone",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "any;+;chat-uuid-abc123"}],
+            },
+        }
+        record = adapter._extract_payload_record(payload) or {}
+        chat_guid = adapter._value(
+            record.get("chatGuid"),
+            payload.get("chatGuid"),
+            record.get("chat_guid"),
+            payload.get("chat_guid"),
+            payload.get("guid"),
+        )
+        if not chat_guid:
+            _chats = record.get("chats") or []
+            if _chats and isinstance(_chats[0], dict):
+                chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
+        assert chat_guid == "any;+;chat-uuid-abc123"
+
     def test_extract_payload_record_accepts_list_data(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {


### PR DESCRIPTION
## Summary

When BlueBubbles v1.9+ fires a webhook for a new message, the payload's top-level `chatGuid` field is sometimes absent — the chat GUID is only available in the `chats` array at `data.chats[0].guid`. The BlueBubbles adapter currently checks five fallback locations for `chatGuid` (record and payload, snake_case and camelCase, plus `payload.guid`) but doesn't look inside the `chats` array, so it falls through to using the sender's phone/email as the session chat ID.

This causes two observable bugs when a user is a participant in both a DM and a group chat with the bot:

1. **DM and group sessions merge.** Every message from that user ends up with the same `session_chat_id` (their own address), so the bot can't distinguish which thread the message came from.

2. **Outbound routing becomes ambiguous.** `_resolve_chat_guid()` iterates all chats and returns the first one where the address appears as a participant; group chats typically sort ahead of DMs by activity, so replies and cron messages intended for the DM can land in a group chat.

Observed in production: a user's scheduled morning brief was delivered to a group chat with his spouse instead of his DM thread. Confirmed by other users in [this Discord thread](https://discord.gg/NousResearch) and endorsed by @Gille as a real adapter bug worth a PR.

## Fix

Adds a single fallback in `_handle_webhook` that extracts `chat_guid` from `record[\"chats\"][0][\"guid\"]` when the existing top-level lookups return nothing. The `chats` array is included in every `new-message` webhook payload in BB v1.9.9 (verified against a live server).

Backwards compatible — if a future BB version starts including `chatGuid` at the top level, that path still wins.

## Test plan

- [x] Added `test_webhook_extracts_chat_guid_from_chats_array_dm` — real BB v1.9.9 DM payload shape
- [x] Added `test_webhook_extracts_chat_guid_from_chats_array_group` — group chat payload with `;+;` GUID
- [x] Existing `test_webhook_prefers_chat_guid_over_message_guid` still passes (top-level `chatGuid` still wins when present)
- [x] Verified live on BB v1.9.9: DM messages now carry `any;-;<phone>` as `session_chat_id`, group messages carry `any;+;<chat-uuid>`, outbound routing no longer cross-contaminates