### PR TITLE
feat: harden incomplete-task surfacing

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -166,7 +166,10 @@ SKILLS_GUIDANCE = (
     "or discovering a non-trivial workflow, save the approach as a "
     "skill with skill_manage so you can reuse it next time.\n"
     "When using a skill and finding it outdated, incomplete, or wrong, "
-    "patch it immediately with skill_manage(action='patch') — don't wait to be asked. "
+    "patch it immediately with skill_manage(action='patch') — don't wait to be asked.\n"
+    "If you used an existing skill and had to compensate for missing steps, bad commands, "
+    "or new pitfalls, updating that skill is part of done. Do not declare the task finished "
+    "until the skill is patched or you explicitly confirm that no skill update was needed. "
     "Skills that aren't maintained become liabilities."
 )
 
@@ -182,7 +185,14 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "the task, use them instead of telling the user what you would do.\n"
     "Every response should either (a) contain tool calls that make progress, or "
     "(b) deliver a final result to the user. Responses that only describe intentions "
-    "without acting are not acceptable."
+    "without acting are not acceptable.\n"
+    "A task is NOT complete just because nothing crashed or because you produced a plausible "
+    "status update. If the requested result did not happen, call it interrupted, failed, or "
+    "not completed. Do not soften this with phrases like 'almost done' or 'basically finished'.\n"
+    "Before your final response, verify the actual outcome. If you changed files, read them or "
+    "run tests. If you executed commands, check their real effect. If you used a todo list, do "
+    "not finish while items remain pending or in_progress unless you explicitly mark them "
+    "cancelled and explain why."
 )
 
 # Model name substrings that trigger tool-use enforcement guidance.
@@ -242,6 +252,10 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- Formatting: does the output match the requested format or schema?\n"
     "- Safety: if the next step has side effects (file writes, commands, API calls), "
     "confirm scope before executing.\n"
+    "- Completion truthfulness: if the requested result did not happen, do NOT present the task as done. "
+    "Say it was interrupted, failed, or not completed.\n"
+    "- Verification evidence: if you modified anything, verify the post-change state with a tool before finalizing.\n"
+    "- Todo closure: if you used the todo tool, all remaining items must be completed or cancelled before you stop.\n"
     "</verification>\n"
     "\n"
     "<missing_context>\n"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7258,14 +7258,26 @@ class GatewayRunner:
                             from gateway.platforms.base import MessageEvent, MessageType
                             from gateway.session import SessionSource
                             from gateway.config import Platform
-                            _platform_enum = Platform(platform_name)
-                            _source = SessionSource(
-                                platform=_platform_enum,
-                                chat_id=chat_id,
-                                thread_id=thread_id or None,
-                                user_id=user_id or None,
-                                user_name=user_name or None,
-                            )
+
+                            _source = None
+                            try:
+                                session_entry = getattr(self.session_store, "_entries", {}).get(session_key)
+                                if session_entry and getattr(session_entry, "origin", None):
+                                    _source = session_entry.origin
+                            except Exception:
+                                _source = None
+
+                            if _source is None:
+                                _platform_enum = Platform(platform_name)
+                                _source = SessionSource(
+                                    platform=_platform_enum,
+                                    chat_id=chat_id,
+                                    chat_type="group" if str(chat_id).startswith("-") else "dm",
+                                    thread_id=thread_id or None,
+                                    user_id=user_id or None,
+                                    user_name=user_name or None,
+                                )
+
                             synth_event = MessageEvent(
                                 text=synth_text,
                                 message_type=MessageType.TEXT,
@@ -8118,6 +8130,10 @@ class GatewayRunner:
             
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
+            exit_reason = result.get("exit_reason") or ""
+            _task_completed = bool(result.get("completed"))
+            if final_response and not _task_completed and exit_reason and not final_response.startswith("⚠️ Task not completed"):
+                final_response = f"⚠️ Task not completed - {exit_reason}\n\n" + final_response
 
             # Extract actual token counts from the agent instance used for this run
             _last_prompt_toks = 0
@@ -8142,6 +8158,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "exit_reason": exit_reason,
+                    "completed": _task_completed,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -8233,6 +8251,8 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "exit_reason": exit_reason,
+                "completed": _task_completed,
             }
         
         # Start progress message sender if enabled

