### PR TITLE
fix(browser): fix Camofox JS eval endpoint, userId, and package rename

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -362,7 +362,7 @@ def _run_post_setup(post_setup_key: str):
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
 
     elif post_setup_key == "camofox":
-        camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camoufox-browser"
+        camofox_dir = PROJECT_ROOT / "node_modules" / "@askjo" / "camofox-browser"
         if not camofox_dir.exists() and shutil.which("npm"):
             _print_info("    Installing Camofox browser server...")
             import subprocess
@@ -376,7 +376,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    npm install failed - run manually: npm install")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
-            _print_info("      npx @askjo/camoufox-browser")
+            _print_info("      npx @askjo/camofox-browser")
             _print_info("    First run downloads the Camoufox engine (~300MB)")
             _print_info("    Or use Docker: docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
         elif not shutil.which("npm"):

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@askjo/camoufox-browser": "^1.0.0",
+        "@askjo/camofox-browser": "^1.5.2",
         "agent-browser": "^0.13.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@appium/logger": {
@@ -33,20 +33,19 @@
         "npm": ">=8"
       }
     },
-    "node_modules/@askjo/camoufox-browser": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@askjo/camoufox-browser/-/camoufox-browser-1.0.12.tgz",
-      "integrity": "sha512-MxRvjK6SkX6zJSNleoO32g9iwhJAcXpaAgj4pik7y2SrYXqcHllpG7FfLkKE7d5bnBt7pO82rdarVYu6xtW2RA==",
-      "deprecated": "Renamed to @askjo/camofox-browser",
+    "node_modules/@askjo/camofox-browser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@askjo/camofox-browser/-/camofox-browser-1.5.2.tgz",
+      "integrity": "sha512-SvRCzhWnJaplxHkRVF9l1OWako6pp2eUw2mZKHOERUfLWDO2Xe/IKI+5bB+UT1TNvO45P6XdhgfAtihcTEARCg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "camoufox-js": "^0.8.5",
-        "dotenv": "^17.2.3",
         "express": "^4.18.2",
         "playwright": "^1.50.0",
         "playwright-core": "^1.58.0",
         "playwright-extra": "^4.3.6",
+        "prom-client": "^15.1.3",
         "puppeteer-extra-plugin-stealth": "^2.11.2"
       },
       "engines": {
@@ -120,6 +119,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -977,6 +985,12 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1792,18 +1806,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -4032,6 +4034,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5267,6 +5282,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/teen_process": {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
   "dependencies": {
     "agent-browser": "^0.13.0",
-    "@askjo/camoufox-browser": "^1.0.0"
+    "@askjo/camofox-browser": "^1.5.2"
   },
   "overrides": {
     "lodash": "4.18.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1748,7 +1748,7 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
     try:
         tab_info = _ensure_tab(task_id or "default")
         tab_id = tab_info.get("tab_id") or tab_info.get("id")
-        resp = _post(f"/tabs/{tab_id}/eval", body={"expression": expression})
+        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": tab_info["user_id"]})
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp


### PR DESCRIPTION
## Summary

Fixes the Camofox browser backend which was broken due to:

1. **JS eval broken** — `_camofox_eval()` in `browser_tool.py` used wrong endpoint (`/eval` → `/evaluate`) and was missing the required `userId` field in the request body. All other Camofox API calls already include `userId`.

2. **NPM package renamed** — The upstream Camofox package was renamed from `@askjo/camoufox-browser` (old, v1.0.12) to `@askjo/camofox-browser` (current, v1.5.2). Updated `package.json`, `package-lock.json`, and the post-setup paths in `tools_config.py`.

3. **Node engine bump** — `camoufox-js` (dependency of camofox-browser v1.5.2) requires Node 20+. Updated engine constraint from `>=18` to `>=20`.

## Files Changed

- `tools/browser_tool.py` — Fix `_camofox_eval()` endpoint and add `userId`
- `package.json` — Update package name and version, bump Node engine
- `package-lock.json` — Regenerated
- `hermes_cli/tools_config.py` — Update post-setup directory check and npx command

## Test Plan

- All 47 camofox tests pass
- All 55 browser hardening/cleanup/SSRF tests pass
- E2E verified: `_camofox_eval()` now produces clean connection error (not TypeError) without server
- Verified `npm install` successfully installs `@askjo/camofox-browser@1.5.2`

## Related PRs (supersedes)

- Supersedes #9472 (eval endpoint + userId fix — same change, contributor: @Ifkellx)
- Supersedes #8267 (package rename — contributor: @hishamank)
- #7208 is stale — the bugs it fixes were already resolved on main