### PR TITLE
fix(gateway): regression causing display.streaming to override root gateway streaming config

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -9,6 +9,10 @@ Resolution order (first non-None wins):
     3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
     4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
+Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
+top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
+sets an explicit per-platform override.
+
 Backward compatibility: ``display.tool_progress_overrides`` is still read as a
 fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
 config migration (version bump) automatically moves the old format into the new
@@ -143,10 +147,13 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>)
-    val = display_cfg.get(setting)
-    if val is not None:
-        return _normalise(setting, val)
+    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # that key controls only CLI terminal streaming; gateway token streaming is
+    # governed by the top-level streaming config plus per-platform overrides.
+    if setting != "streaming":
+        val = display_cfg.get(setting)
+        if val is not None:
+            return _normalise(setting, val)
 
     # 3. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -297,6 +297,15 @@ class TestStreamingPerPlatform:
         result = resolve_display_setting(config, "telegram", "streaming")
         assert result is None  # caller should check global StreamingConfig
 
+    def test_global_display_streaming_is_cli_only(self):
+        """display.streaming must not act as a gateway streaming override."""
+        from gateway.display_config import resolve_display_setting
+
+        for value in (True, False):
+            config = {"display": {"streaming": value}}
+            assert resolve_display_setting(config, "telegram", "streaming") is None
+            assert resolve_display_setting(config, "discord", "streaming") is None
+
     def test_explicit_false_disables(self):
         """Explicit False disables streaming for that platform."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -573,6 +573,27 @@ async def test_run_agent_streaming_does_not_enable_completed_interim_commentary(
 
 
 @pytest.mark.asyncio
+async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-display-streaming-cli-only",
+        config_data={
+            "display": {
+                "streaming": True,
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+    assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_interim_commentary_works_with_tool_progress_off(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,


### PR DESCRIPTION
## Summary

Salvage of PR #8347 by @asheriif — cherry-picked onto current main.

Fixes a regression introduced by PR #8006 (per-platform display config) where the CLI-only `display.streaming` config key leaks into gateway streaming decisions, causing streaming to be enabled on messaging platforms even when `streaming.enabled: false` is set.

The fix adds a guard in `resolve_display_setting()` to skip `display.streaming` at step 2 (global display settings), since that key only controls CLI terminal streaming. Gateway streaming is governed by the top-level `streaming` config, with per-platform overrides via `display.platforms.<platform>.streaming` still working.

Fixes #8338

## Changes
- `gateway/display_config.py` — skip `display.streaming` in global display resolution (step 2)
- `tests/gateway/test_display_config.py` — test that global `display.streaming` is ignored for gateway
- `tests/gateway/test_run_progress_topics.py` — integration test: `display.streaming: true` + `streaming.enabled: false` does NOT enable gateway streaming

## Test results
- 101 targeted tests passed (display_config + run_progress_topics + stream_consumer)
- 2799/2799 gateway tests passed (7 pre-existing failures in unrelated areas)

Credit: @asheriif (original implementation)