--- a/run_agent.py
+++ b/run_agent.py
@@ -8042,6 +8042,16 @@ class AIAgent:
         truncated_response_prefix = ""
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+
+        def _result_payload(**kwargs):
+            payload = {
+                "messages": messages,
+                "api_calls": api_call_count,
+                "completed": False,
+                "exit_reason": _turn_exit_reason,
+            }
+            payload.update(kwargs)
+            return payload
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -8183,8 +8193,32 @@ class AIAgent:
             # External recall context is injected into the user message, not the system
             # prompt, so the stable cache prefix remains unchanged.
             effective_system = active_system_prompt or ""
+            _dynamic_ephemeral_parts = []
             if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+                _dynamic_ephemeral_parts.append(self.ephemeral_system_prompt)
+            _active_todos = []
+            try:
+                _active_todos = [
+                    item for item in self._todo_store.read()
+                    if item.get("status") in ("pending", "in_progress")
+                ]
+            except Exception:
+                _active_todos = []
+            if _active_todos:
+                _dynamic_ephemeral_parts.append(
+                    "IMPORTANT: You still have active todo items. Do not declare the task done while any todo is pending or in_progress. "
+                    "Either finish them, mark them cancelled with a reason, or explicitly state that the task is not complete."
+                )
+            if (
+                self._skill_nudge_interval > 0
+                and self._iters_since_skill >= self._skill_nudge_interval
+                and "skill_manage" in self.valid_tool_names
+            ):
+                _dynamic_ephemeral_parts.append(
+                    "IMPORTANT: This turn has crossed the skill-review threshold. If you used or discovered a non-trivial workflow, or had to compensate for a bad/outdated skill, review and patch/create the skill before declaring the task done."
+                )
+            if _dynamic_ephemeral_parts:
+                effective_system = (effective_system + "\n\n" + "\n\n".join(_dynamic_ephemeral_parts)).strip()
             # NOTE: Plugin context from pre_llm_call hooks is injected into the
             # user message (see injection block above), NOT the system prompt.
             # This is intentional — system prompt modifications break the prompt
@@ -8536,13 +8570,11 @@ class AIAgent:
                             self._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
-                                "failed": True  # Mark as failure for filtering
-                            }
+                            _turn_exit_reason = "invalid_api_response"
+                            return _result_payload(
+                                error=f"Invalid API response after {max_retries} retries: {_failure_hint}",
+                                failed=True,
+                            )
                         
                         # Backoff before retry — jittered exponential: 5s base, 120s cap
                         wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
@@ -8557,13 +8589,11 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                                 self._persist_session(messages, conversation_history)
                                 self.clear_interrupt()
-                                return {
-                                    "final_response": f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
-                                    "messages": messages,
-                                    "api_calls": api_call_count,
-                                    "completed": False,
-                                    "interrupted": True,
-                                }
+                                _turn_exit_reason = "interrupted_during_retry_wait"
+                                return _result_payload(
+                                    final_response=f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
+                                    interrupted=True,
+                                )
                             time.sleep(0.2)
                             # Touch activity every ~30s so the gateway's inactivity
                             # monitor knows we're alive during backoff waits.
@@ -8664,14 +8694,12 @@ class AIAgent:
                             )
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "final_response": _exhaust_response,
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": _exhaust_error,
-                            }
+                            _turn_exit_reason = "thinking_budget_exhausted"
+                            return _result_payload(
+                                final_response=_exhaust_response,
+                                partial=True,
+                                error=_exhaust_error,
+                            )
 
                         if self.api_mode == "chat_completions":
                             assistant_message = response.choices[0].message
