### PR TITLE
fix: gateway auto-recovers from unexpected SIGTERM via systemd (#5646)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9261,8 +9261,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     runner = GatewayRunner(config)
     
+    # Track whether a signal initiated the shutdown (vs. internal request).
+    # When an unexpected SIGTERM kills the gateway, we exit non-zero so
+    # systemd's Restart=on-failure revives the process.  systemctl stop
+    # is safe: systemd tracks stop-requested state independently of exit
+    # code, so Restart= never fires for a deliberate stop.
+    _signal_initiated_shutdown = False
+
     # Set up signal handlers
     def shutdown_signal_handler():
+        nonlocal _signal_initiated_shutdown
+        _signal_initiated_shutdown = True
+        logger.info("Received SIGTERM/SIGINT — initiating shutdown")
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
@@ -9331,6 +9341,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)
+
+    # When a signal (SIGTERM/SIGINT) caused the shutdown and it wasn't a
+    # planned restart (/restart, /update, SIGUSR1), exit non-zero so
+    # systemd's Restart=on-failure revives the process.  This covers:
+    #   - hermes update killing the gateway mid-work
+    #   - External kill commands
+    #   - WSL2/container runtime sending unexpected signals
+    # systemctl stop is safe: systemd tracks "stop requested" state
+    # independently of exit code, so Restart= never fires for it.
+    if _signal_initiated_shutdown and not runner._restart_requested:
+        logger.info(
+            "Exiting with code 1 (signal-initiated shutdown without restart "
+            "request) so systemd Restart=on-failure can revive the gateway."
+        )
+        return False  # → sys.exit(1) in the caller
 
     return True
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -266,9 +266,25 @@ def read_runtime_status() -> Optional[dict[str, Any]]:
 
 
 def remove_pid_file() -> None:
-    """Remove the gateway PID file if it exists."""
+    """Remove the gateway PID file, but only if it belongs to this process.
+
+    During --replace handoffs, the old process's atexit handler can fire AFTER
+    the new process has written its own PID file.  Blindly removing the file
+    would delete the new process's record, leaving the gateway running with no
+    PID file (invisible to ``get_running_pid()``).
+    """
     try:
-        _get_pid_path().unlink(missing_ok=True)
+        path = _get_pid_path()
+        record = _read_json_file(path)
+        if record is not None:
+            try:
+                file_pid = int(record["pid"])
+            except (KeyError, TypeError, ValueError):
+                file_pid = None
+            if file_pid is not None and file_pid != os.getpid():
+                # PID file belongs to a different process — leave it alone.
+                return
+        path.unlink(missing_ok=True)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary

Fixes #5646 — gateway exits cleanly (status=0) after receiving SIGTERM, and systemd's `Restart=on-failure` never revives it because 0 = success. The gateway stays dead permanently until manually restarted.

This was the root cause of the recurring "gateway dies mid-agent-run" reports from WSL2 and systemd users. When `hermes update` or any external process sends SIGTERM to the gateway, it handled the signal gracefully and exited 0. systemd saw a clean exit and did nothing.

### Changes

**1. Signal-initiated shutdown exits non-zero**

When SIGTERM/SIGINT triggers shutdown and no restart was requested (via `/restart`, `/update`, or SIGUSR1), `start_gateway()` returns `False` → `sys.exit(1)`. systemd's `Restart=on-failure` sees the non-zero exit and auto-restarts after `RestartSec=30`.

This is safe because `systemctl stop` tracks its own stop-requested state independently of exit code — `Restart=` never fires for a deliberate stop, regardless of what the process returns.

Also adds a log line: `Received SIGTERM/SIGINT — initiating shutdown` so the cause of unexpected shutdowns is visible in agent.log (previously it was just "Stopping gateway..." with no indication of why).

**2. PID file ownership guard**

`remove_pid_file()` now verifies the PID file belongs to the current process before deleting it. During `--replace` handoffs, the old process's `atexit` handler could fire AFTER the new process had already written its PID file — deleting the new record. This left the gateway running but invisible to `get_running_pid()`, causing:
- `hermes gateway status` showing "not running" when it was
- "Another gateway already running" errors on next restart attempt

## How this resolves the reported scenarios

| Scenario | Before | After |
|----------|--------|-------|
| External SIGTERM (update, kill, WSL2) | Exit 0, gateway dead forever | Exit 1, systemd restarts in 30s |
| `systemctl stop hermes-gateway` | Exit 0, stays stopped | Exit 1, but systemd tracks stop-requested → stays stopped |
| `/restart` from Telegram | Exit 75, systemd restarts | Exit 75, systemd restarts (unchanged) |
| PID file race during --replace | Old process deletes new PID file | Old process skips deletion (file belongs to new PID) |

## Test plan
- All restart drain tests pass (13)
- All gateway service tests pass (84)
- All update gateway restart tests pass (34)
