### PR TITLE
fix(openviking): salvage three OpenViking fixes — search ordering, gateway reset commit, setup env vars

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3972,6 +3972,11 @@ class GatewayRunner:
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
                 try:
+                    if hasattr(_old_agent, "shutdown_memory_provider"):
+                        _old_agent.shutdown_memory_provider()
+                except Exception:
+                    pass
+                try:
                     if hasattr(_old_agent, "close"):
                         _old_agent.close()
                 except Exception:

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -324,6 +324,9 @@ def cmd_setup(args) -> None:
                 val = _prompt(desc, default=str(effective_default) if effective_default else None)
                 if val:
                     provider_config[key] = val
+                    # Also write to .env if this field has an env_var
+                    if env_var and env_var not in env_writes:
+                        env_writes[env_var] = val
 
     # Write activation key to config.yaml
     config["memory"]["provider"] = name
@@ -409,12 +412,13 @@ def cmd_status(args) -> None:
                     else:
                         print(f"  Status:    not available ✗")
                         schema = p.get_config_schema() if hasattr(p, "get_config_schema") else []
-                        secrets = [f for f in schema if f.get("secret")]
-                        if secrets:
+                        # Check all fields that have env_var (both secret and non-secret)
+                        required_fields = [f for f in schema if f.get("env_var")]
+                        if required_fields:
                             print(f"  Missing:")
-                            for s in secrets:
-                                env_var = s.get("env_var", "")
-                                url = s.get("url", "")
+                            for f in required_fields:
+                                env_var = f.get("env_var", "")
+                                url = f.get("url", "")
                                 is_set = bool(os.environ.get(env_var))
                                 mark = "✓" if is_set else "✗"
                                 line = f"    {mark} {env_var}"

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -509,19 +509,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
         result = resp.get("result", {})
 
         # Format results for the model — keep it concise
-        formatted = []
+        scored_entries = []
         for ctx_type in ("memories", "resources", "skills"):
             items = result.get(ctx_type, [])
             for item in items:
+                raw_score = item.get("score")
+                sort_score = raw_score if raw_score is not None else 0.0
                 entry = {
                     "uri": item.get("uri", ""),
                     "type": ctx_type.rstrip("s"),
-                    "score": round(item.get("score", 0), 3),
+                    "score": round(raw_score, 3) if raw_score is not None else 0.0,
                     "abstract": item.get("abstract", ""),
                 }
                 if item.get("relations"):
                     entry["related"] = [r.get("uri") for r in item["relations"][:3]]
-                formatted.append(entry)
+                scored_entries.append((sort_score, entry))
+
+        scored_entries.sort(key=lambda x: x[0], reverse=True)
+        formatted = [entry for _, entry in scored_entries]
 
         return json.dumps({
             "results": formatted,

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import MagicMock
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+def test_tool_search_sorts_by_raw_score_across_buckets():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "result": {
+            "memories": [
+                {"uri": "viking://memories/1", "score": 0.9003, "abstract": "memory result"},
+            ],
+            "resources": [
+                {"uri": "viking://resources/1", "score": 0.9004, "abstract": "resource result"},
+            ],
+            "skills": [
+                {"uri": "viking://skills/1", "score": 0.8999, "abstract": "skill result"},
+            ],
+            "total": 3,
+        }
+    }
+
+    result = json.loads(provider._tool_search({"query": "ranking"}))
+
+    assert [entry["uri"] for entry in result["results"]] == [
+        "viking://resources/1",
+        "viking://memories/1",
+        "viking://skills/1",
+    ]
+    assert [entry["score"] for entry in result["results"]] == [0.9, 0.9, 0.9]
+    assert result["total"] == 3
+
+
+def test_tool_search_sorts_missing_raw_score_after_negative_scores():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "result": {
+            "memories": [
+                {"uri": "viking://memories/missing", "abstract": "missing score"},
+            ],
+            "resources": [
+                {"uri": "viking://resources/negative", "score": -0.25, "abstract": "negative score"},
+            ],
+            "skills": [
+                {"uri": "viking://skills/positive", "score": 0.1, "abstract": "positive score"},
+            ],
+            "total": 3,
+        }
+    }
+
+    result = json.loads(provider._tool_search({"query": "ranking"}))
+
+    assert [entry["uri"] for entry in result["results"]] == [
+        "viking://skills/positive",
+        "viking://memories/missing",
+        "viking://resources/negative",
+    ]
+    assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
+    assert result["total"] == 3


### PR DESCRIPTION
## Summary

Salvages three independent OpenViking-related fixes from community PRs onto current main. All are confirmed bugs still present on main, plugin/setup scoped only (no core file changes).

### Cherry-picked commits (contributor authorship preserved):

**1. Sort search results by score** (from PR #7250 by @Disaster-Terminator)
- `_tool_search()` results were grouped by bucket order (memories → resources → skills), so lower-scoring items from an earlier bucket ranked above higher-scoring items
- Fix: aggregate all buckets then sort by raw score descending
- Includes 2 focused tests

**2. Trigger memory provider shutdown on /new and /reset** (from PR #7762 by @fancydirty)
- Gateway's `_handle_reset_command()` called `close()` but never `shutdown_memory_provider()`
- Session expiry and gateway shutdown already called it — this was an inconsistency
- Without it, OpenViking's session commit (memory extraction trigger) was skipped on `/new`
- 5-line fix in gateway/run.py

**3. Write non-secret env vars during memory setup** (from PR #9150 by @ZaynJarvis)
- Non-secret schema fields with `env_var` (like `OPENVIKING_ENDPOINT`) were prompted during setup but never written to `.env`
- Since `is_available()` checks `os.environ.get("OPENVIKING_ENDPOINT")`, the provider appeared unconfigured after setup
- Also fixes status output to check all fields with `env_var`, not just secrets

## Test results
- `tests/plugins/memory/` — 159 passed
- `tests/gateway/test_session_reset_notify.py` — 13 passed  
- `tests/gateway/` — 2838 passed (7 pre-existing failures unrelated to these changes)
- `tests/hermes_cli/` — 1988 passed (4 pre-existing failures unrelated)

## Closes
Supersedes #7250, #7762, #9150