### PR TITLE
fix: /model picker omits configured models for custom providers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1671,7 +1671,9 @@ def _normalize_custom_provider_entry(
         normalized["model"] = model_name.strip()
 
     models = entry.get("models")
-    if isinstance(models, dict) and models:
+    if isinstance(models, list) and models:
+        normalized["models"] = models
+    elif isinstance(models, dict) and models:
         normalized["models"] = models
 
     context_length = entry.get("context_length")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1006,16 +1006,21 @@ def list_authenticated_providers(
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
 
-            # Build models list from both default_model and full models array
+            # Build models list from both default_model and full models config.
             models_list = []
             if default_model:
                 models_list.append(default_model)
-            # Also include the full models list from config
             cfg_models = ep_cfg.get("models", [])
-            if isinstance(cfg_models, list):
-                for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+            if isinstance(cfg_models, dict):
+                for model_id in cfg_models.keys():
+                    m_str = str(model_id).strip()
+                    if m_str and m_str not in models_list:
+                        models_list.append(m_str)
+            elif isinstance(cfg_models, list):
+                for model_id in cfg_models:
+                    m_str = str(model_id).strip()
+                    if m_str and m_str not in models_list:
+                        models_list.append(m_str)
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1031,13 +1031,12 @@ def list_authenticated_providers(
             })
 
     # --- 4. Saved custom providers from config ---
-    # Each ``custom_providers`` entry represents one model under a named
-    # provider. Entries sharing the same provider name are grouped into a
-    # single picker row so that e.g. four Ollama Cloud entries
-    # (qwen3-coder, glm-5.1, kimi-k2, minimax-m2.7) appear as one
-    # "Ollama Cloud" row with four models inside instead of four
-    # duplicate "Ollama Cloud" rows. Entries with distinct provider names
-    # still produce separate rows (e.g. Ollama Cloud vs Moonshot).
+    # Legacy ``custom_providers`` entries store one saved ``model`` plus an
+    # optional ``models`` mapping for per-model metadata (for example
+    # ``context_length`` overrides keyed by model ID). The v12+ ``providers``
+    # compatibility layer can also surface ``models`` as a list. Show the saved
+    # model plus any additional model IDs from either representation in a single
+    # picker row per named provider.
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
@@ -1067,11 +1066,16 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
 
-            # Also include the full models array from config
+            # Also include any extra models declared in config.
             cfg_models = entry.get("models", [])
-            if isinstance(cfg_models, list):
-                for m in cfg_models:
-                    m_str = str(m).strip()
+            if isinstance(cfg_models, dict):
+                for model_id in cfg_models.keys():
+                    m_str = str(model_id).strip()
+                    if m_str and m_str not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_str)
+            elif isinstance(cfg_models, list):
+                for model_id in cfg_models:
+                    m_str = str(model_id).strip()
                     if m_str and m_str not in groups[slug]["models"]:
                         groups[slug]["models"].append(m_str)
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1067,6 +1067,14 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
 
+            # Also include the full models array from config
+            cfg_models = entry.get("models", [])
+            if isinstance(cfg_models, list):
+                for m in cfg_models:
+                    m_str = str(m).strip()
+                    if m_str and m_str not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_str)
+
         for slug, grp in groups.items():
             if slug in seen_slugs:
                 continue

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -61,3 +61,45 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_lists_custom_provider_models_dict_keys(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "qwen3.5:27b",
+                    "provider": "custom",
+                    "base_url": "http://localhost:11434/v1",
+                },
+                "providers": {},
+                "custom_providers": [
+                    {
+                        "name": "My Local LLM",
+                        "base_url": "http://localhost:11434/v1",
+                        "model": "qwen3.5:27b",
+                        "models": {
+                            "qwen3.5:27b": {"context_length": 32768},
+                            "deepseek-r1:70b": {"context_length": 65536},
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    result = await _make_runner()._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "My Local LLM" in result
+    assert "qwen3.5:27b" in result
+    assert "deepseek-r1:70b" in result

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -103,3 +103,45 @@ async def test_handle_model_command_lists_custom_provider_models_dict_keys(tmp_p
     assert "My Local LLM" in result
     assert "qwen3.5:27b" in result
     assert "deepseek-r1:70b" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_lists_user_provider_models_dict_keys(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "model-a",
+                    "provider": "my-provider",
+                    "base_url": "http://example.com/v1",
+                },
+                "providers": {
+                    "my-provider": {
+                        "name": "My Provider",
+                        "api": "http://example.com/v1",
+                        "default_model": "model-a",
+                        "models": {
+                            "model-a": {"context_length": 32768},
+                            "model-b": {"context_length": 65536},
+                        },
+                    }
+                },
+                "custom_providers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    result = await _make_runner()._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "My Provider" in result
+    assert "model-a" in result
+    assert "model-b" in result

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -116,6 +116,39 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+def test_list_authenticated_providers_includes_models_dict_keys_from_user_providers(monkeypatch):
+    """User-defined providers should also expose model IDs from models dict keys."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "my-provider": {
+            "name": "My Provider",
+            "api": "http://example.com/v1",
+            "default_model": "model-a",
+            "models": {
+                "model-a": {"context_length": 32768},
+                "model-b": {"context_length": 65536},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "my-provider"),
+        None
+    )
+
+    assert user_prov is not None
+    assert user_prov["total_models"] == 2
+    assert user_prov["models"] == ["model-a", "model-b"]
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## What

Fix the `/model` picker so extra configured model IDs actually appear for user-defined endpoints in both config shapes:

1. Legacy `custom_providers` entries:
   - singular `model`
   - optional `models` as a `dict` or `list`
2. Keyed `providers:` entries:
   - `default_model`
   - optional `models` as a `list` or `dict`

## Root cause

Two different picker paths were dropping extra model IDs:

1. `_normalize_custom_provider_entry()` in `config.py` only preserved `providers.<name>.models` when it was a `dict`, so compatibility rows lost `models: [...]`.
2. `list_authenticated_providers()` in `model_switch.py` expanded extra models for compatibility `custom_providers` rows, but the direct `user_providers` path only handled `models` lists and ignored `models` dict keys.

## Reproduction

### Legacy `custom_providers`

```yaml
custom_providers:
  - name: my-provider
    base_url: https://example.com/v1
    model: gpt-4o
    models:
      gpt-4o:
        context_length: 128000
      claude-sonnet-4:
        context_length: 200000
```

Before: `/model` showed only `gpt-4o`.
After: `/model` shows both `gpt-4o` and `claude-sonnet-4`.

### Keyed `providers:`

```yaml
providers:
  my-provider:
    api: https://example.com/v1
    default_model: gpt-4o
    models:
      gpt-4o:
        context_length: 128000
      claude-sonnet-4:
        context_length: 200000
```

Before: the direct `providers:` picker path only showed `gpt-4o`.
After: `/model` shows both configured models.

This also fixes the `providers:` list form:

```yaml
providers:
  my-provider:
    api: https://example.com/v1
    default_model: gpt-4o
    models:
      - gpt-4o
      - claude-sonnet-4
```

## Fix

1. Preserve `models` in `config.py` when it is either a `list` or a `dict`.
2. In `model_switch.py`, merge the saved/default model with additional model IDs from:
   - `custom_providers[].models` dict keys or list values
   - `providers.<name>.models` dict keys or list values
3. Add regression coverage for CLI and gateway `/model` output.
