### PR TITLE
fix: add sms platform to PLATFORMS registry

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -26,6 +26,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("whatsapp",       PlatformInfo(label="📱 WhatsApp",        default_toolset="hermes-whatsapp")),
     ("signal",         PlatformInfo(label="📡 Signal",          default_toolset="hermes-signal")),
     ("bluebubbles",    PlatformInfo(label="💙 BlueBubbles",     default_toolset="hermes-bluebubbles")),
+    ("sms",            PlatformInfo(label="📱 SMS (Twilio)",    default_toolset="hermes-sms")),
     ("email",          PlatformInfo(label="📧 Email",           default_toolset="hermes-email")),
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),
     ("mattermost",     PlatformInfo(label="💬 Mattermost",      default_toolset="hermes-mattermost")),


### PR DESCRIPTION
## Summary
Adds the missing `sms` platform entry to the `PLATFORMS` registry in `hermes_cli/platforms.py`, fixing a `KeyError: 'sms'` crash when the SMS (Twilio) gateway receives inbound messages.

## Root Cause
The SMS platform adapter (`gateway/platforms/sms.py`) and toolset (`hermes-sms`) exist, but the platform was never registered in the `PLATFORMS` dict used by `tools_config.py` for agent toolset bootstrapping.

## Fix
Added one line: `("sms", PlatformInfo(label="📱 SMS (Twilio)", default_toolset="hermes-sms"))`

## Test Plan
- [ ] Verified: `PLATFORMS['sms']` resolves correctly
- [ ] Verified: `_get_platform_tools(config, 'sms')` returns expected toolset

Closes NousResearch/hermes-agent#9789