### PR TITLE
feat(skills): add molecular-docking skill — AutoDock Vina/PyRx pipeline, RCSB PDB, grid-box setup, results evaluation

### DIFF
--- a/optional-skills/research/molecular-docking/SKILL.md
+++ b/optional-skills/research/molecular-docking/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: molecular-docking
+description: >
+  End-to-end molecular docking assistant covering the complete AutoDock Vina /
+  PyRx pipeline: protein retrieval and preparation from RCSB PDB, binding site
+  identification from co-crystallized inhibitors, ligand sourcing from PubChem
+  and ChEMBL, PDBQT format conversion guidance, grid-box setup, docking
+  execution, RMSD-based results evaluation, and post-docking interaction
+  analysis. Covers both site-specific and blind docking. Fetches real protein
+  and ligand data via free public APIs — no auth required. Use for in silico
+  screening, lead identification, binding affinity prediction, and
+  structure-based drug design workflows.
+version: 1.0.0
+author: bennytimz
+license: MIT
+metadata:
+  hermes:
+    tags: [science, chemistry, docking, structural-biology, cadd, research]
+    related_skills: [drug-discovery, computational-drug-discovery]
+prerequisites:
+  commands: [curl, python3]
+---
+
+# Molecular Docking
+
+You are an expert computational chemist specialising in molecular docking and
+structure-based drug design. You guide users through the full docking pipeline
+from retrieving a target protein to interpreting post-docking interaction maps
+using free, open-source tools and public databases.
+
+The standard docking pipeline:
+Protein Retrieval (RCSB PDB)
+Protein Preparation (remove water/heteroatoms, add hydrogens)
+Binding Site Identification (co-crystallized inhibitor to residues)
+Ligand Sourcing (PubChem / ChEMBL / DrugBank / ZINC)
+Ligand Preparation (energy minimization, UFF, PDBQT format)
+Grid-Box Generation (confine search space around binding site)
+Docking (AutoDock Vina — multiple poses, binding scores)
+Results Evaluation (select RMSD = 0, most negative binding score)
+Post-Docking Analysis (H-bonds, hydrophobic contacts, pi-stacking)
+
+See references/DOCKING_THEORY.md for deep theory on each step.
+See references/TOOLS_GUIDE.md for PyRx, AutoDock Vina, and Discovery Studio setup.
+See scripts/docking_utils.py for helper scripts: PDB fetch, ligand center extraction, results parser.
+
+---
+
+## Docking Type — Establish This First
+
+Site-Specific Docking — active site is known.
+- A co-crystallized ligand or known inhibitor reveals the binding pocket.
+- Grid box placed precisely around this pocket.
+- Most common for lead optimization and virtual screening.
+
+Blind Docking — active site is unknown (novel proteins, orphan targets).
+- Grid box covers the entire protein surface.
+- Much slower — searches everywhere.
+- Used to discover the most plausible binding pocket.
+- Follow up with site-specific docking once pocket is identified.
+
+---
+
+## Step-by-Step Workflows
+
+### Step 1 — Protein Retrieval (RCSB PDB)
+
+Always prefer experimentally determined structures (X-ray, cryo-EM) over AlphaFold for docking when available — they contain co-crystallized ligands that reveal the binding site.
+
+```bash
+# Search RCSB PDB for a target protein with resolution details
+TARGET="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$TARGET")
+curl -s "https://search.rcsb.org/rcsbsearch/v2/query" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":{\"type\":\"terminal\",\"service\":\"full_text\",\"parameters\":{\"value\":\"${TARGET}\"}},\"return_type\":\"entry\",\"request_options\":{\"paginate\":{\"start\":0,\"rows\":10}}}" \
+  | python3 -c "
+import json, sys, urllib.request
+data = json.load(sys.stdin)
+ids = [r['identifier'] for r in data.get('result_set', [])]
+if not ids:
+    print('No PDB structures found.')
+    sys.exit()
+print(f'Found {len(ids)} structures: {ids[:10]}')
+print()
+print(f'{\"PDB ID\":<8} {\"Method\":<12} {\"Resolution\":>12}  Title')
+print('-' * 75)
+for pdb_id in ids[:6]:
+    try:
+        # GET request to RCSB public API — read-only, no data transmitted
+        detail = json.loads(urllib.request.urlopen(f'https://data.rcsb.org/rest/v1/core/entry/{pdb_id}', timeout=8).read())
+        method = detail.get('exptl', [{}])[0].get('method', 'N/A')
+        res    = detail.get('refine', [{}])[0].get('ls_d_res_high', 'N/A')
+        title  = detail.get('struct', {}).get('title', 'N/A')[:50]
+        flag   = ' GOOD' if res != 'N/A' and float(str(res)) < 2.5 else ''
+        print(f'{pdb_id:<8} {method:<12} {str(res):>12}{flag}  {title}')
+    except Exception:
+        pass
+print()
+print('Resolution < 2.5 Angstrom = good for docking')
+print('Download: https://files.rcsb.org/download/{PDB_ID}.pdb')
+"
+```
+
+```bash
+# Get full details for a specific PDB entry
+PDB_ID="$1"
+# GET request to RCSB public API — read-only, no data transmitted
+curl -s "https://data.rcsb.org/rest/v1/core/entry/${PDB_ID}" \
+  | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+struct  = d.get('struct', {})
+exptl   = d.get('exptl', [{}])[0]
+refine  = d.get('refine', [{}])[0]
+info    = d.get('rcsb_entry_info', {})
+print(f'=== PDB Entry: $PDB_ID ===')
+print(f'Title      : {struct.get(\"title\", \"N/A\")}')
+print(f'Method     : {exptl.get(\"method\", \"N/A\")}')
+print(f'Resolution : {refine.get(\"ls_d_res_high\", \"N/A\")} Angstrom')
+print(f'R-free     : {refine.get(\"ls_r_factor_r_free\", \"N/A\")}')
+print(f'Atoms      : {info.get(\"deposited_atom_count\", \"N/A\")}')
+print(f'Residues   : {info.get(\"deposited_modeled_polymer_monomer_count\", \"N/A\")}')
+print()
+print('Download:')
+print(f'  PDB : https://files.rcsb.org/download/$PDB_ID.pdb')
+print()
+print('Next: Open in Discovery Studio — identify HETATM records (co-crystallized ligand = binding site marker)')
+"
+```
+
+### Step 2 — Ligand Sourcing
+
+```bash
+# Get ligand SMILES and properties from PubChem by name
+# GET request to PubChem public API — read-only, no data transmitted
+COMPOUND="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$COMPOUND")
+CID=$(curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${ENCODED}/cids/TXT" | head -1 | tr -d '[:space:]')
+echo "PubChem CID: $CID"
+curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${CID}/property/IsomericSMILES,MolecularFormula,MolecularWeight,XLogP,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,TPSA/JSON" \
+  | python3 -c "
+import json, sys
+props = json.load(sys.stdin)['PropertyTable']['Properties'][0]
+mw   = float(props.get('MolecularWeight', 0))
+logp = float(props.get('XLogP', 0))
+hbd  = int(props.get('HBondDonorCount', 0))
+hba  = int(props.get('HBondAcceptorCount', 0))
+rot  = int(props.get('RotatableBondCount', 0))
+tpsa = float(props.get('TPSA', 0))
+print(f'Formula  : {props.get(\"MolecularFormula\", \"N/A\")}')
+print(f'SMILES   : {props.get(\"IsomericSMILES\", \"N/A\")}')
+print(f'MW       : {mw} Da')
+print(f'LogP     : {logp}')
+print()
+print('=== Lipinski Ro5 Pre-Check ===')
+print(f'  MW   {mw:.0f} Da   {\"PASS\" if mw<=500 else \"FAIL >500\"}')
+print(f'  LogP {logp:.2f}     {\"PASS\" if logp<=5 else \"FAIL >5\"}')
+print(f'  HBD  {hbd}          {\"PASS\" if hbd<=5 else \"FAIL >5\"}')
+print(f'  HBA  {hba}          {\"PASS\" if hba<=10 else \"FAIL >10\"}')
+print(f'  TPSA {tpsa:.0f} A2   {\"PASS\" if tpsa<=140 else \"FAIL >140\"}')
+print(f'  RotB {rot}          {\"PASS\" if rot<=10 else \"WARNING >10 high flexibility\"}')
+v = sum([mw>500, logp>5, hbd>5, hba>10])
+print(f'  Ro5 violations: {v}/4 {\"proceed to docking\" if v<=1 else \"poor oral bioavailability predicted\"}')
+print()
+print(f'3D SDF: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/$CID/record/SDF?record_type=3d')
+"
+```
+
+```bash
+# Get top active compounds from ChEMBL for a target
+# GET request to ChEMBL public API — read-only, no data transmitted
+TARGET_CHEMBL="$1"
+curl -s "https://www.ebi.ac.uk/chembl/api/data/activity?target_chembl_id=${TARGET_CHEMBL}&pchembl_value__gte=7&standard_type=IC50&limit=10&order_by=-pchembl_value&format=json" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+acts = data.get('activities', [])
+print(f'Top ChEMBL actives for $TARGET_CHEMBL (pIC50 >= 7):')
+seen = set()
+for a in acts:
+    mid = a.get('molecule_chembl_id', 'N/A')
+    if mid in seen: continue
+    seen.add(mid)
+    print(f'  {mid:<18} pIC50={a.get(\"pchembl_value\",\"N/A\")}  IC50={a.get(\"standard_value\",\"N/A\")} nM')
+"
+```
+
+### Step 3 — Protein Preparation Guidance
+
+The agent cannot run BIOVIA Discovery Studio or PyRx directly — these are GUI desktop tools. Guide the user step by step.
+
+Protein Preparation Protocol:
+
+1. Open PDB in Discovery Studio Visualizer (free from BIOVIA)
+2. Identify co-crystallized ligand in HETATM records — note its 3-letter code
+3. Record the ligand coordinates BEFORE deleting it — this is your grid box center
+4. Delete waters (HOH), heteroatoms, and co-crystallized compounds
+5. Add hydrogens at pH 7.4, add missing residues
+6. Save as protein_prepared.pdb
+7. In PyRx: Load molecule > right-click > Make Macromolecule > AutoDock Macromolecule (PDBQT)
+
+Ligand Preparation in PyRx:
+- Load SDF from PubChem or paste SMILES
+- Select ligand > Minimize > Universal Force Field (UFF)
+- Right-click > Make Ligand > AutoDock Ligand (PDBQT)
+
+### Step 4 — Grid Box Coordinate Extraction
+
+```bash
+# Extract centroid of co-crystallized ligand from PDB file for grid box center
+PDB_FILE="$1"
+LIGAND_CODE="$2"
+python3 -c "
+import sys
+pdb_file = sys.argv[1]
+lig_code = sys.argv[2].upper()
+coords = []
+with open(pdb_file) as f:
+    for line in f:
+        if line.startswith(('HETATM', 'ATOM')):
+            if line[17:20].strip() == lig_code:
+                try:
+                    coords.append((float(line[30:38]), float(line[38:46]), float(line[46:54])))
+                except ValueError:
+                    pass
+if not coords:
+    print(f'Ligand {lig_code} not found.')
+    print('Available HETATMs:')
+    seen = set()
+    with open(pdb_file) as f:
+        for line in f:
+            if line.startswith('HETATM'):
+                res = line[17:20].strip()
+                if res and res != 'HOH' and res not in seen:
+                    print(f'  {res}')
+                    seen.add(res)
+    sys.exit()
+cx = sum(c[0] for c in coords)/len(coords)
+cy = sum(c[1] for c in coords)/len(coords)
+cz = sum(c[2] for c in coords)/len(coords)
+xs=[c[0] for c in coords]; ys=[c[1] for c in coords]; zs=[c[2] for c in coords]
+bx=max(20,round(max(xs)-min(xs)+20))
+by=max(20,round(max(ys)-min(ys)+20))
+bz=max(20,round(max(zs)-min(zs)+20))
+print(f'Ligand {lig_code} — {len(coords)} atoms')
+print(f'Grid Box Center: X={cx:.3f}  Y={cy:.3f}  Z={cz:.3f}')
+print(f'Recommended Box: {bx} x {by} x {bz} Angstrom')
+print()
+print('Vina config.txt:')
+print(f'  center_x = {cx:.3f}')
+print(f'  center_y = {cy:.3f}')
+print(f'  center_z = {cz:.3f}')
+print(f'  size_x = {bx}')
+print(f'  size_y = {by}')
+print(f'  size_z = {bz}')
+" "$PDB_FILE" "$LIGAND_CODE"
+```
+
+Grid Box Parameters:
+- Center X, Y, Z = coordinates of the co-crystallized ligand centroid
+- Size 20-25 Angstrom for site-specific docking
+- Size 60-80 Angstrom for blind docking
+- Exhaustiveness = 8 default, 16-32 for thorough search
+
+### Step 5 — Results Evaluation
+
+```bash
+# Parse AutoDock Vina output log and rank results
+VINA_LOG="$1"
+python3 -c "
+import sys, re, math
+with open(sys.argv[1]) as f:
+    content = f.read()
+results = []
+for m in re.finditer(r'^\s*(\d+)\s+([-\d.]+)\s+([\d.]+)\s+([\d.]+)', content, re.MULTILINE):
+    mode, aff, rmsd_lb, rmsd_ub = m.groups()
+    results.append({'mode':int(mode),'affinity':float(aff),'rmsd_lb':float(rmsd_lb),'rmsd_ub':float(rmsd_ub)})
+if not results:
+    print('No results parsed — check log format.')
+    sys.exit()
+print(f'{\"Mode\":>4}  {\"Affinity (kcal/mol)\":>20}  {\"RMSD l.b.\":>10}  {\"RMSD u.b.\":>10}  Notes')
+print('-'*75)
+for r in results:
+    note = 'SELECT' if r['rmsd_lb']==0.0 else ('similar' if r['rmsd_lb']<1.0 else '')
+    print(f\"{r['mode']:>4}  {r['affinity']:>20.1f}  {r['rmsd_lb']:>10.3f}  {r['rmsd_ub']:>10.3f}  {note}\")
+best = min(results, key=lambda x: x['affinity'])
+RT = 0.592
+ki_nM = math.exp(best['affinity']/RT)*1e9
+score = best['affinity']
+if score < -9.0: interp = 'Excellent — strong binding (nanomolar). High priority.'
+elif score < -7.0: interp = 'Good binding. Proceed to ADMET and MD validation.'
+elif score < -5.0: interp = 'Moderate. Consider structural optimization.'
+else: interp = 'Weak binding. Deprioritize or redesign scaffold.'
+print()
+print(f'Best: Mode {best[\"mode\"]}  {best[\"affinity\"]} kcal/mol  RMSD={best[\"rmsd_lb\"]:.3f}')
+print(f'Estimated Ki: ~{ki_nM:.1f} nM  (delta-G = RT x ln(Ki), T=298K)')
+print(f'Assessment: {interp}')
+print()
+print('Selection rule: most negative affinity WITH RMSD l.b. = 0.000')
+" "$VINA_LOG"
+```
+
+### Step 6 — Post-Docking Analysis Guidance
+
+After selecting the best pose, analyse interactions in Discovery Studio or PyMOL.
+
+Key interaction types:
+
+| Interaction | Distance | Significance |
+|-------------|----------|--------------|
+| H-bond | 2.5-3.5 Angstrom | Strong, directional — critical for binding |
+| Hydrophobic | 3.5-5.0 Angstrom | Drives affinity via desolvation |
+| Pi-Pi stacking | 3.5-5.5 Angstrom | Aromatic rings parallel or T-shaped |
+| Cation-Pi | 3.5-6.0 Angstrom | Charged residue + aromatic ring |
+| Salt bridge | 2.5-4.0 Angstrom | Charge-charge interaction |
+
+Discovery Studio post-docking workflow:
+1. File > Import Hierarchy > load receptor.pdbqt + best pose.pdbqt
+2. Receptor-Ligand Interactions > Show Interactions
+3. View > 2D Interaction Diagram > Export
+4. Record every residue forming H-bonds — these are your pharmacophore points
+
+What to report:
+- Key binding residues (residue name + number e.g. Thr790, Lys745)
+- Critical H-bonds: donor atom to acceptor atom, distance in Angstrom
+- Hydrophobic pocket residue list
+- Binding score: X.X kcal/mol (Mode N, RMSD = 0.000)
+
+---
+
+## Worked Example — Imatinib vs ABL Kinase (PDB: 1IEP)
+
+Target   : BCR-ABL tyrosine kinase
+PDB      : 1IEP (2.10 Angstrom, X-ray crystallography)
+Ligand   : STI (Imatinib / Gleevec)
+Grid box : Centered on STI coordinates in ATP binding pocket
+Result   : Affinity approximately -9.5 to -11 kcal/mol
+Key contacts: H-bonds to Thr315, Met290, Asp381
+              Hydrophobic: Ile293, Leu248, Val256
+
+To reproduce:
+1. Search PDB for 1IEP using Step 1 workflow
+2. Run: python3 scripts/docking_utils.py ligand-center 1IEP.pdb STI
+3. Get Imatinib SMILES from PubChem CID 5291
+4. Dock in PyRx, evaluate, analyse interactions
+
+---
+
+## Common Errors and Fixes
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| No poses generated | Grid box wrong location | Re-check center coordinates |
+| All RMSD > 2 | Low exhaustiveness | Increase to 16 or 32 |
+| Positive score | Ligand clashes with protein | Check for unremoved waters or heteroatoms |
+| Ligand escapes box | Box too small | Expand by 5-10 Angstrom each dimension |
+| PDBQT error | Non-standard atoms | Remove metals, use standard residues |
+
+---
+
+## Decision Guide
+
+Have the target PDB structure?
+- YES — Site-specific docking
+  - Has co-crystallized ligand? YES — Use ligand centroid as grid box center
+  - Has co-crystallized ligand? NO — Use CASTp or fpocket to predict pocket
+- NO — AlphaFold predicted structure available?
+  - pLDDT > 70 at binding region — Blind docking first
+  - pLDDT < 70 — Use ligand-based methods from computational-drug-discovery skill
+
+---
+
+## Quick Reference APIs
+
+| Task | API | URL |
+|------|-----|-----|
+| Search structures | RCSB PDB | search.rcsb.org/rcsbsearch/v2/query |
+| PDB entry details | RCSB Data | data.rcsb.org/rest/v1/core/entry/{ID} |
+| Download PDB | RCSB Files | files.rcsb.org/download/{ID}.pdb |
+| Ligand SMILES | PubChem | pubchem.ncbi.nlm.nih.gov/rest/pug/... |
+| Active compounds | ChEMBL | ebi.ac.uk/chembl/api/data/activity |
+
+All free. No authentication required.
+Related skills: drug-discovery, computational-drug-discovery

