### PR TITLE
fix: ensure distribution fallback selects a valid toolset

### DIFF
--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -85,6 +85,26 @@ class TestSampleToolsetsFromDistribution:
             result = sample_toolsets_from_distribution("reasoning")
             assert len(result) >= 1
 
+    def test_fallback_skips_invalid_highest_probability_toolset(self, monkeypatch):
+        monkeypatch.setitem(
+            DISTRIBUTIONS,
+            "_test_invalid_highest",
+            {
+                "description": "fallback should choose highest valid toolset",
+                "toolsets": {
+                    "invalid_toolset_name": 99,
+                    "web": 1,
+                },
+            },
+        )
+        try:
+            # Force random path to select none initially, then fallback path runs.
+            with patch("toolset_distributions.random.random", return_value=1.0):
+                result = sample_toolsets_from_distribution("_test_invalid_highest")
+            assert result == ["web"]
+        finally:
+            del DISTRIBUTIONS["_test_invalid_highest"]
+
 
 class TestDistributionStructure:
     def test_all_have_required_keys(self):

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -277,12 +277,17 @@ def sample_toolsets_from_distribution(distribution_name: str) -> List[str]:
         if random.random() * 100 < probability:
             selected_toolsets.append(toolset_name)
     
-    # If no toolsets were selected (can happen with low probabilities), 
-    # ensure at least one toolset is selected by picking the highest probability one
+    # If no toolsets were selected (can happen with low probabilities),
+    # ensure at least one *valid* toolset is selected by picking the highest
+    # probability valid candidate.
     if not selected_toolsets and dist["toolsets"]:
-        # Find toolset with highest probability
-        highest_prob_toolset = max(dist["toolsets"].items(), key=lambda x: x[1])[0]
-        if validate_toolset(highest_prob_toolset):
+        valid_candidates = [
+            (toolset_name, probability)
+            for toolset_name, probability in dist["toolsets"].items()
+            if validate_toolset(toolset_name)
+        ]
+        if valid_candidates:
+            highest_prob_toolset = max(valid_candidates, key=lambda x: x[1])[0]
             selected_toolsets.append(highest_prob_toolset)
     
     return selected_toolsets


### PR DESCRIPTION
## What
Harden fallback behavior in `sample_toolsets_from_distribution()`.

## Why
When random sampling returns no toolsets, previous fallback picked the highest-probability entry even if it was invalid, which could still return an empty result.

## Change
- Fallback now selects the highest-probability **valid** toolset.
- Added regression test for the “invalid highest-probability toolset” edge case.

## Validation
- `pytest -q -o addopts="" tests/test_toolset_distributions.py`
- Result: 16 passed