### PR TITLE
fix(gateway): DingTalk adapter compat with dingtalk-stream >= 0.20

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -18,9 +18,12 @@ Configuration in config.yaml:
 """
 
 import asyncio
+import inspect
+import json
 import logging
 import os
 import re
+import threading
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -128,12 +131,21 @@ class DingTalkAdapter(BasePlatformAdapter):
             return False
 
     async def _run_stream(self) -> None:
-        """Run the blocking stream client with auto-reconnection."""
+        """Run the stream client with auto-reconnection.
+
+        dingtalk-stream >= 0.20 changed start() from sync to async. When async,
+        it needs its own event loop in a dedicated thread because internally it
+        runs a blocking WebSocket loop.
+        """
         backoff_idx = 0
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await asyncio.to_thread(self._stream_client.start)
+                start_fn = self._stream_client.start
+                if inspect.iscoroutinefunction(start_fn):
+                    await asyncio.to_thread(self._run_stream_sync, start_fn)
+                else:
+                    await asyncio.to_thread(start_fn)
             except asyncio.CancelledError:
                 return
             except Exception as e:
@@ -148,6 +160,15 @@ class DingTalkAdapter(BasePlatformAdapter):
             logger.info("[%s] Reconnecting in %ds...", self.name, delay)
             await asyncio.sleep(delay)
             backoff_idx += 1
+
+    @staticmethod
+    def _run_stream_sync(async_start_fn) -> None:
+        """Run an async start() in a fresh event loop on the current thread."""
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(async_start_fn())
+        finally:
+            loop.close()
 
     async def disconnect(self) -> None:
         """Disconnect from DingTalk."""
@@ -173,34 +194,37 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     # -- Inbound message processing -----------------------------------------
 
-    async def _on_message(self, message: "ChatbotMessage") -> None:
-        """Process an incoming DingTalk chatbot message."""
-        msg_id = getattr(message, "message_id", None) or uuid.uuid4().hex
+    async def _on_message(self, message) -> None:
+        """Process an incoming DingTalk chatbot message.
+
+        Supports both legacy ChatbotMessage (dingtalk-stream < 0.20) and
+        CallbackMessage (>= 0.20) where fields live inside message.data.
+        """
+        msg = self._normalize_message(message)
+
+        msg_id = msg.get("message_id") or uuid.uuid4().hex
         if self._dedup.is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
 
-        text = self._extract_text(message)
+        text = self._extract_text_from_data(msg)
         if not text:
             logger.debug("[%s] Empty message, skipping", self.name)
             return
 
-        # Chat context
-        conversation_id = getattr(message, "conversation_id", "") or ""
-        conversation_type = getattr(message, "conversation_type", "1")
+        conversation_id = msg.get("conversation_id", "")
+        conversation_type = msg.get("conversation_type", "1")
         is_group = str(conversation_type) == "2"
-        sender_id = getattr(message, "sender_id", "") or ""
-        sender_nick = getattr(message, "sender_nick", "") or sender_id
-        sender_staff_id = getattr(message, "sender_staff_id", "") or ""
+        sender_id = msg.get("sender_id", "")
+        sender_nick = msg.get("sender_nick", "") or sender_id
+        sender_staff_id = msg.get("sender_staff_id", "")
 
         chat_id = conversation_id or sender_id
         chat_type = "group" if is_group else "dm"
 
-        # Store session webhook for reply routing (validate origin to prevent SSRF)
-        session_webhook = getattr(message, "session_webhook", None) or ""
+        session_webhook = msg.get("session_webhook", "")
         if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
             if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
-                # Evict oldest entry to cap memory growth
                 try:
                     self._session_webhooks.pop(next(iter(self._session_webhooks)))
                 except StopIteration:
@@ -209,15 +233,14 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         source = self.build_source(
             chat_id=chat_id,
-            chat_name=getattr(message, "conversation_title", None),
+            chat_name=msg.get("conversation_title"),
             chat_type=chat_type,
             user_id=sender_id,
             user_name=sender_nick,
             user_id_alt=sender_staff_id if sender_staff_id else None,
         )
 
-        # Parse timestamp
-        create_at = getattr(message, "create_at", None)
+        create_at = msg.get("create_at")
         try:
             timestamp = datetime.fromtimestamp(int(create_at) / 1000, tz=timezone.utc) if create_at else datetime.now(tz=timezone.utc)
         except (ValueError, OSError, TypeError):
@@ -237,17 +260,55 @@ class DingTalkAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     @staticmethod
-    def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
+    def _normalize_message(message) -> Dict[str, Any]:
+        """Convert a ChatbotMessage or CallbackMessage into a plain dict.
+
+        dingtalk-stream >= 0.20 delivers a CallbackMessage whose payload is
+        in message.data (JSON string or dict).  Older versions deliver a
+        ChatbotMessage with attributes directly on the object.
+        """
+        data = getattr(message, "data", None)
+        if data is not None:
+            if isinstance(data, str):
+                try:
+                    data = json.loads(data)
+                except (json.JSONDecodeError, TypeError):
+                    data = {}
+            if isinstance(data, dict) and data:
+                _FIELD_MAP = {
+                    "msgId": "message_id",
+                    "text": "text",
+                    "senderId": "sender_id",
+                    "senderNick": "sender_nick",
+                    "senderStaffId": "sender_staff_id",
+                    "conversationId": "conversation_id",
+                    "conversationType": "conversation_type",
+                    "conversationTitle": "conversation_title",
+                    "sessionWebhook": "session_webhook",
+                    "createAt": "create_at",
+                    "robotCode": "robot_code",
+                }
+                return {v: data[k] for k, v in _FIELD_MAP.items() if k in data}
+
+        _ATTRS = [
+            "message_id", "text", "sender_id", "sender_nick",
+            "sender_staff_id", "conversation_id", "conversation_type",
+            "conversation_title", "session_webhook", "create_at",
+            "rich_text",
+        ]
+        return {a: getattr(message, a, None) for a in _ATTRS}
+
+    @staticmethod
+    def _extract_text_from_data(msg: Dict[str, Any]) -> str:
+        """Extract plain text from a normalised message dict."""
+        text = msg.get("text") or ""
         if isinstance(text, dict):
             content = text.get("content", "").strip()
         else:
             content = str(text).strip()
 
-        # Fall back to rich text if present
         if not content:
-            rich_text = getattr(message, "rich_text", None)
+            rich_text = msg.get("rich_text")
             if rich_text and isinstance(rich_text, list):
                 parts = [item["text"] for item in rich_text
                          if isinstance(item, dict) and item.get("text")]
@@ -306,7 +367,13 @@ class DingTalkAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 
 class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
-    """dingtalk-stream ChatbotHandler that forwards messages to the adapter."""
+    """dingtalk-stream ChatbotHandler that forwards messages to the adapter.
+
+    dingtalk-stream >= 0.20 changed process() from sync to async and passes
+    CallbackMessage instead of ChatbotMessage.  This handler is async to
+    satisfy the new SDK, and dispatches to the gateway's main event loop
+    thread-safely (the stream SDK runs in its own thread/loop).
+    """
 
     def __init__(self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop):
         if DINGTALK_STREAM_AVAILABLE:
@@ -314,10 +381,11 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
         self._adapter = adapter
         self._loop = loop
 
-    def process(self, message: "ChatbotMessage"):
-        """Called by dingtalk-stream in its thread when a message arrives.
+    async def process(self, message):
+        """Called by dingtalk-stream when a message arrives.
 
-        Schedules the async handler on the main event loop.
+        In >= 0.20 this runs in the stream client's own event loop thread.
+        We schedule _on_message on the gateway's main loop and wait for it.
         """
         loop = self._loop
         if loop is None or loop.is_closed():

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -74,7 +74,7 @@ class TestDingTalkAdapterInit:
 
 
 # ---------------------------------------------------------------------------