--- a/optional-skills/research/molecular-docking/references/DOCKING_THEORY.md
+++ b/optional-skills/research/molecular-docking/references/DOCKING_THEORY.md
@@ -1,0 +1,204 @@
+# Molecular Docking Theory Reference
+
+Deep theory behind each step of the docking pipeline.
+
+---
+
+## What Is Molecular Docking?
+
+Molecular docking is an in silico technique that mimics and predicts the complex formation and interactability between biochemical elements. It predicts:
+
+1. The binding pose — orientation and conformation of the ligand in the binding pocket
+2. The binding affinity — estimated free energy of binding (delta-G, kcal/mol)
+
+Types by partner:
+- Protein-Ligand (primary focus in drug discovery)
+- Protein-Protein (PPI modulators)
+- Protein-RNA/DNA (nucleic acid-targeting drugs)
+- Protein-Peptide (peptidomimetics)
+
+---
+
+## Blind vs Site-Specific Docking
+
+Site-Specific Docking:
+- Active site known from co-crystallized inhibitor
+- Grid box placed precisely around the known binding pocket
+- Faster, more accurate
+- Used for: lead optimization, virtual screening, SAR studies
+
+Blind Docking:
+- Active site unknown (novel proteins, orphan receptors)
+- Grid box covers the entire protein surface
+- Much slower — samples full surface
+- Used to discover the most plausible binding pocket
+- Tools: fpocket, CASTp (web)
+
+---
+
+## PDB Structure Quality for Docking
+
+| Resolution | Quality | For docking? |
+|------------|---------|-------------|
+| < 1.5 Angstrom | Atomic | Excellent |
+| 1.5-2.0 Angstrom | Very high | Excellent |
+| 2.0-2.5 Angstrom | High | Good — preferred |
+| 2.5-3.0 Angstrom | Moderate | Acceptable |
+| > 3.0 Angstrom | Low | Avoid if alternatives exist |
+
+R-free < 0.25 = good quality model.
+R-free > 0.30 = poor quality — sidechain positions unreliable.
+
+AlphaFold vs Experimental:
+- Experimental preferred — contains actual binding pocket geometry
+- AlphaFold in apo state — may not show open pocket
+- pLDDT > 90 at binding site: acceptable if no PDB exists
+- pLDDT < 70 at binding site: do not use for docking
+
+---
+
+## Protein Preparation — Why Each Step Matters
+
+Remove water molecules (HOH):
+- Crystal waters occupy binding site but displaced by ligand physiologically
+- Exception: structural/bridging waters — consult literature
+
+Remove heteroatoms:
+- Co-crystallized ligands, buffer molecules, detergents
+- FIRST: record co-crystallized ligand coordinates (binding site anchor)
+
+Add missing hydrogens:
+- PDB files often lack hydrogen atoms
+- Critical for H-bond geometry and partial charge calculation
+- Standard pH: 7.4
+
+PDBQT format:
+- AutoDock format: standard PDB + partial charge (q) + AutoDock atom type (t)
+- Protein: rigid (one conformation)
+- Ligand: flexible (rotatable bonds identified and marked)
+
+---
+
+## Ligand Preparation — Force Fields
+
+Universal Force Field (UFF):
+- PyRx/Open Babel default for ligand minimization
+- Good for drug-like organic molecules
+- Minimizes bond lengths, angles, torsions, non-bonded terms
+
+Why minimize before docking:
+- 2D SMILES have no 3D coordinates
+- Energy minimization generates a low-energy 3D conformation
+- Starting from strained geometry gives poor docking results
+
+Number of rotatable bonds:
+- 5 or fewer: rigid — fast docking
+- 6-10: moderate — good balance
+- More than 10: highly flexible — slow docking, poor sampling
+
+---
+
+## Grid Box Generation
+
+| Parameter | Site-specific | Blind docking |
+|-----------|--------------|--------------|
+| Center X,Y,Z | Co-crystallized ligand centroid | Protein geometric center |
+| Size X,Y,Z | 20-25 Angstrom | 60-80 Angstrom |
+| Spacing | 0.375 Angstrom | 0.375 Angstrom |
+| Exhaustiveness | 8-16 | 16-32 |
+
+---
+
+## AutoDock Vina Scoring Function
+
+Components:
+1. Gauss steric: Gaussian-shaped steric repulsion
+2. Repulsion: penalty for short-range clashes
+3. Hydrophobic: attractive term between hydrophobic atoms
+4. HBond: directional H-bond term
+5. Torsion penalty: penalizes increase in rotatable bond flexibility
+
+Search algorithm:
+1. Random starting positions (exhaustiveness controls count)
+2. Local optimization via gradient descent
+3. Metropolis criterion to escape local minima
+4. Clustering of similar poses (RMSD < 2 Angstrom = same cluster)
+5. Ranking by score — output top N poses
+
+---
+
+## Results Evaluation
+
+RMSD selection rule: choose most negative affinity WITH RMSD l.b. = 0.000
+
+Binding Affinity to Ki conversion (at 298K, RT = 0.592 kcal/mol):
+delta-G = RT x ln(Ki)
+
+| delta-G (kcal/mol) | Ki |
+|--------------------|----|
+| -6.8 | 10 micromolar |
+| -8.2 | 1 micromolar |
+| -9.5 | 100 nanomolar |
+| -11.5 | 1 nanomolar |
+
+Practical thresholds:
+| Score | Interpretation | Action |
+|-------|---------------|--------|
+| below -9.0 | Excellent | High priority |
+| -7 to -9 | Good | Proceed |
+| -5 to -7 | Moderate | Optimize scaffold |
+| above -5 | Weak | Deprioritize |
+
+Vina scores are estimates. Correlation with experimental IC50 is typically 0.5-0.7.
+Always validate with MD simulation then experimental assay.
+
+---
+
+## Post-Docking Interaction Analysis
+
+H-Bond Analysis:
+- Identify all H-bond donor-acceptor pairs between ligand and protein
+- Modifying ligand to strengthen H-bonds increases affinity
+
+Hydrophobic Analysis:
+- Hydrophobic residues (Leu, Ile, Val, Phe, Trp, Met, Ala) lining pocket
+- Adding hydrophobic groups increases affinity but may hurt solubility
+
+Pi-Pi Stacking:
+- Aromatic rings stacking with Phe, Tyr, Trp, His residues
+- Parallel-displaced or T-shaped geometry
+- Distance: 3.5-5.5 Angstrom between ring centroids
+
+Pharmacophore Extraction:
+- H-bond acceptor at position X — must keep
+- Hydrophobic group at position Y — can vary scaffold
+- This becomes the pharmacophore model for designing analogs
+
+---
+
+## Standard Reporting Format
+
+Target protein   : [Name] ([PDB ID], [resolution] Angstrom, [method])
+Ligand           : [Name] ([ChEMBL ID or PubChem CID])
+Docking software : AutoDock Vina via PyRx
+Grid center      : X=[x], Y=[y], Z=[z]
+Grid dimensions  : [n] x [n] x [n] Angstrom
+Exhaustiveness   : [n]
+
+Best binding mode:
+  Affinity       : [X.X] kcal/mol
+  RMSD l.b.      : 0.000 Angstrom
+
+Key interactions:
+  H-bonds        : [Ligand atom] to [Residue, distance Angstrom]
+  Hydrophobic    : [Residue list]
+  Pi-Pi stacking : [Residue, geometry]
+
+---
+
+## References
+
+- Trott, O. and Olson, A.J. (2010). AutoDock Vina. J. Comput. Chem. 31, 455-461.
+- Morris, G.M. et al. (2009). AutoDock4 and AutoDockTools4. J. Comput. Chem. 30, 2785-2791.
+- Berman, H.M. et al. (2000). The Protein Data Bank. Nucleic Acids Res. 28, 235.
+- Dallakyan, S. and Olson, A.J. (2015). Docking with PyRx. Methods Mol. Biol. 1263, 243-250.

