### PR TITLE
fix(matrix): encrypt outbound attachments in E2EE rooms

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -873,12 +873,35 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
 
+        upload_data = data
+        encrypted_file = None
+        state_store = getattr(self._client, "state_store", None)
+        room_is_encrypted = False
+        if self._encryption and getattr(self._client, "crypto", None) and state_store:
+            try:
+                room_is_encrypted = bool(await state_store.is_encrypted(RoomID(room_id)))
+            except Exception as exc:
+                logger.debug(
+                    "Matrix: failed to inspect room encryption state for media upload: %s",
+                    exc,
+                )
+
+        if room_is_encrypted:
+            try:
+                from mautrix.crypto.attachments import encrypt_attachment
+
+                upload_data, encrypted_file = encrypt_attachment(data)
+            except Exception as exc:
+                logger.error("Matrix: attachment encryption failed: %s", exc)
+                return SendResult(success=False, error=str(exc))
+
         # Upload to homeserver.
         try:
             mxc_url = await self._client.upload_media(
-                data,
+                upload_data,
                 mime_type=content_type,
                 filename=filename,
+                size=len(upload_data),
             )
         except Exception as exc:
             logger.error("Matrix: upload failed: %s", exc)
@@ -888,12 +911,17 @@ class MatrixAdapter(BasePlatformAdapter):
         msg_content: Dict[str, Any] = {
             "msgtype": msgtype,
             "body": caption or filename,
-            "url": str(mxc_url),
             "info": {
                 "mimetype": content_type,
                 "size": len(data),
             },
         }
+        if encrypted_file is not None:
+            encrypted_file_payload = encrypted_file.serialize()
+            encrypted_file_payload["url"] = str(mxc_url)
+            msg_content["file"] = encrypted_file_payload
+        else:
+            msg_content["url"] = str(mxc_url)
 
         # Add MSC3245 voice flag for native voice messages.
         if is_voice:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1141,6 +1141,88 @@ class TestMatrixEncryptedSendFallback:
         assert fake_client.send_message_event.await_count == 2
 
 
+class TestMatrixUploadAndSend:
+    @pytest.mark.asyncio
+    async def test_upload_and_send_unencrypted_room_uses_plain_url(self):
+        adapter = _make_adapter()
+        adapter._encryption = True
+
+        fake_client = MagicMock()
+        fake_client.crypto = object()
+        fake_client.state_store = MagicMock()
+        fake_client.state_store.is_encrypted = AsyncMock(return_value=False)
+        fake_client.upload_media = AsyncMock(return_value="mxc://matrix.example.org/plain")
+        fake_client.send_message_event = AsyncMock(return_value="$plain_event")
+        adapter._client = fake_client
+
+        result = await adapter._upload_and_send(
+            "!room:example.org",
+            b"plain bytes",
+            "plain.txt",
+            "text/plain",
+            "m.file",
+        )
+
+        assert result.success is True
+        fake_client.upload_media.assert_awaited_once_with(
+            b"plain bytes",
+            mime_type="text/plain",
+            filename="plain.txt",
+            size=len(b"plain bytes"),
+        )
+        sent_content = fake_client.send_message_event.await_args.args[2]
+        assert sent_content["url"] == "mxc://matrix.example.org/plain"
+        assert "file" not in sent_content
+
+    @pytest.mark.asyncio
+    async def test_upload_and_send_encrypted_room_uses_file_payload(self):
+        adapter = _make_adapter()
+        adapter._encryption = True
+
+        fake_client = MagicMock()
+        fake_client.crypto = object()
+        fake_client.state_store = MagicMock()
+        fake_client.state_store.is_encrypted = AsyncMock(return_value=True)
+        fake_client.upload_media = AsyncMock(return_value="mxc://matrix.example.org/encrypted")
+        fake_client.send_message_event = AsyncMock(return_value="$encrypted_event")
+        adapter._client = fake_client
+
+        encrypted_file = MagicMock()
+        encrypted_file.serialize.return_value = {
+            "key": {"k": "secret"},
+            "iv": "iv",
+            "hashes": {"sha256": "hash"},
+            "v": "v2",
+        }
+
+        fake_attachments = types.ModuleType("mautrix.crypto.attachments")
+        fake_attachments.encrypt_attachment = MagicMock(
+            return_value=(b"ciphertext", encrypted_file)
+        )
+
+        with patch.dict(sys.modules, {"mautrix.crypto.attachments": fake_attachments}):
+            result = await adapter._upload_and_send(
+                "!room:example.org",
+                b"plaintext",
+                "secret.txt",
+                "text/plain",
+                "m.file",
+            )
+
+        assert result.success is True
+        fake_attachments.encrypt_attachment.assert_called_once_with(b"plaintext")
+        fake_client.upload_media.assert_awaited_once_with(
+            b"ciphertext",
+            mime_type="text/plain",
+            filename="secret.txt",
+            size=len(b"ciphertext"),
+        )
+        sent_content = fake_client.send_message_event.await_args.args[2]
+        assert "url" not in sent_content
+        assert sent_content["file"]["url"] == "mxc://matrix.example.org/encrypted"
+        assert sent_content["file"]["key"] == {"k": "secret"}
+
+
 # ---------------------------------------------------------------------------
 # E2EE: MegolmEvent key request + buffering via _on_encrypted_event
 # ---------------------------------------------------------------------------
