### PR TITLE
fix(cli): honor active profile in backup and import

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ def _format_size(nbytes: int) -> str:
 
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_hermes_home()
 
     if not hermes_root.is_dir():
         print(f"Error: Hermes home directory not found at {hermes_root}")
@@ -302,7 +302,7 @@ def run_import(args) -> None:
         print(f"Error: Not a valid zip file: {zip_path}")
         sys.exit(1)
 
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_hermes_home()
 
     with zipfile.ZipFile(zip_path, "r") as zf:
         # Validate

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -71,6 +71,7 @@ AUTHOR_MAP = {
     "eri@plasticlabs.ai": "Erosika",
     "hjcpuro@gmail.com": "hjc-puro",
     "xaydinoktay@gmail.com": "aydnOktay",
+    "xowiekk@gmail.com": "Xowiek",
     "abdullahfarukozden@gmail.com": "Farukest",
     "lovre.pesut@gmail.com": "rovle",
     "hakanerten02@hotmail.com": "teyrebaz33",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -233,6 +233,27 @@ class TestBackup:
         zips = list(tmp_path.glob("hermes-backup-*.zip"))
         assert len(zips) == 1
 
+    def test_backup_uses_active_profile_home(self, tmp_path, monkeypatch):
+        """Backup should archive the active profile, not the default Hermes root."""
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (default_home / "config.yaml").write_text("default: true\n")
+        (profile_home / "config.yaml").write_text("profile: coder\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "profile-backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            assert zf.read("config.yaml").decode("utf-8").strip() == "profile: coder"
+            assert "profiles/coder/config.yaml" not in zf.namelist()
+
 
 # ---------------------------------------------------------------------------
 # _validate_backup_zip tests
@@ -446,6 +467,27 @@ class TestImport:
         from hermes_cli.backup import run_import
         with pytest.raises(SystemExit):
             run_import(args)
+
+    def test_import_uses_active_profile_home(self, tmp_path, monkeypatch):
+        """Import should restore into the active profile, not the default Hermes root."""
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "profile.zip"
+        self._make_backup_zip(zip_path, {
+            "config.yaml": "profile: restored\n",
+        })
+
+        args = Namespace(zipfile=str(zip_path), force=True)
+
+        from hermes_cli.backup import run_import
+        run_import(args)
+
+        assert (profile_home / "config.yaml").read_text().strip() == "profile: restored"
+        assert not (default_home / "config.yaml").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `hermes backup` and `hermes import` so both commands operate on the active profile home instead of always targeting the default Hermes root.

## Problem

Backup and import are profile-scoped operations, but they were resolving their target directory from the default root.

That caused two incorrect behaviors when a non-default profile was active:

- `hermes backup` archived files from the default root instead of the active profile
- `hermes import` restored files into the default root instead of the active profile home

## Root Cause

`run_backup()` and `run_import()` in `hermes_cli/backup.py` used `get_default_hermes_root()`.

That helper is correct when the code needs the global Hermes root, but not for backup/import. These commands should follow the current active home and therefore use `get_hermes_home()`.

## Fix

Replace the two profile-targeting call sites so backup and import resolve against the active Hermes home.

This change is intentionally narrow:

- no refactor
- no new abstraction
- no behavior change outside the profile-targeting fix

## Coverage

Added regression coverage for both paths:

- `test_backup_uses_active_profile_home`
- `test_import_uses_active_profile_home`

## Validation

Verified with:

```bash
python -m pytest tests/hermes_cli/test_backup.py -q

69 passed, 20 warnings