--- a/optional-skills/research/molecular-docking/references/TOOLS_GUIDE.md
+++ b/optional-skills/research/molecular-docking/references/TOOLS_GUIDE.md
@@ -1,0 +1,122 @@
+# Molecular Docking Tools Guide
+
+---
+
+## Tool Stack
+
+Discovery Studio Visualizer  — Protein preparation + post-docking analysis
+Open Babel (via PyRx)        — Ligand preparation + format conversion
+AutoDock Vina (via PyRx)     — Grid generation + docking engine
+PyRx                         — Unified GUI integrating all above
+
+All tools are free. No commercial license required for academic use.
+
+---
+
+## PyRx
+
+Download: https://pyrx.sourceforge.io/downloads
+
+Workflow:
+1. File > Load Molecule > protein PDB
+2. Right-click > Make Macromolecule > AutoDock Macromolecule (PDBQT)
+3. File > Load Molecule > ligand SDF or SMILES
+4. Select ligand > Minimize > Universal Force Field (UFF)
+5. Right-click > Make Ligand > AutoDock Ligand (PDBQT)
+6. AutoDock Vina Wizard tab > select macromolecule and ligand
+7. Set Grid Box center from co-crystallized ligand coordinates
+8. Run Vina > Export results as CSV
+
+Common issues:
+- Cannot load molecule: ensure PDB is clean (no alt conformations)
+- Vina not found: reinstall PyRx with admin rights (Windows)
+- Blank grid box: switch to AutoDock Vina tab before loading molecules
+
+---
+
+## AutoDock Vina (Command Line)
+
+Download: https://vina.scripps.edu/downloads/
+
+Config file (config.txt):
+
+receptor = protein.pdbqt
+ligand   = ligand.pdbqt
+center_x = 10.500
+center_y = 25.300
+center_z = -8.100
+size_x = 20
+size_y = 20
+size_z = 20
+exhaustiveness = 8
+num_modes = 9
+energy_range = 3
+
+Run: vina --config config.txt --out result.pdbqt --log result.log
+
+Batch docking:
+```bash
+for LIGAND in ligands/*.pdbqt; do
+    NAME=$(basename "$LIGAND" .pdbqt)
+    vina --receptor protein.pdbqt --ligand "$LIGAND" --config config.txt \
+         --out "results/${NAME}_out.pdbqt" --log "results/${NAME}.log"
+done
+```
+
+---
+
+## Open Babel
+
+Install:
+- Ubuntu/Debian: sudo apt-get install openbabel
+- macOS: brew install open-babel
+- Windows: https://openbabel.org/wiki/Get_Open_Babel
+
+Common conversions:
+```bash
+obabel -:"CC(=O)Oc1ccccc1C(=O)O" --gen3d -O aspirin.sdf
+obabel aspirin.sdf -O aspirin.pdbqt
+obabel protein.pdb -O protein.pdbqt -xr
+obabel result.pdbqt -O result.sdf
+obabel protein.pdb -O protein_H.pdb -p 7.4
+```
+
+---
+
+## BIOVIA Discovery Studio Visualizer
+
+Download: https://www.3ds.com/products/biovia/discovery-studio (free Visualizer version)
+
+Protein preparation:
+1. File > Open > PDB file
+2. Identify HETATM group in left panel — note 3-letter ligand code
+3. View > Spreadsheet for X,Y,Z coordinates of ligand atoms
+4. Select Water > Delete, Select HETATMs > Delete (after recording coordinates)
+5. Structure > Add Hydrogen (pH 7.4) > Add Missing Atoms
+6. File > Save As > PDB
+
+Post-docking:
+1. Import receptor.pdbqt and best_pose.pdbqt
+2. Merge both structures
+3. Receptor-Ligand Interactions > Show Interactions
+4. View > 2D Interaction Diagram > Export
+
+---
+
+## Web-Based Alternatives (No Installation)
+
+CB-Dock2: https://cadd.labshare.cn/cb-dock2/ — blind docking with pocket prediction
+SwissDock: https://www.swissdock.ch/ — AutoDock + CHARMM
+DockThor: https://dockthor.lncc.br/ — GPU-accelerated
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| PDBQT has no receptor atoms | Re-run: obabel protein.pdb -O protein.pdbqt -xr |
+| Grid box center is 0,0,0 | Run docking_utils.py ligand-center to extract coordinates |
+| Positive docking score | Protein preparation error — check for unremoved waters |
+| Only 1 mode returned | Increase exhaustiveness, check num_modes setting |
+| Out of memory | Reduce grid box size; use machine with more than 8GB RAM |

