### PR TITLE
Feat/task tree accounting

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -454,17 +454,46 @@ class HermesACPAgent(acp.Agent):
             await conn.session_update(session_id, update)
 
         usage = None
-        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+        usage_data = result.get("usage")
+        if not usage_data and isinstance(result, dict):
+            usage_data = {
+                "prompt_tokens": result.get("prompt_tokens", result.get("input_tokens", 0)),
+                "completion_tokens": result.get("completion_tokens", result.get("output_tokens", 0)),
+                "total_tokens": result.get("total_tokens", 0),
+                "reasoning_tokens": result.get("reasoning_tokens"),
+                "cached_tokens": result.get("cache_read_tokens"),
+            }
+            if not any(v not in (None, 0) for v in usage_data.values()):
+                usage_data = None
+        if usage_data and isinstance(usage_data, dict):
+            prompt_tokens = usage_data.get("prompt_tokens", usage_data.get("input_tokens", usage_data.get("inputTokens", 0)))
+            completion_tokens = usage_data.get("completion_tokens", usage_data.get("output_tokens", usage_data.get("outputTokens", 0)))
+            total_tokens = usage_data.get("total_tokens", usage_data.get("totalTokens", 0))
+            reasoning_tokens = usage_data.get("reasoning_tokens", usage_data.get("thoughtTokens"))
+            cached_tokens = usage_data.get("cached_tokens", usage_data.get("cache_read_tokens", usage_data.get("cachedReadTokens")))
             usage = Usage(
-                input_tokens=result.get("prompt_tokens", 0),
-                output_tokens=result.get("completion_tokens", 0),
-                total_tokens=result.get("total_tokens", 0),
-                thought_tokens=result.get("reasoning_tokens"),
-                cached_read_tokens=result.get("cache_read_tokens"),
+                input_tokens=prompt_tokens,
+                output_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                thought_tokens=reasoning_tokens,
+                cached_read_tokens=cached_tokens,
             )
 
+        runtime_meta = None
+        actual_provider = result.get("actual_provider") if isinstance(result, dict) else None
+        actual_base_url = result.get("actual_base_url") if isinstance(result, dict) else None
+        actual_api_mode = result.get("actual_api_mode") if isinstance(result, dict) else None
+        if any(value for value in (actual_provider, actual_base_url, actual_api_mode)):
+            runtime_meta = {
+                "hermesRuntime": {
+                    "provider": actual_provider,
+                    "base_url": actual_base_url,
+                    "api_mode": actual_api_mode,
+                }
+            }
+
         stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
-        return PromptResponse(stop_reason=stop_reason, usage=usage)
+        return PromptResponse(stop_reason=stop_reason, usage=usage, field_meta=runtime_meta)
 
     # ---- Slash commands (headless) -------------------------------------------
 

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -313,19 +313,27 @@ class CopilotACPClient:
             tools=tools,
             tool_choice=tool_choice,
         )
-        response_text, reasoning_text = self._run_prompt(
+        response_text, reasoning_text, usage_data, runtime_meta = self._run_prompt(
             prompt_text,
             timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
-        usage = SimpleNamespace(
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
-        )
+        usage = None
+        if usage_data and isinstance(usage_data, dict):
+            prompt_tokens = usage_data.get("prompt_tokens", usage_data.get("input_tokens", usage_data.get("inputTokens", 0)))
+            completion_tokens = usage_data.get("completion_tokens", usage_data.get("output_tokens", usage_data.get("outputTokens", 0)))
+            total_tokens = usage_data.get("total_tokens", usage_data.get("totalTokens", 0))
+            cached_tokens = usage_data.get("cached_tokens", usage_data.get("cache_read_tokens", usage_data.get("cachedReadTokens", 0))) or 0
+            reasoning_tokens = usage_data.get("reasoning_tokens", usage_data.get("thoughtTokens", 0)) or 0
+            usage = SimpleNamespace(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+                reasoning_tokens=reasoning_tokens,
+            )
         assistant_message = SimpleNamespace(
             content=cleaned_text,
             tool_calls=tool_calls,
@@ -339,9 +347,17 @@ class CopilotACPClient:
             choices=[choice],
             usage=usage,
             model=model or "copilot-acp",
+            hermes_provider=(runtime_meta or {}).get("provider"),
+            hermes_base_url=(runtime_meta or {}).get("base_url"),
+            hermes_api_mode=(runtime_meta or {}).get("api_mode"),
         )
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]:
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -465,7 +481,7 @@ class CopilotACPClient:
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
-            _request(
+            prompt_result = _request(
                 "session/prompt",
                 {
                     "sessionId": session_id,
@@ -478,8 +494,20 @@ class CopilotACPClient:
                 },
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
-            )
-            return "".join(text_parts), "".join(reasoning_parts)
+            ) or {}
+            usage_data = prompt_result.get("usage") if isinstance(prompt_result, dict) else None
+            runtime_meta = None
+            if isinstance(prompt_result, dict):
+                raw_meta = prompt_result.get("_meta") or prompt_result.get("meta")
+                if isinstance(raw_meta, dict):
+                    candidate = raw_meta.get("hermesRuntime")
+                    if isinstance(candidate, dict):
+                        runtime_meta = {
+                            "provider": candidate.get("provider"),
+                            "base_url": candidate.get("base_url"),
+                            "api_mode": candidate.get("api_mode"),
+                        }
+            return "".join(text_parts), "".join(reasoning_parts), usage_data, runtime_meta
         finally:
             self.close()
 

--- a/cli.py
+++ b/cli.py
@@ -6767,11 +6767,7 @@ class HermesCLI:
             active_root_count = sum(1 for run in root_runs if run.get("ended_at") is None)
             single_root = len(root_runs) == 1
             if compact_all_scope:
-                if active_root_count > 0:
-                    warnings.append({
-                        "type": "run_active",
-                        "message": "Some root runs are still active; totals may still change.",
-                    })
+                pass
             else:
                 if active_root_count == 1:
                     warnings.append({

--- a/cli.py
+++ b/cli.py
@@ -4477,6 +4477,53 @@ class HermesCLI:
             _ask()
         return result[0]
 
+    def _interactive_provider_selection(
+        self, providers: list, current_model: str, current_provider: str
+    ) -> str | None:
+        """Show provider picker, return slug or None on cancel."""
+        choices = []
+        for p in providers:
+            count = p.get("total_models", len(p.get("models", [])))
+            label = f"{p['name']} ({count} model{'s' if count != 1 else ''})"
+            if p.get("is_current"):
+                label += "  ← current"
+            choices.append(label)
+
+        default_idx = next(
+            (i for i, p in enumerate(providers) if p.get("is_current")), 0
+        )
+
+        idx = self._run_curses_picker(
+            f"Select a provider (current: {current_model} on {current_provider}):",
+            choices,
+            default_index=default_idx,
+        )
+        if idx is None:
+            return None
+        return providers[idx]["slug"]
+
+    def _interactive_model_selection(
+        self, model_list: list, provider_data: dict
+    ) -> str | None:
+        """Show model picker for a given provider, return model_id or None on cancel."""
+        pname = provider_data.get("name", provider_data.get("slug", ""))
+        total = provider_data.get("total_models", len(model_list))
+
+        if not model_list:
+            _cprint(f"\n  No models listed for {pname}.")
+            return self._prompt_text_input("  Enter model name manually (or Enter to cancel): ")
+
+        choices = list(model_list) + ["Enter custom model name"]
+        idx = self._run_curses_picker(
+            f"Select model from {pname} ({len(model_list)} of {total}):",
+            choices,
+        )
+        if idx is None:
+            return None
+        if idx < len(model_list):
+            return model_list[idx]
+        return self._prompt_text_input("  Enter model name: ")
+
     def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
@@ -4666,10 +4713,10 @@ class HermesCLI:
             user_provs = None
             custom_provs = None
             try:
-                from hermes_cli.config import get_compatible_custom_providers, load_config
+                from hermes_cli.config import load_config
                 cfg = load_config()
                 user_provs = cfg.get("providers")
-                custom_provs = get_compatible_custom_providers(cfg)
+                custom_provs = cfg.get("custom_providers")
             except Exception:
                 pass
 
@@ -5455,6 +5502,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "accounting":
+            self._show_accounting(cmd_original)
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "debug":
@@ -6474,6 +6523,424 @@ class HermesCLI:
             logging.getLogger().setLevel(logging.INFO)
             for quiet_logger in ('tools', 'run_agent', 'trajectory_compressor', 'cron', 'hermes_cli'):
                 logging.getLogger(quiet_logger).setLevel(logging.ERROR)
+
+    def _resolve_accounting_scope(self, target: str, accounting_db, session_db) -> tuple[str, list[str]]:
+        target = (target or "current").strip()
+        lowered = target.lower()
+        if lowered == "all":
+            return "all", [row["run_id"] for row in accounting_db.list_root_runs()]
+        if target and lowered != "current":
+            return "root run", [target]
+
+        session_id = getattr(self, "session_id", None)
+        session_ids: list[str] = []
+        if session_id:
+            if session_db is not None:
+                session_ids = session_db.get_session_ancestor_ids(session_id)
+            else:
+                session_ids = [session_id]
+        root_runs = accounting_db.list_root_runs(local_session_ids=session_ids) if session_ids else []
+        if not root_runs:
+            agent = getattr(self, "agent", None)
+            root_run_id = getattr(agent, "root_run_id", None)
+            if root_run_id:
+                run = accounting_db.get_agent_run(root_run_id)
+                if run is not None:
+                    root_runs = [run]
+        return "current session", [row["run_id"] for row in root_runs if row.get("run_id")]
+
+    @staticmethod
+    def _accounting_total_tokens(row: dict) -> int:
+        return (
+            int(row.get("input_tokens") or 0)
+            + int(row.get("output_tokens") or 0)
+            + int(row.get("cache_read_tokens") or 0)
+            + int(row.get("cache_write_tokens") or 0)
+            + int(row.get("reasoning_tokens") or 0)
+        )
+
+    @staticmethod
+    def _format_accounting_usage_summary(row: dict) -> str:
+        parts = [
+            f"in {int(row.get('input_tokens') or 0):,}",
+            f"out {int(row.get('output_tokens') or 0):,}",
+        ]
+        if int(row.get("cache_read_tokens") or 0):
+            parts.append(f"cache-read {int(row.get('cache_read_tokens') or 0):,}")
+        if int(row.get("cache_write_tokens") or 0):
+            parts.append(f"cache-write {int(row.get('cache_write_tokens') or 0):,}")
+        if int(row.get("reasoning_tokens") or 0):
+            parts.append(f"reasoning {int(row.get('reasoning_tokens') or 0):,}")
+        parts.append(f"total {HermesCLI._accounting_total_tokens(row):,}")
+        return "  ".join(parts)
+
+    @staticmethod
+    def _aggregate_accounting_breakdown_rows(rows: list[dict]) -> list[dict]:
+        grouped: dict[tuple, dict] = {}
+        for row in rows:
+            key = (
+                row.get("provider"),
+                row.get("base_url"),
+                row.get("model"),
+                row.get("api_mode"),
+            )
+            agg = grouped.setdefault(key, {
+                "provider": row.get("provider"),
+                "base_url": row.get("base_url"),
+                "model": row.get("model"),
+                "api_mode": row.get("api_mode"),
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "exact_event_count": 0,
+                "unknown_event_count": 0,
+            })
+            agg["input_tokens"] += int(row.get("input_tokens") or 0)
+            agg["output_tokens"] += int(row.get("output_tokens") or 0)
+            agg["cache_read_tokens"] += int(row.get("cache_read_tokens") or 0)
+            agg["cache_write_tokens"] += int(row.get("cache_write_tokens") or 0)
+            agg["reasoning_tokens"] += int(row.get("reasoning_tokens") or 0)
+            agg["estimated_cost_usd"] += float(row.get("estimated_cost_usd") or 0.0)
+            agg["exact_event_count"] += int(row.get("exact_event_count") or 0)
+            agg["unknown_event_count"] += int(row.get("unknown_event_count") or 0)
+        return sorted(
+            grouped.values(),
+            key=lambda row: (
+                HermesCLI._accounting_total_tokens(row),
+                float(row.get("estimated_cost_usd") or 0.0),
+                int(row.get("exact_event_count") or 0),
+            ),
+            reverse=True,
+        )
+
+    @staticmethod
+    def _prepare_accounting_breakdown_rows(
+        rows: list[dict],
+        *,
+        compact_all_scope: bool,
+        limit: int = 10,
+    ) -> tuple[list[dict], int]:
+        if not compact_all_scope:
+            return rows, 0
+
+        rows = sorted(
+            rows,
+            key=lambda row: (
+                float(row.get("estimated_cost_usd") or 0.0),
+                HermesCLI._accounting_total_tokens(row),
+                int(row.get("exact_event_count") or 0),
+            ),
+            reverse=True,
+        )
+
+        if limit <= 0 or len(rows) <= limit:
+            return rows, 0
+        return rows[:limit], len(rows) - limit
+
+    @staticmethod
+    def _format_accounting_note_prefix(warning_type: str | None) -> str:
+        return "NOTE" if warning_type == "run_active" else "WARNING"
+
+    @staticmethod
+    def _summarize_accounting_warnings(
+        warnings: list[dict],
+        *,
+        compact_all_scope: bool,
+    ) -> list[dict]:
+        if not compact_all_scope or not warnings:
+            return warnings
+
+        summarized: list[dict] = []
+        missing_session_link_count = 0
+        deferred_run_active = None
+        seen = set()
+
+        for warning in warnings:
+            warning_type = warning.get("type")
+            if warning_type == "missing_session_link":
+                missing_session_link_count += 1
+                continue
+            if warning_type == "run_active":
+                deferred_run_active = warning
+                continue
+
+            key = (warning_type, warning.get("message"))
+            if key in seen:
+                continue
+            seen.add(key)
+            summarized.append(warning)
+
+        if missing_session_link_count:
+            noun = "run" if missing_session_link_count == 1 else "runs"
+            summarized.append({
+                "type": "missing_session_link",
+                "message": (
+                    "No matching local session row was found for "
+                    f"{missing_session_link_count} {noun} in this scope."
+                ),
+            })
+
+        if deferred_run_active is not None:
+            summarized.append(deferred_run_active)
+
+        return summarized
+
+    @staticmethod
+    def _format_accounting_timestamp(timestamp_value) -> str:
+        if timestamp_value is None:
+            return "n/a"
+        try:
+            return datetime.fromtimestamp(float(timestamp_value)).strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return "n/a"
+
+    @staticmethod
+    def _format_accounting_cost(amount) -> str:
+        if amount is None:
+            return "n/a"
+        return f"${float(amount):.5f}"
+
+    @staticmethod
+    def _short_run_id(run_id: str | None) -> str:
+        return (run_id or "unknown")[:8]
+
+    def _show_accounting(self, command: str = "/accounting"):
+        """Show accounting for the current session, all runs, or a specific root run."""
+        from hermes_state import AccountingDB, SessionDB
+
+        parts = command.split(maxsplit=1)
+        target = parts[1].strip() if len(parts) > 1 else "current"
+
+        created_accounting_db = False
+        accounting_db = getattr(getattr(self, "agent", None), "_accounting_db", None)
+        if accounting_db is None:
+            accounting_db = AccountingDB()
+            created_accounting_db = True
+
+        session_db = getattr(self, "_session_db", None)
+        created_session_db = False
+        if session_db is None:
+            try:
+                session_db = SessionDB()
+                created_session_db = True
+            except Exception:
+                session_db = None
+
+        try:
+            if target == "all":
+                print("⏳ Summarizing all-scope accounting...")
+            scope_label, root_run_ids = self._resolve_accounting_scope(target, accounting_db, session_db)
+            if not root_run_ids:
+                print("(._.) No accounting found for the requested scope.")
+                return
+
+            run_tree = accounting_db.get_task_run_tree(root_run_ids=root_run_ids)
+            if not run_tree:
+                if scope_label == "root run":
+                    print(f"(._.) Root run not found: {target}")
+                else:
+                    print("(._.) No accounting found for the requested scope.")
+                return
+
+            summary = accounting_db.get_task_usage_summary(root_run_ids=root_run_ids)
+            breakdown = sorted(
+                accounting_db.get_task_usage_breakdown(root_run_ids=root_run_ids),
+                key=lambda row: (
+                    self._accounting_total_tokens(row),
+                    float(row.get("estimated_cost_usd") or 0.0),
+                ),
+                reverse=True,
+            )
+            display_breakdown = self._aggregate_accounting_breakdown_rows(breakdown)
+            compact_all_scope = scope_label == "all"
+            display_breakdown, omitted_breakdown_count = self._prepare_accounting_breakdown_rows(
+                display_breakdown,
+                compact_all_scope=compact_all_scope,
+            )
+            session_links = accounting_db.get_task_session_links(root_run_ids=root_run_ids, session_db=session_db)
+            warnings = list(accounting_db.get_task_provenance_warnings(root_run_ids=root_run_ids, session_db=session_db))
+
+            root_runs = [run for run in run_tree if run.get("parent_run_id") is None]
+            active_root_count = sum(1 for run in root_runs if run.get("ended_at") is None)
+            single_root = len(root_runs) == 1
+            if compact_all_scope:
+                if active_root_count > 0:
+                    warnings.append({
+                        "type": "run_active",
+                        "message": "Some root runs are still active; totals may still change.",
+                    })
+            else:
+                if active_root_count == 1:
+                    warnings.append({
+                        "type": "run_active",
+                        "message": "Run is still active; totals may still change.",
+                    })
+                elif active_root_count > 1:
+                    warnings.append({
+                        "type": "run_active",
+                        "message": f"{active_root_count} runs are still active; totals may still change.",
+                    })
+
+            warnings = self._summarize_accounting_warnings(warnings, compact_all_scope=compact_all_scope)
+            root_run = root_runs[0] if single_root else None
+            root_sessions = sorted({
+                link.get("local_session_id")
+                for link in session_links
+                if link.get("local_session_id") and link.get("run_id") in {run.get("run_id") for run in root_runs}
+            })
+            all_sessions = sorted({
+                link.get("local_session_id")
+                for link in session_links
+                if link.get("local_session_id")
+            })
+            child_sessions = sorted({
+                link.get("local_session_id")
+                for link in session_links
+                if link.get("local_session_id") and link.get("run_id") not in {run.get("run_id") for run in root_runs}
+            })
+            started_candidates = [run.get("started_at") for run in root_runs if run.get("started_at") is not None]
+            ended_candidates = [run.get("ended_at") for run in root_runs if run.get("ended_at") is not None]
+
+            def _print_totals(label: str, row: dict) -> None:
+                print(f"  {label:<14} {self._format_accounting_usage_summary(row)}")
+
+            def _run_usage_row(run_id: str) -> dict:
+                rows = [item for item in breakdown if item.get("run_id") == run_id]
+                return {
+                    "input_tokens": sum(int(item.get("input_tokens") or 0) for item in rows),
+                    "output_tokens": sum(int(item.get("output_tokens") or 0) for item in rows),
+                    "cache_read_tokens": sum(int(item.get("cache_read_tokens") or 0) for item in rows),
+                    "cache_write_tokens": sum(int(item.get("cache_write_tokens") or 0) for item in rows),
+                    "reasoning_tokens": sum(int(item.get("reasoning_tokens") or 0) for item in rows),
+                }
+
+            print("Task accounting" if single_root else "Accounting")
+            print(f"Scope: {scope_label}")
+            print(f"Root runs: {summary['root_run_count']}")
+            if single_root and root_run is not None:
+                print(f"Root run: {root_run.get('run_id')}")
+            print(
+                f"Started: {self._format_accounting_timestamp(min(started_candidates) if started_candidates else None)}"
+            )
+            print(
+                "Ended: "
+                + (
+                    self._format_accounting_timestamp(max(ended_candidates) if ended_candidates else None)
+                    if active_root_count == 0
+                    else (
+                        "running"
+                        if active_root_count == len(root_runs)
+                        else ("mixed" if compact_all_scope else "running")
+                    )
+                )
+            )
+            if single_root and root_run is not None:
+                print(f"Session: {root_run.get('local_session_id') or 'n/a'}")
+                print(f"Home: {root_run.get('home_id') or 'n/a'}")
+            else:
+                if compact_all_scope:
+                    print(f"Sessions: {len(all_sessions)} total")
+                else:
+                    print(f"Sessions: {', '.join(root_sessions) if root_sessions else 'n/a'}")
+            print()
+            print("Totals")
+            _print_totals("Root agent only", summary["manager_only"])
+            _print_totals("Subagents only", summary["worker_only"])
+            _print_totals("Whole task" if single_root else "Whole scope", summary["total"])
+            print()
+            print("Usage status")
+            print(f"  Exact events:    {summary['exact_event_count']}")
+            print(f"  Unknown events:  {summary['unknown_event_count']}")
+            print()
+            print("Estimated cost")
+            print(f"  Total: {self._format_accounting_cost(summary['total'].get('estimated_cost_usd'))}")
+            print()
+            print("Breakdown by provider | model | base_url | api_mode")
+            if display_breakdown:
+                for row in display_breakdown:
+                    route_parts = [
+                        row.get("provider") or "unknown",
+                        row.get("model") or "unknown",
+                    ]
+                    if row.get("base_url"):
+                        route_parts.append(row["base_url"])
+                    if row.get("api_mode"):
+                        route_parts.append(f"api_mode={row['api_mode']}")
+                    route = " | ".join(route_parts)
+                    print(f"  {route}")
+                    print(
+                        f"    {self._format_accounting_usage_summary(row)}  "
+                        f"events {int(row.get('exact_event_count') or 0) + int(row.get('unknown_event_count') or 0)}  "
+                        f"exact {int(row.get('exact_event_count') or 0)} unknown {int(row.get('unknown_event_count') or 0)}"
+                    )
+                    print()
+                if omitted_breakdown_count:
+                    noun = "route" if omitted_breakdown_count == 1 else "routes"
+                    print(f"  ... {omitted_breakdown_count} more {noun} omitted from /accounting all")
+                    print()
+            else:
+                print("  none")
+                print()
+
+            if not compact_all_scope:
+                print("Run tree")
+                if run_tree:
+                    for run in run_tree:
+                        role = "root" if run.get("parent_run_id") is None else "child"
+                        row = _run_usage_row(run.get("run_id"))
+                        unknown_count = sum(
+                            int(item.get("unknown_event_count") or 0)
+                            for item in breakdown
+                            if item.get("run_id") == run.get("run_id")
+                        )
+                        status = "exact" if unknown_count == 0 else "mixed"
+                        print(
+                            f"  {role:<8} {self._short_run_id(run.get('run_id'))}  "
+                            f"profile={run.get('profile_name') or run.get('home_id') or 'default'}  "
+                            f"transport={run.get('transport_kind') or 'unknown'}  "
+                            f"launch={run.get('launch_kind') or 'unknown'}  "
+                            f"{self._format_accounting_usage_summary(row)}  {status}"
+                        )
+                else:
+                    print("  none")
+                print()
+
+                print("Session links")
+                if single_root:
+                    print(f"  root run session:   {root_sessions[0] if root_sessions else 'n/a'}")
+                else:
+                    print(f"  root run sessions:  {', '.join(root_sessions) if root_sessions else 'n/a'}")
+                print(f"  child sessions:     {', '.join(child_sessions) if child_sessions else 'none'}")
+                print()
+
+            print("Accounting notes")
+            if compact_all_scope:
+                print("  NOTE: /accounting all shows scope totals and breakdown only; use /accounting <root_run_id> for per-task details.")
+            if warnings:
+                for warning in warnings:
+                    message = warning.get('message', 'unknown warning')
+                    if warning.get("type") == "unknown_usage" and int(summary.get("unknown_event_count") or 0):
+                        unknown_count = int(summary.get("unknown_event_count") or 0)
+                        noun = "event" if unknown_count == 1 else "events"
+                        verb = "is" if unknown_count == 1 else "are"
+                        message = (
+                            f"Unknown/non-exact usage present: {unknown_count} {noun} {verb} non-exact; "
+                            "totals and estimated cost are not exact."
+                        )
+                    prefix = self._format_accounting_note_prefix(warning.get("type"))
+                    print(f"  {prefix}: {message}")
+            else:
+                print("  none")
+        except Exception as e:
+            print(f"  Error generating accounting report: {e}")
+        finally:
+            if created_session_db and session_db is not None:
+                session_db.close()
+            if created_accounting_db and accounting_db is not None:
+                accounting_db.close()
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""

--- a/cli.py
+++ b/cli.py
@@ -6813,10 +6813,10 @@ class HermesCLI:
                     "reasoning_tokens": sum(int(item.get("reasoning_tokens") or 0) for item in rows),
                 }
 
-            print("Task accounting" if single_root else "Accounting")
+            print("Accounting" if compact_all_scope or not single_root else "Task accounting")
             print(f"Scope: {scope_label}")
             print(f"Root runs: {summary['root_run_count']}")
-            if single_root and root_run is not None:
+            if not compact_all_scope and single_root and root_run is not None:
                 print(f"Root run: {root_run.get('run_id')}")
             print(
                 f"Started: {self._format_accounting_timestamp(min(started_candidates) if started_candidates else None)}"
@@ -6833,7 +6833,7 @@ class HermesCLI:
                     )
                 )
             )
