### PR TITLE
fix(feishu): reply in same topic instead of creating new one in topic-mode groups

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2163,13 +2163,28 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id)
+        _raw_thread_id = getattr(message, "thread_id", None) or None
+        _raw_root_id = getattr(message, "root_id", None) or None
+        _resolved_chat_type = self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type)
+        logger.debug(
+            "[Feishu] Thread context: thread_id=%r root_id=%r parent_id=%r chat_type=%r resolved=%r",
+            _raw_thread_id, _raw_root_id,
+            getattr(message, "parent_id", None),
+            chat_info.get("type"), _resolved_chat_type,
+        )
+        # In topic-mode groups (forum), use root_id as fallback for thread_id
+        # to ensure reply_in_thread=True so replies stay in the same topic.
+        _effective_thread_id = _raw_thread_id
+        if not _effective_thread_id and _resolved_chat_type == "forum" and _raw_root_id:
+            _effective_thread_id = _raw_root_id
+            logger.debug("[Feishu] Using root_id %s as thread_id fallback for forum chat", _raw_root_id)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=_resolved_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
-            thread_id=getattr(message, "thread_id", None) or None,
+            thread_id=_effective_thread_id,
             user_id_alt=sender_profile["user_id_alt"],
         )
         normalized = MessageEvent(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7631,15 +7631,15 @@ class GatewayRunner:
                                     adapter.name,
                                 )
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            await adapter.send(chat_id=source.chat_id, content=msg, reply_to=event_message_id, metadata=_progress_metadata)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            result = await adapter.send(chat_id=source.chat_id, content=full_text, reply_to=event_message_id, metadata=_progress_metadata)
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            result = await adapter.send(chat_id=source.chat_id, content=msg, reply_to=event_message_id, metadata=_progress_metadata)
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
 
@@ -7843,6 +7843,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -82,11 +82,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -718,6 +720,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu bot replies creating a **new topic** instead of replying within the existing topic in topic-mode groups (话题模式群).

Root cause: progress messages and streaming responses were sent via the Feishu `create` API (no `reply_to` parameter), which cannot target a specific topic. Only the `reply` API with `reply_in_thread=true` can send messages into an existing topic. Since `reply_to` was missing, the code fell through to the `create` branch in `_send_raw_message()`, causing every bot response to appear as a new topic.

## Related Issue

Fixes #6969

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/stream_consumer.py`**: Add optional `reply_to` parameter to `GatewayStreamConsumer.__init__()` and use it in `_send_or_edit()` when sending the first message chunk
- **`gateway/run.py`**: Pass `reply_to=event_message_id` in all 3 progress-message `adapter.send()` calls inside `send_progress_messages()`, and in the `GatewayStreamConsumer` constructor
- **`gateway/platforms/feishu.py`**: Add defensive `root_id` fallback for `thread_id` in `_process_inbound_message()` for forum-type chats (topic-mode groups where `thread_id` may be absent); add debug logging for thread context

## How to Test

1. Create or use a Feishu group with topic mode enabled (话题模式)
2. Open an existing topic and @mention the bot
3. Verify the bot's reply appears **inside the same topic**, not as a new topic
4. Also verify normal (non-topic) group and DM replies still work correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix — `_send_raw_message` log showing `reply_to=None`:
```
[Feishu] _send_raw_message: reply_to=None reply_in_thread=True msg_type=text metadata={'thread_id': 'omt_1abbed20d40f1c9e'}
```

After fix — bot reply correctly appears within the same Feishu topic.