### PR TITLE
fix(patch): preserve ADD hunk lines regardless of prefix or emptiness

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -78,6 +78,85 @@ class TestParseAddFile:
         assert contents[0] == "import os"
         assert contents[2] == 'print("hello")'
 
+    def test_add_file_preserves_lines_missing_plus_prefix(self):
+        """Regression: LLM-generated ADD patches sometimes omit the `+`
+        prefix on body lines. These must be preserved as content rather
+        than silently dropped, which would truncate the created file.
+        """
+        patch = "\n".join([
+            "*** Begin Patch",
+            "*** Add File: new/module.py",
+            "+def foo():",
+            "    pass",              # missing '+' prefix
+            "+    return 1",
+            "*** End Patch",
+        ])
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+
+        op = ops[0]
+        assert op.operation == OperationType.ADD
+        # All three body lines must survive as '+' content.
+        contents = [l.content for l in op.hunks[0].lines]
+        assert contents == ["def foo():", "    pass", "    return 1"]
+        # And they must all carry the '+' prefix so `_apply_add` (which
+        # filters by prefix) picks them up.
+        assert all(l.prefix == "+" for l in op.hunks[0].lines)
+
+    def test_add_file_preserves_blank_lines(self):
+        """Regression: blank lines inside ADD hunks (truly empty — not
+        even a `+`) were dropped by the general hunk parser's
+        `elif current_op and line:` guard because `""` is falsy."""
+        patch = "\n".join([
+            "*** Begin Patch",
+            "*** Add File: new/module.py",
+            "+def foo():",
+            "",                       # truly empty line
+            "+    return 1",
+            "*** End Patch",
+        ])
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        contents = [l.content for l in ops[0].hunks[0].lines]
+        assert contents == ["def foo():", "", "    return 1"]
+
+
+class TestApplyAddFile:
+    """Apply-phase regression: confirm _apply_add writes every parsed line."""
+
+    def test_apply_add_writes_content_from_missing_plus_lines(self):
+        """Full round-trip: malformed patch (missing `+` prefix) produces
+        a file with the expected complete contents, not a truncated one.
+        """
+        patch = "\n".join([
+            "*** Begin Patch",
+            "*** Add File: greet.py",
+            "+def foo():",
+            "    pass",              # missing '+' — used to be lost
+            "+    return 1",
+            "*** End Patch",
+        ])
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def __init__(self):
+                self.written = {}
+
+            def read_file_raw(self, path):
+                # Destination doesn't exist — required for ADD validation
+                return SimpleNamespace(error="not found", content="")
+
+            def write_file(self, path, content):
+                self.written[path] = content
+                return SimpleNamespace(error=None)
+
+        fake = FakeFileOps()
+        result = apply_v4a_operations(ops, fake)
+        assert result.success is True
+        assert fake.written["greet.py"] == "def foo():\n    pass\n    return 1"
+
 
 class TestParseDeleteFile:
     def test_delete_file(self):

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -178,11 +178,26 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
                 hint = hint_match.group(1) if hint_match else None
                 current_hunk = Hunk(context_hint=hint)
                 
+        elif current_op and current_op.operation == OperationType.ADD:
+            # For ADD operations every line is file content — there is
+            # no context / removal concept when creating a new file.
+            # Preserve empty lines (which the general hunk branch drops
+            # because `""` is falsy) and treat lines without a `+`
+            # prefix as content too, so a malformed LLM patch that
+            # omits the `+` on some lines does not silently lose data.
+            if line.startswith('\\'):
+                # "\ No newline at end of file" marker - skip
+                pass
+            else:
+                if current_hunk is None:
+                    current_hunk = Hunk()
+                content = line[1:] if line.startswith('+') else line
+                current_hunk.lines.append(HunkLine('+', content))
         elif current_op and line:
             # Parse hunk line
             if current_hunk is None:
                 current_hunk = Hunk()
-            
+
             if line.startswith('+'):
                 current_hunk.lines.append(HunkLine('+', line[1:]))
             elif line.startswith('-'):


### PR DESCRIPTION
## Summary

`parse_v4a_patch` shares a single hunk-line parser across all operation types. It's tuned for `UPDATE` hunks — where `+`, `-`, and ` ` have distinct semantics — but it runs for `ADD` hunks too, causing two silent data-loss bugs when LLM-generated patches are slightly malformed.

### Bug 1 — Lines without a `+` prefix are silently dropped

The parser stores non-prefixed lines with an implicit space prefix:

```python
elif line.startswith(' '):
    current_hunk.lines.append(HunkLine(' ', line[1:]))
...
else:
    current_hunk.lines.append(HunkLine(' ', line))  # implicit space prefix
```

`_apply_add` then filters to `+` lines only:

```python
for hunk in op.hunks:
    for line in hunk.lines:
        if line.prefix == '+':
            content_lines.append(line.content)
```

So any line without a `+` prefix is dropped from the created file. Reproducer:

\`\`\`
*** Begin Patch
*** Add File: greet.py
+def foo():
    pass
+    return 1
*** End Patch
\`\`\`

Before this fix, the file is created with `\"def foo():\\n    return 1\"` — `pass` is gone, no error, no warning.

### Bug 2 — Blank lines are dropped

The outer hunk-line branch is guarded by `elif current_op and line:`. `\"\"` is falsy in Python, so any truly empty line (not even a `+` prefix) skips the entire elif chain and is lost.

For `UPDATE` this is rescued in practice by `fuzzy_match`'s whitespace-tolerant strategies. For `ADD`, the empty line just never makes it into the file.

## Fix

`ADD` has no \"context\" or \"removal\" concept — every line in an ADD hunk is new file content. Split the hunk-line parser so ADD hunks run through their own branch that:

- accepts every line (truthy guard dropped, blank lines preserved)
- strips a leading `+` if present, otherwise keeps the full line
- still honours the `\\ No newline at end of file` marker

`UPDATE` / `DELETE` / `MOVE` parsing is untouched.

```python
elif current_op and current_op.operation == OperationType.ADD:
    if line.startswith('\\\\'):
        pass  # \"\\ No newline at end of file\" marker
    else:
        if current_hunk is None:
            current_hunk = Hunk()
        content = line[1:] if line.startswith('+') else line
        current_hunk.lines.append(HunkLine('+', content))
elif current_op and line:
    # ... existing UPDATE / DELETE / MOVE hunk parsing
```

## Test plan

Three new tests in `tests/tools/test_patch_parser.py`:

- [x] `TestParseAddFile::test_add_file_preserves_lines_missing_plus_prefix` — parses a patch with a body line missing `+`, asserts the line survives as `+`-prefixed content
- [x] `TestParseAddFile::test_add_file_preserves_blank_lines` — parses a patch with a truly empty middle line, asserts it survives into the hunk
- [x] `TestApplyAddFile::test_apply_add_writes_content_from_missing_plus_lines` — full round-trip through `apply_v4a_operations` with a fake `file_ops`, asserts the written file contains all three lines (including the no-prefix one)

69 tests in `test_patch_parser.py` + `test_file_operations.py` still pass locally with no regressions — the existing `test_add_file` (which uses all well-formed `+` lines) is unaffected.