### PR TITLE
fix(gateway): include messaging in configurable toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
+    ("messaging",       "💬 Messaging",                 "send_message"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -169,6 +169,7 @@ AUTHOR_MAP = {
     "oncuevtv@gmail.com": "sprmn24",
     "programming@olafthiele.com": "olafthiele",
     "r2668940489@gmail.com": "r266-tech",
+    "ruzzgarcn@gmail.com": "Ruzzgar",
     "s5460703@gmail.com": "BlackishGreen33",
     "saul.jj.wu@gmail.com": "SaulJWu",
     "shenhaocheng19990111@gmail.com": "hcshen0111",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -22,6 +22,19 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     assert enabled
 
 
+def test_get_platform_tools_includes_messaging_for_gateway_defaults():
+    """Default gateway composites should expose send_message via messaging."""
+    config = {}
+
+    enabled = _get_platform_tools(
+        config,
+        "telegram",
+        include_default_mcp_servers=False,
+    )
+
+    assert "messaging" in enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 


### PR DESCRIPTION
## Root Cause

Gateway platform defaults include `send_message` through `_HERMES_CORE_TOOLS`, and `toolsets.py` already defines the `messaging` toolset. However, `hermes_cli.tools_config._get_platform_tools()` reverse-maps composite platform toolsets only through `CONFIGURABLE_TOOLSETS`. Because `messaging` was missing from that list, gateway defaults such as `hermes-telegram` resolved without the `messaging` toolset, silently dropping `send_message`.

## Repro

1. Use default gateway platform toolset resolution for Telegram.
2. `toolsets.py` contains `send_message` and the `messaging` toolset.
3. `CONFIGURABLE_TOOLSETS` does not contain `messaging`.
4. `_get_platform_tools({}, "telegram")` cannot reverse-map `send_message` back to `messaging`.

## Fix

Add `messaging` to `CONFIGURABLE_TOOLSETS` so default gateway composite toolsets resolve it like other built-in toolsets.

## Tests

Added `test_get_platform_tools_includes_messaging_for_gateway_defaults`.

I attempted to run:

`python -m pytest tests\hermes_cli\test_tools_config.py -q`


