### PR TITLE
fix(run_agent): blocked tools skip completion callbacks to match start-side guards

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7480,7 +7480,12 @@ class AIAgent:
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, len(function_result))
 
-            if self.tool_progress_callback:
+            # Blocked tools skip lifecycle callbacks so consumers never see
+            # a `tool.completed` event for a tool that never fired
+            # `tool.started`. See the matching start-side guards above at
+            # `if _block_msg is None and self.tool_progress_callback:` /
+            # `if _block_msg is None and self.tool_start_callback:`.
+            if _block_msg is None and self.tool_progress_callback:
                 try:
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
@@ -7489,14 +7494,20 @@ class AIAgent:
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
-            self._current_tool = None
-            self._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s)")
+            if _block_msg is None:
+                self._current_tool = None
+                self._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s)")
+            else:
+                # Still refresh activity so a batch of blocked tools doesn't
+                # look idle to the gateway's inactivity monitor, but use a
+                # distinct message that reflects what actually happened.
+                self._touch_activity(f"tool blocked by plugin: {function_name}")
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
                 logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
 
-            if self.tool_complete_callback:
+            if _block_msg is None and self.tool_complete_callback:
                 try:
                     self.tool_complete_callback(tool_call.id, function_name, function_args, function_result)
                 except Exception as cb_err:
@@ -7509,10 +7520,13 @@ class AIAgent:
                 env=get_active_env(effective_task_id),
             )
 
-            # Discover subdirectory context files from tool arguments
-            subdir_hints = self._subdirectory_hints.check_tool_call(function_name, function_args)
-            if subdir_hints:
-                function_result += subdir_hints
+            # Discover subdirectory context files from tool arguments — skip
+            # for blocked tools since the tool never ran, so treating its
+            # args as "used" would leak context the agent shouldn't have.
+            if _block_msg is None:
+                subdir_hints = self._subdirectory_hints.check_tool_call(function_name, function_args)
+                if subdir_hints:
+                    function_result += subdir_hints
 
             tool_msg = {
                 "role": "tool",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1541,6 +1541,56 @@ class TestConcurrentToolExecution:
         assert messages[0]["role"] == "tool"
         assert json.loads(messages[0]["content"]) == {"error": "Blocked by policy"}
 
+    def test_sequential_blocked_tool_skips_complete_callbacks(self, agent, monkeypatch):
+        """Sequential path: blocked tool must also skip completion callbacks.
+
+        Regression for the gap where the introduction of pre_tool_call
+        blocking guarded the start-side callbacks (`tool_start_callback`,
+        `tool_progress_callback('tool.started', ...)`) but left the
+        completion-side callbacks (`tool_complete_callback`,
+        `tool_progress_callback('tool.completed', ...)`) unguarded.
+
+        Consumers that track the `(started, completed)` lifecycle would
+        see a `completed` event for a tool that never fired `started`,
+        breaking state machines on the gateway / session recorder side.
+        """
+        tool_call = _mock_tool_call(
+            name="web_search", arguments='{"q":"test"}', call_id="c1"
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Blocked by policy",
+        )
+
+        starts: list = []
+        completes: list = []
+        progress_events: list = []
+
+        agent.tool_start_callback = lambda *a: starts.append(a)
+        agent.tool_complete_callback = lambda *a: completes.append(a)
+        agent.tool_progress_callback = lambda event, *a, **kw: progress_events.append(event)
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=AssertionError("should not run"),
+        ):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        # Neither side of the lifecycle should fire for a blocked tool.
+        assert starts == []
+        assert completes == []
+        assert "tool.started" not in progress_events
+        assert "tool.completed" not in progress_events
+
+        # But the error result MUST still land in the message history
+        # so the model can see the block reason and adjust.
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert json.loads(messages[0]["content"]) == {"error": "Blocked by policy"}
+
     def test_blocked_memory_tool_does_not_reset_counter(self, agent, monkeypatch):
         """Blocked memory tool should not reset the nudge counter."""
         agent._turns_since_memory = 5


### PR DESCRIPTION
## Summary

The pre_tool_call blocking feature (`eabc0a2f`) guards the **start-side** lifecycle callbacks so a blocked tool never fires `tool.started`:

```python
if _block_msg is None and self.tool_progress_callback:
    self.tool_progress_callback(\"tool.started\", ...)
if _block_msg is None and self.tool_start_callback:
    self.tool_start_callback(...)
```

But the **completion-side** callbacks after the dispatch switch were left unguarded:

```python
if self.tool_progress_callback:                            # <-- not guarded
    self.tool_progress_callback(\"tool.completed\", ...)
self._current_tool = None                                   # <-- not guarded
self._touch_activity(f\"tool completed: {function_name} ...\")  # <-- not guarded
if self.tool_complete_callback:                             # <-- not guarded
    self.tool_complete_callback(...)
```

## Impact

Consumers that track the `(started, completed)` lifecycle — gateway streaming UIs, session recorders, progress dashboards — see a `completed` event for a tool that never fired `started`, which breaks state machines on the consumer side. The activity log also reports \"tool completed: X\" for a tool that was never executed.

The commit message for `eabc0a2f` explicitly claims:

> Blocked tools skip all side effects (counter resets, checkpoints, callbacks, read-loop tracker).

So this is a gap between stated intent and implementation — a straight-forward consistency fix, not a design change.

## Fix

Add `_block_msg is None` guards to:
- `tool_progress_callback('tool.completed', ...)`
- `tool_complete_callback`
- `self._current_tool = None` reset
- Subdir-hints discovery (which reads tool args — for a blocked tool the args were never \"used\", so treating them as context would leak info the agent shouldn't have)

Activity is still refreshed for blocked tools, but with a distinct message:
```python
else:
    self._touch_activity(f\"tool blocked by plugin: {function_name}\")
```

This way a batch of blocked tools doesn't look idle to the gateway inactivity monitor, while the log stays semantically accurate about what happened.

## Test plan

New test `test_sequential_blocked_tool_skips_complete_callbacks` in `TestConcurrentToolExecution`:

- [x] Registers both start and complete callbacks (and a progress-event recorder)
- [x] Runs a blocked tool through `_execute_tool_calls_sequential`
- [x] Asserts `starts == []`, `completes == []`, and neither `'tool.started'` nor `'tool.completed'` appear in the progress events
- [x] Asserts the error result still lands in `messages` so the model can see the block reason

The existing `test_sequential_blocked_tool_skips_checkpoints_and_callbacks` still passes — this new test complements it by covering the completion side of the lifecycle that the existing test doesn't touch.

All 23 tests in `TestConcurrentToolExecution` pass locally with no regressions.