### PR TITLE
feat(matrix): add interactive controls and thinking panes

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1700,6 +1700,14 @@ class MatrixAdapter(BasePlatformAdapter):
         """Public wrapper for sending an emoji reaction to a Matrix event."""
         return await self._send_reaction(room_id, event_id, emoji)
 
+    async def _seed_control_reactions(self, room_id: str, event_id: str, emojis: list[str]) -> None:
+        """Pre-seed interactive control reactions so clients expose tap targets."""
+        for emoji in emojis:
+            try:
+                await self.send_reaction(room_id, event_id, emoji)
+            except Exception as exc:
+                logger.debug("Matrix control reaction seed failed for %s on %s: %s", emoji, event_id, exc)
+
     async def _redact_reaction(
         self, room_id: str, reaction_event_id: str, reason: str = "",
     ) -> bool:
@@ -2195,6 +2203,7 @@ class MatrixAdapter(BasePlatformAdapter):
         }
         self._approval_state[result.message_id] = state
         self._register_event_role(result.message_id, "interactive_control", chat_id, metadata, control_type="approval")
+        await self._seed_control_reactions(chat_id, result.message_id, ["✅", "🔁", "♾️", "❌"])
         return result
 
     async def send_model_picker(
@@ -2250,6 +2259,11 @@ class MatrixAdapter(BasePlatformAdapter):
         }
         self._model_picker_state[result.message_id] = state
         self._register_event_role(result.message_id, "interactive_control", chat_id, metadata, control_type="model_picker")
+        await self._seed_control_reactions(
+            chat_id,
+            result.message_id,
+            [self._number_emoji(idx) for idx in range(len(page_items))] + (["▶️"] if len(providers) > page_size else []) + ["❌"],
+        )
         return result
 
     async def _edit_model_picker_message(self, message_id: str, state: Dict[str, Any]) -> SendResult:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -270,6 +270,13 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_state: Dict[str, Dict[str, Any]] = {}
         self._model_picker_state: Dict[str, Dict[str, Any]] = {}
 
+        # Matrix thinking / acting panes.
+        self._thinking_enabled: bool = config.extra.get(
+            "thinking_fields_enabled",
+            os.getenv("MATRIX_THINKING_FIELDS_ENABLED", "false").lower() in ("true", "1", "yes"),
+        )
+        self._thinking_manager: Optional[Any] = None
+
         # Text batching: merge rapid successive messages (Telegram-style).
         # Matrix clients split long messages around 4000 chars.
         self._text_batch_delay_seconds = float(os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6"))
@@ -596,6 +603,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 await api.session.close()
                 return False
 
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(self)
+        except ImportError:
+            pass
+
         # Register event handlers.
         from mautrix.client import InternalEventType as IntEvt
 
@@ -656,6 +669,12 @@ class MatrixAdapter(BasePlatformAdapter):
         """Disconnect from Matrix."""
         self._closing = True
 
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(None)
+        except ImportError:
+            pass
+
         if self._approval_state:
             try:
                 from tools.approval import resolve_gateway_approval
@@ -667,6 +686,12 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_state.clear()
         self._model_picker_state.clear()
         self._event_roles.clear()
+
+        if self._thinking_manager:
+            try:
+                await self._thinking_manager.abort_all("Gateway restarting")
+            except Exception as exc:
+                logger.debug("Matrix: could not abort active thinking panes on disconnect: %s", exc)
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -690,6 +715,167 @@ class MatrixAdapter(BasePlatformAdapter):
             self._client = None
 
         logger.info("Matrix: disconnected")
+
+    # ------------------------------------------------------------------
+    # Thinking / acting panes
+    # ------------------------------------------------------------------
+
+    def _get_thinking_manager(self):
+        if self._thinking_manager is None and self._client:
+            from gateway.platforms.matrix_thinking import ThinkingManager
+
+            self._thinking_manager = ThinkingManager(self)
+        return self._thinking_manager
+
+    async def start_thinking(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Processing request...",
+        model_label: str = "",
+        initial_content_md: str = "",
+        thread_id: Optional[str] = None,
+    ) -> Optional[str]:
+        if not self._thinking_enabled or not self._client:
+            return None
+        mgr = self._get_thinking_manager()
+        if not mgr:
+            return None
+        return await mgr.start(
+            room_id,
+            task_id,
+            initial_summary,
+            field_kind="thinking",
+            model_label=model_label,
+            initial_content_md=initial_content_md,
+            thread_id=thread_id,
+        )
+
+    async def update_thinking(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id,
+            step_info,
+            content_md,
+            field_kind="thinking",
+            model_label=model_label,
+            append_line=append_line,
+        )
+
+    async def finalize_thinking(
+        self,
+        task_id: str,
+        final_summary: str = "Task complete",
+        collapse: bool = True,
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id,
+            final_summary,
+            collapse,
+            field_kind="thinking",
+            model_label=model_label,
+        )
+
+    async def abort_thinking(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id,
+            reason,
+            field_kind="thinking",
+            model_label=model_label,
+        )
+
+    async def start_tool_activity(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Tool activity",
+        model_label: str = "",
+        initial_content_md: str = "",
+        thread_id: Optional[str] = None,
+    ) -> Optional[str]:
+        if not self._thinking_enabled or not self._client:
+            return None
+        mgr = self._get_thinking_manager()
+        if not mgr:
+            return None
+        return await mgr.start(
+            room_id,
+            task_id,
+            initial_summary,
+            field_kind="tools",
+            model_label=model_label,
+            initial_content_md=initial_content_md,
+            thread_id=thread_id,
+        )
+
+    async def update_tool_activity(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id,
+            step_info,
+            content_md,
+            field_kind="tools",
+            model_label=model_label,
+            append_line=append_line,
+        )
+
+    async def finalize_tool_activity(
+        self,
+        task_id: str,
+        final_summary: str = "Tool activity complete",
+        collapse: bool = True,
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id,
+            final_summary,
+            collapse,
+            field_kind="tools",
+            model_label=model_label,
+        )
+
+    async def abort_tool_activity(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id,
+            reason,
+            field_kind="tools",
+            model_label=model_label,
+        )
 
     async def send(
         self,
@@ -1509,6 +1695,10 @@ class MatrixAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("Matrix: reaction send error: %s", exc)
             return None
+
+    async def send_reaction(self, room_id: str, event_id: str, emoji: str) -> Optional[str]:
+        """Public wrapper for sending an emoji reaction to a Matrix event."""
+        return await self._send_reaction(room_id, event_id, emoji)
 
     async def _redact_reaction(
         self, room_id: str, reaction_event_id: str, reason: str = "",

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -679,6 +679,8 @@ class MatrixAdapter(BasePlatformAdapter):
             set_matrix_adapter(None)
         except ImportError:
             pass
+        except Exception as exc:
+            logger.warning("Matrix: failed to clear tool adapter binding during disconnect: %s", exc)
 
         if self._approval_state:
             try:
@@ -702,8 +704,10 @@ class MatrixAdapter(BasePlatformAdapter):
             self._sync_task.cancel()
             try:
                 await self._sync_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
+            except Exception as exc:
+                logger.warning("Matrix: sync task raised during disconnect: %s", exc)
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -849,7 +849,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         task_id: str,
         final_summary: str = "Tool activity complete",
-        collapse: bool = True,
+        collapse: bool = False,
         model_label: Optional[str] = None,
     ) -> None:
         if not self._thinking_enabled or not self._thinking_manager:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -32,7 +32,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 from html import escape as _html_escape
 
@@ -261,6 +261,15 @@ class MatrixAdapter(BasePlatformAdapter):
         ).lower() not in ("false", "0", "no")
         self._pending_reactions: dict[tuple[str, str], str] = {}
 
+        # Interactive controls and outbound event-role routing.
+        allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
+        self._allowed_user_ids: Set[str] = {
+            u.strip() for u in allowed_users_raw.split(",") if u.strip()
+        }
+        self._event_roles: Dict[str, Dict[str, Any]] = {}
+        self._approval_state: Dict[str, Dict[str, Any]] = {}
+        self._model_picker_state: Dict[str, Dict[str, Any]] = {}
+
         # Text batching: merge rapid successive messages (Telegram-style).
         # Matrix clients split long messages around 4000 chars.
         self._text_batch_delay_seconds = float(os.getenv("HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS", "0.6"))
@@ -280,6 +289,57 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    def _register_event_role(
+        self,
+        event_id: str,
+        role: str,
+        room_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        **extra: Any,
+    ) -> None:
+        """Register outbound event role metadata for later reaction routing."""
+        if not event_id:
+            return
+        entry = {
+            "role": role,
+            "room_id": room_id,
+            "thread_id": (metadata or {}).get("thread_id"),
+            "created_at": time.time(),
+        }
+        entry.update(extra)
+        self._event_roles[event_id] = entry
+
+    def _pop_event_role(self, event_id: str) -> Optional[Dict[str, Any]]:
+        if not event_id:
+            return None
+        return self._event_roles.pop(event_id, None)
+
+    def _get_event_role(self, event_id: str) -> Optional[Dict[str, Any]]:
+        if not event_id:
+            return None
+        return self._event_roles.get(event_id)
+
+    def _is_authorized_interaction_user(self, sender: str, state: Dict[str, Any]) -> bool:
+        """Authorize a reaction sender for an interactive control."""
+        if sender == self._user_id:
+            return False
+        allowed = self._allowed_user_ids
+        if allowed:
+            return sender in allowed or "*" in allowed
+        authorized_actor = state.get("authorized_actor")
+        if authorized_actor:
+            return sender == authorized_actor
+        return True
+
+    @staticmethod
+    def _normalize_reaction_key(key: str) -> str:
+        return (key or "").replace("\ufe0f", "").strip()
+
+    @staticmethod
+    def _number_emoji(index: int) -> str:
+        numerals = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"]
+        return numerals[index]
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -595,6 +655,18 @@ class MatrixAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
+
+        if self._approval_state:
+            try:
+                from tools.approval import resolve_gateway_approval
+                for state in list(self._approval_state.values()):
+                    if not state.get("resolved"):
+                        resolve_gateway_approval(state["session_key"], "deny")
+            except Exception:
+                pass
+        self._approval_state.clear()
+        self._model_picker_state.clear()
+        self._event_roles.clear()
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -1478,6 +1550,113 @@ class MatrixAdapter(BasePlatformAdapter):
             "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
         )
 
