### PR TITLE
feat(matrix): add Matrix tools and platform hint

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -324,13 +324,6 @@ PLATFORM_HINTS = {
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be uploaded as attachments."
     ),
-    "matrix": (
-        "You are connected via Matrix, a decentralized messaging protocol. "
-        "When the Matrix-specific toolset is available, you can manage Matrix rooms and events "
-        "using tools such as matrix_send_reaction, matrix_redact_message, matrix_create_room, "
-        "matrix_invite_user, matrix_fetch_history, and matrix_set_presence. "
-        "Messages support rich HTML formatting via org.matrix.custom.html."
-    ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "
         "Please do not use markdown as it does not render. "
@@ -393,7 +386,10 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.jpg, .png, .webp) are sent as inline photos, "
         "audio (.ogg, .mp3) as voice/audio messages, video (.mp4) inline, "
-        "and other files as downloadable attachments."
+        "and other files as downloadable attachments. "
+        "When the Matrix-specific toolset is available, you can manage Matrix rooms and events "
+        "using tools such as matrix_send_reaction, matrix_redact_message, matrix_create_room, "
+        "matrix_invite_user, matrix_fetch_history, and matrix_set_presence."
     ),
     "feishu": (
         "You are in a Feishu (Lark) workspace communicating with your user. "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -324,6 +324,13 @@ PLATFORM_HINTS = {
         "attachments, audio as file attachments. You can also include image URLs "
         "in markdown format ![alt](url) and they will be uploaded as attachments."
     ),
+    "matrix": (
+        "You are connected via Matrix, a decentralized messaging protocol. "
+        "When the Matrix-specific toolset is available, you can manage Matrix rooms and events "
+        "using tools such as matrix_send_reaction, matrix_redact_message, matrix_create_room, "
+        "matrix_invite_user, matrix_fetch_history, and matrix_set_presence. "
+        "Messages support rich HTML formatting via org.matrix.custom.html."
+    ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "
         "Please do not use markdown as it does not render. "

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -685,13 +685,17 @@ class MatrixAdapter(BasePlatformAdapter):
             set_matrix_adapter(None)
         except ImportError:
             pass
+        except Exception as exc:
+            logger.warning("Matrix: failed to clear tool adapter binding during disconnect: %s", exc)
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
             try:
                 await self._sync_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
+            except Exception as exc:
+                logger.warning("Matrix: sync task raised during disconnect: %s", exc)
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -609,6 +609,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 await api.session.close()
                 return False
 
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(self)
+        except ImportError:
+            pass
+
         # Register event handlers.
         from mautrix.client import InternalEventType as IntEvt
         from mautrix.client.dispatcher import MembershipEventDispatcher
@@ -673,6 +679,12 @@ class MatrixAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
+
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(None)
+        except ImportError:
+            pass
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -1591,6 +1603,10 @@ class MatrixAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("Matrix: reaction send error: %s", exc)
             return None
+
+    async def send_reaction(self, room_id: str, event_id: str, emoji: str) -> Optional[str]:
+        """Public wrapper for sending an emoji reaction to a Matrix event."""
+        return await self._send_reaction(room_id, event_id, emoji)
 
     async def _redact_reaction(
         self,

--- a/tests/gateway/test_matrix_tools.py
+++ b/tests/gateway/test_matrix_tools.py
@@ -143,3 +143,25 @@ class TestMatrixToolHandlers:
         result = json.loads(_handle_set_presence({"state": "online", "status_msg": "ready"}))
         assert result["success"] is True
         adapter.set_presence.assert_awaited_once_with(state="online", status_msg="ready")
+
+    def test_send_reaction_retries_transient_failures(self):
+        adapter = DummyAdapter()
+        adapter.send_reaction = AsyncMock(side_effect=[RuntimeError("temporary"), "$reaction"])
+        set_matrix_adapter(adapter)
+
+        result = json.loads(_handle_send_reaction({"room_id": "!r:ex", "event_id": "$e", "emoji": "👍"}))
+
+        assert result["success"] is True
+        assert result["reaction_event_id"] == "$reaction"
+        assert adapter.send_reaction.await_count == 2
+
+    def test_set_presence_returns_error_after_retry_budget_exhausted(self):
+        adapter = DummyAdapter()
+        adapter.set_presence = AsyncMock(side_effect=RuntimeError("homeserver unavailable"))
+        set_matrix_adapter(adapter)
+
+        result = json.loads(_handle_set_presence({"state": "online", "status_msg": "ready"}))
+
+        assert "error" in result
+        assert "Failed to set presence" in result["error"]
+        assert adapter.set_presence.await_count == 3

--- a/tests/gateway/test_matrix_tools.py
+++ b/tests/gateway/test_matrix_tools.py
@@ -1,0 +1,145 @@
+"""Tests for Matrix LLM-callable tools and registrations."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.prompt_builder import PLATFORM_HINTS
+from model_tools import get_all_tool_names, get_toolset_for_tool
+from tools.matrix_tools import (
+    _handle_create_room,
+    _handle_fetch_history,
+    _handle_invite_user,
+    _handle_redact_message,
+    _handle_send_reaction,
+    _handle_set_presence,
+    set_matrix_adapter,
+)
+from tools.registry import registry
+from toolsets import TOOLSETS, resolve_toolset
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.send_reaction = AsyncMock(return_value="$reaction")
+        self.redact_message = AsyncMock(return_value=True)
+        self.create_room = AsyncMock(return_value="!new:example.org")
+        self.invite_user = AsyncMock(return_value=True)
+        self.fetch_room_history = AsyncMock(return_value=[{"event_id": "$e1", "body": "hello"}])
+        self.set_presence = AsyncMock(return_value=True)
+        self._loop = None
+
+
+@pytest.fixture(autouse=True)
+def _clear_matrix_adapter():
+    set_matrix_adapter(None)
+    yield
+    set_matrix_adapter(None)
+
+
+class TestMatrixToolRegistration:
+    def test_model_tools_discovers_matrix_tools(self):
+        names = set(get_all_tool_names())
+        for name in {
+            "matrix_send_reaction",
+            "matrix_redact_message",
+            "matrix_create_room",
+            "matrix_invite_user",
+            "matrix_fetch_history",
+            "matrix_set_presence",
+        }:
+            assert name in names
+            assert get_toolset_for_tool(name) == "matrix"
+
+    def test_toolset_wiring_is_matrix_specific(self):
+        assert "matrix" in TOOLSETS
+        assert "matrix" in TOOLSETS["hermes-matrix"]["includes"]
+        resolved = set(resolve_toolset("hermes-matrix"))
+        assert "matrix_send_reaction" in resolved
+        assert "matrix_fetch_history" in resolved
+
+    def test_platform_hint_includes_matrix(self):
+        assert "matrix" in PLATFORM_HINTS
+        assert "matrix_send_reaction" in PLATFORM_HINTS["matrix"]
+
+    def test_registry_hides_matrix_tools_without_live_adapter(self):
+        defs = registry.get_definitions({"matrix_send_reaction", "matrix_fetch_history"}, quiet=True)
+        assert defs == []
+
+    def test_registry_exposes_matrix_tools_with_live_adapter(self):
+        set_matrix_adapter(DummyAdapter())
+        defs = registry.get_definitions({"matrix_send_reaction", "matrix_fetch_history"}, quiet=True)
+        fn_names = {d["function"]["name"] for d in defs}
+        assert fn_names == {"matrix_send_reaction", "matrix_fetch_history"}
+
+
+class TestMatrixToolHandlers:
+    def test_send_reaction_requires_live_adapter(self):
+        result = json.loads(_handle_send_reaction({"room_id": "!r:ex", "event_id": "$e", "emoji": "👍"}))
+        assert "error" in result
+        assert "not connected" in result["error"].lower()
+
+    def test_send_reaction_uses_public_adapter_api(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        result = json.loads(_handle_send_reaction({"room_id": "!r:ex", "event_id": "$e", "emoji": "👍"}))
+        assert result["success"] is True
+        assert result["reaction_event_id"] == "$reaction"
+        adapter.send_reaction.assert_awaited_once_with("!r:ex", "$e", "👍")
+
+    def test_redact_message_validates_ids(self):
+        result = json.loads(_handle_redact_message({"room_id": "bad", "event_id": "$e"}))
+        assert "error" in result
+        result = json.loads(_handle_redact_message({"room_id": "!r:ex", "event_id": "bad"}))
+        assert "error" in result
+
+    def test_create_room_blocks_public_rooms_by_default(self, monkeypatch):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        monkeypatch.delenv("MATRIX_ALLOW_PUBLIC_ROOMS", raising=False)
+        result = json.loads(_handle_create_room({"name": "Public", "preset": "public_chat"}))
+        assert "error" in result
+        adapter.create_room.assert_not_called()
+
+    def test_create_room_allows_public_rooms_when_enabled(self, monkeypatch):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        monkeypatch.setenv("MATRIX_ALLOW_PUBLIC_ROOMS", "true")
+        result = json.loads(_handle_create_room({"name": "Public", "preset": "public_chat"}))
+        assert result["success"] is True
+        adapter.create_room.assert_awaited_once()
+
+    def test_invite_user_validates_user_id(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        result = json.loads(_handle_invite_user({"room_id": "!r:ex", "user_id": "nope"}))
+        assert "error" in result
+        adapter.invite_user.assert_not_called()
+
+    def test_fetch_history_delegates_to_existing_adapter_method(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        result = json.loads(_handle_fetch_history({"room_id": "!r:ex", "limit": 25, "start": "tok"}))
+        assert result["count"] == 1
+        adapter.fetch_room_history.assert_awaited_once_with("!r:ex", limit=25, start="tok")
+
+    def test_fetch_history_clamps_invalid_limit(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        _handle_fetch_history({"room_id": "!r:ex", "limit": 999})
+        adapter.fetch_room_history.assert_awaited_once_with("!r:ex", limit=200, start="")
+
+    def test_set_presence_validates_state(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        result = json.loads(_handle_set_presence({"state": "busy"}))
+        assert "error" in result
+        adapter.set_presence.assert_not_called()
+
+    def test_set_presence_calls_adapter(self):
+        adapter = DummyAdapter()
+        set_matrix_adapter(adapter)
+        result = json.loads(_handle_set_presence({"state": "online", "status_msg": "ready"}))
+        assert result["success"] is True
+        adapter.set_presence.assert_awaited_once_with(state="online", status_msg="ready")

--- a/tools/matrix_tools.py
+++ b/tools/matrix_tools.py
@@ -28,6 +28,8 @@ _MAX_NAME_LEN = 255
 _MAX_TOPIC_LEN = 1000
 _MAX_STATUS_LEN = 255
 _ALLOWED_PRESETS = frozenset(("private_chat", "public_chat"))
+_TOOL_RETRY_ATTEMPTS = 3
+_TOOL_RETRY_DELAY_SECONDS = 0.5
 
 
 def set_matrix_adapter(adapter: Optional[Any]) -> None:
@@ -51,7 +53,7 @@ def _ensure_adapter() -> Any:
     return adapter
 
 
-def _run_async(coro):
+def _run_async(coro: Any) -> Any:
     """Run an async coroutine from a sync tool handler."""
     adapter = _ensure_adapter()
     adapter_loop = getattr(adapter, "_loop", None)
@@ -78,6 +80,31 @@ def _run_async(coro):
     return asyncio.run(coro)
 
 
+def _run_async_retry(async_fn: Any, *args: Any, attempts: int = _TOOL_RETRY_ATTEMPTS, delay_seconds: float = _TOOL_RETRY_DELAY_SECONDS, **kwargs: Any) -> Any:
+    """Run an adapter coroutine with light retry for transient homeserver failures."""
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return _run_async(async_fn(*args, **kwargs))
+        except TimeoutError:
+            raise
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= attempts:
+                break
+            logger.warning(
+                "Matrix tools: %s failed on attempt %d/%d; retrying in %.1fs",
+                getattr(async_fn, "__name__", repr(async_fn)),
+                attempt,
+                attempts,
+                delay_seconds,
+            )
+            import time
+            time.sleep(delay_seconds * attempt)
+    assert last_exc is not None
+    raise last_exc
+
+
 def _json_error(message: str) -> str:
     return json.dumps({"error": message}, ensure_ascii=False)
 
@@ -98,7 +125,7 @@ def _handle_send_reaction(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        reaction_event_id = _run_async(adapter.send_reaction(room_id, event_id, emoji))
+        reaction_event_id = _run_async_retry(adapter.send_reaction, room_id, event_id, emoji)
         return json.dumps({"success": bool(reaction_event_id), "reaction_event_id": reaction_event_id}, ensure_ascii=False)
     except Exception as exc:
         logger.error("matrix_send_reaction error: %s", exc)
@@ -117,7 +144,7 @@ def _handle_redact_message(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        ok = _run_async(adapter.redact_message(room_id, event_id, reason=reason))
+        ok = _run_async_retry(adapter.redact_message, room_id, event_id, reason=reason)
         return json.dumps({"success": bool(ok)}, ensure_ascii=False)
     except Exception as exc:
         logger.error("matrix_redact_message error: %s", exc)
@@ -143,7 +170,7 @@ def _handle_create_room(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        room_id = _run_async(adapter.create_room(name=name, topic=topic, invite=invite, is_direct=is_direct, preset=preset))
+        room_id = _run_async_retry(adapter.create_room, name=name, topic=topic, invite=invite, is_direct=is_direct, preset=preset)
         if not room_id:
             return json.dumps({"success": False, "error": "Room creation failed"}, ensure_ascii=False)
         return json.dumps({"success": True, "room_id": room_id}, ensure_ascii=False)
@@ -163,7 +190,7 @@ def _handle_invite_user(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        ok = _run_async(adapter.invite_user(room_id, user_id))
+        ok = _run_async_retry(adapter.invite_user, room_id, user_id)
         return json.dumps({"success": bool(ok)}, ensure_ascii=False)
     except Exception as exc:
         logger.error("matrix_invite_user error: %s", exc)
@@ -183,7 +210,7 @@ def _handle_fetch_history(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        messages = _run_async(adapter.fetch_room_history(room_id, limit=limit, start=start))
+        messages = _run_async_retry(adapter.fetch_room_history, room_id, limit=limit, start=start)
         return json.dumps({"count": len(messages), "messages": messages}, ensure_ascii=False)
     except Exception as exc:
         logger.error("matrix_fetch_history error: %s", exc)
@@ -199,7 +226,7 @@ def _handle_set_presence(args: dict, **_kw) -> str:
 
     try:
         adapter = _ensure_adapter()
-        ok = _run_async(adapter.set_presence(state=state, status_msg=status_msg))
+        ok = _run_async_retry(adapter.set_presence, state=state, status_msg=status_msg)
         return json.dumps({"success": bool(ok)}, ensure_ascii=False)
     except Exception as exc:
         logger.error("matrix_set_presence error: %s", exc)

--- a/tools/matrix_tools.py
+++ b/tools/matrix_tools.py
@@ -1,0 +1,333 @@
+"""LLM-callable Matrix tools.
+
+These tools wrap the live Matrix gateway adapter when Hermes is connected to
+Matrix. They are intentionally thin wrappers around the existing
+``MatrixAdapter`` public APIs so the tool layer does NOT duplicate Matrix SDK
+logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from typing import Any, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_adapter: Optional[Any] = None
+_adapter_lock = threading.Lock()
+
+_MAX_EMOJI_LEN = 32
+_MAX_REASON_LEN = 500
+_MAX_NAME_LEN = 255
+_MAX_TOPIC_LEN = 1000
+_MAX_STATUS_LEN = 255
+_ALLOWED_PRESETS = frozenset(("private_chat", "public_chat"))
+
+
+def set_matrix_adapter(adapter: Optional[Any]) -> None:
+    """Bind the currently connected Matrix adapter for tool use."""
+    global _adapter
+    with _adapter_lock:
+        _adapter = adapter
+
+
+def _check_matrix_connected() -> bool:
+    """Return True only when a live Matrix adapter instance is available."""
+    with _adapter_lock:
+        return _adapter is not None
+
+
+def _ensure_adapter() -> Any:
+    with _adapter_lock:
+        adapter = _adapter
+    if adapter is None:
+        raise RuntimeError("Matrix adapter is not connected")
+    return adapter
+
+
+def _run_async(coro):
+    """Run an async coroutine from a sync tool handler."""
+    adapter = _ensure_adapter()
+    adapter_loop = getattr(adapter, "_loop", None)
+    if adapter_loop is not None and adapter_loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(coro, adapter_loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result(timeout=30)
+
+    return asyncio.run(coro)
+
+
+def _json_error(message: str) -> str:
+    return json.dumps({"error": message}, ensure_ascii=False)
+
+
+def _handle_send_reaction(args: dict, **_kw) -> str:
+    room_id = str(args.get("room_id", "")).strip()
+    event_id = str(args.get("event_id", "")).strip()
+    emoji = str(args.get("emoji", "")).strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return _json_error("room_id is required and must start with '!'")
+    if not event_id or not event_id.startswith("$"):
+        return _json_error("event_id is required and must start with '$'")
+    if not emoji:
+        return _json_error("emoji is required and must be non-empty")
+    if len(emoji) > _MAX_EMOJI_LEN:
+        return _json_error(f"emoji must be at most {_MAX_EMOJI_LEN} characters")
+
+    try:
+        adapter = _ensure_adapter()
+        reaction_event_id = _run_async(adapter.send_reaction(room_id, event_id, emoji))
+        return json.dumps({"success": bool(reaction_event_id), "reaction_event_id": reaction_event_id}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_send_reaction error: %s", exc)
+        return _json_error(f"Failed to send reaction: {exc}")
+
+
+def _handle_redact_message(args: dict, **_kw) -> str:
+    room_id = str(args.get("room_id", "")).strip()
+    event_id = str(args.get("event_id", "")).strip()
+    reason = str(args.get("reason", ""))[:_MAX_REASON_LEN]
+
+    if not room_id or not room_id.startswith("!"):
+        return _json_error("room_id is required and must start with '!'")
+    if not event_id or not event_id.startswith("$"):
+        return _json_error("event_id is required and must start with '$'")
+
+    try:
+        adapter = _ensure_adapter()
+        ok = _run_async(adapter.redact_message(room_id, event_id, reason=reason))
+        return json.dumps({"success": bool(ok)}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_redact_message error: %s", exc)
+        return _json_error(f"Failed to redact message: {exc}")
+
+
+def _handle_create_room(args: dict, **_kw) -> str:
+    name = str(args.get("name", ""))[:_MAX_NAME_LEN]
+    topic = str(args.get("topic", ""))[:_MAX_TOPIC_LEN]
+    invite = args.get("invite", [])
+    is_direct = bool(args.get("is_direct", False))
+    preset = str(args.get("preset", "private_chat"))
+
+    if invite and not isinstance(invite, list):
+        return _json_error("invite must be a list of user IDs")
+    for user_id in invite or []:
+        if not isinstance(user_id, str) or not user_id.startswith("@"):
+            return _json_error(f"Invalid user ID in invite list: {user_id!r}")
+    if preset not in _ALLOWED_PRESETS:
+        return _json_error(f"Invalid preset: {preset!r}. Must be one of: {', '.join(sorted(_ALLOWED_PRESETS))}")
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in ("true", "1", "yes"):
+        return _json_error("Public room creation is disabled by default. Set MATRIX_ALLOW_PUBLIC_ROOMS=true to allow.")
+
+    try:
+        adapter = _ensure_adapter()
+        room_id = _run_async(adapter.create_room(name=name, topic=topic, invite=invite, is_direct=is_direct, preset=preset))
+        if not room_id:
+            return json.dumps({"success": False, "error": "Room creation failed"}, ensure_ascii=False)
+        return json.dumps({"success": True, "room_id": room_id}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_create_room error: %s", exc)
+        return _json_error(f"Failed to create room: {exc}")
+
+
+def _handle_invite_user(args: dict, **_kw) -> str:
+    room_id = str(args.get("room_id", "")).strip()
+    user_id = str(args.get("user_id", "")).strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return _json_error("room_id is required and must start with '!'")
+    if not user_id or not user_id.startswith("@"):
+        return _json_error("user_id is required and must start with '@'")
+
+    try:
+        adapter = _ensure_adapter()
+        ok = _run_async(adapter.invite_user(room_id, user_id))
+        return json.dumps({"success": bool(ok)}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_invite_user error: %s", exc)
+        return _json_error(f"Failed to invite user: {exc}")
+
+
+def _handle_fetch_history(args: dict, **_kw) -> str:
+    room_id = str(args.get("room_id", "")).strip()
+    limit = args.get("limit", 50)
+    start = str(args.get("start", "")).strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return _json_error("room_id is required and must start with '!'")
+    if not isinstance(limit, int) or limit < 1:
+        limit = 50
+    limit = min(limit, 200)
+
+    try:
+        adapter = _ensure_adapter()
+        messages = _run_async(adapter.fetch_room_history(room_id, limit=limit, start=start))
+        return json.dumps({"count": len(messages), "messages": messages}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_fetch_history error: %s", exc)
+        return _json_error(f"Failed to fetch history: {exc}")
+
+
+def _handle_set_presence(args: dict, **_kw) -> str:
+    state = str(args.get("state", "")).strip().lower()
+    status_msg = str(args.get("status_msg", ""))[:_MAX_STATUS_LEN]
+
+    if state not in ("online", "offline", "unavailable"):
+        return _json_error(f"Invalid state: {state!r}. Must be 'online', 'offline', or 'unavailable'")
+
+    try:
+        adapter = _ensure_adapter()
+        ok = _run_async(adapter.set_presence(state=state, status_msg=status_msg))
+        return json.dumps({"success": bool(ok)}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("matrix_set_presence error: %s", exc)
+        return _json_error(f"Failed to set presence: {exc}")
+
+
+registry.register(
+    name="matrix_send_reaction",
+    toolset="matrix",
+    schema={
+        "name": "matrix_send_reaction",
+        "description": "Send an emoji reaction to a specific message in a Matrix room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string", "description": "Matrix room ID starting with '!'."},
+                "event_id": {"type": "string", "description": "Target Matrix event ID starting with '$'."},
+                "emoji": {"type": "string", "description": "Emoji reaction to apply."},
+            },
+            "required": ["room_id", "event_id", "emoji"],
+        },
+    },
+    handler=_handle_send_reaction,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)
+
+registry.register(
+    name="matrix_redact_message",
+    toolset="matrix",
+    schema={
+        "name": "matrix_redact_message",
+        "description": "Redact a Matrix event from a room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string"},
+                "event_id": {"type": "string"},
+                "reason": {"type": "string", "description": "Optional reason for redaction."},
+            },
+            "required": ["room_id", "event_id"],
+        },
+    },
+    handler=_handle_redact_message,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)
+
+registry.register(
+    name="matrix_create_room",
+    toolset="matrix",
+    schema={
+        "name": "matrix_create_room",
+        "description": "Create a Matrix room. Public room creation is gated by MATRIX_ALLOW_PUBLIC_ROOMS.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "topic": {"type": "string"},
+                "invite": {"type": "array", "items": {"type": "string"}},
+                "is_direct": {"type": "boolean"},
+                "preset": {"type": "string", "enum": ["private_chat", "public_chat"]},
+            },
+            "required": [],
+        },
+    },
+    handler=_handle_create_room,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)
+
+registry.register(
+    name="matrix_invite_user",
+    toolset="matrix",
+    schema={
+        "name": "matrix_invite_user",
+        "description": "Invite a user to a Matrix room.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string"},
+                "user_id": {"type": "string"},
+            },
+            "required": ["room_id", "user_id"],
+        },
+    },
+    handler=_handle_invite_user,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)
+
+registry.register(
+    name="matrix_fetch_history",
+    toolset="matrix",
+    schema={
+        "name": "matrix_fetch_history",
+        "description": "Fetch recent message history from a Matrix room using the adapter's existing history API.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "room_id": {"type": "string"},
+                "limit": {"type": "integer", "description": "Maximum messages to return (1-200)."},
+                "start": {"type": "string", "description": "Optional pagination token."},
+            },
+            "required": ["room_id"],
+        },
+    },
+    handler=_handle_fetch_history,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)
+
+registry.register(
+    name="matrix_set_presence",
+    toolset="matrix",
+    schema={
+        "name": "matrix_set_presence",
+        "description": "Set Matrix presence to online, offline, or unavailable.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "state": {"type": "string", "enum": ["online", "offline", "unavailable"]},
+                "status_msg": {"type": "string"},
+            },
+            "required": ["state"],
+        },
+    },
+    handler=_handle_set_presence,
+    check_fn=_check_matrix_connected,
+    emoji="🟣",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -202,6 +202,19 @@ TOOLSETS = {
         "includes": []
     },
 