@@ -1829,6 +1911,4 @@ class TestMatrixPresence:
         self.adapter._client = None
         result = await self.adapter.set_presence("online")
         assert result is False
-
-
 


### PR DESCRIPTION
## What does this PR do?

Fixes outbound Matrix attachments in encrypted rooms.

Today the Matrix gateway always uploads the original bytes and sends a plain
`url` payload. That works for unencrypted rooms, but it is not the correct
event shape for E2EE rooms. In encrypted rooms we need to encrypt the upload
payload first, send the encrypted bytes to the homeserver, and include a
Matrix `file` object in the event content so clients can decrypt the media.

This change keeps the unencrypted path unchanged and only switches behavior
when the room is marked encrypted in the Matrix state store.

## Related Issue

No exact upstream issue found for outbound encrypted Matrix attachments.

Closest related Matrix issues / PRs:
- #4339 / #4343
- #3487 / #3140 / #4196

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `gateway/platforms/matrix.py` to detect encrypted rooms before sending attachments.
- Encrypt outbound attachment bytes with `mautrix.crypto.attachments.encrypt_attachment()` for E2EE rooms.
- Upload the encrypted bytes and pass explicit upload `size`.
- Send a Matrix `file` payload for encrypted rooms and preserve the existing plain `url` payload for unencrypted rooms.
- Add focused async tests in `tests/gateway/test_matrix.py` covering both encrypted and unencrypted attachment sends.

## How to Test

1. Run `pytest tests/gateway/test_matrix.py -q`.
2. In an unencrypted Matrix room, send an attachment through Hermes and confirm clients receive a normal media event with a usable MXC URL.
3. In an encrypted Matrix room, send an attachment through Hermes and confirm clients receive and decrypt the file successfully.

Local validation used for this PR:
- `pytest tests/gateway/test_matrix.py -q -o addopts=''` -> `113 passed, 1 warning in 0.44s`
- Live validation on a Hermes deployment sent an encrypted `.txt` attachment successfully to an E2EE Matrix room:
  - event ID: `$UOu2wev4mgz-KJBfc4gu93g0spHdttqPpNnjUnFM0Ek`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```text
pytest tests/gateway/test_matrix.py -q -o addopts=''
113 passed, 1 warning in 0.44s
```

Live Matrix validation:

```text
Encrypted attachment test from Hermes patch validation
event_id=$UOu2wev4mgz-KJBfc4gu93g0spHdttqPpNnjUnFM0Ek
```