+    async def _resolve_interactive_approval(
+        self, target_event_id: str, choice: str, sender: str
+    ) -> None:
+        state = self._approval_state.get(target_event_id)
+        if not state or state.get("resolved"):
+            return
+        if not self._is_authorized_interaction_user(sender, state):
+            return
+
+        state["resolved"] = True
+        self._approval_state.pop(target_event_id, None)
+        self._pop_event_role(target_event_id)
+
+        from tools.approval import resolve_gateway_approval
+
+        resolve_gateway_approval(state["session_key"], choice)
+        label_map = {
+            "once": "✅ Approved once",
+            "session": "✅ Approved for session",
+            "always": "✅ Approved permanently",
+            "deny": "❌ Denied",
+        }
+        label = label_map.get(choice, "Resolved")
+        try:
+            await self.edit_message(state["room_id"], target_event_id, f"{label} by {sender}")
+        except Exception:
+            pass
+
+    async def _resolve_model_picker_reaction(
+        self, target_event_id: str, key: str, sender: str
+    ) -> None:
+        state = self._model_picker_state.get(target_event_id)
+        if not state or state.get("resolved"):
+            return
+        if not self._is_authorized_interaction_user(sender, state):
+            return
+
+        key_norm = self._normalize_reaction_key(key)
+        page = int(state.get("page", 0))
+        page_size = int(state.get("page_size", 9))
+
+        if key_norm == "❌":
+            state["resolved"] = True
+            self._model_picker_state.pop(target_event_id, None)
+            self._pop_event_role(target_event_id)
+            try:
+                await self.edit_message(state["room_id"], target_event_id, "❌ Model selection cancelled")
+            except Exception:
+                pass
+            return
+
+        if state.get("stage") == "provider":
+            providers = state.get("providers", [])
+            max_page = max(0, (len(providers) - 1) // page_size)
+            if key_norm == "▶":
+                state["page"] = min(max_page, page + 1)
+                await self._edit_model_picker_message(target_event_id, state)
+                return
+            if key_norm == "◀":
+                state["page"] = max(0, page - 1)
+                await self._edit_model_picker_message(target_event_id, state)
+                return
+
+            page_items = providers[page * page_size:(page + 1) * page_size]
+            for idx, provider in enumerate(page_items):
+                if key == self._number_emoji(idx):
+                    state["stage"] = "model"
+                    state["page"] = 0
+                    state["selected_provider"] = provider
+                    await self._edit_model_picker_message(target_event_id, state)
+                    return
+            return
+
+        if key_norm == "↩":
+            state["stage"] = "provider"
+            state["selected_provider"] = None
+            state["page"] = 0
+            await self._edit_model_picker_message(target_event_id, state)
+            return
+
+        selected_provider = state.get("selected_provider") or {}
+        models = selected_provider.get("models", [])
+        max_page = max(0, (len(models) - 1) // page_size)
+        if key_norm == "▶":
+            state["page"] = min(max_page, page + 1)
+            await self._edit_model_picker_message(target_event_id, state)
+            return
+        if key_norm == "◀":
+            state["page"] = max(0, page - 1)
+            await self._edit_model_picker_message(target_event_id, state)
+            return
+
+        page_items = models[page * page_size:(page + 1) * page_size]
+        for idx, model_id in enumerate(page_items):
+            if key == self._number_emoji(idx):
+                callback = state["on_model_selected"]
+                provider_slug = selected_provider.get("slug") or selected_provider.get("name") or ""
+                result_text = await callback(state["room_id"], model_id, provider_slug)
+                state["resolved"] = True
+                self._model_picker_state.pop(target_event_id, None)
+                self._pop_event_role(target_event_id)
+                try:
+                    await self.edit_message(state["room_id"], target_event_id, result_text)
+                except Exception:
+                    pass
+                return
+
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""
         sender = str(getattr(event, "sender", ""))
@@ -1499,6 +1678,25 @@ class MatrixAdapter(BasePlatformAdapter):
             elif hasattr(relates_to, "event_id"):
                 reacts_to = str(getattr(relates_to, "event_id", ""))
                 key = str(getattr(relates_to, "key", ""))
+
+            role_info = self._get_event_role(reacts_to)
+            if role_info and role_info.get("role") == "interactive_control":
+                control_type = role_info.get("control_type")
+                if control_type == "approval":
+                    choice_map = {
+                        "✅": "once",
+                        "🔁": "session",
+                        "♾": "always",
+                        "❌": "deny",
+                    }
+                    choice = choice_map.get(self._normalize_reaction_key(key))
+                    if choice:
+                        await self._resolve_interactive_approval(reacts_to, choice, sender)
+                    return
+                if control_type == "model_picker":
+                    await self._resolve_model_picker_reaction(reacts_to, key, sender)
+                    return
+
             logger.info(
                 "Matrix: reaction %s from %s on %s in %s",
                 key, sender, reacts_to, room_id,
@@ -1772,6 +1970,148 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a notice message (bot-appropriate, non-alerting)."""
         return await self._send_simple_message(chat_id, text, "m.notice")
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Matrix approval control message routed by event-role metadata."""
+        cmd_preview = command[:1500] + "..." if len(command) > 1500 else command
+        text = (
+            "⚠️ Command Approval Required\n\n"
+            f"`{cmd_preview}`\n\n"
+            f"Reason: {description}\n\n"
+            "React with:\n"
+            "✅ Allow once\n"
+            "🔁 Allow for session\n"
+            "♾️ Allow always\n"
+            "❌ Deny"
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        state = {
+            "control_type": "approval",
+            "session_key": session_key,
+            "room_id": chat_id,
+            "thread_id": (metadata or {}).get("thread_id"),
+            "authorized_actor": (metadata or {}).get("sender_id"),
+            "resolved": False,
+        }
+        self._approval_state[result.message_id] = state
+        self._register_event_role(result.message_id, "interactive_control", chat_id, metadata, control_type="approval")
+        return result
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected: Callable[[str, str, str], Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Matrix model-picker control message using numbered reactions."""
+        page_size = 9
+        page_items = providers[:page_size]
+        provider_lines = []
+        for idx, provider in enumerate(page_items):
+            label = provider.get("name") or provider.get("slug") or "provider"
+            count = provider.get("total_models", len(provider.get("models", [])))
+            marker = " ✓" if provider.get("is_current") else ""
+            provider_lines.append(f"{self._number_emoji(idx)} {label} ({count}){marker}")
+
+        text = (
+            "⚙️ Model Configuration\n\n"
+            f"Current model: `{current_model or 'unknown'}`\n"
+            f"Provider: {current_provider}\n\n"
+            "React to choose a provider:\n"
+            + "\n".join(provider_lines)
+        )
+        if len(providers) > page_size:
+            text += "\n\nReact with ▶️ for next page."
+        text += "\nReact with ❌ to cancel."
+
+        result = await self.send(chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        state = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": chat_id,
+            "thread_id": (metadata or {}).get("thread_id"),
+            "session_key": session_key,
+            "authorized_actor": (metadata or {}).get("sender_id"),
+            "providers": providers,
+            "current_model": current_model,
+            "current_provider": current_provider,
+            "on_model_selected": on_model_selected,
+            "page": 0,
+            "page_size": page_size,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        self._model_picker_state[result.message_id] = state
+        self._register_event_role(result.message_id, "interactive_control", chat_id, metadata, control_type="model_picker")
+        return result
+
+    async def _edit_model_picker_message(self, message_id: str, state: Dict[str, Any]) -> SendResult:
+        room_id = state["room_id"]
+        page = int(state.get("page", 0))
+        page_size = int(state.get("page_size", 9))
+
+        if state.get("stage") == "provider":
+            providers = state.get("providers", [])
+            start = page * page_size
+            page_items = providers[start:start + page_size]
+            lines = []
+            for idx, provider in enumerate(page_items):
+                label = provider.get("name") or provider.get("slug") or "provider"
+                count = provider.get("total_models", len(provider.get("models", [])))
+                lines.append(f"{self._number_emoji(idx)} {label} ({count})")
+            text = (
+                "⚙️ Model Configuration\n\n"
+                f"Current model: `{state.get('current_model') or 'unknown'}`\n"
+                f"Provider: {state.get('current_provider') or 'unknown'}\n\n"
+                "React to choose a provider:\n"
+                + "\n".join(lines)
+            )
+            if start > 0:
+                text += "\n\nReact with ◀️ for previous page."
+            if start + page_size < len(providers):
+                text += "\nReact with ▶️ for next page."
+            text += "\nReact with ❌ to cancel."
+            return await self.edit_message(room_id, message_id, text)
+
+        selected_provider = state.get("selected_provider") or {}
+        models = selected_provider.get("models", [])
+        start = page * page_size
+        page_items = models[start:start + page_size]
+        lines = []
+        for idx, model_id in enumerate(page_items):
+            marker = " ✓" if model_id == state.get("current_model") else ""
+            lines.append(f"{self._number_emoji(idx)} {model_id}{marker}")
+        provider_name = selected_provider.get("name") or selected_provider.get("slug") or "provider"
+        text = (
+            "⚙️ Model Configuration\n\n"
+            f"Provider: {provider_name}\n"
+            "React to choose a model:\n"
+            + "\n".join(lines)
+        )
+        if start > 0:
+            text += "\n\nReact with ◀️ for previous page."
+        if start + page_size < len(models):
+            text += "\nReact with ▶️ for next page."
+        text += "\nReact with ↩️ to go back."
+        text += "\nReact with ❌ to cancel."
+        return await self.edit_message(room_id, message_id, text)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2200,7 +2200,11 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _send_simple_message(
-        self, chat_id: str, text: str, msgtype: str,
+        self,
+        chat_id: str,
+        text: str,
+        msgtype: str,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a simple message (emote, notice) with optional HTML formatting."""
         if not self._client or not text:
@@ -2211,6 +2215,15 @@ class MatrixAdapter(BasePlatformAdapter):
         if html and html != text:
             msg_content["format"] = "org.matrix.custom.html"
             msg_content["formatted_body"] = html
+
+        thread_id = (metadata or {}).get("thread_id")
+        if thread_id:
+            msg_content["m.relates_to"] = {
+                "rel_type": "m.thread",
+                "event_id": thread_id,
+                "is_falling_back": True,
+                "m.in_reply_to": {"event_id": thread_id},
+            }
 
         try:
             event_id = await self._client.send_message_event(
@@ -2224,13 +2237,13 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an emote message (/me style action)."""
-        return await self._send_simple_message(chat_id, text, "m.emote")
+        return await self._send_simple_message(chat_id, text, "m.emote", metadata=metadata)
 
     async def send_notice(
         self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a notice message (bot-appropriate, non-alerting)."""
-        return await self._send_simple_message(chat_id, text, "m.notice")
+        return await self._send_simple_message(chat_id, text, "m.notice", metadata=metadata)
 
     async def send_exec_approval(
         self,

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -208,13 +208,17 @@ class MatrixAdapter(BasePlatformAdapter):
             config.extra.get("homeserver", "")
             or os.getenv("MATRIX_HOMESERVER", "")
         ).rstrip("/")
-        self._access_token: str = config.token or os.getenv("MATRIX_ACCESS_TOKEN", "")
+        explicit_access_token = config.token or config.extra.get("access_token", "")
+        explicit_password = config.extra.get("password", "")
+        self._access_token: str = explicit_access_token or (
+            "" if explicit_password else os.getenv("MATRIX_ACCESS_TOKEN", "")
+        )
         self._user_id: str = (
             config.extra.get("user_id", "")
             or os.getenv("MATRIX_USER_ID", "")
         )
         self._password: str = (
-            config.extra.get("password", "")
+            explicit_password
             or os.getenv("MATRIX_PASSWORD", "")
         )
         self._encryption: bool = config.extra.get(
@@ -331,12 +335,12 @@ class MatrixAdapter(BasePlatformAdapter):
         """Authorize a reaction sender for an interactive control."""
         if sender == self._user_id:
             return False
-        allowed = self._allowed_user_ids
-        if allowed:
-            return sender in allowed or "*" in allowed
         authorized_actor = state.get("authorized_actor")
         if authorized_actor:
             return sender == authorized_actor
+        allowed = self._allowed_user_ids
+        if allowed:
+            return sender in allowed or "*" in allowed
         return True
 
     @staticmethod
@@ -1813,7 +1817,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
             page_items = providers[page * page_size:(page + 1) * page_size]
             for idx, provider in enumerate(page_items):
-                if key == self._number_emoji(idx):
+                if key_norm == self._normalize_reaction_key(self._number_emoji(idx)):
                     state["stage"] = "model"
                     state["page"] = 0
                     state["selected_provider"] = provider
@@ -1842,7 +1846,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         page_items = models[page * page_size:(page + 1) * page_size]
         for idx, model_id in enumerate(page_items):
-            if key == self._number_emoji(idx):
+            if key_norm == self._normalize_reaction_key(self._number_emoji(idx)):
                 callback = state["on_model_selected"]
                 provider_slug = selected_provider.get("slug") or selected_provider.get("name") or ""
                 result_text = await callback(state["room_id"], model_id, provider_slug)

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -270,6 +270,10 @@ class MatrixAdapter(BasePlatformAdapter):
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
         }
+        self._approval_require_sender: bool = config.extra.get(
+            "approval_require_sender",
+            os.getenv("MATRIX_APPROVAL_REQUIRE_SENDER", "true").lower() in ("true", "1", "yes"),
+        )
         self._event_roles: Dict[str, Dict[str, Any]] = {}
         self._approval_state: Dict[str, Dict[str, Any]] = {}
         self._model_picker_state: Dict[str, Dict[str, Any]] = {}
@@ -331,16 +335,13 @@ class MatrixAdapter(BasePlatformAdapter):
             return None
         return self._event_roles.get(event_id)
 
-    def _is_authorized_interaction_user(self, sender: str, state: Dict[str, Any]) -> bool:
+    def _is_authorized_interaction_user(self, sender: str, state: Dict[str, Any], *, require_sender: bool = True) -> bool:
         """Authorize a reaction sender for an interactive control."""
         if sender == self._user_id:
             return False
         authorized_actor = state.get("authorized_actor")
-        if authorized_actor:
+        if authorized_actor and require_sender:
             return sender == authorized_actor
-        allowed = self._allowed_user_ids
-        if allowed:
-            return sender in allowed or "*" in allowed
         return True
 
     @staticmethod
@@ -993,11 +994,18 @@ class MatrixAdapter(BasePlatformAdapter):
                 pass
 
     async def edit_message(
-        self, chat_id: str, message_id: str, content: str
+        self, chat_id: str, message_id: str, content: str, metadata: Optional[Dict[str, Any]] = None
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
 
         formatted = self.format_message(content)
+        relates_to: Dict[str, Any] = {
+            "rel_type": "m.replace",
+            "event_id": message_id,
+        }
+        thread_id = (metadata or {}).get("thread_id")
+        if thread_id:
+            relates_to["m.in_reply_to"] = {"event_id": thread_id}
         msg_content: Dict[str, Any] = {
             "msgtype": "m.text",
             "body": f"* {formatted}",
@@ -1005,10 +1013,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "msgtype": "m.text",
                 "body": formatted,
             },
-            "m.relates_to": {
-                "rel_type": "m.replace",
-                "event_id": message_id,
-            },
+            "m.relates_to": relates_to,
         }
 
         html = self._markdown_to_html(formatted)
@@ -1706,11 +1711,40 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _seed_control_reactions(self, room_id: str, event_id: str, emojis: list[str]) -> None:
         """Pre-seed interactive control reactions so clients expose tap targets."""
+        seen = set()
         for emoji in emojis:
+            if not emoji or emoji in seen:
+                continue
+            seen.add(emoji)
             try:
                 await self.send_reaction(room_id, event_id, emoji)
             except Exception as exc:
                 logger.debug("Matrix control reaction seed failed for %s on %s: %s", emoji, event_id, exc)
+
+    def _model_picker_reactions(self, state: Dict[str, Any]) -> list[str]:
+        page = int(state.get("page", 0))
+        page_size = int(state.get("page_size", 9))
+        if state.get("stage") == "provider":
+            providers = state.get("providers", [])
+            page_items = providers[page * page_size:(page + 1) * page_size]
+            emojis = [self._number_emoji(idx) for idx in range(len(page_items))]
+            if page > 0:
+                emojis.append("◀️")
+            if (page + 1) * page_size < len(providers):
+                emojis.append("▶️")
+            emojis.append("❌")
+            return emojis
+
+        selected_provider = state.get("selected_provider") or {}
+        models = selected_provider.get("models", [])
+        page_items = models[page * page_size:(page + 1) * page_size]
+        emojis = [self._number_emoji(idx) for idx in range(len(page_items))]
+        if page > 0:
+            emojis.append("◀️")
+        if (page + 1) * page_size < len(models):
+            emojis.append("▶️")
+        emojis.extend(["↩️", "❌"])
+        return emojis
 
     async def _redact_reaction(
         self, room_id: str, reaction_event_id: str, reason: str = "",
@@ -1758,7 +1792,17 @@ class MatrixAdapter(BasePlatformAdapter):
         state = self._approval_state.get(target_event_id)
         if not state or state.get("resolved"):
             return
-        if not self._is_authorized_interaction_user(sender, state):
+        if not self._is_authorized_interaction_user(sender, state, require_sender=self._approval_require_sender):
+            if self._approval_require_sender and state.get("authorized_actor"):
+                try:
+                    feedback = f"⚠️ Approval requires reaction from {state['authorized_actor']}. Sender validation is enabled."
+                    await self.send_notice(
+                        state["room_id"],
+                        feedback,
+                        metadata={"thread_id": state.get("thread_id")} if state.get("thread_id") else None,
+                    )
+                except Exception:
+                    pass
             return
 
         state["resolved"] = True
@@ -1776,7 +1820,12 @@ class MatrixAdapter(BasePlatformAdapter):
         }
         label = label_map.get(choice, "Resolved")
         try:
-            await self.edit_message(state["room_id"], target_event_id, f"{label} by {sender}")
+            await self.edit_message(
+                state["room_id"],
+                target_event_id,
+                f"{label} by {sender}",
+                metadata={"thread_id": state.get("thread_id")} if state.get("thread_id") else None,
+            )
         except Exception:
             pass
 
@@ -1798,7 +1847,12 @@ class MatrixAdapter(BasePlatformAdapter):
             self._model_picker_state.pop(target_event_id, None)
             self._pop_event_role(target_event_id)
             try:
-                await self.edit_message(state["room_id"], target_event_id, "❌ Model selection cancelled")
+                await self.edit_message(
+                    state["room_id"],
+                    target_event_id,
+                    "❌ Model selection cancelled",
+                    metadata={"thread_id": state.get("thread_id")} if state.get("thread_id") else None,
+                )
             except Exception:
                 pass
             return
@@ -1854,7 +1908,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 self._model_picker_state.pop(target_event_id, None)
                 self._pop_event_role(target_event_id)
                 try:
-                    await self.edit_message(state["room_id"], target_event_id, result_text)
+                    await self.edit_message(
+                        state["room_id"],
+                        target_event_id,
+                        result_text,
+                        metadata={"thread_id": state.get("thread_id")} if state.get("thread_id") else None,
+                    )
                 except Exception:
                     pass
                 return
@@ -2263,11 +2322,7 @@ class MatrixAdapter(BasePlatformAdapter):
         }
         self._model_picker_state[result.message_id] = state
         self._register_event_role(result.message_id, "interactive_control", chat_id, metadata, control_type="model_picker")
-        await self._seed_control_reactions(
-            chat_id,
-            result.message_id,
-            [self._number_emoji(idx) for idx in range(len(page_items))] + (["▶️"] if len(providers) > page_size else []) + ["❌"],
-        )
+        await self._seed_control_reactions(chat_id, result.message_id, self._model_picker_reactions(state))
         return result
 
     async def _edit_model_picker_message(self, message_id: str, state: Dict[str, Any]) -> SendResult:
@@ -2296,30 +2351,38 @@ class MatrixAdapter(BasePlatformAdapter):
             if start + page_size < len(providers):
                 text += "\nReact with ▶️ for next page."
             text += "\nReact with ❌ to cancel."
-            return await self.edit_message(room_id, message_id, text)
+        else:
+            selected_provider = state.get("selected_provider") or {}
+            models = selected_provider.get("models", [])
+            start = page * page_size
+            page_items = models[start:start + page_size]
+            lines = []
+            for idx, model_id in enumerate(page_items):
+                marker = " ✓" if model_id == state.get("current_model") else ""
+                lines.append(f"{self._number_emoji(idx)} {model_id}{marker}")
+            provider_name = selected_provider.get("name") or selected_provider.get("slug") or "provider"
+            text = (
+                "⚙️ Model Configuration\n\n"
+                f"Provider: {provider_name}\n"
+                "React to choose a model:\n"
+                + "\n".join(lines)
+            )
+            if start > 0:
+                text += "\n\nReact with ◀️ for previous page."
+            if start + page_size < len(models):
+                text += "\nReact with ▶️ for next page."
+            text += "\nReact with ↩️ to go back."
+            text += "\nReact with ❌ to cancel."
 
-        selected_provider = state.get("selected_provider") or {}
-        models = selected_provider.get("models", [])
-        start = page * page_size
-        page_items = models[start:start + page_size]
-        lines = []
-        for idx, model_id in enumerate(page_items):
-            marker = " ✓" if model_id == state.get("current_model") else ""
-            lines.append(f"{self._number_emoji(idx)} {model_id}{marker}")
-        provider_name = selected_provider.get("name") or selected_provider.get("slug") or "provider"
-        text = (
-            "⚙️ Model Configuration\n\n"
-            f"Provider: {provider_name}\n"
-            "React to choose a model:\n"
-            + "\n".join(lines)
+        result = await self.edit_message(
+            room_id,
+            message_id,
+            text,
+            metadata={"thread_id": state.get("thread_id")} if state.get("thread_id") else None,
         )
-        if start > 0:
-            text += "\n\nReact with ◀️ for previous page."
-        if start + page_size < len(models):
-            text += "\nReact with ▶️ for next page."
-        text += "\nReact with ↩️ to go back."
-        text += "\nReact with ❌ to cancel."
-        return await self.edit_message(room_id, message_id, text)
+        if result.success:
+            await self._seed_control_reactions(room_id, message_id, self._model_picker_reactions(state))
+        return result
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -1,0 +1,364 @@
+"""Buffered Matrix thinking/acting panes for agent introspection."""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from gateway.platforms.matrix import MatrixAdapter
+
+logger = logging.getLogger(__name__)
+
+_MIN_EDIT_INTERVAL = 3.0
+_MAX_BODY_SIZE = 60_000
+
+
+@dataclass
+class ThinkingSession:
+    room_id: str
+    event_id: str
+    task_id: str
+    started_at: float
+    last_update: float
+    step_count: int = 0
+    content_lines: list[str] = field(default_factory=list)
+    finalized: bool = False
+    field_kind: str = "thinking"
+    title: str = "Agent Thinking: Hermes"
+    summary: str = ""
+    model_label: str = ""
+    dirty: bool = False
+    flush_task: Optional[asyncio.Task] = None
+    thread_id: Optional[str] = None
+
+
+class ThinkingManager:
+    def __init__(self, adapter: "MatrixAdapter"):
+        self._adapter = adapter
+        self._sessions: Dict[str, ThinkingSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Processing request...",
+        *,
+        field_kind: str = "thinking",
+        model_label: str = "",
+        initial_content_md: str = "",
+        thread_id: Optional[str] = None,
+    ) -> Optional[str]:
+        key = self._session_key(task_id, field_kind)
+        async with self._lock:
+            _, existing = self._lookup_session_locked(task_id, field_kind)
+            if existing and not existing.finalized:
+                if model_label:
+                    existing.model_label = model_label
+                if initial_content_md:
+                    existing.content_lines.append(initial_content_md)
+                    existing.dirty = True
+                    self._ensure_flush_locked(key, existing, 0.0)
+                return existing.event_id
+
+        now = time.time()
+        title = self._field_title(field_kind, model_label)
+        initial_lines = [initial_content_md] if initial_content_md else []
+        html_body = self._build_html(
+            title=title,
+            summary=initial_summary,
+            step=0,
+            ts=now,
+            content_html=self._lines_to_html(initial_lines),
+            open_tag=True,
+        )
+        plaintext = self._plaintext_summary(title, initial_summary)
+        content = self._msg_content(html_body, plaintext, thread_id=thread_id)
+
+        try:
+            raw_event_id = await asyncio.wait_for(
+                self._adapter._client.send_message_event(room_id, "m.room.message", content),
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.error("Matrix thinking: failed to start %s in %s: %s", field_kind, room_id, exc)
+            return None
+
+        event_id = str(getattr(raw_event_id, "event_id", raw_event_id) or "")
+        if not event_id:
+            return None
+
+        session = ThinkingSession(
+            room_id=room_id,
+            event_id=event_id,
+            task_id=task_id,
+            started_at=now,
+            last_update=now,
+            field_kind=field_kind,
+            title=title,
+            summary=initial_summary,
+            model_label=model_label,
+            content_lines=initial_lines,
+            thread_id=thread_id,
+        )
+        async with self._lock:
+            self._sessions[key] = session
+        return event_id
+
+    async def update(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        snapshot = None
+        key = self._session_key(task_id, field_kind)
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session or session.finalized:
+                return
+            if step_info:
+                session.summary = step_info
+            if model_label:
+                session.model_label = model_label
+                session.title = self._field_title(field_kind, model_label)
+            if content_md and append_line:
+                session.content_lines.append(content_md)
+            session.step_count += 1
+            session.dirty = True
+
+            now = time.time()
+            elapsed = now - session.last_update
+            if elapsed >= _MIN_EDIT_INTERVAL and (session.flush_task is None or session.flush_task.done()):
+                snapshot = self._snapshot_locked(session)
+                session.last_update = now
+                session.dirty = False
+            else:
+                self._ensure_flush_locked(key, session, max(0.0, _MIN_EDIT_INTERVAL - elapsed))
+
+        if snapshot:
+            await self._send_edit_snapshot(snapshot)
+
+    async def finalize(
+        self,
+        task_id: str,
+        final_summary: str = "Task complete",
+        collapse: bool = True,
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        key = self._session_key(task_id, field_kind)
+        snapshot = None
+        flush_task = None
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session:
+                return
+            session.finalized = True
+            if field_kind == "thinking" and final_summary and not final_summary.startswith(("✅", "⚠️")):
+                session.summary = f"✅ {final_summary}"
+            else:
+                session.summary = final_summary
+            if model_label:
+                session.model_label = model_label
+                session.title = self._field_title(field_kind, model_label)
+            flush_task = session.flush_task
+            session.flush_task = None
+            snapshot = self._snapshot_locked(session)
+
+        if flush_task and not flush_task.done():
+            flush_task.cancel()
+            try:
+                await flush_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._send_edit_snapshot(snapshot, final=True, collapse=collapse)
+        async with self._lock:
+            self._sessions.pop(key, None)
+
+    async def abort(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        await self.finalize(
+            task_id,
+            f"⚠️ {reason}",
+            collapse=True,
+            field_kind=field_kind,
+            model_label=model_label,
+        )
+
+    async def abort_all(self, reason: str = "Gateway restarting") -> None:
+        async with self._lock:
+            pending = [(session.task_id, session.field_kind) for session in self._sessions.values()]
+        for task_id, field_kind in pending:
+            try:
+                await self.abort(task_id, reason, field_kind=field_kind)
+            except Exception as exc:
+                logger.debug("Matrix thinking: abort_all failed for %s/%s: %s", task_id, field_kind, exc)
+
+    def has_session(self, task_id: str, field_kind: str = "thinking") -> bool:
+        return self._session_key(task_id, field_kind) in self._sessions
+
+    @staticmethod
+    def _field_title(field_kind: str, model_label: str = "") -> str:
+        if field_kind == "tools":
+            return "Agent Acting:"
+        suffix = f" via {model_label}" if model_label else ""
+        return f"Agent Thinking: Hermes{suffix}"
+
+    @staticmethod
+    def _plaintext_summary(title: str, summary: str) -> str:
+        return f"{title}\n{summary}".strip()
+
+    @staticmethod
+    def _elapsed_str(started_at: float) -> str:
+        elapsed = max(0, int(time.time() - started_at))
+        minutes, seconds = divmod(elapsed, 60)
+        if minutes:
+            return f"{minutes}m{seconds}s"
+        return f"{seconds}s"
+
+    @staticmethod
+    def _msg_content(formatted_body: str, body: str, *, thread_id: Optional[str] = None) -> Dict[str, Any]:
+        content: Dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": body,
+            "format": "org.matrix.custom.html",
+            "formatted_body": formatted_body,
+        }
+        if thread_id:
+            content["m.relates_to"] = {
+                "rel_type": "m.thread",
+                "event_id": thread_id,
+                "is_falling_back": True,
+            }
+        return content
+
+    @staticmethod
+    def _edit_content(event_id: str, formatted_body: str, body: str) -> Dict[str, Any]:
+        return {
+            "msgtype": "m.text",
+            "body": f"* {body}",
+            "format": "org.matrix.custom.html",
+            "formatted_body": f"* {formatted_body}",
+            "m.new_content": {
+                "msgtype": "m.text",
+                "body": body,
+                "format": "org.matrix.custom.html",
+                "formatted_body": formatted_body,
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": event_id,
+            },
+        }
+
+    @staticmethod
+    def _lines_to_html(lines: list[str]) -> str:
+        if not lines:
+            return ""
+        escaped = [html.escape(line) for line in lines]
+        return "<br/>".join(escaped)
+
+    def _build_html(
+        self,
+        *,
+        title: str,
+        summary: str,
+        step: int,
+        ts: float,
+        content_html: str,
+        open_tag: bool = True,
+    ) -> str:
+        _ = ts
+        summary_html = html.escape(summary or "")
+        title_html = html.escape(title)
+        details_open = " open" if open_tag else ""
+        step_label = "Starting" if step == 0 else f"Update {step}"
+        body = content_html or html.escape(summary or "")
+        return (
+            f"<details{details_open}><summary>{title_html}</summary>"
+            f"<p><strong>{summary_html}</strong> · {step_label}</p>"
+            f"<div>{body}</div>"
+            f"</details>"
+        )[:_MAX_BODY_SIZE]
+
+    def _session_key(self, task_id: str, field_kind: str) -> str:
+        return f"{task_id}:{field_kind}"
+
+    def _lookup_session_locked(self, task_id: str, field_kind: str):
+        key = self._session_key(task_id, field_kind)
+        return key, self._sessions.get(key)
+
+    def _snapshot_locked(self, session: ThinkingSession) -> Dict[str, Any]:
+        return {
+            "room_id": session.room_id,
+            "event_id": session.event_id,
+            "task_id": session.task_id,
+            "field_kind": session.field_kind,
+            "title": session.title,
+            "summary": session.summary,
+            "step_count": session.step_count,
+            "content_html": self._lines_to_html(session.content_lines),
+            "started_at": session.started_at,
+            "thread_id": session.thread_id,
+        }
+
+    def _ensure_flush_locked(self, key: str, session: ThinkingSession, delay: float) -> None:
+        if session.flush_task and not session.flush_task.done():
+            return
+
+        async def _flush_later() -> None:
+            try:
+                await asyncio.sleep(delay)
+                async with self._lock:
+                    current = self._sessions.get(key)
+                    if not current or current.finalized or not current.dirty:
+                        return
+                    snapshot = self._snapshot_locked(current)
+                    current.last_update = time.time()
+                    current.dirty = False
+                await self._send_edit_snapshot(snapshot)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("Matrix thinking: deferred flush failed: %s", exc)
+
+        session.flush_task = asyncio.create_task(_flush_later())
+
+    async def _send_edit_snapshot(self, snapshot: Dict[str, Any], *, final: bool = False, collapse: bool = True) -> None:
+        if not snapshot:
+            return
+        title = snapshot["title"]
+        body = self._plaintext_summary(title, snapshot["summary"])
+        formatted = self._build_html(
+            title=title,
+            summary=snapshot["summary"],
+            step=snapshot["step_count"],
+            ts=time.time(),
+            content_html=snapshot["content_html"],
+            open_tag=not (final and collapse),
+        )
+        content = self._edit_content(snapshot["event_id"], formatted, body)
+        try:
+            await self._adapter._client.send_message_event(snapshot["room_id"], "m.room.message", content)
+        except Exception as exc:
+            logger.debug("Matrix thinking: edit failed for %s: %s", snapshot["event_id"], exc)

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 _MIN_EDIT_INTERVAL = 3.0
 _MAX_BODY_SIZE = 60_000
+_EDIT_RETRY_ATTEMPTS = 3
+_EDIT_RETRY_BASE_DELAY_SECONDS = 1.0
 
 
 @dataclass
@@ -108,6 +110,7 @@ class ThinkingManager:
         )
         async with self._lock:
             self._sessions[key] = session
+        logger.debug("Matrix thinking: started %s pane for task %s in %s", field_kind, task_id, room_id)
         return event_id
 
     async def update(
@@ -147,6 +150,13 @@ class ThinkingManager:
                 self._ensure_flush_locked(key, session, max(0.0, _MIN_EDIT_INTERVAL - elapsed))
 
         if snapshot:
+            logger.debug(
+                "Matrix thinking: sending %s update for task %s (step=%s, body_chars=%s)",
+                field_kind,
+                task_id,
+                snapshot["step_count"],
+                len(snapshot["content_html"]),
+            )
             await self._send_edit_snapshot(snapshot)
 
     async def finalize(
@@ -187,6 +197,13 @@ class ThinkingManager:
 
         if collapse is None:
             collapse = field_kind == "thinking"
+        logger.debug(
+            "Matrix thinking: finalizing %s pane for task %s (summary=%r, collapse=%s)",
+            field_kind,
+            task_id,
+            final_summary,
+            collapse,
+        )
         await self._send_edit_snapshot(snapshot, final=True, collapse=collapse)
         async with self._lock:
             self._sessions.pop(key, None)
@@ -380,7 +397,25 @@ class ThinkingManager:
             body,
             thread_id=snapshot.get("thread_id"),
         )
-        try:
-            await self._adapter._client.send_message_event(snapshot["room_id"], "m.room.message", content)
-        except Exception as exc:
-            logger.debug("Matrix thinking: edit failed for %s: %s", snapshot["event_id"], exc)
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, _EDIT_RETRY_ATTEMPTS + 1):
+            try:
+                await self._adapter._client.send_message_event(snapshot["room_id"], "m.room.message", content)
+                return
+            except Exception as exc:
+                last_exc = exc
+                if attempt >= _EDIT_RETRY_ATTEMPTS:
+                    logger.debug("Matrix thinking: edit failed for %s after %d attempts: %s", snapshot["event_id"], attempt, exc)
+                    return
+                delay = _EDIT_RETRY_BASE_DELAY_SECONDS * attempt
+                logger.warning(
+                    "Matrix thinking: edit failed for %s on attempt %d/%d; retrying in %.1fs: %s",
+                    snapshot["event_id"],
+                    attempt,
+                    _EDIT_RETRY_ATTEMPTS,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+        if last_exc is not None:
+            logger.debug("Matrix thinking: edit failed for %s: %s", snapshot["event_id"], last_exc)

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -31,7 +31,7 @@ class ThinkingSession:
     content_lines: list[str] = field(default_factory=list)
     finalized: bool = False
     field_kind: str = "thinking"
-    title: str = "🤔 Agent Thinking: Hermes"
+    title: str = "🧠 Agent Thinking:"
     summary: str = ""
     model_label: str = ""
     dirty: bool = False
@@ -219,7 +219,7 @@ class ThinkingManager:
         await self.finalize(
             task_id,
             f"⚠️ {reason}",
-            collapse=True,
+            collapse=(field_kind == "thinking"),
             field_kind=field_kind,
             model_label=model_label,
         )
@@ -240,8 +240,9 @@ class ThinkingManager:
     def _field_title(field_kind: str, model_label: str = "") -> str:
         if field_kind == "tools":
             return "⚡ Agent Acting:"
-        suffix = f" via {model_label}" if model_label else ""
-        return f"🧐 Agent Thinking: Hermes{suffix}"
+        if model_label:
+            return f"🧠 Agent Thinking: Utilizing {model_label}"
+        return "🧠 Agent Thinking:"
 
     @staticmethod
     def _plaintext_summary(title: str, summary: str) -> str:

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -29,7 +29,7 @@ class ThinkingSession:
     content_lines: list[str] = field(default_factory=list)
     finalized: bool = False
     field_kind: str = "thinking"
-    title: str = "Agent Thinking: Hermes"
+    title: str = "🤔 Agent Thinking: Hermes"
     summary: str = ""
     model_label: str = ""
     dirty: bool = False
@@ -61,7 +61,7 @@ class ThinkingManager:
                 if model_label:
                     existing.model_label = model_label
                 if initial_content_md:
-                    existing.content_lines.append(initial_content_md)
+                    self._append_content_locked(existing, initial_content_md, append_line=True)
                     existing.dirty = True
                     self._ensure_flush_locked(key, existing, 0.0)
                 return existing.event_id
@@ -132,8 +132,8 @@ class ThinkingManager:
             if model_label:
                 session.model_label = model_label
                 session.title = self._field_title(field_kind, model_label)
-            if content_md and append_line:
-                session.content_lines.append(content_md)
+            if content_md:
+                self._append_content_locked(session, content_md, append_line=append_line)
             session.step_count += 1
             session.dirty = True
 
@@ -153,7 +153,7 @@ class ThinkingManager:
         self,
         task_id: str,
         final_summary: str = "Task complete",
-        collapse: bool = True,
+        collapse: Optional[bool] = None,
         *,
         field_kind: str = "thinking",
         model_label: Optional[str] = None,
@@ -185,6 +185,8 @@ class ThinkingManager:
             except asyncio.CancelledError:
                 pass
 
+        if collapse is None:
+            collapse = field_kind == "thinking"
         await self._send_edit_snapshot(snapshot, final=True, collapse=collapse)
         async with self._lock:
             self._sessions.pop(key, None)
@@ -220,9 +222,9 @@ class ThinkingManager:
     @staticmethod
     def _field_title(field_kind: str, model_label: str = "") -> str:
         if field_kind == "tools":
-            return "Agent Acting:"
+            return "⚡ Agent Acting:"
         suffix = f" via {model_label}" if model_label else ""
-        return f"Agent Thinking: Hermes{suffix}"
+        return f"🤔 Agent Thinking: Hermes{suffix}"
 
     @staticmethod
     def _plaintext_summary(title: str, summary: str) -> str:
@@ -275,8 +277,20 @@ class ThinkingManager:
     def _lines_to_html(lines: list[str]) -> str:
         if not lines:
             return ""
-        escaped = [html.escape(line) for line in lines]
-        return "<br/>".join(escaped)
+        text = "\n".join(lines)
+        text = text[:_MAX_BODY_SIZE]
+        escaped = html.escape(text)
+        return "<pre><code>" + escaped + "</code></pre>"
+
+    @staticmethod
+    def _append_content_locked(session: ThinkingSession, content_md: str, *, append_line: bool) -> None:
+        if not content_md:
+            return
+        text = str(content_md)
+        if append_line or not session.content_lines:
+            session.content_lines.append(text)
+        else:
+            session.content_lines[-1] += text
 
     def _build_html(
         self,
@@ -297,7 +311,7 @@ class ThinkingManager:
         return (
             f"<details{details_open}><summary>{title_html}</summary>"
             f"<p><strong>{summary_html}</strong> · {step_label}</p>"
-            f"<div>{body}</div>"
+            f"<blockquote>{body}</blockquote>"
             f"</details>"
         )[:_MAX_BODY_SIZE]
 

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -224,7 +224,7 @@ class ThinkingManager:
         if field_kind == "tools":
             return "⚡ Agent Acting:"
         suffix = f" via {model_label}" if model_label else ""
-        return f"🤔 Agent Thinking: Hermes{suffix}"
+        return f"🧐 Agent Thinking: Hermes{suffix}"
 
     @staticmethod
     def _plaintext_summary(title: str, summary: str) -> str:

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -255,7 +255,13 @@ class ThinkingManager:
         return content
 
     @staticmethod
-    def _edit_content(event_id: str, formatted_body: str, body: str) -> Dict[str, Any]:
+    def _edit_content(event_id: str, formatted_body: str, body: str, *, thread_id: Optional[str] = None) -> Dict[str, Any]:
+        relates_to: Dict[str, Any] = {
+            "rel_type": "m.replace",
+            "event_id": event_id,
+        }
+        if thread_id:
+            relates_to["m.in_reply_to"] = {"event_id": thread_id}
         return {
             "msgtype": "m.text",
             "body": f"* {body}",
@@ -267,10 +273,7 @@ class ThinkingManager:
                 "format": "org.matrix.custom.html",
                 "formatted_body": formatted_body,
             },
-            "m.relates_to": {
-                "rel_type": "m.replace",
-                "event_id": event_id,
-            },
+            "m.relates_to": relates_to,
         }
 
     @staticmethod
@@ -371,7 +374,12 @@ class ThinkingManager:
             content_html=snapshot["content_html"],
             open_tag=not (final and collapse),
         )
-        content = self._edit_content(snapshot["event_id"], formatted, body)
+        content = self._edit_content(
+            snapshot["event_id"],
+            formatted,
+            body,
+            thread_id=snapshot.get("thread_id"),
+        )
         try:
             await self._adapter._client.send_message_event(snapshot["room_id"], "m.room.message", content)
         except Exception as exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7458,7 +7458,18 @@ class GatewayRunner:
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        _matrix_adapter = self.adapters.get(source.platform)
+        _matrix_thinking_active = bool(
+            source.platform == Platform.MATRIX
+            and _matrix_adapter
+            and getattr(_matrix_adapter, "_thinking_enabled", False)
+        )
+        _matrix_tool_activity_enabled = _matrix_thinking_active and progress_mode != "off"
+        tool_progress_enabled = (
+            progress_mode != "off"
+            and source.platform != Platform.WEBHOOK
+            and not _matrix_thinking_active
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -7715,11 +7726,56 @@ class GatewayRunner:
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _thinking_started = [False]
+        _tool_field_started = [False]
+        _thinking_task_id = session_key or session_id or ""
+        _model_label_holder = [None]
+
+        def _set_model_label(model_name: str = "", provider_name: str = "") -> None:
+            model_name = (model_name or "").strip()
+            provider_name = (provider_name or "").strip()
+            if model_name:
+                _model_label_holder[0] = (
+                    f"{model_name} via {provider_name}" if provider_name else model_name
+                )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
                 return
             try:
+                if message:
+                    _fb_match = re.search(
+                        r"switching to fallback:\s*(.+?)\s+via\s+([^\s]+)",
+                        message,
+                        re.IGNORECASE,
+                    )
+                    if _fb_match:
+                        _set_model_label(_fb_match.group(1), _fb_match.group(2))
+                if _matrix_thinking_active:
+                    if message and not _thinking_started[0]:
+                        _thinking_started[0] = True
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.start_thinking(
+                                _status_chat_id,
+                                _thinking_task_id,
+                                message,
+                                model_label=_model_label_holder[0] or "",
+                                initial_content_md=message,
+                                thread_id=_progress_thread_id,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                    elif message:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.update_thinking(
+                                _thinking_task_id,
+                                message,
+                                message,
+                                model_label=_model_label_holder[0],
+                            ),
+                            _loop_for_step,
+                        )
+                    return
                 asyncio.run_coroutine_threadsafe(
                     _status_adapter.send(
                         _status_chat_id,
@@ -7730,6 +7786,50 @@ class GatewayRunner:
                 )
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
+
+        def _matrix_tool_progress_sync(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
+            if not (_matrix_tool_activity_enabled and _status_adapter):
+                return
+            if event_type not in ("tool.started",):
+                return
+            try:
+                from agent.display import get_tool_emoji
+                import json as _json
+
+                emoji = get_tool_emoji(tool_name, default="⚙️")
+                if progress_mode == "verbose" and args:
+                    args_str = _json.dumps(args, ensure_ascii=False, default=str)
+                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                elif preview:
+                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                else:
+                    msg = f"{emoji} {tool_name}"
+
+                if not _tool_field_started[0]:
+                    _tool_field_started[0] = True
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.start_tool_activity(
+                            _status_chat_id,
+                            _thinking_task_id,
+                            "Tool activity",
+                            model_label=_model_label_holder[0] or "",
+                            initial_content_md=msg,
+                            thread_id=_progress_thread_id,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=10)
+                else:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.update_tool_activity(
+                            _thinking_task_id,
+                            tool_name or "Tool activity",
+                            msg,
+                            model_label=_model_label_holder[0],
+                        ),
+                        _loop_for_step,
+                    )
+            except Exception as _e:
+                logger.debug("matrix tool activity callback error: %s", _e)
 
         def run_sync():
             # The conditional re-assignment of `message` further below
@@ -7862,6 +7962,10 @@ class GatewayRunner:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            _set_model_label(
+                turn_route.get("model", ""),
+                turn_route.get("runtime", {}).get("provider", ""),
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -7915,7 +8019,11 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = (
+                _matrix_tool_progress_sync
+                if _matrix_thinking_active
+                else (progress_callback if tool_progress_enabled else None)
+            )
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
@@ -7923,6 +8031,73 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
+
+            if _matrix_thinking_active:
+                def _thinking_callback_sync(text: str) -> None:
+                    if not text:
+                        return
+                    try:
+                        if not _thinking_started[0]:
+                            _thinking_started[0] = True
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.start_thinking(
+                                    _status_chat_id,
+                                    _thinking_task_id,
+                                    "Processing request...",
+                                    model_label=_model_label_holder[0] or "",
+                                    initial_content_md=text,
+                                    thread_id=_progress_thread_id,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        else:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.update_thinking(
+                                    _thinking_task_id,
+                                    "Thinking...",
+                                    text,
+                                    model_label=_model_label_holder[0],
+                                ),
+                                _loop_for_step,
+                            )
+                    except Exception as _e:
+                        logger.debug("thinking_callback error: %s", _e)
+
+                def _reasoning_callback_sync(text: str) -> None:
+                    if not text:
+                        return
+                    try:
+                        if not _thinking_started[0]:
+                            _thinking_started[0] = True
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.start_thinking(
+                                    _status_chat_id,
+                                    _thinking_task_id,
+                                    "Reasoning...",
+                                    model_label=_model_label_holder[0] or "",
+                                    initial_content_md=text,
+                                    thread_id=_progress_thread_id,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=10)
+                        else:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.update_thinking(
+                                    _thinking_task_id,
+                                    "Reasoning...",
+                                    text,
+                                    model_label=_model_label_holder[0],
+                                ),
+                                _loop_for_step,
+                            )
+                    except Exception as _e:
+                        logger.debug("reasoning_callback error: %s", _e)
+
+                agent.thinking_callback = _thinking_callback_sync
+                agent.reasoning_callback = _reasoning_callback_sync
+            else:
+                agent.thinking_callback = None
+                agent.reasoning_callback = None
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:
@@ -8105,6 +8280,54 @@ class GatewayRunner:
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()
+
+            _final_model_label = _model_label_holder[0]
+            _final_agent = agent_holder[0]
+            if _final_agent:
+                _set_model_label(
+                    getattr(_final_agent, "model", "") or "",
+                    getattr(_final_agent, "provider", "") or "",
+                )
+                _final_model_label = _model_label_holder[0]
+
+            if _matrix_thinking_active and _thinking_started[0]:
+                _is_error = result.get("failed") or result.get("error")
+                try:
+                    if _is_error:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.abort_thinking(
+                                _thinking_task_id,
+                                str(result.get("error", "Agent error")),
+                                model_label=_final_model_label,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                    else:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.finalize_thinking(
+                                _thinking_task_id,
+                                f"Complete ({result.get('api_calls', 0)} API calls)",
+                                collapse=True,
+                                model_label=_final_model_label,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                except Exception as _e:
+                    logger.debug("thinking finalize error: %s", _e)
+
+            if _matrix_thinking_active and _tool_field_started[0]:
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.finalize_tool_activity(
+                            _thinking_task_id,
+                            f"Complete ({result.get('api_calls', 0)} API calls)",
+                            collapse=True,
+                            model_label=_final_model_label,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=10)
+                except Exception as _e:
+                    logger.debug("tool activity finalize error: %s", _e)
             
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8045,7 +8045,7 @@ class GatewayRunner:
                                     _thinking_task_id,
                                     "Processing request...",
                                     model_label=_model_label_holder[0] or "",
-                                    initial_content_md=text,
+                                    initial_content_md="",
                                     thread_id=_progress_thread_id,
                                 ),
                                 _loop_for_step,
@@ -8055,7 +8055,7 @@ class GatewayRunner:
                                 _status_adapter.update_thinking(
                                     _thinking_task_id,
                                     "Thinking...",
-                                    text,
+                                    "",
                                     model_label=_model_label_holder[0],
                                     append_line=False,
                                 ),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8057,6 +8057,7 @@ class GatewayRunner:
                                     "Thinking...",
                                     text,
                                     model_label=_model_label_holder[0],
+                                    append_line=False,
                                 ),
                                 _loop_for_step,
                             )
@@ -8087,6 +8088,7 @@ class GatewayRunner:
                                     "Reasoning...",
                                     text,
                                     model_label=_model_label_holder[0],
+                                    append_line=False,
                                 ),
                                 _loop_for_step,
                             )
@@ -8321,7 +8323,7 @@ class GatewayRunner:
                         _status_adapter.finalize_tool_activity(
                             _thinking_task_id,
                             f"Complete ({result.get('api_calls', 0)} API calls)",
-                            collapse=True,
+                            collapse=False,
                             model_label=_final_model_label,
                         ),
                         _loop_for_step,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4423,7 +4423,9 @@ class GatewayRunner:
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 
-                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    metadata = {"sender_id": source.user_id} if source.user_id else {}
+                    if source.thread_id:
+                        metadata["thread_id"] = source.thread_id
                     result = await adapter.send_model_picker(
                         chat_id=source.chat_id,
                         providers=providers,
@@ -7725,7 +7727,9 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = {"sender_id": source.user_id} if source.user_id else {}
+        if _progress_thread_id:
+            _status_thread_metadata["thread_id"] = _progress_thread_id
         _thinking_started = [False]
         _tool_field_started = [False]
         _thinking_task_id = session_key or session_id or ""
@@ -8318,16 +8322,27 @@ class GatewayRunner:
                     logger.debug("thinking finalize error: %s", _e)
 
             if _matrix_thinking_active and _tool_field_started[0]:
+                _is_error = result.get("failed") or result.get("error")
                 try:
-                    asyncio.run_coroutine_threadsafe(
-                        _status_adapter.finalize_tool_activity(
-                            _thinking_task_id,
-                            f"Complete ({result.get('api_calls', 0)} API calls)",
-                            collapse=False,
-                            model_label=_final_model_label,
-                        ),
-                        _loop_for_step,
-                    ).result(timeout=10)
+                    if _is_error:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.abort_tool_activity(
+                                _thinking_task_id,
+                                str(result.get("error", "Agent error")),
+                                model_label=_final_model_label,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
+                    else:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.finalize_tool_activity(
+                                _thinking_task_id,
+                                f"Complete ({result.get('api_calls', 0)} API calls)",
+                                collapse=False,
+                                model_label=_final_model_label,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=10)
                 except Exception as _e:
                     logger.debug("tool activity finalize error: %s", _e)
             

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -50,6 +50,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATTERMOST_HOME_CHANNEL", "MATTERMOST_REPLY_MODE",
     "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
     "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD",
+    "MATRIX_APPROVAL_REQUIRE_SENDER",
     "MATRIX_RECOVERY_KEY",
 })
 import yaml
@@ -1273,6 +1274,14 @@ OPTIONAL_ENV_VARS = {
     "MATRIX_AUTO_THREAD": {
         "description": "Auto-create threads for messages in Matrix rooms (default: true)",
         "prompt": "Auto-create threads in rooms (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_APPROVAL_REQUIRE_SENDER": {
+        "description": "Require Matrix approvals to be reacted by the original requester (default: true). Set false to allow any room member to approve.",
+        "prompt": "Require approval reactions from original requester (true/false)",
         "url": None,
         "password": False,
         "category": "messaging",

--- a/plans/matrix-reimplementation-v090.md
+++ b/plans/matrix-reimplementation-v090.md
@@ -1,0 +1,330 @@
+# Matrix Reimplementation Plan for Hermes v0.9.0
+
+> Status: ACTIVE WORK PLAN
+> Repo: `~/.hermes/hermes-agent`
+> Base: `v2026.4.13` / `v0.9.0`
+> Constraint: DO NOT restart the gateway without Chris's approval.
+
+## Goal
+Reintroduce Whyland's missing Matrix functionality on top of the current mautrix-based Hermes Agent implementation without regressing existing Matrix behavior or non-Matrix platforms.
+
+## Upstream baseline already present
+- `gateway/platforms/matrix.py` is mautrix-based
+- `gateway/run.py` already supports generic adapter hooks:
+  - `send_exec_approval(...)`
+  - `send_model_picker(...)`
+- Matrix adapter already has public methods for:
+  - `redact_message`
+  - `fetch_room_history`
+  - `create_room`
+  - `invite_user`
+  - `set_presence`
+  - `send_read_receipt`
+- Matrix adapter already has internal reaction plumbing:
+  - `_send_reaction`
+  - `_on_reaction`
+
+## Still missing upstream
+- `tools/matrix_tools.py`
+- Matrix tool registration in `model_tools.py`
+- Matrix toolset wiring in `toolsets.py`
+- Matrix platform hint in `agent/prompt_builder.py`
+- Matrix approval UI implementation
+- Matrix model picker implementation
+- Matrix thinking/acting pane implementation
+
+## Core design rule: event-role registry / interaction routing
+Matrix interaction behavior MUST be driven by explicit runtime event roles, not string matching or ad hoc skip logic.
+
+### Event roles
+- `conversation_output`
+- `processing_lifecycle_target`
+- `interactive_control`
+- `thinking_pane`
+- `acting_pane`
+- `system_status` (optional)
+
+### Routing rules
+- Processing lifecycle reactions ONLY apply to `processing_lifecycle_target`
+- Approval/model picker control events are registered as `interactive_control`
+- Thinking/Acting pane events are registered as `thinking_pane` / `acting_pane`
+- `_on_reaction(...)` routes based on target event role metadata
+
+### Control state requirements
+State MUST be keyed by authoritative event identity, including:
+- `event_id`
+- `room_id`
+- thread/root context
+- session key
+- authorized actor/user context
+- subtype (`approval`, `model_picker`)
+
+This avoids cross-resolution and makes teardown safe.
+
+---
+
+# Branch A — Matrix tools + platform hint
+
+## Branch name
+`feat/matrix-tools-v090`
+
+## Status
+IMPLEMENTED LOCALLY
+
+## Scope
+Restore Matrix agent-callable tools and platform hint with minimal adapter surface changes.
+
+## Files
+### Create
+- `tools/matrix_tools.py`
+- `tests/gateway/test_matrix_tools.py`
+
+### Modify
+- `gateway/platforms/matrix.py`
+- `model_tools.py`
+- `toolsets.py`
+- `agent/prompt_builder.py`
+
+## Rules
+- REUSE existing public `MatrixAdapter` methods
+- DO NOT duplicate raw Matrix SDK/API logic in `tools/matrix_tools.py`
+- DO NOT add Matrix tools to `_HERMES_CORE_TOOLS`
+- Add Matrix tools only via Matrix-specific toolset wiring
+- Tool availability requires a live connected Matrix adapter
+- Preserve optional import/discovery behavior in `model_tools._discover_tools()`
+
+## Tool list
+- `matrix_send_reaction`
+- `matrix_redact_message`
+- `matrix_create_room`
+- `matrix_invite_user`
+- `matrix_fetch_history`
+- `matrix_set_presence`
+
+## Public wrapper decision
+A minimal public `send_reaction(...)` wrapper was added so tools DO NOT call private adapter internals.
+
+## Acceptance criteria
+- Matrix tools are discoverable only in Matrix-specific tool context
+- Tools require a live adapter instance
+- Disconnected adapter path fails cleanly
+- No import-time failures if Matrix gateway is absent/inactive
+- Matrix platform hint accurately reflects tool availability
+- No runtime change when Matrix tools are unused
+
+## DO NOT break
+- Shared core toolsets
+- Existing Matrix gateway runtime behavior
+- Current mautrix lifecycle
+- Optional tool discovery behavior
+
+## Tests
+- `tests/gateway/test_matrix_tools.py`
+- `tests/gateway/test_matrix.py`
+- `tests/test_toolsets.py`
+- `tests/test_model_tools.py`
+- `tests/agent/test_prompt_builder.py`
+
+## Local validation result
+Command run:
+```bash
+venv/bin/python -m pytest \
+  tests/gateway/test_matrix_tools.py \
+  tests/gateway/test_matrix.py \
+  tests/test_toolsets.py \
+  tests/test_model_tools.py \
+  tests/agent/test_prompt_builder.py \
+  -o 'addopts=' -q
+```
+
+Result:
+- `272 passed`
+
+## Local commit
+- `dc1a275e` — `feat(matrix): add Matrix tool wrappers and platform hint`
+
+---
+
+# Branch B — Matrix approval UI + model picker
+
+## Branch name
+`feat/matrix-interactive-v090`
+
+## Status
+IMPLEMENTED LOCALLY
+
+## Scope
+Implement Matrix-native interactive approval and model selection using existing upstream gateway hooks.
+
+## Files
+### Create
+- `tests/gateway/test_matrix_interactive.py`
+
+### Modify
+- `gateway/platforms/matrix.py`
+
+## Rules
+- Implement:
+  - `send_exec_approval(...)`
+  - `send_model_picker(...)`
+- REUSE `_on_reaction(...)`
+- Use event-role registry and interaction routing
+- Control state must be keyed by authoritative control event identity
+- Preserve gateway fallback behavior if interactive send fails
+- Consume current metadata shape from `gateway/run.py`, especially thread metadata
+
+## Acceptance criteria
+- Approval and model picker render correctly
+- Selection resolves exactly once
+- Duplicate reactions/events do not double-resolve
+- Self-reactions are ignored
+- Wrong-user / unauthorized reactions are ignored
+- Malformed / irrelevant reactions are ignored
+- Timeout/cancel/stale-state cleanup works
+- Disconnect/restart cleans pending state and resolves/cancels waiters exactly once
+- Controls render in correct Matrix thread/root context
+- If interactive send fails, existing text fallback still works
+- Processing lifecycle reactions never target interactive control events
+- No stray bot emoji reaction on approval/model-picker messages
+- Multiple concurrent controls in the same room/thread do not cross-resolve
+
+## DO NOT break
+- Existing Matrix processing lifecycle reactions
+- Existing text fallback approval flow
+- Current `/model` persistence behavior in gateway
+- Non-Matrix approval/model-picker behavior
+- Existing `_on_reaction()` self-ignore / dedup behavior
+
+## Tests
+- `tests/gateway/test_matrix_interactive.py`
+- `tests/gateway/test_matrix.py`
+- `tests/gateway/test_model_switch_persistence.py`
+
+## Local validation result
+Command run:
+```bash
+venv/bin/python -m pytest \
+  tests/gateway/test_matrix_interactive.py \
+  tests/gateway/test_matrix.py \
+  tests/gateway/test_model_switch_persistence.py \
+  -o 'addopts=' -q
+```
+
+Result:
+- `133 passed`
+
+## Local commit
+- `4aee3621` — `feat(matrix): add interactive approval and model picker`
+
+---
+
+# Branch C — Matrix thinking/acting panes
+
+## Planned branch name
+`feat/matrix-thinking-v090`
+
+## Status
+IMPLEMENTED LOCALLY
+
+## Scope
+Add Matrix-only panes:
+- `Agent Thinking: <AgentName> via <ModelName>`
+- `Agent Acting:`
+
+while preserving current Hermes action formatting.
+
+## Files
+### Create
+- `gateway/platforms/matrix_thinking.py`
+- `tests/gateway/test_matrix_thinking.py`
+- `tests/gateway/test_matrix_run_regression.py`
+- optional: `tests/gateway/test_matrix_thinking_delta_merge.py`
+
+### Modify
+- `gateway/platforms/matrix.py`
+- `gateway/run.py`
+
+## Rules
+- REUSE existing gateway callback outputs
+- DO NOT invent a new acting formatter
+- DO NOT add provider-specific reasoning parsing
+- `Agent Acting` MUST preserve existing Hermes:
+  - emoji
+  - tool/action labels
+  - quoted args/labels
+  - ordering
+- Matrix-only suppression applies only to pane/interim progress traffic
+- Suppression MUST NOT suppress final assistant response
+- Keep `gateway/run.py` patch surface minimal
+- Explicitly define behavior for:
+  - no reasoning available
+  - non-streaming turn
+  - final-only reasoning
+  - tool-only turn
+
+## Acceptance criteria
+- Thinking heading format:
+  - `Agent Thinking: <AgentName> via <ModelName>`
+- Acting heading:
+  - `Agent Acting:`
+- Acting preserves current Hermes action formatting semantics
+- No reasoning/tool event loss under rapid updates
+- Repeated edits remain stable under bursts
+- Edit failure falls back safely with bounded replacement behavior
+- No duplicate Matrix timeline spam from pane traffic
+- Final assistant response still delivered exactly once
+- If `tool_progress` is off, Acting pane is off
+- When panes are disabled, behavior matches current upstream
+- No regressions for non-Matrix platforms
+- Finalize on success, abort on timeout, cleanup on restart/disconnect all work
+- Pane edits preserve Matrix thread/root context
+
+## DO NOT break
+- Existing tool progress behavior on other platforms
+- Existing stream/reasoning behavior outside Matrix
+- Existing Matrix behavior when panes are disabled
+- Current approval/model/session-note behavior in `gateway/run.py`
+- Current Matrix batching/split-message aggregation
+- Final response delivery
+
+## Planned tests
+- `tests/gateway/test_matrix_thinking.py`
+- `tests/gateway/test_matrix_run_regression.py`
+- optional `tests/gateway/test_matrix_thinking_delta_merge.py`
+- `tests/gateway/test_matrix.py`
+- `tests/gateway/test_model_switch_persistence.py`
+
+## Local validation result
+Command run:
+```bash
+venv/bin/python -m pytest \
+  tests/gateway/test_matrix_interactive.py \
+  tests/gateway/test_matrix.py \
+  tests/gateway/test_model_switch_persistence.py \
+  tests/gateway/test_matrix_thinking.py \
+  tests/gateway/test_matrix_run_regression.py \
+  -o 'addopts=' -q
+```
+
+Result:
+- `141 passed`
+
+## Local branch state
+- Branch C branch: `feat/matrix-thinking-v090`
+- Branch C includes:
+  - `gateway/platforms/matrix_thinking.py`
+  - `tests/gateway/test_matrix_thinking.py`
+  - `tests/gateway/test_matrix_run_regression.py`
+
+---
+
+# Restart / validation rule
+Before any gateway restart for validation, STOP and get Chris's approval first.
+
+## Current next step
+- Branch B needs restart-based live validation before moving to Branch C.
+
+## Current repo state snapshot
+- Branch A commit: `dc1a275e`
+- Branch B commit: `4aee3621`
+- Branch C: not started

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1869,6 +1869,42 @@ class TestMatrixMessageTypes:
         assert content["msgtype"] == "m.notice"
 
     @pytest.mark.asyncio
+    async def test_send_notice_preserves_thread_metadata(self):
+        mock_client = MagicMock()
+        mock_client.send_message_event = AsyncMock(return_value="$notice-thread")
+        self.adapter._client = mock_client
+
+        result = await self.adapter.send_notice(
+            "!room:ex",
+            "Threaded notice",
+            metadata={"thread_id": "$thread1"},
+        )
+
+        assert result.success is True
+        call_args = mock_client.send_message_event.call_args
+        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
+        assert content["msgtype"] == "m.notice"
+        assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$thread1"
+
+    @pytest.mark.asyncio
+    async def test_send_emote_preserves_thread_metadata(self):
+        mock_client = MagicMock()
+        mock_client.send_message_event = AsyncMock(return_value="$emote-thread")
+        self.adapter._client = mock_client
+
+        result = await self.adapter.send_emote(
+            "!room:ex",
+            "waves in thread",
+            metadata={"thread_id": "$thread2"},
+        )
+
+        assert result.success is True
+        call_args = mock_client.send_message_event.call_args
+        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
+        assert content["msgtype"] == "m.emote"
+        assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$thread2"
+
+    @pytest.mark.asyncio
     async def test_send_emote_empty_text(self):
         self.adapter._client = MagicMock()
         result = await self.adapter.send_emote("!room:ex", "")

--- a/tests/gateway/test_matrix_interactive.py
+++ b/tests/gateway/test_matrix_interactive.py
@@ -75,6 +75,44 @@ class TestMatrixExecApproval:
         adapter.send.assert_awaited_once()
         assert adapter.send.call_args.kwargs["metadata"]["thread_id"] == "$thread2"
 
+    async def test_send_exec_approval_seeds_reaction_choices(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$approval"))
+        adapter.send_reaction = AsyncMock(return_value=SendResult(success=True, message_id="$rxn"))
+
+        await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="rm -rf /tmp/x",
+            session_key="session-1",
+        )
+
+        seeded = [call.args[2] for call in adapter.send_reaction.await_args_list]
+        assert seeded == ["✅", "🔁", "♾️", "❌"]
+
+    async def test_send_model_picker_seeds_number_reactions_and_cancel(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$picker"))
+        adapter.send_reaction = AsyncMock(return_value=SendResult(success=True, message_id="$rxn"))
+
+        async def _on_selected(_chat_id, _model_id, _provider_slug):
+            return "done"
+
+        providers = [
+            {"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"], "total_models": 1, "is_current": True},
+            {"slug": "custom-vllm", "name": "vLLM", "models": ["m1", "m2"], "total_models": 2},
+        ]
+        await adapter.send_model_picker(
+            chat_id="!room:example.org",
+            providers=providers,
+            current_model="gpt-5.4",
+            current_provider="openai-codex",
+            session_key="session-1",
+            on_model_selected=_on_selected,
+        )
+
+        seeded = [call.args[2] for call in adapter.send_reaction.await_args_list]
+        assert seeded == ["1️⃣", "2️⃣", "❌"]
+
     async def test_approval_reaction_resolves_once(self):
         adapter = _make_adapter()
         adapter._approval_state["$approval"] = {

--- a/tests/gateway/test_matrix_interactive.py
+++ b/tests/gateway/test_matrix_interactive.py
@@ -1,0 +1,269 @@
+"""Tests for Matrix interactive approval and model picker controls."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    from gateway.platforms.matrix import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+def _reaction_event(event_id: str, sender: str, target_event_id: str, key: str, room_id: str = "!room:example.org"):
+    return SimpleNamespace(
+        event_id=event_id,
+        sender=sender,
+        room_id=room_id,
+        content={
+            "m.relates_to": {
+                "event_id": target_event_id,
+                "key": key,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+class TestMatrixExecApproval:
+    async def test_send_exec_approval_stores_control_state(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$approval"))
+
+        result = await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="rm -rf /tmp/x",
+            session_key="session-1",
+            description="dangerous command",
+            metadata={"thread_id": "$thread1", "sender_id": "@chris:example.org"},
+        )
+
+        assert result.success is True
+        assert "$approval" in adapter._approval_state
+        state = adapter._approval_state["$approval"]
+        assert state["session_key"] == "session-1"
+        assert state["thread_id"] == "$thread1"
+        assert state["authorized_actor"] == "@chris:example.org"
+        assert adapter._event_roles["$approval"]["role"] == "interactive_control"
+        assert adapter._event_roles["$approval"]["control_type"] == "approval"
+        assert adapter._pending_reactions == {}
+
+    async def test_send_exec_approval_preserves_thread_metadata(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$approval"))
+
+        await adapter.send_exec_approval(
+            chat_id="!room:example.org",
+            command="ls",
+            session_key="session-1",
+            metadata={"thread_id": "$thread2"},
+        )
+
+        adapter.send.assert_awaited_once()
+        assert adapter.send.call_args.kwargs["metadata"]["thread_id"] == "$thread2"
+
+    async def test_approval_reaction_resolves_once(self):
+        adapter = _make_adapter()
+        adapter._approval_state["$approval"] = {
+            "session_key": "session-1",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "authorized_actor": "@chris:example.org",
+            "resolved": False,
+        }
+        adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            event = _reaction_event("$r1", "@chris:example.org", "$approval", "✅")
+            await adapter._on_reaction(event)
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_called_once_with("session-1", "once")
+        assert "$approval" not in adapter._approval_state
+
+    async def test_approval_wrong_user_ignored(self):
+        adapter = _make_adapter()
+        adapter._approval_state["$approval"] = {
+            "session_key": "session-1",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "authorized_actor": "@chris:example.org",
+            "resolved": False,
+        }
+        adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
+        adapter.edit_message = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._on_reaction(_reaction_event("$r1", "@intruder:example.org", "$approval", "✅"))
+
+        mock_resolve.assert_not_called()
+        assert "$approval" in adapter._approval_state
+
+    async def test_approval_self_reaction_ignored(self):
+        adapter = _make_adapter()
+        adapter._approval_state["$approval"] = {
+            "session_key": "session-1",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "authorized_actor": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
+        adapter.edit_message = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._on_reaction(_reaction_event("$r1", "@bot:example.org", "$approval", "✅"))
+
+        mock_resolve.assert_not_called()
+
+    async def test_disconnect_denies_pending_approvals_once(self):
+        adapter = _make_adapter()
+        adapter._approval_state["$approval"] = {
+            "session_key": "session-1",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "authorized_actor": None,
+            "resolved": False,
+        }
+        adapter._model_picker_state["$picker"] = {"resolved": False}
+        adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
+        adapter._sync_task = None
+        adapter._client = None
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter.disconnect()
+
+        mock_resolve.assert_called_once_with("session-1", "deny")
+        assert adapter._approval_state == {}
+        assert adapter._model_picker_state == {}
+        assert adapter._event_roles == {}
+
+
+@pytest.mark.asyncio
+class TestMatrixModelPicker:
+    async def test_send_model_picker_stores_control_state(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$picker"))
+
+        async def _on_selected(_chat_id, _model_id, _provider_slug):
+            return "done"
+
+        providers = [
+            {"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"], "total_models": 1, "is_current": True},
+            {"slug": "custom-vllm", "name": "vLLM", "models": ["m1", "m2"], "total_models": 2},
+        ]
+        result = await adapter.send_model_picker(
+            chat_id="!room:example.org",
+            providers=providers,
+            current_model="gpt-5.4",
+            current_provider="openai-codex",
+            session_key="session-1",
+            on_model_selected=_on_selected,
+            metadata={"thread_id": "$thread1", "sender_id": "@chris:example.org"},
+        )
+
+        assert result.success is True
+        state = adapter._model_picker_state["$picker"]
+        assert state["stage"] == "provider"
+        assert state["thread_id"] == "$thread1"
+        assert state["authorized_actor"] == "@chris:example.org"
+        assert adapter._event_roles["$picker"]["control_type"] == "model_picker"
+
+    async def test_model_picker_provider_then_model_selection(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="Model switched")
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter._model_picker_state["$picker"] = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": "!room:example.org",
+            "thread_id": "$thread1",
+            "session_key": "session-1",
+            "authorized_actor": "@chris:example.org",
+            "providers": [
+                {"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"]},
+                {"slug": "custom-vllm", "name": "vLLM", "models": ["m1", "m2"]},
+            ],
+            "current_model": "gpt-5.4",
+            "current_provider": "openai-codex",
+            "on_model_selected": callback,
+            "page": 0,
+            "page_size": 9,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$picker"] = {"role": "interactive_control", "control_type": "model_picker"}
+
+        await adapter._on_reaction(_reaction_event("$r1", "@chris:example.org", "$picker", "2️⃣"))
+        assert adapter._model_picker_state["$picker"]["stage"] == "model"
+        assert adapter._model_picker_state["$picker"]["selected_provider"]["slug"] == "custom-vllm"
+
+        await adapter._on_reaction(_reaction_event("$r2", "@chris:example.org", "$picker", "1️⃣"))
+        callback.assert_awaited_once_with("!room:example.org", "m1", "custom-vllm")
+        assert "$picker" not in adapter._model_picker_state
+
+    async def test_model_picker_wrong_user_ignored(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="Model switched")
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter._model_picker_state["$picker"] = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "session_key": "session-1",
+            "authorized_actor": "@chris:example.org",
+            "providers": [{"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"]}],
+            "current_model": "gpt-5.4",
+            "current_provider": "openai-codex",
+            "on_model_selected": callback,
+            "page": 0,
+            "page_size": 9,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$picker"] = {"role": "interactive_control", "control_type": "model_picker"}
+
+        await adapter._on_reaction(_reaction_event("$r1", "@intruder:example.org", "$picker", "1️⃣"))
+        callback.assert_not_called()
+        assert adapter._model_picker_state["$picker"]["stage"] == "provider"
+
+    async def test_model_picker_cancel_cleans_state(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="Model switched")
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter._model_picker_state["$picker"] = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "session_key": "session-1",
+            "authorized_actor": None,
+            "providers": [{"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"]}],
+            "current_model": "gpt-5.4",
+            "current_provider": "openai-codex",
+            "on_model_selected": callback,
+            "page": 0,
+            "page_size": 9,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$picker"] = {"role": "interactive_control", "control_type": "model_picker"}
+
+        await adapter._on_reaction(_reaction_event("$r1", "@chris:example.org", "$picker", "❌"))
+        assert "$picker" not in adapter._model_picker_state
+        callback.assert_not_called()

--- a/tests/gateway/test_matrix_interactive.py
+++ b/tests/gateway/test_matrix_interactive.py
@@ -9,7 +9,7 @@ from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 
 
-def _make_adapter():
+def _make_adapter(extra=None):
     from gateway.platforms.matrix import MatrixAdapter
 
     config = PlatformConfig(
@@ -18,6 +18,7 @@ def _make_adapter():
         extra={
             "homeserver": "https://matrix.example.org",
             "user_id": "@bot:example.org",
+            **(extra or {}),
         },
     )
     return MatrixAdapter(config)
@@ -144,12 +145,35 @@ class TestMatrixExecApproval:
         }
         adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
         adapter.edit_message = AsyncMock()
+        adapter.send_notice = AsyncMock(return_value=SendResult(success=True, message_id="$notice"))
 
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
             await adapter._on_reaction(_reaction_event("$r1", "@intruder:example.org", "$approval", "✅"))
 
         mock_resolve.assert_not_called()
+        adapter.send_notice.assert_awaited_once()
+        assert "Approval requires reaction from @chris:example.org" in adapter.send_notice.await_args.args[1]
         assert "$approval" in adapter._approval_state
+
+    async def test_approval_wrong_user_can_resolve_when_sender_validation_disabled(self):
+        adapter = _make_adapter({"approval_require_sender": False})
+        adapter._approval_state["$approval"] = {
+            "session_key": "session-1",
+            "room_id": "!room:example.org",
+            "thread_id": None,
+            "authorized_actor": "@chris:example.org",
+            "resolved": False,
+        }
+        adapter._event_roles["$approval"] = {"role": "interactive_control", "control_type": "approval"}
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter.send_notice = AsyncMock(return_value=SendResult(success=True, message_id="$notice"))
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._on_reaction(_reaction_event("$r1", "@intruder:example.org", "$approval", "✅"))
+
+        mock_resolve.assert_called_once_with("session-1", "once")
+        adapter.send_notice.assert_not_called()
+        assert "$approval" not in adapter._approval_state
 
     async def test_approval_self_reaction_ignored(self):
         adapter = _make_adapter()
@@ -253,6 +277,68 @@ class TestMatrixModelPicker:
         await adapter._on_reaction(_reaction_event("$r2", "@chris:example.org", "$picker", "1️⃣"))
         callback.assert_awaited_once_with("!room:example.org", "m1", "custom-vllm")
         assert "$picker" not in adapter._model_picker_state
+
+    async def test_model_picker_reseeds_reactions_after_provider_selection(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="Model switched")
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter.send_reaction = AsyncMock(return_value=SendResult(success=True, message_id="$rxn"))
+        adapter._model_picker_state["$picker"] = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": "!room:example.org",
+            "thread_id": "$thread1",
+            "session_key": "session-1",
+            "authorized_actor": "@chris:example.org",
+            "providers": [
+                {"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.4"]},
+                {"slug": "custom-vllm", "name": "vLLM", "models": ["m1", "m2"]},
+            ],
+            "current_model": "gpt-5.4",
+            "current_provider": "openai-codex",
+            "on_model_selected": callback,
+            "page": 0,
+            "page_size": 9,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$picker"] = {"role": "interactive_control", "control_type": "model_picker"}
+
+        await adapter._on_reaction(_reaction_event("$r1", "@chris:example.org", "$picker", "2️⃣"))
+
+        seeded = [call.args[2] for call in adapter.send_reaction.await_args_list]
+        assert seeded == ["1️⃣", "2️⃣", "↩️", "❌"]
+
+    async def test_model_picker_reseeds_reactions_after_page_change(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(return_value="Model switched")
+        adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="$edit"))
+        adapter.send_reaction = AsyncMock(return_value=SendResult(success=True, message_id="$rxn"))
+        adapter._model_picker_state["$picker"] = {
+            "control_type": "model_picker",
+            "stage": "provider",
+            "room_id": "!room:example.org",
+            "thread_id": "$thread1",
+            "session_key": "session-1",
+            "authorized_actor": "@chris:example.org",
+            "providers": [
+                {"slug": f"provider-{idx}", "name": f"Provider {idx}", "models": ["gpt-5.4"]}
+                for idx in range(10)
+            ],
+            "current_model": "gpt-5.4",
+            "current_provider": "provider-0",
+            "on_model_selected": callback,
+            "page": 0,
+            "page_size": 9,
+            "selected_provider": None,
+            "resolved": False,
+        }
+        adapter._event_roles["$picker"] = {"role": "interactive_control", "control_type": "model_picker"}
+
+        await adapter._on_reaction(_reaction_event("$r1", "@chris:example.org", "$picker", "▶️"))
+
+        seeded = [call.args[2] for call in adapter.send_reaction.await_args_list]
+        assert seeded == ["1️⃣", "◀️", "❌"]
 
     async def test_model_picker_wrong_user_ignored(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_matrix_run_regression.py
+++ b/tests/gateway/test_matrix_run_regression.py
@@ -1,0 +1,220 @@
+"""Gateway integration regressions for Matrix thinking/acting panes."""
+
+import importlib
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class MatrixThinkingAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.MATRIX)
+        self._thinking_enabled = True
+        self.calls = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.calls.append(("send", content))
+        return SendResult(success=True, message_id="msg-1")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.calls.append(("edit", content))
+        return SendResult(success=True, message_id=message_id)
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def start_thinking(self, room_id, task_id, initial_summary="Processing request...", model_label="", initial_content_md="", thread_id=None):
+        self.calls.append(("start_thinking", initial_summary, model_label, initial_content_md, thread_id))
+        return "$thinking"
+
+    async def update_thinking(self, task_id, step_info, content_md="", model_label=None, append_line=True):
+        self.calls.append(("update_thinking", step_info, content_md, model_label, append_line))
+
+    async def finalize_thinking(self, task_id, final_summary="Task complete", collapse=True, model_label=None):
+        self.calls.append(("finalize_thinking", final_summary, model_label, collapse))
+
+    async def abort_thinking(self, task_id, reason="Aborted", model_label=None):
+        self.calls.append(("abort_thinking", reason, model_label))
+
+    async def start_tool_activity(self, room_id, task_id, initial_summary="Tool activity", model_label="", initial_content_md="", thread_id=None):
+        self.calls.append(("start_tool_activity", initial_summary, model_label, initial_content_md, thread_id))
+        return "$tools"
+
+    async def update_tool_activity(self, task_id, step_info, content_md="", model_label=None, append_line=True):
+        self.calls.append(("update_tool_activity", step_info, content_md, model_label, append_line))
+
+    async def finalize_tool_activity(self, task_id, final_summary="Tool activity complete", collapse=True, model_label=None):
+        self.calls.append(("finalize_tool_activity", final_summary, model_label, collapse))
+
+    async def abort_tool_activity(self, task_id, reason="Aborted", model_label=None):
+        self.calls.append(("abort_tool_activity", reason, model_label))
+
+    def has_pending_interrupt(self, session_key: str) -> bool:
+        return False
+
+    def get_pending_message(self, session_key: str):
+        return None
+
+
+class FakeAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.thinking_callback = kwargs.get("thinking_callback")
+        self.reasoning_callback = kwargs.get("reasoning_callback")
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+        self.model = "gpt-5.4"
+        self.provider = "openai-codex"
+        self.session_id = kwargs.get("session_id")
+        self.context_compressor = None
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.status_callback:
+            self.status_callback("info", "switching to fallback: gpt-5.4 via openai-codex")
+        if self.reasoning_callback:
+            self.reasoning_callback("Reasoning delta")
+        if self.thinking_callback:
+            self.thinking_callback("Thinking status")
+        if self.tool_progress_callback:
+            self.tool_progress_callback("tool.started", "terminal", '"pwd"')
+            self.tool_progress_callback("tool.started", "search_files", '"turn_route"')
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class FakeAgentReasoningFirst(FakeAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.reasoning_callback:
+            self.reasoning_callback("Reasoning arrived first")
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agent_started_at = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._effective_model = None
+    runner._effective_provider = None
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, {})
+    runner._load_reasoning_config = lambda: None
+    runner._evict_cached_agent = lambda session_key: runner._agent_cache.pop(session_key, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_matrix_run_routes_thinking_reasoning_and_tools_to_panes(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"display": {"tool_progress": "all"}})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***", "provider": "anthropic", "base_url": "https://api.anthropic.com"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(platform=Platform.MATRIX, chat_id="!room:example.org", chat_type="dm", thread_id=None)
+
+    result = await runner._run_agent(message="hello", context_prompt="", history=[], source=source, session_id="sess-1", session_key="agent:main:matrix:dm:!room:example.org")
+
+    assert result["final_response"] == "done"
+    call_names = [name for name, *_ in adapter.calls]
+    assert "start_thinking" in call_names
+    assert "update_thinking" in call_names
+    assert "start_tool_activity" in call_names
+    assert "update_tool_activity" in call_names
+    assert "finalize_thinking" in call_names
+    assert "finalize_tool_activity" in call_names
+    assert "send" not in call_names
+
+
+@pytest.mark.asyncio
+async def test_matrix_run_reasoning_first_still_starts_thinking_pane(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgentReasoningFirst
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"display": {"tool_progress": "all"}})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***", "provider": "anthropic", "base_url": "https://api.anthropic.com"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(platform=Platform.MATRIX, chat_id="!room:example.org", chat_type="dm", thread_id=None)
+
+    result = await runner._run_agent(message="hello", context_prompt="", history=[], source=source, session_id="sess-2", session_key="agent:main:matrix:dm:!room:example.org")
+
+    assert result["final_response"] == "done"
+    call_names = [name for name, *_ in adapter.calls]
+    assert "start_thinking" in call_names
+    assert "start_tool_activity" not in call_names
+
+
+@pytest.mark.asyncio
+async def test_matrix_run_respects_tool_progress_off(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"display": {"tool_progress": "off"}})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***", "provider": "anthropic", "base_url": "https://api.anthropic.com"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(platform=Platform.MATRIX, chat_id="!room:example.org", chat_type="dm", thread_id=None)
+
+    result = await runner._run_agent(message="hello", context_prompt="", history=[], source=source, session_id="sess-3", session_key="agent:main:matrix:dm:!room:example.org")
+
+    assert result["final_response"] == "done"
+    call_names = [name for name, *_ in adapter.calls]
+    assert "start_thinking" in call_names
+    assert "start_tool_activity" not in call_names
+    assert "update_tool_activity" not in call_names
+    assert "finalize_tool_activity" not in call_names

--- a/tests/gateway/test_matrix_run_regression.py
+++ b/tests/gateway/test_matrix_run_regression.py
@@ -56,7 +56,7 @@ class MatrixThinkingAdapter(BasePlatformAdapter):
     async def update_tool_activity(self, task_id, step_info, content_md="", model_label=None, append_line=True):
         self.calls.append(("update_tool_activity", step_info, content_md, model_label, append_line))
 
-    async def finalize_tool_activity(self, task_id, final_summary="Tool activity complete", collapse=True, model_label=None):
+    async def finalize_tool_activity(self, task_id, final_summary="Tool activity complete", collapse=False, model_label=None):
         self.calls.append(("finalize_tool_activity", final_summary, model_label, collapse))
 
     async def abort_tool_activity(self, task_id, reason="Aborted", model_label=None):
@@ -159,6 +159,8 @@ async def test_matrix_run_routes_thinking_reasoning_and_tools_to_panes(monkeypat
     assert "update_tool_activity" in call_names
     assert "finalize_thinking" in call_names
     assert "finalize_tool_activity" in call_names
+    assert any(call[0] == "finalize_tool_activity" and call[3] is False for call in adapter.calls)
+    assert any(call[0] == "update_thinking" and call[4] is False for call in adapter.calls)
     assert "send" not in call_names
 
 

--- a/tests/gateway/test_matrix_run_regression.py
+++ b/tests/gateway/test_matrix_run_regression.py
@@ -160,7 +160,8 @@ async def test_matrix_run_routes_thinking_reasoning_and_tools_to_panes(monkeypat
     assert "finalize_thinking" in call_names
     assert "finalize_tool_activity" in call_names
     assert any(call[0] == "finalize_tool_activity" and call[3] is False for call in adapter.calls)
-    assert any(call[0] == "update_thinking" and call[4] is False for call in adapter.calls)
+    assert any(call[0] == "update_thinking" and call[2] == "Reasoning delta" and call[4] is False for call in adapter.calls)
+    assert any(call[0] == "update_thinking" and call[1] == "Thinking..." and call[2] == "" and call[4] is False for call in adapter.calls)
     assert "send" not in call_names
 
 

--- a/tests/gateway/test_matrix_run_regression.py
+++ b/tests/gateway/test_matrix_run_regression.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -18,6 +19,8 @@ class MatrixThinkingAdapter(BasePlatformAdapter):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.MATRIX)
         self._thinking_enabled = True
         self.calls = []
+        self._send_exec_approval_mock = AsyncMock(return_value=SendResult(success=True, message_id="$approval"))
+        self._send_model_picker_mock = AsyncMock(return_value=SendResult(success=True, message_id="$picker"))
 
     async def connect(self) -> bool:
         return True
@@ -62,6 +65,12 @@ class MatrixThinkingAdapter(BasePlatformAdapter):
     async def abort_tool_activity(self, task_id, reason="Aborted", model_label=None):
         self.calls.append(("abort_tool_activity", reason, model_label))
 
+    async def send_model_picker(self, **kwargs):
+        return await self._send_model_picker_mock(**kwargs)
+
+    async def send_exec_approval(self, **kwargs):
+        return await self._send_exec_approval_mock(**kwargs)
+
     def has_pending_interrupt(self, session_key: str) -> bool:
         return False
 
@@ -101,6 +110,23 @@ class FakeAgentReasoningFirst(FakeAgent):
         if self.reasoning_callback:
             self.reasoning_callback("Reasoning arrived first")
         return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class FakeAgentApprovalNotify(FakeAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        from tools.approval import _gateway_notify_cbs, get_current_session_key
+
+        session_key = get_current_session_key()
+        notify_cb = _gateway_notify_cbs[session_key]
+        notify_cb({"command": "rm -rf /tmp/example", "description": "dangerous command"})
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class FakeAgentFailureAfterTool(FakeAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.tool_progress_callback:
+            self.tool_progress_callback("tool.started", "terminal", '"pwd"')
+        return {"final_response": "", "messages": [], "api_calls": 1, "failed": True, "error": "tool blew up"}
 
 
 def _make_runner(adapter):
@@ -219,5 +245,105 @@ async def test_matrix_run_respects_tool_progress_off(monkeypatch, tmp_path):
     call_names = [name for name, *_ in adapter.calls]
     assert "start_thinking" in call_names
     assert "start_tool_activity" not in call_names
+
+
+@pytest.mark.asyncio
+async def test_matrix_model_picker_real_path_passes_sender_id(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("model:\n  default: gpt-5.4\n  provider: openai-codex\n")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"openai-codex": {"label": "OpenAI Codex", "models": {"gpt-5.4": {"label": "gpt-5.4"}}}},
+    )
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    event = SimpleNamespace(
+        text="/model",
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_type="dm",
+            user_id="@chris:example.org",
+            thread_id="$thread-1",
+        ),
+        get_command_args=lambda: "",
+    )
+
+    result = await runner._handle_model_command(event)
+
+    assert result is None
+    metadata = adapter._send_model_picker_mock.await_args.kwargs["metadata"]
+    assert metadata["thread_id"] == "$thread-1"
+    assert metadata["sender_id"] == "@chris:example.org"
+
+
+@pytest.mark.asyncio
+async def test_matrix_approval_real_path_passes_sender_id(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgentApprovalNotify
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"display": {"tool_progress": "all"}})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***", "provider": "anthropic", "base_url": "https://api.anthropic.com"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:example.org",
+        chat_type="dm",
+        user_id="@chris:example.org",
+        thread_id="$thread-approval",
+    )
+
+    result = await runner._run_agent(message="hello", context_prompt="", history=[], source=source, session_id="sess-approval", session_key="agent:main:matrix:dm:!room:example.org")
+
+    assert result["final_response"] == "done"
+    adapter._send_exec_approval_mock.assert_awaited_once()
+    metadata = adapter._send_exec_approval_mock.await_args.kwargs["metadata"]
+    assert metadata["thread_id"] == "$thread-approval"
+    assert metadata["sender_id"] == "@chris:example.org"
+
+
+@pytest.mark.asyncio
+async def test_matrix_run_aborts_tool_activity_on_failed_turn(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgentFailureAfterTool
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"display": {"tool_progress": "all"}})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***", "provider": "anthropic", "base_url": "https://api.anthropic.com"})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = MatrixThinkingAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(platform=Platform.MATRIX, chat_id="!room:example.org", chat_type="dm", thread_id=None)
+
+    result = await runner._run_agent(message="hello", context_prompt="", history=[], source=source, session_id="sess-fail", session_key="agent:main:matrix:dm:!room:example.org")
+
+    assert result["final_response"].startswith("⚠️")
+    call_names = [name for name, *_ in adapter.calls]
+    assert "start_tool_activity" in call_names
+    assert "abort_tool_activity" in call_names
+    assert "finalize_tool_activity" not in call_names
     assert "update_tool_activity" not in call_names
     assert "finalize_tool_activity" not in call_names

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -1,0 +1,98 @@
+"""Tests for Matrix thinking/acting panes."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(thinking_enabled=True):
+    from gateway.platforms.matrix import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test123",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+            "thinking_fields_enabled": thinking_enabled,
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._client = AsyncMock()
+    return adapter
+
+
+class TestThinkingManagerTitles:
+    def test_field_titles_match_branch_c_requirement(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "Agent Thinking: Hermes via gpt-5.4 via openai-codex"
+        assert ThinkingManager._field_title("tools", "gpt-5.4 via openai-codex") == "Agent Acting:"
+
+    def test_plaintext_summary_includes_required_heading(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        text = ThinkingManager._plaintext_summary(
+            "Agent Thinking: Hermes via gpt-5.4 via openai-codex",
+            "Processing request...",
+        )
+        assert "Agent Thinking: Hermes via gpt-5.4 via openai-codex" in text
+        assert "Processing request..." in text
+
+
+class TestThinkingManagerLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_thinking_uses_branch_c_heading(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        send_message_event = AsyncMock(return_value="$evt_123")
+        adapter._client.send_message_event = send_message_event
+
+        mgr = ThinkingManager(adapter)
+        event_id = await mgr.start(
+            "!room:example.org",
+            "task-1",
+            "Processing request...",
+            field_kind="thinking",
+            model_label="gpt-5.4 via openai-codex",
+            initial_content_md="first delta",
+        )
+
+        assert event_id == "$evt_123"
+        content = send_message_event.call_args.args[2]
+        assert "Agent Thinking: Hermes via gpt-5.4 via openai-codex" in content["formatted_body"]
+        assert "first delta" in content["formatted_body"]
+
+    @pytest.mark.asyncio
+    async def test_start_tool_activity_uses_agent_acting_heading(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        send_message_event = AsyncMock(return_value="$evt_456")
+        adapter._client.send_message_event = send_message_event
+
+        mgr = ThinkingManager(adapter)
+        event_id = await mgr.start(
+            "!room:example.org",
+            "task-2",
+            "Tool activity",
+            field_kind="tools",
+            model_label="gpt-5.4 via openai-codex",
+            initial_content_md='💻 terminal: "pwd"',
+        )
+
+        assert event_id == "$evt_456"
+        content = send_message_event.call_args.args[2]
+        assert "Agent Acting:" in content["formatted_body"]
+        assert '💻 terminal: &quot;pwd&quot;' in content["formatted_body"]
+
+    def test_elapsed_str_still_formats_duration(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        now = time.time()
+        assert ThinkingManager._elapsed_str(now - 45) == "45s"
+        assert ThinkingManager._elapsed_str(now - 125) == "2m5s"

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -185,6 +185,31 @@ class TestThinkingManagerLifecycle:
         assert content["m.relates_to"]["event_id"] == "$event"
         assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$thread-1"
 
+    @pytest.mark.asyncio
+    async def test_send_edit_snapshot_retries_transient_failures(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        adapter._client.send_message_event = AsyncMock(side_effect=[RuntimeError("temporary"), "$evt_retry"])
+        mgr = ThinkingManager(adapter)
+
+        snapshot = {
+            "room_id": "!room:example.org",
+            "event_id": "$event",
+            "task_id": "task-retry",
+            "field_kind": "thinking",
+            "title": "🧐 Agent Thinking: Hermes via gpt-5.4 via openai-codex",
+            "summary": "Processing request...",
+            "step_count": 1,
+            "content_html": "<pre><code>reasoning</code></pre>",
+            "started_at": time.time(),
+            "thread_id": "$thread-retry",
+        }
+
+        await mgr._send_edit_snapshot(snapshot)
+
+        assert adapter._client.send_message_event.await_count == 2
+
     def test_elapsed_str_still_formats_duration(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -26,26 +26,27 @@ def _make_adapter(thinking_enabled=True):
 
 
 class TestThinkingManagerTitles:
-    def test_field_titles_match_branch_c_requirement_with_friendly_emoji(self):
+    def test_field_titles_use_brain_icon_and_provider_model_utilization_label(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
-        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "🧐 Agent Thinking: Hermes via gpt-5.4 via openai-codex"
+        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "🧠 Agent Thinking: Utilizing gpt-5.4 via openai-codex"
+        assert ThinkingManager._field_title("thinking", "") == "🧠 Agent Thinking:"
         assert ThinkingManager._field_title("tools", "gpt-5.4 via openai-codex") == "⚡ Agent Acting:"
 
-    def test_plaintext_summary_includes_required_heading(self):
+    def test_plaintext_summary_includes_updated_heading(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
         text = ThinkingManager._plaintext_summary(
-            "Agent Thinking: Hermes via gpt-5.4 via openai-codex",
+            "🧠 Agent Thinking: Utilizing gpt-5.4 via openai-codex",
             "Processing request...",
         )
-        assert "Agent Thinking: Hermes via gpt-5.4 via openai-codex" in text
+        assert "🧠 Agent Thinking: Utilizing gpt-5.4 via openai-codex" in text
         assert "Processing request..." in text
 
 
 class TestThinkingManagerLifecycle:
     @pytest.mark.asyncio
-    async def test_start_thinking_uses_branch_c_heading(self):
+    async def test_start_thinking_uses_updated_heading(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
         adapter = _make_adapter()
@@ -64,7 +65,7 @@ class TestThinkingManagerLifecycle:
 
         assert event_id == "$evt_123"
         content = send_message_event.call_args.args[2]
-        assert "Agent Thinking: Hermes via gpt-5.4 via openai-codex" in content["formatted_body"]
+        assert "🧠 Agent Thinking: Utilizing gpt-5.4 via openai-codex" in content["formatted_body"]
         assert "first delta" in content["formatted_body"]
 
     @pytest.mark.asyncio
@@ -171,13 +172,26 @@ class TestThinkingManagerLifecycle:
         tools_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
         assert "<details open><summary>" in tools_payload["formatted_body"]
 
+    @pytest.mark.asyncio
+    async def test_tools_abort_stays_expanded_by_default(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        adapter._client.send_message_event = AsyncMock(return_value="$evt_abort")
+
+        mgr = ThinkingManager(adapter)
+        await mgr.start("!room:example.org", "task-tools-abort", "Tool activity", field_kind="tools")
+        await mgr.abort("task-tools-abort", "tool failed", field_kind="tools")
+        tools_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
+        assert "<details open><summary>" in tools_payload["formatted_body"]
+
     def test_edit_content_preserves_thread_relation(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
         content = ThinkingManager._edit_content(
             "$event",
-            "<details open><summary>🧐 Agent Thinking</summary></details>",
-            "🧐 Agent Thinking\nReasoning...",
+            "<details open><summary>🧠 Agent Thinking:</summary></details>",
+            "🧠 Agent Thinking:\nReasoning...",
             thread_id="$thread-1",
         )
 
@@ -198,7 +212,7 @@ class TestThinkingManagerLifecycle:
             "event_id": "$event",
             "task_id": "task-retry",
             "field_kind": "thinking",
-            "title": "🧐 Agent Thinking: Hermes via gpt-5.4 via openai-codex",
+            "title": "🧠 Agent Thinking: Utilizing gpt-5.4 via openai-codex",
             "summary": "Processing request...",
             "step_count": 1,
             "content_html": "<pre><code>reasoning</code></pre>",

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -171,6 +171,20 @@ class TestThinkingManagerLifecycle:
         tools_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
         assert "<details open><summary>" in tools_payload["formatted_body"]
 
+    def test_edit_content_preserves_thread_relation(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        content = ThinkingManager._edit_content(
+            "$event",
+            "<details open><summary>🧐 Agent Thinking</summary></details>",
+            "🧐 Agent Thinking\nReasoning...",
+            thread_id="$thread-1",
+        )
+
+        assert content["m.relates_to"]["rel_type"] == "m.replace"
+        assert content["m.relates_to"]["event_id"] == "$event"
+        assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$thread-1"
+
     def test_elapsed_str_still_formats_duration(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -29,7 +29,7 @@ class TestThinkingManagerTitles:
     def test_field_titles_match_branch_c_requirement_with_friendly_emoji(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
-        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "🤔 Agent Thinking: Hermes via gpt-5.4 via openai-codex"
+        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "🧐 Agent Thinking: Hermes via gpt-5.4 via openai-codex"
         assert ThinkingManager._field_title("tools", "gpt-5.4 via openai-codex") == "⚡ Agent Acting:"
 
     def test_plaintext_summary_includes_required_heading(self):
@@ -92,7 +92,38 @@ class TestThinkingManagerLifecycle:
         assert "<pre" in content["formatted_body"]
 
     @pytest.mark.asyncio
-    async def test_thinking_delta_updates_append_as_flowing_text_not_single_word_lines(self):
+    async def test_thinking_callback_updates_summary_without_polluting_body(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        adapter._client.send_message_event = AsyncMock(return_value="$evt_summary")
+
+        mgr = ThinkingManager(adapter)
+        await mgr.start(
+            "!room:example.org",
+            "task-summary",
+            "Processing request...",
+            field_kind="thinking",
+            model_label="gpt-5.4 via openai-codex",
+            initial_content_md="",
+        )
+        mgr._sessions["task-summary:thinking"].last_update = 0
+        await mgr.update(
+            "task-summary",
+            "(◔_◔) processing...",
+            "",
+            field_kind="thinking",
+            append_line=False,
+        )
+        interim_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
+        interim_formatted = interim_payload["formatted_body"]
+        assert "(◔_◔) processing..." in interim_formatted
+        assert "<pre><code></code></pre>" not in interim_formatted
+
+        await mgr.finalize("task-summary", "done", field_kind="thinking")
+
+    @pytest.mark.asyncio
+    async def test_reasoning_deltas_append_as_flowing_text_not_single_word_lines(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
         adapter = _make_adapter()
@@ -119,7 +150,8 @@ class TestThinkingManagerLifecycle:
         final_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
         formatted = final_payload["formatted_body"]
         assert "I am considering the issue" in formatted
-        assert "I am<br/> considering the issue" not in formatted
+        assert "I am\n considering the issue" not in formatted
+        assert "<pre><code>I am considering the issue</code></pre>" in formatted
 
     @pytest.mark.asyncio
     async def test_tools_finalize_stays_expanded_by_default_while_thinking_collapses(self):

--- a/tests/gateway/test_matrix_thinking.py
+++ b/tests/gateway/test_matrix_thinking.py
@@ -26,11 +26,11 @@ def _make_adapter(thinking_enabled=True):
 
 
 class TestThinkingManagerTitles:
-    def test_field_titles_match_branch_c_requirement(self):
+    def test_field_titles_match_branch_c_requirement_with_friendly_emoji(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
 
-        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "Agent Thinking: Hermes via gpt-5.4 via openai-codex"
-        assert ThinkingManager._field_title("tools", "gpt-5.4 via openai-codex") == "Agent Acting:"
+        assert ThinkingManager._field_title("thinking", "gpt-5.4 via openai-codex") == "🤔 Agent Thinking: Hermes via gpt-5.4 via openai-codex"
+        assert ThinkingManager._field_title("tools", "gpt-5.4 via openai-codex") == "⚡ Agent Acting:"
 
     def test_plaintext_summary_includes_required_heading(self):
         from gateway.platforms.matrix_thinking import ThinkingManager
@@ -87,8 +87,57 @@ class TestThinkingManagerLifecycle:
 
         assert event_id == "$evt_456"
         content = send_message_event.call_args.args[2]
-        assert "Agent Acting:" in content["formatted_body"]
+        assert "⚡ Agent Acting:" in content["formatted_body"]
         assert '💻 terminal: &quot;pwd&quot;' in content["formatted_body"]
+        assert "<pre" in content["formatted_body"]
+
+    @pytest.mark.asyncio
+    async def test_thinking_delta_updates_append_as_flowing_text_not_single_word_lines(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        adapter._client.send_message_event = AsyncMock(return_value="$evt_flow")
+
+        mgr = ThinkingManager(adapter)
+        await mgr.start(
+            "!room:example.org",
+            "task-flow",
+            "Reasoning...",
+            field_kind="thinking",
+            model_label="gpt-5.4 via openai-codex",
+            initial_content_md="I am",
+        )
+        await mgr.update(
+            "task-flow",
+            "Reasoning...",
+            " considering the issue",
+            field_kind="thinking",
+            append_line=False,
+        )
+        await mgr.finalize("task-flow", "done", field_kind="thinking")
+
+        final_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
+        formatted = final_payload["formatted_body"]
+        assert "I am considering the issue" in formatted
+        assert "I am<br/> considering the issue" not in formatted
+
+    @pytest.mark.asyncio
+    async def test_tools_finalize_stays_expanded_by_default_while_thinking_collapses(self):
+        from gateway.platforms.matrix_thinking import ThinkingManager
+
+        adapter = _make_adapter()
+        adapter._client.send_message_event = AsyncMock(return_value="$evt_expand")
+
+        mgr = ThinkingManager(adapter)
+        await mgr.start("!room:example.org", "task-think", "Thinking...", field_kind="thinking")
+        await mgr.finalize("task-think", "done", field_kind="thinking")
+        thinking_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
+        assert "<details><summary>" in thinking_payload["formatted_body"]
+
+        await mgr.start("!room:example.org", "task-tools", "Tool activity", field_kind="tools")
+        await mgr.finalize("task-tools", "done", field_kind="tools")
+        tools_payload = adapter._client.send_message_event.await_args_list[-1].args[2]
+        assert "<details open><summary>" in tools_payload["formatted_body"]
 
     def test_elapsed_str_still_formats_duration(self):
         from gateway.platforms.matrix_thinking import ThinkingManager

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -3,8 +3,10 @@
 import yaml
 import pytest
 
+from unittest.mock import AsyncMock
+
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -14,14 +16,18 @@ def _make_runner():
     runner.adapters = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._pending_model_notes = {}
+    runner._evict_cached_agent = lambda session_key: None
     return runner
 
 
-def _make_event(text="/model"):
+def _make_event(text="/model", *, platform=Platform.TELEGRAM, user_id="user-1", thread_id=None):
     return MessageEvent(
         text=text,
         message_type=MessageType.TEXT,
-        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+        source=SessionSource(platform=platform, chat_id="12345", chat_type="dm", user_id=user_id, thread_id=thread_id),
     )
 
 
@@ -61,3 +67,62 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_matrix_picker_passes_sender_identity(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openai-codex",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                },
+                "providers": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {
+            "openai-codex": {
+                "label": "OpenAI Codex",
+                "models": {"gpt-5.4": {"label": "gpt-5.4"}},
+            }
+        },
+    )
+
+    class MatrixPickerAdapter:
+        def __init__(self):
+            self.mock = AsyncMock(return_value=SendResult(success=True, message_id="$picker"))
+
+        async def send_model_picker(self, **kwargs):
+            return await self.mock(**kwargs)
+
+    adapter = MatrixPickerAdapter()
+
+    runner = _make_runner()
+    runner.adapters = {Platform.MATRIX: adapter}
+
+    result = await runner._handle_model_command(
+        _make_event(
+            "/model",
+            platform=Platform.MATRIX,
+            user_id="@chris:matrix.whyland.com",
+            thread_id="$thread-1",
+        )
+    )
+
+    assert result is None
+    adapter.mock.assert_awaited_once()
+    metadata = adapter.mock.await_args.kwargs["metadata"]
+    assert metadata["thread_id"] == "$thread-1"
+    assert metadata["sender_id"] == "@chris:matrix.whyland.com"


### PR DESCRIPTION
## What does this PR do?

Adds the Matrix-specific interactive control layer and introspection panes on the current mautrix adapter. This includes approval reactions, `/model` picker reactions, requester-bound approval validation, explicit feedback on invalid approval reactors, threaded thinking/acting pane updates, and failure-aware tool activity finalization.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- implement Matrix approval UI and model picker in `gateway/platforms/matrix.py`
- wire real runner paths to pass requester `sender_id` and `thread_id` through `gateway/run.py`
- add configurable approval sender validation (`MATRIX_APPROVAL_REQUIRE_SENDER`) with explicit feedback on invalid reactors
- re-seed model-picker reactions after provider/page/stage edits
- add `gateway/platforms/matrix_thinking.py` thinking + acting panes
- preserve thread context on Matrix UI edits and simple notice/emote messages
- abort/error-finalize tool activity when a turn fails after tool activity has started
- add/extend regression coverage across interactive, thinking, and run-loop tests

## How to Test

1. `~/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' tests/gateway/test_matrix.py tests/gateway/test_matrix_interactive.py tests/gateway/test_matrix_thinking.py tests/gateway/test_matrix_run_regression.py tests/gateway/test_model_command_custom_providers.py`
2. Optional broader integrated validation: `~/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' tests/gateway/test_matrix.py tests/gateway/test_matrix_tools.py tests/gateway/test_matrix_interactive.py tests/gateway/test_matrix_thinking.py tests/gateway/test_matrix_run_regression.py tests/gateway/test_model_command_custom_providers.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_voice.py`
3. In a live Matrix room, trigger a dangerous command and confirm the approval control appears, invalid reactors get explicit feedback, and valid reactors resolve exactly once
4. Trigger a `/model` interaction and confirm reactions remain available after paging/stage changes
5. Verify threaded thinking/acting panes stay in-thread and failed runs do not falsely finalize tool activity as success

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Branch B scoped validation after latest fixes: `133 passed in 2.39s`
- Branch C scoped validation after latest fixes: `148 passed in 3.19s`
- Integrated Matrix validation after latest fixes: `213 passed in 4.71s`

## Notes

This PR intentionally includes the interactive-controls line plus the thinking/acting pane line together because both layers share `gateway/platforms/matrix.py` heavily. Keeping them together produces a cleaner upstream review surface than forcing an artificial split with duplicate Matrix adapter churn.

## Integration Notes

- Validated stacked with #9826 on `v2026.4.13`, including E2EE + cross-signing.
- Matrix media tool selection (`send_video` / `send_document`) depends on #9826's Matrix prompt hint/tool surface.
- If stacking manually, resolve `gateway/platforms/matrix.py` and `tests/gateway/test_matrix.py` in favor of #9827, then preserve the disconnect warning hardening in `MatrixAdapter.disconnect()`.
