### PR TITLE
fix(auth): update Z.AI coding plan probe model to glm-5.1

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -388,8 +388,8 @@ ZAI_ENDPOINTS = [
     # (id, base_url, default_model, label)
     ("global",        "https://api.z.ai/api/paas/v4",        "glm-5",   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", "glm-5",   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  "glm-4.7", "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", "glm-4.7", "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  "glm-5.1", "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", "glm-5.1", "China (Coding Plan)"),
 ]
 
 


### PR DESCRIPTION
Updates the Z.AI coding plan endpoint detection probe from "glm-4.7" to "glm-5.1".

The endpoint detector probes each candidate URL with a real API call using a hard-coded model. Newer Z.AI Coding Plan accounts only have access to "glm-5.1", so the old probe with "glm-4.7" would fail and fall back to the general "paas" endpoint, which then returns "Insufficient balance" (1113) for coding-only keys.

With this change, coding plan keys are correctly routed to the "api/coding/paas/v4" endpoint and can use "glm-5.1".

Fixes #8461