### PR TITLE
Remove conflicting /q alias from /queue

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5504,7 +5504,7 @@ class HermesCLI:
         elif canonical == "btw":
             self._handle_btw_command(cmd_original)
         elif canonical == "queue":
-            # Extract prompt after "/queue " or "/q "
+            # Extract prompt after "/queue "
             parts = cmd_original.split(None, 1)
             payload = parts[1].strip() if len(parts) > 1 else ""
             if not payload:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -88,7 +88,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("btw", "Ephemeral side question using session context (no tools, not persisted)", "Session",
                args_hint="<question>"),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
-               aliases=("q",), args_hint="<prompt>"),
+               args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -71,6 +71,7 @@ AUTHOR_MAP = {
     "eri@plasticlabs.ai": "Erosika",
     "hjcpuro@gmail.com": "hjc-puro",
     "xaydinoktay@gmail.com": "aydnOktay",
+    "xowiekk@gmail.com": "Xowiek",
     "abdullahfarukozden@gmail.com": "Farukest",
     "lovre.pesut@gmail.com": "rovle",
     "hakanerten02@hotmail.com": "teyrebaz33",

--- a/tests/hermes_cli/test_command_alias_collisions.py
+++ b/tests/hermes_cli/test_command_alias_collisions.py
@@ -1,0 +1,29 @@
+"""Regression tests for command alias collisions."""
+
+from collections import defaultdict
+import unittest
+
+from hermes_cli.commands import COMMAND_REGISTRY, gateway_help_lines, resolve_command
+
+
+class TestCommandAliasCollisions(unittest.TestCase):
+    def test_aliases_are_unique_across_commands(self):
+        owners: dict[str, list[str]] = defaultdict(list)
+
+        for cmd in COMMAND_REGISTRY:
+            for alias in cmd.aliases:
+                owners[alias].append(cmd.name)
+
+        collisions = {alias: names for alias, names in owners.items() if len(names) > 1}
+        self.assertEqual(collisions, {})
+
+    def test_queue_help_does_not_advertise_quit_alias(self):
+        queue_lines = [line for line in gateway_help_lines() if line.startswith("`/queue ")]
+
+        self.assertEqual(len(queue_lines), 1)
+        self.assertNotIn("`/q`", queue_lines[0])
+        self.assertEqual(resolve_command("q").name, "quit")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix a conflicting `/q` alias in the slash-command registry.

Before this change, `/q` was assigned to both `queue` and `quit`. That made command lookup and help output disagree: `/q` resolved to `quit`, while help still advertised `/q` as an alias for `/queue`.

## Fix

Remove the conflicting `q` alias from `queue` and keep the existing `/q -> quit` behavior unchanged.

Also update the related CLI comment so it matches the actual behavior.

## Tests

Added regression coverage for:

- alias uniqueness across commands
- `/queue` help no longer showing `/q`
- `resolve_command("q")` continuing to resolve to `quit`

Validation:

```bash
python -m unittest discover -s tests/hermes_cli -p test_command_alias_collisions.py -v

Result: 
test_aliases_are_unique_across_commands ... ok
test_queue_help_does_not_advertise_quit_alias ... ok

Ran 2 tests in 0.010s

OK