### PR TITLE
fix(openviking): correct account default

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,7 +10,7 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account (default: root)
+  OPENVIKING_ACCOUNT   — Tenant account (default: default)
   OPENVIKING_USER      — Tenant user (default: default)
 
 Capabilities:
@@ -83,7 +83,7 @@ class _VikingClient:
                  account: str = "", user: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
+        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._httpx = _get_httpx()
         if self._httpx is None:
@@ -282,9 +282,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "api_key",
-                "description": "OpenViking API key",
+                "description": "OpenViking API key (leave blank for local dev mode)",
                 "secret": True,
                 "env_var": "OPENVIKING_API_KEY",
+            },
+            {
+                "key": "account",
+                "description": "OpenViking tenant account ID (default, used when local mode, OPENVIKING_API_KEY is empty)",
+                "default": "default",
+                "env_var": "OPENVIKING_ACCOUNT",
+            },
+            {
+                "key": "user",
+                "description": "OpenViking user ID within the account (default, used when local mode, OPENVIKING_API_KEY is empty)",
+                "default": "default",
+                "env_var": "OPENVIKING_USER",
             },
         ]
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -85,6 +85,7 @@ class _VikingClient:
         self._api_key = api_key
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
+        self._agent = user or os.environ.get("OPENVIKING_AGENT", "hermes")
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -94,6 +95,7 @@ class _VikingClient:
             "Content-Type": "application/json",
             "X-OpenViking-Account": self._account,
             "X-OpenViking-User": self._user,
+            "X-OpenViking-Agent": self._agent,
         }
         if self._api_key:
             h["X-API-Key"] = self._api_key
@@ -288,15 +290,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "account",
-                "description": "OpenViking tenant account ID (default, used when local mode, OPENVIKING_API_KEY is empty)",
+                "description": "OpenViking tenant account ID ([default], used when local mode, OPENVIKING_API_KEY is empty)",
                 "default": "default",
                 "env_var": "OPENVIKING_ACCOUNT",
             },
             {
                 "key": "user",
-                "description": "OpenViking user ID within the account (default, used when local mode, OPENVIKING_API_KEY is empty)",
+                "description": "OpenViking user ID within the account ([default], used when local mode, OPENVIKING_API_KEY is empty)",
                 "default": "default",
                 "env_var": "OPENVIKING_USER",
+            },
+            {
+                "key": "agent",
+                "description": "OpenViking agent ID within the account ([hermes], useful in multi-agent mode)",
+                "default": "hermes",
+                "env_var": "OPENVIKING_AGENT",
             },
         ]
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -81,12 +81,12 @@ class _VikingClient:
     """Thin HTTP client for the OpenViking REST API."""
 
     def __init__(self, endpoint: str, api_key: str = "",
-                 account: str = "", user: str = ""):
+                 account: str = "", user: str = "", agent: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
         self._user = user or os.environ.get("OPENVIKING_USER", "default")
-        self._agent = user or os.environ.get("OPENVIKING_AGENT", "hermes")
+        self._agent = agent or os.environ.get("OPENVIKING_AGENT", "hermes")
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -312,11 +312,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
         self._api_key = os.environ.get("OPENVIKING_API_KEY", "")
+        self._account = os.environ.get("OPENVIKING_ACCOUNT", "default")
+        self._user = os.environ.get("OPENVIKING_USER", "default")
+        self._agent = os.environ.get("OPENVIKING_AGENT", "hermes")
         self._session_id = session_id
         self._turn_count = 0
 
         try:
-            self._client = _VikingClient(self._endpoint, self._api_key)
+            self._client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
             if not self._client.health():
                 logger.warning("OpenViking server at %s is not reachable", self._endpoint)
                 self._client = None
