### PR TITLE
fix(colors): readable defaults on light terminals via HERMES_THEME + COLORFGBG

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from typing import Optional
 
 
 def should_use_color() -> bool:
@@ -31,8 +32,82 @@ class Colors:
     CYAN = "\033[36m"
 
 
+# Per issue #8526: on light-background terminals (e.g. the default macOS
+# Terminal.app profile), yellow text renders near-invisible against white
+# and dim text loses nearly all contrast. In "light" mode we swap those
+# two codes for high-contrast alternatives. Red/green/cyan/blue already
+# have acceptable contrast on both backgrounds and are left alone so
+# existing semantic meaning (error=red, ok=green, info=cyan) is preserved.
+_LIGHT_REMAP = {
+    Colors.YELLOW: Colors.MAGENTA,
+    # Dropping DIM means the text renders in the terminal's default
+    # foreground, which on a light background is a dark color and is
+    # comfortably readable.
+    Colors.DIM: "",
+}
+
+
+def _parse_colorfgbg_bg(value: str) -> Optional[int]:
+    """Return the background color index from a COLORFGBG value, or None.
+
+    COLORFGBG is conventionally ``<fg>;<bg>`` (sometimes with a middle
+    segment). Only the trailing segment is the background. Non-integer
+    values (e.g. ``default``) yield None so callers can fall through
+    rather than guessing.
+    """
+    if not value:
+        return None
+    parts = value.split(";")
+    if not parts:
+        return None
+    bg = parts[-1].strip()
+    try:
+        return int(bg)
+    except ValueError:
+        return None
+
+
+def _detect_theme_from_colorfgbg() -> Optional[str]:
+    """Best-effort background-color detection from the COLORFGBG env var.
+
+    Returns ``"light"`` for indices commonly used for white / light-grey
+    backgrounds (7, 15), ``"dark"`` for clearly dark indices (0-6, 8),
+    and ``None`` otherwise so we fall back to the default behavior.
+    """
+    bg = _parse_colorfgbg_bg(os.environ.get("COLORFGBG", ""))
+    if bg is None:
+        return None
+    if bg in (7, 15):
+        return "light"
+    if 0 <= bg <= 6 or bg == 8:
+        return "dark"
+    return None
+
+
+def _resolve_theme() -> Optional[str]:
+    """Return ``"light"``, ``"dark"``, or ``None`` (unknown / default).
+
+    Priority:
+
+    1. ``HERMES_THEME`` env var — ``light`` / ``dark`` are explicit
+       overrides; ``auto`` (or unset) falls through to step 2.
+    2. ``COLORFGBG``-based auto-detection.
+
+    Anything else (including unrecognized ``HERMES_THEME`` values) returns
+    ``None`` so callers keep their current dark-optimized defaults.
+    """
+    explicit = (os.environ.get("HERMES_THEME") or "").strip().lower()
+    if explicit in ("light", "dark"):
+        return explicit
+    if explicit in ("", "auto"):
+        return _detect_theme_from_colorfgbg()
+    return None
+
+
 def color(text: str, *codes) -> str:
     """Apply color codes to text (only when color output is appropriate)."""
     if not should_use_color():
         return text
+    if _resolve_theme() == "light":
+        codes = tuple(_LIGHT_REMAP.get(c, c) for c in codes)
     return "".join(codes) + text + Colors.RESET

