### PR TITLE
fix(config): avoid silent Windows .env decoding corruption

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2637,11 +2637,16 @@ def load_env() -> Dict[str, str]:
     env_vars = {}
     
     if env_path.exists():
-        # On Windows, open() defaults to the system locale (cp1252) which can
-        # fail on UTF-8 .env files. Use explicit UTF-8 only on Windows.
-        open_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
-        with open(env_path, **open_kw) as f:
-            raw_lines = f.readlines()
+        # On Windows, .env files may be saved in cp1252. Try UTF-8 first so
+        # modern files still work, then fall back instead of silently
+        # replacing bytes and corrupting values like paths/passwords.
+        try:
+            open_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+            with open(env_path, **open_kw) as f:
+                raw_lines = f.readlines()
+        except UnicodeDecodeError:
+            with open(env_path, encoding="latin-1") as f:
+                raw_lines = f.readlines()
         # Sanitize before parsing: split concatenated lines & drop stale
         # placeholders so corrupted .env files don't produce invalid tokens.
         lines = _sanitize_env_lines(raw_lines)
@@ -2715,11 +2720,15 @@ def sanitize_env_file() -> int:
     if not env_path.exists():
         return 0
 
-    read_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
     write_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
 
-    with open(env_path, **read_kw) as f:
-        original_lines = f.readlines()
+    try:
+        read_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+        with open(env_path, **read_kw) as f:
+            original_lines = f.readlines()
+    except UnicodeDecodeError:
+        with open(env_path, encoding="latin-1") as f:
+            original_lines = f.readlines()
 
     sanitized = _sanitize_env_lines(original_lines)
 
@@ -2763,13 +2772,17 @@ def save_env_value(key: str, value: str):
     
     # On Windows, open() defaults to the system locale (cp1252) which can
     # cause OSError errno 22 on UTF-8 .env files.
-    read_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
     write_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
 
     lines = []
     if env_path.exists():
-        with open(env_path, **read_kw) as f:
-            lines = f.readlines()
+        try:
+            read_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+            with open(env_path, **read_kw) as f:
+                lines = f.readlines()
+        except UnicodeDecodeError:
+            with open(env_path, encoding="latin-1") as f:
+                lines = f.readlines()
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
     
@@ -2827,11 +2840,15 @@ def remove_env_value(key: str) -> bool:
         os.environ.pop(key, None)
         return False
 
-    read_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
     write_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
 
-    with open(env_path, **read_kw) as f:
-        lines = f.readlines()
+    try:
+        read_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+        with open(env_path, **read_kw) as f:
+            lines = f.readlines()
+    except UnicodeDecodeError:
+        with open(env_path, encoding="latin-1") as f:
+            lines = f.readlines()
     lines = _sanitize_env_lines(lines)
 
     new_lines = [line for line in lines if not line.strip().startswith(f"{key}=")]

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -151,6 +151,16 @@ class TestSaveEnvValueSecure:
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
 
+    def test_load_env_windows_falls_back_to_latin1_for_cp1252_files(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_bytes(b"MESSAGING_CWD=Caf\xe9\n")
+
+        with patch("hermes_cli.config._IS_WINDOWS", True), \
+             patch("hermes_cli.config.get_env_path", return_value=env_path):
+            env_values = load_env()
+
+        assert env_values["MESSAGING_CWD"] == "Caf\xe9"
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):


### PR DESCRIPTION
## Root Cause

On Windows, `hermes_cli.config` read `.env` files using `encoding="utf-8", errors="replace"`.

This caused decode errors to be silently masked instead of handled explicitly, which could corrupt non-ASCII values from legacy single-byte encoded `.env` files. In practice, values such as `MESSAGING_CWD=Café` could be loaded as `Caf�`.

## Repro

1. Write a Windows `.env` file containing cp1252-encoded non-ASCII bytes.
2. Call `load_env()`.
3. Before this change, the decoded value is corrupted.

Example:
- expected: `Café`
- actual before fix: `Caf�`

## Fix Summary

Keep the existing control flow, but change the Windows decode behavior to:

- try UTF-8 first
- fall back to `latin-1` on `UnicodeDecodeError`

Applied the same minimal fallback to all relevant `.env` read sites in `hermes_cli.config`:

- `load_env()`
- `sanitize_env_file()`
- `save_env_value()`
- `remove_env_value()`

This keeps UTF-8 behavior unchanged for normal cases while avoiding silent corruption for legacy single-byte encoded files.

## Test Evidence

Added regression test:
- `test_load_env_windows_falls_back_to_latin1_for_cp1252_files`

Relevant test run:
- `tests/hermes_cli/test_config.py`
- `tests/hermes_cli/test_env_loader.py`
- `tests/hermes_cli/test_env_sanitize_on_load.py`


- `55 passed in 0.59s`