### PR TITLE
docs: automation templates gallery + comparison post

### DIFF
--- a/hermes-already-has-routines.md
+++ b/hermes-already-has-routines.md
@@ -1,0 +1,160 @@
+# Hermes Agent Has Had "Routines" Since March
+
+Anthropic just announced [Claude Code Routines](https://claude.com/blog/introducing-routines-in-claude-code) — scheduled tasks, GitHub event triggers, and API-triggered agent runs. Bundled prompt + repo + connectors, running on their infrastructure.
+
+It's a good feature. We shipped it two months ago.
+
+---
+
+## The Three Trigger Types — Side by Side
+
+Claude Code Routines offers three ways to trigger an automation:
+
+**1. Scheduled (cron)**
+> "Every night at 2am: pull the top bug from Linear, attempt a fix, and open a draft PR."
+
+Hermes equivalent — works today:
+```bash
+hermes cron create "0 2 * * *" \
+  "Pull the top bug from the issue tracker, attempt a fix, and open a draft PR." \
+  --name "Nightly bug fix" \
+  --deliver telegram
+```
+
+**2. GitHub Events (webhook)**
+> "Flag PRs that touch the /auth-provider module and post to #auth-changes."
+
+Hermes equivalent — works today:
+```bash
+hermes webhook subscribe auth-watch \
+  --events "pull_request" \
+  --prompt "PR #{pull_request.number}: {pull_request.title} by {pull_request.user.login}. Check if it touches the auth-provider module. If yes, summarize the changes." \
+  --deliver slack
+```
+
+**3. API Triggers**
+> "Read the alert payload, find the owning service, post a triage summary to #oncall."
+
+Hermes equivalent — works today:
+```bash
+hermes webhook subscribe alert-triage \
+  --prompt "Alert: {alert.name} — Severity: {alert.severity}. Find the owning service, investigate, and post a triage summary with proposed first steps." \
+  --deliver slack
+```
+
+Every use case in their blog post — backlog triage, docs drift, deploy verification, alert correlation, library porting, bespoke PR review — has a working Hermes implementation. No new features needed. It's been shipping since March 2026.
+
+---
+
+## What's Different
+
+| | Claude Code Routines | Hermes Agent |
+|---|---|---|
+| **Scheduled tasks** | ✅ Schedule-based | ✅ Any cron expression + human-readable intervals |
+| **GitHub triggers** | ✅ PR, issue, push events | ✅ Any GitHub event via webhook subscriptions |
+| **API triggers** | ✅ POST to unique endpoint | ✅ POST to webhook routes with HMAC auth |
+| **MCP connectors** | ✅ Native connectors | ✅ Full MCP client support |
+| **Script pre-processing** | ❌ | ✅ Python scripts run before agent, inject context |
+| **Skill chaining** | ❌ | ✅ Load multiple skills per automation |
+| **Daily limit** | 5-25 runs/day | **Unlimited** |
+| **Model choice** | Claude only | **Any model** — Claude, GPT, Gemini, DeepSeek, Qwen, local |
+| **Delivery targets** | GitHub comments | Telegram, Discord, Slack, SMS, email, GitHub comments, webhooks, local files |
+| **Infrastructure** | Anthropic's servers | **Your infrastructure** — VPS, home server, laptop |
+| **Data residency** | Anthropic's cloud | **Your machines** |
+| **Cost** | Pro/Max/Team/Enterprise subscription | Your API key, your rates |
+| **Open source** | No | **Yes** — MIT license |
+
+---
+
+## Things Hermes Does That Routines Can't
+
+### Script Injection
+
+Run a Python script *before* the agent. The script's stdout becomes context. The script handles mechanical work (fetching, diffing, computing); the agent handles reasoning.
+
+```bash
+hermes cron create "every 1h" \
+  "If CHANGE DETECTED, summarize what changed. If NO_CHANGE, respond with [SILENT]." \
+  --script ~/.hermes/scripts/watch-site.py \
+  --name "Pricing monitor" \
+  --deliver telegram
+```
+
+The `[SILENT]` pattern means you only get notified when something actually happens. No spam.
+
+### Multi-Skill Workflows
+
+Chain specialized skills together. Each skill teaches the agent a specific capability, and the prompt ties them together.
+
+```bash
+hermes cron create "0 8 * * *" \
+  "Search arXiv for papers on language model reasoning. Save the top 3 as Obsidian notes." \
+  --skills "arxiv,obsidian" \
+  --name "Paper digest"
+```
+
+### Deliver Anywhere
+
+One automation, any destination:
+
+```bash
+--deliver telegram                      # Telegram home channel
+--deliver discord                       # Discord home channel  
+--deliver slack                         # Slack channel
+--deliver sms:+15551234567              # Text message
+--deliver telegram:-1001234567890:42    # Specific Telegram forum topic
+--deliver local                         # Save to file, no notification
+```
+
+### Model-Agnostic
+
+Your nightly triage can run on Claude. Your deploy verification can run on GPT. Your cost-sensitive monitors can run on DeepSeek or a local model. Same automation system, any backend.
+
+---
+
+## The Limits Tell the Story
+
+Claude Code Routines: **5 routines per day** on Pro. **25 on Enterprise.** That's their ceiling.
+
+Hermes has no daily limit. Run 500 automations a day if you want. The only constraint is your API budget, and you choose which models to use for which tasks.
+
+A nightly backlog triage on Sonnet costs roughly $0.02-0.05. A monitoring check on DeepSeek costs fractions of a cent. You control the economics.
+
+---
+
+## Get Started
+
+Hermes Agent is open source and free. The automation infrastructure — cron scheduler, webhook platform, skill system, multi-platform delivery — is built in.
+
+```bash
+pip install hermes-agent
+hermes setup
+```
+
+Set up a scheduled task in 30 seconds:
+```bash
+hermes cron create "0 9 * * 1" \
+  "Generate a weekly AI news digest. Search the web for major announcements, trending repos, and notable papers. Keep it under 500 words with links." \
+  --name "Weekly digest" \
+  --deliver telegram
+```
+
+Set up a GitHub webhook in 60 seconds:
+```bash
+hermes gateway setup    # enable webhooks
+hermes webhook subscribe pr-review \
+  --events "pull_request" \
+  --prompt "Review PR #{pull_request.number}: {pull_request.title}" \
+  --skills "github-code-review" \
+  --deliver github_comment
+```
+
+Full automation templates gallery: [hermes-agent.nousresearch.com/docs/guides/automation-templates](https://hermes-agent.nousresearch.com/docs/guides/automation-templates)
+
+Documentation: [hermes-agent.nousresearch.com](https://hermes-agent.nousresearch.com)
+
+GitHub: [github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)
+
+---
+
+*Hermes Agent is built by [Nous Research](https://nousresearch.com). Open source, model-agnostic, runs on your infrastructure.*

--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: fitness-nutrition
+description: >
+  Gym workout planner and nutrition tracker. Search 690+ exercises by muscle,
+  equipment, or category via wger. Look up macros and calories for 380,000+
+  foods via USDA FoodData Central. Compute BMI, TDEE, one-rep max, macro
+  splits, and body fat — pure Python, no pip installs. Built for anyone
+  chasing gains, cutting weight, or just trying to eat better.
+version: 1.0.0
+authors:
+  - haileymarshall
+license: MIT
+metadata:
+  hermes:
+    tags: [health, fitness, nutrition, gym, workout, diet, exercise]
+    category: health
+    prerequisites:
+      commands: [curl, python3]
+required_environment_variables:
+  - name: USDA_API_KEY
+    prompt: "USDA FoodData Central API key (free)"
+    help: "Get one free at https://fdc.nal.usda.gov/api-key-signup/ — or skip to use DEMO_KEY with lower rate limits"
+    required_for: "higher rate limits on food/nutrition lookups (DEMO_KEY works without signup)"
+    optional: true
+---
+
+# Fitness & Nutrition
+
+Expert fitness coach and sports nutritionist skill. Two data sources
+plus offline calculators — everything a gym-goer needs in one place.
+
+**Data sources (all free, no pip dependencies):**
+
+- **wger** (https://wger.de/api/v2/) — open exercise database, 690+ exercises with muscles, equipment, images. Public endpoints need zero authentication.
+- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government nutrition database, 380,000+ foods. `DEMO_KEY` works instantly; free signup for higher limits.
+
+**Offline calculators (pure stdlib Python):**
+
+- BMI, TDEE (Mifflin-St Jeor), one-rep max (Epley/Brzycki/Lombardi), macro splits, body fat % (US Navy method)
+
+---
+
+## When to Use
+
+Trigger this skill when the user asks about:
+- Exercises, workouts, gym routines, muscle groups, workout splits
+- Food macros, calories, protein content, meal planning, calorie counting
+- Body composition: BMI, body fat, TDEE, caloric surplus/deficit
+- One-rep max estimates, training percentages, progressive overload
+- Macro ratios for cutting, bulking, or maintenance
+
+---
+
+## Procedure
+
+### Exercise Lookup (wger API)
+
+All wger public endpoints return JSON and require no auth. Always add
+`format=json` and `language=2` (English) to exercise queries.
+
+**Step 1 — Identify what the user wants:**
+
+- By muscle → use `/api/v2/exercise/?muscles={id}&language=2&status=2&format=json`
+- By category → use `/api/v2/exercise/?category={id}&language=2&status=2&format=json`
+- By equipment → use `/api/v2/exercise/?equipment={id}&language=2&status=2&format=json`
+- By name → use `/api/v2/exercise/search/?term={query}&language=english&format=json`
+- Full details → use `/api/v2/exerciseinfo/{exercise_id}/?format=json`
+
+**Step 2 — Reference IDs (so you don't need extra API calls):**
+
+Exercise categories:
+
+| ID | Category    |
+|----|-------------|
+| 8  | Arms        |
+| 9  | Legs        |
+| 10 | Abs         |
+| 11 | Chest       |
+| 12 | Back        |
+| 13 | Shoulders   |
+| 14 | Calves      |
+| 15 | Cardio      |
+
+Muscles:
+
+| ID | Muscle                    | ID | Muscle                  |
+|----|---------------------------|----|-------------------------|
+| 1  | Biceps brachii            | 2  | Anterior deltoid        |
+| 3  | Serratus anterior         | 4  | Pectoralis major        |
+| 5  | Obliquus externus         | 6  | Gastrocnemius           |
+| 7  | Rectus abdominis          | 8  | Gluteus maximus         |
+| 9  | Trapezius                 | 10 | Quadriceps femoris      |
+| 11 | Biceps femoris            | 12 | Latissimus dorsi        |
+| 13 | Brachialis                | 14 | Triceps brachii         |
+| 15 | Soleus                    |    |                         |
+
+Equipment:
+
+| ID | Equipment      |
+|----|----------------|
+| 1  | Barbell        |
+| 3  | Dumbbell       |
+| 4  | Gym mat        |
+| 5  | Swiss Ball     |
+| 6  | Pull-up bar    |
+| 7  | none (bodyweight) |
+| 8  | Bench          |
+| 9  | Incline bench  |
+| 10 | Kettlebell     |
+
+**Step 3 — Fetch and present results:**
+
+```bash
+# Search exercises by name
+QUERY="$1"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$QUERY")
+curl -s "https://wger.de/api/v2/exercise/search/?term=${ENCODED}&language=english&format=json" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for s in data.get('suggestions',[])[:10]:
+    d=s.get('data',{})
+    print(f\"  ID {d.get('id','?'):>4} | {d.get('name','N/A'):<35} | Category: {d.get('category','N/A')}\")
+"
+```
+
+```bash
+# Get full details for a specific exercise
+EXERCISE_ID="$1"
+curl -s "https://wger.de/api/v2/exerciseinfo/${EXERCISE_ID}/?format=json" \
+  | python3 -c "
+import json,sys,html,re
+data=json.load(sys.stdin)
+trans=[t for t in data.get('translations',[]) if t.get('language')==2]
+t=trans[0] if trans else data.get('translations',[{}])[0]
+desc=re.sub('<[^>]+>','',html.unescape(t.get('description','N/A')))
+print(f\"Exercise  : {t.get('name','N/A')}\")
+print(f\"Category  : {data.get('category',{}).get('name','N/A')}\")
+print(f\"Primary   : {', '.join(m.get('name_en','') for m in data.get('muscles',[])) or 'N/A'}\")
+print(f\"Secondary : {', '.join(m.get('name_en','') for m in data.get('muscles_secondary',[])) or 'none'}\")
+print(f\"Equipment : {', '.join(e.get('name','') for e in data.get('equipment',[])) or 'bodyweight'}\")
+print(f\"How to    : {desc[:500]}\")
+imgs=data.get('images',[])
+if imgs: print(f\"Image     : {imgs[0].get('image','')}\")
+"
+```
+
+```bash
+# List exercises filtering by muscle, category, or equipment
+# Combine filters as needed: ?muscles=4&equipment=1&language=2&status=2
+FILTER="$1"  # e.g. "muscles=4" or "category=11" or "equipment=3"
+curl -s "https://wger.de/api/v2/exercise/?${FILTER}&language=2&status=2&limit=20&format=json" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+print(f'Found {data.get(\"count\",0)} exercises.')
+for ex in data.get('results',[]):
+    print(f\"  ID {ex['id']:>4} | muscles: {ex.get('muscles',[])} | equipment: {ex.get('equipment',[])}\")
+"
+```
+
+### Nutrition Lookup (USDA FoodData Central)
+
+Uses `USDA_API_KEY` env var if set, otherwise falls back to `DEMO_KEY`.
+DEMO_KEY = 30 requests/hour. Free signup key = 1,000 requests/hour.
+
+```bash
+# Search foods by name
+FOOD="$1"
+API_KEY="${USDA_API_KEY:-DEMO_KEY}"
+ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$FOOD")
+curl -s "https://api.nal.usda.gov/fdc/v1/foods/search?api_key=${API_KEY}&query=${ENCODED}&pageSize=5&dataType=Foundation,SR%20Legacy" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+foods=data.get('foods',[])
+if not foods: print('No foods found.'); sys.exit()
+for f in foods:
+    n={x['nutrientName']:x.get('value','?') for x in f.get('foodNutrients',[])}
+    cal=n.get('Energy','?'); prot=n.get('Protein','?')
+    fat=n.get('Total lipid (fat)','?'); carb=n.get('Carbohydrate, by difference','?')
+    print(f\"{f.get('description','N/A')}\")
+    print(f\"  Per 100g: {cal} kcal | {prot}g protein | {fat}g fat | {carb}g carbs\")
+    print(f\"  FDC ID: {f.get('fdcId','N/A')}\")
+    print()
+"
+```
+
+```bash
+# Detailed nutrient profile by FDC ID
+FDC_ID="$1"
+API_KEY="${USDA_API_KEY:-DEMO_KEY}"
+curl -s "https://api.nal.usda.gov/fdc/v1/food/${FDC_ID}?api_key=${API_KEY}" \
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(f\"Food: {d.get('description','N/A')}\")
+print(f\"{'Nutrient':<40} {'Amount':>8} {'Unit'}\")
+print('-'*56)
+for x in sorted(d.get('foodNutrients',[]),key=lambda x:x.get('nutrient',{}).get('rank',9999)):
+    nut=x.get('nutrient',{}); amt=x.get('amount',0)
+    if amt and float(amt)>0:
+        print(f\"  {nut.get('name',''):<38} {amt:>8} {nut.get('unitName','')}\")
+"
+```
+
+### Offline Calculators
+
+Use the helper scripts in `scripts/` for batch operations,
+or run inline for single calculations:
+
+- `python3 scripts/body_calc.py bmi <weight_kg> <height_cm>`
+- `python3 scripts/body_calc.py tdee <weight_kg> <height_cm> <age> <M|F> <activity 1-5>`
+- `python3 scripts/body_calc.py 1rm <weight> <reps>`
+- `python3 scripts/body_calc.py macros <tdee_kcal> <cut|maintain|bulk>`
+- `python3 scripts/body_calc.py bodyfat <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>`
+
+See `references/FORMULAS.md` for the science behind each formula.
+
+---
+
+## Pitfalls
+
+- wger exercise endpoint returns **all languages by default** — always add `language=2` for English
+- wger includes **unverified user submissions** — add `status=2` to only get approved exercises
+- USDA `DEMO_KEY` has **30 req/hour** — add `sleep 2` between batch requests or get a free key
+- USDA data is **per 100g** — remind users to scale to their actual portion size
+- BMI does not distinguish muscle from fat — high BMI in muscular people is not necessarily unhealthy
+- Body fat formulas are **estimates** (±3-5%) — recommend DEXA scans for precision
+- 1RM formulas lose accuracy above 10 reps — use sets of 3-5 for best estimates
+- wger's `exercise/search` endpoint uses `term` not `query` as the parameter name
+
+---
+
+## Verification
+
+After running exercise search: confirm results include exercise names, muscle groups, and equipment.
+After nutrition lookup: confirm per-100g macros are returned with kcal, protein, fat, carbs.
+After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most adults).
+
+---
+
+## Quick Reference
+
+| Task | Source | Endpoint |
+|------|--------|----------|
+| Search exercises by name | wger | `GET /api/v2/exercise/search/?term=&language=english` |
+| Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
+| Filter by muscle | wger | `GET /api/v2/exercise/?muscles={id}&language=2&status=2` |
+| Filter by equipment | wger | `GET /api/v2/exercise/?equipment={id}&language=2&status=2` |
+| List categories | wger | `GET /api/v2/exercisecategory/` |
+| List muscles | wger | `GET /api/v2/muscle/` |
+| Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |
+| Food details | USDA | `GET /fdc/v1/food/{fdcId}` |
+| BMI / TDEE / 1RM / macros | offline | `python3 scripts/body_calc.py` |

--- a/optional-skills/health/fitness-nutrition/references/FORMULAS.md
+++ b/optional-skills/health/fitness-nutrition/references/FORMULAS.md
@@ -1,0 +1,100 @@
+# Formulas Reference
+
+Scientific references for all calculators used in the fitness-nutrition skill.
+
+## BMI (Body Mass Index)
+
+**Formula:** BMI = weight (kg) / height (m)²
+
+| Category     | BMI Range  |
+|-------------|------------|
+| Underweight | < 18.5     |
+| Normal      | 18.5 – 24.9 |
+| Overweight  | 25.0 – 29.9 |
+| Obese       | 30.0+      |
+
+**Limitation:** BMI does not distinguish muscle from fat. A muscular person
+can have a high BMI while being lean. Use body fat % for a better picture.
+
+Reference: Quetelet, A. (1832). Keys et al., Int J Obes (1972).
+
+## TDEE (Total Daily Energy Expenditure)
+
+Uses the **Mifflin-St Jeor equation** — the most accurate BMR predictor for
+the general population according to the ADA (2005).
+
+**BMR formulas:**
+
+- Male: BMR = 10 × weight(kg) + 6.25 × height(cm) − 5 × age + 5
+- Female: BMR = 10 × weight(kg) + 6.25 × height(cm) − 5 × age − 161
+
+**Activity multipliers:**
+
+| Level | Description                    | Multiplier |
+|-------|--------------------------------|------------|
+| 1     | Sedentary (desk job)           | 1.200      |
+| 2     | Lightly active (1-3 days/wk)   | 1.375      |
+| 3     | Moderately active (3-5 days)   | 1.550      |
+| 4     | Very active (6-7 days)         | 1.725      |
+| 5     | Extremely active (2x/day)      | 1.900      |
+
+Reference: Mifflin et al., Am J Clin Nutr 51, 241-247 (1990).
+
+## One-Rep Max (1RM)
+
+Three validated formulas. Average of all three is most reliable.
+
+- **Epley:** 1RM = w × (1 + r/30)
+- **Brzycki:** 1RM = w × 36 / (37 − r)
+- **Lombardi:** 1RM = w × r^0.1
+
+All formulas are most accurate for r ≤ 10. Above 10 reps, error increases.
+
+Reference: LeSuer et al., J Strength Cond Res 11(4), 211-213 (1997).
+
+## Macro Splits
+
+Recommended splits based on goal:
+
+| Goal         | Protein | Fat  | Carbs | Calorie Offset |
+|-------------|---------|------|-------|----------------|
+| Fat loss    | 40%     | 30%  | 30%   | −500 kcal      |
+| Maintenance | 30%     | 30%  | 40%   | 0              |
+| Lean bulk   | 30%     | 25%  | 45%   | +400 kcal      |
+
+Protein targets for muscle growth: 1.6–2.2 g/kg body weight per day.
+Minimum fat intake: 0.5 g/kg to support hormone production.
+
+Conversion: Protein = 4 kcal/g, Fat = 9 kcal/g, Carbs = 4 kcal/g.
+
+Reference: Morton et al., Br J Sports Med 52, 376–384 (2018).
+
+## Body Fat % (US Navy Method)
+
+**Male:**
+
+BF% = 86.010 × log₁₀(waist − neck) − 70.041 × log₁₀(height) + 36.76
+
+**Female:**
+
+BF% = 163.205 × log₁₀(waist + hip − neck) − 97.684 × log₁₀(height) − 78.387
+
+All measurements in centimeters.
+
+| Category      | Male   | Female |
+|--------------|--------|--------|
+| Essential    | 2-5%   | 10-13% |
+| Athletic     | 6-13%  | 14-20% |
+| Fitness      | 14-17% | 21-24% |
+| Average      | 18-24% | 25-31% |
+| Obese        | 25%+   | 32%+   |
+
+Accuracy: ±3-5% compared to DEXA. Measure at the navel (waist),
+at the Adam's apple (neck), and widest point (hip, females only).
+
+Reference: Hodgdon & Beckett, Naval Health Research Center (1984).
+
+## APIs
+
+- wger: https://wger.de/api/v2/ — AGPL-3.0, exercise data is CC-BY-SA 3.0
+- USDA FoodData Central: https://api.nal.usda.gov/fdc/v1/ — public domain (CC0 1.0)

--- a/optional-skills/health/fitness-nutrition/scripts/body_calc.py
+++ b/optional-skills/health/fitness-nutrition/scripts/body_calc.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+body_calc.py — All-in-one fitness calculator.
+
+Subcommands:
+  bmi      <weight_kg> <height_cm>
+  tdee     <weight_kg> <height_cm> <age> <M|F> <activity 1-5>
+  1rm      <weight> <reps>
+  macros   <tdee_kcal> <cut|maintain|bulk>
+  bodyfat  <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>
+
+No external dependencies — stdlib only.
+"""
+import sys
+import math
+
+
+def bmi(weight_kg, height_cm):
+    h = height_cm / 100
+    val = weight_kg / (h * h)
+    if val < 18.5:
+        cat = "Underweight"
+    elif val < 25:
+        cat = "Normal weight"
+    elif val < 30:
+        cat = "Overweight"
+    else:
+        cat = "Obese"
+    print(f"BMI: {val:.1f} — {cat}")
+    print()
+    print("Ranges:")
+    print(f"  Underweight : < 18.5")
+    print(f"  Normal      : 18.5 – 24.9")
+    print(f"  Overweight  : 25.0 – 29.9")
+    print(f"  Obese       : 30.0+")
+
+
+def tdee(weight_kg, height_cm, age, sex, activity):
+    if sex.upper() == "M":
+        bmr = 10 * weight_kg + 6.25 * height_cm - 5 * age + 5
+    else:
+        bmr = 10 * weight_kg + 6.25 * height_cm - 5 * age - 161
+
+    multipliers = {
+        1: ("Sedentary (desk job, no exercise)", 1.2),
+        2: ("Lightly active (1-3 days/week)", 1.375),
+        3: ("Moderately active (3-5 days/week)", 1.55),
+        4: ("Very active (6-7 days/week)", 1.725),
+        5: ("Extremely active (athlete + physical job)", 1.9),
+    }
+
+    label, mult = multipliers.get(activity, ("Moderate", 1.55))
+    total = bmr * mult
+
+    print(f"BMR (Mifflin-St Jeor): {bmr:.0f} kcal/day")
+    print(f"Activity: {label} (x{mult})")
+    print(f"TDEE: {total:.0f} kcal/day")
+    print()
+    print("Calorie targets:")
+    print(f"  Aggressive cut (-750): {total - 750:.0f} kcal/day")
+    print(f"  Fat loss       (-500): {total - 500:.0f} kcal/day")
+    print(f"  Mild cut       (-250): {total - 250:.0f} kcal/day")
+    print(f"  Maintenance          : {total:.0f} kcal/day")
+    print(f"  Lean bulk      (+250): {total + 250:.0f} kcal/day")
+    print(f"  Bulk           (+500): {total + 500:.0f} kcal/day")
+
+
+def one_rep_max(weight, reps):
+    if reps < 1:
+        print("Error: reps must be at least 1.")
+        sys.exit(1)
+    if reps == 1:
+        print(f"1RM = {weight:.1f} (actual single)")
+        return
+
+    epley = weight * (1 + reps / 30)
+    brzycki = weight * (36 / (37 - reps)) if reps < 37 else 0
+    lombardi = weight * (reps ** 0.1)
+    avg = (epley + brzycki + lombardi) / 3
+
+    print(f"Estimated 1RM ({weight} x {reps} reps):")
+    print(f"  Epley    : {epley:.1f}")
+    print(f"  Brzycki  : {brzycki:.1f}")
+    print(f"  Lombardi : {lombardi:.1f}")
+    print(f"  Average  : {avg:.1f}")
+    print()
+    print("Training percentages off average 1RM:")
+    for pct, rep_range in [
+        (100, "1"), (95, "1-2"), (90, "3-4"), (85, "4-6"),
+        (80, "6-8"), (75, "8-10"), (70, "10-12"),
+        (65, "12-15"), (60, "15-20"),
+    ]:
+        print(f"  {pct:>3}% = {avg * pct / 100:>7.1f}  (~{rep_range} reps)")
+
+
+def macros(tdee_kcal, goal):
+    goal = goal.lower()
+    if goal in ("cut", "lose", "deficit"):
+        cals = tdee_kcal - 500
+        p, f, c = 0.40, 0.30, 0.30
+        label = "Fat Loss (-500 kcal)"
+    elif goal in ("bulk", "gain", "surplus"):
+        cals = tdee_kcal + 400
+        p, f, c = 0.30, 0.25, 0.45
+        label = "Lean Bulk (+400 kcal)"
+    else:
+        cals = tdee_kcal
+        p, f, c = 0.30, 0.30, 0.40
+        label = "Maintenance"
+
+    prot_g = cals * p / 4
+    fat_g = cals * f / 9
+    carb_g = cals * c / 4
+
+    print(f"Goal: {label}")
+    print(f"Daily calories: {cals:.0f} kcal")
+    print()
+    print(f"  Protein : {prot_g:>6.0f}g ({p * 100:.0f}%)  = {prot_g * 4:.0f} kcal")
+    print(f"  Fat     : {fat_g:>6.0f}g ({f * 100:.0f}%)  = {fat_g * 9:.0f} kcal")
+    print(f"  Carbs   : {carb_g:>6.0f}g ({c * 100:.0f}%)  = {carb_g * 4:.0f} kcal")
+    print()
+    print(f"Per meal (3 meals): P {prot_g / 3:.0f}g | F {fat_g / 3:.0f}g | C {carb_g / 3:.0f}g")
+    print(f"Per meal (4 meals): P {prot_g / 4:.0f}g | F {fat_g / 4:.0f}g | C {carb_g / 4:.0f}g")
+
+
+def bodyfat(sex, neck_cm, waist_cm, hip_cm, height_cm):
+    sex = sex.upper()
+    if sex == "M":
+        if waist_cm <= neck_cm:
+            print("Error: waist must be larger than neck."); sys.exit(1)
+        bf = 86.010 * math.log10(waist_cm - neck_cm) - 70.041 * math.log10(height_cm) + 36.76
+    else:
+        if (waist_cm + hip_cm) <= neck_cm:
+            print("Error: waist + hip must be larger than neck."); sys.exit(1)
+        bf = 163.205 * math.log10(waist_cm + hip_cm - neck_cm) - 97.684 * math.log10(height_cm) - 78.387
+
+    print(f"Estimated body fat: {bf:.1f}%")
+
+    if sex == "M":
+        ranges = [
+            (6, "Essential fat (2-5%)"),
+            (14, "Athletic (6-13%)"),
+            (18, "Fitness (14-17%)"),
+            (25, "Average (18-24%)"),
+        ]
+        default = "Obese (25%+)"
+    else:
+        ranges = [
+            (14, "Essential fat (10-13%)"),
+            (21, "Athletic (14-20%)"),
+            (25, "Fitness (21-24%)"),
+            (32, "Average (25-31%)"),
+        ]
+        default = "Obese (32%+)"
+
+    cat = default
+    for threshold, label in ranges:
+        if bf < threshold:
+            cat = label
+            break
+
+    print(f"Category: {cat}")
+    print(f"Method: US Navy circumference formula")
+
+
+def usage():
+    print(__doc__)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+
+    cmd = sys.argv[1].lower()
+
+    try:
+        if cmd == "bmi":
+            bmi(float(sys.argv[2]), float(sys.argv[3]))
+
+        elif cmd == "tdee":
+            tdee(
+                float(sys.argv[2]), float(sys.argv[3]),
+                int(sys.argv[4]), sys.argv[5], int(sys.argv[6]),
+            )
+
+        elif cmd in ("1rm", "orm"):
+            one_rep_max(float(sys.argv[2]), int(sys.argv[3]))
+
+        elif cmd == "macros":
+            macros(float(sys.argv[2]), sys.argv[3])
+
+        elif cmd == "bodyfat":
+            sex = sys.argv[2]
+            if sex.upper() == "M":
+                bodyfat(sex, float(sys.argv[3]), float(sys.argv[4]), 0, float(sys.argv[5]))
+            else:
+                bodyfat(sex, float(sys.argv[3]), float(sys.argv[4]), float(sys.argv[5]), float(sys.argv[6]))
+
+        else:
+            print(f"Unknown command: {cmd}")
+            usage()
+
+    except (IndexError, ValueError) as e:
+        print(f"Error: {e}")
+        usage()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/health/fitness-nutrition/scripts/nutrition_search.py
+++ b/optional-skills/health/fitness-nutrition/scripts/nutrition_search.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+nutrition_search.py — Search USDA FoodData Central for nutrition info.
+
+Usage:
+  python3 nutrition_search.py "chicken breast"
+  python3 nutrition_search.py "rice" "eggs" "broccoli"
+  echo -e "oats\\nbanana\\nwhey protein" | python3 nutrition_search.py -
+
+Reads USDA_API_KEY from environment, falls back to DEMO_KEY.
+No external dependencies.
+"""
+import sys
+import os
+import json
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+
+API_KEY = os.environ.get("USDA_API_KEY", "DEMO_KEY")
+BASE = "https://api.nal.usda.gov/fdc/v1"
+
+
+def search(query, max_results=3):
+    encoded = urllib.parse.quote(query)
+    url = (
+        f"{BASE}/foods/search?api_key={API_KEY}"
+        f"&query={encoded}&pageSize={max_results}"
+        f"&dataType=Foundation,SR%20Legacy"
+    )
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except Exception as e:
+        print(f"  API error: {e}", file=sys.stderr)
+        return None
+
+
+def display(food):
+    nutrients = {n["nutrientName"]: n.get("value", "?") for n in food.get("foodNutrients", [])}
+    cal = nutrients.get("Energy", "?")
+    prot = nutrients.get("Protein", "?")
+    fat = nutrients.get("Total lipid (fat)", "?")
+    carb = nutrients.get("Carbohydrate, by difference", "?")
+    fib = nutrients.get("Fiber, total dietary", "?")
+    sug = nutrients.get("Sugars, total including NLEA", "?")
+
+    print(f"  {food.get('description', 'N/A')}")
+    print(f"    Calories : {cal} kcal")
+    print(f"    Protein  : {prot}g")
+    print(f"    Fat      : {fat}g")
+    print(f"    Carbs    : {carb}g (fiber: {fib}g, sugar: {sug}g)")
+    print(f"    FDC ID   : {food.get('fdcId', 'N/A')}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    if sys.argv[1] == "-":
+        queries = [line.strip() for line in sys.stdin if line.strip()]
+    else:
+        queries = sys.argv[1:]
+
+    for query in queries:
+        print(f"\n--- {query.upper()} (per 100g) ---")
+        data = search(query, max_results=2)
+        if not data or not data.get("foods"):
+            print("  No results found.")
+        else:
+            for food in data["foods"]:
+                display(food)
+                print()
+        if len(queries) > 1:
+            time.sleep(1)  # respect rate limits
+
+    if API_KEY == "DEMO_KEY":
+        print("\nTip: using DEMO_KEY (30 req/hr). Set USDA_API_KEY for 1000 req/hr.")
+        print("Free signup: https://fdc.nal.usda.gov/api-key-signup/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -245,6 +245,9 @@ def _get_required_environment_variables(
         if isinstance(required_for, str) and required_for.strip():
             normalized["required_for"] = required_for.strip()
 
+        if entry.get("optional"):
+            normalized["optional"] = True
+
         seen.add(env_name)
         required.append(normalized)
 
@@ -378,6 +381,8 @@ def _remaining_required_environment_names(
     remaining = []
     for entry in required_env_vars:
         name = entry["name"]
+        if entry.get("optional"):
+            continue
         if name in missing_names or not _is_env_var_persisted(name, env_snapshot):
             remaining.append(name)
     return remaining
@@ -1042,7 +1047,8 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         missing_required_env_vars = [
             e
             for e in required_env_vars
-            if not _is_env_var_persisted(e["name"], env_snapshot)
+            if not e.get("optional")
+            and not _is_env_var_persisted(e["name"], env_snapshot)
         ]
         capture_result = _capture_required_environment_variables(
             skill_name,

--- a/website/docs/guides/automation-templates.md
+++ b/website/docs/guides/automation-templates.md
@@ -1,0 +1,593 @@
+---
+sidebar_position: 15
+title: "Automation Templates"
+description: "Ready-to-use automation recipes — scheduled tasks, GitHub event triggers, API webhooks, and multi-skill workflows"
+---
+
+# Automation Templates
+
+Copy-paste recipes for common automation patterns. Each template uses Hermes's built-in [cron scheduler](/docs/user-guide/features/cron) for time-based triggers and [webhook platform](/docs/user-guide/messaging/webhooks) for event-driven triggers.
+
+Every template works with **any model** — not locked to a single provider.
+
+:::tip Three Trigger Types
+| Trigger | How | Tool |
+|---------|-----|------|
+| **Schedule** | Runs on a cadence (hourly, nightly, weekly) | `cronjob` tool or `/cron` slash command |
+| **GitHub Event** | Fires on PR opens, pushes, issues, CI results | Webhook platform (`hermes webhook subscribe`) |
+| **API Call** | External service POSTs JSON to your endpoint | Webhook platform (config.yaml routes or `hermes webhook subscribe`) |
+
+All three support delivery to Telegram, Discord, Slack, SMS, email, GitHub comments, or local files.
+:::
+
+---
+
+## Development Workflow
+
+### Nightly Backlog Triage
+
+Label, prioritize, and summarize new issues every night. Delivers a digest to your team channel.
+
+**Trigger:** Schedule (nightly)
+
+```bash
+hermes cron create "0 2 * * *" \
+  "You are a project manager triaging the NousResearch/hermes-agent GitHub repo.
+
+1. Run: gh issue list --repo NousResearch/hermes-agent --state open --json number,title,labels,author,createdAt --limit 30
+2. Identify issues opened in the last 24 hours
+3. For each new issue:
+   - Suggest a priority label (P0-critical, P1-high, P2-medium, P3-low)
+   - Suggest a category label (bug, feature, docs, security)
+   - Write a one-line triage note
+4. Summarize: total open issues, new today, breakdown by priority
+
+Format as a clean digest. If no new issues, respond with [SILENT]." \
+  --name "Nightly backlog triage" \
+  --deliver telegram
+```
+
+### Automatic PR Code Review
+
+Review every pull request automatically when it's opened. Posts a review comment directly on the PR.
+
+**Trigger:** GitHub webhook
+
+**Option A — Dynamic subscription (CLI):**
+
+```bash
+hermes webhook subscribe github-pr-review \
+  --events "pull_request" \
+  --prompt "Review this pull request:
+Repository: {repository.full_name}
+PR #{pull_request.number}: {pull_request.title}
+Author: {pull_request.user.login}
+Action: {action}
+Diff URL: {pull_request.diff_url}
+
+Fetch the diff with: curl -sL {pull_request.diff_url}
+
+Review for:
+- Security issues (injection, auth bypass, secrets in code)
+- Performance concerns (N+1 queries, unbounded loops, memory leaks)
+- Code quality (naming, duplication, error handling)
+- Missing tests for new behavior
+
+Post a concise review. If the PR is a trivial docs/typo change, say so briefly." \
+  --skills "github-code-review" \
+  --deliver github_comment
+```
+
+**Option B — Static route (config.yaml):**
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      secret: "your-global-secret"
+      routes:
+        github-pr-review:
+          events: ["pull_request"]
+          secret: "github-webhook-secret"
+          prompt: |
+            Review PR #{pull_request.number}: {pull_request.title}
+            Repository: {repository.full_name}
+            Author: {pull_request.user.login}
+            Diff URL: {pull_request.diff_url}
+            Review for security, performance, and code quality.
+          skills: ["github-code-review"]
+          deliver: "github_comment"
+          deliver_extra:
+            repo: "{repository.full_name}"
+            pr_number: "{pull_request.number}"
+```
+
+Then in GitHub: **Settings → Webhooks → Add webhook** → Payload URL: `http://your-server:8644/webhooks/github-pr-review`, Content type: `application/json`, Secret: `github-webhook-secret`, Events: **Pull requests**.
+
+### Docs Drift Detection
+
+Weekly scan of merged PRs to find API changes that need documentation updates.
+
+**Trigger:** Schedule (weekly)
+
+```bash
+hermes cron create "0 9 * * 1" \
+  "Scan the NousResearch/hermes-agent repo for documentation drift.
+
+1. Run: gh pr list --repo NousResearch/hermes-agent --state merged --json number,title,files,mergedAt --limit 30
+2. Filter to PRs merged in the last 7 days
+3. For each merged PR, check if it modified:
+   - Tool schemas (tools/*.py) — may need docs/reference/tools-reference.md update
+   - CLI commands (hermes_cli/commands.py, hermes_cli/main.py) — may need docs/reference/cli-commands.md update
+   - Config options (hermes_cli/config.py) — may need docs/user-guide/configuration.md update
+   - Environment variables — may need docs/reference/environment-variables.md update
+4. Cross-reference: for each code change, check if the corresponding docs page was also updated in the same PR
+
+Report any gaps where code changed but docs didn't. If everything is in sync, respond with [SILENT]." \
+  --name "Docs drift detection" \
+  --deliver telegram
+```
+
+### Dependency Security Audit
+
+Daily scan for known vulnerabilities in project dependencies.
+
+**Trigger:** Schedule (daily)
+
+```bash
+hermes cron create "0 6 * * *" \
+  "Run a dependency security audit on the hermes-agent project.
+
+1. cd ~/.hermes/hermes-agent && source .venv/bin/activate
+2. Run: pip audit --format json 2>/dev/null || pip audit 2>&1
+3. Run: npm audit --json 2>/dev/null (in website/ directory if it exists)
+4. Check for any CVEs with CVSS score >= 7.0
+
+If vulnerabilities found:
+- List each one with package name, version, CVE ID, severity
+- Check if an upgrade is available
+- Note if it's a direct dependency or transitive
+
+If no vulnerabilities, respond with [SILENT]." \
+  --name "Dependency audit" \
+  --deliver telegram
+```
+
+---
+
+## DevOps & Monitoring
+
+### Deploy Verification
+
+Trigger smoke tests after every deployment. Your CI/CD pipeline POSTs to the webhook when a deploy completes.
+
+**Trigger:** API call (webhook)
+
+```bash
+hermes webhook subscribe deploy-verify \
+  --events "deployment" \
+  --prompt "A deployment just completed:
+Service: {service}
+Environment: {environment}
+Version: {version}
+Deployed by: {deployer}
+
+Run these verification steps:
+1. Check if the service is responding: curl -s -o /dev/null -w '%{http_code}' {health_url}
+2. Search recent logs for errors: check the deployment payload for any error indicators
+3. Verify the version matches: curl -s {health_url}/version
+
+Report: deployment status (healthy/degraded/failed), response time, any errors found.
+If healthy, keep it brief. If degraded or failed, provide detailed diagnostics." \
+  --deliver telegram
+```
+
+Your CI/CD pipeline triggers it:
+
+```bash
+curl -X POST http://your-server:8644/webhooks/deploy-verify \
+  -H "Content-Type: application/json" \
+  -H "X-Hub-Signature-256: sha256=$(echo -n '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}' | openssl dgst -sha256 -hmac 'your-secret' | cut -d' ' -f2)" \
+  -d '{"service":"api","environment":"prod","version":"2.1.0","deployer":"ci","health_url":"https://api.example.com/health"}'
+```
+
+### Alert Triage
+
+Correlate monitoring alerts with recent changes to draft a response. Works with Datadog, PagerDuty, Grafana, or any alerting system that can POST JSON.
+
+**Trigger:** API call (webhook)
+
+```bash
+hermes webhook subscribe alert-triage \
+  --prompt "Monitoring alert received:
+Alert: {alert.name}
+Severity: {alert.severity}
+Service: {alert.service}
+Message: {alert.message}
+Timestamp: {alert.timestamp}
+
+Investigate:
+1. Search the web for known issues with this error pattern
+2. Check if this correlates with any recent deployments or config changes
+3. Draft a triage summary with:
+   - Likely root cause
+   - Suggested first response steps
+   - Escalation recommendation (P1-P4)
+
+Be concise. This goes to the on-call channel." \
+  --deliver slack
+```
+
+### Uptime Monitor
+
+Check endpoints every 30 minutes. Only notify when something is down.
+
+**Trigger:** Schedule (every 30 min)
+
+```python title="~/.hermes/scripts/check-uptime.py"
+import urllib.request, json, time
+
+ENDPOINTS = [
+    {"name": "API", "url": "https://api.example.com/health"},
+    {"name": "Web", "url": "https://www.example.com"},
+    {"name": "Docs", "url": "https://docs.example.com"},
+]
+
+results = []
+for ep in ENDPOINTS:
+    try:
+        start = time.time()
+        req = urllib.request.Request(ep["url"], headers={"User-Agent": "Hermes-Monitor/1.0"})
+        resp = urllib.request.urlopen(req, timeout=10)
+        elapsed = round((time.time() - start) * 1000)
+        results.append({"name": ep["name"], "status": resp.getcode(), "ms": elapsed})
+    except Exception as e:
+        results.append({"name": ep["name"], "status": "DOWN", "error": str(e)})
+
+down = [r for r in results if r.get("status") == "DOWN" or (isinstance(r.get("status"), int) and r["status"] >= 500)]
+if down:
+    print("OUTAGE DETECTED")
+    for r in down:
+        print(f"  {r['name']}: {r.get('error', f'HTTP {r[\"status\"]}')} ")
+    print(f"\nAll results: {json.dumps(results, indent=2)}")
+else:
+    print("NO_ISSUES")
+```
+
+```bash
+hermes cron create "every 30m" \
+  "If the script reports OUTAGE DETECTED, summarize which services are down and suggest likely causes. If NO_ISSUES, respond with [SILENT]." \
+  --script ~/.hermes/scripts/check-uptime.py \
+  --name "Uptime monitor" \
+  --deliver telegram
+```
+
+---
+
+## Research & Intelligence
+
+### Competitive Repository Scout
+
+Monitor competitor repos for interesting PRs, features, and architectural decisions.
+
+**Trigger:** Schedule (daily)
+
+```bash
+hermes cron create "0 8 * * *" \
+  "Scout these AI agent repositories for notable activity in the last 24 hours:
+
+Repos to check:
+- anthropics/claude-code
+- openai/codex
+- All-Hands-AI/OpenHands
+- Aider-AI/aider
+
+For each repo:
+1. gh pr list --repo <repo> --state all --json number,title,author,createdAt,mergedAt --limit 15
+2. gh issue list --repo <repo> --state open --json number,title,labels,createdAt --limit 10
+
+Focus on:
+- New features being developed
+- Architectural changes
+- Integration patterns we could learn from
+- Security fixes that might affect us too
+
+Skip routine dependency bumps and CI fixes. If nothing notable, respond with [SILENT].
+If there are findings, organize by repo with brief analysis of each item." \
+  --skills "competitive-pr-scout" \
+  --name "Competitor scout" \
+  --deliver telegram
+```
+
+### AI News Digest
+
+Weekly roundup of AI/ML developments.
+
+**Trigger:** Schedule (weekly)
+
+```bash
+hermes cron create "0 9 * * 1" \
+  "Generate a weekly AI news digest covering the past 7 days:
+
+1. Search the web for major AI announcements, model releases, and research breakthroughs
+2. Search for trending ML repositories on GitHub
+3. Check arXiv for highly-cited papers on language models and agents
+
+Structure:
+## Headlines (3-5 major stories)
+## Notable Papers (2-3 papers with one-sentence summaries)
+## Open Source (interesting new repos or major releases)
+## Industry Moves (funding, acquisitions, launches)
+
+Keep each item to 1-2 sentences. Include links. Total under 600 words." \
+  --name "Weekly AI digest" \
+  --deliver telegram
+```
+
+### Paper Digest with Notes
+
+Daily arXiv scan that saves summaries to your note-taking system.
+
+**Trigger:** Schedule (daily)
+
+```bash
+hermes cron create "0 8 * * *" \
+  "Search arXiv for the 3 most interesting papers on 'language model reasoning' OR 'tool-use agents' from the past day. For each paper, create an Obsidian note with the title, authors, abstract summary, key contribution, and potential relevance to Hermes Agent development." \
+  --skills "arxiv,obsidian" \
+  --name "Paper digest" \
+  --deliver local
+```
+
+---
+
+## GitHub Event Automations
+
+### Issue Auto-Labeling
+
+Automatically label and respond to new issues.
+
+**Trigger:** GitHub webhook
+
+```bash
+hermes webhook subscribe github-issues \
+  --events "issues" \
+  --prompt "New GitHub issue received:
+Repository: {repository.full_name}
+Issue #{issue.number}: {issue.title}
+Author: {issue.user.login}
+Action: {action}
+Body: {issue.body}
+Labels: {issue.labels}
+
+If this is a new issue (action=opened):
+1. Read the issue title and body carefully
+2. Suggest appropriate labels (bug, feature, docs, security, question)
+3. If it's a bug report, check if you can identify the affected component from the description
+4. Post a helpful initial response acknowledging the issue
+
+If this is a label or assignment change, respond with [SILENT]." \
+  --deliver github_comment
+```
+
+### CI Failure Analysis
+
+Analyze CI failures and post diagnostics on the PR.
+
+**Trigger:** GitHub webhook
+
+```yaml
+# config.yaml route
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        ci-failure:
+          events: ["check_run"]
+          secret: "ci-secret"
+          prompt: |
+            CI check failed:
+            Repository: {repository.full_name}
+            Check: {check_run.name}
+            Status: {check_run.conclusion}
+            PR: #{check_run.pull_requests.0.number}
+            Details URL: {check_run.details_url}
+
+            If conclusion is "failure":
+            1. Fetch the log from the details URL if accessible
+            2. Identify the likely cause of failure
+            3. Suggest a fix
+            If conclusion is "success", respond with [SILENT].
+          deliver: "github_comment"
+          deliver_extra:
+            repo: "{repository.full_name}"
+            pr_number: "{check_run.pull_requests.0.number}"
+```
+
+### Auto-Port Changes Across Repos
+
+When a PR merges in one repo, automatically port the equivalent change to another.
+
+**Trigger:** GitHub webhook
+
+```bash
+hermes webhook subscribe auto-port \
+  --events "pull_request" \
+  --prompt "PR merged in the source repository:
+Repository: {repository.full_name}
+PR #{pull_request.number}: {pull_request.title}
+Author: {pull_request.user.login}
+Action: {action}
+Merge commit: {pull_request.merge_commit_sha}
+
+If action is 'closed' and pull_request.merged is true:
+1. Fetch the diff: curl -sL {pull_request.diff_url}
+2. Analyze what changed
+3. Determine if this change needs to be ported to the Go SDK equivalent
+4. If yes, create a branch, apply the equivalent changes, and open a PR on the target repo
+5. Reference the original PR in the new PR description
+
+If action is not 'closed' or not merged, respond with [SILENT]." \
+  --skills "github-pr-workflow" \
+  --deliver log
+```
+
+---
+
+## Business Operations
+
+### Stripe Payment Monitoring
+
+Track payment events and get summaries of failures.
+
+**Trigger:** API call (webhook)
+
+```bash
+hermes webhook subscribe stripe-payments \
+  --events "payment_intent.succeeded,payment_intent.payment_failed,charge.dispute.created" \
+  --prompt "Stripe event received:
+Event type: {type}
+Amount: {data.object.amount} cents ({data.object.currency})
+Customer: {data.object.customer}
+Status: {data.object.status}
+
+For payment_intent.payment_failed:
+- Identify the failure reason from {data.object.last_payment_error}
+- Suggest whether this is a transient issue (retry) or permanent (contact customer)
+
+For charge.dispute.created:
+- Flag as urgent
+- Summarize the dispute details
+
+For payment_intent.succeeded:
+- Brief confirmation only
+
+Keep responses concise for the ops channel." \
+  --deliver slack
+```
+
+### Daily Revenue Summary
+
+Compile key business metrics every morning.
+
+**Trigger:** Schedule (daily)
+
+```bash
+hermes cron create "0 8 * * *" \
+  "Generate a morning business metrics summary.
+
+Search the web for:
+1. Current Bitcoin and Ethereum prices
+2. S&P 500 status (pre-market or previous close)
+3. Any major tech/AI industry news from the last 12 hours
+
+Format as a brief morning briefing, 3-4 bullet points max.
+Deliver as a clean, scannable message." \
+  --name "Morning briefing" \
+  --deliver telegram
+```
+
+---
+
+## Multi-Skill Workflows
+
+### Security Audit Pipeline
+
+Combine multiple skills for a comprehensive weekly security review.
+
+**Trigger:** Schedule (weekly)
+
+```bash
+hermes cron create "0 3 * * 0" \
+  "Run a comprehensive security audit of the hermes-agent codebase.
+
+1. Check for dependency vulnerabilities (pip audit, npm audit)
+2. Search the codebase for common security anti-patterns:
+   - Hardcoded secrets or API keys
+   - SQL injection vectors (string formatting in queries)
+   - Path traversal risks (user input in file paths without validation)
+   - Unsafe deserialization (pickle.loads, yaml.load without SafeLoader)
+3. Review recent commits (last 7 days) for security-relevant changes
+4. Check if any new environment variables were added without being documented
+
+Write a security report with findings categorized by severity (Critical, High, Medium, Low).
+If nothing found, report a clean bill of health." \
+  --skills "codebase-security-audit" \
+  --name "Weekly security audit" \
+  --deliver telegram
+```
+
+### Content Pipeline
+
+Research, draft, and prepare content on a schedule.
+
+**Trigger:** Schedule (weekly)
+
+```bash
+hermes cron create "0 10 * * 3" \
+  "Research and draft a technical blog post outline about a trending topic in AI agents.
+
+1. Search the web for the most discussed AI agent topics this week
+2. Pick the most interesting one that's relevant to open-source AI agents
+3. Create an outline with:
+   - Hook/intro angle
+   - 3-4 key sections
+   - Technical depth appropriate for developers
+   - Conclusion with actionable takeaway
+4. Save the outline to ~/drafts/blog-$(date +%Y%m%d).md
+
+Keep the outline to ~300 words. This is a starting point, not a finished post." \
+  --name "Blog outline" \
+  --deliver local
+```
+
+---
+
+## Quick Reference
+
+### Cron Schedule Syntax
+
+| Expression | Meaning |
+|-----------|---------|
+| `every 30m` | Every 30 minutes |
+| `every 2h` | Every 2 hours |
+| `0 2 * * *` | Daily at 2:00 AM |
+| `0 9 * * 1` | Every Monday at 9:00 AM |
+| `0 9 * * 1-5` | Weekdays at 9:00 AM |
+| `0 3 * * 0` | Every Sunday at 3:00 AM |
+| `0 */6 * * *` | Every 6 hours |
+
+### Delivery Targets
+
+| Target | Flag | Notes |
+|--------|------|-------|
+| Same chat | `--deliver origin` | Default — delivers to where the job was created |
+| Local file | `--deliver local` | Saves output, no notification |
+| Telegram | `--deliver telegram` | Home channel, or `telegram:CHAT_ID` for specific |
+| Discord | `--deliver discord` | Home channel, or `discord:CHANNEL_ID` |
+| Slack | `--deliver slack` | Home channel |
+| SMS | `--deliver sms:+15551234567` | Direct to phone number |
+| Specific thread | `--deliver telegram:-100123:456` | Telegram forum topic |
+
+### Webhook Template Variables
+
+| Variable | Description |
+|----------|-------------|
+| `{pull_request.title}` | PR title |
+| `{issue.number}` | Issue number |
+| `{repository.full_name}` | `owner/repo` |
+| `{action}` | Event action (opened, closed, etc.) |
+| `{__raw__}` | Full JSON payload (truncated at 4000 chars) |
+| `{sender.login}` | GitHub user who triggered the event |
+
+### The [SILENT] Pattern
+
+When a cron job's response contains `[SILENT]`, delivery is suppressed. Use this to avoid notification spam on quiet runs:
+
+```
+If nothing noteworthy happened, respond with [SILENT].
+```
+
+This means you only get notified when the agent has something to report.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -152,6 +152,7 @@ const sidebars: SidebarsConfig = {
         'guides/use-voice-mode-with-hermes',
         'guides/build-a-hermes-plugin',
         'guides/automate-with-cron',
+        'guides/automation-templates',
         'guides/cron-troubleshooting',
         'guides/work-with-skills',
         'guides/delegation-patterns',


### PR DESCRIPTION
## Summary

Adds an automation templates gallery to the docs site with 15+ ready-to-use recipes, plus a comparison post showing Hermes has had schedule/webhook/API triggers since March 2026.

### New files
- `website/docs/guides/automation-templates.md` — copy-paste recipes for cron, webhook, and API-triggered automations
- `hermes-already-has-routines.md` — shareable comparison post (Claude Code Routines vs Hermes)
- `website/sidebars.ts` — added automation-templates to Guides & Tutorials nav

### Context
Claude Code Routines launched April 14 2026. All three trigger types (scheduled, GitHub events, API calls) have been in Hermes since March via the cron scheduler and webhook platform.