### PR TITLE
fix: prepend primary model as fallback when smart routing selects cheap model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2868,6 +2868,23 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+
+            # When smart routing selected a cheap model, prepend the primary
+            # model as the first fallback so the agent retries on the strong
+            # model before giving up or falling through to user-configured
+            # fallback providers.
+            effective_fallback = self._fallback_model
+            if route_label is not None:
+                primary_fb = {
+                    "provider": self.provider,
+                    "model": self.model,
+                    "base_url": self.base_url or "",
+                }
+                if isinstance(effective_fallback, list):
+                    effective_fallback = [primary_fb] + list(effective_fallback)
+                else:
+                    effective_fallback = [primary_fb]
+
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -2898,7 +2915,7 @@ class HermesCLI:
                 clarify_callback=self._clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
 
-                fallback_model=self._fallback_model,
+                fallback_model=effective_fallback,
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -713,6 +713,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
 
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
+
+        # When smart routing selected a cheap model, prepend the primary model
+        # as the first fallback so a 403 retries on the strong model first.
+        if turn_route.get("label") is not None:
+            primary_fb = {
+                "provider": runtime.get("provider", ""),
+                "model": model,
+                "base_url": runtime.get("base_url", ""),
+            }
+            if isinstance(fallback_model, list):
+                fallback_model = [primary_fb] + list(fallback_model)
+            else:
+                fallback_model = [primary_fb] if fallback_model is None else [primary_fb, fallback_model]
+
         credential_pool = None
         runtime_provider = str(turn_route["runtime"].get("provider") or "").strip().lower()
         if runtime_provider:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1302,6 +1302,26 @@ class GatewayRunner:
         return None
 
     @staticmethod
+    def _effective_fallback(turn_route: dict, fallback_model, primary_model: str, primary_provider: str, primary_base_url: str = "") -> list | dict | None:
+        """Prepend the primary model as first fallback when smart routing is active.
+
+        When a cheap model was selected via smart routing (turn_route["label"] is
+        not None), the agent should fall back to the primary (strong) model before
+        trying any user-configured fallback providers.  This ensures a 403 from an
+        unsupported cheap model doesn't kill the request outright.
+        """
+        if turn_route.get("label") is None:
+            return fallback_model
+        primary_fb = {
+            "provider": primary_provider,
+            "model": primary_model,
+            "base_url": primary_base_url or "",
+        }
+        if isinstance(fallback_model, list):
+            return [primary_fb] + list(fallback_model)
+        return [primary_fb] if fallback_model is None else [primary_fb, fallback_model]
+
+    @staticmethod
     def _load_smart_model_routing() -> dict:
         """Load optional smart cheap-vs-strong model routing config."""
         try:
