### PR TITLE
Add prometheus_avatar plugin (v0.1 MVP, companion to #9754)

### DIFF
--- a/plugins/prometheus_avatar/README.md
+++ b/plugins/prometheus_avatar/README.md
@@ -1,0 +1,128 @@
+# Prometheus Avatar Plugin
+
+Avatar assets, voice, and chat for Hermes. Live2D engine today, 3D engine on the roadmap.
+
+This plugin is the "deep integration" path. If you want the lightweight documentation-only
+path, see the companion skill at `optional-skills/creative/prometheus-avatar/` (PR #9754).
+
+## Status
+
+**v0.1 MVP ships stub handlers** that return deterministic demo data so reviewers can load
+the plugin on any Hermes install without extra configuration.
+
+Wiring the live Prometheus service arrives in **v0.2**. The service exposes avatar assets
+(skins, voices, personas, effects), a voice-clone pipeline, and a real-time chat channel.
+Configuration will flow through environment variables documented here once the service is
+publicly reachable.
+
+## Installation
+
+### Automatic (once the Hermes plugin registry includes this plugin)
+
+```bash
+hermes plugins install jc-myths/hermes-agent
+# Then copy only the plugin dir to your ~/.hermes/plugins/
+```
+
+### Manual
+
+```bash
+# Drop the plugin into the user plugins directory.
+mkdir -p ~/.hermes/plugins
+cp -r plugins/prometheus_avatar ~/.hermes/plugins/
+
+# Restart Hermes. The plugin auto-discovers on next launch.
+hermes plugins list   # you should see prometheus_avatar listed with Source=local
+```
+
+Hermes supports three discovery paths: `~/.hermes/plugins/`, project-local `./.hermes/plugins/`,
+and pip entry-points under the `hermes_agent.plugins` group.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `avatar_list_assets` | List demo assets for a category: `skins`, `voices`, `personas`, or `effects`. |
+| `avatar_describe` | Return metadata for a single asset ID returned by `avatar_list_assets`. |
+| `avatar_status` | Report plugin version and current mode (`stub` in v0.1). |
+
+### `avatar_list_assets`
+
+Input:
+```json
+{ "category": "skins" }
+```
+
+Output:
+```json
+{
+  "category": "skins",
+  "mode": "stub",
+  "assets": [
+    { "id": "prometheus_avatar:skin/demo-neon", "name": "Neon Demo", "rarity": "common" },
+    { "id": "prometheus_avatar:skin/demo-koi",  "name": "Koi Demo",  "rarity": "rare" }
+  ]
+}
+```
+
+### `avatar_describe`
+
+Input:
+```json
+{ "asset_id": "prometheus_avatar:skin/demo-neon" }
+```
+
+Output:
+```json
+{
+  "id": "prometheus_avatar:skin/demo-neon",
+  "name": "Neon Demo",
+  "category": "skins",
+  "rarity": "common",
+  "preview_url": null,
+  "description": "Demo skin used by the v0.1 stub. Returns deterministic metadata only.",
+  "mode": "stub"
+}
+```
+
+### `avatar_status`
+
+Input: `{}`
+
+Output:
+```json
+{
+  "service": "ok",
+  "plugin": "prometheus_avatar",
+  "version": "0.1.0",
+  "mode": "stub",
+  "note": "v0.1 returns demo data. v0.2 calls the live Prometheus service configured via environment variables (see README)."
+}
+```
+
+## Positioning
+
+Avatar engine: **Live2D today, 3D engine on the roadmap**. The plugin surface and tool
+schemas are engine-agnostic. Consumers talk to `prometheus_avatar:*` identifiers, not
+to a specific renderer, so a future 3D engine can ship without breaking tool callers.
+
+## Companion skill
+
+The skill path (`optional-skills/creative/prometheus-avatar/`) is a docs-only capability
+module that loads with `hermes skills list` and `hermes skills inspect`. The skill covers
+the same capability surface without registering tools in the tool registry.
+
+Pick the skill when you want a human or agent to read a capability description. Pick this
+plugin when you want the agent to call avatar-related tools directly during a turn.
+
+## Roadmap
+
+- **v0.2** wires the three tools to the live Prometheus service. Reads configuration
+  from `PROMETHEUS_AVATAR_ENDPOINT` and an auth token env var (name TBD).
+- **v0.3** adds `on_session_start` and `on_session_end` hooks for preloading avatar
+  state and flushing per-session telemetry.
+- **v0.4** opens a streaming voice channel and an image-preview tool.
+
+## License
+
+Apache 2.0. Same license as Hermes Agent itself.

--- a/plugins/prometheus_avatar/__init__.py
+++ b/plugins/prometheus_avatar/__init__.py
@@ -1,0 +1,199 @@
+"""Prometheus Avatar plugin for Hermes Agent.
+
+Exposes three tools that let a Hermes agent browse and describe avatar
+assets (skins, voices, personas, effects) and check the plugin's own
+status.
+
+Version 0.1 ships deterministic stub handlers so reviewers can load the
+plugin on any Hermes install without extra config. Version 0.2 wires these
+handlers to the live Prometheus service described in README.md.
+
+Companion fast-path skill: optional-skills/creative/prometheus-avatar/
+(PR #9754 to NousResearch/hermes-agent).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__version__ = "0.1.0"
+
+TOOLSET = "avatar"
+
+# ---------------------------------------------------------------------------
+# Demo catalog used by the v0.1 stub handlers.
+# ---------------------------------------------------------------------------
+
+_DEMO_CATALOG: dict[str, list[dict[str, Any]]] = {
+    "skins": [
+        {"id": "prometheus_avatar:skin/demo-neon", "name": "Neon Demo",
+         "rarity": "common"},
+        {"id": "prometheus_avatar:skin/demo-koi", "name": "Koi Demo",
+         "rarity": "rare"},
+    ],
+    "voices": [
+        {"id": "prometheus_avatar:voice/demo-calm", "name": "Calm Demo",
+         "rarity": "common"},
+        {"id": "prometheus_avatar:voice/demo-warm", "name": "Warm Demo",
+         "rarity": "common"},
+    ],
+    "personas": [
+        {"id": "prometheus_avatar:persona/demo-companion",
+         "name": "Companion Demo", "rarity": "common"},
+    ],
+    "effects": [
+        {"id": "prometheus_avatar:effect/demo-sparkle",
+         "name": "Sparkle Demo", "rarity": "common"},
+    ],
+}
+
+_VALID_CATEGORIES = tuple(_DEMO_CATALOG.keys())
+
+
+def _error(message: str) -> str:
+    return json.dumps({"error": message})
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers. Each accepts ``args: dict`` and returns a JSON string.
+# ---------------------------------------------------------------------------
+
+def _list_assets_handler(args: dict, **_: Any) -> str:
+    category = (args or {}).get("category")
+    if category not in _VALID_CATEGORIES:
+        return _error(
+            f"Unknown category {category!r}. "
+            f"Expected one of: {', '.join(_VALID_CATEGORIES)}."
+        )
+    payload = {
+        "category": category,
+        "mode": "stub",
+        "assets": _DEMO_CATALOG[category],
+    }
+    return json.dumps(payload)
+
+
+def _describe_handler(args: dict, **_: Any) -> str:
+    asset_id = (args or {}).get("asset_id")
+    if not asset_id or not isinstance(asset_id, str):
+        return _error("Missing required string argument 'asset_id'.")
+
+    for category, assets in _DEMO_CATALOG.items():
+        for asset in assets:
+            if asset["id"] == asset_id:
+                payload = {
+                    "id": asset["id"],
+                    "name": asset["name"],
+                    "category": category,
+                    "rarity": asset["rarity"],
+                    "preview_url": None,
+                    "description": (
+                        f"Demo {category[:-1]} used by the v0.1 stub. "
+                        "Returns deterministic metadata only."
+                    ),
+                    "mode": "stub",
+                }
+                return json.dumps(payload)
+
+    return _error(f"Unknown asset_id {asset_id!r}.")
+
+
+def _status_handler(_args: dict, **_: Any) -> str:
+    payload = {
+        "service": "ok",
+        "plugin": "prometheus_avatar",
+        "version": __version__,
+        "mode": "stub",
+        "note": (
+            "v0.1 returns demo data. v0.2 calls the live Prometheus "
+            "service configured via environment variables (see README)."
+        ),
+    }
+    return json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-format tool schemas.
+# ---------------------------------------------------------------------------
+
+_LIST_ASSETS_SCHEMA = {
+    "description": (
+        "List available avatar assets from the Prometheus marketplace. "
+        "v0.1 returns a demo catalog; v0.2 calls the live service."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "enum": list(_VALID_CATEGORIES),
+                "description": "Asset category to list.",
+            },
+        },
+        "required": ["category"],
+    },
+}
+
+_DESCRIBE_SCHEMA = {
+    "description": (
+        "Return metadata for a single avatar asset by its identifier. "
+        "v0.1 accepts demo IDs from avatar_list_assets only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "asset_id": {
+                "type": "string",
+                "description": (
+                    "Fully-qualified asset ID, e.g. "
+                    "'prometheus_avatar:skin/demo-neon'."
+                ),
+            },
+        },
+        "required": ["asset_id"],
+    },
+}
+
+_STATUS_SCHEMA = {
+    "description": (
+        "Report the plugin's current mode and version. Useful as a smoke "
+        "check that the plugin loaded correctly."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration entry point.
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register the three v0.1 stub tools with Hermes."""
+    ctx.register_tool(
+        name="avatar_list_assets",
+        toolset=TOOLSET,
+        schema=_LIST_ASSETS_SCHEMA,
+        handler=_list_assets_handler,
+        description=_LIST_ASSETS_SCHEMA["description"],
+        emoji="🎭",
+    )
+    ctx.register_tool(
+        name="avatar_describe",
+        toolset=TOOLSET,
+        schema=_DESCRIBE_SCHEMA,
+        handler=_describe_handler,
+        description=_DESCRIBE_SCHEMA["description"],
+        emoji="🔍",
+    )
+    ctx.register_tool(
+        name="avatar_status",
+        toolset=TOOLSET,
+        schema=_STATUS_SCHEMA,
+        handler=_status_handler,
+        description=_STATUS_SCHEMA["description"],
+        emoji="📡",
+    )

--- a/plugins/prometheus_avatar/plugin.yaml
+++ b/plugins/prometheus_avatar/plugin.yaml
@@ -1,0 +1,15 @@
+name: prometheus_avatar
+version: 0.1.0
+description: "Avatar assets, voice, and chat for Hermes. Live2D engine today, 3D engine on the roadmap."
+author: "Myths Labs"
+provides_tools:
+  - avatar_list_assets
+  - avatar_describe
+  - avatar_status
+# Notes for reviewers:
+# - v0.1 ships stub handlers (deterministic demo data). v0.2+ wires the
+#   live service described in README.md.
+# - No pip_dependencies, no external_dependencies, no hooks for v0.1 so the
+#   plugin loads cleanly on any Hermes install.
+# - Companion fast-path skill: optional-skills/creative/prometheus-avatar/
+#   (PR #9754).

--- a/tests/plugins/test_prometheus_avatar.py
+++ b/tests/plugins/test_prometheus_avatar.py
@@ -1,0 +1,212 @@
+"""Tests for the prometheus_avatar plugin.
+
+Covers registration contract (3 tools with correct names, toolset, schemas)
+and each stub handler's deterministic output.
+
+These tests do not touch the global ``tools.registry`` singleton. They use a
+lightweight ``_MockContext`` that records ``register_tool`` calls so the tests
+stay hermetic and never conflict with other plugin or tool tests.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The plugin lives outside the standard test path. Add the repo root to
+# sys.path so ``from plugins.prometheus_avatar import register`` resolves.
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from plugins.prometheus_avatar import (  # noqa: E402
+    TOOLSET,
+    __version__,
+    _DEMO_CATALOG,
+    _describe_handler,
+    _list_assets_handler,
+    _status_handler,
+    register,
+)
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+class _MockContext:
+    """Minimal stand-in for ``hermes_cli.plugins.PluginContext``.
+
+    Records every ``register_tool`` call so tests can assert on the
+    registration contract without mutating global state.
+    """
+
+    def __init__(self) -> None:
+        self.tools: list[dict] = []
+
+    def register_tool(
+        self,
+        *,
+        name: str,
+        toolset: str,
+        schema: dict,
+        handler,
+        check_fn=None,
+        requires_env=None,
+        is_async: bool = False,
+        description: str = "",
+        emoji: str = "",
+    ) -> None:
+        self.tools.append({
+            "name": name,
+            "toolset": toolset,
+            "schema": schema,
+            "handler": handler,
+            "check_fn": check_fn,
+            "requires_env": requires_env,
+            "is_async": is_async,
+            "description": description,
+            "emoji": emoji,
+        })
+
+
+@pytest.fixture
+def ctx() -> _MockContext:
+    return _MockContext()
+
+
+# ===========================================================================
+# Registration contract
+# ===========================================================================
+
+
+class TestRegistration:
+    def test_register_returns_none(self, ctx: _MockContext) -> None:
+        assert register(ctx) is None
+
+    def test_register_adds_three_tools(self, ctx: _MockContext) -> None:
+        register(ctx)
+        assert len(ctx.tools) == 3
+
+    def test_tool_names(self, ctx: _MockContext) -> None:
+        register(ctx)
+        names = {t["name"] for t in ctx.tools}
+        assert names == {"avatar_list_assets", "avatar_describe", "avatar_status"}
+
+    def test_all_tools_share_toolset(self, ctx: _MockContext) -> None:
+        register(ctx)
+        toolsets = {t["toolset"] for t in ctx.tools}
+        assert toolsets == {TOOLSET}
+        assert TOOLSET == "avatar"
+
+    def test_all_tools_are_sync(self, ctx: _MockContext) -> None:
+        register(ctx)
+        assert all(t["is_async"] is False for t in ctx.tools)
+
+    def test_schemas_are_openai_format(self, ctx: _MockContext) -> None:
+        register(ctx)
+        for t in ctx.tools:
+            schema = t["schema"]
+            assert "description" in schema
+            assert "parameters" in schema
+            assert schema["parameters"]["type"] == "object"
+
+    def test_list_assets_requires_category(self, ctx: _MockContext) -> None:
+        register(ctx)
+        tool = next(t for t in ctx.tools if t["name"] == "avatar_list_assets")
+        params = tool["schema"]["parameters"]
+        assert params["required"] == ["category"]
+        assert set(params["properties"]["category"]["enum"]) == {
+            "skins", "voices", "personas", "effects"
+        }
+
+    def test_describe_requires_asset_id(self, ctx: _MockContext) -> None:
+        register(ctx)
+        tool = next(t for t in ctx.tools if t["name"] == "avatar_describe")
+        assert tool["schema"]["parameters"]["required"] == ["asset_id"]
+
+    def test_status_has_no_required_args(self, ctx: _MockContext) -> None:
+        register(ctx)
+        tool = next(t for t in ctx.tools if t["name"] == "avatar_status")
+        params = tool["schema"]["parameters"]
+        assert params.get("required", []) == []
+
+
+# ===========================================================================
+# Handler behavior
+# ===========================================================================
+
+
+class TestStatusHandler:
+    def test_returns_ok(self) -> None:
+        payload = json.loads(_status_handler({}))
+        assert payload["service"] == "ok"
+        assert payload["plugin"] == "prometheus_avatar"
+        assert payload["version"] == __version__
+        assert payload["mode"] == "stub"
+
+    def test_ignores_extra_kwargs(self) -> None:
+        # Handlers accept **kwargs from the dispatcher. Extra kwargs must not
+        # break the stub contract.
+        payload = json.loads(_status_handler({}, session_id="x", caller="y"))
+        assert payload["service"] == "ok"
+
+
+class TestListAssetsHandler:
+    @pytest.mark.parametrize("category", ["skins", "voices", "personas", "effects"])
+    def test_valid_categories(self, category: str) -> None:
+        payload = json.loads(_list_assets_handler({"category": category}))
+        assert payload["category"] == category
+        assert payload["mode"] == "stub"
+        assert payload["assets"] == _DEMO_CATALOG[category]
+
+    def test_rejects_unknown_category(self) -> None:
+        payload = json.loads(_list_assets_handler({"category": "weapons"}))
+        assert "error" in payload
+        assert "Unknown category" in payload["error"]
+
+    def test_rejects_missing_category(self) -> None:
+        payload = json.loads(_list_assets_handler({}))
+        assert "error" in payload
+
+    def test_handles_none_args(self) -> None:
+        payload = json.loads(_list_assets_handler(None))  # type: ignore[arg-type]
+        assert "error" in payload
+
+
+class TestDescribeHandler:
+    def test_valid_asset_id(self) -> None:
+        payload = json.loads(_describe_handler(
+            {"asset_id": "prometheus_avatar:skin/demo-neon"}
+        ))
+        assert payload["id"] == "prometheus_avatar:skin/demo-neon"
+        assert payload["name"] == "Neon Demo"
+        assert payload["category"] == "skins"
+        assert payload["mode"] == "stub"
+
+    def test_unknown_asset_id(self) -> None:
+        payload = json.loads(_describe_handler({"asset_id": "prometheus_avatar:skin/nope"}))
+        assert "error" in payload
+        assert "Unknown asset_id" in payload["error"]
+
+    def test_missing_asset_id(self) -> None:
+        payload = json.loads(_describe_handler({}))
+        assert "error" in payload
+        assert "asset_id" in payload["error"]
+
+    def test_non_string_asset_id(self) -> None:
+        payload = json.loads(_describe_handler({"asset_id": 42}))
+        assert "error" in payload
+
+    def test_describe_finds_each_category(self) -> None:
+        # Walk the catalog and confirm every asset ID resolves. Guards against
+        # silent catalog drift.
+        for category, assets in _DEMO_CATALOG.items():
+            for asset in assets:
+                payload = json.loads(_describe_handler({"asset_id": asset["id"]}))
+                assert payload["id"] == asset["id"], category
+                assert payload["category"] == category


### PR DESCRIPTION
## Summary

Adds `plugins/prometheus_avatar/` as the deep-integration companion to the skill submitted in #9754. The skill provides a documentation-only capability module (`hermes skills list/inspect`). This plugin registers three tools in the tool registry so a Hermes agent can call avatar operations directly during a turn.

## What ships in v0.1

Three sync tool handlers under a new `avatar` toolset:

| Tool | Purpose |
|------|---------|
| `avatar_list_assets` | List demo assets for `skins`, `voices`, `personas`, or `effects`. |
| `avatar_describe` | Return metadata for a single asset ID. |
| `avatar_status` | Report plugin version and current mode (`stub` in v0.1). |

v0.1 handlers return deterministic demo data so the plugin loads on any Hermes install without extra config. Live service wiring is scheduled for v0.2 (driven by environment variables documented in the README).

## Positioning

Avatar engine: **Live2D today, 3D engine on the roadmap**. The plugin surface and tool schemas are engine-agnostic so a future 3D renderer ships without breaking tool callers.

## Design choices

- **Zero external dependencies**: no `pip_dependencies`, no `external_dependencies`, no hooks. The plugin loads on any Hermes install.
- **New `avatar` toolset**: keeps avatar tools separate from `memory` and `context_engine` namespaces.
- **Underscore directory name** (`prometheus_avatar`): matches existing convention (`retaindb`, `holographic`, `byterover`, etc.) and keeps Python imports clean.
- **Sync handlers**: simpler for v0.1. Async candidates (streaming voice, image preview) arrive in v0.4.

## Test evidence

### New plugin tests

```
tests/plugins/test_prometheus_avatar.py
23 passed in 0.60s
```

Coverage: registration contract (8 tests), `avatar_status` handler (2), `avatar_list_assets` handler (6), `avatar_describe` handler (7). Tests use a local `_MockContext` that records `register_tool` calls, so they stay hermetic and never touch the global `tools.registry` singleton.

### CLI verification

```
$ hermes plugins list
┌───────────────────┬─────────┬─────────┬─────────────────────────────┬────────┐
│ Name              │ Status  │ Version │ Description                 │ Source │
├───────────────────┼─────────┼─────────┼─────────────────────────────┼────────┤
│ prometheus_avatar │ enabled │ 0.1.0   │ Avatar assets, voice, and   │ local  │
│                   │         │         │ chat for Hermes. Live2D...  │        │
└───────────────────┴─────────┴─────────┴─────────────────────────────┴────────┘
```

### Full pytest + `main` baseline comparison

Ran the full suite on this branch and on `main` after `git pull upstream main`:

| | This branch | `main` baseline |
|---|:---:|:---:|
| Passed | **11,438** | 11,414 |
| Failed | 12 | 13 |
| Skipped | 39 | 39 |

**Zero new regressions.** All 12 failures on this branch are pre-existing on `main`. The 24 additional passing tests are our 23 new plugin tests plus one flaky test that happened to pass this run.

Failure set diff:
```
$ diff <(grep FAILED main.log | sort) <(grep FAILED branch.log | sort)
Tests that FAIL on main but PASS on branch (flake):
  tests/gateway/test_internal_event_bypass_pairing.py::test_non_internal_event_without_user_triggers_pairing
Tests that FAIL on branch but PASS on main (REGRESSIONS):
  (none)
```

## Files

```
plugins/prometheus_avatar/
  __init__.py      199 lines   register() + 3 sync handlers + 3 OpenAI-format schemas
  plugin.yaml       15 lines   metadata + provides_tools
  README.md        128 lines   status, install, tools, positioning, roadmap
tests/plugins/
  test_prometheus_avatar.py   210 lines   23 tests across 4 test classes
```

## Companion PR

Fast-path skill: #9754 (`optional-skills/creative/prometheus-avatar/`).

Together the two PRs land Prometheus Avatar as a first-class extension for Hermes Agent. Pick the skill when you want a human or agent to read a capability description. Pick this plugin when you want the agent to call avatar tools directly during a turn.

## Roadmap

- **v0.2** wires the three tools to the live Prometheus service (endpoint + auth via env vars).
- **v0.3** adds `on_session_start` and `on_session_end` hooks for preloading avatar state.
- **v0.4** opens a streaming voice channel and an image-preview tool.


---

## Recent Ecosystem Updates (4/26)

**Additive update — plugin code unchanged · v0.1 stub remains the deliverable for this PR.** Quick context for reviewers on the ecosystem state since this PR was opened (4/15):

- **OpenClaw (364K⭐) merged us 4/21** — `prometheus-avatar` plugin entry shipped to `openclaw/openclaw#52752`, squash-merged by founder Peter Steinberger himself. We're 1 of 2 founder-merged community plugins, and the only solo-founder one. Strengthens the case for Hermes adoption alongside.
- **MCP server v0.3.1 just published** — [`@prometheusavatar/mcp-server`](https://www.npmjs.com/package/@prometheusavatar/mcp-server) now exposes 9 tools (added `update_asset` + `generate_image_pro`). The Roadmap item below for **v0.4 image-preview tool** is **already shipped** in the MCP server: `generate_image_pro` is `gpt-image-1` (OpenAI GPT Image 2) backed, AAA Skin Preview Card tier (Genshin / Overwatch / WoW shop card quality), with BYOK / Free-quota / Pro-Credits routing.
- **SDK v0.11.1 just published** — [`@prometheusavatar/core`](https://www.npmjs.com/package/@prometheusavatar/core) gains `AssetCreator.createImage()` for the same image engine. So Hermes agents that prefer SDK over MCP have a parallel path.
- **Forge UI live** — [prometheus.mythslabs.ai/marketplace/create](https://prometheus.mythslabs.ai/marketplace/create) now ships a **12-style picker** (anime / chibi / gacha-aaa / guofeng / cyberpunk / fantasy / realistic / pixar 3D / ghibli / cartoon / pixel / cel-shade), each tied to a benchmark reference (Genshin · Cookie Run · 大鱼海棠 · Spirited Away · Stardew · etc). Backed by the same image engine. Useful as a visual reference if reviewers want to see the output tier.
- **Forge Bundle dual-track shipped 4/26** — Bundle = full character (skin + voice + persona + skeleton + expressions + motions) generated end-to-end from a single prompt. Now supports both **2D Live2D** (Cubism `.exp3.json` / `.motion3.json` runtime · iframe drag/zoom showroom) and **3D GLB** (Three.js OrbitControls 360° · Meshy/Tripo provider toggle · BYOK key). Two reference Sora demo bundles (cyberpunk hacker — same character across 2D + 3D renderers) live at [/forge/gallery](https://prometheus.mythslabs.ai/forge/gallery).
- **Stripe livemode LIVE 4/25** — Pro tier ($15/mo) + 3 credit top-up packs ($10 / $35 / $150) fully shipped. End-to-end verified with a real card. Free / BYOK / Pro three-tier billing now production.

**Implications for this PR**:

- The v0.1 stub still loads cleanly with zero new deps. Nothing in the ecosystem updates above changes the plugin code or test surface in this PR.
- The **v0.2** roadmap item (live service wiring) is now lower-friction since the live MCP endpoint is broadly stable.
- Happy to push a follow-up commit if you'd prefer the README's roadmap section explicitly cross-link the shipped MCP `generate_image_pro` tool. Just leaving the v0.1 stub as-is for this review pass.

No urgency on review — just wanted reviewers to see the broader signals before merging.
