### PR TITLE
fix(security): cover Move and no-space headers in patch_tool sensitive path check

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -161,6 +161,87 @@ class TestPatchHandler:
         assert "Unknown mode" in result["error"]
 
 
+class TestPatchSensitivePathExtraction:
+    """Regression tests for patch_tool sensitive-path extraction.
+
+    The sensitive path check relies on a regex that parses V4A patch
+    headers. These tests cover:
+
+    1. `Move File:` operations (previously missed — the regex only
+       matched Update/Add/Delete, so Move could target /etc/* without
+       hitting the check).
+    2. `***Keyword File:` with no space after `***` (previously missed —
+       the regex required `\\s+` even though patch_parser accepts `\\s*`).
+    """
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_move_to_sensitive_dst_blocked(self, mock_get):
+        from tools.file_tools import patch_tool
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Move File: /tmp/work.txt -> /etc/crontab\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_move_from_sensitive_src_blocked(self, mock_get):
+        from tools.file_tools import patch_tool
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Move File: /etc/hosts -> /tmp/leak.txt\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_update_no_space_after_asterisks_blocked(self, mock_get):
+        """`***Update File:` (no space after asterisks) must also be caught.
+
+        patch_parser.py accepts this form (`\\s*` in its regex), so the
+        sensitive path check must be at least as lenient or the check
+        is bypassed.
+        """
+        from tools.file_tools import patch_tool
+        patch_text = (
+            "*** Begin Patch\n"
+            "***Update File: /etc/resolv.conf\n"
+            "@@ @@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_patch_move_safe_paths_not_blocked(self, mock_get):
+        """Safe Move operations should still reach the file_ops dispatch."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.patch_v4a.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import patch_tool
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Move File: /tmp/a.txt -> /tmp/b.txt\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=patch_text))
+        assert "error" not in result
+        mock_ops.patch_v4a.assert_called_once()
+
+
 class TestSearchHandler:
     @patch("tools.file_tools._get_file_ops")
     def test_search_calls_file_ops(self, mock_get):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -572,8 +572,16 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _paths_to_check.append(path)
     if mode == "patch" and patch:
         import re as _re
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
+        # `\s*` (not `\s+`) matches patch_parser leniency: it accepts
+        # `***Update File:` without a space after the asterisks.
+        for _m in _re.finditer(r'^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
             _paths_to_check.append(_m.group(1).strip())
+        # Move operations use `src -> dst`; check both endpoints so a
+        # sensitive destination (e.g. /etc/crontab) is refused before
+        # it reaches the lower-level write deny list.
+        for _m in _re.finditer(r'^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+)$', patch, _re.MULTILINE):
+            _paths_to_check.append(_m.group(1).strip())
+            _paths_to_check.append(_m.group(2).strip())
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p)
         if sensitive_err:


### PR DESCRIPTION
## Summary

`patch_tool` extracts file paths from V4A patch text via regex so the sensitive path check (`_check_sensitive_path`) can refuse writes to `/etc/*`, `/boot/*`, `/usr/lib/systemd/*`, etc. before they reach the low-level file ops. The regex had two gaps that let carefully-crafted patches bypass the check entirely:

### Gap 1: `Move` operations were never extracted

The regex matched only `Update|Add|Delete`:

```python
re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, re.MULTILINE)
```

`*** Move File: src -> dst` is a valid V4A operation (see `tools/patch_parser.py:114`), but its paths were never added to `_paths_to_check`. A patch like:

\`\`\`
*** Begin Patch
*** Move File: /tmp/work.txt -> /etc/crontab
*** End Patch
\`\`\`

sailed past the broad `_SENSITIVE_PATH_PREFIXES = (\"/etc/\", \"/boot/\", ...)` pre-check and fell back on the much narrower `file_operations.WRITE_DENIED_PREFIXES`, which only blocks `/etc/sudoers.d/` and `/etc/systemd/`. On a root-running gateway (common for Dockerized Matrix E2EE deployments) the move would then actually execute, giving an adversary-influenced prompt a persistence vector via `/etc/crontab`, `/etc/profile.d/<x>.sh`, `/etc/ld.so.conf.d/<x>.conf`, `/etc/resolv.conf`, etc.

### Gap 2: `\s+` required, but parser accepts `\s*`

The regex required one-or-more whitespace between `***` and the keyword, but `tools/patch_parser.py` uses `\s*`:

\`\`\`python
# patch_parser.py:111
update_match = re.match(r'\*\*\*\s*Update\s+File:\s*(.+)', line)
\`\`\`

So a header written as `***Update File: /etc/hosts` (no space after the asterisks) parsed and applied fine, but skipped the sensitive path pre-check.

## Fix

- Extend the regex block to also capture Move `src` and `dst`.
- Loosen the leading whitespace to `\s*` to match parser leniency.

Minimum-viable regex change; both layers (`file_tools` and `file_operations`) still enforce their own deny lists as defense in depth. No behavior change for safe patches — only adds paths to the pre-check, nothing is relaxed.

## Test plan

New test class `TestPatchSensitivePathExtraction` in `tests/tools/test_file_tools.py`:

- [x] `test_patch_move_to_sensitive_dst_blocked` — Move targeting `/etc/crontab` is refused before `_get_file_ops` is called
- [x] `test_patch_move_from_sensitive_src_blocked` — Move reading from `/etc/hosts` is refused
- [x] `test_patch_update_no_space_after_asterisks_blocked` — `***Update File: /etc/resolv.conf` (no leading space) is refused
- [x] `test_patch_move_safe_paths_not_blocked` — Move between two `/tmp/*` paths still reaches `file_ops.patch_v4a`

All existing tests in `test_file_tools.py`, `test_file_write_safety.py`, and `test_patch_parser.py` still pass (62 passed locally with no regressions).

## Notes

While investigating I noticed `file_tools._SENSITIVE_PATH_PREFIXES` (broad: all of `/etc/`, `/boot/`, `/usr/lib/systemd/`, `/private/etc/`, `/private/var/`) is much broader than `file_operations.WRITE_DENIED_PREFIXES` (narrow: only `/etc/sudoers.d/` and `/etc/systemd/` on the system side). Unifying them is out of scope for this PR, but the gap is worth a follow-up — right now defense-in-depth relies on the upper layer catching everything the lower layer misses, which is exactly what this bug exploited.