@@ -5381,7 +5401,11 @@ class GatewayRunner:
                     platform=platform_key,
                     user_id=source.user_id,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=self._effective_fallback(
+                        turn_route, self._fallback_model,
+                        model, runtime_kwargs.get("provider", ""),
+                        runtime_kwargs.get("base_url", ""),
+                    ),
                 )
 
                 return agent.run_conversation(
@@ -5561,7 +5585,11 @@ class GatewayRunner:
                     session_id=task_id,
                     platform=platform_key,
                     session_db=None,
-                    fallback_model=self._fallback_model,
+                    fallback_model=self._effective_fallback(
+                        turn_route, self._fallback_model,
+                        model, runtime_kwargs.get("provider", ""),
+                        runtime_kwargs.get("base_url", ""),
+                    ),
                     skip_memory=True,
                     skip_context_files=True,
                     persist_session=False,
@@ -7916,7 +7944,11 @@ class GatewayRunner:
                     platform=platform_key,
                     user_id=source.user_id,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=self._effective_fallback(
+                        turn_route, self._fallback_model,
+                        model, runtime_kwargs.get("provider", ""),
+                        runtime_kwargs.get("base_url", ""),
+                    ),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/tests/agent/test_smart_route_primary_fallback.py
+++ b/tests/agent/test_smart_route_primary_fallback.py
@@ -1,0 +1,70 @@
+"""Tests for smart-route → primary-model fallback injection.
+
+When smart model routing selects a cheap model, the primary (strong) model
+should be prepended to the fallback chain so that a 403 from the cheap model
+provider retries on the primary before giving up.
+"""
+from gateway.run import GatewayRunner
+
+
+# -- GatewayRunner._effective_fallback (static method) -----------------------
+
+def test_no_injection_when_label_is_none():
+    """When turn_route['label'] is None (primary model used), return fallback unchanged."""
+    turn_route = {"label": None, "model": "claude-opus-4-6", "runtime": {}}
+    existing_fb = [{"provider": "openai", "model": "gpt-4o", "base_url": ""}]
+    result = GatewayRunner._effective_fallback(
+        turn_route, existing_fb, "claude-opus-4-6", "copilot",
+    )
+    assert result is existing_fb  # exact same object, untouched
+
+
+def test_prepends_primary_when_label_set_and_no_existing_fallback():
+    """When smart route active and no user fallback, create a list with just the primary."""
+    turn_route = {"label": "smart route → gpt-5-mini (copilot)", "model": "gpt-5-mini"}
+    result = GatewayRunner._effective_fallback(
+        turn_route, None, "claude-opus-4-6", "copilot", "https://api.githubcopilot.com",
+    )
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["model"] == "claude-opus-4-6"
+    assert result[0]["provider"] == "copilot"
+    assert result[0]["base_url"] == "https://api.githubcopilot.com"
+
+
+def test_prepends_primary_when_label_set_and_existing_list_fallback():
+    """When smart route active and user has a fallback list, primary goes first."""
+    turn_route = {"label": "smart route → gpt-5-mini (copilot)"}
+    existing_fb = [
+        {"provider": "openai", "model": "gpt-4o", "base_url": ""},
+    ]
+    result = GatewayRunner._effective_fallback(
+        turn_route, existing_fb, "claude-opus-4-6", "copilot",
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["model"] == "claude-opus-4-6"
+    assert result[0]["provider"] == "copilot"
+    assert result[1] == existing_fb[0]
+
+
+def test_prepends_primary_when_label_set_and_existing_dict_fallback():
+    """When smart route active and user has a legacy dict fallback, produce [primary, dict]."""
+    turn_route = {"label": "smart route → gpt-5-mini (copilot)"}
+    existing_fb = {"provider": "openai", "model": "gpt-4o"}
+    result = GatewayRunner._effective_fallback(
+        turn_route, existing_fb, "claude-opus-4-6", "copilot",
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["model"] == "claude-opus-4-6"
+    assert result[1] is existing_fb
+
+
+def test_base_url_defaults_to_empty_string():
+    """If no base_url is passed, the fallback entry should have ''."""
+    turn_route = {"label": "smart route → cheap"}
+    result = GatewayRunner._effective_fallback(
+        turn_route, None, "my-model", "my-provider",
+    )
+    assert result[0]["base_url"] == ""


### PR DESCRIPTION
## Summary

When smart model routing selects a cheap model (e.g. `gpt-5-mini`) for simple prompts, a non-retryable error from the cheap model's provider (e.g. HTTP 403 because the provider doesn't support that model) would abort the entire request immediately — even though the primary (strong) model would have worked fine.

This PR prepends the primary model as the **first entry** in the fallback chain whenever smart routing is active, so the retry sequence becomes:

1. Try cheap model (e.g. `gpt-5-mini` via copilot) → 403
2. **Fall back to primary model** (e.g. `claude-opus-4-6` via copilot) → works ✓
3. Then any user-configured fallback providers (if primary also fails)

When smart routing is not active (`label` is `None`), the fallback chain is left completely untouched.

## Reproduction

```
⚠️  API call failed (attempt 1/3): PermissionDeniedError [HTTP 403]
   🔌 Provider: copilot  Model: gpt-5-mini
   📝 Error: Access to this endpoint is forbidden.
⚠️ Non-retryable error (HTTP 403) — trying fallback...
❌ Non-retryable client error (HTTP 403). Aborting.
```

This happens when:
- `smart_model_routing` is enabled in `config.yaml`
- The cheap model (e.g. `gpt-5-mini`) is not available on the provider
- No fallback chain includes the primary model

## Changes

| File | Change |
|------|--------|
| `cli.py` | Build `effective_fallback` in `_init_agent()` when `route_label` is set |
| `gateway/run.py` | Add `_effective_fallback()` static helper; apply to all 3 AIAgent creation sites (background tasks, /btw, main handler) |
| `cron/scheduler.py` | Inline fallback injection after `resolve_turn_route` |
| `tests/agent/test_smart_route_primary_fallback.py` | 5 new tests covering: no-op when label is None, no existing fallback, list fallback, dict fallback, empty base_url |

## Test Plan

- [x] All 6 existing `test_smart_model_routing.py` tests pass
- [x] All 5 new `test_smart_route_primary_fallback.py` tests pass
- [x] Manual verification: agent with copilot provider + smart routing enabled no longer crashes on `gpt-5-mini` 403 — falls back to primary model

## Related Issues

Partially related to #6673 (cron fallback chain was missing entirely — that's now fixed in the codebase, and this PR adds smart-route-aware primary injection on top).