### PR TITLE
fix(gateway): harden proxy mode SSE streaming — 3 resilience bugs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7573,7 +7573,10 @@ class GatewayRunner:
         _start = time.time()
 
         try:
-            _timeout = ClientTimeout(total=0, sock_read=1800)
+            # sock_connect bounds the TCP connect phase so an unreachable
+            # proxy host (DNS fail, firewall, remote down) fails fast
+            # instead of hanging until the OS default gives up.
+            _timeout = ClientTimeout(total=0, sock_read=1800, sock_connect=30)
             async with _AioClientSession(timeout=_timeout) as session:
                 async with session.post(
                     f"{proxy_url}/v1/chat/completions",
@@ -7595,7 +7598,10 @@ class GatewayRunner:
 
                     # Parse SSE stream
                     buffer = ""
+                    done = False
                     async for chunk in resp.content.iter_any():
+                        if done:
+                            break
                         text = chunk.decode("utf-8", errors="replace")
                         buffer += text
 
@@ -7608,18 +7614,32 @@ class GatewayRunner:
                             if line.startswith("data: "):
                                 data = line[6:]
                                 if data.strip() == "[DONE]":
+                                    # Stop both loops — a buggy upstream
+                                    # that holds the connection open after
+                                    # [DONE] would otherwise block us for
+                                    # up to sock_read seconds.
+                                    done = True
                                     break
                                 try:
                                     obj = json.loads(data)
-                                    choices = obj.get("choices", [])
-                                    if choices:
-                                        delta = choices[0].get("delta", {})
-                                        content = delta.get("content", "")
-                                        if content:
-                                            full_response += content
-                                            if _stream_consumer:
-                                                _stream_consumer.on_delta(content)
-                                except json.JSONDecodeError:
+                                    choices = obj.get("choices") or []
+                                    if not isinstance(choices, list) or not choices:
+                                        continue
+                                    first = choices[0]
+                                    if not isinstance(first, dict):
+                                        continue
+                                    delta = first.get("delta") or {}
+                                    if not isinstance(delta, dict):
+                                        continue
+                                    content = delta.get("content", "")
+                                    if content:
+                                        full_response += content
+                                        if _stream_consumer:
+                                            _stream_consumer.on_delta(content)
+                                except (json.JSONDecodeError, TypeError, AttributeError):
+                                    # One malformed chunk should not abort
+                                    # the whole stream — skip it and keep
+                                    # parsing the rest.
                                     pass
 
         except asyncio.CancelledError:

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -427,6 +427,135 @@ class TestRunAgentViaProxy:
         assert messages[0]["content"] == "hello"
 
 
+class TestStreamingResilience:
+    """Tests for SSE streaming robustness — hang avoidance and malformed-chunk tolerance."""
+
+    @pytest.mark.asyncio
+    async def test_done_marker_stops_reading_trailing_chunks(self, monkeypatch):
+        """After `[DONE]`, no further SSE chunks must be processed.
+
+        A buggy upstream that holds the connection open and streams more
+        chunks after `[DONE]` should not leak those chunks into the
+        response. Regression test for the inner `break` that only exited
+        the line-parse loop, leaving the outer chunk loop to keep reading
+        until sock_read timeout.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        # Content → [DONE] → MORE content. The trailing chunk must be
+        # dropped. With the pre-fix code it would be appended to
+        # full_response, since `break` only exited the inner loop.
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                'data: [DONE]\n',
+                'data: {"choices":[{"delta":{"content":" IGNORED"}}]}\n',
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_client_timeout_sets_sock_connect(self, monkeypatch):
+        """ClientTimeout must bound the TCP connect phase.
+
+        Without an explicit ``sock_connect``, an unreachable proxy host
+        hangs for the OS default (minutes) before failing. The fix sets
+        a short connect cap so the gateway surfaces the error quickly.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(status=200, sse_chunks=['data: [DONE]\n'])
+        session = _FakeSession(resp)
+
+        captured = {}
+
+        def _capture_timeout(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout", side_effect=_capture_timeout):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert "sock_connect" in captured, (
+            "ClientTimeout should set sock_connect to bound TCP connect"
+        )
+        assert 0 < captured["sock_connect"] <= 60, (
+            f"sock_connect should be a short, reasonable cap — got {captured['sock_connect']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_chunk_is_skipped_not_fatal(self, monkeypatch):
+        """One bad SSE chunk must not abort the whole stream.
+
+        Pre-fix: `choices[0].get(...)` raised ``AttributeError`` when
+        ``choices[0]`` was ``None``, escaping the narrow
+        ``except json.JSONDecodeError`` and bubbling to the outer
+        ``except Exception`` which returned whatever partial response
+        was accumulated. All later chunks were lost.
+
+        Post-fix: type guards + broader exception handling skip the bad
+        chunk and keep parsing.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                'data: {"choices":[null]}\n',
+                'data: {"choices":"wrong-type"}\n',
+                'data: {"choices":[{"delta":"wrong-type"}]}\n',
+                'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+                'data: [DONE]\n',
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "Hello world"
+
+
 class TestEnvVarRegistration:
     """Verify GATEWAY_PROXY_URL and GATEWAY_PROXY_KEY are registered."""
 


### PR DESCRIPTION
## Summary

Gateway proxy mode (added in 90c98345) forwards platform messages to a remote Hermes API server via SSE streaming. The streaming loop in `_run_agent_via_proxy` has three resilience gaps that can hang the gateway or silently truncate responses on imperfect upstream behaviour.

## Bug 1 — `[DONE]` doesn't break the outer chunk loop

```python
async for chunk in resp.content.iter_any():
    ...
    while \"\\n\" in buffer:
        ...
        if data.strip() == \"[DONE]\":
            break   # <-- only exits the inner while
```

The `break` exits the inner line-parse loop, leaving the outer `async for chunk in resp.content.iter_any()` to keep reading. If the upstream holds the connection open after `[DONE]` (buggy proxy, crashed server, network stall), the client waits up to `sock_read=1800` seconds (30 minutes) for the next chunk.

**Fix:** Set a `done` flag when `[DONE]` is seen and check it at the top of the outer loop.

## Bug 2 — No TCP connect timeout

```python
_timeout = ClientTimeout(total=0, sock_read=1800)
```

`total=0` disables the aiohttp total timeout, `sock_read=1800` is set, but `sock_connect` defaults to `None` = no timeout. An unreachable proxy host (DNS failure, firewall block, remote server down) hangs on TCP connect for the OS default — typically multiple minutes — before surfacing an error. Users see a frozen gateway with no indication anything is wrong.

**Fix:** Add `sock_connect=30` so connect failures surface within 30 seconds.

## Bug 3 — SSE JSON parse exception handling too narrow

```python
try:
    obj = json.loads(data)
    choices = obj.get(\"choices\", [])
    if choices:
        delta = choices[0].get(\"delta\", {})   # AttributeError if choices[0] is None
        ...
except json.JSONDecodeError:
    pass
```

A response like \`{\"choices\": [null]}\` parses fine in `json.loads`, then `choices[0].get(\"delta\", {})` raises `AttributeError: 'NoneType' object has no attribute 'get'`. That escapes the narrow `except json.JSONDecodeError` and bubbles up to the outer `except Exception`, aborting the entire stream. Any chunks after the bad one are lost; the user sees the accumulated partial response with no explanation.

**Fix:** Add type guards (`isinstance(choices, list)`, `isinstance(first, dict)`, `isinstance(delta, dict)`) and extend the caught exceptions to `(json.JSONDecodeError, TypeError, AttributeError)`. One malformed chunk now skips cleanly; the stream keeps parsing.

## Test plan

New test class `TestStreamingResilience` in `tests/gateway/test_proxy_mode.py`:

- [x] `test_done_marker_stops_reading_trailing_chunks` — streams content → `[DONE]` → more content, asserts the trailing content is dropped
- [x] `test_client_timeout_sets_sock_connect` — captures ClientTimeout kwargs via `side_effect` and asserts `sock_connect` is set to a reasonable bound
- [x] `test_malformed_chunk_is_skipped_not_fatal` — streams good/bad/good chunks (covering `choices=[null]`, `choices=\"wrong-type\"`, `delta=\"wrong-type\"`) and asserts both good chunks are captured

All 20 existing tests in `test_proxy_mode.py` still pass (verified locally, no regressions).

## Scope

All three bugs are in the same function (`_run_agent_via_proxy`), introduced by the same commit (90c98345), and are all SSE streaming resilience issues. Bundling them into one PR minimises review overhead and keeps the resilience story coherent — each fix is small and orthogonal, but they share the same test fixture patterns.