### PR TITLE
feat: add visual-first video commentary pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
 | [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |
 | [Context Files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Project context that shapes every conversation |
+| [Visual-first Video Commentary](https://hermes-agent.nousresearch.com/docs/user-guide/features/video-commentary) | Generate a 基于视频画面的中文讲解版 with Azure OpenAI vision + Azure Speech |
 | [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Project structure, agent loop, key classes |
 | [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Development setup, PR process, code style |
 | [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |

--- a/scripts/visual_commentary_pipeline.py
+++ b/scripts/visual_commentary_pipeline.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the visual-first video commentary pipeline."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.video_commentary.pipeline import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_video_commentary.py
+++ b/tests/tools/test_video_commentary.py
@@ -1,0 +1,119 @@
+"""Tests for the video commentary engineering helpers."""
+
+from pathlib import Path
+
+from tools.video_commentary.core import (
+    DEFAULT_TERM_MAP,
+    Segment,
+    atempo_chain,
+    build_azure_tts_ssml,
+    build_segments,
+    build_srt_text,
+    format_srt_timestamp,
+    normalize_terms,
+    sample_times,
+)
+
+
+class TestBuildSegments:
+    def test_merges_short_segments_into_previous_and_splits_long_ones(self):
+        segments = build_segments(
+            duration=30.0,
+            cuts=[2.0, 5.0, 21.0],
+            min_segment=3.0,
+            max_segment=8.0,
+        )
+
+        assert [(s.start, s.end, s.duration) for s in segments] == [
+            (0.0, 5.0, 5.0),
+            (5.0, 13.0, 8.0),
+            (13.0, 21.0, 8.0),
+            (21.0, 25.5, 4.5),
+            (25.5, 30.0, 4.5),
+        ]
+
+    def test_ignores_duplicate_and_tiny_boundaries(self):
+        segments = build_segments(
+            duration=10.0,
+            cuts=[0.0, 0.01, 4.0, 4.0, 9.98],
+            min_segment=1.0,
+            max_segment=10.0,
+        )
+
+        assert [(s.start, s.end, s.duration) for s in segments] == [
+            (0.0, 4.0, 4.0),
+            (4.0, 10.0, 6.0),
+        ]
+
+
+class TestSampleTimes:
+    def test_short_segment_uses_midpoint(self):
+        segment = Segment(id=1, start=4.0, end=7.0, duration=3.0)
+        assert sample_times(segment) == [5.5]
+
+    def test_longer_segment_uses_three_samples(self):
+        segment = Segment(id=2, start=10.0, end=20.0, duration=10.0)
+        assert sample_times(segment) == [11.2, 15.0, 18.8]
+
+
+class TestNormalizeTerms:
+    def test_applies_default_glossary_and_punctuation_spacing_cleanup(self):
+        text = "ashure  openaai ， deep seek !"
+        assert normalize_terms(text, DEFAULT_TERM_MAP) == "Azure OpenAI， DeepSeek!"
+
+    def test_accepts_custom_term_map(self):
+        assert normalize_terms("foo demo", {"foo": "Bar"}) == "Bar demo"
+
+
+class TestTempoChain:
+    def test_single_stage(self):
+        assert atempo_chain(1.25) == "atempo=1.25000"
+
+    def test_multi_stage_for_large_speedup(self):
+        assert atempo_chain(4.0) == "atempo=2.0,atempo=2.0"
+
+
+class TestSrtHelpers:
+    def test_format_srt_timestamp(self):
+        assert format_srt_timestamp(3661.275) == "01:01:01,275"
+
+    def test_build_srt_text(self):
+        items = [
+            {"start": 0.0, "end": 2.5, "narration_zh": "第一页概览。"},
+            {"start": 2.5, "end": 5.0, "narration_zh": "这里进入细节。"},
+        ]
+
+        assert build_srt_text(items) == (
+            "1\n"
+            "00:00:00,000 --> 00:00:02,500\n"
+            "第一页概览。\n\n"
+            "2\n"
+            "00:00:02,500 --> 00:00:05,000\n"
+            "这里进入细节。\n"
+        )
+
+
+class TestAzureSsml:
+    def test_builds_ssml_with_optional_duration_and_escaping(self):
+        ssml = build_azure_tts_ssml(
+            text="AT&T <Azure>",
+            voice="zh-CN-XiaoxiaoNeural",
+            rate="+5%",
+            target_duration_ms=18000,
+            style="professional",
+        )
+
+        assert "mstts:audioduration value=\"18000ms\"" in ssml
+        assert "<prosody rate=\"+5%\">AT&amp;T &lt;Azure&gt;</prosody>" in ssml
+        assert 'style="professional"' in ssml
+        assert "xmlns:mstts=\"https://www.w3.org/2001/mstts\"" in ssml
+
+    def test_omits_optional_nodes_when_not_requested(self):
+        ssml = build_azure_tts_ssml(
+            text="讲解内容",
+            voice="zh-CN-XiaoxiaoNeural",
+        )
+
+        assert "mstts:audioduration" not in ssml
+        assert "mstts:express-as" not in ssml
+        assert "<prosody rate=\"+0%\">讲解内容</prosody>" in ssml

--- a/tools/video_commentary/__init__.py
+++ b/tools/video_commentary/__init__.py
@@ -1,0 +1,31 @@
+"""Visual-first video commentary pipeline helpers."""
+
+from .core import (
+    DEFAULT_TERM_MAP,
+    Segment,
+    SegmentNarration,
+    atempo_chain,
+    build_azure_tts_ssml,
+    build_segments,
+    build_srt_text,
+    format_srt_timestamp,
+    normalize_terms,
+    sample_times,
+    serialize_manifest,
+    write_srt_file,
+)
+
+__all__ = [
+    "DEFAULT_TERM_MAP",
+    "Segment",
+    "SegmentNarration",
+    "atempo_chain",
+    "build_azure_tts_ssml",
+    "build_segments",
+    "build_srt_text",
+    "format_srt_timestamp",
+    "normalize_terms",
+    "sample_times",
+    "serialize_manifest",
+    "write_srt_file",
+]

--- a/tools/video_commentary/core.py
+++ b/tools/video_commentary/core.py
@@ -1,0 +1,211 @@
+"""Core helpers for the visual-first video commentary pipeline."""
+
+from __future__ import annotations
+
+import html
+import json
+import math
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence
+
+DEFAULT_TERM_MAP = {
+    "ashure": "Azure",
+    "azri": "Azure",
+    "asheri": "Azure",
+    "openaai": "OpenAI",
+    "coher": "Cohere",
+    "mistol": "Mistral",
+    "deep seek": "DeepSeek",
+    "copilot studio": "Copilot Studio",
+    "ai air.com": "ai.azure.com",
+    "ai. air.com": "ai.azure.com",
+}
+
+
+@dataclass
+class Segment:
+    id: int
+    start: float
+    end: float
+    duration: float
+
+
+@dataclass
+class SegmentNarration:
+    id: int
+    start: float
+    end: float
+    duration: float
+    title: str
+    visible_points: List[str]
+    on_screen_text: List[str]
+    narration_zh: str
+    frame_paths: List[str]
+    audio_path: str = ""
+    audio_duration: float = 0.0
+    fitted_audio_path: str = ""
+    fitted_audio_duration: float = 0.0
+
+
+def normalize_terms(text: str, term_map: Mapping[str, str] | None = None) -> str:
+    out = str(text)
+    for bad, good in (term_map or DEFAULT_TERM_MAP).items():
+        out = re.sub(re.escape(bad), good, out, flags=re.I)
+    out = re.sub(r"\s+([，。！？；：,.!?;:])", r"\1", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def build_segments(
+    duration: float,
+    cuts: Sequence[float],
+    *,
+    min_segment: float,
+    max_segment: float,
+) -> List[Segment]:
+    points = [0.0] + [c for c in cuts if 0.05 <= c <= duration - 0.05] + [duration]
+    raw: List[tuple[float, float]] = []
+    for start, end in zip(points, points[1:]):
+        if end - start <= 0.05:
+            continue
+        raw.append((start, end))
+
+    merged: List[tuple[float, float]] = []
+    carry_start: float | None = None
+    for start, end in raw:
+        span = end - start
+        if carry_start is not None:
+            start = carry_start
+            span = end - start
+            carry_start = None
+        if not merged and span < min_segment:
+            carry_start = start
+            continue
+        if merged and span < min_segment:
+            prev_start, _prev_end = merged[-1]
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+    if carry_start is not None and merged:
+        prev_start, _prev_end = merged[-1]
+        merged[-1] = (prev_start, duration)
+
+    final: List[Segment] = []
+    seg_id = 1
+    for start, end in merged:
+        span = end - start
+        if span <= max_segment:
+            final.append(Segment(seg_id, round(start, 3), round(end, 3), round(span, 3)))
+            seg_id += 1
+            continue
+
+        pieces = max(2, math.ceil(span / max_segment))
+        step = span / pieces
+        cursor = start
+        for idx in range(pieces):
+            piece_end = end if idx == pieces - 1 else cursor + step
+            final.append(
+                Segment(
+                    id=seg_id,
+                    start=round(cursor, 3),
+                    end=round(piece_end, 3),
+                    duration=round(piece_end - cursor, 3),
+                )
+            )
+            seg_id += 1
+            cursor = piece_end
+    return final
+
+
+def sample_times(segment: Segment) -> List[float]:
+    if segment.duration <= 4:
+        return [round(segment.start + segment.duration / 2, 3)]
+    a = segment.start + segment.duration * 0.12
+    b = segment.start + segment.duration * 0.50
+    c = segment.end - segment.duration * 0.12
+    return sorted(
+        {
+            round(max(segment.start + 0.05, min(point, segment.end - 0.05)), 3)
+            for point in (a, b, c)
+        }
+    )
+
+
+def atempo_chain(speedup: float) -> str:
+    remaining = speedup
+    filters: List[str] = []
+    while remaining > 2.0:
+        filters.append("atempo=2.0")
+        remaining /= 2.0
+    while remaining < 0.5:
+        filters.append("atempo=0.5")
+        remaining /= 0.5
+    if abs(remaining - round(remaining)) < 1e-9:
+        filters.append(f"atempo={remaining:.1f}")
+    else:
+        filters.append(f"atempo={remaining:.5f}")
+    return ",".join(filters)
+
+
+def format_srt_timestamp(ts: float) -> str:
+    milliseconds = int(round((ts - int(ts)) * 1000))
+    total_seconds = int(ts)
+    seconds = total_seconds % 60
+    minutes = (total_seconds // 60) % 60
+    hours = total_seconds // 3600
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{milliseconds:03d}"
+
+
+def build_srt_text(narrations: Iterable[Mapping[str, object] | SegmentNarration]) -> str:
+    lines: List[str] = []
+    for index, item in enumerate(narrations, start=1):
+        record = asdict(item) if isinstance(item, SegmentNarration) else dict(item)
+        lines.extend(
+            [
+                str(index),
+                f"{format_srt_timestamp(float(record['start']))} --> {format_srt_timestamp(float(record['end']))}",
+                str(record["narration_zh"]),
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def write_srt_file(narrations: Iterable[Mapping[str, object] | SegmentNarration], out_path: Path) -> None:
+    out_path.write_text(build_srt_text(narrations), encoding="utf-8")
+
+
+def build_azure_tts_ssml(
+    *,
+    text: str,
+    voice: str,
+    rate: str = "+0%",
+    target_duration_ms: int | None = None,
+    style: str | None = None,
+) -> str:
+    duration_node = (
+        f'        <mstts:audioduration value="{int(target_duration_ms)}ms"/>\n'
+        if target_duration_ms
+        else ""
+    )
+    escaped_text = html.escape(text)
+    prosody = f'<prosody rate="{rate}">{escaped_text}</prosody>'
+    if style:
+        content = f'<mstts:express-as style="{html.escape(style)}">{prosody}</mstts:express-as>'
+    else:
+        content = prosody
+    return (
+        "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" "
+        "xmlns:mstts=\"https://www.w3.org/2001/mstts\" xml:lang=\"zh-CN\">\n"
+        f"  <voice name=\"{html.escape(voice)}\">\n"
+        f"{duration_node}"
+        f"    {content}\n"
+        "  </voice>\n"
+        "</speak>"
+    )
+
+
+def serialize_manifest(narrations: Sequence[SegmentNarration]) -> str:
+    return json.dumps([asdict(item) for item in narrations], ensure_ascii=False, indent=2)

--- a/tools/video_commentary/pipeline.py
+++ b/tools/video_commentary/pipeline.py
@@ -1,0 +1,539 @@
+"""End-to-end visual-first video commentary pipeline for Azure OpenAI + Azure Speech."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import List
+
+import requests
+
+try:
+    import imageio_ffmpeg
+except Exception as exc:  # pragma: no cover
+    imageio_ffmpeg = None
+    _IMAGEIO_IMPORT_ERROR = exc
+else:
+    _IMAGEIO_IMPORT_ERROR = None
+
+from .core import (
+    Segment,
+    SegmentNarration,
+    atempo_chain,
+    build_azure_tts_ssml,
+    build_segments,
+    normalize_terms,
+    sample_times,
+    serialize_manifest,
+    write_srt_file,
+)
+
+DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-21"
+DEFAULT_AZURE_SPEECH_VOICE = "zh-CN-XiaoxiaoNeural"
+DEFAULT_AZURE_SPEECH_STYLE = "professional"
+DEFAULT_OUTPUT_AUDIO_FORMAT = "audio-24khz-96kbitrate-mono-mp3"
+
+
+def env_required(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def find_ffmpeg() -> str:
+    if os.getenv("FFMPEG_BIN"):
+        return os.environ["FFMPEG_BIN"]
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+    if imageio_ffmpeg is not None:
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    raise SystemExit(
+        "ffmpeg not found. Install ffmpeg or imageio-ffmpeg. "
+        f"imageio-ffmpeg import error: {_IMAGEIO_IMPORT_ERROR!r}"
+    )
+
+
+def find_ffprobe(ffmpeg_bin: str) -> str:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe:
+        return ffprobe
+    candidate = str(Path(ffmpeg_bin).with_name("ffprobe"))
+    if Path(candidate).exists():
+        return candidate
+    raise SystemExit("ffprobe not found. Install ffprobe or make it adjacent to ffmpeg.")
+
+
+def run(cmd: List[str], *, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=check, text=True, capture_output=capture)
+
+
+def ffprobe_duration(ffprobe_bin: str, media_path: Path) -> float:
+    proc = run(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(media_path),
+        ]
+    )
+    return float(proc.stdout.strip())
+
+
+def detect_scene_cuts(ffmpeg_bin: str, video_path: Path, threshold: float) -> List[float]:
+    proc = run(
+        [
+            ffmpeg_bin,
+            "-hide_banner",
+            "-i",
+            str(video_path),
+            "-filter:v",
+            f"select='gt(scene,{threshold})',showinfo",
+            "-an",
+            "-f",
+            "null",
+            "-",
+        ],
+        check=False,
+    )
+    text = (proc.stderr or "") + "\n" + (proc.stdout or "")
+    matches = re.findall(r"pts_time:([0-9]+(?:\.[0-9]+)?)", text)
+    return sorted({round(float(item), 3) for item in matches if float(item) > 0})
+
+
+def extract_frame(ffmpeg_bin: str, video_path: Path, timestamp: float, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            ffmpeg_bin,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-ss",
+            f"{timestamp:.3f}",
+            "-i",
+            str(video_path),
+            "-frames:v",
+            "1",
+            str(out_path),
+        ]
+    )
+
+
+def image_to_data_url(path: Path) -> str:
+    mime = "image/jpeg" if path.suffix.lower() in {".jpg", ".jpeg"} else "image/png"
+    data = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{data}"
+
+
+def call_azure_openai_vision(*, frame_paths: List[Path], segment: Segment, previous_narration: str) -> dict:
+    endpoint = env_required("AZURE_OPENAI_ENDPOINT").rstrip("/")
+    api_key = env_required("AZURE_OPENAI_API_KEY")
+    deployment = env_required("AZURE_OPENAI_DEPLOYMENT")
+    api_version = os.getenv("AZURE_OPENAI_API_VERSION", DEFAULT_AZURE_OPENAI_API_VERSION)
+
+    max_chars = max(18, min(90, int(segment.duration * 8)))
+    user_prompt = textwrap.dedent(
+        f"""
+        你是视频讲解编辑。请仅根据提供的关键帧，为这一段视频生成“基于画面的中文讲解”。
+
+        目标：
+        1. 不要逐字朗读所有屏幕文字。
+        2. 优先讲当前画面在展示什么、焦点是什么、和上一段相比新增了什么。
+        3. 口吻要像自然中文口播，不要像 OCR 或图像描述。
+        4. 讲解必须能在大约 {segment.duration:.1f} 秒内说完，尽量控制在 {max_chars} 个中文字符以内。
+        5. 如画面信息很少，就简短说明“这里继续展示/演示……”。
+        6. 专名保持英文，例如 Azure AI Foundry、OpenAI、Mistral、Cohere、DeepSeek、GitHub、Copilot Studio。
+
+        时间窗：{segment.start:.3f}s - {segment.end:.3f}s
+        上一段讲解：{previous_narration or '无'}
+
+        只返回 JSON，不要 markdown，不要额外解释。格式：
+        {{
+          "title": "一句话标题",
+          "visible_points": ["要点1", "要点2"],
+          "on_screen_text": ["识别到的关键屏幕文本1", "关键文本2"],
+          "narration_zh": "1到3句自然中文讲解"
+        }}
+        """
+    ).strip()
+
+    content = [{"type": "text", "text": user_prompt}]
+    for path in frame_paths:
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": image_to_data_url(path), "detail": "low"},
+            }
+        )
+
+    payload = {
+        "messages": [
+            {
+                "role": "system",
+                "content": "你是擅长做产品演示和 slide 视频重述的中文讲解编辑。输出必须是有效 JSON。",
+            },
+            {"role": "user", "content": content},
+        ],
+        "temperature": 0.2,
+        "max_tokens": 900,
+    }
+    url = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+    response = requests.post(
+        url,
+        headers={"api-key": api_key, "Content-Type": "application/json"},
+        json=payload,
+        timeout=180,
+    )
+    response.raise_for_status()
+    raw = response.json()["choices"][0]["message"]["content"]
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", raw, re.S)
+        if not match:
+            raise RuntimeError(f"Model did not return JSON: {raw[:500]}")
+        parsed = json.loads(match.group(0))
+
+    parsed.setdefault("title", f"segment_{segment.id}")
+    parsed.setdefault("visible_points", [])
+    parsed.setdefault("on_screen_text", [])
+    parsed.setdefault("narration_zh", "这里展示了当前画面的核心内容。")
+    parsed["title"] = normalize_terms(str(parsed["title"]))
+    parsed["visible_points"] = [normalize_terms(str(item)) for item in parsed["visible_points"]][:6]
+    parsed["on_screen_text"] = [normalize_terms(str(item)) for item in parsed["on_screen_text"]][:8]
+    parsed["narration_zh"] = normalize_terms(str(parsed["narration_zh"]))
+    return parsed
+
+
+def azure_speech_token() -> str:
+    key = env_required("AZURE_SPEECH_KEY")
+    region = env_required("AZURE_SPEECH_REGION")
+    response = requests.post(
+        f"https://{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken",
+        headers={"Ocp-Apim-Subscription-Key": key},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def synthesize_azure_tts(
+    text: str,
+    out_path: Path,
+    *,
+    voice: str,
+    rate: str = "+0%",
+    target_duration_ms: int | None = None,
+    style: str | None = DEFAULT_AZURE_SPEECH_STYLE,
+) -> None:
+    token = azure_speech_token()
+    region = env_required("AZURE_SPEECH_REGION")
+    ssml = build_azure_tts_ssml(
+        text=text,
+        voice=voice,
+        rate=rate,
+        target_duration_ms=target_duration_ms,
+        style=style,
+    )
+    response = requests.post(
+        f"https://{region}.tts.speech.microsoft.com/cognitiveservices/v1",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/ssml+xml",
+            "X-Microsoft-OutputFormat": DEFAULT_OUTPUT_AUDIO_FORMAT,
+            "User-Agent": "visual-commentary-pipeline",
+        },
+        data=ssml.encode("utf-8"),
+        timeout=120,
+    )
+    response.raise_for_status()
+    out_path.write_bytes(response.content)
+
+
+def fit_audio_to_budget(
+    ffmpeg_bin: str,
+    ffprobe_bin: str,
+    src_audio: Path,
+    dst_audio: Path,
+    *,
+    budget_seconds: float,
+) -> float:
+    src_duration = ffprobe_duration(ffprobe_bin, src_audio)
+    if src_duration <= budget_seconds * 1.02:
+        shutil.copyfile(src_audio, dst_audio)
+        return src_duration
+    speedup = max(1.0, src_duration / max(0.6, budget_seconds))
+    run(
+        [
+            ffmpeg_bin,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(src_audio),
+            "-filter:a",
+            atempo_chain(speedup),
+            "-ar",
+            "24000",
+            "-ac",
+            "1",
+            str(dst_audio),
+        ]
+    )
+    return ffprobe_duration(ffprobe_bin, dst_audio)
+
+
+def compose_commentary_track(
+    ffmpeg_bin: str,
+    narrations: List[SegmentNarration],
+    *,
+    full_duration: float,
+    out_audio: Path,
+    temp_dir: Path,
+) -> None:
+    filter_file = temp_dir / "amix_filter.txt"
+    inputs = [
+        ffmpeg_bin,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-t",
+        f"{full_duration:.3f}",
+        "-i",
+        "anullsrc=r=24000:cl=mono",
+    ]
+    chains: List[str] = []
+    mix_inputs = ["[0:a]"]
+    for index, item in enumerate(narrations, start=1):
+        inputs.extend(["-i", item.fitted_audio_path])
+        delay_ms = max(0, int(round(item.start * 1000)))
+        chains.append(f"[{index}:a]adelay={delay_ms}|{delay_ms},volume=1.25[a{index}]")
+        mix_inputs.append(f"[a{index}]")
+    chains.append(
+        "".join(mix_inputs)
+        + f"amix=inputs={len(mix_inputs)}:duration=longest:normalize=0,"
+        "loudnorm=I=-16:TP=-1.5:LRA=11[mix]"
+    )
+    filter_file.write_text(";\n".join(chains), encoding="utf-8")
+    run(
+        inputs
+        + [
+            "-filter_complex_script",
+            str(filter_file),
+            "-map",
+            "[mix]",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            str(out_audio),
+        ]
+    )
+
+
+def mux_video(ffmpeg_bin: str, video_path: Path, commentary_audio: Path, srt_path: Path, output_path: Path) -> None:
+    run(
+        [
+            ffmpeg_bin,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(video_path),
+            "-i",
+            str(commentary_audio),
+            "-i",
+            str(srt_path),
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+            "-map",
+            "2:0",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            "-c:s",
+            "mov_text",
+            "-metadata:s:s:0",
+            "language=zho",
+            "-shortest",
+            str(output_path),
+        ]
+    )
+
+
+def narrate_video(args: argparse.Namespace) -> dict:
+    ffmpeg_bin = find_ffmpeg()
+    ffprobe_bin = find_ffprobe(ffmpeg_bin)
+
+    input_video = Path(args.input).expanduser().resolve()
+    output_video = Path(args.output).expanduser().resolve()
+    workdir = Path(args.workdir).expanduser().resolve()
+    frames_dir = workdir / "frames"
+    raw_audio_dir = workdir / "tts_raw"
+    fit_audio_dir = workdir / "tts_fit"
+    workdir.mkdir(parents=True, exist_ok=True)
+    frames_dir.mkdir(exist_ok=True)
+    raw_audio_dir.mkdir(exist_ok=True)
+    fit_audio_dir.mkdir(exist_ok=True)
+
+    duration = ffprobe_duration(ffprobe_bin, input_video)
+    cuts = detect_scene_cuts(ffmpeg_bin, input_video, args.scene_threshold)
+    segments = build_segments(
+        duration,
+        cuts,
+        min_segment=args.min_segment,
+        max_segment=args.max_segment,
+    )
+
+    narrations: List[SegmentNarration] = []
+    previous_narration = ""
+    for segment in segments:
+        seg_dir = frames_dir / f"seg_{segment.id:03d}"
+        seg_dir.mkdir(exist_ok=True)
+        frame_paths: List[Path] = []
+        for index, timestamp in enumerate(sample_times(segment), start=1):
+            frame_path = seg_dir / f"frame_{index:02d}.jpg"
+            extract_frame(ffmpeg_bin, input_video, timestamp, frame_path)
+            frame_paths.append(frame_path)
+
+        vision = call_azure_openai_vision(
+            frame_paths=frame_paths,
+            segment=segment,
+            previous_narration=previous_narration,
+        )
+        narration = SegmentNarration(
+            id=segment.id,
+            start=segment.start,
+            end=segment.end,
+            duration=segment.duration,
+            title=vision["title"],
+            visible_points=vision["visible_points"],
+            on_screen_text=vision["on_screen_text"],
+            narration_zh=vision["narration_zh"],
+            frame_paths=[str(path) for path in frame_paths],
+        )
+
+        raw_audio = raw_audio_dir / f"seg_{segment.id:03d}.mp3"
+        fitted_audio = fit_audio_dir / f"seg_{segment.id:03d}.mp3"
+        target_duration_ms = int(max(800, round((segment.duration - args.segment_buffer) * 1000)))
+        synthesize_azure_tts(
+            narration.narration_zh,
+            raw_audio,
+            voice=os.getenv("AZURE_SPEECH_VOICE", DEFAULT_AZURE_SPEECH_VOICE),
+            rate=args.base_rate,
+            target_duration_ms=target_duration_ms,
+            style=args.azure_style,
+        )
+        raw_duration = ffprobe_duration(ffprobe_bin, raw_audio)
+        fitted_duration = fit_audio_to_budget(
+            ffmpeg_bin,
+            ffprobe_bin,
+            raw_audio,
+            fitted_audio,
+            budget_seconds=max(0.8, segment.duration - args.segment_buffer),
+        )
+        narration.audio_path = str(raw_audio)
+        narration.audio_duration = round(raw_duration, 3)
+        narration.fitted_audio_path = str(fitted_audio)
+        narration.fitted_audio_duration = round(fitted_duration, 3)
+        narrations.append(narration)
+        previous_narration = narration.narration_zh
+
+        print(
+            f"[segment {segment.id:03d}] {segment.start:.2f}-{segment.end:.2f}s | {narration.narration_zh}"
+        )
+
+    srt_path = workdir / "commentary_zh.srt"
+    manifest_path = workdir / "commentary_manifest.json"
+    audio_mix_path = workdir / "commentary_zh.m4a"
+
+    write_srt_file(narrations, srt_path)
+    manifest_path.write_text(serialize_manifest(narrations), encoding="utf-8")
+    compose_commentary_track(
+        ffmpeg_bin,
+        narrations,
+        full_duration=duration,
+        out_audio=audio_mix_path,
+        temp_dir=workdir,
+    )
+    output_video.parent.mkdir(parents=True, exist_ok=True)
+    mux_video(ffmpeg_bin, input_video, audio_mix_path, srt_path, output_video)
+    return {
+        "input_video": str(input_video),
+        "output_video": str(output_video),
+        "manifest": str(manifest_path),
+        "srt": str(srt_path),
+        "audio": str(audio_mix_path),
+        "segments": len(narrations),
+        "duration": round(duration, 3),
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a Chinese commentary video from visual slide/demo content."
+    )
+    parser.add_argument("--input", required=True, help="Input video path")
+    parser.add_argument("--output", required=True, help="Output video path")
+    parser.add_argument("--workdir", required=True, help="Working directory")
+    parser.add_argument(
+        "--scene-threshold",
+        type=float,
+        default=0.32,
+        help="ffmpeg scene cut threshold (0.2~0.5 typical)",
+    )
+    parser.add_argument("--min-segment", type=float, default=3.0, help="Merge segments shorter than this")
+    parser.add_argument("--max-segment", type=float, default=12.0, help="Split segments longer than this")
+    parser.add_argument(
+        "--segment-buffer",
+        type=float,
+        default=0.35,
+        help="Reserve silence inside each segment",
+    )
+    parser.add_argument(
+        "--base-rate",
+        default="+0%",
+        help="Base Azure Speech SSML prosody rate, e.g. +5%%",
+    )
+    parser.add_argument(
+        "--azure-style",
+        default=DEFAULT_AZURE_SPEECH_STYLE,
+        help="Azure Speech mstts:express-as style, e.g. professional / calm / cheerful",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    print(json.dumps(narrate_video(args), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/website/docs/user-guide/features/video-commentary.md
+++ b/website/docs/user-guide/features/video-commentary.md
@@ -1,0 +1,134 @@
+---
+title: Visual-first video commentary
+sidebar_position: 6
+---
+
+# Visual-first video commentary
+
+Hermes now includes an engineering-friendly Python pipeline for turning a slide deck recording, UI walkthrough, or product demo into a **基于视频画面的中文讲解版**.
+
+This pipeline is intentionally **visual-first**, not a speech-to-speech translation layer. It looks at the video frames, detects presentation segments, asks an Azure OpenAI vision-capable deployment to summarize what changed on screen, and then uses Azure Speech to generate a Chinese narration track that fits each segment's time budget.
+
+## What it produces
+
+Given an input `.mp4`, the pipeline can generate:
+
+- a dubbed commentary video
+- a standalone mixed commentary audio track
+- a Chinese `.srt` subtitle file
+- a segment manifest JSON for review/regeneration workflows
+
+## Entry point
+
+```bash
+python scripts/visual_commentary_pipeline.py \
+  --input input.mp4 \
+  --output out/commentary_zh.mp4 \
+  --workdir out/work
+```
+
+## Required environment variables
+
+### Azure OpenAI
+
+```bash
+export AZURE_OPENAI_ENDPOINT="https://<resource>.openai.azure.com"
+export AZURE_OPENAI_API_KEY="..."
+export AZURE_OPENAI_DEPLOYMENT="<vision-capable deployment>"
+# optional
+export AZURE_OPENAI_API_VERSION="2024-10-21"
+```
+
+### Azure Speech
+
+```bash
+export AZURE_SPEECH_KEY="..."
+export AZURE_SPEECH_REGION="eastus"
+# optional
+export AZURE_SPEECH_VOICE="zh-CN-XiaoxiaoNeural"
+```
+
+## How timing control works
+
+For slide-by-slide narration, the best results come from combining three layers:
+
+1. **Segment-aware script generation** — the prompt asks the model to keep each narration short enough for the current segment.
+2. **Azure Speech SSML rate/style control** — the pipeline emits SSML with `prosody rate` and `mstts:express-as` style.
+3. **Azure `mstts:audioduration` targeting** — each TTS request can request a target duration for the segment before ffmpeg does any fallback tempo fitting.
+
+The pipeline therefore follows this strategy:
+
+- first shorten the text at generation time
+- then ask Azure Speech to aim for the segment budget
+- finally use ffmpeg `atempo` as a last-mile fit when the clip is still slightly too long
+
+This produces far more natural results than trying to stretch an entire full-video narration after the fact.
+
+## Useful flags
+
+```bash
+python scripts/visual_commentary_pipeline.py \
+  --input demo.mp4 \
+  --output out/demo_commentary.mp4 \
+  --workdir out/demo_work \
+  --scene-threshold 0.32 \
+  --min-segment 3 \
+  --max-segment 12 \
+  --segment-buffer 0.35 \
+  --base-rate "+0%" \
+  --azure-style professional
+```
+
+### Flag meanings
+
+- `--scene-threshold`: ffmpeg scene detection sensitivity
+- `--min-segment`: merge tiny cuts into neighboring segments
+- `--max-segment`: split overly long segments into smaller narration windows
+- `--segment-buffer`: reserve a little silence inside each segment
+- `--base-rate`: global SSML speaking-rate adjustment
+- `--azure-style`: Azure Speech expressive speaking style such as `professional`, `calm`, or `cheerful`
+
+## When this works best
+
+This pipeline is best for:
+
+- slide deck recordings
+- Azure / portal walkthroughs
+- product demos
+- dashboards and analytics demos
+- architecture explanation videos
+
+It is less suitable for:
+
+- dense multi-speaker conversational videos
+- videos where the main information is only in source audio
+- highly dynamic cinematic footage with no stable screen structure
+
+## Engineering layout
+
+The implementation is split into:
+
+- `tools/video_commentary/core.py` — reusable timing / SRT / SSML helpers
+- `tools/video_commentary/pipeline.py` — Azure + ffmpeg end-to-end pipeline
+- `scripts/visual_commentary_pipeline.py` — runnable script entrypoint
+- `tests/tools/test_video_commentary.py` — unit coverage for core helpers
+
+## Dependencies and assumptions
+
+The pipeline expects:
+
+- `ffmpeg` and `ffprobe` available on `PATH`, or `imageio-ffmpeg` installed
+- network access to Azure OpenAI and Azure Speech
+- an Azure OpenAI deployment that supports image input
+
+## Recommended workflow for productization
+
+If you're using this for a real deck-production workflow, keep each segment as a reviewable unit with:
+
+- segment start/end
+- generated Chinese narration
+- raw TTS clip duration
+- fitted clip duration
+- frame samples used for prompt grounding
+
+That makes it easy to selectively regenerate only one slide after script edits, voice changes, or glossary fixes.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -71,6 +71,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/vision',
             'user-guide/features/image-generation',
             'user-guide/features/tts',
+            'user-guide/features/video-commentary',
           ],
         },
         {


### PR DESCRIPTION
## Summary
- add a visual-first Azure OpenAI + Azure Speech video commentary pipeline
- split the MVP into reusable core and pipeline modules under tools/video_commentary
- add docs and unit tests for segment timing, SSML, and subtitle helpers

## Test Plan
- source /data/workspace/hermes-runtime/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_video_commentary.py -q
- source /data/workspace/hermes-runtime/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_video_commentary.py tests/tools/test_tts_speed.py -q
- source /data/workspace/hermes-runtime/hermes-agent/venv/bin/activate && python scripts/visual_commentary_pipeline.py --help

## Notes
- this pipeline targets 基于视频画面的中文讲解版 rather than speech translation
- Azure Speech timing control uses prosody rate + mstts:express-as + mstts:audioduration, with ffmpeg atempo as a fallback
