### PR TITLE
fix: preserve configured cwd in local terminal snapshots

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -294,7 +294,11 @@ class BaseEnvironment(ABC):
         instead of running with ``bash -l``.
         """
         # Full capture: env vars, functions (filtered), aliases, shell options.
+        quoted_init_cwd = (
+            shlex.quote(self.cwd) if self.cwd != "~" and not self.cwd.startswith("~/") else self.cwd
+        )
         bootstrap = (
+            f"cd {quoted_init_cwd} || exit 126\n"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"


### PR DESCRIPTION
## Summary
- cd into the configured working directory before capturing the local shell snapshot
- preserve the intended workspace for subsequent local terminal tool calls

## Problem
For local terminal environments, `init_session()` captured the shell snapshot before changing into the configured cwd. When Hermes was launched from its install repo, later terminal calls like `pwd` could resolve to the Hermes repo instead of the configured workspace.

## Reproduction
- configure `TERMINAL_CWD` to a project directory
- start Hermes from a different directory, such as the Hermes install repo
- run the local terminal tool with `pwd`
- observe that it returns the process cwd instead of the configured workspace

## Fix
- prepend `cd {self.cwd}` to the snapshot bootstrap script in `BaseEnvironment.init_session()`
- ensure the initial snapshot and persisted cwd are captured from the configured workspace

## Validation
- `python -m py_compile tools/environments/base.py`
- direct local reproduction now returns the configured workspace path instead of the Hermes repo path