### PR TITLE
fix(skills): add fallback directive for Oh My OpenCode agent conflict…

### DIFF
--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -195,6 +195,9 @@ terminal(command="opencode stats --days 7 --models anthropic/claude-sonnet-4")
 - Avoid sharing one working directory across parallel OpenCode sessions.
 - Enter may need to be pressed twice to submit in the TUI (once to finalize text, once to send).
 
+## Oh My OpenCode Compatibility (Fallback)
+If the environment uses "Oh My OpenCode" (especially on macOS), the default `Sisyphus - Ultraworker` agent may be unavailable or removed. If you attempt to run a command and encounter the error `default agent "Sisyphus - Ultraworker" not found`, do NOT fail the task. Immediately retry the exact same command by explicitly appending `--agent build` to use the fallback agent.
+
 ## Verification
 
 Smoke test:
@@ -216,3 +219,4 @@ Success criteria:
 4. For long tasks, provide progress updates from `process` logs.
 5. Report concrete outcomes (files changed, tests, remaining risks).
 6. Exit interactive sessions with Ctrl+C or kill, never `/exit`.
+7. If the default Sisyphus agent is missing, always append `--agent build` to your commands.


### PR DESCRIPTION
…s in opencode skill (#9804)

## What does this PR do?


Resolves #9804

### Root Cause Analysis
The `opencode` skill lacked explicit fallback instructions for environments modified by "Oh My OpenCode" on macOS. In such environments, the default `Sisyphus - Ultraworker` agent is replaced by standard agents (`build`, `plan`). When the LLM attempted to execute `opencode` commands, the CLI threw a fatal error because it implicitly expected the `Sisyphus` agent, causing the LLM to halt the task.

### Implementation Details
* Injected a system-level directive (`Oh My OpenCode Compatibility`) directly into `skills/autonomous-ai-agents/opencode/SKILL.md`.
* Instructed the LLM to dynamically catch the `Sisyphus - Ultraworker not found` error output.
* Established a deterministic fallback routing rule: the LLM is now instructed to immediately retry the failed command by explicitly appending the `--agent build` flag.

### System Impact
* Restores OpenCode skill functionality for macOS users running customized OpenCode installations.
* Enhances the LLM's autonomous error-recovery loop, preventing premature task failure due to missing default agents.

