### PR TITLE
fix(cli): route context pressure warnings through TUI printer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2915,6 +2915,7 @@ class HermesCLI:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            self.agent._line_printer = _cprint
             self._active_agent_route_signature = (
                 effective_model,
                 runtime.get("provider"),
@@ -5849,6 +5850,8 @@ class HermesCLI:
                     skip_context_files=True,
                     persist_session=False,
                 )
+                btw_agent._print_fn = _cprint
+                btw_agent._line_printer = _cprint
 
                 btw_prompt = (
                     "[Ephemeral /btw side question. Answer using the conversation "

--- a/run_agent.py
+++ b/run_agent.py
@@ -663,6 +663,9 @@ class AIAgent:
         # instead of going directly to stdout where patch_stdout's StdoutProxy
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
+        # Optional single-line status printer for ANSI-sensitive TUI paths
+        # such as context-pressure warnings.
+        self._line_printer = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
@@ -7552,12 +7555,14 @@ class AIAgent:
 
 
 
-    def _emit_context_pressure(self, compaction_progress: float, compressor) -> None:
+    def _emit_context_pressure(self, compaction_progress: float, compressor, line_printer=None) -> None:
         """Notify the user that context is approaching the compaction threshold.
 
         Args:
             compaction_progress: How close to compaction (0.0–1.0, where 1.0 = fires).
             compressor: The ContextCompressor instance (for threshold/context info).
+            line_printer: Optional callable to print a single line. When provided,
+                takes precedence over instance printers.
 
         Purely user-facing — does NOT modify the message stream.
         For CLI: prints a formatted line with a progress bar.
@@ -7577,7 +7582,11 @@ class AIAgent:
                 threshold_percent=threshold_pct,
                 compression_enabled=self.compression_enabled,
             )
-            self._safe_print(line)
+            emit = line_printer or self._line_printer or self._print_fn or print
+            try:
+                emit(line)
+            except (OSError, ValueError):
+                pass
 
         # Gateway / external consumers
         if self.status_callback:

--- a/tests/run_agent/test_context_pressure.py
+++ b/tests/run_agent/test_context_pressure.py
@@ -208,6 +208,44 @@ class TestContextPressureFlags:
         captured = capsys.readouterr()
         assert "▰" not in captured.out
 
+    def test_emit_prefers_explicit_line_printer(self, agent):
+        """Explicit line_printer should override instance printers."""
+        agent.platform = "cli"
+        agent.status_callback = None
+        explicit = MagicMock()
+        instance_printer = MagicMock()
+        fallback_print = MagicMock()
+        agent._line_printer = instance_printer
+        agent._print_fn = fallback_print
+
+        compressor = MagicMock()
+        compressor.context_length = 200_000
+        compressor.threshold_tokens = 100_000
+
+        agent._emit_context_pressure(0.85, compressor, line_printer=explicit)
+
+        explicit.assert_called_once()
+        instance_printer.assert_not_called()
+        fallback_print.assert_not_called()
+
+    def test_emit_uses_instance_line_printer_before_print_fn(self, agent):
+        """CLI line_printer should win over _print_fn when both exist."""
+        agent.platform = "cli"
+        agent.status_callback = None
+        instance_printer = MagicMock()
+        fallback_print = MagicMock()
+        agent._line_printer = instance_printer
+        agent._print_fn = fallback_print
+
+        compressor = MagicMock()
+        compressor.context_length = 200_000
+        compressor.threshold_tokens = 100_000
+
+        agent._emit_context_pressure(0.85, compressor)
+
+        instance_printer.assert_called_once()
+        fallback_print.assert_not_called()
+
     def test_flag_reset_on_compression(self, agent):
         """After _compress_context, context pressure flag should reset."""
         agent._context_pressure_warned_at = 0.85

--- a/tests/test_cli_btw_output.py
+++ b/tests/test_cli_btw_output.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+import cli as cli_module
+from cli import HermesCLI
+
+
+def _make_cli_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(return_value={
+        "model": "anthropic/claude-opus-4.6",
+        "runtime": {
+            "api_key": "test-key-1234567890",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+            "api_mode": None,
+            "command": None,
+            "args": [],
+        },
+        "request_overrides": None,
+    })
+    cli.conversation_history = []
+    cli.reasoning_config = None
+    cli.service_tier = None
+    cli._providers_only = None
+    cli._providers_ignore = None
+    cli._providers_order = None
+    cli._provider_sort = None
+    cli._provider_require_params = None
+    cli._provider_data_collection = None
+    cli._fallback_model = None
+    cli._app = None
+    cli.bell_on_complete = False
+    cli._invalidate = MagicMock()
+    return cli
+
+
+class TestCliBtwOutput:
+    def test_btw_agent_routes_status_output_through_cprint(self):
+        cli = _make_cli_stub()
+        created_agents = []
+
+        class _FakeAgent:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self._print_fn = None
+                self._line_printer = None
+                created_agents.append(self)
+
+            def run_conversation(self, **kwargs):
+                return {}
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None, name=None):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        with (
+            patch.object(cli_module, "AIAgent", _FakeAgent),
+            patch.object(cli_module.threading, "Thread", _ImmediateThread),
+            patch.object(cli_module, "_cprint") as mock_cprint,
+        ):
+            cli._handle_btw_command("/btw explain this bug")
+
+        assert len(created_agents) == 1
+        assert created_agents[0]._print_fn is mock_cprint
+        assert created_agents[0]._line_printer is mock_cprint


### PR DESCRIPTION
## What does this PR do?

Fixes raw ANSI escape output in the CLI context-pressure warning path.

`AIAgent._emit_context_pressure()` now supports a dedicated single-line printer path for ANSI-sensitive TUI output, and the CLI wires that printer into both the main interactive agent and the ephemeral `/btw` side-agent. This keeps the warning line inside prompt_toolkit's renderer instead of falling back to bare `print()` in CLI paths that do not consistently inherit `_print_fn`.

This is related to the same class of TUI escape-rendering bugs as `/tools list` and `/yolo`, but it fixes a different surface: context-pressure warnings and `/btw` side-agents.

## Related Issue

No dedicated issue found for this exact surface.
Related to #4128.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: add an explicit `line_printer` path for `_emit_context_pressure()` and define `_line_printer` on `AIAgent`
- `cli.py`: wire `_line_printer = _cprint` into the main CLI agent
- `cli.py`: wire `_print_fn` and `_line_printer` into the `/btw` side-agent so ANSI status lines stay TUI-safe there too
- `tests/run_agent/test_context_pressure.py`: add precedence tests for `line_printer` vs `_line_printer` vs `_print_fn`
- `tests/test_cli_btw_output.py`: add a regression test that verifies `/btw` agents inherit the TUI-safe printer

## How to Test

1. Run `pytest -n 0 tests/run_agent/test_context_pressure.py -q`
2. Run `pytest -n 0 tests/test_cli_btw_output.py -q`
3. In the CLI, trigger a context-pressure warning or exercise the `/btw` side-agent path and confirm warning/status lines render through the TUI instead of showing raw escape sequences

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed:

```text
pytest -n 0 tests/run_agent/test_context_pressure.py -q
33 passed in 7.14s

pytest -n 0 tests/test_cli_btw_output.py -q
1 passed in 3.32s
```

Full-suite status on this Windows environment:

```text
pytest tests/ -q
exit 137

pytest tests/ -q -n 0
ERROR tests/hermes_cli/test_gateway_service.py: ModuleNotFoundError: No module named 'pwd'
ERROR tests/tools/test_memory_tool.py: ModuleNotFoundError: No module named 'fcntl'
```

These full-suite failures reproduced from `upstream/main` before this fix and appear to be pre-existing Windows/platform issues rather than regressions from this PR.