### PR TITLE
fix: add focus_topic and api_mode to ContextEngine ABC

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -26,7 +26,7 @@ Lifecycle:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class ContextEngine(ABC):
@@ -78,6 +78,7 @@ class ContextEngine(ABC):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Compact the message list and return the new message list.
 
@@ -86,6 +87,13 @@ class ContextEngine(ABC):
         context budget. The implementation is free to summarize, build a
         DAG, or do anything else — as long as the returned list is a valid
         OpenAI-format message sequence.
+
+        Args:
+            messages: Full conversation message list (OpenAI format).
+            current_tokens: Approximate current token count, if known.
+            focus_topic: Optional focus string for guided compression,
+                passed by ``/compact <topic>``. When set, the engine
+                should preserve context relevant to this topic.
         """
 
     # -- Optional: pre-flight check ----------------------------------------
@@ -173,12 +181,21 @@ class ContextEngine(ABC):
         base_url: str = "",
         api_key: str = "",
         provider: str = "",
+        api_mode: str = "",
     ) -> None:
         """Called when the user switches models or on fallback activation.
 
         Default updates context_length and recalculates threshold_tokens
         from threshold_percent. Override if your engine needs more
         (e.g. recalculate DAG budgets, switch summary models).
+
+        Args:
+            model: Model identifier string (e.g. 'anthropic/claude-opus-4.6').
+            context_length: Context window size in tokens.
+            base_url: API base URL, if applicable.
+            api_key: API key, if applicable.
+            provider: Provider name (e.g. 'anthropic', 'openai').
+            api_mode: API mode string (e.g. 'responses', 'chat').
         """
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self.threshold_percent)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5700,6 +5700,7 @@ class AIAgent:
                     base_url=self.base_url,
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
+                    api_mode=self.api_mode,
                 )
 
             self._emit_status(

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -58,10 +58,17 @@ class LCMEngine(ContextEngine):
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Return True if compaction should fire this turn."""
 
-    def compress(self, messages: list, current_tokens: int = None) -> list:
+    def compress(self, messages: list, current_tokens: int = None,
+                 focus_topic: str = None) -> list:
         """Compact the message list and return a new (possibly shorter) list.
 
         The returned list must be a valid OpenAI-format message sequence.
+
+        Args:
+            messages: Full conversation message list.
+            current_tokens: Approximate current token count.
+            focus_topic: Optional focus string for guided compression,
+                passed by /compact <topic>.
         """
 ```
 
@@ -87,7 +94,7 @@ These have sensible defaults in the ABC. Override as needed:
 | `on_session_start(session_id, **kwargs)` | No-op | You need to load persisted state (DAG, DB) |
 | `on_session_end(session_id, messages)` | No-op | You need to flush state, close connections |
 | `on_session_reset()` | Resets token counters | You have per-session state to clear |
-| `update_model(model, context_length, ...)` | Updates context_length + threshold | You need to recalculate budgets on model switch |
+| `update_model(model, context_length, ..., api_mode="")` | Updates context_length + threshold | You need to recalculate budgets on model switch |
 | `get_tool_schemas()` | Returns `[]` | Your engine provides agent-callable tools (e.g., `lcm_grep`) |
 | `handle_tool_call(name, args, **kwargs)` | Returns error JSON | You implement tool handlers |
 | `should_compress_preflight(messages)` | Returns `False` | You can do a cheap pre-API-call estimate |


### PR DESCRIPTION
## Problem

run_agent.py passes two kwargs not in the ContextEngine ABC:

| Caller | Method | Extra kwarg |
|---|---|---|
| run_agent.py:6752 | compress() | focus_topic=focus_topic |
| run_agent.py:1600 | update_model() | api_mode=self.api_mode |

The built-in ContextCompressor accepts both, so the default path works. Any third-party plugin implementing the ABC as documented gets TypeError. No try/except or proxy layer absorbs these.

Also: run_agent.py:5673 (fallback activation) does not pass api_mode while line 1600 does — inconsistency that silently drops the value after fallback.

Discovered during [hermes-lcm](https://github.com/stephenschoettler/hermes-lcm) integration.

## Fix

Explicit defaulted params (not **kwargs — these are stable, meaningful concepts):
- compress(): add focus_topic: Optional[str] = None
- update_model(): add api_mode: str = ""
- run_agent.py:5673: add missing api_mode=self.api_mode
- Plugin docs: updated to document both params

Non-breaking — ContextCompressor already accepts both. Matches the explicit-params-with-defaults pattern used by on_session_start() and handle_tool_call() in the ABC.

## Notes

- should_compress_preflight() has zero callers (separate issue)
- run_agent.py:8732 writes private attrs directly on the engine (separate issue)