### PR TITLE
fix(gateway/bluebubbles): remove invalid "message" from webhook event registration

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -257,7 +257,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message", "message"],
+            "events": ["new-message", "updated-message"],
         }
 
         try:


### PR DESCRIPTION
## Summary

The BlueBubbles adapter registers its webhook with three events: `["new-message", "updated-message", "message"]`. The third, `"message"`, is not a valid event type in the BlueBubbles server API — BB rejects the registration payload with HTTP 400 Bad Request.

Currently this is masked by the crash-resilience check in `_register_webhook`, which reuses any existing registration matching the webhook URL and short-circuits before reaching the API call. So an already-registered webhook from a prior run keeps working. But any fresh install, or any restart after `_unregister_webhook` has run during a clean shutdown, fails to re-register and silently stops receiving messages.

**Observed in production:** after a gateway restart on v0.9.0 (which auto-unregisters on shutdown), the next startup hit this 400 and the bot went silent until the invalid event was removed. Error log:

```
WARNING gateway.platforms.bluebubbles: [bluebubbles] failed to register webhook with server:
Client error '400 Bad Request' for url 'http://localhost:1234/api/v1/webhook?password=***'
```

## Fix

Drop `"message"` from the event list. BlueBubbles documents `new-message` and `updated-message` as the message event types ([BB docs](https://docs.bluebubbles.app/)); there is no `"message"` event. The two remaining events cover all inbound message webhooks, so no functionality is lost.

## Test plan

- [x] Verified live on BB v1.9.9: after removing `"message"`, registration returns 200 and webhook receives events as expected
- [x] Confirmed the full gateway flow (receive message → agent response → send back) works end-to-end