@@ -372,7 +378,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                client = _VikingClient(self._endpoint, self._api_key)
+                client = _VikingClient(
+                    self._endpoint, self._api_key,
+                    account=self._account, user=self._user, agent=self._agent,
+                )
                 resp = client.post("/api/v1/search/find", {
                     "query": query,
                     "top_k": 5,
@@ -407,7 +416,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _sync():
             try:
-                client = _VikingClient(self._endpoint, self._api_key)
+                client = _VikingClient(
+                    self._endpoint, self._api_key,
+                    account=self._account, user=self._user, agent=self._agent,
+                )
                 sid = self._session_id
 
                 # Add user message
@@ -463,7 +475,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _write():
             try:
-                client = _VikingClient(self._endpoint, self._api_key)
+                client = _VikingClient(
+                    self._endpoint, self._api_key,
+                    account=self._account, user=self._user, agent=self._agent,
+                )
                 # Add as a user message with memory context so the commit
                 # picks it up as an explicit memory during extraction
                 client.post(f"/api/v1/sessions/{self._session_id}/messages", {

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -12,6 +12,7 @@ Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
   OPENVIKING_ACCOUNT   — Tenant account (default: default)
   OPENVIKING_USER      — Tenant user (default: default)
+  OPENVIKING_AGENT   — Tenant agent (default: hermes)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -192,6 +192,7 @@ AUTHOR_MAP = {
     "zhouboli@gmail.com": "zhouboli",
     "zqiao@microsoft.com": "tomqiaozc",
     "zzn+pa@zzn.im": "xinbenlv",
+    "zaynjarvis@gmail.com": "ZaynJarvis",
 }
 
 


### PR DESCRIPTION
This PR changes the default OPENVIKING_ACCOUNT from 'root' to 'default', making dev API mode take effect.

Changes:

- Change default OPENVIKING_ACCOUNT from 'root' to 'default'
- Add account and user config options to get_config_schema()
- Update docstring to reflect new default
- Change default OPENVIKING_ACCOUNT from 'root' to 'default' (for default "mostly" local mode users)
- Add account and user config options to get_config_schema(), so set it in setup
- Update docstring to reflect new default, as in how it works, why should use default

Breaking change notice:
Existing users who relied on the 'root' account will need to either: (but unlikely there will be such users, ov happy to assist if there are.)
1. Set OPENVIKING_ACCOUNT=root in their environment, or

2. Migrate their data to the 'default' account

Reproduce:

1. install openviking uv tool install openviking or uv tool upgrade openviking, setup with local mode and no OPENVIKING_API_KEY
```
example ~/.openviking/ov.conf:
{
  "log": {"level": "debug"},
  "server": {"root_api_key": ""},
  "storage": {
    "workspace": "~/.openviking/data"
  },
  "embedding": {
    "dense": {
      "api_base" : "https://api.openai.com/v1",
      "api_key"  : "sk-proj-...wA",
      "provider": "openai",
      "dimension": 1024,
      "model"    : "text-embedding-3-small"
    }
  },
  "vlm": {
    "api_base" : "https://api.openai.com/v1",
    "api_key"  : "sk-proj-...wA",
    "provider"  : "openai",
    "model"    : "gpt-5.4-nano"
  }
}
```
2. run ov ls viking://session/default -s to check existing sessions
3. run this extracted curl with root, to add message
```
curl -X POST "http://127.0.0.1:1933/api/v1/sessions/yyy/messages" \
       -H "Content-Type: application/json" \
       -H "X-OpenViking-Account: root" \
       -H "X-OpenViking-User: default" \
       -H "X-API-Key: " -d '{
         "role": "user",
         "parts": [
           {"type": "text", "text": "[Remember] User prefer responses in Chinese"}
         ]
       }'
```
4. run ov ls viking://session/default -s to check existing sessions again, it won't show new session stored
5. run the updated default account
```
curl -X POST "http://127.0.0.1:1933/api/v1/sessions/yyy/messages" \
       -H "Content-Type: application/json" \
       -H "X-OpenViking-Account: default" \
       -H "X-OpenViking-User: default" \
       -H "X-API-Key: " -d '{
         "role": "user",
         "parts": [
           {"type": "text", "text": "[Remember] User prefer responses in Chinese"}
         ]
       }'
```
6. ov ls viking://session/default -s will show new session.

issue reproduce screenshot:
<img width="1774" height="1420" alt="image" src="https://github.com/user-attachments/assets/f3ae7a49-fc7d-4ce3-9740-1faf458b5b98" />


correct e2e test reproduce (after fix)
<img width="2086" height="1138" alt="image" src="https://github.com/user-attachments/assets/2b17c991-fdd3-45fe-9fc8-4c32aebb18ef" />