@@ -8704,14 +8732,12 @@ class AIAgent:
                                 partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
-                                return {
-                                    "final_response": partial_response or None,
-                                    "messages": messages,
-                                    "api_calls": api_call_count,
-                                    "completed": False,
-                                    "partial": True,
-                                    "error": "Response remained truncated after 3 continuation attempts",
-                                }
+                                _turn_exit_reason = "length_continuation_exhausted"
+                                return _result_payload(
+                                    final_response=partial_response or None,
+                                    partial=True,
+                                    error="Response remained truncated after 3 continuation attempts",
+                                )
 
                         if self.api_mode == "chat_completions":
                             assistant_message = response.choices[0].message
@@ -8732,14 +8758,12 @@ class AIAgent:
                                 )
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
-                                return {
-                                    "final_response": None,
-                                    "messages": messages,
-                                    "api_calls": api_call_count,
-                                    "completed": False,
-                                    "partial": True,
-                                    "error": "Response truncated due to output length limit",
-                                }
+                                _turn_exit_reason = "output_length_truncated"
+                                return _result_payload(
+                                    final_response=None,
+                                    partial=True,
+                                    error="Response truncated due to output length limit",
+                                )
 
                         # If we have prior messages, roll back to last complete state
                         if len(messages) > 1:
@@ -8749,26 +8773,23 @@ class AIAgent:
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
 
-                            return {
-                                "final_response": None,
-                                "messages": rolled_back_messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": "Response truncated due to output length limit"
-                            }
+                            _turn_exit_reason = "output_length_truncated_rolled_back"
+                            return _result_payload(
+                                final_response=None,
+                                messages=rolled_back_messages,
+                                partial=True,
+                                error="Response truncated due to output length limit"
+                            )
                         else:
                             # First message was truncated - mark as failed
                             self._vprint(f"{self.log_prefix}❌ First response truncated - cannot recover", force=True)
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "final_response": None,
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "failed": True,
-                                "error": "First response truncated due to output length limit"
-                            }
+                            _turn_exit_reason = "first_response_truncated"
+                            return _result_payload(
+                                final_response=None,
+                                failed=True,
+                                error="First response truncated due to output length limit"
+                            )
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
@@ -9145,13 +9166,11 @@ class AIAgent:
                         self._vprint(f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
-                        return {
-                            "final_response": f"Operation interrupted: handling API error ({error_type}: {self._clean_error_message(str(api_error))}).",
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "interrupted": True,
-                        }
+                        _turn_exit_reason = "interrupted_during_error_handling"
+                        return _result_payload(
+                            final_response=f"Operation interrupted: handling API error ({error_type}: {self._clean_error_message(str(api_error))}).",
+                            interrupted=True,
+                        )
                     
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
@@ -9250,13 +9269,11 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True
-                            }
+                            _turn_exit_reason = "payload_too_large"
+                            return _result_payload(
+                                error=f"Request payload too large: max compression attempts ({max_compression_attempts}) reached.",
+                                partial=True
+                            )
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
@@ -9279,13 +9296,11 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": "Request payload too large (413). Cannot compress further.",
-                                "partial": True
-                            }
+                            _turn_exit_reason = "payload_too_large"
+                            return _result_payload(
+                                error="Request payload too large (413). Cannot compress further.",
+                                partial=True
+                            )
 
                     # Check for context-length errors BEFORE generic 4xx handler.
                     # The classifier detects context overflow from: explicit error
@@ -9330,13 +9345,11 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                                 logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                                 self._persist_session(messages, conversation_history)
-                                return {
-                                    "messages": messages,
-                                    "completed": False,
-                                    "api_calls": api_call_count,
-                                    "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
-                                    "partial": True
-                                }
+                                _turn_exit_reason = "context_overflow"
+                                return _result_payload(
+                                    error=f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
+                                    partial=True
+                                )
                             restart_with_compressed_messages = True
                             break
 
