### PR TITLE
fix(cli): generate usable profile aliases on Windows

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -966,7 +966,8 @@ def run_doctor(args):
                     parts.append("⚠ missing config")
                 if not (p.path / ".env").exists():
                     parts.append("no .env")
-                wrapper = wrapper_dir / p.name
+                wrapper_name = f"{p.name}.cmd" if os.name == "nt" else p.name
+                wrapper = wrapper_dir / wrapper_name
                 if not wrapper.exists():
                     parts.append("no alias")
                 status = ", ".join(parts) if parts else "configured"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4316,7 +4316,8 @@ def cmd_profile(args):
         model, provider = _read_config_model(profile_dir)
         gw = _check_gateway_running(profile_dir)
         skills = _count_skills(profile_dir)
-        wrapper = _get_wrapper_dir() / name
+        wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+        wrapper = _get_wrapper_dir() / wrapper_name
 
         print(f"\nProfile: {name}")
         print(f"Path:    {profile_dir}")
@@ -4352,11 +4353,8 @@ def cmd_profile(args):
             if collision:
                 print(f"Error: {collision}")
                 sys.exit(1)
-            wrapper_path = create_wrapper_script(alias_name)
+            wrapper_path = create_wrapper_script(alias_name, profile_name=name)
             if wrapper_path:
-                # If custom name, write the profile name into the wrapper
-                if custom_name:
-                    wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
                 print(f"✓ Alias created: {wrapper_path}")
                 if not _is_wrapper_dir_in_path():
                     print(f"⚠ {_get_wrapper_dir()} is not in your PATH.")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -197,23 +197,19 @@ def check_alias_collision(name: str) -> Optional[str]:
 
     # Check existing commands in PATH
     wrapper_dir = _get_wrapper_dir()
