### PR TITLE
fix(config): load discord.reply_to_mode from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -692,6 +692,17 @@ def load_gateway_config() -> GatewayConfig:
                     ):
                         if yaml_key in allow_mentions_cfg and not os.getenv(env_key):
                             os.environ[env_key] = str(allow_mentions_cfg[yaml_key]).lower()
+                # reply_to_mode: whether bot replies reference the triggering message (off/first/all)
+                # Supported at top-level (discord.reply_to_mode) or nested (discord.extra.reply_to_mode)
+                # Note: YAML 1.1 parses bare 'off' as boolean False, so we handle that explicitly.
+                _extra = discord_cfg.get("extra") if isinstance(discord_cfg.get("extra"), dict) else {}
+                _rtp_sources = (
+                    discord_cfg["reply_to_mode"] if "reply_to_mode" in discord_cfg
+                    else _extra.get("reply_to_mode")
+                )
+                if _rtp_sources is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
+                    _rtp_str = "off" if _rtp_sources is False else str(_rtp_sources).lower()
+                    os.environ["DISCORD_REPLY_TO_MODE"] = _rtp_str
 
             # Telegram settings → env vars (env vars take precedence)
             telegram_cfg = yaml_cfg.get("telegram", {})

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig, GatewayConfig, Platform, _apply_env_overrides
+from gateway.config import PlatformConfig, GatewayConfig, Platform, _apply_env_overrides, load_gateway_config
 
 
 def _ensure_discord_mock():
@@ -396,3 +396,67 @@ class TestReplyToText:
         event = reply_text_adapter.handle_message.await_args.args[0]
         assert event.reply_to_message_id == "555"
         assert event.reply_to_text is None
+
+
+class TestYamlConfigLoading:
+    """Tests for reply_to_mode loaded from config.yaml discord section."""
+
+    def _write_config(self, tmp_path, content: str):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(content, encoding="utf-8")
+        return hermes_home
+
+    def test_top_level_reply_to_mode_off(self, tmp_path, monkeypatch):
+        """discord.reply_to_mode: off sets DISCORD_REPLY_TO_MODE env var."""
+        hermes_home = self._write_config(tmp_path, "discord:\n  reply_to_mode: off\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REPLY_TO_MODE") == "off"
+
+    def test_top_level_reply_to_mode_all(self, tmp_path, monkeypatch):
+        hermes_home = self._write_config(tmp_path, "discord:\n  reply_to_mode: all\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REPLY_TO_MODE") == "all"
+
+    def test_extra_reply_to_mode_off(self, tmp_path, monkeypatch):
+        """discord.extra.reply_to_mode: off is also honoured."""
+        hermes_home = self._write_config(
+            tmp_path, "discord:\n  extra:\n    reply_to_mode: \"off\"\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REPLY_TO_MODE") == "off"
+
+    def test_env_var_takes_precedence_over_yaml(self, tmp_path, monkeypatch):
+        """Existing DISCORD_REPLY_TO_MODE env var is not overwritten by YAML."""
+        hermes_home = self._write_config(tmp_path, "discord:\n  reply_to_mode: all\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "first")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REPLY_TO_MODE") == "first"
+
+    def test_top_level_takes_precedence_over_extra(self, tmp_path, monkeypatch):
+        """discord.reply_to_mode wins over discord.extra.reply_to_mode."""
+        hermes_home = self._write_config(
+            tmp_path,
+            "discord:\n  reply_to_mode: all\n  extra:\n    reply_to_mode: \"off\"\n",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_REPLY_TO_MODE") == "all"


### PR DESCRIPTION
## Problem

`discord.reply_to_mode` (and `discord.extra.reply_to_mode`) set in `config.yaml` was silently ignored. The gateway only honoured the `DISCORD_REPLY_TO_MODE` environment variable, so users who configured the value via YAML got no effect and the adapter always fell back to the default (`first`).

The same YAML-to-env-var bridge already exists for `require_mention`, `auto_thread`, `free_response_channels`, `reactions`, `ignored_channels`, `allowed_channels`, and `no_thread_channels` — `reply_to_mode` was the only Discord config key missing it.

## Fix

**`gateway/config.py`** — add `reply_to_mode` to the Discord YAML env-var bridge block (lines ~583-614), following the existing pattern. Two lookup paths are supported for backwards compatibility:
- `discord.reply_to_mode` (preferred, top-level)
- `discord.extra.reply_to_mode` (legacy, for configs that placed it under `extra:`)

Top-level takes precedence. An existing `DISCORD_REPLY_TO_MODE` env var is never overwritten.

**YAML 1.1 edge case handled**: bare `off` in YAML is parsed as boolean `False` by PyYAML. The fix detects `False` and normalises it to the string `"off"` before setting the env var.

## Tests

5 new tests added to `tests/gateway/test_discord_reply_mode.py` (`TestYamlConfigLoading`):
- `test_top_level_reply_to_mode_off` — bare `off` (YAML boolean False) → `"off"`
- `test_top_level_reply_to_mode_all` — string `all` → `"all"`
- `test_extra_reply_to_mode_off` — quoted `"off"` under `extra:` → `"off"`
- `test_env_var_takes_precedence_over_yaml` — pre-existing env var not overwritten
- `test_top_level_takes_precedence_over_extra` — top-level wins over `extra:`

All 33 tests in the file pass.