### PR TITLE
fix: sanitize api_messages and extra string fields during ASCII-codec recovery (#6843)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,3 +105,4 @@ tesseracttars-creator <tesseracttars@gmail.com> <tesseracttars@gmail.com>
 xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
+MestreY0d4-Uninter <241404605+MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>

--- a/run_agent.py
+++ b/run_agent.py
@@ -457,6 +457,15 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                             if sanitized != fn_args:
                                 fn["arguments"] = sanitized
                                 found = True
+        # Sanitize any additional top-level string fields (e.g. reasoning_content)
+        for key, value in msg.items():
+            if key in {"content", "name", "tool_calls", "role"}:
+                continue
+            if isinstance(value, str):
+                sanitized = _strip_non_ascii(value)
+                if sanitized != value:
+                    msg[key] = sanitized
+                    found = True
     return found
 
 
@@ -8931,7 +8940,19 @@ class AIAgent:
                             # ASCII codec: the system encoding can't handle
                             # non-ASCII characters at all. Sanitize all
                             # non-ASCII content from messages/tool schemas and retry.
+                            # Sanitize both the canonical `messages` list and
+                            # `api_messages` (the API-copy built before the retry
+                            # loop, which may contain extra fields like
+                            # reasoning_content that are not in `messages`).
                             _messages_sanitized = _sanitize_messages_non_ascii(messages)
+                            if isinstance(api_messages, list):
+                                _sanitize_messages_non_ascii(api_messages)
+                            # Also sanitize the last api_kwargs if already built,
+                            # so a leftover non-ASCII value in a transformed field
+                            # (e.g. extra_body, reasoning_content) doesn't survive
+                            # into the next attempt via _build_api_kwargs cache paths.
+                            if isinstance(api_kwargs, dict):
+                                _sanitize_structure_non_ascii(api_kwargs)
                             _prefill_sanitized = False
                             if isinstance(getattr(self, "prefill_messages", None), list):
                                 _prefill_sanitized = _sanitize_messages_non_ascii(self.prefill_messages)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -203,3 +203,64 @@ class TestSanitizeStructureNonAscii:
         assert _sanitize_structure_non_ascii(payload) is True
         assert payload["default_headers"]["X-Title"] == "Hermes  Agent"
         assert payload["default_headers"]["User-Agent"] == "Hermes/1.0 "
+
+
+class TestApiMessagesAndApiKwargsSanitized:
+    """Regression tests for #6843 follow-up: api_messages and api_kwargs must
+    be sanitized alongside messages during ASCII-codec recovery.
+
+    The original fix only sanitized the canonical `messages` list.
+    api_messages is a separate API-copy built before the retry loop; it may
+    carry extra fields (reasoning_content, extra_body) with non-ASCII chars
+    that are not present in `messages`.  Without sanitizing api_messages and
+    api_kwargs, the retry still raises UnicodeEncodeError even after the
+    'System encoding is ASCII — stripped...' log line appears.
+    """
+
+    def test_api_messages_with_reasoning_content_is_sanitized(self):
+        """api_messages may contain reasoning_content not in messages."""
+        api_messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Sure!",
+                # reasoning_content is injected by the API-copy builder and
+                # is NOT present in the canonical messages list
+                "reasoning_content": "Let me think \xab step by step \xbb",
+            },
+        ]
+        found = _sanitize_messages_non_ascii(api_messages)
+        assert found is True
+        assert "\xab" not in api_messages[2]["reasoning_content"]
+        assert "\xbb" not in api_messages[2]["reasoning_content"]
+
+    def test_api_kwargs_with_non_ascii_extra_body_is_sanitized(self):
+        """api_kwargs may contain non-ASCII in extra_body or other fields."""
+        api_kwargs = {
+            "model": "glm-5.1",
+            "messages": [{"role": "user", "content": "ok"}],
+            "extra_body": {
+                "system": "Think carefully \u2192 answer",
+            },
+        }
+        found = _sanitize_structure_non_ascii(api_kwargs)
+        assert found is True
+        assert "\u2192" not in api_kwargs["extra_body"]["system"]
+
+    def test_messages_clean_but_api_messages_dirty_both_get_sanitized(self):
+        """Even when canonical messages are clean, api_messages may be dirty."""
+        messages = [{"role": "user", "content": "hello"}]
+        api_messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning_content": "step \xab done",
+            },
+        ]
+        # messages sanitize returns False (nothing to clean)
+        assert _sanitize_messages_non_ascii(messages) is False
+        # api_messages sanitize must catch the dirty reasoning_content
+        assert _sanitize_messages_non_ascii(api_messages) is True
+        assert "\xab" not in api_messages[1]["reasoning_content"]


### PR DESCRIPTION
This follow-up fixes the remaining UnicodeEncodeError path reported in #6843.

## What changed

- `_sanitize_messages_non_ascii` now walks all extra top-level string fields in each message dict (any key not in `{content, name, tool_calls, role}`), so `reasoning_content` and future extras are cleaned in both `messages` and `api_messages`.
- The ASCII-codec recovery block now also sanitizes `api_messages` and `api_kwargs` directly, not just the canonical `messages` list.

## Why

The previous recovery path logged "System encoding is ASCII — stripped non-ASCII characters…" and returned successfully, but the retry still failed because `api_messages` is a separate API-copy built *before* the retry loop. It carries `reasoning_content` (copied from the `reasoning` field in multi-turn conversations) which is not part of the original `messages` sanitization pass. The non-ASCII character (e.g. `\xab` at position 208 in BKLronin's report) survived in `api_messages` and triggered a second `UnicodeEncodeError` on the next attempt.

## How to test

Reproduce on an ASCII locale (macOS or `LANG=C`) in a multi-turn session that has generated reasoning content. Confirm:
1. The recovery log appears once.
2. The retry succeeds — no second `UnicodeEncodeError`.

Adds regression tests covering:
- `reasoning_content` with non-ASCII in `api_messages`
- `extra_body` with non-ASCII in `api_kwargs`
- canonical `messages` clean but `api_messages` dirty

Fixes #6843