### PR TITLE
fix(cli): preserve legacy root prefill_messages_file support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -380,6 +380,15 @@ def load_cli_config() -> Dict[str, Any]:
                 and agent_file_config.get("max_turns") is not None
             ):
                 defaults["agent"]["max_turns"] = file_config["max_turns"]
+
+            # Handle legacy root-level prefill_messages_file (backwards compat)
+            # - copy to agent.prefill_messages_file whenever the nested key is
+            # missing so CLI/runtime behavior matches gateway and cron.
+            if "prefill_messages_file" in file_config and not (
+                isinstance(agent_file_config, dict)
+                and agent_file_config.get("prefill_messages_file") is not None
+            ):
+                defaults["agent"]["prefill_messages_file"] = file_config["prefill_messages_file"]
         except Exception as e:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -331,6 +331,51 @@ class TestRootLevelProviderOverride:
         assert "provider" not in result  # root key still cleaned up
 
 
+class TestRootLevelPrefillMessagesFile:
+    def test_root_prefill_messages_file_is_copied_into_agent_section(self, tmp_path, monkeypatch):
+        """Legacy root-level prefill_messages_file should still populate agent.prefill_messages_file."""
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(yaml.safe_dump({
+            "prefill_messages_file": "prefill.json",
+        }))
+
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cfg = cli.load_cli_config()
+
+        assert cfg["prefill_messages_file"] == "prefill.json"
+        assert cfg["agent"]["prefill_messages_file"] == "prefill.json"
+
+    def test_agent_prefill_messages_file_wins_over_legacy_root_key(self, tmp_path, monkeypatch):
+        """An explicit agent.prefill_messages_file should not be replaced by the legacy root key."""
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(yaml.safe_dump({
+            "prefill_messages_file": "legacy.json",
+            "agent": {
+                "prefill_messages_file": "nested.json",
+            },
+        }))
+
+        import cli
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        cfg = cli.load_cli_config()
+
+        assert cfg["prefill_messages_file"] == "legacy.json"
+        assert cfg["agent"]["prefill_messages_file"] == "nested.json"
+
+
 class TestProviderResolution:
     def test_api_key_is_string_or_none(self):
         cli = _make_cli()


### PR DESCRIPTION
## Summary
- map legacy root-level `prefill_messages_file` into `agent.prefill_messages_file` during CLI config loading
- keep nested `agent.prefill_messages_file` authoritative when both keys are present
- add regression coverage for both the legacy fallback and nested-key precedence

## Test Plan
- `python -m pytest tests/cli/test_cli_init.py::TestRootLevelPrefillMessagesFile -q`
- `python -m pytest tests/cli/test_cli_init.py -q`
- manual repro: load config with only root-level `prefill_messages_file` and verify CLI config exposes the same value under `agent.prefill_messages_file`

## Notes
- This keeps CLI behavior aligned with gateway and cron without changing the canonical config schema in this PR.
- I did not run `python -m pytest tests/ -q` because upstream `main` is currently red in this environment on many unrelated failures; I validated the directly affected CLI test surface instead.

Closes #9635