### PR TITLE
fix: use POSIX `-e` instead of BSD `-ax` in ps for Docker compatibility

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,11 +222,13 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
+                ["ps", "eww", "-e", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
+            if result.returncode != 0:
+                return pids
             for line in result.stdout.split('\n'):
                 stripped = line.strip()
                 if not stripped or 'grep' in stripped:


### PR DESCRIPTION
## Summary
- Replace `-ax` (BSD-style) with `-e` (POSIX) in the `ps` command used by `find_gateway_pids()` so it works in Docker containers running procps 4.0.4+
- Add a return-code guard so that if `ps` fails for any reason, the function returns gracefully instead of parsing error output as process listings

Closes #9723

## Test plan
- Existing `test_gateway.py` tests pass (14/14)
- The fix changes only the `ps` flag from `-ax` to `-e`, which is the POSIX equivalent for selecting all processes