### PR TITLE
fix(weixin): align send_image_file param with other adapters

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,


### PR DESCRIPTION
## Summary

Fixes parameter name mismatch in Weixin adapter's `send_image_file()` method.

## Problem

The Weixin adapter uses `path` as the parameter name, but:
- The gateway base class calls it with `image_path`
- All other 12 platform adapters use `image_path`

This causes image sending to fail with:
```
WeixinAdapter.send_image_file() got an unexpected keyword argument 'image_path'
```

## Solution

Changed parameter name from `path` to `image_path` to align with all other adapters.

## Testing

- Verified that images can now be sent successfully via Weixin adapter
- Confirmed API consistency across all platform adapters

## Related

This is a bug fix for API consistency. All other adapters (telegram, discord, slack, signal, whatsapp, etc.) already use `image_path`.
