### PR TITLE
fix: remove @staticmethod from _context_completions that references self

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Summary
Fixes a crash when typing `@` in the CLI input — `_context_completions` was decorated as `@staticmethod` but called `self._fuzzy_file_completions()`, an instance method.

## Root Cause
The method was decorated as `@staticmethod` (no `self` parameter) but the body references `self._fuzzy_file_completions()` on line 806. Introduced in PR #9467 when fuzzy file completion code was added to what was previously a static method.

## Fix
Removed `@staticmethod` decorator and added `self` as the first parameter. The caller on line 976 already passes `self` correctly.

## Test Plan
- [ ] Verified syntax and import: `from hermes_cli.commands import SlashCommandCompleter` works
- [ ] No existing unit tests for this specific method (test_commands.py has 0 tests)

Closes NousResearch/hermes-agent#9817