--- a/tests/hermes_cli/test_colors.py
+++ b/tests/hermes_cli/test_colors.py
@@ -1,0 +1,194 @@
+"""Tests for hermes_cli.colors theme handling (issue #8526).
+
+These tests cover:
+  * ``NO_COLOR`` still wins over any theme configuration.
+  * ``HERMES_THEME=light|dark`` takes priority over ``COLORFGBG``.
+  * ``COLORFGBG``-based auto-detection is only consulted when
+    ``HERMES_THEME`` is unset or set to ``auto``.
+  * In light mode, yellow/dim text is remapped to codes that are
+    readable on a white background; every other ANSI code is left
+    untouched so semantic meaning (error=red, ok=green, info=cyan)
+    is preserved.
+"""
+
+import sys
+
+import pytest
+
+from hermes_cli.colors import (
+    Colors,
+    _resolve_theme,
+    color,
+    should_use_color,
+)
+
+
+class _FakeTTY:
+    """Minimal stdout stub whose ``isatty`` returns True."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+@pytest.fixture
+def tty(monkeypatch):
+    """Pretend stdout is a TTY so ``color()`` does not short-circuit."""
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Clear every env var that influences theme resolution."""
+    for var in ("NO_COLOR", "TERM", "HERMES_THEME", "COLORFGBG"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestShouldUseColor:
+    def test_no_color_env_disables_color(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert should_use_color() is False
+
+    def test_no_color_empty_string_still_disables_color(self, monkeypatch, tty, clean_env):
+        # Per https://no-color.org/ the presence of NO_COLOR — even empty — disables color.
+        monkeypatch.setenv("NO_COLOR", "")
+        assert should_use_color() is False
+
+    def test_no_color_wins_over_hermes_theme(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("HERMES_THEME", "light")
+        # Even with light theme explicitly set, NO_COLOR still disables color.
+        assert color("x", Colors.YELLOW) == "x"
+
+    def test_term_dumb_disables_color(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("TERM", "dumb")
+        assert should_use_color() is False
+
+
+class TestResolveTheme:
+    def test_hermes_theme_light(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "light")
+        assert _resolve_theme() == "light"
+
+    def test_hermes_theme_dark(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "dark")
+        assert _resolve_theme() == "dark"
+
+    def test_hermes_theme_is_case_insensitive(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "LIGHT")
+        assert _resolve_theme() == "light"
+
+    def test_hermes_theme_with_whitespace(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "  dark  ")
+        assert _resolve_theme() == "dark"
+
+    def test_auto_falls_back_to_colorfgbg_light(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "auto")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert _resolve_theme() == "light"
+
+    def test_unset_falls_back_to_colorfgbg_light(self, monkeypatch, clean_env):
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert _resolve_theme() == "light"
+
+    def test_colorfgbg_dark_bg(self, monkeypatch, clean_env):
+        monkeypatch.setenv("COLORFGBG", "15;0")
+        assert _resolve_theme() == "dark"
+
+    def test_colorfgbg_light_grey_bg(self, monkeypatch, clean_env):
+        monkeypatch.setenv("COLORFGBG", "0;7")
+        assert _resolve_theme() == "light"
+
+    def test_colorfgbg_default_segment_returns_none(self, monkeypatch, clean_env):
+        # Some terminals report "default" instead of a numeric background.
+        # We don't guess — fall through so callers keep their current defaults.
+        monkeypatch.setenv("COLORFGBG", "0;default")
+        assert _resolve_theme() is None
+
+    def test_colorfgbg_three_segments_uses_last(self, monkeypatch, clean_env):
+        # rxvt reports ``fg;?;bg`` with a middle marker.
+        monkeypatch.setenv("COLORFGBG", "15;default;0")
+        assert _resolve_theme() == "dark"
+
+    def test_hermes_theme_overrides_colorfgbg(self, monkeypatch, clean_env):
+        # User's explicit choice must win over COLORFGBG auto-detection.
+        monkeypatch.setenv("HERMES_THEME", "dark")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert _resolve_theme() == "dark"
+
+    def test_unrecognized_hermes_theme_value_returns_none(self, monkeypatch, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "sepia")
+        assert _resolve_theme() is None
+
+    def test_no_env_returns_none(self, clean_env):
+        assert _resolve_theme() is None
+
+
+class TestColorRemapLightTheme:
+    def test_remaps_yellow(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "light")
+        out = color("warn", Colors.YELLOW)
+        assert Colors.YELLOW not in out
+        assert Colors.MAGENTA in out
+        assert "warn" in out
+        assert out.endswith(Colors.RESET)
+
+    def test_remaps_dim_to_default_foreground(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "light")
+        out = color("hint", Colors.DIM)
+        # DIM remap is empty, so the output is just the text + RESET.
+        assert Colors.DIM not in out
+        assert out == "hint" + Colors.RESET
+
+    def test_preserves_unmapped_colors(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "light")
+        for code in (
+            Colors.RED,
+            Colors.GREEN,
+            Colors.CYAN,
+            Colors.BLUE,
+            Colors.MAGENTA,
+            Colors.BOLD,
+        ):
+            out = color("x", code)
+            assert code in out, f"expected {code!r} preserved in light mode"
+
+    def test_remap_applies_to_combined_codes(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "light")
+        out = color("warn", Colors.BOLD, Colors.YELLOW)
+        # BOLD stays, YELLOW is swapped to MAGENTA.
+        assert Colors.BOLD in out
+        assert Colors.MAGENTA in out
+        assert Colors.YELLOW not in out
+
+
+class TestColorRemapDarkAndDefault:
+    def test_dark_theme_preserves_yellow(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "dark")
+        out = color("warn", Colors.YELLOW)
+        assert Colors.YELLOW in out
+        assert Colors.MAGENTA not in out
+
+    def test_dark_theme_preserves_dim(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "dark")
+        out = color("hint", Colors.DIM)
+        assert Colors.DIM in out
+
+    def test_default_no_env_preserves_yellow(self, monkeypatch, tty, clean_env):
+        # No HERMES_THEME, no COLORFGBG → behave exactly as before.
+        out = color("warn", Colors.YELLOW)
+        assert Colors.YELLOW in out
+
+
+class TestColorRemapAutoDetection:
+    def test_auto_with_light_colorfgbg_remaps_yellow(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("HERMES_THEME", "auto")
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert Colors.YELLOW not in color("warn", Colors.YELLOW)
+
+    def test_unset_with_light_colorfgbg_remaps_yellow(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert Colors.YELLOW not in color("warn", Colors.YELLOW)
+
+    def test_unset_with_dark_colorfgbg_preserves_yellow(self, monkeypatch, tty, clean_env):
+        monkeypatch.setenv("COLORFGBG", "15;0")
+        assert Colors.YELLOW in color("warn", Colors.YELLOW)


### PR DESCRIPTION
## Summary

Fixes #8526 — on light-theme terminals (reported against macOS Terminal.app's default profile), `hermes` renders yellow-on-white and dim-on-white text that's effectively unreadable. The reporter's screenshot shows the interactive chat, but the problem applies to every CLI surface (status, doctor, setup menus, cron list, etc.) because they all funnel through `hermes_cli/colors.py::color()`.

## Fix

Small, call-site-free theme layer in `hermes_cli/colors.py`:

- `HERMES_THEME=light|dark` — explicit opt-in override.
- `HERMES_THEME=auto` (or unset) — conservative background auto-detection via `COLORFGBG`. Only `bg ∈ {7, 15}` is treated as light; `0–6, 8` are treated as dark; anything else (including the literal `default` some terminals emit) falls through and keeps today's behavior, so no one who's currently happy gets new visuals by accident.
- `NO_COLOR` is honored **first**, identical to before — no theme configuration can override it.

In light mode, `color()` remaps exactly two codes:

| Code | Light remap | Rationale |
|------|-------------|-----------|
| `YELLOW` (33) | `MAGENTA` (35) | High contrast on white; still reads as "warning-ish" |
| `DIM` (2) | `""` (unset) | Terminal's default foreground is already readable on a light background |

Red, green, cyan, blue, magenta, and bold are untouched so existing semantic meaning (error = red, ok = green, info = cyan) is preserved.

Scope is intentionally narrow:
- **One file** for the behavior change (`hermes_cli/colors.py`, ~70 lines added) plus `tests/hermes_cli/test_colors.py`.
- No call-site rewrites. Every existing `color(text, Colors.YELLOW)` / `Colors.DIM` usage (~200 across 14 modules) picks up the new behavior automatically.
- No new dependencies.
- No Rich/UI theming — out of scope; those live outside this helper.

## Test plan

New `tests/hermes_cli/test_colors.py` covers:

- [x] `NO_COLOR` still wins over any theme configuration (including `HERMES_THEME=light`).
- [x] `HERMES_THEME=light|dark` takes priority over `COLORFGBG`; case-insensitive, tolerates surrounding whitespace.
- [x] `HERMES_THEME=auto` (and unset) fall through to `COLORFGBG` detection.
- [x] `COLORFGBG` parsing: uses the trailing segment; handles 2- and 3-segment forms (rxvt uses `fg;?;bg`); `default` segment returns `None`.
- [x] Light mode remaps `YELLOW → MAGENTA` and drops `DIM`; dark mode and the default (no-env) path preserve both.
- [x] Light mode leaves red/green/blue/cyan/magenta/bold untouched.
- [x] Combined codes (e.g. `BOLD + YELLOW`) remap only the yellow.
- [ ] I wasn't able to run the full pytest suite locally from this sandbox (no usable Python available), so the tests above are my best-effort; happy to iterate if CI catches anything.

## Notes

- Reporter opted in to submit a PR themselves; posting this so they can see it early, but happy to defer if they'd prefer to take it.
- No public API or signature changes.
- If maintainers would prefer a different light-mode swap for `YELLOW` (e.g. `BLUE` instead of `MAGENTA`), that's a one-line change in `_LIGHT_REMAP`.