-    try:
-        result = subprocess.run(
-            ["which", name], capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            existing_path = result.stdout.strip()
-            # Allow overwriting our own wrappers
-            if existing_path == str(wrapper_dir / name):
-                try:
-                    content = (wrapper_dir / name).read_text()
-                    if "hermes -p" in content:
-                        return None  # it's our wrapper, safe to overwrite
-                except Exception:
-                    pass
-            return f"'{name}' conflicts with an existing command ({existing_path})"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+    wrapper_path = wrapper_dir / wrapper_name
+    existing_path = shutil.which(name)
+    if existing_path:
+        # Allow overwriting our own wrappers
+        if Path(existing_path).resolve() == wrapper_path.resolve():
+            try:
+                content = wrapper_path.read_text()
+                if "hermes -p" in content:
+                    return None  # it's our wrapper, safe to overwrite
+            except Exception:
+                pass
+        return f"'{name}' conflicts with an existing command ({existing_path})"
 
     return None  # safe
 
@@ -224,7 +220,7 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
-def create_wrapper_script(name: str) -> Optional[Path]:
+def create_wrapper_script(name: str, profile_name: Optional[str] = None) -> Optional[Path]:
     """Create a shell wrapper script at ~/.local/bin/<name>.
 
     Returns the path to the created wrapper, or None if creation failed.
@@ -236,10 +232,15 @@ def create_wrapper_script(name: str) -> Optional[Path]:
         print(f"⚠ Could not create {wrapper_dir}: {e}")
         return None
 
-    wrapper_path = wrapper_dir / name
+    wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+    wrapper_path = wrapper_dir / wrapper_name
+    target_profile = profile_name or name
     try:
-        wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
-        wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        if os.name == "nt":
+            wrapper_path.write_text(f'@echo off\nhermes -p {target_profile} %*\n')
+        else:
+            wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {target_profile} "$@"\n')
+            wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path
     except OSError as e:
         print(f"⚠ Could not create wrapper at {wrapper_path}: {e}")
@@ -248,7 +249,8 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
 def remove_wrapper_script(name: str) -> bool:
     """Remove the wrapper script for a profile. Returns True if removed."""
-    wrapper_path = _get_wrapper_dir() / name
+    wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+    wrapper_path = _get_wrapper_dir() / wrapper_name
     if wrapper_path.exists():
         try:
             # Verify it's our wrapper before removing
@@ -362,7 +364,8 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_path = wrapper_dir / name
+            wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+            alias_path = wrapper_dir / wrapper_name
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -542,7 +545,8 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     ]
 
     # Check for service
-    wrapper_path = _get_wrapper_dir() / name
+    wrapper_name = f"{name}.cmd" if os.name == "nt" else name
+    wrapper_path = _get_wrapper_dir() / wrapper_name
     has_wrapper = wrapper_path.exists()
     if has_wrapper:
         items.append(f"Command alias ({wrapper_path})")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,6 +113,7 @@ AUTHOR_MAP = {
     "m@statecraft.systems": "mbierling",
     "balyan.sid@gmail.com": "balyansid",
     "oluwadareab12@gmail.com": "bennytimz",
+    "xowiekk@gmail.com": "Xowiek",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──
     "1115117931@qq.com": "aaronagent",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -39,6 +39,7 @@ def _make_hermes_tree(root: Path) -> None:
     (root / "cron").mkdir(exist_ok=True)
     (root / "cron" / "jobs.json").write_text("[]")
 
+
     # Memories
     (root / "memories").mkdir(exist_ok=True)
     (root / "memories" / "notes.json").write_text("{}")
@@ -66,6 +67,11 @@ def _make_hermes_tree(root: Path) -> None:
     # Logs (should be included)
     (root / "logs").mkdir(exist_ok=True)
     (root / "logs" / "agent.log").write_text("log line\n")
+
+
+def _expected_wrapper_path(base: Path, name: str) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    return base / f"{name}{suffix}"
 
 
 # ---------------------------------------------------------------------------
@@ -872,11 +878,11 @@ class TestProfileRestoration:
         assert (hermes_home / "profiles" / "researcher" / "config.yaml").exists()
 
         # Wrapper scripts should be created
-        assert (wrapper_dir / "coder").exists()
-        assert (wrapper_dir / "researcher").exists()
+        assert _expected_wrapper_path(wrapper_dir, "coder").exists()
+        assert _expected_wrapper_path(wrapper_dir, "researcher").exists()
 
         # Wrappers should contain the right content
-        coder_wrapper = (wrapper_dir / "coder").read_text()
+        coder_wrapper = _expected_wrapper_path(wrapper_dir, "coder").read_text()
         assert "hermes -p coder" in coder_wrapper
 
     def test_import_skips_profile_dirs_without_config(self, tmp_path, monkeypatch):
@@ -902,8 +908,8 @@ class TestProfileRestoration:
         run_import(args)
 
         # Only valid profile should get a wrapper
-        assert (wrapper_dir / "valid").exists()
-        assert not (wrapper_dir / "empty").exists()
+        assert _expected_wrapper_path(wrapper_dir, "valid").exists()
+        assert not _expected_wrapper_path(wrapper_dir, "empty").exists()
 
     def test_import_without_profiles_module(self, tmp_path, monkeypatch):
         """Import gracefully handles missing profiles module (fresh install)."""

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -8,6 +8,7 @@ and shell completion generation.
 import json
 import io
 import os
+import shutil
 import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -52,6 +53,11 @@ def profile_env(tmp_path, monkeypatch):
     default_home.mkdir(exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", str(default_home))
     return tmp_path
+
+
+def _expected_wrapper_path(base: Path, name: str) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    return base / f"{name}{suffix}"
 
 
 # ===================================================================
@@ -341,9 +347,7 @@ class TestAliasCollision:
     """Tests for check_alias_collision()."""
 
     def test_normal_name_returns_none(self, profile_env):
-        # Mock 'which' to return not-found
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=1, stdout="")
+        with patch("hermes_cli.profiles.shutil.which", return_value=None):
             result = check_alias_collision("mybot")
         assert result is None
 
@@ -361,6 +365,24 @@ class TestAliasCollision:
         result = check_alias_collision("default")
         assert result is not None
         assert "reserved" in result.lower()
+
+
+class TestWrapperScripts:
+    def test_wrapper_is_resolvable_from_path(self, profile_env, monkeypatch):
+        from hermes_cli.profiles import create_wrapper_script
+
+        wrapper = create_wrapper_script("mybot")
+        original_path = os.environ.get("PATH", "")
+        monkeypatch.setenv("PATH", f"{wrapper.parent}{os.pathsep}{original_path}")
+
+        assert wrapper == _expected_wrapper_path(wrapper.parent, "mybot")
+        assert shutil.which("mybot") == str(wrapper)
+
+        content = wrapper.read_text()
+        if os.name == "nt":
+            assert content == "@echo off\nhermes -p mybot %*\n"
+        else:
+            assert content == '#!/bin/sh\nexec hermes -p mybot "$@"\n'
 
 
 # ===================================================================


### PR DESCRIPTION
## What this fixes

This fixes Windows profile aliases generated by `hermes profile create` / `hermes profile alias` so they are actually runnable from `PATH`.

Before this change, the alias flow still assumed a Unix-style wrapper model in a few places. On Windows, that meant the alias file could be created successfully but still not resolve as a usable command.

## Why it broke

There were two platform-specific problems in the alias flow:

- alias collision checks relied on a Unix-oriented `which` path
- wrapper generation still wrote an extensionless `#!/bin/sh` launcher on Windows

That produced a file on disk, but not one Windows could naturally resolve as a command.

A simple repro was:

- generate an alias like `coder`
- add the wrapper directory to `PATH`
- check `shutil.which("coder")`

Before this fix, the wrapper existed, but command resolution still returned `None`.

## What changed

The fix stays local to the wrapper/alias path:

- Windows wrappers are now generated as `.cmd`
- Windows wrapper contents now invoke Hermes using the native `%*` argument forwarding style
- alias collision checks now use `shutil.which()` for cross-platform behavior
- alias lookup/display paths now account for the Windows wrapper extension
- the custom alias flow no longer overwrites the intended target with POSIX wrapper content

No refactor or new abstraction was introduced here; this is just a targeted platform-correctness fix.

## Validation

Added regression coverage to verify that the generated wrapper:

- uses the expected platform-specific extension
- is resolvable through `PATH`
- contains the expected platform-appropriate launcher content

Additional validation performed:

- `python -m py_compile` succeeded for the touched production and test files
- functional verification script passed for wrapper creation and `PATH` resolution behavior

