### PR TITLE
fix: notify main agent when background review creates skills

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1370,6 +1370,11 @@ class AIAgent:
         
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
+
+        # Notifications from the background review thread (skill/memory creates).
+        # Drained at the top of the next run_conversation() call and injected as
+        # [System: ...] messages so the LLM knows what happened.
+        self._pending_bg_notifications: List[str] = []
         
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
@@ -2927,6 +2932,7 @@ class AIAgent:
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user.
                 actions = []
+                skill_notifications = []  # Track skill creates for main agent notification
                 for msg in getattr(review_agent, "_session_messages", []):
                     if not isinstance(msg, dict) or msg.get("role") != "tool":
                         continue
@@ -2940,6 +2946,9 @@ class AIAgent:
                     target = data.get("target", "")
                     if "created" in message.lower():
                         actions.append(message)
+                        # Skill creation — collect name/path for main agent notification
+                        skill_path = data.get("path") or data.get("skill_md") or ""
+                        skill_notifications.append((message, skill_path))
                     elif "updated" in message.lower():
                         actions.append(message)
                     elif "added" in message.lower() or (target and "add" in message.lower()):
@@ -2959,6 +2968,32 @@ class AIAgent:
                     if _bg_cb:
                         try:
                             _bg_cb(f"💾 {summary}")
+                        except Exception:
+                            pass
+
+                # Notify the main agent about skill creations so the LLM
+                # can respond when the user asks about them.
+                if skill_notifications:
+                    for msg_text, path in skill_notifications:
+                        note = msg_text
+                        if path:
+                            note += f" Path: {path}. Use skill_view to read it."
+                        # list.append is GIL-atomic — safe from background thread
+                        self._pending_bg_notifications.append(note)
+
+                    # Invalidate the main agent's cached system prompt so the
+                    # skills index rebuilds on the next turn.
+                    # Attribute assignment is GIL-atomic — safe from background thread.
+                    self._cached_system_prompt = None
+
+                    # Also clear the DB-stored prompt so the gateway path
+                    # (which loads from the session DB, not the instance cache)
+                    # rebuilds fresh on the next turn.
+                    if self._session_db:
+                        try:
+                            self._session_db.update_system_prompt(
+                                self.session_id, None
+                            )
                         except Exception:
                             pass
 
@@ -8779,6 +8814,14 @@ class AIAgent:
             if self._turns_since_memory >= self._memory_nudge_interval:
                 _should_review_memory = True
                 self._turns_since_memory = 0
+
+        # Drain any pending notifications from the background review thread.
+        # These appear before the user's new message so the LLM knows about
+        # skill/memory creates that happened between turns.
+        if self._pending_bg_notifications:
+            for _bg_note in self._pending_bg_notifications:
+                messages.append({"role": "user", "content": f"[System: {_bg_note}]"})
+            self._pending_bg_notifications.clear()
 
         # Add user message
         user_msg = {"role": "user", "content": user_message}


### PR DESCRIPTION
## Summary

- When the background review thread creates a skill, the terminal notification
  is visible to the user but the main agent's conversation context is never
  updated — the LLM genuinely doesn't know about the skill creation.
- Adds a pending notification queue (`_pending_bg_notifications`) that the
  background review thread appends to (GIL-atomic `list.append`), drained
  synchronously at the start of each `run_conversation()` call as
  `[System: ...]` messages before the user's new message.
- Invalidates `_cached_system_prompt` on the main agent so the skills index
  rebuilds on the next turn, picking up the new skill from disk.
- Clears the DB-stored system prompt so the gateway path (fresh `AIAgent`
  per message, loads prompt from session DB) also rebuilds.

## Test plan

- [ ] Start `hermes chat`, trigger 10+ tool-calling iterations to fire
  background review, wait for "Skill 'X' created." terminal notification,
  then ask the agent about the skill — it should know about it and be able
  to call `skill_view` to read it
- [ ] Verify the skill appears in the system prompt on subsequent turns
  (ask the agent to list its skills)
- [ ] Gateway: verify the next message after background skill creation has
  an updated skills index in the system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)