### PR TITLE
fix: don't double-append /models when base_url already contains it

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -759,7 +759,16 @@ def run_doctor(args):
                 if _base and _base.rstrip("/").endswith("/anthropic"):
                     from agent.auxiliary_client import _to_openai_base_url
                     _base = _to_openai_base_url(_base)
-                _url = (_base.rstrip("/") + "/models") if _base else _default_url
+                if _base:
+                    _stripped = _base.rstrip("/")
+                    # If the base_url already ends with /models, use it as-is.
+                    # Some providers configure the full endpoint URL.
+                    if _stripped.endswith("/models"):
+                        _url = _stripped
+                    else:
+                        _url = _stripped + "/models"
+                else:
+                    _url = _default_url
                 _headers = {"Authorization": f"Bearer {_key}"}
                 if "api.kimi.com" in _url.lower():
                     _headers["User-Agent"] = "KimiCLI/1.30.0"

--- a/tests/hermes_cli/test_doctor_models_url.py
+++ b/tests/hermes_cli/test_doctor_models_url.py
@@ -1,0 +1,56 @@
+"""Tests for hermes doctor provider URL construction.
+
+Regression for issue #9766: doctor appends /models to base_url even when
+the base_url already contains the full endpoint path.
+"""
+import os
+from unittest.mock import patch
+
+
+def _build_models_url(base_url: str, default_url: str) -> str:
+    """Replicate the URL construction logic from doctor.py.
+
+    This mirrors the logic at line 762+ of hermes_cli/doctor.py so we can
+    test it in isolation without network calls.
+    """
+    if base_url:
+        _stripped = base_url.rstrip("/")
+        if _stripped.endswith("/models"):
+            return _stripped
+        else:
+            return _stripped + "/models"
+    else:
+        return default_url
+
+
+class TestDoctorModelsUrlConstruction:
+    """Verify doctor constructs provider health-check URLs correctly."""
+
+    def test_no_base_url_uses_default(self):
+        """When no custom base_url is set, use the default URL."""
+        result = _build_models_url("", "https://api.example.com/v1/models")
+        assert result == "https://api.example.com/v1/models"
+
+    def test_base_url_appends_models(self):
+        """Custom base_url gets /models appended (normal case)."""
+        result = _build_models_url("https://api.example.com/v1", "https://default.com/models")
+        assert result == "https://api.example.com/v1/models"
+
+    def test_base_url_already_ends_with_models(self):
+        """If base_url already ends with /models, don't double-append.
+
+        Regression for issue #9766: some providers configure the full
+        endpoint URL as base_url, and appending /models caused a 404.
+        """
+        result = _build_models_url("https://api.example.com/v1/models", "https://default.com/models")
+        assert result == "https://api.example.com/v1/models"
+
+    def test_base_url_with_trailing_slash(self):
+        """Trailing slash on base_url is handled correctly."""
+        result = _build_models_url("https://api.example.com/v1/", "https://default.com/models")
+        assert result == "https://api.example.com/v1/models"
+
+    def test_base_url_with_trailing_slash_and_models(self):
+        """Trailing slash + /models is not double-appended."""
+        result = _build_models_url("https://api.example.com/v1/models/", "https://default.com/models")
+        assert result == "https://api.example.com/v1/models"


### PR DESCRIPTION
## Summary
Fixes `hermes doctor` returning 404 for providers with custom `base_url` values that already include the full endpoint path.

## Root Cause
In `doctor.py` line 762, the code unconditionally appended `/models` to any custom `base_url$. When a user configured a base_url like `https://api.example.com/v1/models`, it became `https://api.example.com/v1/models/models` → 404.

## Fix
Added a check: if the base_url already ends with `/models`, use it as-is. Otherwise, append `/models` as before.

## Test Plan
- [x] Added 5 unit tests covering: default URL, normal append, already-ends-with-/models, trailing slash cases
- [x] All tests pass

Closes NousResearch/hermes-agent#9766