-            if single_root and root_run is not None:
+            if not compact_all_scope and single_root and root_run is not None:
                 print(f"Session: {root_run.get('local_session_id') or 'n/a'}")
                 print(f"Home: {root_run.get('home_id') or 'n/a'}")
             else:
@@ -6845,7 +6845,7 @@ class HermesCLI:
             print("Totals")
             _print_totals("Root agent only", summary["manager_only"])
             _print_totals("Subagents only", summary["worker_only"])
-            _print_totals("Whole task" if single_root else "Whole scope", summary["total"])
+            _print_totals("Whole scope" if compact_all_scope else ("Whole task" if single_root else "Whole scope"), summary["total"])
             print()
             print("Usage status")
             print(f"  Exact events:    {summary['exact_event_count']}")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
+- GET  /api/accounting             — Hermes-native accounting summary/breakdown/run-tree view
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - GET  /health                     — health check
@@ -394,6 +395,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._accounting_db: Optional[Any] = None  # Lazy-init AccountingDB for Hermes-native reporting
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -490,7 +492,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # Session DB helper
     # ------------------------------------------------------------------
 
-    def _ensure_session_db(self):
+    def _ensure_session_db(self, *, create_if_missing: bool = True, suppress_errors: bool = True):
         """Lazily initialise and return the shared SessionDB instance.
 
         Sessions are persisted to ``state.db`` so that ``hermes sessions list``
@@ -498,11 +500,176 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         if self._session_db is None:
             try:
-                from hermes_state import SessionDB
-                self._session_db = SessionDB()
+                from hermes_state import SessionDB, DEFAULT_DB_PATH
+                if not create_if_missing and not DEFAULT_DB_PATH.exists():
+                    return None
+                self._session_db = SessionDB(db_path=DEFAULT_DB_PATH)
             except Exception as e:
                 logger.debug("SessionDB unavailable for API server: %s", e)
+                if not suppress_errors:
+                    raise
         return self._session_db
+
+    def _ensure_accounting_db(self, *, create_if_missing: bool = True, suppress_errors: bool = True):
+        """Lazily initialise and return the shared AccountingDB instance."""
+        if self._accounting_db is None:
+            try:
+                from hermes_state import AccountingDB, DEFAULT_ACCOUNTING_DB_PATH
+                if not create_if_missing and not DEFAULT_ACCOUNTING_DB_PATH.exists():
+                    return None
+                self._accounting_db = AccountingDB(db_path=DEFAULT_ACCOUNTING_DB_PATH)
+            except Exception as e:
+                logger.debug("AccountingDB unavailable for API server: %s", e)
+                if not suppress_errors:
+                    raise
+        return self._accounting_db
+
+    @staticmethod
+    def _accounting_total_tokens(row: Dict[str, Any]) -> int:
+        return (
+            int(row.get("input_tokens") or 0)
+            + int(row.get("output_tokens") or 0)
+            + int(row.get("cache_read_tokens") or 0)
+            + int(row.get("cache_write_tokens") or 0)
+            + int(row.get("reasoning_tokens") or 0)
+        )
+
+    def _resolve_accounting_request(self, request: "web.Request", accounting_db, session_db):
+        """Resolve API query parameters into a concrete accounting scope."""
+        root_run_id = request.query.get("root_run_id", "").strip()
+        session_id = request.query.get("session_id", "").strip()
+        scope = request.query.get("scope", "").strip().lower()
+        selectors = int(bool(root_run_id)) + int(bool(session_id)) + int(bool(scope))
+
+        if selectors != 1:
+            return None, None, web.json_response(
+                {
+                    "error": (
+                        "Provide exactly one scope selector: root_run_id=<id>, "
+                        "session_id=<id>, or scope=all"
+                    )
+                },
+                status=400,
+            )
+
+        if scope:
+            if scope != "all":
+                return None, None, web.json_response(
+                    {"error": "Invalid scope. Supported values: all"},
+                    status=400,
+                )
+            root_run_ids = [row["root_run_id"] for row in accounting_db.list_root_runs() if row.get("root_run_id")]
+            return {"type": "all", "root_run_ids": root_run_ids}, root_run_ids, None
+
+        if root_run_id:
+            run_tree = accounting_db.get_task_run_tree(root_run_id=root_run_id)
+            if not run_tree:
+                return None, None, web.json_response(
+                    {"error": f"Root run not found: {root_run_id}"},
+                    status=404,
+                )
+            return {
+                "type": "root_run",
+                "root_run_id": root_run_id,
+                "root_run_ids": [root_run_id],
+            }, [root_run_id], None
+
+        session_ids = [session_id]
+        if session_db is not None:
+            session_ids = session_db.get_session_ancestor_ids(session_id) or [session_id]
+        root_run_ids = accounting_db.list_root_run_ids_for_sessions(session_ids)
+        if not root_run_ids:
+            if session_db is None:
+                return None, None, web.json_response(
+                    {
+                        "error": (
+                            "Session lineage metadata was unavailable and exact-session lookup "
+                            f"found no accounting for session: {session_id}"
+                        )
+                    },
+                    status=503,
+                )
+            return None, None, web.json_response(
+                {"error": f"No accounting found for session: {session_id}"},
+                status=404,
+            )
+        return {
+            "type": "session",
+            "session_id": session_id,
+            "root_run_ids": root_run_ids,
+        }, root_run_ids, None
+
+    def _build_accounting_payload(
+        self,
+        scope_info: Dict[str, Any],
+        root_run_ids: List[str],
+        accounting_db,
+        session_db,
+        extra_warnings: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Build the structured JSON payload for /api/accounting."""
+        summary = accounting_db.get_task_usage_summary(root_run_ids=root_run_ids)
+        breakdown = sorted(
+            accounting_db.get_task_usage_breakdown(root_run_ids=root_run_ids),
+            key=lambda row: (
+                self._accounting_total_tokens(row),
+                float(row.get("estimated_cost_usd") or 0.0),
+            ),
+            reverse=True,
+        )
+        run_tree = accounting_db.get_task_run_tree(root_run_ids=root_run_ids)
+        session_links = []
+        try:
+            session_links = accounting_db.get_task_session_links(root_run_ids=root_run_ids, session_db=session_db)
+        except Exception as e:
+            logger.warning("Session link enrichment failed for /api/accounting: %s", e)
+            session_links = accounting_db.get_task_session_links(root_run_ids=root_run_ids, session_db=None)
+            warnings = [{
+                "type": "session_linkage_unavailable",
+                "message": "Session linkage metadata was unavailable; session link details may be partial.",
+            }]
+        else:
+            warnings = []
+
+        try:
+            warnings.extend(
+                accounting_db.get_task_provenance_warnings(root_run_ids=root_run_ids, session_db=session_db)
+            )
+        except Exception as e:
+            logger.warning("Provenance enrichment failed for /api/accounting: %s", e)
+            warnings.extend([
+                {
+                    "type": "session_provenance_unavailable",
+                    "message": "Session provenance metadata was unavailable; provenance warnings may be incomplete.",
+                }
+            ])
+            warnings.extend(
+                accounting_db.get_task_provenance_warnings(root_run_ids=root_run_ids, session_db=None)
+            )
+        if extra_warnings:
+            warnings.extend(extra_warnings)
+
+        root_runs = [run for run in run_tree if run.get("parent_run_id") is None]
+        active_root_count = sum(1 for run in root_runs if run.get("ended_at") is None)
+        if active_root_count == 1:
+            warnings.append({
+                "type": "run_active",
+                "message": "Run is still active; totals may still change.",
+            })
+        elif active_root_count > 1:
+            warnings.append({
+                "type": "run_active",
+                "message": f"{active_root_count} runs are still active; totals may still change.",
+            })
+
+        return {
+            "scope": scope_info,
+            "summary": summary,
+            "breakdown": breakdown,
+            "run_tree": run_tree,
+            "session_links": session_links,
+            "warnings": warnings,
+        }
 
     # ------------------------------------------------------------------
     # Agent creation helper
@@ -585,6 +752,143 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
             ],
         })
+
+    async def _handle_accounting(self, request: "web.Request") -> "web.Response":
+        """GET /api/accounting — structured accounting for an explicit scope."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        root_run_id = request.query.get("root_run_id", "").strip()
+        session_id = request.query.get("session_id", "").strip()
+        scope = request.query.get("scope", "").strip().lower()
+        selectors = int(bool(root_run_id)) + int(bool(session_id)) + int(bool(scope))
+        if selectors != 1:
+            return web.json_response(
+                {
+                    "error": (
+                        "Provide exactly one scope selector: root_run_id=<id>, "
+                        "session_id=<id>, or scope=all"
+                    )
+                },
+                status=400,
+            )
+        if scope and scope != "all":
+            return web.json_response(
+                {"error": "Invalid scope. Supported values: all"},
+                status=400,
+            )
+
+        try:
+            accounting_db = self._ensure_accounting_db(
+                create_if_missing=False,
+                suppress_errors=False,
+            )
+        except Exception as e:
+            logger.warning("AccountingDB open failed for /api/accounting: %s", e)
+            return web.json_response({"error": "Accounting DB unavailable"}, status=500)
+        if accounting_db is None:
+            if scope == "all":
+                return web.json_response(
+                    {
+                        "scope": {"type": "all", "root_run_ids": []},
+                        "summary": {
+                            "root_run_id": None,
+                            "root_run_ids": [],
+                            "root_run_count": 0,
+                            "manager_only": {
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                                "cache_read_tokens": 0,
+                                "cache_write_tokens": 0,
+                                "reasoning_tokens": 0,
+                                "estimated_cost_usd": 0.0,
+                            },
+                            "worker_only": {
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                                "cache_read_tokens": 0,
+                                "cache_write_tokens": 0,
+                                "reasoning_tokens": 0,
+                                "estimated_cost_usd": 0.0,
+                            },
+                            "total": {
+                                "input_tokens": 0,
+                                "output_tokens": 0,
+                                "cache_read_tokens": 0,
+                                "cache_write_tokens": 0,
+                                "reasoning_tokens": 0,
+                                "estimated_cost_usd": 0.0,
+                            },
+                            "exact_event_count": 0,
+                            "unknown_event_count": 0,
+                            "first_event_at": None,
+                            "last_event_at": None,
+                            "child_run_count": 0,
+                        },
+                        "breakdown": [],
+                        "run_tree": [],
+                        "session_links": [],
+                        "warnings": [],
+                    }
+                )
+            if root_run_id:
+                return web.json_response({"error": f"Root run not found: {root_run_id}"}, status=404)
+            return web.json_response({"error": f"No accounting found for session: {session_id}"}, status=404)
+
+        session_db = None
+        extra_warnings: List[Dict[str, Any]] = []
+        if session_id:
+            try:
+                session_db = self._ensure_session_db(
+                    create_if_missing=False,
+                    suppress_errors=False,
+                )
+            except Exception as e:
+                logger.warning("Session lineage lookup failed for /api/accounting: %s", e)
+                session_db = None
+            if session_db is None:
+                extra_warnings.append({
+                    "type": "session_lineage_unavailable",
+                    "message": "Session lineage metadata was unavailable; session-scoped resolution may be partial.",
+                })
+            scope_info, root_run_ids, scope_err = self._resolve_accounting_request(
+                request, accounting_db, session_db
+            )
+        else:
+            scope_info, root_run_ids, scope_err = self._resolve_accounting_request(
+                request, accounting_db, session_db
+            )
+        if scope_err:
+            return scope_err
+
+        if not session_id:
+            try:
+                session_db = self._ensure_session_db(
+                    create_if_missing=False,
+                    suppress_errors=False,
+                )
+            except Exception as e:
+                logger.warning("Optional session metadata lookup failed for /api/accounting: %s", e)
+                session_db = None
+            if session_db is None:
+                extra_warnings.append({
+                    "type": "session_linkage_unavailable",
+                    "message": "Session linkage metadata was unavailable; session link details may be partial.",
+                })
+
+        try:
+            payload = self._build_accounting_payload(
+                scope_info=scope_info,
+                root_run_ids=root_run_ids,
+                accounting_db=accounting_db,
+                session_db=session_db,
+                extra_warnings=extra_warnings,
+            )
+        except Exception as e:
+            logger.warning("Accounting payload build failed for /api/accounting: %s", e)
+            return web.json_response({"error": "Accounting payload unavailable"}, status=500)
+        return web.json_response(payload)
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -1785,6 +2089,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
+            self._app.router.add_get("/api/accounting", self._handle_accounting)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -456,6 +456,7 @@ def run_import(args) -> None:
 # (skills, repo, sessions/).
 _QUICK_STATE_FILES = (
     "state.db",
+    "accounting.db",
     "config.yaml",
     ".env",
     "auth.json",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -150,6 +150,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("accounting", "Show accounting for the current session, all runs, or a specific root run", "Info",
+               cli_only=True, args_hint="[current|all|root_run_id]"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
@@ -169,7 +171,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
 
 # ---------------------------------------------------------------------------
-# Derived lookups -- rebuilt once at import time, refreshed by rebuild_lookups()
+# Derived lookups
 # ---------------------------------------------------------------------------
 
 def _build_command_lookup() -> dict[str, CommandDef]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -30,8 +30,9 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+DEFAULT_ACCOUNTING_DB_PATH = get_hermes_home() / "accounting.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -81,7 +82,20 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT,
     reasoning TEXT,
     reasoning_details TEXT,
-    codex_reasoning_items TEXT
+    codex_reasoning_items TEXT,
+    run_id TEXT,
+    root_run_id TEXT,
+    provider TEXT,
+    base_url TEXT,
+    model TEXT,
+    api_mode TEXT,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    estimated_cost_usd REAL,
+    usage_status TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -110,6 +124,565 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
 END;
 """