@@ -9380,13 +9393,11 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
-                                "partial": True
-                            }
+                            _turn_exit_reason = "context_overflow"
+                            return _result_payload(
+                                error=f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached.",
+                                partial=True
+                            )
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
@@ -9411,13 +9422,11 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                             logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "messages": messages,
-                                "completed": False,
-                                "api_calls": api_call_count,
-                                "error": f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
-                                "partial": True
-                            }
+                            _turn_exit_reason = "context_overflow"
+                            return _result_payload(
+                                error=f"Context length exceeded ({approx_tokens:,} tokens). Cannot compress further.",
+                                partial=True
+                            )
 
                     # Check for non-retryable client errors.  The classifier
                     # already accounts for 413, 429, 529 (transient), context
@@ -9493,14 +9502,12 @@ class AIAgent:
                             )
                         else:
                             self._persist_session(messages, conversation_history)
-                        return {
-                            "final_response": None,
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "failed": True,
-                            "error": str(api_error),
-                        }
+                        _turn_exit_reason = "client_error"
+                        return _result_payload(
+                            final_response=None,
+                            failed=True,
+                            error=str(api_error),
+                        )
 
                     if retry_count >= max_retries:
                         # Before falling back, try rebuilding the primary
@@ -9576,14 +9583,12 @@ class AIAgent:
                                 "execute_code with Python's open() for large "
                                 "files, or to write in smaller sections."
                             )
-                        return {
-                            "final_response": _final_response,
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "failed": True,
-                            "error": _final_summary,
-                        }
+                        _turn_exit_reason = "max_retries_exhausted"
+                        return _result_payload(
+                            final_response=_final_response,
+                            failed=True,
+                            error=_final_summary,
+                        )
 
                     # For rate limits, respect the Retry-After header if present
                     _retry_after = None
@@ -9618,13 +9623,11 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                             self._persist_session(messages, conversation_history)
                             self.clear_interrupt()
-                            return {
-                                "final_response": f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries}).",
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "interrupted": True,
-                            }
+                            _turn_exit_reason = "interrupted_during_retry_wait"
+                            return _result_payload(
+                                final_response=f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries}).",
+                                interrupted=True,
+                            )
                         time.sleep(0.2)  # Check interrupt every 200ms
                         # Touch activity every ~30s so the gateway's inactivity
                         # monitor knows we're alive during backoff waits.
@@ -9768,14 +9771,13 @@ class AIAgent:
                         self._cleanup_task_resources(effective_task_id)
                         self._persist_session(messages, conversation_history)
                         
-                        return {
-                            "final_response": None,
-                            "messages": rolled_back_messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "partial": True,
-                            "error": "Incomplete REASONING_SCRATCHPAD after 2 retries"
-                        }
+                        _turn_exit_reason = "incomplete_reasoning_scratchpad"
+                        return _result_payload(
+                            final_response=None,
+                            messages=rolled_back_messages,
+                            partial=True,
+                            error="Incomplete REASONING_SCRATCHPAD after 2 retries"
+                        )
                 
                 # Reset incomplete scratchpad counter on clean response
                 self._incomplete_scratchpad_retries = 0
@@ -9818,14 +9820,12 @@ class AIAgent:
 
                     self._codex_incomplete_retries = 0
                     self._persist_session(messages, conversation_history)
-                    return {
-                        "final_response": None,
-                        "messages": messages,
-                        "api_calls": api_call_count,
-                        "completed": False,
-                        "partial": True,
-                        "error": "Codex response remained incomplete after 3 continuation attempts",
-                    }
+                    _turn_exit_reason = "codex_incomplete_response"
+                    return _result_payload(
+                        final_response=None,
+                        partial=True,
+                        error="Codex response remained incomplete after 3 continuation attempts",
+                    )
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
                 
