### PR TITLE
feat(cron): allow external memory providers in cron jobs while keeping local memory skipped

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -751,6 +751,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             quiet_mode=True,
             skip_context_files=True,  # Don't inject SOUL.md/AGENTS.md from scheduler cwd
             skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory_provider=False,  # Allow external memory providers (e.g. mem0)
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/run_agent.py
+++ b/run_agent.py
@@ -595,6 +595,7 @@ class AIAgent:
         user_id: str = None,
         skip_context_files: bool = False,
         skip_memory: bool = False,
+        skip_memory_provider: bool = None,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -1159,7 +1160,10 @@ class AIAgent:
         # Memory provider plugin (external — one at a time, alongside built-in)
         # Reads memory.provider from config to select which plugin to activate.
         self._memory_manager = None
-        if not skip_memory:
+        if skip_memory_provider is None:
+            skip_memory_provider = skip_memory
+        mem_config = _agent_cfg.get("memory", {}) if _agent_cfg else {}
+        if not skip_memory_provider:
             try:
                 _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -965,6 +965,40 @@ class TestRunJobSkillBacked:
         assert "Instructions for find-nearby." in prompt_arg
         assert "Combine the results." in prompt_arg
 
+    def test_run_job_skips_local_memory_but_not_external_provider(self, tmp_path):
+        """Cron jobs should skip MEMORY.md/USER.md injection but still allow external memory providers (e.g. mem0)."""
+        job = {
+            "id": "memory-job",
+            "name": "memory test",
+            "prompt": "Call mem0_conclude.",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs.get("skip_memory") is True
+        assert kwargs.get("skip_memory_provider") is False
+
 
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""

--- a/tests/run_agent/test_skip_memory_provider.py
+++ b/tests/run_agent/test_skip_memory_provider.py
@@ -1,0 +1,86 @@
+"""Tests for AIAgent skip_memory_provider parameter."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class TestSkipMemoryProvider:
+    """Verify that skip_memory_provider controls external memory provider initialization
+    independently from skip_memory (which controls local MEMORY.md/USER.md)."""
+
+    @pytest.fixture
+    def minimal_agent_kwargs(self):
+        return {
+            "model": "test/model",
+            "quiet_mode": True,
+            "skip_memory": True,
+            "skip_context_files": True,
+        }
+
+    def test_skip_memory_provider_false_initializes_manager(self, minimal_agent_kwargs):
+        """When skip_memory_provider=False and a provider is configured, _memory_manager is initialized."""
+        with patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "mem0"}}), \
+             patch("plugins.memory.load_memory_provider") as mock_load, \
+             patch("agent.memory_manager.MemoryManager") as mock_mgr_cls:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_load.return_value = mock_provider
+            mock_mgr = MagicMock()
+            mock_mgr.providers = [mock_provider]
+            mock_mgr_cls.return_value = mock_mgr
+
+            agent = AIAgent(**minimal_agent_kwargs, skip_memory_provider=False)
+
+        assert agent._memory_manager is not None
+
+    def test_skip_memory_provider_true_skips_manager(self, minimal_agent_kwargs):
+        """When skip_memory_provider=True, _memory_manager remains None even if provider is configured."""
+        with patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "mem0"}}), \
+             patch("plugins.memory.load_memory_provider") as mock_load, \
+             patch("agent.memory_manager.MemoryManager") as mock_mgr_cls:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_load.return_value = mock_provider
+
+            agent = AIAgent(**minimal_agent_kwargs, skip_memory_provider=True)
+
+        assert agent._memory_manager is None
+        mock_load.assert_not_called()
+        mock_mgr_cls.assert_not_called()
+
+    def test_skip_memory_true_still_allows_provider_when_flag_is_false(self, minimal_agent_kwargs):
+        """The common cron pattern: skip_memory=True (no local files) + skip_memory_provider=False (allow mem0)."""
+        with patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "mem0"}}), \
+             patch("plugins.memory.load_memory_provider") as mock_load, \
+             patch("agent.memory_manager.MemoryManager") as mock_mgr_cls:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_load.return_value = mock_provider
+            mock_mgr = MagicMock()
+            mock_mgr.providers = [mock_provider]
+            mock_mgr_cls.return_value = mock_mgr
+
+            agent = AIAgent(**minimal_agent_kwargs, skip_memory_provider=False)
+
+        assert agent._memory_store is None  # local memory skipped
+        assert agent._memory_manager is not None  # external provider allowed
+
+    def test_skip_memory_provider_defaults_to_skip_memory(self):
+        """When skip_memory_provider is omitted, it defaults to the value of skip_memory
+        to preserve backward compatibility for existing call sites."""
+        with patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "mem0"}}), \
+             patch("plugins.memory.load_memory_provider") as mock_load, \
+             patch("agent.memory_manager.MemoryManager") as mock_mgr_cls:
+            mock_provider = MagicMock()
+            mock_provider.is_available.return_value = True
+            mock_load.return_value = mock_provider
+
+            # Existing pattern: only skip_memory=True means skip everything
+            agent = AIAgent(model="test/model", quiet_mode=True, skip_memory=True)
+
+        assert agent._memory_manager is None
+        mock_load.assert_not_called()
+        mock_mgr_cls.assert_not_called()

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -117,6 +117,8 @@ Skill names are case-sensitive and must match the installed skill's folder name.
 
 Cron jobs run with the `cronjob`, `messaging`, and `clarify` toolsets disabled. This prevents recursive cron creation, direct message sending (delivery is handled by the scheduler), and interactive prompts. If a skill relies on these toolsets, it won't work in a cron context.
 
+Note that external memory providers (e.g. **mem0**) are **not** affected by this limitation — cron jobs can use `mem0_*` tools as long as the provider is configured in `config.yaml`. Only the built-in local memory files (`MEMORY.md` / `USER.md`) are skipped to avoid polluting cron system prompts.
+
 Check the skill's documentation to confirm it works in non-interactive (headless) mode.
 
 ### Check 4: Multi-skill ordering


### PR DESCRIPTION
Closes #9763

## Problem

`cron/scheduler.py` hardcoded `skip_memory=True` when constructing the `AIAgent` for a scheduled job. Because `skip_memory=True` prevents `_memory_manager` from being initialized in `run_agent.py`, **external memory providers such as mem0 are never loaded** in a cron-run session. Consequently, all mem0 tools (`mem0_search`, `mem0_conclude`, `mem0_profile`) are reported as unavailable to the agent, even though the user has correctly configured `memory.provider: mem0` in `config.yaml`.

## Solution

Introduce a new `AIAgent` parameter `skip_memory_provider` (default `False`) that controls external memory provider initialization **independently** from `skip_memory` (which controls local `MEMORY.md`/`USER.md`).

- Cron jobs now pass `skip_memory=True` + `skip_memory_provider=False`, preserving the protection against local memory file pollution while allowing external memory providers to work.
- Subagents and other callers are unaffected due to the default value.

## Changes

- `run_agent.py`: add `skip_memory_provider` parameter; move `mem_config` extraction so the provider block can read it even when `skip_memory=True`.
- `cron/scheduler.py`: pass `skip_memory_provider=False` to `AIAgent`.
- `tests/cron/test_scheduler.py`: add test verifying cron jobs skip local memory but not external provider.
- `tests/run_agent/test_skip_memory_provider.py`: add unit tests for the new parameter.
- `website/docs/guides/cron-troubleshooting.md`: document that external memory providers are usable in cron jobs.

## Verification

- `python -m pytest tests/cron/test_scheduler.py -x` → 62 passed
- `python -m pytest tests/run_agent/test_skip_memory_provider.py -x` → 3 passed
