### PR TITLE
fix(model): normalize provider:model syntax consistently

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -572,19 +572,25 @@ def switch_model(
                         ),
                     )
             else:
-                # --- Step c: On aggregator, convert vendor:model to vendor/model ---
+                # --- Step c: Normalize provider:model to provider/model ---
                 # Only convert when there's no slash — a slash means the name
                 # is already in vendor/model format and the colon is a variant
                 # tag (:free, :extended, :fast) that must be preserved.
                 colon_pos = raw_input.find(":")
-                if colon_pos > 0 and "/" not in raw_input and is_aggregator(current_provider):
+                if colon_pos > 0 and "/" not in raw_input:
                     left = raw_input[:colon_pos].strip().lower()
                     right = raw_input[colon_pos + 1:].strip()
-                    if left and right:
-                        # Colons become slashes for aggregator slugs
+                    provider_like = resolve_provider_full(
+                        left,
+                        user_providers,
+                        custom_providers,
+                    )
+                    if provider_like is not None and right:
+                        # Convert only when the left side resolves like a provider.
+                        # This preserves model suffixes like :free, :extended, :fast.
                         new_model = f"{left}/{right}"
                         logger.debug(
-                            "Converted vendor:model '%s' to aggregator slug '%s'",
+                            "Normalized provider:model '%s' to '%s'",
                             raw_input, new_model,
                         )
 

--- a/tests/hermes_cli/test_model_switch_provider_colon_syntax.py
+++ b/tests/hermes_cli/test_model_switch_provider_colon_syntax.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_switch_model_normalizes_provider_colon_syntax_even_when_current_provider_is_not_aggregator(
+    monkeypatch,
+):
+    seen = {}
+
+    def fake_detect_provider_for_model(model, current_provider):
+        seen["model"] = model
+        seen["current_provider"] = current_provider
+        return None
+
+    def fake_resolve_provider_full(provider, user_providers=None, custom_providers=None):
+        if provider == "alibaba":
+            return SimpleNamespace(id="alibaba", name="Alibaba", base_url="", source="built-in")
+        return None
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_provider_full",
+        fake_resolve_provider_full,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        fake_detect_provider_for_model,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_info",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *a, **k: None,
+    )
+
+    result = switch_model(
+        raw_input="Alibaba:qwen3.6-plus",
+        current_provider="alibaba",
+        current_model="qwen3.6-plus",
+        current_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        current_api_key="test-key",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert seen["model"] == "alibaba/qwen3.6-plus"
+    assert seen["current_provider"] == "alibaba"
+
+
+def test_switch_model_does_not_rewrite_variant_suffix_when_model_is_already_provider_slash_model(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_info",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *a, **k: None,
+    )
+
+    result = switch_model(
+        raw_input="qwen/qwen3-coder:free",
+        current_provider="openrouter",
+        current_model="openai/gpt-5",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="test-key",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.new_model == "qwen/qwen3-coder:free"


### PR DESCRIPTION
Fixes #9748

## Summary

Normalize `/model` input so `provider:model` works consistently instead of only being rewritten when the current provider is an aggregator.

## Problem

Currently `/model Alibaba:qwen3.6-plus` can fail while `/model Alibaba/qwen3.6-plus` works depending on the current provider state.

The implementation only rewrites `provider:model` to `provider/model` when `is_aggregator(current_provider)` is true.

## Changes

- remove the aggregator-only gate from `provider:model` normalization
- only rewrite when the left side resolves as a valid provider
- preserve existing `provider/model:variant` inputs like `:free`
- add regression tests for:
  - `Alibaba:qwen3.6-plus`
  - already-correct slash syntax with variant suffixes

## Testing

```bash
python -m pytest tests/hermes_cli/test_model_switch_provider_colon_syntax.py
python -m pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py