### PR TITLE
feat(gateway): add optional inbound message timestamp prefix

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -258,6 +258,9 @@ class GatewayConfig:
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
+    # Prepend a compact timestamp to each inbound user message
+    message_timestamp_prefix: bool = False
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -357,6 +360,7 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "message_timestamp_prefix": self.message_timestamp_prefix,
         }
     
     @classmethod
@@ -403,6 +407,11 @@ class GatewayConfig:
             data.get("unauthorized_dm_behavior"),
             "pair",
         )
+        message_timestamp_prefix = data.get("message_timestamp_prefix")
+        if message_timestamp_prefix is None:
+            gateway_cfg = data.get("gateway")
+            if isinstance(gateway_cfg, dict):
+                message_timestamp_prefix = gateway_cfg.get("message_timestamp_prefix")
 
         return cls(
             platforms=platforms,
@@ -418,6 +427,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            message_timestamp_prefix=_coerce_bool(message_timestamp_prefix, False),
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -509,6 +519,10 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            gateway_cfg = yaml_cfg.get("gateway")
+            if isinstance(gateway_cfg, dict) and "message_timestamp_prefix" in gateway_cfg:
+                gw_data["message_timestamp_prefix"] = gateway_cfg["message_timestamp_prefix"]
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27,6 +27,7 @@ import time
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
+from zoneinfo import ZoneInfo
 
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
@@ -2967,6 +2968,8 @@ class GatewayRunner:
         )
         if _is_shared_thread and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
+        if getattr(self.config, "message_timestamp_prefix", False):
+            message_text = f"{self._format_inbound_message_timestamp()} {message_text}".strip()
 
         if event.media_urls:
             image_paths = []
@@ -3099,6 +3102,17 @@ class GatewayRunner:
                 logger.debug("@ context reference expansion failed: %s", exc)
 
         return message_text
+
+    def _format_inbound_message_timestamp(self) -> str:
+        """Return a compact timestamp prefix for inbound user messages."""
+        tz_name = os.getenv("HERMES_TIMEZONE", "").strip()
+        tz = ZoneInfo("UTC")
+        if tz_name:
+            try:
+                tz = ZoneInfo(tz_name)
+            except Exception:
+                logger.warning("Invalid HERMES_TIMEZONE %r for inbound timestamp prefix; using UTC", tz_name)
+        return f"[{datetime.now(tz).strftime('%m-%d %H:%M')}]"
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -191,6 +191,7 @@ AUTHOR_MAP = {
     "zhouboli@gmail.com": "zhouboli",
     "zqiao@microsoft.com": "tomqiaozc",
     "zzn+pa@zzn.im": "xinbenlv",
+    "lijiawen@umich.edu": "Jiawen-lee",
 }
 
 

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -1,5 +1,6 @@
-"""Gateway STT config tests — honor stt.enabled: false from config.yaml."""
+"""Gateway inbound-prep config tests."""
 
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -30,6 +31,27 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     config = load_gateway_config()
 
     assert config.stt_enabled is False
+
+
+def test_gateway_config_timestamp_prefix_from_nested_gateway_dict():
+    config = GatewayConfig.from_dict({"gateway": {"message_timestamp_prefix": True}})
+    assert config.message_timestamp_prefix is True
+
+
+def test_load_gateway_config_bridges_timestamp_prefix_from_config_yaml(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.dump({"gateway": {"message_timestamp_prefix": True}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config = load_gateway_config()
+
+    assert config.message_timestamp_prefix is True
 
 
 @pytest.mark.asyncio
@@ -114,3 +136,69 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_prepends_utc_timestamp_when_enabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(message_timestamp_prefix=True)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="hey, what day is it?",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    frozen = datetime(2026, 4, 14, 23, 47, tzinfo=timezone.utc)
+    with patch("gateway.run.datetime") as mock_datetime:
+        mock_datetime.now.return_value = frozen
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result == "[04-14 23:47] hey, what day is it?"
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_keeps_sender_prefix_before_timestamp():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        message_timestamp_prefix=True,
+        thread_sessions_per_user=False,
+    )
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="thread",
+        thread_id="456",
+        user_name="alice",
+    )
+    event = MessageEvent(
+        text="can you check this later?",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    frozen = datetime(2026, 4, 14, 23, 47, tzinfo=timezone.utc)
+    with patch("gateway.run.datetime") as mock_datetime:
+        mock_datetime.now.return_value = frozen
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result == "[04-14 23:47] [alice] can you check this later?"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This PR adds an optional configuration flag `message_timestamp_prefix` that prepends a compact timestamp to inbound user messages before they are passed to the agent.

When enabled, Hermes will prefix inbound messages like:

```bash
[04-14 23:47] hello
```

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #9628 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [着 ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

### Config support

Added new optional gateway config:

```
gateway.message_timestamp_prefix: true
```

Implemented:

- config parsing support
- nested `gateway:` YAML compatibility
- serialization/deserialization handling

Files:

```
gateway/config.py
```


### Runtime timestamp injection

Prepends timestamp during inbound message preprocessing:

```
gateway/run.py::_prepare_inbound_message_text()
```

Adds helper:

```
_format_inbound_message_timestamp()
```

Behavior:

- format: `[MM-DD HH:MM]`
- default timezone: UTC
- override via:

```
HERMES_TIMEZONE=America/New_York
```

Gracefully falls back to UTC if timezone invalid.


### Ordering guarantees

Preserves sender-prefix ordering in shared threads:

```
[timestamp] [username] message
```

Example:

```
[04-14 23:47] [alice] can you check this later?
```


### Tests added

Added coverage for:

- config parsing via nested `gateway:` dict
- config.yaml loading bridge behavior
- timestamp prefix formatting
- ordering with username prefixes
- UTC default handling

Files:

```
tests/gateway/test_stt_config.py
```

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Enable the feature in config:

```
gateway:
  message_timestamp_prefix: true
```

2. Run Hermes normally

```
hermes
```

3. Send a message from any platform

Expected:

```
[MM-DD HH:MM] your message
```

Optional timezone override:

```
export HERMES_TIMEZONE=America/New_York
```

Restart Hermes and verify updated timestamps.


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

