### PR TITLE
fix(config): support multiple and wildcard models for subagents for different task profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -608,6 +608,10 @@ DEFAULT_CONFIG = {
                                # independent of the parent's max_iterations)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "allowed_models": [],    # allowlist for subagent `model` overrides. Entries may be
+                                 # fnmatch strings (e.g. "anthropic/*") or dicts
+                                 # ({model: ..., provider: ...}) that pin a provider per model
+                                 # so the allowlist doubles as a router. Empty = no restriction.
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -29,6 +29,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _match_allowed_model,
 )
 
 
@@ -1276,6 +1277,197 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
+
+
+def _run_ok(task_index=0):
+    return {
+        "task_index": task_index, "status": "completed",
+        "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+    }
+
+
+class TestModelOverride(unittest.TestCase):
+    """Tests for delegate_task `model` parameter (top-level + per-task)."""
+
+    def test_schema_has_model_fields(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_top_level_model_forwarded_to_child(self, mock_run, mock_build, mock_cfg):
+        """Top-level `model` param overrides config's delegation.model."""
+        mock_cfg.return_value = {
+            "max_iterations": 50, "model": "config/fallback",
+            "provider": "", "allowed_models": [],
+        }
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = _run_ok()
+
+        delegate_task(
+            goal="do something",
+            model="per-call/override",
+            parent_agent=_make_mock_parent(),
+        )
+        self.assertEqual(mock_build.call_args[1]["model"], "per-call/override")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_model_overrides_top_level(self, mock_run, mock_build, mock_cfg):
+        """Each task's `model` field wins over the top-level `model` param;
+        tasks without a `model` field fall back to the top-level value."""
+        mock_cfg.return_value = {
+            "max_iterations": 50, "model": "",
+            "provider": "", "allowed_models": [],
+        }
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = [_run_ok(0), _run_ok(1)]
+
+        delegate_task(
+            tasks=[
+                {"goal": "Task A", "model": "anthropic/claude-haiku-4.5"},
+                {"goal": "Task B"},  # falls back to top-level
+            ],
+            model="top-level/model",
+            parent_agent=_make_mock_parent(),
+        )
+
+        calls = mock_build.call_args_list
+        self.assertEqual(calls[0][1]["model"], "anthropic/claude-haiku-4.5")
+        self.assertEqual(calls[1][1]["model"], "top-level/model")
+
+
+class TestAllowedModels(unittest.TestCase):
+    """Tests for delegation.allowed_models allowlist enforcement."""
+
+    def test_matcher_empty_allowlist_permits_any(self):
+        self.assertEqual(_match_allowed_model("anthropic/claude-opus-4.6", []), (None, None))
+
+    def test_matcher_wildcard_match_and_block(self):
+        self.assertEqual(
+            _match_allowed_model("anthropic/claude-haiku-4.5", ["anthropic/*"]),
+            (None, None),
+        )
+        err, prov = _match_allowed_model("openai/gpt-4o", ["anthropic/*"])
+        self.assertIsNotNone(err)
+        self.assertIn("openai/gpt-4o", err)
+        self.assertIn("allowed_models", err)
+        self.assertIsNone(prov)
+
+    def test_matcher_dict_entry_routes_to_provider(self):
+        """Dict entries pin a provider for their exact model."""
+        allowlist = [
+            "anthropic/*",
+            {"model": "google/gemini-2.5-flash", "provider": "openrouter"},
+            {"model": "meta-llama/llama-4-scout", "provider": "nous"},
+        ]
+        # Dict entries match exactly and return the routed provider
+        self.assertEqual(
+            _match_allowed_model("google/gemini-2.5-flash", allowlist),
+            (None, "openrouter"),
+        )
+        self.assertEqual(
+            _match_allowed_model("meta-llama/llama-4-scout", allowlist),
+            (None, "nous"),
+        )
+        # String patterns still match and return no provider override
+        self.assertEqual(
+            _match_allowed_model("anthropic/claude-opus-4.6", allowlist),
+            (None, None),
+        )
+        # Non-matches still produce an error
+        err, prov = _match_allowed_model("openai/gpt-4o", allowlist)
+        self.assertIsNotNone(err)
+        self.assertIsNone(prov)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_top_level_model_blocked_by_allowlist(self, mock_run, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 50, "model": "", "provider": "",
+            "allowed_models": ["anthropic/*"],
+        }
+        result = json.loads(delegate_task(
+            goal="do something",
+            model="openai/gpt-4o",
+            parent_agent=_make_mock_parent(),
+        ))
+        self.assertIn("error", result)
+        self.assertIn("openai/gpt-4o", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_model_blocked_by_allowlist(self, mock_run, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 50, "model": "", "provider": "",
+            "allowed_models": ["anthropic/*"],
+        }
+        result = json.loads(delegate_task(
+            tasks=[{"goal": "task A", "model": "openai/gpt-4o"}],
+            parent_agent=_make_mock_parent(),
+        ))
+        self.assertIn("error", result)
+        self.assertIn("Task 0", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_dict_entry_reroutes_per_task_provider(
+        self, mock_run, mock_build, mock_cfg, mock_resolve
+    ):
+        """A dict allowlist entry re-resolves credentials for that provider."""
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "model": "",
+            "provider": "anthropic",
+            "allowed_models": [
+                "anthropic/*",
+                {"model": "google/gemini-2.5-flash", "provider": "openrouter"},
+            ],
+        }
+        anthropic_creds = {
+            "model": "", "provider": "anthropic",
+            "base_url": "https://api.anthropic.com", "api_key": "ak-anthropic",
+            "api_mode": "anthropic_messages",
+        }
+        openrouter_creds = {
+            "model": "google/gemini-2.5-flash", "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1", "api_key": "ak-openrouter",
+            "api_mode": "chat_completions",
+        }
+        # First call: initial delegation creds resolution (anthropic default)
+        # Second call: re-resolution for the routed openrouter task
+        mock_resolve.side_effect = [anthropic_creds, openrouter_creds]
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = [_run_ok(0), _run_ok(1)]
+
+        delegate_task(
+            tasks=[
+                {"goal": "Task A", "model": "anthropic/claude-opus-4.6"},
+                {"goal": "Task B", "model": "google/gemini-2.5-flash"},
+            ],
+            parent_agent=_make_mock_parent(),
+        )
+
+        # Two builds, one per task
+        self.assertEqual(mock_build.call_count, 2)
+        calls = mock_build.call_args_list
+        # Task A: anthropic model, keeps anthropic creds
+        self.assertEqual(calls[0][1]["model"], "anthropic/claude-opus-4.6")
+        self.assertEqual(calls[0][1]["override_provider"], "anthropic")
+        self.assertEqual(calls[0][1]["override_api_key"], "ak-anthropic")
+        # Task B: routed via dict entry to openrouter creds
+        self.assertEqual(calls[1][1]["model"], "google/gemini-2.5-flash")
+        self.assertEqual(calls[1][1]["override_provider"], "openrouter")
+        self.assertEqual(calls[1][1]["override_api_key"], "ak-openrouter")
+        # Only one extra resolve call (the cache should prevent more)
+        self.assertEqual(mock_resolve.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import fnmatch
 import json
 import logging
 logger = logging.getLogger(__name__)
@@ -620,11 +621,48 @@ def _run_single_child(
         except Exception:
             logger.debug("Failed to close child agent after delegation")
 
+def _match_allowed_model(
+    model: str, allowed_models: list
+) -> "tuple[Optional[str], Optional[str]]":
+    """Match a requested model against `delegation.allowed_models`.
+
+    Entries may be either:
+      - A string fnmatch pattern (e.g. "anthropic/*") — permits any matching
+        model and reuses the default resolved delegation provider.
+      - A dict ``{"model": <exact model id>, "provider": <provider name>}`` —
+        permits that exact model and pins the named provider for it, so the
+        allowlist doubles as a model→provider router.
+
+    Returns ``(error, provider_override)``:
+      - ``(None, None)`` — permitted with no provider change (empty allowlist
+        or string-pattern match).
+      - ``(None, <provider>)`` — permitted; re-resolve credentials against
+        ``<provider>`` for this task.
+      - ``(<error_msg>, None)`` — not permitted.
+    """
+    if not allowed_models:
+        return None, None
+    for entry in allowed_models:
+        if isinstance(entry, dict):
+            if entry.get("model") == model:
+                prov = (entry.get("provider") or "").strip() or None
+                return None, prov
+        elif isinstance(entry, str):
+            if fnmatch.fnmatch(model, entry):
+                return None, None
+    return (
+        f"Model '{model}' is not in delegation.allowed_models "
+        f"({allowed_models}).",
+        None,
+    )
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    model: Optional[str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -634,8 +672,8 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+      - Single: provide goal (+ optional context, toolsets, model)
+      - Batch:  provide tasks array [{goal, context, toolsets, model}, ...]
 
     Returns JSON with results array, one entry per task.
     """
@@ -656,6 +694,7 @@ def delegate_task(
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
+    allowed_models: list = cfg.get("allowed_models") or []
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -666,6 +705,22 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Top-level model param overrides delegation.model from config.
+    # Per-task model fields (set below) override this further.
+    if model and model.strip():
+        creds = dict(creds)
+        creds["model"] = model.strip()
+
+    # Validate top-level model override against allowlist. A dict-form entry
+    # may route this model to a different provider; capture that as the
+    # default provider override for any task that inherits this model.
+    top_provider_override: Optional[str] = None
+    if creds.get("model") and allowed_models:
+        err, prov = _match_allowed_model(creds["model"], allowed_models)
+        if err:
+            return tool_error(err)
+        top_provider_override = prov
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -687,10 +742,25 @@ def delegate_task(
     if not task_list:
         return tool_error("No tasks provided.")
 
-    # Validate each task has a goal
+    # Validate each task has a goal, and check per-task model overrides
+    # against the allowlist. Capture any provider override produced by a
+    # dict-form entry so the build loop can re-resolve creds for it.
+    task_provider_overrides: Dict[int, str] = {}
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        task_model = (task.get("model") or "").strip()
+        if task_model:
+            if allowed_models:
+                err, prov = _match_allowed_model(task_model, allowed_models)
+                if err:
+                    return tool_error(f"Task {i}: {err}")
+                if prov:
+                    task_provider_overrides[i] = prov
+        elif top_provider_override:
+            # Task inherits the top-level model; also inherit its dict-routed
+            # provider so the child runs on the same routed credentials.
+            task_provider_overrides[i] = top_provider_override
 
     overall_start = time.monotonic()
     results = []
@@ -709,15 +779,40 @@ def delegate_task(
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
+    # Cache provider re-resolution across tasks that share the same routed
+    # provider so we don't hit runtime_provider more than once per provider.
+    provider_creds_cache: Dict[str, dict] = {}
     try:
         for i, t in enumerate(task_list):
+            # Per-task model overrides the resolved creds, letting batch tasks
+            # each target a different model on the same provider.
+            task_model = (t.get("model") or "").strip() or creds["model"]
+
+            # If the allowlist routed this task to a different provider,
+            # re-resolve a full credential bundle for that provider once.
+            task_creds = creds
+            routed_provider = task_provider_overrides.get(i)
+            if routed_provider and routed_provider != creds.get("provider"):
+                if routed_provider not in provider_creds_cache:
+                    try:
+                        provider_creds_cache[routed_provider] = (
+                            _resolve_delegation_credentials(
+                                {"provider": routed_provider, "model": task_model},
+                                parent_agent,
+                            )
+                        )
+                    except ValueError as exc:
+                        return tool_error(f"Task {i}: {exc}")
+                task_creds = provider_creds_cache[routed_provider]
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=task_model,
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
             )
@@ -1019,6 +1114,14 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for subagents (e.g. 'anthropic/claude-sonnet-4.6'). "
+                    "Overrides delegation.model from config; keeps the resolved provider. "
+                    "Must match delegation.allowed_models if that list is set."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -1030,6 +1133,13 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override. Takes priority over the top-level "
+                                "model param for this task only."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
@@ -1094,6 +1204,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        model=args.get("model"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -158,6 +158,36 @@ Each subagent gets its own terminal session. They can work on the same project d
 
 ---
 
+## Pattern: Right-Size the Model
+
+Match model capability to task complexity to keep costs down by passing a `model` per task:
+
+```python
+delegate_task(tasks=[
+    {
+        "goal": "Audit the payment processing code for security vulnerabilities",
+        "context": "Project at /home/user/app. Payment code: src/payments/.",
+        "model": "anthropic/claude-opus-4.6",   # heavy reasoning
+        "toolsets": ["file"]
+    },
+    {
+        "goal": "Reformat CHANGELOG.md so each version header is an H2",
+        "context": "File at /home/user/app/CHANGELOG.md",
+        "model": "anthropic/claude-haiku-4.5",  # cheap, mechanical
+        "toolsets": ["file"]
+    },
+    {
+        "goal": "Find the latest stable release version of FastAPI",
+        "model": "google/gemini-2.5-flash",     # fast for web lookup
+        "toolsets": ["web"]
+    },
+])
+```
+
+By default the per-task `model` reuses the currently-resolved delegation provider. If you want each model to target a different provider, list them as `{model, provider}` dicts under `delegation.allowed_models` — the allowlist then doubles as a router. See [Model Override](/docs/user-guide/features/delegation#model-override).
+
+---
+
 ## Pattern: Gather Then Analyze
 
 Use `execute_code` for mechanical data gathering, then delegate the reasoning-heavy analysis:
@@ -221,6 +251,7 @@ Restricting toolsets keeps the subagent focused and prevents accidental side eff
 - **Separate terminals** — each subagent gets its own terminal session with separate working directory and state
 - **No conversation history** — subagents see only what you put in `goal` and `context`
 - **Default 50 iterations** — set `max_iterations` lower for simple tasks to save cost
+- **Model allowlist** — if `delegation.allowed_models` is configured, `model` values must match a listed pattern
 
 ---
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1254,6 +1254,12 @@ delegation:
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
+  # allowed_models:                         # Model allowlist for delegate_task model param (empty = any model)
+  #   - "anthropic/*"                       # fnmatch string, reuses default provider
+  #   - model: "google/gemini-2.5-flash"    # dict form, pins provider per model
+  #     provider: "openrouter"
+  #   - model: "meta-llama/llama-4-scout"
+  #     provider: "nous"
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
@@ -1262,7 +1268,9 @@ delegation:
 
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
-**Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+**Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). For model selection: per-task `model` field → top-level `model` param passed to `delegate_task` → `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+
+**Allowed models:** When `delegation.allowed_models` is set, any `model` override passed to `delegate_task` must match one of its entries. Entries may be [fnmatch](https://docs.python.org/3/library/fnmatch.html) strings (e.g. `anthropic/*`) that reuse the default delegation provider, or `{model, provider}` dicts that pin a specific provider for a specific model — so the allowlist doubles as a model→provider router. Dict-routed tasks have their credentials re-resolved on demand via the same runtime provider system used by CLI/gateway startup. An empty list (the default) permits any model.
 
 ## Clarify
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -119,10 +119,9 @@ delegate_task(
 
 ## Batch Mode Details
 
-When you provide a `tasks` array, subagents run in **parallel** using a thread pool:
+When you provide a `tasks` array, subagents run in **parallel** via a `ThreadPoolExecutor`:
 
-- **Maximum concurrency:** 3 tasks (the `tasks` array is truncated to 3 if longer)
-- **Thread pool:** Uses `ThreadPoolExecutor` with `MAX_CONCURRENT_CHILDREN = 3` workers
+- **Maximum concurrency:** Default 3, configurable via `delegation.max_concurrent_children` in `config.yaml`. Exceeding the limit returns an error — split the batch or raise the limit.
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
 - **Interrupt propagation:** Interrupting the parent (e.g., sending a new message) interrupts all active children
@@ -131,16 +130,65 @@ Single-task delegation runs directly without thread pool overhead.
 
 ## Model Override
 
-You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
+Subagents inherit the parent's model by default. You can route them to a different model at three levels:
 
-```yaml
-# In ~/.hermes/config.yaml
-delegation:
-  model: "google/gemini-flash-2.0"    # Cheaper model for subagents
-  provider: "openrouter"              # Optional: route subagents to a different provider
+```python
+# Per-call (highest precedence): pass `model` to delegate_task
+delegate_task(
+    goal="Summarize these release notes",
+    model="google/gemini-2.5-flash",
+    toolsets=["file"],
+)
+
+# Per-task in batch mode: each task chooses its own model (and toolsets)
+delegate_task(tasks=[
+    {
+        "goal": "Deep architectural review of src/auth/",
+        "model": "anthropic/claude-opus-4.6",   # heavy reasoning
+        "toolsets": ["file"],
+    },
+    {
+        "goal": "Fix typos in the README",
+        "model": "anthropic/claude-haiku-4.5",  # cheap, mechanical
+        "toolsets": ["file"],
+    },
+    {
+        "goal": "Find the latest stable FastAPI release version",
+        "model": "google/gemini-2.5-flash",     # fast for web lookup
+        "toolsets": ["web"],
+    },
+])
 ```
 
-If omitted, subagents use the same model as the parent.
+Or set a session-wide default in `config.yaml`:
+
+```yaml
+delegation:
+  model: "google/gemini-flash-2.0"    # default for all subagents
+  provider: "openrouter"              # optional provider override
+```
+
+**Resolution order:** per-task `model` → top-level `model` param → `delegation.model` → parent model. The resolved provider from config (or parent) is always reused; override `delegation.provider` if subagents need a different provider.
+
+### Allowed models
+
+To cap which models subagents can be sent to, configure an allowlist. Entries may be either [fnmatch](https://docs.python.org/3/library/fnmatch.html) strings that reuse the default delegation provider, or `{model, provider}` dicts that pin a provider per model — so the allowlist doubles as a model→provider router:
+
+```yaml
+delegation:
+  model: "anthropic/claude-sonnet-4.6"     # default model for subagents
+  provider: "anthropic"                    # default provider for subagents
+  allowed_models:
+    - "anthropic/*"                        # any Anthropic model, runs on the default provider
+    - model: "google/gemini-2.5-flash"     # exact match, routed to a specific provider
+      provider: "openrouter"
+    - model: "meta-llama/llama-4-scout"
+      provider: "nous"
+```
+
+With that config, a subagent asking for `anthropic/claude-opus-4.6` runs on the default Anthropic creds, while `google/gemini-2.5-flash` and `meta-llama/llama-4-scout` each get routed to their own provider bundle (base URL, API key, API mode are re-resolved on demand via the same runtime provider system used by CLI/gateway startup).
+
+When `allowed_models` is set, any `model` override that does not match returns an error before spawning. An empty list (the default) allows any model.
 
 ## Toolset Selection Tips
 
@@ -206,9 +254,12 @@ Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children 
 # In ~/.hermes/config.yaml
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets
-  model: "google/gemini-3-flash-preview"             # Optional provider/model override
-  provider: "openrouter"                             # Optional built-in provider
+  model: "google/gemini-3-flash-preview"    # Optional default model for subagents
+  provider: "openrouter"                    # Optional default provider for subagents
+  allowed_models:                           # Optional model allowlist (empty = any model allowed)
+    - "anthropic/*"                         # fnmatch string: reuses default provider
+    - model: "google/gemini-2.5-flash"      # dict form: pins provider for that model
+      provider: "openrouter"
 
 # Or use a direct custom endpoint instead of provider:
 delegation:


### PR DESCRIPTION
Adds support for allow listing various model ids that subagents can defer too. Sometimes you want a setup where you can defer to Opus for things like planning and reasoning, but also use smaller models like LFM for quick edits or parsing.

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

