### PR TITLE
feat(browser): add selector parameter for element-level screenshot in browser_vision

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -745,6 +745,10 @@ BROWSER_TOOL_SCHEMAS = [
                     "type": "boolean",
                     "default": False,
                     "description": "If true, overlay numbered [N] labels on interactive elements. Each [N] maps to ref @eN for subsequent browser commands. Useful for QA and spatial reasoning about page layout."
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Optional: Element selector to screenshot (e.g., '@e1', '.modal', '#content'). If omitted, captures viewport."
                 }
             },
             "required": ["question"]
@@ -1884,7 +1888,7 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         }, ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+def browser_vision(question: str, annotate: bool = False, selector: Optional[str] = None, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
     
@@ -1899,6 +1903,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     Args:
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
+        selector: Optional element selector to screenshot (e.g., '@e1', '.modal', '#content')
         task_id: Task identifier for session isolation
         
     Returns:
@@ -1929,7 +1934,11 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         screenshot_args = []
         if annotate:
             screenshot_args.append("--annotate")
-        screenshot_args.append("--full")
+        if selector:
+            # Element-level screenshot
+            screenshot_args.append(selector)
+        else:
+            screenshot_args.append("--full")
         screenshot_args.append(str(screenshot_path))
         result = _run_browser_command(
             effective_task_id, 
@@ -2373,7 +2382,7 @@ registry.register(
     name="browser_vision",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_vision"],
-    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), selector=args.get("selector"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👁️",
 )


### PR DESCRIPTION

## Summary

Add `selector` parameter to `browser_vision` tool for capturing specific DOM elements instead of full viewport, matching agent-browser's element screenshot capability.

## Background

The `browser_vision` tool currently only supports full viewport screenshots (`--full`). However, agent-browser supports element-level screenshots via selector parameter, which is useful when you only need to capture a specific element (e.g., a modal, a tweet card, a form).

## Changes

- Add `selector` parameter to tool schema
- Update `browser_vision()` function signature
- Pass selector to agent-browser screenshot command — mutually exclusive with `--full`
- Update registry handler to pass selector parameter

## Documentation Evidence

From agent-browser docs (https://www.mintlify.com/vercel-labs/agent-browser/commands/screenshots):

```
agent-browser screenshot [selector] [path]  # Screenshot (--full for full page)
agent-browser screenshot @e1 element.png  # Screenshot specific element
agent-browser screenshot ".modal" dialog.png  # Screenshot by CSS selector
```

Selector is mutually exclusive with `--full` — when selector is provided, it captures that element instead of full page.

## Test Results

Verified implementation with actual tests:

| Command | File Size | Behavior |
|---------|----------|----------|
| `agent-browser screenshot @e1 test-element.png` | 2917 bytes | Element screenshot |
| `agent-browser screenshot --full test-full.png` | 15744 bytes | Full page screenshot |
| `agent-browser screenshot --full @e1` | 15744 bytes | **Ignored @e1, captured full page** |

Test confirms selector and --full are mutually exclusive (selector takes precedence when provided).

**Hermes Agent in-browser test:**
```
browser_vision(question="截取这个推文的内容", selector="@e38")
```
✅ Success —截图保存到 `/Users/hushicai/.hermes/cache/screenshots/browser_screenshot_58ffa11312014b118931a9ad1da2c940.png`

## Usage

```python
# Element screenshot
browser_vision(question="...", selector="@e1")

# Full viewport (default, backward compatible)
browser_vision(question="...")

# Annotated element screenshot
browser_vision(question="...", selector="@e1", annotate=True)
```
