### PR TITLE
docs(update): remove unsupported --check command

### DIFF
--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -65,11 +65,7 @@ If `git status --short` shows unexpected changes after `hermes update`, stop and
 hermes version
 ```
 
-Compare against the latest release at the [GitHub releases page](https://github.com/NousResearch/hermes-agent/releases) or check for available updates:
-
-```bash
-hermes update --check
-```
+Compare against the latest release at the [GitHub releases page](https://github.com/NousResearch/hermes-agent/releases).
 
 ### Updating from Messaging Platforms
 


### PR DESCRIPTION
## Summary
- remove the stale \ example from the update guide
- keep the docs aligned with the current CLI, which only supports \
- continue pointing readers to \ and GitHub releases for version checks

## Context
The current docs advertise \, but the command is not implemented in this branch. That led directly to backlog confusion in support.

There is already an open upstream PR to add the flag for real: #7299. This docs PR is just a stopgap so the published guidance matches current behavior until that lands.

## Testing
- not run (docs-only change)
