### PR TITLE
fix(alibaba): accept both DASHSCOPE_API_KEY and ALIBABA_API_KEY env vars

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -179,7 +179,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
         inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        api_key_env_vars=("DASHSCOPE_API_KEY",),
+        api_key_env_vars=("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),
     "minimax-cn": ProviderConfig(

--- a/run_agent.py
+++ b/run_agent.py
@@ -894,9 +894,13 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        # Provider-specific env var mappings for providers with non-obvious key names
+                        _provider_env_var_hint = {
+                            "alibaba": "DASHSCOPE_API_KEY (or ALIBABA_API_KEY)",
+                        }.get(_explicit, f"{_explicit.upper()}_API_KEY")
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_provider_env_var_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key


### PR DESCRIPTION
- Add ALIBABA_API_KEY as fallback env var for alibaba provider
- Update error message to show correct env var names for alibaba
- Fixes #9506

  When the `alibaba` provider is set in config.yaml but no API key is    
  found, the error message instructs users to set `ALIBABA_API_KEY`, but
  the actual env var Hermes reads is `DASHSCOPE_API_KEY`.                
                                                            
  ### Changes

  **1. hermes_cli/auth.py** - Add ALIBABA_API_KEY as fallback env var for alibaba provider
  
  ```python
  api_key_env_vars=("DASHSCOPE_API_KEY", "ALIBABA_API_KEY"),
  ```
                                                                       
  **2. run_agent.py**  - Updated error message to show correct env var names

  ```python
  _provider_env_var_hint = {                                             
      "alibaba": "DASHSCOPE_API_KEY (or ALIBABA_API_KEY)",  
  }.get(_explicit, f"{_explicit.upper()}_API_KEY")
```   

  Before / After
                                                                         
  Before: Error says ALIBABA_API_KEY (which doesn't work)                
  After: Error says DASHSCOPE_API_KEY (or ALIBABA_API_KEY) (both work)
                                                                         
  Testing                                                   

  - Verified auth.py loads both env vars correctly                       
  - Verified error message logic for all providers
                                                                         
  Checklist                                                 

  - Follow Conventional Commits
  - Only changes related to this fix
  - Tested on macOS