### PR TITLE
fix(cli): show custom provider models dict in model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1066,6 +1066,14 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            cfg_models = entry.get("models", [])
+            if isinstance(cfg_models, dict):
+                cfg_models = list(cfg_models.keys())
+            if isinstance(cfg_models, list):
+                for model_id in cfg_models:
+                    model_id = str(model_id).strip()
+                    if model_id and model_id not in groups[slug]["models"]:
+                        groups[slug]["models"].append(model_id)
 
         for slug, grp in groups.items():
             if slug in seen_slugs:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -182,6 +182,7 @@ AUTHOR_MAP = {
     "unayung@gmail.com": "Unayung",
     "vorvul.danylo@gmail.com": "WorldInnovationsDepartment",
     "win4r@outlook.com": "win4r",
+    "xowiekk@gmail.com": "Xowiek",
     "xush@xush.org": "KUSH42",
     "yangzhi.see@gmail.com": "SeeYangZhi",
     "yongtenglei@gmail.com": "yongtenglei",

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -116,6 +116,40 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+def test_list_authenticated_providers_includes_models_dict_from_custom_providers(monkeypatch):
+    """Legacy custom_providers entries should expose models dict keys in /model."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    custom_providers = [
+        {
+            "name": "cch_anthropic",
+            "base_url": "http://localhost:23000",
+            "api_mode": "anthropic_messages",
+            "models": {
+                "glm-5-turbo": {"context_length": 202752},
+                "MiniMax-M2.1": {"context_length": 196608},
+            },
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    custom_provider = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "cch_anthropic"),
+        None,
+    )
+
+    assert custom_provider is not None
+    assert custom_provider["total_models"] == 2
+    assert custom_provider["models"] == ["glm-5-turbo", "MiniMax-M2.1"]
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## What was wrong

The `/model` picker handled legacy `custom_providers` entries as if they only had a single `model` field.

That worked for older configs, but it missed providers defined with a `models:` collection. In those cases, the picker could show the provider as having `0 models` even though model IDs were present in config.

## Change

When building picker groups for legacy `custom_providers`, also collect model IDs from `models` when it is provided as:

- a dict
- a list

The existing single-`model` behavior is kept as-is, and model deduplication still works the same way.

## Why this is safe

This is a narrow fix in the picker aggregation path only.

It does not change:
- provider auth
- provider resolution
- runtime model switching behavior outside the displayed model list

## Coverage

Added regression coverage for the legacy `custom_providers` + `models` dict case so the picker now reports the expected model count and names.

## Verification

Focused run:

```bash
py -m pytest tests/hermes_cli/test_user_providers_model_switch.py -q

9 passed, 9 warnings 2.32s

Related run:

py -m pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_codex_cli_model_picker.py -q

Result:

81 passed, 81 warnings 14.88s