+
+
+ACCOUNTING_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS agent_runs (
+    run_id TEXT PRIMARY KEY,
+    parent_run_id TEXT,
+    root_run_id TEXT NOT NULL,
+    local_session_id TEXT,
+    home_id TEXT NOT NULL,
+    profile_name TEXT,
+    launch_kind TEXT NOT NULL,
+    transport_kind TEXT NOT NULL,
+    source TEXT,
+    model_hint TEXT,
+    provider_hint TEXT,
+    base_url_hint TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    metadata_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_root ON agent_runs(root_run_id);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_parent ON agent_runs(parent_run_id);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_home_profile ON agent_runs(home_id, profile_name);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    root_run_id TEXT NOT NULL,
+    home_id TEXT NOT NULL,
+    profile_name TEXT,
+    local_session_id TEXT,
+    provider TEXT,
+    base_url TEXT,
+    model TEXT,
+    api_mode TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd REAL,
+    usage_status TEXT NOT NULL,
+    recorded_at REAL NOT NULL,
+    request_fingerprint TEXT,
+    metadata_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_run ON usage_events(run_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_usage_events_root ON usage_events(root_run_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_usage_events_home_profile ON usage_events(home_id, profile_name, event_id);
+"""
+
+
+class AccountingDB:
+    """Global ledger DB for attributable runs and exact usage events."""
+
+    _WRITE_MAX_RETRIES = 15
+    _WRITE_RETRY_MIN_S = 0.020
+    _WRITE_RETRY_MAX_S = 0.150
+    _CHECKPOINT_EVERY_N_WRITES = 50
+
+    def __init__(self, db_path: Path = None):
+        self.db_path = db_path or DEFAULT_ACCOUNTING_DB_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._write_count = 0
+        self._conn = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=1.0,
+            isolation_level=None,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(ACCOUNTING_SCHEMA_SQL)
+        self._conn.commit()
+
+    def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
+        last_err: Optional[Exception] = None
+        for attempt in range(self._WRITE_MAX_RETRIES):
+            try:
+                with self._lock:
+                    self._conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        result = fn(self._conn)
+                        self._conn.commit()
+                    except BaseException:
+                        try:
+                            self._conn.rollback()
+                        except Exception:
+                            pass
+                        raise
+                self._write_count += 1
+                if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
+                    self._try_wal_checkpoint()
+                return result
+            except sqlite3.OperationalError as exc:
+                err_msg = str(exc).lower()
+                if "locked" in err_msg or "busy" in err_msg:
+                    last_err = exc
+                    if attempt < self._WRITE_MAX_RETRIES - 1:
+                        jitter = random.uniform(self._WRITE_RETRY_MIN_S, self._WRITE_RETRY_MAX_S)
+                        time.sleep(jitter)
+                        continue
+                raise
+        raise last_err or sqlite3.OperationalError("database is locked after max retries")
+
+    def _try_wal_checkpoint(self) -> None:
+        try:
+            with self._lock:
+                self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        except Exception:
+            pass
+
+    def close(self):
+        with self._lock:
+            if self._conn:
+                try:
+                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                except Exception:
+                    pass
+                self._conn.close()
+                self._conn = None
+
+    @staticmethod
+    def _decode_json(value: Optional[str]) -> Any:
+        if not value:
+            return None
+        try:
+            return json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            return value
+
+    def create_agent_run(
+        self,
+        *,
+        run_id: str,
+        root_run_id: str,
+        parent_run_id: str = None,
+        local_session_id: str = None,
+        home_id: str,
+        profile_name: str = None,
+        launch_kind: str,
+        transport_kind: str,
+        source: str = None,
+        model_hint: str = None,
+        provider_hint: str = None,
+        base_url_hint: str = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        started_at: Optional[float] = None,
+    ) -> None:
+        started_at = time.time() if started_at is None else float(started_at)
+        metadata_json = json.dumps(metadata) if metadata is not None else None
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO agent_runs (
+                       run_id, parent_run_id, root_run_id, local_session_id,
+                       home_id, profile_name, launch_kind, transport_kind,
+                       source, model_hint, provider_hint, base_url_hint,
+                       started_at, ended_at, metadata_json
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+                   ON CONFLICT(run_id) DO UPDATE SET
+                       parent_run_id = excluded.parent_run_id,
+                       root_run_id = excluded.root_run_id,
+                       home_id = excluded.home_id,
+                       profile_name = excluded.profile_name,
+                       launch_kind = excluded.launch_kind,
+                       transport_kind = excluded.transport_kind,
+                       source = excluded.source,
+                       model_hint = excluded.model_hint,
+                       provider_hint = excluded.provider_hint,
+                       base_url_hint = excluded.base_url_hint,
+                       ended_at = NULL,
+                       metadata_json = COALESCE(excluded.metadata_json, agent_runs.metadata_json)""",
+                (
+                    run_id,
+                    parent_run_id,
+                    root_run_id,
+                    local_session_id,
+                    home_id,
+                    profile_name,
+                    launch_kind,
+                    transport_kind,
+                    source,
+                    model_hint,
+                    provider_hint,
+                    base_url_hint,
+                    started_at,
+                    metadata_json,
+                ),
+            )
+
+        self._execute_write(_do)
+
+    def end_agent_run(self, run_id: str) -> None:
+        ended_at = time.time()
+        self._execute_write(lambda conn: conn.execute("UPDATE agent_runs SET ended_at = ? WHERE run_id = ?", (ended_at, run_id)))
+
+    def get_agent_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM agent_runs WHERE run_id = ?", (run_id,)).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["metadata_json"] = self._decode_json(result.get("metadata_json"))
+        return result
+
+    def get_latest_root_run_id_for_session(self, local_session_id: str) -> Optional[str]:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT root_run_id
+                FROM agent_runs
+                WHERE local_session_id = ?
+                ORDER BY started_at DESC, run_id DESC
+                LIMIT 1
+                """,
+                (local_session_id,),
+            ).fetchone()
+        return None if row is None else row["root_run_id"]
+
+    def list_root_runs(self, local_session_ids: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        clauses = ["parent_run_id IS NULL"]
+        params: List[Any] = []
+        if local_session_ids is not None:
+            cleaned = [str(s).strip() for s in local_session_ids if str(s).strip()]
+            if not cleaned:
+                return []
+            placeholders = ", ".join("?" for _ in cleaned)
+            clauses.append(f"local_session_id IN ({placeholders})")
+            params.extend(cleaned)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM agent_runs {where_sql} ORDER BY started_at ASC, run_id ASC",
+                tuple(params),
+            ).fetchall()
+        results = []
+        for row in rows:
+            item = dict(row)
+            item["metadata_json"] = self._decode_json(item.get("metadata_json"))
+            results.append(item)
+        return results
+
+    def list_root_run_ids_for_sessions(self, local_session_ids: List[str]) -> List[str]:
+        cleaned = [str(s).strip() for s in local_session_ids if str(s).strip()]
+        if not cleaned:
+            return []
+        placeholders = ", ".join("?" for _ in cleaned)
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT root_run_id, MIN(started_at) AS first_started_at
+                FROM agent_runs
+                WHERE local_session_id IN ({placeholders}) AND root_run_id IS NOT NULL
+                GROUP BY root_run_id
+                ORDER BY first_started_at ASC, root_run_id ASC
+                """,
+                tuple(cleaned),
+            ).fetchall()
+        return [str(row["root_run_id"]).strip() for row in rows if str(row["root_run_id"]).strip()]
+
+    def _normalize_root_run_ids(
+        self,
+        root_run_id: Optional[str] = None,
+        root_run_ids: Optional[List[str]] = None,
+    ) -> List[str]:
+        if root_run_ids is not None:
+            ordered: List[str] = []
+            seen: set[str] = set()
+            for value in root_run_ids:
+                cleaned = str(value or "").strip()
+                if cleaned and cleaned not in seen:
+                    seen.add(cleaned)
+                    ordered.append(cleaned)
+            return ordered
+        if root_run_id is not None:
+            cleaned = str(root_run_id).strip()
+            return [cleaned] if cleaned else []
+        return [row["run_id"] for row in self.list_root_runs()]
+
+    def append_usage_event(
+        self,
+        *,
+        run_id: str,
+        root_run_id: str,
+        home_id: str,
+        profile_name: str = None,
+        local_session_id: str = None,
+        provider: str = None,
+        base_url: str = None,
+        model: str = None,
+        api_mode: str = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        estimated_cost_usd: Optional[float] = None,
+        usage_status: str = "exact",
+        request_fingerprint: str = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        recorded_at = time.time()
+        metadata_json = json.dumps(metadata) if metadata is not None else None
+
+        def _do(conn):
+            cursor = conn.execute(
+                """INSERT INTO usage_events (
+                       run_id, root_run_id, home_id, profile_name, local_session_id,
+                       provider, base_url, model, api_mode,
+                       input_tokens, output_tokens, cache_read_tokens,
+                       cache_write_tokens, reasoning_tokens, estimated_cost_usd,
+                       usage_status, recorded_at, request_fingerprint, metadata_json
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    run_id,
+                    root_run_id,
+                    home_id,
+                    profile_name,
+                    local_session_id,
+                    provider,
+                    base_url,
+                    model,
+                    api_mode,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    reasoning_tokens,
+                    estimated_cost_usd,
+                    usage_status,
+                    recorded_at,
+                    request_fingerprint,
+                    metadata_json,
+                ),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def get_usage_events(
+        self,
+        *,
+        run_id: str = None,
+        root_run_id: str = None,
+        root_run_ids: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        clauses = []
+        params: List[Any] = []
+        if run_id is not None:
+            clauses.append("run_id = ?")
+            params.append(run_id)
+        normalized_root_ids = self._normalize_root_run_ids(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        if run_id is None and (root_run_id is not None or root_run_ids is not None):
+            if not normalized_root_ids:
+                return []
+            placeholders = ", ".join("?" for _ in normalized_root_ids)
+            clauses.append(f"root_run_id IN ({placeholders})")
+            params.extend(normalized_root_ids)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM usage_events {where_sql} ORDER BY event_id ASC",
+                tuple(params),
+            ).fetchall()
+        results = []
+        for row in rows:
+            item = dict(row)
+            item["metadata_json"] = self._decode_json(item.get("metadata_json"))
+            results.append(item)
+        return results
+
+    def get_task_run_tree(
+        self,
+        root_run_id: Optional[str] = None,
+        *,
+        root_run_ids: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        normalized_root_ids = self._normalize_root_run_ids(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        if (root_run_id is not None or root_run_ids is not None) and not normalized_root_ids:
+            return []
+        if normalized_root_ids:
+            placeholders = ", ".join("?" for _ in normalized_root_ids)
+            query = (
+                f"SELECT * FROM agent_runs WHERE root_run_id IN ({placeholders}) "
+                "ORDER BY started_at ASC, run_id ASC"
+            )
+            params: tuple[Any, ...] = tuple(normalized_root_ids)
+        else:
+            query = "SELECT * FROM agent_runs ORDER BY started_at ASC, run_id ASC"
+            params = ()
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+        results = []
+        for row in rows:
+            item = dict(row)
+            item["metadata_json"] = self._decode_json(item.get("metadata_json"))
+            results.append(item)
+        return results
+
+    @staticmethod
+    def _sum_usage_rows(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+        totals = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "estimated_cost_usd": 0.0,
+        }
+        for row in rows:
+            totals["input_tokens"] += int(row.get("input_tokens") or 0)
+            totals["output_tokens"] += int(row.get("output_tokens") or 0)
+            totals["cache_read_tokens"] += int(row.get("cache_read_tokens") or 0)
+            totals["cache_write_tokens"] += int(row.get("cache_write_tokens") or 0)
+            totals["reasoning_tokens"] += int(row.get("reasoning_tokens") or 0)
+            totals["estimated_cost_usd"] += float(row.get("estimated_cost_usd") or 0.0)
+        return totals
+
+    def get_task_usage_summary(
+        self,
+        root_run_id: Optional[str] = None,
+        *,
+        root_run_ids: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        normalized_root_ids = self._normalize_root_run_ids(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        runs = self.get_task_run_tree(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        events = self.get_usage_events(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        root_run_id_set = {r["run_id"] for r in runs if r.get("parent_run_id") is None}
+        manager_events = [e for e in events if e.get("run_id") in root_run_id_set]
+        worker_events = [e for e in events if e.get("run_id") not in root_run_id_set]
+        exact_count = sum(1 for e in events if e.get("usage_status") == "exact")
+        unknown_count = sum(1 for e in events if e.get("usage_status") != "exact")
+        timestamps = [float(e.get("recorded_at")) for e in events if e.get("recorded_at") is not None]
+        return {
+            "root_run_id": normalized_root_ids[0] if len(normalized_root_ids) == 1 else None,
+            "root_run_ids": normalized_root_ids,
+            "root_run_count": len(root_run_id_set),
+            "manager_only": self._sum_usage_rows(manager_events),
+            "worker_only": self._sum_usage_rows(worker_events),
+            "total": self._sum_usage_rows(events),
+            "exact_event_count": exact_count,
+            "unknown_event_count": unknown_count,
+            "first_event_at": min(timestamps) if timestamps else None,
+            "last_event_at": max(timestamps) if timestamps else None,
+            "child_run_count": sum(1 for r in runs if r.get("parent_run_id") is not None),
+        }
+
+    def get_task_usage_breakdown(
+        self,
+        root_run_id: Optional[str] = None,
+        *,
+        root_run_ids: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        events = self.get_usage_events(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        runs_by_id = {
+            r["run_id"]: r
+            for r in self.get_task_run_tree(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        }
+        grouped: Dict[tuple, Dict[str, Any]] = {}
+        for e in events:
+            run = runs_by_id.get(e.get("run_id"), {})
+            key = (
+                e.get("provider"),
+                e.get("base_url"),
+                e.get("model"),
+                e.get("api_mode"),
+                e.get("profile_name"),
+                e.get("home_id"),
+                run.get("launch_kind"),
+                run.get("transport_kind"),
+                e.get("run_id"),
+            )
+            row = grouped.setdefault(key, {
+                "provider": e.get("provider"),
+                "base_url": e.get("base_url"),
+                "model": e.get("model"),
+                "api_mode": e.get("api_mode"),
+                "profile_name": e.get("profile_name"),
+                "home_id": e.get("home_id"),
+                "launch_kind": run.get("launch_kind"),
+                "transport_kind": run.get("transport_kind"),
+                "run_id": e.get("run_id"),
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "exact_event_count": 0,
+                "unknown_event_count": 0,
+            })
+            row["input_tokens"] += int(e.get("input_tokens") or 0)
+            row["output_tokens"] += int(e.get("output_tokens") or 0)
+            row["cache_read_tokens"] += int(e.get("cache_read_tokens") or 0)
+            row["cache_write_tokens"] += int(e.get("cache_write_tokens") or 0)
+            row["reasoning_tokens"] += int(e.get("reasoning_tokens") or 0)
+            row["estimated_cost_usd"] += float(e.get("estimated_cost_usd") or 0.0)
+            if e.get("usage_status") == "exact":
+                row["exact_event_count"] += 1
+            else:
+                row["unknown_event_count"] += 1
+        return list(grouped.values())
+
+    def get_task_session_links(
+        self,
+        root_run_id: Optional[str] = None,
+        *,
+        root_run_ids: Optional[List[str]] = None,
+        session_db=None,
+    ) -> List[Dict[str, Any]]:
+        links = []
+        for run in self.get_task_run_tree(root_run_id=root_run_id, root_run_ids=root_run_ids):
+            local_session_id = run.get("local_session_id")
+            parent_session_id = None
+            if session_db is not None and local_session_id:
+                session = session_db.get_session(local_session_id)
+                if session:
+                    parent_session_id = session.get("parent_session_id")
+            links.append({
+                "run_id": run.get("run_id"),
+                "root_run_id": run.get("root_run_id"),
+                "local_session_id": local_session_id,
+                "parent_session_id": parent_session_id,
+                "session_rotated": parent_session_id is not None,
+            })
+        return links
+
+    def get_task_provenance_warnings(
+        self,
+        root_run_id: Optional[str] = None,
+        *,
+        root_run_ids: Optional[List[str]] = None,
+        session_db=None,
+    ) -> List[Dict[str, Any]]:
+        warnings: List[Dict[str, Any]] = []
+        events = self.get_usage_events(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        normalized_root_ids = self._normalize_root_run_ids(root_run_id=root_run_id, root_run_ids=root_run_ids)
+        if any(e.get("usage_status") != "exact" for e in events):
+            warnings.append({
+                "type": "unknown_usage",
+                "root_run_id": normalized_root_ids[0] if len(normalized_root_ids) == 1 else None,
+                "message": "One or more usage events are non-exact and should be treated cautiously.",
+            })
+        if session_db is not None:
+            for run in self.get_task_run_tree(root_run_id=root_run_id, root_run_ids=root_run_ids):
+                local_session_id = run.get("local_session_id")
+                if local_session_id and session_db.get_session(local_session_id) is None:
+                    warnings.append({
+                        "type": "missing_session_link",
+                        "run_id": run.get("run_id"),
+                        "local_session_id": local_session_id,
+                        "message": "No matching local session row was found for this run.",
+                    })
+        return warnings
 
 
 class SessionDB:
@@ -329,6 +902,33 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add assistant telemetry columns so per-message usage,
+                # provider/model attribution, and run linkage can be persisted
+                # and queried later by /usage and accounting-adjacent views.
+                for col_name, col_type in [
+                    ("run_id", "TEXT"),
+                    ("root_run_id", "TEXT"),
+                    ("provider", "TEXT"),
+                    ("base_url", "TEXT"),
+                    ("model", "TEXT"),
+                    ("api_mode", "TEXT"),
+                    ("input_tokens", "INTEGER DEFAULT 0"),
+                    ("output_tokens", "INTEGER DEFAULT 0"),
+                    ("cache_read_tokens", "INTEGER DEFAULT 0"),
+                    ("cache_write_tokens", "INTEGER DEFAULT 0"),
+                    ("reasoning_tokens", "INTEGER DEFAULT 0"),
+                    ("estimated_cost_usd", "REAL"),
+                    ("usage_status", "TEXT"),
+                ]:
+                    try:
+                        safe = col_name.replace('"', '""')
+                        cursor.execute(
+                            f'ALTER TABLE messages ADD COLUMN "{safe}" {col_type}'
+                        )
+                    except sqlite3.OperationalError:
+                        pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -499,6 +1099,44 @@ class SessionDB:
             conn.execute(sql, params)
         self._execute_write(_do)
 
+    def set_token_counts(
+        self,
+        session_id: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        model: str = None,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        estimated_cost_usd: Optional[float] = None,
+        actual_cost_usd: Optional[float] = None,
+        cost_status: Optional[str] = None,
+        cost_source: Optional[str] = None,
+        pricing_version: Optional[str] = None,
+        billing_provider: Optional[str] = None,
+        billing_base_url: Optional[str] = None,
+        billing_mode: Optional[str] = None,
+    ) -> None:
+        """Compatibility wrapper for callers that set cumulative token totals."""
+        self.update_token_counts(
+            session_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model=model,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            reasoning_tokens=reasoning_tokens,
+            estimated_cost_usd=estimated_cost_usd,
+            actual_cost_usd=actual_cost_usd,
+            cost_status=cost_status,
+            cost_source=cost_source,
+            pricing_version=pricing_version,
+            billing_provider=billing_provider,
+            billing_base_url=billing_base_url,
+            billing_mode=billing_mode,
+            absolute=True,
+        )
+
     def ensure_session(
         self,
         session_id: str,
@@ -528,6 +1166,284 @@ class SessionDB:
             )
             row = cursor.fetchone()
         return dict(row) if row else None
+
+    def get_session_ancestor_ids(self, session_id: str) -> List[str]:
+        """Return the current session id plus its parent chain, oldest-first."""
+        cleaned = str(session_id or "").strip()
+        if not cleaned:
+            return []
+        ordered: List[str] = []
+        seen: set[str] = set()
+        current = cleaned
+        while current and current not in seen:
+            seen.add(current)
+            ordered.append(current)
+            session = self.get_session(current)
+            if not session:
+                break
+            parent = session.get("parent_session_id")
+            current = str(parent).strip() if parent else ""
+        ordered.reverse()
+        return ordered
+
+    @staticmethod
+    def _build_stats_token_dict(
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int,
+        cache_write_tokens: int,
+        reasoning_tokens: int,
+    ) -> Dict[str, int]:
+        input_tokens = int(input_tokens or 0)
+        output_tokens = int(output_tokens or 0)
+        cache_read_tokens = int(cache_read_tokens or 0)
+        cache_write_tokens = int(cache_write_tokens or 0)
+        reasoning_tokens = int(reasoning_tokens or 0)
+        return {
+            "input": input_tokens,
+            "output": output_tokens,
+            "cache_read": cache_read_tokens,
+            "cache_write": cache_write_tokens,
+            "reasoning": reasoning_tokens,
+            "total": input_tokens + output_tokens + cache_read_tokens + cache_write_tokens + reasoning_tokens,
+        }
+
+    def get_session_stats(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return persisted usage/accounting telemetry for a session.
+
+        Prefers assistant-message telemetry when present because it preserves
+        per-response provider/model attribution and exact-vs-unknown usage
+        status. Falls back to the coarse session-row counters when message-level
+        telemetry has not been recorded.
+        """
+        session = self.get_session(session_id)
+        if session is None:
+            return None
+
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT provider, base_url, model, api_mode,
+                       input_tokens, output_tokens, cache_read_tokens,
+                       cache_write_tokens, reasoning_tokens,
+                       estimated_cost_usd, usage_status
+                FROM messages
+                WHERE session_id = ?
+                  AND role = 'assistant'
+                  AND usage_status IS NOT NULL
+                ORDER BY timestamp ASC, id ASC
+                """,
+                (session_id,),
+            ).fetchall()
+            assistant_count_row = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM messages WHERE session_id = ? AND role = 'assistant'",
+                (session_id,),
+            ).fetchone()
+
+        assistant_messages = int((assistant_count_row or {"count": 0})["count"] or 0)
+        session_input_tokens = int(session.get("input_tokens") or 0)
+        session_output_tokens = int(session.get("output_tokens") or 0)
+        session_cache_read_tokens = int(session.get("cache_read_tokens") or 0)
+        session_cache_write_tokens = int(session.get("cache_write_tokens") or 0)
+        session_reasoning_tokens = int(session.get("reasoning_tokens") or 0)
+        session_estimated_cost = session.get("estimated_cost_usd")
+
+        if rows:
+            totals = {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+            exact_message_count = 0
+            unknown_message_count = 0
+            estimated_cost_total = 0.0
+            saw_cost = False
+            grouped: Dict[tuple, Dict[str, Any]] = {}
+
+            for row in rows:
+                item = dict(row)
+                input_tokens = int(item.get("input_tokens") or 0)
+                output_tokens = int(item.get("output_tokens") or 0)
+                cache_read_tokens = int(item.get("cache_read_tokens") or 0)
+                cache_write_tokens = int(item.get("cache_write_tokens") or 0)
+                reasoning_tokens = int(item.get("reasoning_tokens") or 0)
+                usage_status = item.get("usage_status") or "unknown"
+                estimated_cost = item.get("estimated_cost_usd")
+
+                totals["input_tokens"] += input_tokens
+                totals["output_tokens"] += output_tokens
+                totals["cache_read_tokens"] += cache_read_tokens
+                totals["cache_write_tokens"] += cache_write_tokens
+                totals["reasoning_tokens"] += reasoning_tokens
+
+                if usage_status == "exact":
+                    exact_message_count += 1
+                else:
+                    unknown_message_count += 1
+
+                if estimated_cost is not None:
+                    estimated_cost_total += float(estimated_cost)
+                    saw_cost = True
+
+                key = (
+                    item.get("provider"),
+                    item.get("base_url"),
+                    item.get("model"),
+                    item.get("api_mode"),
+                )
+                breakdown_row = grouped.setdefault(key, {
+                    "provider": item.get("provider"),
+                    "base_url": item.get("base_url"),
+                    "model": item.get("model"),
+                    "api_mode": item.get("api_mode"),
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "total_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "exact_message_count": 0,
+                    "unknown_message_count": 0,
+                })
+                breakdown_row["input_tokens"] += input_tokens
+                breakdown_row["output_tokens"] += output_tokens
+                breakdown_row["cache_read_tokens"] += cache_read_tokens
+                breakdown_row["cache_write_tokens"] += cache_write_tokens
+                breakdown_row["reasoning_tokens"] += reasoning_tokens
+                breakdown_row["total_tokens"] += (
+                    input_tokens + output_tokens + cache_read_tokens + cache_write_tokens + reasoning_tokens
+                )
+                if estimated_cost is not None:
+                    breakdown_row["estimated_cost_usd"] += float(estimated_cost)
+                if usage_status == "exact":
+                    breakdown_row["exact_message_count"] += 1
+                else:
+                    breakdown_row["unknown_message_count"] += 1
+
+            residual_input_tokens = max(0, session_input_tokens - totals["input_tokens"])
+            residual_output_tokens = max(0, session_output_tokens - totals["output_tokens"])
+            residual_cache_read_tokens = max(0, session_cache_read_tokens - totals["cache_read_tokens"])
+            residual_cache_write_tokens = max(0, session_cache_write_tokens - totals["cache_write_tokens"])
+            residual_reasoning_tokens = max(0, session_reasoning_tokens - totals["reasoning_tokens"])
+            residual_assistant_messages = max(0, assistant_messages - len(rows))
+            residual_estimated_cost = None
+            if session_estimated_cost is not None:
+                residual_estimated_cost = max(0.0, float(session_estimated_cost) - estimated_cost_total)
+
+            has_residual_usage = any([
+                residual_input_tokens,
+                residual_output_tokens,
+                residual_cache_read_tokens,
+                residual_cache_write_tokens,
+                residual_reasoning_tokens,
+                residual_assistant_messages,
+                residual_estimated_cost not in (None, 0.0),
+            ])
+            if has_residual_usage:
+                unknown_message_count += residual_assistant_messages
+                grouped[(
+                    session.get("billing_provider"),
+                    session.get("billing_base_url"),
+                    session.get("model"),
+                    session.get("billing_mode"),
+                    "legacy_residual",
+                )] = {
+                    "provider": session.get("billing_provider"),
+                    "base_url": session.get("billing_base_url"),
+                    "model": session.get("model"),
+                    "api_mode": session.get("billing_mode"),
+                    "input_tokens": residual_input_tokens,
+                    "output_tokens": residual_output_tokens,
+                    "cache_read_tokens": residual_cache_read_tokens,
+                    "cache_write_tokens": residual_cache_write_tokens,
+                    "reasoning_tokens": residual_reasoning_tokens,
+                    "total_tokens": (
+                        residual_input_tokens + residual_output_tokens + residual_cache_read_tokens
+                        + residual_cache_write_tokens + residual_reasoning_tokens
+                    ),
+                    "estimated_cost_usd": residual_estimated_cost,
+                    "exact_message_count": 0,
+                    "unknown_message_count": residual_assistant_messages,
+                }
+
+            breakdown = sorted(
+                grouped.values(),
+                key=lambda row: (
+                    int(row.get("total_tokens") or 0),
+                    float(row.get("estimated_cost_usd") or 0.0),
+                    int(row.get("exact_message_count") or 0),
+                ),
+                reverse=True,
+            )
+            merged_input_tokens = max(session_input_tokens, totals["input_tokens"])
+            merged_output_tokens = max(session_output_tokens, totals["output_tokens"])
+            merged_cache_read_tokens = max(session_cache_read_tokens, totals["cache_read_tokens"])
+            merged_cache_write_tokens = max(session_cache_write_tokens, totals["cache_write_tokens"])
+            merged_reasoning_tokens = max(session_reasoning_tokens, totals["reasoning_tokens"])
+            merged_estimated_cost = (
+                max(float(session_estimated_cost or 0.0), estimated_cost_total)
+                if (session_estimated_cost is not None or saw_cost)
+                else None
+            )
+            return {
+                "session_id": session_id,
+                "telemetry_source": "mixed" if has_residual_usage else "messages",
+                "assistant_messages": assistant_messages,
+                "tokens": self._build_stats_token_dict(
+                    input_tokens=merged_input_tokens,
+                    output_tokens=merged_output_tokens,
+                    cache_read_tokens=merged_cache_read_tokens,
+                    cache_write_tokens=merged_cache_write_tokens,
+                    reasoning_tokens=merged_reasoning_tokens,
+                ),
+                "estimated_cost_usd": merged_estimated_cost,
+                "exact_message_count": exact_message_count,
+                "unknown_message_count": unknown_message_count,
+                "breakdown": breakdown,
+            }
+
+        input_tokens = session_input_tokens
+        output_tokens = session_output_tokens
+        cache_read_tokens = session_cache_read_tokens
+        cache_write_tokens = session_cache_write_tokens
+        reasoning_tokens = session_reasoning_tokens
+        estimated_cost = session_estimated_cost
+        return {
+            "session_id": session_id,
+            "telemetry_source": "sessions",
+            "assistant_messages": assistant_messages,
+            "tokens": self._build_stats_token_dict(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                reasoning_tokens=reasoning_tokens,
+            ),
+            "estimated_cost_usd": estimated_cost,
+            "exact_message_count": 0,
+            "unknown_message_count": 0,
+            "breakdown": [
+                {
+                    "provider": session.get("billing_provider"),
+                    "base_url": session.get("billing_base_url"),
+                    "model": session.get("model"),
+                    "api_mode": session.get("billing_mode"),
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_write_tokens": cache_write_tokens,
+                    "reasoning_tokens": reasoning_tokens,
+                    "total_tokens": input_tokens + output_tokens + cache_read_tokens + cache_write_tokens + reasoning_tokens,
+                    "estimated_cost_usd": estimated_cost,
+                    "exact_message_count": 0,
+                    "unknown_message_count": 0,
+                }
+            ],
+        }
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
@@ -801,6 +1717,19 @@ class SessionDB:
         reasoning: str = None,
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
+        run_id: str = None,
+        root_run_id: str = None,
+        provider: str = None,
+        base_url: str = None,
+        model: str = None,
+        api_mode: str = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        estimated_cost_usd: Optional[float] = None,
+        usage_status: str = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -828,8 +1757,12 @@ class SessionDB:
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_details, codex_reasoning_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   reasoning, reasoning_details, codex_reasoning_items,
+                   run_id, root_run_id, provider, base_url, model, api_mode,
+                   input_tokens, output_tokens, cache_read_tokens,
+                   cache_write_tokens, reasoning_tokens, estimated_cost_usd,
+                   usage_status)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -843,6 +1776,19 @@ class SessionDB:
                     reasoning,
                     reasoning_details_json,
                     codex_items_json,
+                    run_id,
+                    root_run_id,
+                    provider,
+                    base_url,
+                    model,
+                    api_mode,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    reasoning_tokens,
+                    estimated_cost_usd,
+                    usage_status,
                 ),
             )
             msg_id = cursor.lastrowid

--- a/run_agent.py
+++ b/run_agent.py
@@ -44,6 +44,7 @@ from datetime import datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from hermes_state import AccountingDB
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -108,6 +109,15 @@ from agent.trajectory import (
 )
 from utils import atomic_json_write, env_var_enabled
 
+
+
+def _infer_accounting_home_id() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        name = get_active_profile_name() or "default"
+        return name
+    except Exception:
+        return "default"
 
 
 class _SafeWriter:
@@ -596,7 +606,15 @@ class AIAgent:
         skip_context_files: bool = False,
         skip_memory: bool = False,
         session_db=None,
+        accounting_db=None,
+        run_id: str = None,
         parent_session_id: str = None,
+        parent_run_id: str = None,
+        root_run_id: str = None,
+        home_id: str = None,
+        profile_name: str = None,
+        launch_kind: str = None,
+        transport_kind: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
@@ -1117,7 +1135,38 @@ class AIAgent:
                 logger.warning(
                     "Session DB create_session failed (session_search still available): %s", e
                 )
-        
+
+        self._accounting_db = accounting_db or (AccountingDB() if self.persist_session else None)
+        self.run_id = run_id or uuid.uuid4().hex
+        self.parent_run_id = parent_run_id
+        self.root_run_id = root_run_id or self.run_id
+        self.home_id = home_id or _infer_accounting_home_id()
+        inferred_profile = None if self.home_id in {"default", "custom"} else self.home_id
+        self.profile_name = profile_name if profile_name is not None else inferred_profile
+        self.launch_kind = launch_kind or ("root" if self.parent_run_id is None else "delegate_task")
+        self.transport_kind = transport_kind or ("acp" if (self.acp_command or command) else "direct")
+        self._has_started_root_task_run = False
+        self._current_assistant_telemetry = None
+        self._accounting_run_closed = False
+        try:
+            if self.persist_session and self._accounting_db is not None:
+                self._accounting_db.create_agent_run(
+                    run_id=self.run_id,
+                    parent_run_id=self.parent_run_id,
+                    root_run_id=self.root_run_id,
+                    local_session_id=self.session_id,
+                    home_id=self.home_id,
+                    profile_name=self.profile_name,
+                    launch_kind=self.launch_kind,
+                    transport_kind=self.transport_kind,
+                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model_hint=self.model,
+                    provider_hint=self.provider,
+                    base_url_hint=self.base_url,
+                )
+        except Exception:
+            logger.debug("Could not create accounting run", exc_info=True)
+
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
         self._todo_store = TodoStore()
@@ -2341,6 +2390,19 @@ class AIAgent:
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    run_id=msg.get("run_id") if role == "assistant" else None,
+                    root_run_id=msg.get("root_run_id") if role == "assistant" else None,
+                    provider=msg.get("provider") if role == "assistant" else None,
+                    base_url=msg.get("base_url") if role == "assistant" else None,
+                    model=msg.get("model") if role == "assistant" else None,
+                    api_mode=msg.get("api_mode") if role == "assistant" else None,
+                    input_tokens=msg.get("input_tokens", 0) if role == "assistant" else 0,
+                    output_tokens=msg.get("output_tokens", 0) if role == "assistant" else 0,
+                    cache_read_tokens=msg.get("cache_read_tokens", 0) if role == "assistant" else 0,
+                    cache_write_tokens=msg.get("cache_write_tokens", 0) if role == "assistant" else 0,
+                    reasoning_tokens=msg.get("reasoning_tokens", 0) if role == "assistant" else 0,
+                    estimated_cost_usd=msg.get("estimated_cost_usd") if role == "assistant" else None,
+                    usage_status=msg.get("usage_status") if role == "assistant" else None,
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -2987,6 +3049,21 @@ class AIAgent:
             "budget_max": self.iteration_budget.max_total,
         }
 
+    def _end_current_accounting_run(self) -> None:
+        if getattr(self, "_accounting_run_closed", False):
+            return
+        accounting_db = getattr(self, "_accounting_db", None)
+        run_id = getattr(self, "run_id", None)
+        if accounting_db is None or not run_id:
+            self._accounting_run_closed = True
+            return
+        try:
+            accounting_db.end_agent_run(run_id)
+        except Exception:
+            logger.debug("Could not end accounting run", exc_info=True)
+        else:
+            self._accounting_run_closed = True
+
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
 
@@ -2995,6 +3072,7 @@ class AIAgent:
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
         """
+        self._end_current_accounting_run()
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
@@ -3027,6 +3105,7 @@ class AIAgent:
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
         """
+        self._end_current_accounting_run()
         task_id = getattr(self, "session_id", None) or ""
 
         # 1. Kill background processes for this task
@@ -6474,6 +6553,9 @@ class AIAgent:
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
+        telemetry = getattr(self, "_current_assistant_telemetry", None)
+        if telemetry:
+            msg.update(telemetry)
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
@@ -6804,6 +6886,24 @@ class AIAgent:
                     model=self.model,
                     parent_session_id=old_session_id,
                 )
+                try:
+                    if self.persist_session and self._accounting_db is not None:
+                        self._accounting_db.create_agent_run(
+                            run_id=self.run_id,
+                            parent_run_id=self.parent_run_id,
+                            root_run_id=self.root_run_id,
+                            local_session_id=self.session_id,
+                            home_id=self.home_id,
+                            profile_name=self.profile_name,
+                            launch_kind=self.launch_kind,
+                            transport_kind=self.transport_kind,
+                            source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            model_hint=self.model,
+                            provider_hint=self.provider,
+                            base_url_hint=self.base_url,
+                        )
+                except Exception:
+                    logger.debug("Could not refresh accounting run after compression", exc_info=True)
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
@@ -7742,6 +7842,18 @@ class AIAgent:
 
         return final_response
 
+    def _begin_new_root_task_run_if_needed(self) -> None:
+        """Rotate run lineage for each new top-level turn in long-lived sessions."""
+        if self.parent_run_id is not None or self.launch_kind != "root":
+            return
+        if not self._has_started_root_task_run:
+            self._has_started_root_task_run = True
+            return
+        self._end_current_accounting_run()
+        self.run_id = uuid.uuid4().hex
+        self.root_run_id = self.run_id
+        self._accounting_run_closed = False
+
     def run_conversation(
         self,
         user_message: str,
@@ -7783,8 +7895,29 @@ class AIAgent:
         # runtime so this turn gets a fresh attempt with the preferred model.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
         self._restore_primary_runtime()
+        self._begin_new_root_task_run_if_needed()
+        self._current_assistant_telemetry = None
 
-        # Sanitize surrogate characters from user input.  Clipboard paste from
+        try:
+            if self.persist_session and self._accounting_db is not None:
+                self._accounting_db.create_agent_run(
+                    run_id=self.run_id,
+                    parent_run_id=self.parent_run_id,
+                    root_run_id=self.root_run_id,
+                    local_session_id=self.session_id,
+                    home_id=self.home_id,
+                    profile_name=self.profile_name,
+                    launch_kind=self.launch_kind,
+                    transport_kind=self.transport_kind,
+                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model_hint=self.model,
+                    provider_hint=self.provider,
+                    base_url_hint=self.base_url,
+                )
+        except Exception:
+            logger.debug("Could not refresh accounting run", exc_info=True)
+
+        # Sanitize surrogate characters from user input. Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates
         # that are invalid UTF-8 and crash JSON serialization in the OpenAI SDK.
         if isinstance(user_message, str):
@@ -8819,17 +8952,37 @@ class AIAgent:
                             api_duration, _cache_pct,
                         )
 
+                        actual_provider = getattr(response, "hermes_provider", None) or self.provider
+                        actual_base_url = getattr(response, "hermes_base_url", None) or self.base_url
+                        actual_api_mode = getattr(response, "hermes_api_mode", None) or self.api_mode
+
                         cost_result = estimate_usage_cost(
                             self.model,
                             canonical_usage,
-                            provider=self.provider,
-                            base_url=self.base_url,
+                            provider=actual_provider,
+                            base_url=actual_base_url,
                             api_key=getattr(self, "api_key", ""),
                         )
                         if cost_result.amount_usd is not None:
                             self.session_estimated_cost_usd += float(cost_result.amount_usd)
                         self.session_cost_status = cost_result.status
                         self.session_cost_source = cost_result.source
+                        self._current_assistant_telemetry = {
+                            "run_id": self.run_id,
+                            "root_run_id": self.root_run_id,
+                            "provider": actual_provider,
+                            "base_url": actual_base_url,
+                            "model": self.model,
+                            "api_mode": actual_api_mode,
+                            "input_tokens": canonical_usage.input_tokens,
+                            "output_tokens": canonical_usage.output_tokens,
+                            "cache_read_tokens": canonical_usage.cache_read_tokens,
+                            "cache_write_tokens": canonical_usage.cache_write_tokens,
+                            "reasoning_tokens": canonical_usage.reasoning_tokens,
+                            "estimated_cost_usd": float(cost_result.amount_usd)
+                            if cost_result.amount_usd is not None else None,
+                            "usage_status": "exact",
+                        }
 
                         # Persist token counts to session DB for /insights.
                         # Do this for every platform with a session_id so non-CLI
@@ -8838,7 +8991,7 @@ class AIAgent:
                         # is skipped or fails. Gateway/session-store writes use
                         # absolute totals, so they safely overwrite these per-call
                         # deltas instead of double-counting them.
-                        if self._session_db and self.session_id:
+                        if self.persist_session and self._session_db and self.session_id:
                             try:
                                 self._session_db.update_token_counts(
                                     self.session_id,
@@ -8851,18 +9004,60 @@ class AIAgent:
                                     if cost_result.amount_usd is not None else None,
                                     cost_status=cost_result.status,
                                     cost_source=cost_result.source,
-                                    billing_provider=self.provider,
-                                    billing_base_url=self.base_url,
-                                    billing_mode="subscription_included"
-                                    if cost_result.status == "included" else None,
+                                    billing_provider=actual_provider,
+                                    billing_base_url=actual_base_url,
+                                    billing_mode=actual_api_mode,
                                     model=self.model,
                                 )
                             except Exception:
                                 pass  # never block the agent loop
-                        
+
+                        try:
+                            if self.persist_session and self._accounting_db is not None:
+                                self._accounting_db.create_agent_run(
+                                    run_id=self.run_id,
+                                    parent_run_id=self.parent_run_id,
+                                    root_run_id=self.root_run_id,
+                                    local_session_id=self.session_id,
+                                    home_id=self.home_id,
+                                    profile_name=self.profile_name,
+                                    launch_kind=self.launch_kind,
+                                    transport_kind=self.transport_kind,
+                                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                                    model_hint=self.model,
+                                    provider_hint=actual_provider,
+                                    base_url_hint=actual_base_url,
+                                )
+                        except Exception:
+                            pass  # never block the agent loop
+
+                        try:
+                            if self.persist_session and self._accounting_db is not None:
+                                self._accounting_db.append_usage_event(
+                                    run_id=self.run_id,
+                                    root_run_id=self.root_run_id,
+                                    home_id=self.home_id,
+                                    profile_name=self.profile_name,
+                                    local_session_id=self.session_id,
+                                    provider=actual_provider,
+                                    base_url=actual_base_url,
+                                    model=self.model,
+                                    api_mode=actual_api_mode,
+                                    input_tokens=canonical_usage.input_tokens,
+                                    output_tokens=canonical_usage.output_tokens,
+                                    cache_read_tokens=canonical_usage.cache_read_tokens,
+                                    cache_write_tokens=canonical_usage.cache_write_tokens,
+                                    reasoning_tokens=canonical_usage.reasoning_tokens,
+                                    estimated_cost_usd=float(cost_result.amount_usd)
+                                    if cost_result.amount_usd is not None else None,
+                                    usage_status="exact",
+                                )
+                        except Exception:
+                            pass  # never block the agent loop
+
                         if self.verbose_logging:
                             logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
-                        
+
                         # Log cache hit stats when prompt caching is active
                         if self._use_prompt_caching:
                             if self.api_mode == "anthropic_messages":
@@ -8878,6 +9073,65 @@ class AIAgent:
                             hit_pct = (cached / prompt * 100) if prompt > 0 else 0
                             if not self.quiet_mode:
                                 self._vprint(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
+                    else:
+                        actual_provider = getattr(response, "hermes_provider", None) or self.provider
+                        actual_base_url = getattr(response, "hermes_base_url", None) or self.base_url
+                        actual_api_mode = getattr(response, "hermes_api_mode", None) or self.api_mode
+                        self._current_assistant_telemetry = {
+                            "run_id": self.run_id,
+                            "root_run_id": self.root_run_id,
+                            "provider": actual_provider,
+                            "base_url": actual_base_url,
+                            "model": self.model,
+                            "api_mode": actual_api_mode,
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "cache_read_tokens": 0,
+                            "cache_write_tokens": 0,
+                            "reasoning_tokens": 0,
+                            "estimated_cost_usd": None,
+                            "usage_status": "unknown",
+                        }
+                        try:
+                            if self.persist_session and self._accounting_db is not None:
+                                self._accounting_db.create_agent_run(
+                                    run_id=self.run_id,
+                                    parent_run_id=self.parent_run_id,
+                                    root_run_id=self.root_run_id,
+                                    local_session_id=self.session_id,
+                                    home_id=self.home_id,
+                                    profile_name=self.profile_name,
+                                    launch_kind=self.launch_kind,
+                                    transport_kind=self.transport_kind,
+                                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                                    model_hint=self.model,
+                                    provider_hint=actual_provider,
+                                    base_url_hint=actual_base_url,
+                                )
+                        except Exception:
+                            pass  # never block the agent loop
+                        try:
+                            if self.persist_session and self._accounting_db is not None:
+                                self._accounting_db.append_usage_event(
+                                    run_id=self.run_id,
+                                    root_run_id=self.root_run_id,
+                                    home_id=self.home_id,
+                                    profile_name=self.profile_name,
+                                    local_session_id=self.session_id,
+                                    provider=actual_provider,
+                                    base_url=actual_base_url,
+                                    model=self.model,
+                                    api_mode=actual_api_mode,
+                                    input_tokens=0,
+                                    output_tokens=0,
+                                    cache_read_tokens=0,
+                                    cache_write_tokens=0,
+                                    reasoning_tokens=0,
+                                    estimated_cost_usd=None,
+                                    usage_status="unknown",
+                                )
+                        except Exception:
+                            pass  # never block the agent loop
                     
                     has_retried_429 = False  # Reset on success
                     self._touch_activity(f"API call #{api_call_count} completed")
@@ -10546,6 +10800,7 @@ class AIAgent:
                 break
 
         # Build result with interrupt info if applicable
+        actual_runtime_meta = getattr(self, "_current_assistant_telemetry", None) or {}
         result = {
             "final_response": final_response,
             "last_reasoning": last_reasoning,
@@ -10558,6 +10813,9 @@ class AIAgent:
             "model": self.model,
             "provider": self.provider,
             "base_url": self.base_url,
+            "actual_provider": actual_runtime_meta.get("provider") or self.provider,
+            "actual_base_url": actual_runtime_meta.get("base_url") or self.base_url,
+            "actual_api_mode": actual_runtime_meta.get("api_mode") or self.api_mode,
             "input_tokens": self.session_input_tokens,
             "output_tokens": self.session_output_tokens,
             "cache_read_tokens": self.session_cache_read_tokens,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -480,7 +480,7 @@ class TestPrompt:
             "output_tokens": 45,
             "total_tokens": 168,
             "actual_provider": "custom",
-            "actual_base_url": "http://superbif:8000/v1",
+            "actual_base_url": "http://worker.example/v1",
             "actual_api_mode": "chat_completions",
         })
 
@@ -495,7 +495,7 @@ class TestPrompt:
         assert resp.field_meta == {
             "hermesRuntime": {
                 "provider": "custom",
-                "base_url": "http://superbif:8000/v1",
+                "base_url": "http://worker.example/v1",
                 "api_mode": "chat_completions",
             }
         }

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -375,6 +375,132 @@ class TestPrompt:
         state.agent.run_conversation.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_prompt_returns_usage_when_run_conversation_reports_token_totals(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "input_tokens": 123,
+            "output_tokens": 45,
+            "reasoning_tokens": 6,
+            "cache_read_tokens": 7,
+            "total_tokens": 168,
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 123
+        assert resp.usage.output_tokens == 45
+        assert resp.usage.total_tokens == 168
+        assert resp.usage.thought_tokens == 6
+        assert resp.usage.cached_read_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_prompt_accepts_camel_case_usage_fields(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "usage": {
+                "inputTokens": 123,
+                "outputTokens": 45,
+                "totalTokens": 168,
+                "thoughtTokens": 6,
+                "cachedReadTokens": 7,
+            },
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 123
+        assert resp.usage.output_tokens == 45
+        assert resp.usage.total_tokens == 168
+        assert resp.usage.thought_tokens == 6
+        assert resp.usage.cached_read_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_prompt_accepts_snake_case_nested_usage_fields(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "usage": {
+                "input_tokens": 123,
+                "output_tokens": 45,
+                "total_tokens": 168,
+                "reasoning_tokens": 6,
+                "cache_read_tokens": 7,
+            },
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.usage is not None
+        assert resp.usage.input_tokens == 123
+        assert resp.usage.output_tokens == 45
+        assert resp.usage.total_tokens == 168
+        assert resp.usage.thought_tokens == 6
+        assert resp.usage.cached_read_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_prompt_returns_runtime_metadata_in_meta(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "input_tokens": 123,
+            "output_tokens": 45,
+            "total_tokens": 168,
+            "actual_provider": "custom",
+            "actual_base_url": "http://superbif:8000/v1",
+            "actual_api_mode": "chat_completions",
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.field_meta == {
+            "hermesRuntime": {
+                "provider": "custom",
+                "base_url": "http://superbif:8000/v1",
+                "api_mode": "chat_completions",
+            }
+        }
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch
+
+from agent.copilot_acp_client import CopilotACPClient
+
+
+def test_create_chat_completion_returns_usage_when_prompt_result_includes_it():
+    client = CopilotACPClient(api_key="dummy", base_url="acp://copilot", command="hermes", args=["acp"])
+
+    with patch.object(
+        client,
+        "_run_prompt",
+        return_value=(
+            "hi",
+            "",
+            {
+                "prompt_tokens": 123,
+                "completion_tokens": 45,
+                "total_tokens": 168,
+                "reasoning_tokens": 6,
+                "cached_tokens": 7,
+            },
+            None,
+        ),
+    ):
+        resp = client.chat.completions.create(
+            model="google/gemma-4-26B-A4B-it",
+            messages=[{"role": "user", "content": "Reply exactly hi"}],
+        )
+
+    assert resp.choices[0].message.content == "hi"
+    assert resp.usage is not None
+    assert resp.usage.prompt_tokens == 123
+    assert resp.usage.completion_tokens == 45
+    assert resp.usage.total_tokens == 168
+    assert resp.usage.prompt_tokens_details.cached_tokens == 7
+
+
+def test_create_chat_completion_accepts_camel_case_acp_usage_fields():
+    client = CopilotACPClient(api_key="dummy", base_url="acp://copilot", command="hermes", args=["acp"])
+
+    with patch.object(
+        client,
+        "_run_prompt",
+        return_value=(
+            "hi",
+            "",
+            {
+                "inputTokens": 10930,
+                "outputTokens": 2,
+                "totalTokens": 10932,
+                "thoughtTokens": 0,
+                "cachedReadTokens": 0,
+            },
+            None,
+        ),
+    ):
+        resp = client.chat.completions.create(
+            model="google/gemma-4-26B-A4B-it",
+            messages=[{"role": "user", "content": "Reply exactly hi"}],
+        )
+
+    assert resp.usage is not None
+    assert resp.usage.prompt_tokens == 10930
+    assert resp.usage.completion_tokens == 2
+    assert resp.usage.total_tokens == 10932
+    assert resp.usage.prompt_tokens_details.cached_tokens == 0
+
+
+def test_create_chat_completion_accepts_snake_case_nested_usage_fields():
+    client = CopilotACPClient(api_key="dummy", base_url="acp://copilot", command="hermes", args=["acp"])
+
+    with patch.object(
+        client,
+        "_run_prompt",
+        return_value=(
+            "hi",
+            "",
+            {
+                "input_tokens": 19,
+                "output_tokens": 4,
+                "total_tokens": 23,
+                "reasoning_tokens": 2,
+                "cache_read_tokens": 3,
+            },
+            None,
+        ),
+    ):
+        resp = client.chat.completions.create(
+            model="google/gemma-4-26B-A4B-it",
+            messages=[{"role": "user", "content": "Reply exactly hi"}],
+        )
+
+    assert resp.usage is not None
+    assert resp.usage.prompt_tokens == 19
+    assert resp.usage.completion_tokens == 4
+    assert resp.usage.total_tokens == 23
+    assert resp.usage.reasoning_tokens == 2
+    assert resp.usage.prompt_tokens_details.cached_tokens == 3
+
+
+def test_create_chat_completion_surfaces_runtime_metadata_from_acp_meta():
+    client = CopilotACPClient(api_key="dummy", base_url="acp://copilot", command="hermes", args=["acp"])
+
+    with patch.object(
+        client,
+        "_run_prompt",
+        return_value=(
+            "hi",
+            "",
+            {
+                "prompt_tokens": 11,
+                "completion_tokens": 3,
+                "total_tokens": 14,
+            },
+            {
+                "provider": "custom",
+                "base_url": "http://superbif:8000/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+    ):
+        resp = client.chat.completions.create(
+            model="google/gemma-4-26B-A4B-it",
+            messages=[{"role": "user", "content": "Reply exactly hi"}],
+        )
+
+    assert getattr(resp, "hermes_provider", None) == "custom"
+    assert getattr(resp, "hermes_base_url", None) == "http://superbif:8000/v1"
+    assert getattr(resp, "hermes_api_mode", None) == "chat_completions"

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -114,7 +114,7 @@ def test_create_chat_completion_surfaces_runtime_metadata_from_acp_meta():
             },
             {
                 "provider": "custom",
-                "base_url": "http://superbif:8000/v1",
+                "base_url": "http://worker.example/v1",
                 "api_mode": "chat_completions",
             },
         ),
@@ -125,5 +125,5 @@ def test_create_chat_completion_surfaces_runtime_metadata_from_acp_meta():
         )
 
     assert getattr(resp, "hermes_provider", None) == "custom"
-    assert getattr(resp, "hermes_base_url", None) == "http://superbif:8000/v1"
+    assert getattr(resp, "hermes_base_url", None) == "http://worker.example/v1"
     assert getattr(resp, "hermes_api_mode", None) == "chat_completions"

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -92,6 +92,13 @@ class TestSlashCommandPrefixMatching:
             cli_obj.process_command("/help")
         mock_help.assert_called_once()
 
+    def test_accounting_command_dispatches(self):
+        """/accounting current should route to the dedicated handler."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, '_show_accounting') as mock_accounting:
+            cli_obj.process_command("/accounting current")
+        mock_accounting.assert_called_once_with("/accounting current")
+
     def test_skill_command_prefix_matches(self):
         """A prefix that uniquely matches a skill command should dispatch it."""
         cli_obj = _make_cli()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -351,7 +351,7 @@ class TestCLIAccountingReport:
                 parent_run_id="root-run",
                 local_session_id="session-child",
                 home_id="worker",
-                profile_name="superbif-stateless",
+                profile_name="worker-profile",
                 launch_kind="delegate_task",
                 transport_kind="acp",
                 started_at=1_700_000_010.0,
@@ -374,9 +374,9 @@ class TestCLIAccountingReport:
                 root_run_id="root-run",
                 local_session_id="session-child",
                 home_id="worker",
-                profile_name="superbif-stateless",
+                profile_name="worker-profile",
                 provider="custom",
-                base_url="http://superbif:8000/v1",
+                base_url="http://worker.example/v1",
                 model="google/gemma-4-26B-A4B-it",
                 input_tokens=40,
                 output_tokens=4,
@@ -399,13 +399,13 @@ class TestCLIAccountingReport:
             assert "Whole task" in output
             assert "Breakdown by provider | model | base_url | api_mode" in output
             assert "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex" in output
-            assert "custom | google/gemma-4-26B-A4B-it | http://superbif:8000/v1" in output
+            assert "custom | google/gemma-4-26B-A4B-it | http://worker.example/v1" in output
             assert "cache-write 3" in output
             assert "reasoning 2" in output
             assert "Run tree" in output
             assert "root     root-run" in output
             assert "child    child-ru" in output
-            assert "profile=superbif-stateless" in output
+            assert "profile=worker-profile" in output
             assert "transport=acp" in output
             assert "launch=delegate_task" in output
             assert "Session links" in output
@@ -508,7 +508,7 @@ class TestCLIAccountingReport:
                 local_session_id="session-root",
                 home_id="default",
                 provider="custom",
-                base_url="http://superbif:8000/v1",
+                base_url="http://worker.example/v1",
                 model="google/gemma-4-26B-A4B-it",
                 input_tokens=7,
                 output_tokens=2,
@@ -523,7 +523,7 @@ class TestCLIAccountingReport:
             assert "Scope: current session" in output
             assert "Root runs: 2" in output
             assert "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex" in output
-            assert "custom | google/gemma-4-26B-A4B-it | http://superbif:8000/v1" in output
+            assert "custom | google/gemma-4-26B-A4B-it | http://worker.example/v1" in output
             assert "in 12  out 3  total 15" in output
         finally:
             session_db.close()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -740,7 +740,7 @@ class TestCLIAccountingReport:
             assert "Sessions: 2 total" in output
             assert "Sessions: other-session, session-root" not in output
             assert "Ended: running" in output
-            assert "NOTE: Some root runs are still active; totals may still change." in output
+            assert "NOTE: Some root runs are still active; totals may still change." not in output
         finally:
             session_db.close()
             accounting_db.close()
@@ -794,7 +794,7 @@ class TestCLIAccountingReport:
             output = capsys.readouterr().out
 
             assert "Ended: mixed" in output
-            assert "NOTE: Some root runs are still active; totals may still change." in output
+            assert "NOTE: Some root runs are still active; totals may still change." not in output
         finally:
             session_db.close()
             accounting_db.close()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
+from hermes_state import AccountingDB, SessionDB
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -323,6 +324,769 @@ class TestCLIUsageReport:
         assert "Total cost:" in output
         assert "n/a" in output
         assert "Pricing unknown for glm-5" in output
+
+
+class TestCLIAccountingReport:
+    def test_show_accounting_reports_current_task_tree(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            session_db.create_session(session_id="session-child", source="cli", parent_session_id="session-root")
+            accounting_db.create_agent_run(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=1_700_000_000.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="child-run",
+                root_run_id="root-run",
+                parent_run_id="root-run",
+                local_session_id="session-child",
+                home_id="worker",
+                profile_name="superbif-stateless",
+                launch_kind="delegate_task",
+                transport_kind="acp",
+                started_at=1_700_000_010.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=100,
+                output_tokens=10,
+                estimated_cost_usd=0.001,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="child-run",
+                root_run_id="root-run",
+                local_session_id="session-child",
+                home_id="worker",
+                profile_name="superbif-stateless",
+                provider="custom",
+                base_url="http://superbif:8000/v1",
+                model="google/gemma-4-26B-A4B-it",
+                input_tokens=40,
+                output_tokens=4,
+                cache_write_tokens=3,
+                reasoning_tokens=2,
+                estimated_cost_usd=0.002,
+                usage_status="exact",
+            )
+
+            cli_obj._session_db = session_db
+            cli_obj.agent = SimpleNamespace(root_run_id="root-run", run_id="root-run", _accounting_db=accounting_db)
+
+            cli_obj._show_accounting()
+            output = capsys.readouterr().out
+
+            assert "Task accounting" in output
+            assert "Root run: root-run" in output
+            assert "Root agent only" in output
+            assert "Subagents only" in output
+            assert "Whole task" in output
+            assert "Breakdown by provider | model | base_url | api_mode" in output
+            assert "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex" in output
+            assert "custom | google/gemma-4-26B-A4B-it | http://superbif:8000/v1" in output
+            assert "cache-write 3" in output
+            assert "reasoning 2" in output
+            assert "Run tree" in output
+            assert "root     root-run" in output
+            assert "child    child-ru" in output
+            assert "profile=superbif-stateless" in output
+            assert "transport=acp" in output
+            assert "launch=delegate_task" in output
+            assert "Session links" in output
+            assert "Accounting notes" in output
+            assert "NOTE: Run is still active; totals may still change." in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_breakdown_labels_include_api_mode(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            accounting_db.create_agent_run(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=1_700_000_000.0,
+            )
+            for api_mode, input_tokens, output_tokens in (
+                ("responses", 100, 10),
+                ("chat_completions", 40, 4),
+            ):
+                accounting_db.append_usage_event(
+                    run_id="root-run",
+                    root_run_id="root-run",
+                    local_session_id="session-root",
+                    home_id="default",
+                    provider="openai",
+                    base_url="https://api.openai.com/v1",
+                    model="gpt-5.4",
+                    api_mode=api_mode,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            cli_obj.agent = SimpleNamespace(root_run_id="root-run", run_id="root-run", _accounting_db=accounting_db)
+
+            cli_obj._show_accounting()
+            output = capsys.readouterr().out
+
+            assert "Breakdown by provider | model | base_url | api_mode" in output
+            assert "openai | gpt-5.4 | https://api.openai.com/v1 | api_mode=responses" in output
+            assert "openai | gpt-5.4 | https://api.openai.com/v1 | api_mode=chat_completions" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_current_aggregates_all_roots_for_session(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            accounting_db.create_agent_run(
+                run_id="older-root",
+                root_run_id="older-root",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="newer-root",
+                root_run_id="newer-root",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="older-root",
+                root_run_id="older-root",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=5,
+                output_tokens=1,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="newer-root",
+                root_run_id="newer-root",
+                local_session_id="session-root",
+                home_id="default",
+                provider="custom",
+                base_url="http://superbif:8000/v1",
+                model="google/gemma-4-26B-A4B-it",
+                input_tokens=7,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting current")
+            output = capsys.readouterr().out
+
+            assert "Scope: current session" in output
+            assert "Root runs: 2" in output
+            assert "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex" in output
+            assert "custom | google/gemma-4-26B-A4B-it | http://superbif:8000/v1" in output
+            assert "in 12  out 3  total 15" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_breakdown_aggregates_same_route_across_runs(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            for run_id, started_at, input_tokens, output_tokens in (
+                ("older-root", 100.0, 5, 1),
+                ("newer-root", 200.0, 7, 2),
+            ):
+                accounting_db.create_agent_run(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id="session-root",
+                    home_id="default",
+                    launch_kind="root",
+                    transport_kind="direct",
+                    started_at=started_at,
+                )
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id="session-root",
+                    home_id="default",
+                    provider="openai-codex",
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    model="gpt-5.4",
+                    api_mode="codex_responses",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting current")
+            output = capsys.readouterr().out
+
+            route = "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex | api_mode=codex_responses"
+            assert output.count(route) == 1
+            assert "in 12  out 3  total 15  events 2  exact 2 unknown 0" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_aggregates_every_root_run(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            session_db.create_session(session_id="other-session", source="cli")
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="other-session",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=5,
+                output_tokens=1,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="other-session",
+                home_id="default",
+                provider="custom",
+                base_url="http://worker/v1",
+                model="local-model",
+                input_tokens=7,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "Scope: all" in output
+            assert "Root runs: 2" in output
+            assert "openai-codex | gpt-5.4 | https://chatgpt.com/backend-api/codex" in output
+            assert "custom | local-model | http://worker/v1" in output
+            assert "in 12  out 3  total 15" in output
+            assert "Run tree" not in output
+            assert "Session links" not in output
+            assert "/accounting <root_run_id> for per-task details" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_summarizes_repeated_provenance_warnings(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            for run_id, session_id, started_at in (
+                ("root-a", "missing-a", 100.0),
+                ("root-b", "missing-b", 200.0),
+                ("root-c", "missing-c", 300.0),
+            ):
+                accounting_db.create_agent_run(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    launch_kind="root",
+                    transport_kind="direct",
+                    started_at=started_at,
+                )
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider="openai-codex",
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    model="gpt-5.4",
+                    input_tokens=5,
+                    output_tokens=1,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert output.count("No matching local session row was found") == 1
+            assert "No matching local session row was found for 3 runs in this scope." in output
+            assert "Run tree" not in output
+            assert "Session links" not in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_uses_compact_scope_metadata(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            session_db.create_session(session_id="other-session", source="cli")
+            for run_id, session_id, started_at in (
+                ("root-a", "session-root", 100.0),
+                ("root-b", "other-session", 200.0),
+            ):
+                accounting_db.create_agent_run(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    launch_kind="root",
+                    transport_kind="direct",
+                    started_at=started_at,
+                )
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider="openai-codex",
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    model="gpt-5.4",
+                    input_tokens=5,
+                    output_tokens=1,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "⏳ Summarizing all-scope accounting..." in output
+            assert "Sessions: 2 total" in output
+            assert "Sessions: other-session, session-root" not in output
+            assert "Ended: running" in output
+            assert "NOTE: Some root runs are still active; totals may still change." in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_reports_mixed_lifecycle_when_some_roots_ended(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            session_db.create_session(session_id="other-session", source="cli")
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="other-session",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.end_agent_run("root-a")
+            for run_id, session_id in (("root-a", "session-root"), ("root-b", "other-session")):
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider="openai-codex",
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    model="gpt-5.4",
+                    input_tokens=5,
+                    output_tokens=1,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "Ended: mixed" in output
+            assert "NOTE: Some root runs are still active; totals may still change." in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_limits_breakdown_rows(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            for idx in range(12):
+                session_id = f"session-{idx}"
+                session_db.create_session(session_id=session_id, source="cli")
+                run_id = f"root-{idx}"
+                accounting_db.create_agent_run(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    launch_kind="root",
+                    transport_kind="direct",
+                    started_at=100.0 + idx,
+                )
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider=f"provider-{idx}",
+                    base_url=f"http://route-{idx}.example/v1",
+                    model=f"model-{idx}",
+                    api_mode="chat_completions",
+                    input_tokens=100 - idx,
+                    output_tokens=1,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "provider-0 | model-0 | http://route-0.example/v1 | api_mode=chat_completions" in output
+            assert "provider-9 | model-9 | http://route-9.example/v1 | api_mode=chat_completions" in output
+            assert "provider-10 | model-10 | http://route-10.example/v1 | api_mode=chat_completions" not in output
+            assert "provider-11 | model-11 | http://route-11.example/v1 | api_mode=chat_completions" not in output
+            assert "2 more routes omitted from /accounting all" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_keeps_high_cost_routes_visible(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            for idx in range(10):
+                session_id = f"cheap-session-{idx}"
+                session_db.create_session(session_id=session_id, source="cli")
+                run_id = f"cheap-root-{idx}"
+                accounting_db.create_agent_run(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    launch_kind="root",
+                    transport_kind="direct",
+                    started_at=100.0 + idx,
+                )
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider=f"cheap-provider-{idx}",
+                    base_url=f"http://cheap-{idx}.example/v1",
+                    model=f"cheap-model-{idx}",
+                    api_mode="chat_completions",
+                    input_tokens=1000 - idx,
+                    output_tokens=1,
+                    estimated_cost_usd=0.001,
+                    usage_status="exact",
+                )
+
+            session_db.create_session(session_id="expensive-session", source="cli")
+            accounting_db.create_agent_run(
+                run_id="expensive-root",
+                root_run_id="expensive-root",
+                local_session_id="expensive-session",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=500.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="expensive-root",
+                root_run_id="expensive-root",
+                local_session_id="expensive-session",
+                home_id="default",
+                provider="expensive-provider",
+                base_url="http://expensive.example/v1",
+                model="expensive-model",
+                api_mode="chat_completions",
+                input_tokens=5,
+                output_tokens=1,
+                estimated_cost_usd=5.0,
+                usage_status="exact",
+            )
+
+            session_db.create_session(session_id="omitted-session", source="cli")
+            accounting_db.create_agent_run(
+                run_id="omitted-root",
+                root_run_id="omitted-root",
+                local_session_id="omitted-session",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=600.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="omitted-root",
+                root_run_id="omitted-root",
+                local_session_id="omitted-session",
+                home_id="default",
+                provider="omitted-provider",
+                base_url="http://omitted.example/v1",
+                model="omitted-model",
+                api_mode="chat_completions",
+                input_tokens=900,
+                output_tokens=1,
+                estimated_cost_usd=0.0001,
+                usage_status="exact",
+            )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "expensive-provider | expensive-model | http://expensive.example/v1 | api_mode=chat_completions" in output
+            assert "omitted-provider | omitted-model | http://omitted.example/v1 | api_mode=chat_completions" not in output
+            assert "2 more routes omitted from /accounting all" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_all_counts_all_distinct_sessions_in_scope(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root-a"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            for session_id, parent in (
+                ("session-root-a", None),
+                ("session-root-b", None),
+                ("session-child-a", "session-root-a"),
+                ("session-child-b", "session-root-b"),
+            ):
+                session_db.create_session(session_id=session_id, source="cli", parent_session_id=parent)
+
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root-a",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="child-a",
+                root_run_id="root-a",
+                parent_run_id="root-a",
+                local_session_id="session-child-a",
+                home_id="worker",
+                profile_name="worker-a",
+                launch_kind="delegate_task",
+                transport_kind="acp",
+                started_at=110.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="session-root-b",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="child-b",
+                root_run_id="root-b",
+                parent_run_id="root-b",
+                local_session_id="session-child-b",
+                home_id="worker",
+                profile_name="worker-b",
+                launch_kind="delegate_task",
+                transport_kind="acp",
+                started_at=210.0,
+            )
+            for run_id, root_run_id, session_id in (
+                ("root-a", "root-a", "session-root-a"),
+                ("child-a", "root-a", "session-child-a"),
+                ("root-b", "root-b", "session-root-b"),
+                ("child-b", "root-b", "session-child-b"),
+            ):
+                accounting_db.append_usage_event(
+                    run_id=run_id,
+                    root_run_id=root_run_id,
+                    local_session_id=session_id,
+                    home_id="default",
+                    provider="openai-codex",
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    model="gpt-5.4",
+                    input_tokens=5,
+                    output_tokens=1,
+                    usage_status="exact",
+                )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "Sessions: 4 total" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    def test_show_accounting_warns_when_usage_is_non_exact(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            accounting_db.create_agent_run(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=1_700_000_000.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=100,
+                output_tokens=10,
+                estimated_cost_usd=0.001,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=25,
+                output_tokens=5,
+                estimated_cost_usd=0.0002,
+                usage_status="unknown",
+            )
+
+            cli_obj._session_db = session_db
+            cli_obj.agent = SimpleNamespace(root_run_id="root-run", run_id="root-run", _accounting_db=accounting_db)
+
+            cli_obj._show_accounting()
+            output = capsys.readouterr().out
+
+            assert "Unknown events:  1" in output
+            assert "WARNING: Unknown/non-exact usage present" in output
+            assert "totals and estimated cost are not exact" in output
+        finally:
+            session_db.close()
+            accounting_db.close()
 
 
 class TestStatusBarWidthSource:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -745,6 +745,56 @@ class TestCLIAccountingReport:
             session_db.close()
             accounting_db.close()
 
+    def test_show_accounting_all_keeps_summary_shape_with_single_root(self, tmp_path, capsys):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "session-root"
+        cli_obj.agent = None
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="cli")
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                model="gpt-5.4",
+                input_tokens=5,
+                output_tokens=1,
+                usage_status="exact",
+            )
+
+            cli_obj._session_db = session_db
+            with patch("hermes_state.AccountingDB", return_value=accounting_db):
+                cli_obj._show_accounting("/accounting all")
+            output = capsys.readouterr().out
+
+            assert "Accounting\nScope: all" in output
+            assert "Task accounting" not in output
+            assert "Root run:" not in output
+            assert "Session:" not in output
+            assert "Home:" not in output
+            assert "Sessions: 1 total" in output
+            assert "Whole scope" in output
+            assert "Whole task" not in output
+            assert "Run tree" not in output
+            assert "Session links" not in output
+        finally:
+            session_db.close()
+            accounting_db.close()
+
     def test_show_accounting_all_reports_mixed_lifecycle_when_some_roots_ended(self, tmp_path, capsys):
         cli_obj = _make_cli()
         cli_obj.session_id = "session-root"

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -222,6 +222,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_get("/api/accounting", adapter._handle_accounting)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
@@ -345,6 +346,434 @@ class TestModelsEndpoint:
                 headers={"Authorization": "Bearer sk-secret"},
             )
             assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/accounting endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAccountingEndpoint:
+    @pytest.mark.asyncio
+    async def test_requires_explicit_scope_selector(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_ensure_accounting_db", side_effect=AssertionError("should not init accounting db")), \
+                 patch.object(adapter, "_ensure_session_db", side_effect=AssertionError("should not init session db")):
+                resp = await cli.get("/api/accounting")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "exactly one" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_scope_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_ensure_accounting_db", side_effect=AssertionError("should not init accounting db")), \
+                 patch.object(adapter, "_ensure_session_db", side_effect=AssertionError("should not init session db")):
+                resp = await cli.get("/api/accounting?scope=current")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "invalid scope" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_api_key_configured(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/accounting?scope=all")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_accounting_db_open_failure_returns_500(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_ensure_accounting_db", side_effect=RuntimeError("broken db")):
+                resp = await cli.get("/api/accounting?scope=all")
+            assert resp.status == 500
+            data = await resp.json()
+            assert "accounting db unavailable" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_session_scope_falls_back_to_child_session_roots_when_session_db_is_missing(self, adapter, tmp_path):
+        from hermes_state import AccountingDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        try:
+            accounting_db.create_agent_run(
+                run_id="manager-run-a",
+                root_run_id="root-run-a",
+                local_session_id="session-a",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="child-run-a",
+                root_run_id="root-run-a",
+                parent_run_id="manager-run-a",
+                local_session_id="session-b",
+                home_id="worker",
+                profile_name="worker",
+                launch_kind="delegate_task",
+                transport_kind="acp",
+                started_at=110.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="child-run-a",
+                root_run_id="root-run-a",
+                local_session_id="session-b",
+                home_id="worker",
+                profile_name="worker",
+                provider="custom",
+                model="local-model",
+                input_tokens=7,
+                output_tokens=2,
+                usage_status="exact",
+            )
+            adapter._accounting_db = accounting_db
+
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_ensure_session_db", return_value=None):
+                    resp = await cli.get("/api/accounting?session_id=session-b")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["scope"]["root_run_ids"] == ["root-run-a"]
+                assert data["summary"]["root_run_count"] == 1
+                assert data["summary"]["total"]["input_tokens"] == 7
+                assert any(w.get("type") == "session_lineage_unavailable" for w in data["warnings"])
+        finally:
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_session_scope_returns_503_when_lineage_db_is_missing_and_only_ancestor_has_accounting(self, adapter, tmp_path):
+        from hermes_state import AccountingDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        try:
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                provider="openai-codex",
+                model="gpt-5.4",
+                input_tokens=9,
+                output_tokens=1,
+                usage_status="exact",
+            )
+            adapter._accounting_db = accounting_db
+
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_ensure_session_db", return_value=None):
+                    resp = await cli.get("/api/accounting?session_id=session-b")
+                assert resp.status == 503
+                data = await resp.json()
+                assert "lineage metadata was unavailable" in data["error"].lower()
+        finally:
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_root_run_id_still_returns_payload_when_session_db_is_unavailable(self, adapter, tmp_path):
+        from hermes_state import AccountingDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        try:
+            accounting_db.create_agent_run(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                model="gpt-5.4",
+                input_tokens=10,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            adapter._accounting_db = accounting_db
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_ensure_session_db", side_effect=RuntimeError("session db down")):
+                    resp = await cli.get("/api/accounting?root_run_id=root-run")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["summary"]["root_run_count"] == 1
+                assert any(w.get("type") == "session_linkage_unavailable" for w in data["warnings"])
+        finally:
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_accounting_payload_failure_degrades_to_warnings(self, adapter, tmp_path):
+        from hermes_state import AccountingDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        try:
+            accounting_db.create_agent_run(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                provider="custom",
+                model="local-model",
+                input_tokens=7,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            adapter._accounting_db = accounting_db
+            adapter._session_db = MagicMock()
+            adapter._session_db.get_session_ancestor_ids.return_value = ["session-b"]
+            adapter._session_db.get_session.side_effect = RuntimeError("session lookup failed")
+
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/accounting?session_id=session-b")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["summary"]["root_run_count"] == 1
+                assert any(w.get("type") == "session_linkage_unavailable" for w in data["warnings"])
+                assert any(w.get("type") == "session_provenance_unavailable" for w in data["warnings"])
+        finally:
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_root_run_id_returns_structured_accounting_payload(self, adapter, tmp_path):
+        from hermes_state import AccountingDB, SessionDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-root", source="api_server")
+            session_db.create_session(session_id="session-child", source="api_server", parent_session_id="session-root")
+            accounting_db.create_agent_run(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="child-run",
+                root_run_id="root-run",
+                parent_run_id="root-run",
+                local_session_id="session-child",
+                home_id="worker",
+                profile_name="worker",
+                launch_kind="delegate_task",
+                transport_kind="acp",
+                started_at=110.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                local_session_id="session-root",
+                home_id="default",
+                provider="openai-codex",
+                model="gpt-5.4",
+                input_tokens=10,
+                output_tokens=2,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="child-run",
+                root_run_id="root-run",
+                local_session_id="session-child",
+                home_id="worker",
+                profile_name="worker",
+                provider="custom",
+                model="local-model",
+                input_tokens=5,
+                output_tokens=1,
+                usage_status="exact",
+            )
+
+            adapter._accounting_db = accounting_db
+            adapter._session_db = session_db
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/accounting?root_run_id=root-run")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["scope"] == {
+                    "type": "root_run",
+                    "root_run_id": "root-run",
+                    "root_run_ids": ["root-run"],
+                }
+                assert data["summary"]["root_run_count"] == 1
+                assert data["summary"]["total"]["input_tokens"] == 15
+                assert data["summary"]["total"]["output_tokens"] == 3
+                assert len(data["run_tree"]) == 2
+                assert len(data["session_links"]) == 2
+                child_link = next(link for link in data["session_links"] if link["run_id"] == "child-run")
+                assert child_link["parent_session_id"] == "session-root"
+                assert child_link["session_rotated"] is True
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_session_id_aggregates_root_runs_across_ancestor_lineage(self, adapter, tmp_path):
+        from hermes_state import AccountingDB, SessionDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        session_db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            session_db.create_session(session_id="session-a", source="api_server")
+            session_db.create_session(session_id="session-b", source="api_server", parent_session_id="session-a")
+            accounting_db.create_agent_run(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="root-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                provider="openai-codex",
+                model="gpt-5.4",
+                input_tokens=11,
+                output_tokens=1,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="root-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                provider="custom",
+                model="local-model",
+                input_tokens=7,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            adapter._accounting_db = accounting_db
+            adapter._session_db = session_db
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/accounting?session_id=session-b")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["scope"] == {
+                    "type": "session",
+                    "session_id": "session-b",
+                    "root_run_ids": ["root-a", "root-b"],
+                }
+                assert data["summary"]["root_run_count"] == 2
+                assert data["summary"]["total"]["input_tokens"] == 18
+                assert data["summary"]["total"]["output_tokens"] == 3
+        finally:
+            session_db.close()
+            accounting_db.close()
+
+    @pytest.mark.asyncio
+    async def test_scope_all_returns_all_root_runs(self, adapter, tmp_path):
+        from hermes_state import AccountingDB
+
+        accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+        try:
+            accounting_db.create_agent_run(
+                run_id="manager-run-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=100.0,
+            )
+            accounting_db.create_agent_run(
+                run_id="manager-run-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                launch_kind="root",
+                transport_kind="direct",
+                started_at=200.0,
+            )
+            accounting_db.append_usage_event(
+                run_id="manager-run-a",
+                root_run_id="root-a",
+                local_session_id="session-a",
+                home_id="default",
+                provider="openai-codex",
+                model="gpt-5.4",
+                input_tokens=4,
+                output_tokens=1,
+                usage_status="exact",
+            )
+            accounting_db.append_usage_event(
+                run_id="manager-run-b",
+                root_run_id="root-b",
+                local_session_id="session-b",
+                home_id="default",
+                provider="custom",
+                model="local-model",
+                input_tokens=6,
+                output_tokens=2,
+                usage_status="exact",
+            )
+
+            adapter._accounting_db = accounting_db
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/accounting?scope=all")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["scope"] == {
+                    "type": "all",
+                    "root_run_ids": ["root-a", "root-b"],
+                }
+                assert data["summary"]["root_run_count"] == 2
+                assert data["summary"]["total"]["input_tokens"] == 10
+                assert data["summary"]["total"]["output_tokens"] == 3
+        finally:
+            accounting_db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -21,6 +21,7 @@ def _make_hermes_tree(root: Path) -> None:
     (root / ".env").write_text("OPENROUTER_API_KEY=sk-test-123\n")
     (root / "memory_store.db").write_bytes(b"fake-sqlite")
     (root / "hermes_state.db").write_bytes(b"fake-state")
+    (root / "accounting.db").write_bytes(b"fake-accounting")
 
     # Sessions
     (root / "sessions").mkdir(exist_ok=True)
@@ -143,6 +144,8 @@ class TestBackup:
             # Config should be present
             assert "config.yaml" in names
             assert ".env" in names
+            # Databases
+            assert "accounting.db" in names
             # Skills
             assert "skills/my-skill/SKILL.md" in names
             # Profiles
@@ -998,11 +1001,18 @@ class TestQuickSnapshot:
         (home / "cron").mkdir()
         (home / "cron" / "jobs.json").write_text('{"jobs": []}\n')
 
-        # Real SQLite database
+        # Real SQLite databases
         db_path = home / "state.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, data TEXT)")
         conn.execute("INSERT INTO sessions VALUES ('s1', 'hello world')")
+        conn.commit()
+        conn.close()
+
+        accounting_db_path = home / "accounting.db"
+        conn = sqlite3.connect(str(accounting_db_path))
+        conn.execute("CREATE TABLE usage_events (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO usage_events (value) VALUES ('usage row')")
         conn.commit()
         conn.close()
         return home
@@ -1031,6 +1041,17 @@ class TestQuickSnapshot:
         conn.close()
         assert len(rows) == 1
         assert rows[0] == ("s1", "hello world")
+
+    def test_accounting_db_safely_copied(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        db_copy = hermes_home / "state-snapshots" / snap_id / "accounting.db"
+        assert db_copy.exists()
+
+        conn = sqlite3.connect(str(db_copy))
+        rows = conn.execute("SELECT value FROM usage_events").fetchall()
+        conn.close()
+        assert rows == [("usage row",)]
 
     def test_copies_nested_files(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
@@ -1094,6 +1115,22 @@ class TestQuickSnapshot:
         rows = conn.execute("SELECT * FROM sessions").fetchall()
         conn.close()
         assert len(rows) == 1
+
+    def test_restore_accounting_db(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+
+        conn = sqlite3.connect(str(hermes_home / "accounting.db"))
+        conn.execute("INSERT INTO usage_events (value) VALUES ('new row')")
+        conn.commit()
+        conn.close()
+
+        restore_quick_snapshot(snap_id, hermes_home=hermes_home)
+
+        conn = sqlite3.connect(str(hermes_home / "accounting.db"))
+        rows = conn.execute("SELECT value FROM usage_events").fetchall()
+        conn.close()
+        assert rows == [("usage row",)]
 
     def test_restore_nonexistent(self, hermes_home):
         from hermes_cli.backup import restore_quick_snapshot

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -103,6 +103,10 @@ class TestResolveCommand:
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
 
+    def test_accounting_command_resolves(self):
+        assert resolve_command("accounting").name == "accounting"
+        assert resolve_command("/accounting").name == "accounting"
+
     def test_leading_slash_stripped(self):
         assert resolve_command("/help").name == "help"
         assert resolve_command("/bg").name == "background"

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from hermes_state import AccountingDB, SessionDB
 from run_agent import AIAgent
+from tools.delegate_tool import _build_child_agent
 
 
 def _mock_response(*, usage: dict, content: str = "done"):
@@ -14,7 +16,7 @@ def _mock_response(*, usage: dict, content: str = "done"):
     )
 
 
-def _make_agent(session_db, *, platform: str):
+def _make_agent(session_db, *, platform: str, accounting_db=None):
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -26,6 +28,7 @@ def _make_agent(session_db, *, platform: str):
             skip_context_files=True,
             skip_memory=True,
             session_db=session_db,
+            accounting_db=accounting_db,
             session_id=f"{platform}-session",
             platform=platform,
         )
@@ -60,3 +63,405 @@ def test_run_conversation_persists_tokens_for_cron_sessions():
     assert result["final_response"] == "done"
     session_db.update_token_counts.assert_called_once()
     assert session_db.update_token_counts.call_args.args[0] == "cron-session"
+
+
+def test_agent_init_creates_root_run_in_accounting_db(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        agent = _make_agent(MagicMock(), platform="telegram", accounting_db=accounting_db)
+
+        run = accounting_db.get_agent_run(agent.run_id)
+        assert run is not None
+        assert run["run_id"] == agent.run_id
+        assert run["root_run_id"] == agent.root_run_id == agent.run_id
+        assert run["parent_run_id"] is None
+        assert run["local_session_id"] == "telegram-session"
+        assert run["launch_kind"] == "root"
+        assert run["transport_kind"] == "direct"
+        assert run["source"] == "telegram"
+        assert run["home_id"] == "default"
+    finally:
+        accounting_db.close()
+
+
+def test_run_conversation_appends_usage_event_to_accounting_db(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        agent = _make_agent(session_db, platform="cron", accounting_db=accounting_db)
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        events = accounting_db.get_usage_events(run_id=agent.run_id)
+        assert len(events) == 1
+        event = events[0]
+        assert event["run_id"] == agent.run_id
+        assert event["root_run_id"] == agent.root_run_id
+        assert event["local_session_id"] == "cron-session"
+        assert event["provider"] == agent.provider
+        assert event["base_url"] == agent.base_url
+        assert event["model"] == agent.model
+        assert event["input_tokens"] == 11
+        assert event["output_tokens"] == 7
+        assert event["usage_status"] == "exact"
+    finally:
+        accounting_db.close()
+
+
+def test_run_conversation_persists_assistant_message_telemetry_to_state_db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        agent = _make_agent(session_db, platform="telegram")
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        messages = session_db.get_messages("telegram-session")
+        assistant = next(msg for msg in messages if msg["role"] == "assistant")
+        assert assistant["provider"] == agent.provider
+        assert assistant["base_url"] == agent.base_url
+        assert assistant["model"] == agent.model
+        assert assistant["api_mode"] == agent.api_mode
+        assert assistant["input_tokens"] == 11
+        assert assistant["output_tokens"] == 7
+        assert assistant["cache_read_tokens"] == 0
+        assert assistant["cache_write_tokens"] == 0
+        assert assistant["reasoning_tokens"] == 0
+        assert assistant["usage_status"] == "exact"
+        assert assistant["run_id"] == agent.run_id
+        assert assistant["root_run_id"] == agent.root_run_id
+    finally:
+        session_db.close()
+
+
+def test_persist_session_false_skips_session_db_and_accounting_persistence(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=session_db,
+                accounting_db=accounting_db,
+                session_id="ephemeral-session",
+                platform="cli",
+                persist_session=False,
+            )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _mock_response(
+            usage={
+                "prompt_tokens": 11,
+                "completion_tokens": 7,
+                "total_tokens": 18,
+            }
+        )
+
+        assert accounting_db.get_agent_run(agent.run_id) is None
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        session_db.update_token_counts.assert_not_called()
+        assert accounting_db.get_agent_run(agent.run_id) is None
+        assert accounting_db.get_usage_events(run_id=agent.run_id) == []
+    finally:
+        accounting_db.close()
+
+
+def test_run_conversation_rotates_root_run_id_per_new_top_level_turn(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        agent = _make_agent(session_db, platform="cli", accounting_db=accounting_db)
+        first_run_id = agent.run_id
+
+        first = agent.run_conversation("hello")
+        second = agent.run_conversation("hello again")
+
+        assert first["final_response"] == "done"
+        assert second["final_response"] == "done"
+        assert agent.run_id != first_run_id
+        assert agent.root_run_id == agent.run_id
+        first_run = accounting_db.get_agent_run(first_run_id)
+        second_run = accounting_db.get_agent_run(agent.run_id)
+        assert first_run is not None and first_run["ended_at"] is not None
+        assert second_run is not None and second_run["ended_at"] is None
+        assert len(accounting_db.get_usage_events(run_id=first_run_id)) == 1
+        assert len(accounting_db.get_usage_events(run_id=agent.run_id)) == 1
+
+        latest = accounting_db.get_latest_root_run_id_for_session("cli-session")
+        assert latest == agent.run_id
+    finally:
+        accounting_db.close()
+
+
+def test_close_ends_active_run_in_accounting_db(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        agent = _make_agent(MagicMock(), platform="cli", accounting_db=accounting_db)
+
+        run = accounting_db.get_agent_run(agent.run_id)
+        assert run is not None
+        assert run["ended_at"] is None
+
+        agent.close()
+
+        ended = accounting_db.get_agent_run(agent.run_id)
+        assert ended is not None
+        assert ended["ended_at"] is not None
+    finally:
+        accounting_db.close()
+
+
+def test_named_profile_root_run_uses_profile_attribution(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="coder"):
+            agent = _make_agent(session_db, platform="cli", accounting_db=accounting_db)
+
+        run = accounting_db.get_agent_run(agent.run_id)
+        assert run is not None
+        assert run["home_id"] == "coder"
+        assert run["profile_name"] == "coder"
+    finally:
+        accounting_db.close()
+
+
+def test_delegate_child_creates_child_run_and_usage_event_in_same_root_ledger(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        parent = _make_agent(MagicMock(), platform="cli", accounting_db=accounting_db)
+        child = _build_child_agent(
+            task_index=0,
+            goal="Do a child task",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=10,
+            parent_agent=parent,
+        )
+        child.client = MagicMock()
+        child.client.chat.completions.create.return_value = _mock_response(
+            usage={
+                "prompt_tokens": 5,
+                "completion_tokens": 3,
+                "total_tokens": 8,
+            }
+        )
+
+        result = child.run_conversation("hello from child")
+
+        assert result["final_response"] == "done"
+        child_run = accounting_db.get_agent_run(child.run_id)
+        assert child_run is not None
+        assert child_run["parent_run_id"] == parent.run_id
+        assert child_run["root_run_id"] == parent.root_run_id
+        assert child_run["launch_kind"] == "delegate_task"
+        assert child_run["transport_kind"] == "direct"
+
+        events = accounting_db.get_usage_events(run_id=child.run_id)
+        assert len(events) == 1
+        event = events[0]
+        assert event["run_id"] == child.run_id
+        assert event["root_run_id"] == parent.root_run_id
+        assert event["input_tokens"] == 5
+        assert event["output_tokens"] == 3
+        assert event["usage_status"] == "exact"
+    finally:
+        accounting_db.close()
+
+
+def test_direct_run_records_unknown_usage_event_when_usage_missing(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                provider="custom",
+                base_url="http://worker.example/v1",
+                model="worker-model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=session_db,
+                accounting_db=accounting_db,
+                session_id="direct-session",
+                platform="cli",
+            )
+        agent.client = MagicMock()
+        msg = SimpleNamespace(content="done", tool_calls=None)
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        agent.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice],
+            model="worker-model",
+            usage=None,
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        events = accounting_db.get_usage_events(run_id=agent.run_id)
+        assert len(events) == 1
+        event = events[0]
+        assert event["usage_status"] == "unknown"
+        assert event["provider"] == "custom"
+        assert event["base_url"] == "http://worker.example/v1"
+        assert event["model"] == "worker-model"
+        assert event["input_tokens"] == 0
+        assert event["output_tokens"] == 0
+    finally:
+        accounting_db.close()
+
+
+def test_acp_run_records_unknown_usage_event_instead_of_fake_zero(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                provider="copilot-acp",
+                base_url="acp://copilot",
+                acp_command="copilot",
+                acp_args=["--acp", "--stdio"],
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=session_db,
+                accounting_db=accounting_db,
+                session_id="acp-session",
+                platform="cli",
+            )
+        agent.client = MagicMock()
+        msg = SimpleNamespace(content="done", tool_calls=None)
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        agent.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice],
+            model="copilot-acp/gpt-5.4",
+            usage=None,
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        events = accounting_db.get_usage_events(run_id=agent.run_id)
+        assert len(events) == 1
+        event = events[0]
+        assert event["usage_status"] == "unknown"
+        assert event["provider"] == "copilot-acp"
+        assert event["base_url"] == "acp://copilot"
+        assert event["model"] == agent.model
+        assert event["input_tokens"] == 0
+        assert event["output_tokens"] == 0
+    finally:
+        accounting_db.close()
+
+
+def test_acp_run_uses_actual_runtime_metadata_when_response_provides_it(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                provider="copilot-acp",
+                base_url="acp://copilot",
+                acp_command="copilot",
+                acp_args=["--acp", "--stdio"],
+                model="google/gemma-4-26B-A4B-it",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=session_db,
+                accounting_db=accounting_db,
+                session_id="acp-session",
+                platform="cli",
+            )
+        agent.client = MagicMock()
+        msg = SimpleNamespace(content="done", tool_calls=None)
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        agent.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice],
+            model="google/gemma-4-26B-A4B-it",
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+            hermes_provider="custom",
+            hermes_base_url="http://superbif:8000/v1",
+            hermes_api_mode="chat_completions",
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "done"
+        assert result["actual_provider"] == "custom"
+        assert result["actual_base_url"] == "http://superbif:8000/v1"
+        assert result["actual_api_mode"] == "chat_completions"
+
+        run = accounting_db.get_agent_run(agent.run_id)
+        assert run is not None
+        assert run["provider_hint"] == "custom"
+        assert run["base_url_hint"] == "http://superbif:8000/v1"
+
+        events = accounting_db.get_usage_events(run_id=agent.run_id)
+        assert len(events) == 1
+        event = events[0]
+        assert event["usage_status"] == "exact"
+        assert event["provider"] == "custom"
+        assert event["base_url"] == "http://superbif:8000/v1"
+        assert event["api_mode"] == "chat_completions"
+        assert event["input_tokens"] == 5
+        assert event["output_tokens"] == 3
+    finally:
+        accounting_db.close()
+
+
+def test_context_compaction_keeps_same_global_run_id(tmp_path):
+    accounting_db = AccountingDB(db_path=tmp_path / "accounting.db")
+    try:
+        session_db = MagicMock()
+        agent = _make_agent(session_db, platform="cli", accounting_db=accounting_db)
+        original_run_id = agent.run_id
+        original_session_id = agent.session_id
+        agent._cached_system_prompt = "cached-system"
+        agent.context_compressor.compress = MagicMock(return_value=[{"role": "user", "content": "summary"}])
+        agent._build_system_prompt = MagicMock(return_value="new-system")
+
+        compressed, new_system_prompt = agent._compress_context(
+            [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}],
+            "system",
+            approx_tokens=20,
+            task_id=agent.session_id,
+        )
+
+        assert compressed == [{"role": "user", "content": "summary"}]
+        assert new_system_prompt == "new-system"
+        assert agent.run_id == original_run_id
+        assert agent.session_id != original_session_id
+        runs = accounting_db.get_usage_events(run_id=original_run_id)
+        assert runs == []
+        stored_run = accounting_db.get_agent_run(original_run_id)
+        assert stored_run is not None
+        assert stored_run["run_id"] == original_run_id
+    finally:
+        accounting_db.close()

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -407,7 +407,7 @@ def test_acp_run_uses_actual_runtime_metadata_when_response_provides_it(tmp_path
             model="google/gemma-4-26B-A4B-it",
             usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
             hermes_provider="custom",
-            hermes_base_url="http://superbif:8000/v1",
+            hermes_base_url="http://worker.example/v1",
             hermes_api_mode="chat_completions",
         )
 
@@ -415,20 +415,20 @@ def test_acp_run_uses_actual_runtime_metadata_when_response_provides_it(tmp_path
 
         assert result["final_response"] == "done"
         assert result["actual_provider"] == "custom"
-        assert result["actual_base_url"] == "http://superbif:8000/v1"
+        assert result["actual_base_url"] == "http://worker.example/v1"
         assert result["actual_api_mode"] == "chat_completions"
 
         run = accounting_db.get_agent_run(agent.run_id)
         assert run is not None
         assert run["provider_hint"] == "custom"
-        assert run["base_url_hint"] == "http://superbif:8000/v1"
+        assert run["base_url_hint"] == "http://worker.example/v1"
 
         events = accounting_db.get_usage_events(run_id=agent.run_id)
         assert len(events) == 1
         event = events[0]
         assert event["usage_status"] == "exact"
         assert event["provider"] == "custom"
-        assert event["base_url"] == "http://superbif:8000/v1"
+        assert event["base_url"] == "http://worker.example/v1"
         assert event["api_mode"] == "chat_completions"
         assert event["input_tokens"] == 5
         assert event["output_tokens"] == 3

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -490,7 +490,7 @@ class TestAccountingLedger:
             root_run_id="root-run",
             home_id="default",
             provider="custom",
-            base_url="http://superbif:8000/v1",
+            base_url="http://worker.example/v1",
             model="google/gemma-4-26B-A4B-it",
             profile_name="worker",
             input_tokens=40,
@@ -504,7 +504,7 @@ class TestAccountingLedger:
         assert by_provider["openai-codex"]["input_tokens"] == 100
         assert by_provider["openai-codex"]["exact_event_count"] == 1
         assert by_provider["custom"]["unknown_event_count"] == 1
-        assert by_provider["custom"]["base_url"] == "http://superbif:8000/v1"
+        assert by_provider["custom"]["base_url"] == "http://worker.example/v1"
 
     def test_get_task_usage_breakdown_splits_same_route_by_api_mode(self, accounting_db):
         accounting_db.create_agent_run(
@@ -723,7 +723,7 @@ class TestSessionLifecycle:
             role="assistant",
             content="second",
             provider="custom",
-            base_url="http://superbif:8000/v1",
+            base_url="http://worker.example/v1",
             model="google/gemma-4-26B-A4B-it",
             api_mode="chat_completions",
             input_tokens=0,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from pathlib import Path
 
-from hermes_state import SessionDB
+from hermes_state import AccountingDB, SessionDB
 
 
 @pytest.fixture()
@@ -14,6 +14,621 @@ def db(tmp_path):
     session_db = SessionDB(db_path=db_path)
     yield session_db
     session_db.close()
+
+
+@pytest.fixture()
+def accounting_db(tmp_path):
+    """Create an AccountingDB with a temp ledger file."""
+    db_path = tmp_path / "accounting.db"
+    ledger = AccountingDB(db_path=db_path)
+    yield ledger
+    ledger.close()
+
+
+# =========================================================================
+# Global accounting ledger
+# =========================================================================
+
+class TestAccountingLedger:
+    def test_creates_agent_runs_and_usage_events_tables(self, accounting_db):
+        with accounting_db._lock:
+            tables = {
+                row["name"]
+                for row in accounting_db._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+
+        assert "agent_runs" in tables
+        assert "usage_events" in tables
+
+    def test_create_and_end_agent_run(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="run-root",
+            root_run_id="run-root",
+            parent_run_id=None,
+            local_session_id="session-1",
+            home_id="default",
+            profile_name=None,
+            launch_kind="root",
+            transport_kind="direct",
+            source="cli",
+            model_hint="gpt-5.4",
+            provider_hint="openai",
+            base_url_hint="https://api.openai.com/v1",
+            metadata={"purpose": "test"},
+        )
+
+        run = accounting_db.get_agent_run("run-root")
+        assert run is not None
+        assert run["run_id"] == "run-root"
+        assert run["root_run_id"] == "run-root"
+        assert run["parent_run_id"] is None
+        assert run["launch_kind"] == "root"
+        assert run["transport_kind"] == "direct"
+        assert run["metadata_json"] == {"purpose": "test"}
+        assert isinstance(run["started_at"], float)
+        assert run["ended_at"] is None
+
+        accounting_db.end_agent_run("run-root")
+        ended = accounting_db.get_agent_run("run-root")
+        assert isinstance(ended["ended_at"], float)
+
+    def test_append_usage_event_round_trips_structured_fields(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="run-child",
+            root_run_id="run-root",
+            parent_run_id="run-root",
+            local_session_id="session-child",
+            home_id="default",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+        )
+
+        accounting_db.append_usage_event(
+            run_id="run-child",
+            root_run_id="run-root",
+            home_id="default",
+            profile_name="worker",
+            local_session_id="session-child",
+            provider="anthropic",
+            base_url="https://openrouter.ai/api/v1",
+            model="anthropic/claude-sonnet-4",
+            api_mode="responses",
+            input_tokens=123,
+            output_tokens=45,
+            cache_read_tokens=6,
+            cache_write_tokens=7,
+            reasoning_tokens=8,
+            estimated_cost_usd=0.42,
+            usage_status="exact",
+            request_fingerprint="req-1",
+            metadata={"slice": 1},
+        )
+
+        events = accounting_db.get_usage_events(run_id="run-child")
+        assert len(events) == 1
+        event = events[0]
+        assert event["run_id"] == "run-child"
+        assert event["root_run_id"] == "run-root"
+        assert event["provider"] == "anthropic"
+        assert event["model"] == "anthropic/claude-sonnet-4"
+        assert event["input_tokens"] == 123
+        assert event["output_tokens"] == 45
+        assert event["cache_read_tokens"] == 6
+        assert event["cache_write_tokens"] == 7
+        assert event["reasoning_tokens"] == 8
+        assert event["usage_status"] == "exact"
+        assert event["metadata_json"] == {"slice": 1}
+        assert isinstance(event["recorded_at"], float)
+
+    def test_get_usage_events_filters_by_root_run_id(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="run-a",
+            root_run_id="root-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.create_agent_run(
+            run_id="run-b",
+            root_run_id="root-b",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.append_usage_event(
+            run_id="run-a",
+            root_run_id="root-a",
+            home_id="default",
+            input_tokens=10,
+            output_tokens=1,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="run-b",
+            root_run_id="root-b",
+            home_id="default",
+            input_tokens=20,
+            output_tokens=2,
+            usage_status="exact",
+        )
+
+        events = accounting_db.get_usage_events(root_run_id="root-a")
+        assert len(events) == 1
+        assert events[0]["run_id"] == "run-a"
+
+    def test_get_latest_root_run_id_for_session_returns_most_recent_root(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+
+        assert accounting_db.get_latest_root_run_id_for_session("session-a") == "root-run-b"
+        assert accounting_db.get_latest_root_run_id_for_session("missing-session") is None
+
+    def test_create_agent_run_refresh_preserves_original_session_linkage(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            local_session_id="session-old",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            local_session_id="session-new",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+
+        stored = accounting_db.get_agent_run("root-run")
+        assert stored is not None
+        assert stored["local_session_id"] == "session-old"
+        assert accounting_db.get_latest_root_run_id_for_session("session-old") == "root-run"
+        assert accounting_db.list_root_run_ids_for_sessions(["session-old", "session-new"]) == ["root-run"]
+
+    def test_list_root_runs_filters_to_root_runs_for_sessions(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run-a",
+            root_run_id="root-run-a",
+            parent_run_id="root-run-a",
+            local_session_id="session-child",
+            home_id="worker",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+            started_at=110.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-b",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+
+        rows = accounting_db.list_root_runs(local_session_ids=["session-a", "session-child"])
+
+        assert [row["run_id"] for row in rows] == ["root-run-a"]
+
+    def test_list_root_run_ids_for_sessions_includes_child_session_roots(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="manager-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run-a",
+            root_run_id="root-run-a",
+            parent_run_id="manager-run-a",
+            local_session_id="session-child",
+            home_id="worker",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+            started_at=110.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="manager-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-b",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+
+        assert accounting_db.list_root_run_ids_for_sessions(["session-child"]) == ["root-run-a"]
+        assert accounting_db.list_root_run_ids_for_sessions(["session-a", "session-b"]) == ["root-run-a", "root-run-b"]
+
+    def test_get_task_usage_summary_accepts_multiple_root_runs(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run-b",
+            root_run_id="root-run-b",
+            parent_run_id="root-run-b",
+            local_session_id="session-child",
+            home_id="worker",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+            started_at=210.0,
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            provider="openai-codex",
+            model="gpt-5.4",
+            input_tokens=100,
+            output_tokens=10,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-a",
+            home_id="default",
+            provider="openai-codex",
+            model="gpt-5.4",
+            input_tokens=40,
+            output_tokens=4,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="child-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-child",
+            home_id="worker",
+            profile_name="worker",
+            provider="custom",
+            model="local-model",
+            input_tokens=20,
+            output_tokens=2,
+            usage_status="unknown",
+        )
+
+        summary = accounting_db.get_task_usage_summary(root_run_ids=["root-run-a", "root-run-b"])
+        assert summary["root_run_id"] is None
+        assert summary["root_run_ids"] == ["root-run-a", "root-run-b"]
+        assert summary["root_run_count"] == 2
+        assert summary["manager_only"]["input_tokens"] == 140
+        assert summary["manager_only"]["output_tokens"] == 14
+        assert summary["worker_only"]["input_tokens"] == 20
+        assert summary["worker_only"]["output_tokens"] == 2
+        assert summary["total"]["input_tokens"] == 160
+        assert summary["total"]["output_tokens"] == 16
+        assert summary["exact_event_count"] == 2
+        assert summary["unknown_event_count"] == 1
+        assert summary["child_run_count"] == 1
+
+    def test_get_task_usage_summary_without_root_filter_aggregates_all_roots(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=100.0,
+        )
+        accounting_db.create_agent_run(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-b",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            started_at=200.0,
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run-a",
+            root_run_id="root-run-a",
+            local_session_id="session-a",
+            home_id="default",
+            provider="openai-codex",
+            model="gpt-5.4",
+            input_tokens=10,
+            output_tokens=1,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run-b",
+            root_run_id="root-run-b",
+            local_session_id="session-b",
+            home_id="default",
+            provider="custom",
+            model="local-model",
+            input_tokens=20,
+            output_tokens=2,
+            usage_status="exact",
+        )
+
+        summary = accounting_db.get_task_usage_summary()
+        assert summary["root_run_count"] == 2
+        assert summary["total"]["input_tokens"] == 30
+        assert summary["total"]["output_tokens"] == 3
+        assert summary["exact_event_count"] == 2
+
+    def test_get_task_usage_summary_returns_manager_worker_and_total(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run",
+            root_run_id="root-run",
+            parent_run_id="root-run",
+            home_id="default",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            provider="openai-codex",
+            model="gpt-5.4",
+            input_tokens=100,
+            output_tokens=10,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="child-run",
+            root_run_id="root-run",
+            home_id="default",
+            profile_name="worker",
+            provider="custom",
+            model="local-model",
+            input_tokens=40,
+            output_tokens=4,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="child-run",
+            root_run_id="root-run",
+            home_id="default",
+            profile_name="worker",
+            provider="custom",
+            model="local-model",
+            input_tokens=0,
+            output_tokens=0,
+            usage_status="unknown",
+        )
+
+        summary = accounting_db.get_task_usage_summary("root-run")
+        assert summary["root_run_id"] == "root-run"
+        assert summary["manager_only"]["input_tokens"] == 100
+        assert summary["manager_only"]["output_tokens"] == 10
+        assert summary["worker_only"]["input_tokens"] == 40
+        assert summary["worker_only"]["output_tokens"] == 4
+        assert summary["total"]["input_tokens"] == 140
+        assert summary["total"]["output_tokens"] == 14
+        assert summary["exact_event_count"] == 2
+        assert summary["unknown_event_count"] == 1
+        assert summary["child_run_count"] == 1
+
+    def test_get_task_usage_breakdown_groups_by_route_fields(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-5.4",
+            input_tokens=100,
+            output_tokens=10,
+            usage_status="exact",
+        )
+        accounting_db.append_usage_event(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            provider="custom",
+            base_url="http://superbif:8000/v1",
+            model="google/gemma-4-26B-A4B-it",
+            profile_name="worker",
+            input_tokens=40,
+            output_tokens=4,
+            usage_status="unknown",
+        )
+
+        rows = accounting_db.get_task_usage_breakdown("root-run")
+        assert len(rows) == 2
+        by_provider = {row["provider"]: row for row in rows}
+        assert by_provider["openai-codex"]["input_tokens"] == 100
+        assert by_provider["openai-codex"]["exact_event_count"] == 1
+        assert by_provider["custom"]["unknown_event_count"] == 1
+        assert by_provider["custom"]["base_url"] == "http://superbif:8000/v1"
+
+    def test_get_task_usage_breakdown_splits_same_route_by_api_mode(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        for api_mode, input_tokens, output_tokens in (
+            ("responses", 100, 10),
+            ("chat_completions", 40, 4),
+        ):
+            accounting_db.append_usage_event(
+                run_id="root-run",
+                root_run_id="root-run",
+                home_id="default",
+                provider="openai",
+                base_url="https://api.openai.com/v1",
+                model="gpt-5.4",
+                api_mode=api_mode,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                usage_status="exact",
+            )
+
+        rows = accounting_db.get_task_usage_breakdown("root-run")
+
+        assert len(rows) == 2
+        by_api_mode = {row["api_mode"]: row for row in rows}
+        assert by_api_mode["responses"]["input_tokens"] == 100
+        assert by_api_mode["responses"]["output_tokens"] == 10
+        assert by_api_mode["chat_completions"]["input_tokens"] == 40
+        assert by_api_mode["chat_completions"]["output_tokens"] == 4
+
+    def test_get_task_run_tree_returns_runs_for_root(self, accounting_db):
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+            source="cli",
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run",
+            root_run_id="root-run",
+            parent_run_id="root-run",
+            home_id="default",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+            source="cli",
+        )
+
+        tree = accounting_db.get_task_run_tree("root-run")
+        assert [row["run_id"] for row in tree] == ["root-run", "child-run"]
+        assert tree[1]["parent_run_id"] == "root-run"
+        assert tree[1]["transport_kind"] == "acp"
+
+    def test_get_task_session_links_maps_run_to_session_lineage(self, accounting_db, db):
+        db.create_session(session_id="session-a", source="cli")
+        db.create_session(session_id="session-b", source="cli", parent_session_id="session-a")
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run",
+            root_run_id="root-run",
+            parent_run_id="root-run",
+            local_session_id="session-b",
+            home_id="default",
+            launch_kind="delegate_task",
+            transport_kind="direct",
+        )
+
+        links = accounting_db.get_task_session_links("root-run", session_db=db)
+        assert len(links) == 2
+        assert links[0]["local_session_id"] == "session-a"
+        assert links[0]["parent_session_id"] is None
+        assert links[1]["local_session_id"] == "session-b"
+        assert links[1]["parent_session_id"] == "session-a"
+
+    def test_get_task_provenance_warnings_reports_unknown_and_missing_session_rows(self, accounting_db, db):
+        db.create_session(session_id="session-a", source="cli")
+        accounting_db.create_agent_run(
+            run_id="root-run",
+            root_run_id="root-run",
+            local_session_id="session-a",
+            home_id="default",
+            launch_kind="root",
+            transport_kind="direct",
+        )
+        accounting_db.create_agent_run(
+            run_id="child-run",
+            root_run_id="root-run",
+            parent_run_id="root-run",
+            local_session_id="missing-session",
+            home_id="worker",
+            profile_name="worker",
+            launch_kind="delegate_task",
+            transport_kind="acp",
+        )
+        accounting_db.append_usage_event(
+            run_id="child-run",
+            root_run_id="root-run",
+            home_id="worker",
+            profile_name="worker",
+            provider="custom",
+            model="local-model",
+            input_tokens=0,
+            output_tokens=0,
+            usage_status="unknown",
+        )
+
+        warnings = accounting_db.get_task_provenance_warnings("root-run", session_db=db)
+        warning_types = {w["type"] for w in warnings}
+        assert "unknown_usage" in warning_types
+        assert "missing_session_link" in warning_types
 
 
 # =========================================================================
@@ -37,6 +652,14 @@ class TestSessionLifecycle:
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
+
+    def test_get_session_ancestor_ids_returns_current_and_ancestors(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli", parent_session_id="s1")
+        db.create_session(session_id="s3", source="cli", parent_session_id="s2")
+
+        assert db.get_session_ancestor_ids("s3") == ["s1", "s2", "s3"]
+        assert db.get_session_ancestor_ids("missing") == ["missing"]
 
     def test_end_session(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -75,6 +698,156 @@ class TestSessionLifecycle:
 
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
+
+    def test_get_session_stats_prefers_assistant_message_telemetry(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message("s1", role="user", content="hello")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="first",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-5.4",
+            api_mode="responses",
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=1,
+            reasoning_tokens=7,
+            estimated_cost_usd=0.0123,
+            usage_status="exact",
+        )
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="second",
+            provider="custom",
+            base_url="http://superbif:8000/v1",
+            model="google/gemma-4-26B-A4B-it",
+            api_mode="chat_completions",
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            reasoning_tokens=0,
+            estimated_cost_usd=None,
+            usage_status="unknown",
+        )
+
+        stats = db.get_session_stats("s1")
+        assert stats is not None
+        assert stats["telemetry_source"] == "messages"
+        assert stats["assistant_messages"] == 2
+        assert stats["tokens"]["input"] == 100
+        assert stats["tokens"]["output"] == 20
+        assert stats["tokens"]["cache_read"] == 5
+        assert stats["tokens"]["cache_write"] == 1
+        assert stats["tokens"]["reasoning"] == 7
+        assert stats["tokens"]["total"] == 133
+        assert stats["estimated_cost_usd"] == 0.0123
+        assert stats["exact_message_count"] == 1
+        assert stats["unknown_message_count"] == 1
+        assert len(stats["breakdown"]) == 2
+        assert stats["breakdown"][0]["provider"] == "openai-codex"
+        assert stats["breakdown"][0]["model"] == "gpt-5.4"
+
+    def test_get_session_stats_falls_back_to_session_row_without_message_telemetry(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_token_counts(
+            "s1",
+            input_tokens=30,
+            output_tokens=12,
+            cache_read_tokens=4,
+            cache_write_tokens=1,
+            reasoning_tokens=2,
+            estimated_cost_usd=0.0042,
+            billing_provider="openrouter",
+            billing_base_url="https://openrouter.ai/api/v1",
+            billing_mode="chat_completions",
+            model="anthropic/claude-sonnet-4",
+        )
+
+        stats = db.get_session_stats("s1")
+        assert stats is not None
+        assert stats["telemetry_source"] == "sessions"
+        assert stats["tokens"]["input"] == 30
+        assert stats["tokens"]["output"] == 12
+        assert stats["tokens"]["cache_read"] == 4
+        assert stats["tokens"]["cache_write"] == 1
+        assert stats["tokens"]["reasoning"] == 2
+        assert stats["tokens"]["total"] == 49
+        assert stats["estimated_cost_usd"] == 0.0042
+        assert stats["breakdown"] == [
+            {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "model": "anthropic/claude-sonnet-4",
+                "api_mode": "chat_completions",
+                "input_tokens": 30,
+                "output_tokens": 12,
+                "cache_read_tokens": 4,
+                "cache_write_tokens": 1,
+                "reasoning_tokens": 2,
+                "total_tokens": 49,
+                "estimated_cost_usd": 0.0042,
+                "exact_message_count": 0,
+                "unknown_message_count": 0,
+            }
+        ]
+
+    def test_get_session_stats_merges_legacy_session_totals_with_message_telemetry(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.set_token_counts(
+            "s1",
+            input_tokens=130,
+            output_tokens=21,
+            cache_read_tokens=5,
+            cache_write_tokens=1,
+            reasoning_tokens=7,
+            estimated_cost_usd=0.0165,
+            billing_provider="openrouter",
+            billing_base_url="https://openrouter.ai/api/v1",
+            billing_mode="chat_completions",
+            model="anthropic/claude-sonnet-4",
+        )
+        db.append_message("s1", role="assistant", content="legacy assistant")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="new assistant",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-5.4",
+            api_mode="responses",
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=1,
+            reasoning_tokens=7,
+            estimated_cost_usd=0.0123,
+            usage_status="exact",
+        )
+
+        stats = db.get_session_stats("s1")
+        assert stats is not None
+        assert stats["telemetry_source"] == "mixed"
+        assert stats["assistant_messages"] == 2
+        assert stats["tokens"]["input"] == 130
+        assert stats["tokens"]["output"] == 21
+        assert stats["tokens"]["cache_read"] == 5
+        assert stats["tokens"]["cache_write"] == 1
+        assert stats["tokens"]["reasoning"] == 7
+        assert stats["tokens"]["total"] == 164
+        assert stats["estimated_cost_usd"] == 0.0165
+        assert stats["exact_message_count"] == 1
+        assert stats["unknown_message_count"] == 1
+        assert len(stats["breakdown"]) == 2
+        assert stats["breakdown"][0]["provider"] == "openai-codex"
+        assert stats["breakdown"][1]["provider"] == "openrouter"
+        assert stats["breakdown"][1]["input_tokens"] == 30
+        assert stats["breakdown"][1]["output_tokens"] == 1
+        assert stats["breakdown"][1]["unknown_message_count"] == 1
 
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
@@ -176,6 +949,42 @@ class TestMessageStorage:
 
         messages = db.get_messages("s1")
         assert messages[0]["finish_reason"] == "stop"
+
+    def test_assistant_telemetry_persisted_and_restored(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="assistant",
+            content="Done",
+            run_id="run-1",
+            root_run_id="root-1",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-5.4",
+            api_mode="responses",
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=1,
+            reasoning_tokens=7,
+            estimated_cost_usd=0.0123,
+            usage_status="exact",
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["run_id"] == "run-1"
+        assert messages[0]["root_run_id"] == "root-1"
+        assert messages[0]["provider"] == "openai-codex"
+        assert messages[0]["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert messages[0]["model"] == "gpt-5.4"
+        assert messages[0]["api_mode"] == "responses"
+        assert messages[0]["input_tokens"] == 100
+        assert messages[0]["output_tokens"] == 20
+        assert messages[0]["cache_read_tokens"] == 5
+        assert messages[0]["cache_write_tokens"] == 1
+        assert messages[0]["reasoning_tokens"] == 7
+        assert messages[0]["estimated_cost_usd"] == 0.0123
+        assert messages[0]["usage_status"] == "exact"
 
     def test_reasoning_persisted_and_restored(self, db):
         """Reasoning text is stored for assistant messages and restored by
@@ -935,7 +1744,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -991,12 +1800,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to v7
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
 
-
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([
     "delegate_task",   # no recursive delegation
@@ -243,7 +242,7 @@ def _build_child_agent(
     model: Optional[str],
     max_iterations: int,
     parent_agent,
-    # Credential overrides from delegation config (provider:model resolution)
+    *,
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
@@ -345,6 +344,9 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
+    child_home_id = getattr(parent_agent, 'home_id', None)
+    child_profile_name = getattr(parent_agent, 'profile_name', None)
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -367,7 +369,14 @@ def _build_child_agent(
         clarify_callback=None,
         thinking_callback=child_thinking_cb,
         session_db=getattr(parent_agent, '_session_db', None),
+        accounting_db=getattr(parent_agent, '_accounting_db', None),
         parent_session_id=getattr(parent_agent, 'session_id', None),
+        parent_run_id=getattr(parent_agent, 'run_id', None),
+        root_run_id=getattr(parent_agent, 'root_run_id', None),
+        home_id=child_home_id,
+        profile_name=child_profile_name,
+        launch_kind="delegate_task",
+        transport_kind="acp" if effective_acp_command else "direct",
         providers_allowed=parent_agent.providers_allowed,
         providers_ignored=parent_agent.providers_ignored,
         providers_order=parent_agent.providers_order,


### PR DESCRIPTION
## What does this PR do?

This PR adds the task-tree accounting foundation for Hermes.

It introduces a canonical accounting ledger in `accounting.db` for root/child run lineage and usage events, adds assistant-message telemetry to `state.db.messages` so session-level stats stop silently dropping runtime truth, propagates ACP runtime provenance/usage back into persisted accounting, and exposes the resulting data through `/accounting` and the accounting API surface.

## Related Issue

No dedicated issue currently.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added canonical task-tree accounting ledger in `hermes_state.py`:
  - `AccountingDB`
  - `agent_runs`
  - `usage_events`
- Extended `state.db.messages` with assistant-message telemetry:
  - `run_id`
  - `root_run_id`
  - `provider`
  - `base_url`
  - `model`
  - `api_mode`
  - `input_tokens`
  - `output_tokens`
  - `cache_read_tokens`
  - `cache_write_tokens`
  - `reasoning_tokens`
  - `estimated_cost_usd`
  - `usage_status`
- Added `SessionDB.get_session_stats()` so session-level usage/stat views can prefer persisted assistant-message telemetry and fall back to coarse session totals when needed.
- Updated `run_agent.py` to:
  - create/persist run lineage for root/child accounting
  - attach assistant telemetry to persisted assistant messages
  - append exact/unknown usage events to `accounting.db`
  - preserve ACP/runtime truth via actual provider/base_url/api_mode metadata
- Updated `tools/delegate_tool.py` to pass child lineage/accounting context through delegated child agents:
  - `accounting_db`
  - `parent_run_id`
  - `root_run_id`
  - `home_id`
  - `profile_name`
  - `launch_kind`
  - `transport_kind`
- Updated ACP accounting/provenance plumbing in:
  - `acp_adapter/server.py`
  - `agent/copilot_acp_client.py`
- Added `/accounting` CLI surface in:
  - `cli.py`
  - `hermes_cli/commands.py`
- Kept `/accounting all` summary-only and bounded:
  - immediate progress line
  - compact session count
  - no run-tree dump
  - no session-links dump
  - capped breakdown rows
  - sparse/aggregated notes
  - correct all-scope summary shape even when only one root run exists
- Added dedicated accounting API support in:
  - `gateway/platforms/api_server.py`

## How to Test

1. Run the focused accounting/provenance test slice:

```bash
unset API_SERVER_KEY API_SERVER_HOST API_SERVER_PORT HERMES_HOME VIRTUAL_ENV
uv run --extra dev python -m pytest -o addopts='' \
  tests/test_hermes_state.py \
  tests/run_agent/test_token_persistence_non_cli.py \
  tests/acp/test_server.py \
  tests/agent/test_copilot_acp_client.py \
  tests/cli/test_cli_prefix_matching.py \
  tests/cli/test_cli_status_bar.py \
  tests/gateway/test_api_server.py \
  tests/hermes_cli/test_commands.py \
  tests/tools/test_delegate.py \
  tests/tools/test_zombie_process_cleanup.py \
  tests/gateway/test_session_race_guard.py \
  tests/run_agent/test_anthropic_error_handling.py \
  tests/run_agent/test_provider_parity.py \
  -q
```

2. Optional manual smoke:
- start Hermes in a disposable local home
- send a message or two
- run `/usage`
- run `/accounting`
- run `/accounting all`

Verify:
- `/accounting` shows current-session/run-tree accounting
- `/accounting all` stays summary-shaped
- `/accounting all` does not print `Run tree`
- `/accounting all` does not print `Session links`
- `/accounting all` keeps the note:
  - `NOTE: /accounting all shows scope totals and breakdown only; use /accounting <root_run_id> for per-task details.`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass - See note below*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — N/A for this PR
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A for this PR
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A for this PR
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific behavior was intentionally introduced here
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A for this PR

## Screenshots / Logs

<img width="2174" height="1137" alt="image" src="https://github.com/user-attachments/assets/613f7d72-bfcc-4dc5-8a8d-7b18b7cb3628" />

Validation summary:
- Focused accounting/provenance slice:
  - `670 passed, 78 warnings`
- Local manual/accounting smokes:
  - passed
- Full suite on updated `main`:
  - `13 failed, 11361 passed, 93 skipped`
- Full suite on this branch:
  - `13 failed, 11428 passed, 93 skipped`

*Important note:
- I ran `python -m pytest tests/ -q` against both updated `main` and this branch.
- Updated `main` is currently not full-suite green:
  - `13 failed, 11361 passed, 93 skipped`
- This branch is also not full-suite green:
  - `13 failed, 11428 passed, 93 skipped`
- The failed test identities match between updated `main` and this branch.
- Because the repository baseline is still red, the checkbox
  - `I've run pytest tests/ -q and all tests pass`
  remains intentionally unchecked.