### PR TITLE
fix: register 'sms' platform in PLATFORMS registry to fix KeyError

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -26,6 +26,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("whatsapp",       PlatformInfo(label="📱 WhatsApp",        default_toolset="hermes-whatsapp")),
     ("signal",         PlatformInfo(label="📡 Signal",          default_toolset="hermes-signal")),
     ("bluebubbles",    PlatformInfo(label="💙 BlueBubbles",     default_toolset="hermes-bluebubbles")),
+    ("sms",            PlatformInfo(label="📱 SMS (Twilio)",    default_toolset="hermes-sms")),
     ("email",          PlatformInfo(label="📧 Email",           default_toolset="hermes-email")),
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),
     ("mattermost",     PlatformInfo(label="💬 Mattermost",      default_toolset="hermes-mattermost")),

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -455,3 +455,37 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 
     # sorted() must not raise TypeError
     sorted(enabled)
+
+
+# ---------------------------------------------------------------------------
+# Regression: KeyError 'sms' — platform missing from PLATFORMS registry (issue #9789)
+# ---------------------------------------------------------------------------
+
+def test_all_gateway_platforms_registered_in_platforms():
+    """Every platform used by gateway adapters must exist in PLATFORMS.
+
+    Regression for issue #9789: SMS gateway crashed with KeyError: 'sms'
+    because the platform was missing from the PLATFORMS registry in
+    hermes_cli/platforms.py.
+    """
+    from hermes_cli.platforms import PLATFORMS
+    from pathlib import Path
+    import re
+
+    # Discover all platform adapter files in gateway/platforms/
+    platforms_dir = Path(__file__).parent.parent.parent / "gateway" / "platforms"
+    platform_keys = set()
+    for py_file in platforms_dir.glob("*.py"):
+        if py_file.name == "__init__.py":
+            continue
+        content = py_file.read_text()
+        # Match platform = "..." pattern in adapter files
+        for match in re.finditer(r'platform\s*=\s*["\']([a-z_]+)["\']', content):
+            platform_keys.add(match.group(1))
+
+    # Verify each discovered platform key exists in PLATFORMS
+    missing = platform_keys - set(PLATFORMS.keys())
+    assert not missing, (
+        f"Platform(s) {missing} exist in gateway/platforms/ but are missing "
+        f"from PLATFORMS registry in hermes_cli/platforms.py"
+    )


### PR DESCRIPTION
## Summary
Fixes a `KeyError: 'sms'` crash when the SMS (Twilio) gateway receives inbound messages because the platform was missing from the `PLATFORMS` registry.

## Root Cause
The SMS adapter exists in `gateway/platforms/sms.py` and the `hermes-sms` toolset is defined in `toolsets.py`, but the platform key was never registered in `hermes_cli/platforms.py`. When `_get_platform_tools()` looked up `PLATFORMS['sms']`, it crashed.

## Fix
Added `('sms', PlatformInfo(label="📱 SMS (Twilio)", default_toolset="hermes-sms"))` to the PLATFORMS OrderedDict.

## Test Plan
- [x] Added regression test that auto-discovers all gateway platform adapters and verifies each is registered in PLATFORMS
- [x] Test passes

Closes NousResearch/hermes-agent#9789