@@ -9864,14 +9864,12 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.", force=True)
                             self._invalid_tool_retries = 0
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "final_response": None,
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": f"Model generated invalid tool call: {invalid_preview}"
-                            }
+                            _turn_exit_reason = "invalid_tool_call"
+                            return _result_payload(
+                                final_response=None,
+                                partial=True,
+                                error=f"Model generated invalid tool call: {invalid_preview}"
+                            )
 
                         assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         messages.append(assistant_msg)
@@ -9930,14 +9928,12 @@ class AIAgent:
                             self._invalid_json_retries = 0
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-                            return {
-                                "final_response": None,
-                                "messages": messages,
-                                "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": "Response truncated due to output length limit",
-                            }
+                            _turn_exit_reason = "output_length_truncated"
+                            return _result_payload(
+                                final_response=None,
+                                partial=True,
+                                error="Response truncated due to output length limit",
+                            )
 
                         # Track retries for invalid JSON arguments
                         self._invalid_json_retries += 1
@@ -10554,6 +10550,7 @@ class AIAgent:
             "completed": completed,
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
+            "exit_reason": _turn_exit_reason,
             "response_previewed": getattr(self, "_response_was_previewed", False),
             "model": self.model,
             "provider": self.provider,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -21,6 +21,7 @@ from agent.prompt_builder import (
     build_environment_hints,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
+    SKILLS_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -48,6 +49,20 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_skills_guidance_requires_patch_before_done(self):
+        assert "updating that skill is part of done" in SKILLS_GUIDANCE
+        assert "until the skill is patched" in SKILLS_GUIDANCE
+
+    def test_tool_use_enforcement_guidance_requires_truthful_completion(self):
+        assert "A task is NOT complete just because nothing crashed" in TOOL_USE_ENFORCEMENT_GUIDANCE
+        assert "not completed" in TOOL_USE_ENFORCEMENT_GUIDANCE
+        assert "pending or in_progress" in TOOL_USE_ENFORCEMENT_GUIDANCE
+
+    def test_openai_execution_guidance_mentions_completion_truthfulness_and_todo_closure(self):
+        assert "Completion truthfulness" in OPENAI_MODEL_EXECUTION_GUIDANCE
+        assert "Verification evidence" in OPENAI_MODEL_EXECUTION_GUIDANCE
+        assert "Todo closure" in OPENAI_MODEL_EXECUTION_GUIDANCE
 
 
 # =========================================================================

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,6 +8,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -15,6 +16,7 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform
 from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +34,9 @@ class _FakeRegistry:
             return self._sessions.pop(0)
         return None
 
+    def is_completion_consumed(self, session_id):
+        return False
+
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     """Create a GatewayRunner with a fake config for the given mode."""
@@ -45,7 +50,7 @@ def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     runner = GatewayRunner(GatewayConfig())
-    adapter = SimpleNamespace(send=AsyncMock())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     runner.adapters[Platform.TELEGRAM] = adapter
     return runner
 
@@ -243,3 +248,62 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_reuses_session_origin(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="echo hi",
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "telegram:origin-session"
+    origin = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100999",
+        chat_type="group",
+        thread_id="77",
+        user_id="user-123",
+        user_name="tester",
+    )
+    runner.session_store._entries[session_key] = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=origin,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+
+    watcher = _watcher_dict()
+    watcher.update({
+        "session_key": session_key,
+        "chat_id": "fallback-chat",
+        "thread_id": "fallback-thread",
+        "user_id": "fallback-user",
+        "user_name": "fallback-name",
+        "notify_on_complete": True,
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    assert adapter.handle_message.await_count == 1
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.source is origin
+    assert synth_event.source.chat_id == "-100999"
+    assert synth_event.source.thread_id == "77"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1684,6 +1684,7 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+        assert "exit_reason" in result
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
@@ -1754,6 +1755,28 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("hello")
         assert result["interrupted"] is True
+
+    def test_active_todos_and_skill_nudge_are_injected_into_system_prompt(self, agent):
+        self._setup_agent(agent)
+        agent.valid_tool_names = list(set(agent.valid_tool_names) | {"skill_manage"})
+        agent._todo_store.write([
+            {"id": "todo-1", "content": "Finish verification", "status": "in_progress"},
+        ])
+        agent._iters_since_skill = agent._skill_nudge_interval
+        resp = _mock_response(content="Done", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Done"
+        api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert api_messages[0]["role"] == "system"
+        assert "You still have active todo items" in api_messages[0]["content"]
+        assert "skill-review threshold" in api_messages[0]["content"]
 
     def test_invalid_tool_name_retry(self, agent):
         """Model hallucinates an invalid tool name, agent retries and succeeds."""
@@ -2390,6 +2413,7 @@ class TestRetryExhaustion:
             f"Expected completed=False, got: {result}"
         )
         assert result.get("failed") is True
+        assert result.get("exit_reason") == "invalid_api_response"
         assert "error" in result
         assert "Invalid API response" in result["error"]
 

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -2,7 +2,7 @@
 
 import json
 
-from tools.todo_tool import TodoStore, todo_tool
+from tools.todo_tool import TODO_SCHEMA, TodoStore, todo_tool
 
 
 class TestWriteAndRead:
@@ -96,6 +96,13 @@ class TestMergeMode:
         )
         items = store.read()
         assert len(items) == 2
+
+
+class TestSchemaDescription:
+    def test_schema_warns_against_declaring_done_with_active_items(self):
+        desc = TODO_SCHEMA["description"]
+        assert "Do NOT declare the task done" in desc
+        assert "pending or in_progress" in desc
 
 
 class TestTodoToolFunction:

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -220,7 +220,8 @@ TODO_SCHEMA = {
         "status: pending|in_progress|completed|cancelled}\n"
         "List order is priority. Only ONE item in_progress at a time.\n"
         "Mark items completed immediately when done. If something fails, "
-        "cancel it and add a revised item.\n\n"
+        "cancel it and add a revised item.\n"
+        "Do NOT declare the task done while any item remains pending or in_progress unless you explicitly cancel it and explain why.\n\n"
         "Always returns the full current list."
     ),
     "parameters": {


### PR DESCRIPTION
## Summary
- expose `exit_reason` from `run_agent` so incomplete turns are surfaced instead of looking done
- tighten prompt and todo guidance around truthful completion, verification, and active todo closure
- reuse stored session origin for agent-triggered background process notifications

## Why
Hermes can currently sound finished when a turn was actually interrupted, truncated, or otherwise incomplete. This patch makes those states more visible and adds stronger runtime/prompt pressure against declaring tasks done while active todos remain.

## Changes
- `agent/prompt_builder.py`
  - strengthen completion-truthfulness and verification guidance
  - make stale-skill patching part of done
- `run_agent.py`
  - add `exit_reason` to early-return payloads and final result
  - inject dynamic ephemeral warnings when active todos remain or skill review threshold is crossed
- `gateway/run.py`
  - prefix incomplete final responses with `⚠️ Task not completed - <reason>`
  - propagate `exit_reason` / `completed`
  - preserve `session_entry.origin` when injecting background-process completion events
- `tools/todo_tool.py`
  - explicitly warn against declaring done with pending/in_progress items

## Testing
- `python -m py_compile agent/prompt_builder.py run_agent.py gateway/run.py tools/todo_tool.py tests/agent/test_prompt_builder.py tests/tools/test_todo_tool.py tests/run_agent/test_run_agent.py tests/gateway/test_background_process_notifications.py`
- `pytest tests/agent/test_prompt_builder.py tests/tools/test_todo_tool.py tests/gateway/test_background_process_notifications.py tests/run_agent/test_run_agent.py -q`

Passed locally:
- 392 passed
- 1 skipped