-# Message text extraction
+# Message text extraction (via _extract_text_from_data on normalised dicts)
 # ---------------------------------------------------------------------------
 
 
@@ -82,31 +82,23 @@ class TestExtractText:
 
     def test_extracts_dict_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = {"content": "  hello world  "}
-        msg.rich_text = None
-        assert DingTalkAdapter._extract_text(msg) == "hello world"
+        msg = {"text": {"content": "  hello world  "}}
+        assert DingTalkAdapter._extract_text_from_data(msg) == "hello world"
 
     def test_extracts_string_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = "plain text"
-        msg.rich_text = None
-        assert DingTalkAdapter._extract_text(msg) == "plain text"
+        msg = {"text": "plain text"}
+        assert DingTalkAdapter._extract_text_from_data(msg) == "plain text"
 
     def test_falls_back_to_rich_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
-        assert DingTalkAdapter._extract_text(msg) == "part1 part2"
+        msg = {"text": "", "rich_text": [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]}
+        assert DingTalkAdapter._extract_text_from_data(msg) == "part1 part2"
 
     def test_returns_empty_for_no_content(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = None
-        assert DingTalkAdapter._extract_text(msg) == ""
+        msg = {"text": ""}
+        assert DingTalkAdapter._extract_text_from_data(msg) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +254,90 @@ class TestConnect:
         assert len(adapter._session_webhooks) == 0
         assert len(adapter._dedup._seen) == 0
         assert adapter._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Platform enum
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Message normalisation (CallbackMessage vs ChatbotMessage)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMessage:
+
+    def test_normalizes_callback_message_dict_data(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.data = {
+            "msgId": "id-123",
+            "text": {"content": "hello"},
+            "senderId": "u-1",
+            "senderNick": "Alice",
+            "conversationId": "conv-1",
+            "conversationType": "2",
+            "sessionWebhook": "https://api.dingtalk.com/hook",
+        }
+        result = DingTalkAdapter._normalize_message(msg)
+        assert result["message_id"] == "id-123"
+        assert result["text"] == {"content": "hello"}
+        assert result["sender_id"] == "u-1"
+        assert result["sender_nick"] == "Alice"
+        assert result["conversation_id"] == "conv-1"
+        assert result["conversation_type"] == "2"
+        assert result["session_webhook"] == "https://api.dingtalk.com/hook"
+
+    def test_normalizes_callback_message_json_string_data(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.data = json.dumps({"msgId": "id-456", "text": {"content": "hi"}})
+        result = DingTalkAdapter._normalize_message(msg)
+        assert result["message_id"] == "id-456"
+        assert result["text"] == {"content": "hi"}
+
+    def test_normalizes_legacy_chatbot_message(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock(spec=[
+            "message_id", "text", "sender_id", "sender_nick",
+            "sender_staff_id", "conversation_id", "conversation_type",
+            "conversation_title", "session_webhook", "create_at", "rich_text",
+        ])
+        msg.data = None  # no .data attribute in legacy
+        msg.message_id = "legacy-1"
+        msg.text = "hello legacy"
+        msg.sender_id = "u-2"
+        msg.sender_nick = "Bob"
+        msg.sender_staff_id = ""
+        msg.conversation_id = "conv-2"
+        msg.conversation_type = "1"
+        msg.conversation_title = None
+        msg.session_webhook = "https://api.dingtalk.com/wh"
+        msg.create_at = None
+        msg.rich_text = None
+        result = DingTalkAdapter._normalize_message(msg)
+        assert result["message_id"] == "legacy-1"
+        assert result["text"] == "hello legacy"
+        assert result["sender_id"] == "u-2"
+
+
+# ---------------------------------------------------------------------------
+# Async stream start helper
+# ---------------------------------------------------------------------------
+
+
+class TestRunStreamSync:
+
+    def test_runs_async_start_in_new_loop(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        called = []
+
+        async def fake_start():
+            called.append(True)
+
+        DingTalkAdapter._run_stream_sync(fake_start)
+        assert called == [True]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the DingTalk adapter which broke with dingtalk-stream >= 0.20 due to three API changes:

- **`process()` is now async** — SDK awaits the return value, causing `"object tuple can't be used in 'await' expression"`. Fixed by making `_IncomingHandler.process()` async.
- **`start()` is now async** — `asyncio.to_thread()` on a coroutine doesn't work. Fixed by detecting async `start()` via `inspect.iscoroutinefunction` and running it in a fresh event loop on a worker thread.
- **Messages are now `CallbackMessage`** with data in a JSON dict, not `ChatbotMessage` with direct attributes. Fixed by adding `_normalize_message()` that handles both formats.

Backward compatible with dingtalk-stream < 0.20.

Closes #9752

## Test plan

- [x] All 25 existing + new DingTalk adapter tests pass
- [x] New tests for `_normalize_message` covering both CallbackMessage (dict data, JSON string data) and legacy ChatbotMessage
- [x] New test for `_run_stream_sync` helper