### PR TITLE
chore: add MestreY0d4-Uninter noreply to attribution mappings

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
     "27917469+nosleepcassette@users.noreply.github.com": "nosleepcassette",


### PR DESCRIPTION
## Summary
- add `MestreY0d4-Uninter@users.noreply.github.com` to `scripts/release.py` `AUTHOR_MAP`
- add the same noreply identity to `.mailmap`

## Why
Recent refreshed PRs validated correctly but initially tripped `check-attribution` until this noreply was mapped explicitly. This tiny housekeeping change makes future PRs from the same GitHub-linked noreply pass attribution checks without requiring per-branch follow-up.

## Validation
- `python3 -m py_compile scripts/release.py`

## Notes
This is intentionally narrow: no product/runtime behavior change, just contributor attribution metadata.
