### PR TITLE
feat(discord): add DISCORD_ALLOWED_ROLES env var for role-based access control

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -432,6 +432,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         # Text batching: merge rapid successive messages (Telegram-style)
@@ -510,6 +511,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     if uid.strip()
                 }
 
+            # Parse DISCORD_ALLOWED_ROLES — comma-separated role IDs.
+            # Users with ANY of these roles can interact with the bot.
+            roles_env = os.getenv("DISCORD_ALLOWED_ROLES", "")
+            if roles_env:
+                self._allowed_role_ids = {
+                    int(rid.strip()) for rid in roles_env.split(",")
+                    if rid.strip().isdigit()
+                }
+
             # Set up intents.
             # Message Content is required for normal text replies.
             # Server Members is only needed when the allowlist contains usernames
@@ -521,7 +531,10 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.message_content = True
             intents.dm_messages = True
             intents.guild_messages = True
-            intents.members = any(not entry.isdigit() for entry in self._allowed_user_ids)
+            intents.members = (
+                any(not entry.isdigit() for entry in self._allowed_user_ids)
+                or bool(self._allowed_role_ids)  # Need members intent for role lookup
+            )
             intents.voice_states = True
 
             # Resolve proxy (DISCORD_PROXY > generic env vars > macOS system proxy)
@@ -569,7 +582,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
 
                 # Check if the message author is in the allowed user list
-                if not self._is_allowed_user(str(message.author.id)):
+                if not self._is_allowed_user(str(message.author.id), message.author):
                     return
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
@@ -1284,11 +1297,43 @@ class DiscordAdapter(BasePlatformAdapter):
             except OSError:
                 pass
 
-    def _is_allowed_user(self, user_id: str) -> bool:
-        """Check if user is in DISCORD_ALLOWED_USERS."""
-        if not self._allowed_user_ids:
+    def _is_allowed_user(self, user_id: str, author=None) -> bool:
+        """Check if user is allowed via DISCORD_ALLOWED_USERS or DISCORD_ALLOWED_ROLES.
+
+        Uses OR semantics: if the user matches EITHER allowlist, they're allowed.
+        If both allowlists are empty, everyone is allowed (backwards compatible).
+        When author is a Member, checks .roles directly; otherwise falls back
+        to scanning the bot's mutual guilds for a Member record.
+        """
+        has_users = bool(self._allowed_user_ids)
+        has_roles = bool(self._allowed_role_ids)
+        if not has_users and not has_roles:
             return True
-        return user_id in self._allowed_user_ids
+        # Check user ID allowlist
+        if has_users and user_id in self._allowed_user_ids:
+            return True
+        # Check role allowlist
+        if has_roles:
+            # Try direct role check from Member object
+            direct_roles = getattr(author, "roles", None) if author is not None else None
+            if direct_roles:
+                if any(getattr(r, "id", None) in self._allowed_role_ids for r in direct_roles):
+                    return True
+            # Fallback: scan mutual guilds for member's roles
+            if self._client is not None:
+                try:
+                    uid_int = int(user_id)
+                except (TypeError, ValueError):
+                    uid_int = None
+                if uid_int is not None:
+                    for guild in self._client.guilds:
+                        m = guild.get_member(uid_int)
+                        if m is None:
+                            continue
+                        m_roles = getattr(m, "roles", None) or []
+                        if any(getattr(r, "id", None) in self._allowed_role_ids for r in m_roles):
+                            return True
+        return False
 
     async def send_image_file(
         self,


### PR DESCRIPTION
## Summary

Adds a new `DISCORD_ALLOWED_ROLES` environment variable that allows filtering bot interactions by Discord role ID, complementing the existing `DISCORD_ALLOWED_USERS`.

## Changes

- **New env var:** `DISCORD_ALLOWED_ROLES` — comma-separated Discord role IDs
- **OR semantics** with `DISCORD_ALLOWED_USERS`: if a user matches either allowlist, they are permitted
- **Members intent** auto-enabled when roles are configured (needed for guild member role lookup)
- **Updated `_is_allowed_user()`** to accept optional `author` param for direct `Member.roles` check
- **Fallback:** scans mutual guilds when author object lacks roles (e.g. DMs, voice events)
- **Fully backwards compatible:** no behavior change when the env var is unset

## Usage

```bash
# In .env — only users with this Discord role can interact with the bot
DISCORD_ALLOWED_ROLES=1493705176387948674

# Can combine with user allowlist (OR logic)
DISCORD_ALLOWED_USERS=413720629
DISCORD_ALLOWED_ROLES=1493705176387948674
```

## Testing

Tested on a live Discord gateway with role-restricted guild. Bot correctly:
- Allows users with the specified role
- Denies users without the role (silent drop)
- Falls back to user ID allowlist when role check fails
- Works in DMs (no role check needed, falls through to user allowlist)
