### PR TITLE
fix(patch): preserve raw blank lines in V4A hunks

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -78,6 +78,32 @@ class TestParseAddFile:
         assert contents[0] == "import os"
         assert contents[2] == 'print("hello")'
 
+    def test_add_file_preserves_raw_blank_line_between_plus_lines(self):
+        """Regression #9844: a bare empty row between + lines must not be dropped."""
+        patch = """\
+*** Begin Patch
+*** Add File: spaced.py
++first
+
++second
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        lines = [l for l in ops[0].hunks[0].lines if l.prefix == "+"]
+        assert [x.content for x in lines] == ["first", "", "second"]
+
+        class FakeFileOps:
+            written = None
+
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True
+        assert file_ops.written == "first\n\nsecond"
+
 
 class TestParseDeleteFile:
     def test_delete_file(self):
@@ -185,6 +211,38 @@ class TestApplyUpdate:
             '    result = 1\n'
             '    return result + 1'
         )
+
+    def test_update_preserves_raw_blank_line_inside_hunk(self):
+        """Regression #9844: blank patch row between + and context keeps file spacing."""
+        patch = """\
+*** Begin Patch
+*** Update File: gap.py
+ ctx1
+-old
++new
+
+ ctx2
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            written = None
+
+            def read_file_raw(self, path):
+                return SimpleNamespace(
+                    content="ctx1\nold\n\nctx2\n",
+                    error=None,
+                )
+
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True
+        assert file_ops.written == "ctx1\nnew\n\nctx2\n"
 
 
 class TestAdditionOnlyHunks:

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -178,23 +178,35 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
                 hint = hint_match.group(1) if hint_match else None
                 current_hunk = Hunk(context_hint=hint)
                 
-        elif current_op and line:
-            # Parse hunk line
-            if current_hunk is None:
-                current_hunk = Hunk()
-            
-            if line.startswith('+'):
-                current_hunk.lines.append(HunkLine('+', line[1:]))
-            elif line.startswith('-'):
-                current_hunk.lines.append(HunkLine('-', line[1:]))
-            elif line.startswith(' '):
-                current_hunk.lines.append(HunkLine(' ', line[1:]))
-            elif line.startswith('\\'):
-                # "\ No newline at end of file" marker - skip
-                pass
-            else:
-                # Treat as context line (implicit space prefix)
-                current_hunk.lines.append(HunkLine(' ', line))
+        elif current_op:
+            # Blank lines inside a patch body must not be dropped: agents often emit a
+            # raw empty line between hunk rows instead of " +" / " " V4A prefixes.
+            if (
+                line == ""
+                and current_op.operation
+                in (OperationType.ADD, OperationType.UPDATE)
+            ):
+                if current_hunk is None:
+                    current_hunk = Hunk()
+                prefix = "+" if current_op.operation == OperationType.ADD else " "
+                current_hunk.lines.append(HunkLine(prefix, ""))
+            elif line:
+                # Parse hunk line
+                if current_hunk is None:
+                    current_hunk = Hunk()
+
+                if line.startswith('+'):
+                    current_hunk.lines.append(HunkLine('+', line[1:]))
+                elif line.startswith('-'):
+                    current_hunk.lines.append(HunkLine('-', line[1:]))
+                elif line.startswith(' '):
+                    current_hunk.lines.append(HunkLine(' ', line[1:]))
+                elif line.startswith('\\'):
+                    # "\ No newline at end of file" marker - skip
+                    pass
+                else:
+                    # Treat as context line (implicit space prefix)
+                    current_hunk.lines.append(HunkLine(' ', line))
         
         i += 1
     


### PR DESCRIPTION
## Summary
- preserve bare empty lines while parsing ADD/UPDATE hunk bodies so spacing is not silently dropped
- keep existing line-prefix parsing behavior unchanged for non-empty rows
- add regression tests covering ADD and UPDATE flows with raw blank lines

## Test plan
- [x] python -m pytest tests/tools/test_patch_parser.py -q -o addopts=
- [x] CI suite