### PR TITLE
fix: doctor health check uses default URL when base_url has custom path

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -759,7 +759,20 @@ def run_doctor(args):
                 if _base and _base.rstrip("/").endswith("/anthropic"):
                     from agent.auxiliary_client import _to_openai_base_url
                     _base = _to_openai_base_url(_base)
-                _url = (_base.rstrip("/") + "/models") if _base else _default_url
+                # Build the health check URL. If base_url is set, try to use it
+                # intelligently:
+                # - If it ends with /v1 or /v1/, append /models
+                # - If it already has a deeper path (e.g. /v1/chat), don't append
+                # - Otherwise fall back to default_url
+                if _base:
+                    _stripped = _base.rstrip("/")
+                    if _stripped.endswith("/v1") or _stripped.endswith("/v1/models"):
+                        _url = _stripped.rstrip("/models") + "/models"
+                    else:
+                        # Custom path — use default URL to avoid breaking checks
+                        _url = _default_url
+                else:
+                    _url = _default_url
                 _headers = {"Authorization": f"Bearer {_key}"}
                 if "api.kimi.com" in _url.lower():
                     _headers["User-Agent"] = "KimiCLI/1.30.0"


### PR DESCRIPTION
## Summary
Fixes `hermes doctor` provider connectivity checks failing when a custom `base_url` is configured with a non-standard path (e.g., `/anthropic/v1/messages`).

## Root Cause
The doctor unconditionally appended `/models` to any custom `base_url`, creating invalid URLs like `https://api.minimaxi.com/anthropic/v1/messages/models` which returned 404.

## Fix
Only append `/models` when `base_url` ends with `/v1` (standard OpenAI-compatible endpoint). For custom paths, fall back to the provider's default health check URL which is known to work.

## Test Plan
- [ ] Verified syntax and logic for all base_url variants
- [ ] Manual verification with custom base_url configurations

Closes NousResearch/hermes-agent#9766