### PR TITLE
fix: copilot model not show in /model when copilot provider fallback to gh auth token

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1152,6 +1152,30 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 },
             )
 
+    elif provider == "copilot":
+        # Copilot tokens are resolved dynamically via `gh auth token` or
+        # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
+        # the auth store or credential pool, so we resolve them here.
+        try:
+            from hermes_cli.copilot_auth import resolve_copilot_token
+            token, source = resolve_copilot_token()
+            if token:
+                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
+                active_sources.add(source_name)
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    source_name,
+                    {
+                        "source": source_name,
+                        "auth_type": AUTH_TYPE_API_KEY,
+                        "access_token": token,
+                        "label": source,
+                    },
+                )
+        except Exception as exc:
+            logger.debug("Copilot token seed failed: %s", exc)
+
     elif provider == "openai-codex":
         state = _load_provider_state(auth_store, "openai-codex")
         tokens = state.get("tokens") if isinstance(state, dict) else None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1071,3 +1071,40 @@ def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_p
 
     # Should NOT have seeded the claude_code entry
     assert pool.entries() == []
+
+
+def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
+    """Copilot credentials from `gh auth token` should be seeded into the pool."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_abc123", "gh auth token"),
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert pool.has_credentials()
+    entries = pool.entries()
+    assert len(entries) == 1
+    assert entries[0].source == "gh_cli"
+    assert entries[0].access_token == "gho_fake_token_abc123"
+
+
+def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):
+    """Copilot pool should be empty when resolve_copilot_token() returns nothing."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("", ""),
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not pool.has_credentials()
+    assert pool.entries() == []


### PR DESCRIPTION
## What changed and why

Fixes #9768

`/model` (the model picker) calls `list_authenticated_providers()` to discover which providers have valid credentials. It checks:

1. Environment variables (`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`)
2. Hermes auth store (`~/.hermes/auth.json`)
3. OAuth credential pool

However, many copilot users authenticate solely through the GitHub CLI (`gh auth token`). These tokens are resolved dynamically by `resolve_copilot_token()` in `copilot_auth.py` and don't exist in any of the three stores above. As a result, **copilot does not appear in the `/model` provider list** even when the user is actively using it as their provider.

This affects all `/model` entry points — CLI (`cli.py`) and Gateway messaging platforms (`gateway/run.py`) — since they all call the same `list_authenticated_providers()` function.

## Fix

Seed copilot credentials from `resolve_copilot_token()` in the credential pool's `_seed_from_singletons()` (`agent/credential_pool.py`), alongside the existing anthropic and openai-codex seeding logic. This is the correct architectural layer — the credential pool already handles dynamic credential discovery for other providers — rather than adding a one-off fallback in `list_authenticated_providers()`.

## How to test

1. Ensure no copilot env vars are set: `unset COPILOT_GITHUB_TOKEN GH_TOKEN GITHUB_TOKEN`
2. Ensure `gh auth token` returns a valid token
3. Set `provider: copilot` in `~/.hermes/config.yaml`
4. Run `hermes` and type `/model`
5. **Before fix:** copilot does not appear in the provider list
6. **After fix:** copilot appears with its models

### Screenshots

Before
<img width="598" height="311" alt="Screenshot 2026-04-14 at 23 57 44" src="https://github.com/user-attachments/assets/1f8f95da-5938-48d2-9665-2bb68d37b581" />

After
<img width="579" height="245" alt="Screenshot 2026-04-15 at 00 23 08" src="https://github.com/user-attachments/assets/1cf32ca4-fb16-4293-99f0-7bdb6e8c7f7f" />
<img width="611" height="547" alt="Screenshot 2026-04-15 at 00 23 16" src="https://github.com/user-attachments/assets/c13c2fc9-ea11-46a2-bf8b-2ffe47ca3d52" />

### Automated tests

```bash
pytest tests/agent/test_credential_pool.py::test_load_pool_seeds_copilot_via_gh_auth_token tests/agent/test_credential_pool.py::test_load_pool_does_not_seed_copilot_when_no_token -v
```

Two new tests in `tests/agent/test_credential_pool.py`:
- `test_load_pool_seeds_copilot_via_gh_auth_token` — copilot credentials seeded into pool when `resolve_copilot_token()` succeeds
- `test_load_pool_does_not_seed_copilot_when_no_token` — pool stays empty when no token available

## Platform tested

- macOS (Apple Silicon)