### PR TITLE
fix: bind @ context completions to the completer instance

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -734,8 +734,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,6 +1,6 @@
 """Tests for the central command registry and autocomplete."""
 
-from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.completion import CompleteEvent, Completion
 from prompt_toolkit.document import Document
 
 from hermes_cli.commands import (
@@ -360,6 +360,26 @@ class TestSlashCommandCompleter:
 
     def test_no_completions_for_empty_input(self):
         assert _completions(SlashCommandCompleter(), "") == []
+
+    def test_context_completion_uses_instance_fuzzy_completions(self, monkeypatch):
+        completer = SlashCommandCompleter()
+        seen = {}
+
+        def fake_fuzzy(word, query, limit):
+            seen["args"] = (word, query, limit)
+            yield Completion(
+                "@file:tests/hermes_cli/test_commands.py",
+                start_position=-len(word),
+                display="test_commands.py",
+                display_meta="1 KB",
+            )
+
+        monkeypatch.setattr(completer, "_fuzzy_file_completions", fake_fuzzy)
+
+        completions = _completions(completer, "@")
+
+        assert seen["args"] == ("@", "", 30)
+        assert any(item.text == "@file:tests/hermes_cli/test_commands.py" for item in completions)
 
     # -- skill commands via provider ------------------------------------
 


### PR DESCRIPTION
## Summary
- remove the stray `@staticmethod` from `_context_completions`
- add a regression test proving bare `@` completion can call instance fuzzy completion helpers
- preserve the existing `@` completion flow while fixing the NameError crash

## Test Plan
- `python -m pytest tests/hermes_cli/test_commands.py::TestSlashCommandCompleter::test_context_completion_uses_instance_fuzzy_completions -q`
- `python -m pytest tests/hermes_cli/test_commands.py tests/hermes_cli/test_path_completion.py -q`
- manual repro: instantiate `SlashCommandCompleter()` and request completions for `"@"` without crashing

## Notes
- `python -m pytest tests/ -q` is currently red locally on numerous unrelated pre-existing failures in upstream `main` in this environment, so I validated the touched area with focused tests instead.

Closes #9817