### PR TITLE
Fix docker cwd passthrough rewriting POSIX host paths on Windows

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -97,6 +97,7 @@ AUTHOR_MAP = {
     "kennyx102@gmail.com": "bobashopcashier",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",
+    "xowiekk@gmail.com": "Xowiek",
     "hermes@nousresearch.com": "NousResearch",
     "openclaw@sparklab.ai": "openclaw",
     "semihcvlk53@gmail.com": "Himess",

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -134,6 +134,24 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+def test_auto_mount_preserves_posix_host_cwd(monkeypatch):
+    """POSIX-style host paths should not be rewritten before the docker mount."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.os.path, "isdir", lambda p: p == "/home/demo/project")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd="/home/demo/project",
+        auto_mount_cwd=True,
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "/home/demo/project:/workspace" in run_args_str
+
+
 def test_auto_mount_disabled_by_default(monkeypatch, tmp_path):
     """Host cwd should not be mounted unless the caller explicitly opts in."""
     project_dir = tmp_path / "my-project"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -299,7 +299,10 @@ class DockerEnvironment(BaseEnvironment):
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")
 
-        host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        if host_cwd and host_cwd.startswith(("/Users/", "/home/")):
+            host_cwd_abs = host_cwd
+        else:
+            host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -621,7 +621,10 @@ def _get_env_config() -> Dict[str, Any]:
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        if docker_cwd_source.startswith(("/Users/", "/home/")):
+            candidate = docker_cwd_source
+        else:
+            candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in host_prefixes)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))


### PR DESCRIPTION
## Summary

Fix Docker cwd passthrough on Windows so POSIX-style host paths like `/Users/...` and `/home/...` are preserved instead of being rewritten into Windows drive paths before mounting `/workspace`.

## Root Cause

When docker cwd passthrough is enabled, Hermes normalizes `TERMINAL_CWD` and `host_cwd` with `os.path.abspath(os.path.expanduser(...))`.

On Windows, that rewrites POSIX-style host paths such as `/Users/...` and `/home/...` into `C:\...`, which changes the mount source before Docker builds `-v <host_cwd>:/workspace`.

## Repro

On Windows, with:

- `TERMINAL_ENV=docker`
- `TERMINAL_CWD=/Users/someone/projects`
- `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true`

Before this fix, `_get_env_config()` returned:

- `cwd=/workspace`
- `host_cwd=C:\Users\someone\projects`

And constructing a Docker environment with a POSIX-style host cwd could produce a mount like:

- `-v C:\home\demo\project:/workspace`

instead of preserving the original POSIX path.

## Fix

Preserve `/Users/...` and `/home/...` inputs verbatim at the two existing normalization points:

- `tools/terminal_tool.py`
- `tools/environments/docker.py`

All other path handling stays unchanged. No refactor or abstraction changes were introduced.

## Tests

Added regression coverage in:

- `tests/tools/test_docker_environment.py`

Relevant validation run:

```bash
python -m pytest tests/tools/test_modal_sandbox_fixes.py tests/tools/test_docker_environment.py tests/tools/test_windows_compat.py tests/tools/test_terminal_tool.py -q -n0 --maxfail=1

57 passed, 1 warning in 0.91s