### PR TITLE
fix(model_switch): allow vendor:model colon format on all providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -572,12 +572,12 @@ def switch_model(
                         ),
                     )
             else:
-                # --- Step c: On aggregator, convert vendor:model to vendor/model ---
+                # --- Step c: Convert vendor:model to vendor/model ---
                 # Only convert when there's no slash — a slash means the name
                 # is already in vendor/model format and the colon is a variant
                 # tag (:free, :extended, :fast) that must be preserved.
                 colon_pos = raw_input.find(":")
-                if colon_pos > 0 and "/" not in raw_input and is_aggregator(current_provider):
+                if colon_pos > 0 and "/" not in raw_input:
                     left = raw_input[:colon_pos].strip().lower()
                     right = raw_input[colon_pos + 1:].strip()
                     if left and right:

--- a/tests/hermes_cli/test_model_switch_variant_tags.py
+++ b/tests/hermes_cli/test_model_switch_variant_tags.py
@@ -68,3 +68,22 @@ class TestVariantTagPreservation:
         """Standard vendor/model slugs without tags pass through unchanged."""
         result = _run_switch("anthropic/claude-sonnet-4.6")
         assert result == "anthropic/claude-sonnet-4.6"
+
+
+class TestColonFormatOnNonAggregator:
+    """Colon-to-slash conversion must work even when the current provider is not an aggregator."""
+
+    def test_colon_converted_on_non_aggregator_provider(self):
+        """vendor:model on a non-aggregator should convert colon to slash internally.
+
+        The final output is bare (no vendor prefix) because alibaba is a
+        direct provider whose normalize step strips the matching prefix.
+        """
+        result = _run_switch("Alibaba:qwen3.6-plus", current_provider="alibaba")
+        assert result == "qwen3.6-plus"
+
+    def test_colon_converted_on_non_aggregator_matches_slash_format(self):
+        """vendor:model and vendor/model must produce the same result on non-aggregator."""
+        colon_result = _run_switch("Alibaba:qwen3.6-plus", current_provider="alibaba")
+        slash_result = _run_switch("Alibaba/qwen3.6-plus", current_provider="alibaba")
+        assert colon_result == slash_result


### PR DESCRIPTION
## Summary
- Removes the `is_aggregator(current_provider)` guard from the colon-to-slash conversion in `switch_model` Step c (`hermes_cli/model_switch.py` line 580), so `provider:model` and `provider/model` are parsed equivalently on **all** providers, not just aggregators like OpenRouter.
- Adds regression tests confirming that `Alibaba:qwen3.6-plus` and `Alibaba/qwen3.6-plus` produce identical results when the current provider is `alibaba`.

Closes #9748

## Test plan
- `pytest tests/hermes_cli/test_model_switch_variant_tags.py` — all 9 tests pass (7 existing + 2 new).