+    "matrix": {
+        "description": "Matrix room interaction and management tools",
+        "tools": [
+            "matrix_send_reaction",
+            "matrix_redact_message",
+            "matrix_create_room",
+            "matrix_invite_user",
+            "matrix_fetch_history",
+            "matrix_set_presence",
+        ],
+        "includes": []
+    },
+
     "feishu_doc": {
         "description": "Read Feishu/Lark document content",
         "tools": ["feishu_doc_read"],
@@ -222,6 +235,9 @@ TOOLSETS = {
         "tools": [
             "spotify_playback", "spotify_devices", "spotify_queue", "spotify_search",
             "spotify_playlists", "spotify_albums", "spotify_library",
+        ],
+        "includes": []
+    },
         ],
         "includes": []
     },
@@ -377,7 +393,7 @@ TOOLSETS = {
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": ["matrix"]
     },
 
     "hermes-dingtalk": {

--- a/toolsets.py
+++ b/toolsets.py
@@ -238,9 +238,6 @@ TOOLSETS = {
         ],
         "includes": []
     },
-        ],
-        "includes": []
-    },
 
 
     # Scenario-specific toolsets


### PR DESCRIPTION
## What does this PR do?

Adds Matrix-specific agent-callable tools plus Matrix prompt/toolset wiring on top of the current mautrix-based adapter. This reintroduces the missing Matrix tool surface without leaking those tools into non-Matrix contexts.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- add `tools/matrix_tools.py` with Matrix wrappers for reaction, redaction, room creation, invite, history, and presence
- register Matrix tools in `model_tools.py`
- add a dedicated `matrix` toolset and include it from `hermes-matrix` in `toolsets.py`
- add Matrix platform guidance to `agent/prompt_builder.py`
- add coverage in `tests/gateway/test_matrix_tools.py`

## How to Test

1. `~/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' tests/gateway/test_matrix_tools.py tests/gateway/test_matrix.py`
2. Confirm Matrix tools are registered only in Matrix-specific toolsets
3. Confirm the prompt builder includes Matrix tool guidance when running on Matrix

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Branch-scoped validation: `129 passed in 3.65s`