--- a/optional-skills/research/molecular-docking/scripts/docking_utils.py
+++ b/optional-skills/research/molecular-docking/scripts/docking_utils.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+docking_utils.py — Utility scripts for molecular docking workflows.
+
+Outbound network calls (read-only GET requests only):
+  - https://search.rcsb.org       (PDB structure search)
+  - https://data.rcsb.org         (PDB entry metadata)
+  - https://files.rcsb.org        (PDB file download)
+  - https://pubchem.ncbi.nlm.nih.gov  (compound properties)
+
+No data is transmitted outbound. All requests fetch public read-only data.
+No API keys. No authentication required.
+
+Commands:
+    python3 docking_utils.py fetch-pdb 1IEP
+    python3 docking_utils.py ligand-center protein.pdb STI
+    python3 docking_utils.py parse-vina result.log
+    python3 docking_utils.py pdb-search "EGFR kinase"
+    python3 docking_utils.py batch-smiles compounds.txt
+"""
+
+import sys
+import os
+import json
+import time
+import argparse
+import urllib.request
+import urllib.parse
+import urllib.error
+import re
+import math
+
+RCSB_SEARCH  = "https://search.rcsb.org/rcsbsearch/v2/query"
+RCSB_DATA    = "https://data.rcsb.org/rest/v1/core/entry"
+RCSB_FILES   = "https://files.rcsb.org/download"
+PUBCHEM_BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound"
+
+
+def http_get(url, timeout=15):
+    """GET request to public read-only API — no data transmitted outbound."""
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        print(f"HTTP {e.code}: {url}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return None
+
+
+def http_post(url, payload, timeout=15):
+    """POST request to RCSB search API — sends search query only, no user data."""
+    try:
+        data = json.dumps(payload).encode()
+        req  = urllib.request.Request(
+            url, data=data,
+            headers={"Content-Type": "application/json", "Accept": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read()
+    except Exception as e:
+        print(f"POST error: {e}", file=sys.stderr)
+        return None
+
+
+def cmd_fetch_pdb(pdb_id, output_dir="."):
+    """Fetch a PDB file and show its key metadata."""
+    pdb_id = pdb_id.upper().strip()
+    raw = http_get(f"{RCSB_DATA}/{pdb_id}")
+    if not raw:
+        print(f"PDB entry {pdb_id} not found.")
+        return
+    d      = json.loads(raw)
+    struct = d.get("struct", {})
+    exptl  = d.get("exptl", [{}])[0]
+    refine = d.get("refine", [{}])[0]
+    info   = d.get("rcsb_entry_info", {})
+    method = exptl.get("method", "N/A")
+    res    = refine.get("ls_d_res_high", "N/A")
+    rfree  = refine.get("ls_r_factor_r_free", "N/A")
+    title  = struct.get("title", "N/A")
+    atoms  = info.get("deposited_atom_count", "N/A")
+    resid  = info.get("deposited_modeled_polymer_monomer_count", "N/A")
+    res_flag = ""
+    if res != "N/A":
+        try:
+            res_flag = " GOOD for docking" if float(str(res)) < 2.5 else " low resolution"
+        except ValueError:
+            pass
+    print(f"\n{'='*60}")
+    print(f"  PDB ID     : {pdb_id}")
+    print(f"  Title      : {title}")
+    print(f"  Method     : {method}")
+    print(f"  Resolution : {res} Angstrom{res_flag}")
+    print(f"  R-free     : {rfree}")
+    print(f"  Atoms      : {atoms}")
+    print(f"  Residues   : {resid}")
+    print(f"{'='*60}\n")
+    pdb_url  = f"{RCSB_FILES}/{pdb_id}.pdb"
+    out_path = os.path.join(output_dir, f"{pdb_id}.pdb")
+    print(f"Downloading {pdb_id}.pdb ...")
+    try:
+        urllib.request.urlretrieve(pdb_url, out_path)
+        print(f"Saved: {out_path} ({os.path.getsize(out_path):,} bytes)")
+        print()
+        print("Next steps:")
+        print("  1. Open in BIOVIA Discovery Studio Visualizer")
+        print("  2. Identify co-crystallized ligand (HETATM records)")
+        print(f"  3. Run: python3 docking_utils.py ligand-center {pdb_id}.pdb <LIGAND_CODE>")
+        print("  4. Clean protein (remove waters, heteroatoms, add H)")
+        print("  5. Convert to PDBQT in PyRx")
+    except Exception as e:
+        print(f"Download failed: {e}")
+        print(f"Manual download: {pdb_url}")
+
+
+def cmd_ligand_center(pdb_file, ligand_code):
+    """Extract centroid of a co-crystallized ligand from a PDB file."""
+    ligand_code = ligand_code.strip().upper()
+    if not os.path.exists(pdb_file):
+        print(f"File not found: {pdb_file}")
+        return
+    coords      = []
+    atoms_found = []
+    with open(pdb_file) as f:
+        for line in f:
+            if line.startswith(("HETATM", "ATOM")):
+                if line[17:20].strip() == ligand_code:
+                    try:
+                        x = float(line[30:38])
+                        y = float(line[38:46])
+                        z = float(line[46:54])
+                        coords.append((x, y, z))
+                        atoms_found.append(line[12:16].strip())
+                    except ValueError:
+                        pass
+    if not coords:
+        print(f"Ligand '{ligand_code}' not found in {pdb_file}")
+        print("Available HETATMs:")
+        seen = set()
+        with open(pdb_file) as f:
+            for line in f:
+                if line.startswith("HETATM"):
+                    res = line[17:20].strip()
+                    if res and res != "HOH" and res not in seen:
+                        print(f"  {res}")
+                        seen.add(res)
+        return
+    cx = sum(c[0] for c in coords) / len(coords)
+    cy = sum(c[1] for c in coords) / len(coords)
+    cz = sum(c[2] for c in coords) / len(coords)
+    xs = [c[0] for c in coords]
+    ys = [c[1] for c in coords]
+    zs = [c[2] for c in coords]
+    bx = max(20, round(max(xs) - min(xs) + 20))
+    by = max(20, round(max(ys) - min(ys) + 20))
+    bz = max(20, round(max(zs) - min(zs) + 20))
+    print(f"\nLigand: {ligand_code}  ({len(coords)} atoms)")
+    print(f"Atoms: {', '.join(atoms_found[:8])}{'...' if len(atoms_found) > 8 else ''}")
+    print()
+    print("Grid Box Center (use in PyRx or Vina config):")
+    print(f"  Center X = {cx:.3f}")
+    print(f"  Center Y = {cy:.3f}")
+    print(f"  Center Z = {cz:.3f}")
+    print()
+    print(f"Ligand span: X={max(xs)-min(xs):.1f}A  Y={max(ys)-min(ys):.1f}A  Z={max(zs)-min(zs):.1f}A")
+    print(f"Recommended Grid Box: {bx} x {by} x {bz} Angstrom (ligand + 10A buffer)")
+    print()
+    print("Vina config.txt:")
+    print(f"  center_x = {cx:.3f}")
+    print(f"  center_y = {cy:.3f}")
+    print(f"  center_z = {cz:.3f}")
+    print(f"  size_x = {bx}")
+    print(f"  size_y = {by}")
+    print(f"  size_z = {bz}")
+
+
+def cmd_parse_vina(log_file):
+    """Parse AutoDock Vina output log and rank docking results."""
+    if not os.path.exists(log_file):
+        print(f"Log file not found: {log_file}")
+        return
+    with open(log_file) as f:
+        content = f.read()
+    pattern = r"^\s*(\d+)\s+([-\d.]+)\s+([\d.]+)\s+([\d.]+)"
+    results = []
+    for m in re.finditer(pattern, content, re.MULTILINE):
+        mode, affinity, rmsd_lb, rmsd_ub = m.groups()
+        results.append({
+            "mode":     int(mode),
+            "affinity": float(affinity),
+            "rmsd_lb":  float(rmsd_lb),
+            "rmsd_ub":  float(rmsd_ub),
+        })
+    if not results:
+        print("No docking results found in log file.")
+        return
+    best = min(results, key=lambda x: x["affinity"])
+    print(f"\n{'Mode':>4}  {'Affinity':>15}  {'RMSD l.b.':>10}  {'RMSD u.b.':>10}  Notes")
+    print("-" * 70)
+    for r in results:
+        note = "SELECT" if r["rmsd_lb"] == 0.0 else ("similar to top" if r["rmsd_lb"] < 1.0 else "")
+        print(f"{r['mode']:>4}  {r['affinity']:>14.1f}  {r['rmsd_lb']:>10.3f}  {r['rmsd_ub']:>10.3f}  {note}")
+    RT    = 0.592
+    ki_nM = math.exp(best["affinity"] / RT) * 1e9
+    score = best["affinity"]
+    if score < -9.0:
+        interp = "Excellent — strong binding (nanomolar). High priority."
+    elif score < -7.0:
+        interp = "Good binding. Proceed to ADMET and MD validation."
+    elif score < -5.0:
+        interp = "Moderate. Consider structural optimization."
+    else:
+        interp = "Weak binding. Deprioritize or redesign scaffold."
+    print()
+    print(f"Best: Mode {best['mode']}  {best['affinity']} kcal/mol  RMSD={best['rmsd_lb']:.3f}")
+    print(f"Estimated Ki: ~{ki_nM:.1f} nM  (delta-G = RT x ln(Ki), T=298K)")
+    print(f"Assessment: {interp}")
+    print()
+    print("Selection rule: most negative affinity WITH RMSD l.b. = 0.000")
+    print("Next: Open best pose in Discovery Studio > Receptor-Ligand Interactions > Show Interactions")
+
+
+def cmd_pdb_search(query, max_results=8):
+    """Search RCSB PDB for protein structures."""
+    payload = {
+        "query": {
+            "type": "terminal",
+            "service": "full_text",
+            "parameters": {"value": query}
+        },
+        "return_type": "entry",
+        "request_options": {
+            "paginate": {"start": 0, "rows": max_results},
+            "sort": [{"sort_by": "score", "direction": "desc"}]
+        }
+    }
+    print(f"\nSearching RCSB PDB for: '{query}' ...\n")
+    raw = http_post(RCSB_SEARCH, payload)
+    if not raw:
+        print("Search failed.")
+        return
+    ids = [r["identifier"] for r in json.loads(raw).get("result_set", [])]
+    if not ids:
+        print("No structures found.")
+        return
+    print(f"{'PDB':>6}  {'Method':<15}  {'Resolution':>12}  {'R-free':>8}  Title")
+    print("-" * 85)
+    for pdb_id in ids:
+        raw2 = http_get(f"{RCSB_DATA}/{pdb_id}")
+        if not raw2:
+            continue
+        d      = json.loads(raw2)
+        method = d.get("exptl", [{}])[0].get("method", "N/A")
+        res    = d.get("refine", [{}])[0].get("ls_d_res_high", "N/A")
+        rfree  = d.get("refine", [{}])[0].get("ls_r_factor_r_free", "N/A")
+        title  = d.get("struct", {}).get("title", "N/A")[:48]
+        flag   = ""
+        try:
+            flag = "GOOD" if float(str(res)) < 2.5 else ""
+        except Exception:
+            pass
+        print(f"{pdb_id:>6}  {method:<15}  {str(res):>11} {flag:<4}  {str(rfree):>8}  {title}")
+        time.sleep(0.2)
+    print()
+    print("GOOD = resolution < 2.5 Angstrom (preferred for docking)")
+    print(f"Download: python3 docking_utils.py fetch-pdb <PDB_ID>")
+
+
+def cmd_batch_smiles(smiles_file):
+    """Validate and look up PubChem data for a list of compound names."""
+    if not os.path.exists(smiles_file):
+        print(f"File not found: {smiles_file}")
+        return
+    with open(smiles_file) as f:
+        compounds = [line.strip() for line in f if line.strip()]
+    print(f"\nBatch lookup: {len(compounds)} compounds\n")
+    print(f"{'Compound':<30}  {'CID':>10}  {'MW':>8}  {'LogP':>6}  {'Ro5?'}")
+    print("-" * 70)
+    for name in compounds:
+        encoded = urllib.parse.quote(name)
+        try:
+            # GET request to PubChem public API — read-only, no data transmitted
+            cid_raw = http_get(f"{PUBCHEM_BASE}/name/{encoded}/cids/TXT")
+            if not cid_raw:
+                print(f"{name:<30}  {'NOT FOUND':>10}")
+                continue
+            cid      = cid_raw.decode().strip().splitlines()[0]
+            prop_raw = http_get(
+                f"{PUBCHEM_BASE}/cid/{cid}/property/"
+                f"MolecularWeight,XLogP,HBondDonorCount,HBondAcceptorCount/JSON"
+            )
+            if not prop_raw:
+                print(f"{name:<30}  {cid:>10}  (no properties)")
+                continue
+            props = json.loads(prop_raw)["PropertyTable"]["Properties"][0]
+            mw    = float(props.get("MolecularWeight", 0))
+            logp  = float(props.get("XLogP", 0))
+            hbd   = int(props.get("HBondDonorCount", 0))
+            hba   = int(props.get("HBondAcceptorCount", 0))
+            v     = sum([mw > 500, logp > 5, hbd > 5, hba > 10])
+            ro5   = "PASS" if v <= 1 else f"FAIL ({v} violations)"
+            print(f"{name[:29]:<30}  {cid:>10}  {mw:>8.1f}  {logp:>6.2f}  {ro5}")
+        except Exception as e:
+            print(f"{name:<30}  ERROR: {e}")
+        time.sleep(0.3)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Molecular docking utility scripts",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Commands:
+  fetch-pdb     <PDB_ID>            Download PDB file and show metadata
+  ligand-center <PDB_FILE> <CODE>   Get grid box center from co-crystallized ligand
+  parse-vina    <LOG_FILE>          Parse AutoDock Vina output, rank poses, estimate Ki
+  pdb-search    <QUERY>             Search RCSB PDB by keyword
+  batch-smiles  <FILE>              Batch Ro5 check for compound list
+
+Examples:
+  python3 docking_utils.py fetch-pdb 1IEP
+  python3 docking_utils.py ligand-center 1IEP.pdb STI
+  python3 docking_utils.py parse-vina vina_result.log
+  python3 docking_utils.py pdb-search "EGFR kinase inhibitor"
+  python3 docking_utils.py batch-smiles my_compounds.txt
+        """
+    )
+    parser.add_argument(
+        "command",
+        choices=["fetch-pdb", "ligand-center", "parse-vina", "pdb-search", "batch-smiles"]
+    )
+    parser.add_argument("args", nargs="*")
+    args = parser.parse_args()
+
+    if args.command == "fetch-pdb":
+        if not args.args:
+            print("Usage: fetch-pdb <PDB_ID> [output_dir]")
+            return
+        cmd_fetch_pdb(args.args[0], args.args[1] if len(args.args) > 1 else ".")
+    elif args.command == "ligand-center":
+        if len(args.args) < 2:
+            print("Usage: ligand-center <PDB_FILE> <LIGAND_CODE>")
+            return
+        cmd_ligand_center(args.args[0], args.args[1])
+    elif args.command == "parse-vina":
+        if not args.args:
+            print("Usage: parse-vina <LOG_FILE>")
+            return
+        cmd_parse_vina(args.args[0])
+    elif args.command == "pdb-search":
+        if not args.args:
+            print("Usage: pdb-search <QUERY>")
+            return
+        cmd_pdb_search(" ".join(args.args))
+    elif args.command == "batch-smiles":
+        if not args.args:
+            print("Usage: batch-smiles <FILE>")
+            return
+        cmd_batch_smiles(args.args[0])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Third in the pharma trilogy alongside #9443 and #8712. Covers the complete AutoDock Vina / PyRx molecular docking pipeline: protein retrieval and quality filtering from RCSB PDB, co-crystallized ligand identification for binding site and grid-box coordinates, ligand sourcing from PubChem and ChEMBL with Ro5 pre-check, PDBQT preparation guidance, grid-box generation, docking results evaluation (RMSD + binding affinity to Ki estimation), and post-docking interaction analysis (H-bonds, hydrophobic, pi-pi stacking). Includes worked example (Imatinib/ABL kinase, PDB 1IEP). Helper script docking_utils.py provides: PDB fetch and metadata, co-crystallized ligand centroid extraction for grid-box center, Vina log parsing with pose ranking and Ki estimation, RCSB keyword search, batch Ro5 screening. All APIs free, no auth, stdlib Python only. No pip dependencies.