### PR TITLE
fix(hindsight): make cloud client timeout configurable

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_GITHUB_MODELS_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -174,6 +175,7 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
+        base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     else:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -11,6 +11,7 @@ Config via environment variables:
   HINDSIGHT_BUDGET    — recall budget: low/mid/high (default: mid)
   HINDSIGHT_API_URL   — API endpoint
   HINDSIGHT_MODE      — cloud or local (default: cloud)
+  HINDSIGHT_TIMEOUT   — HTTP client timeout in seconds (default: 120)
 
 Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 ~/.hindsight/config.json (legacy, shared) for backward compatibility.
@@ -458,7 +459,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
-                kwargs = {"base_url": self._api_url, "timeout": 30.0}
+                kwargs = {"base_url": self._api_url, "timeout": self._timeout}
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
                 logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s)",
@@ -537,6 +538,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
         self._retain_async = self._config.get("retain_async", True)
+        self._timeout = float(self._config.get("timeout") or os.environ.get("HINDSIGHT_TIMEOUT", 120.0))
 
         _client_version = "unknown"
         try:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -215,13 +215,13 @@ class TestResolveVisionProviderClientModelNormalization:
 
     def test_vision_auto_strips_matching_main_provider_prefix(self, tmp_path):
         _write_config(tmp_path, {
-            "model": {"default": "deepseek/deepseek-chat", "provider": "deepseek"},
+            "model": {"default": "zai/glm-5.1", "provider": "zai"},
         })
         with (
             patch("agent.auxiliary_client._read_nous_auth", return_value=None),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
-                "api_key": "ds-key",
-                "base_url": "https://api.deepseek.com",
+                "api_key": "glm-key",
+                "base_url": "https://api.z.ai/api/paas/v4",
             }),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
@@ -230,7 +230,7 @@ class TestResolveVisionProviderClientModelNormalization:
 
             provider, client, model = resolve_vision_provider_client()
 
-        assert provider == "deepseek"
+        assert provider == "zai"
         assert client is not None
         assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
 

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -215,13 +215,13 @@ class TestResolveVisionProviderClientModelNormalization:
 
     def test_vision_auto_strips_matching_main_provider_prefix(self, tmp_path):
         _write_config(tmp_path, {
-            "model": {"default": "zai/glm-5.1", "provider": "zai"},
+            "model": {"default": "deepseek/deepseek-chat", "provider": "deepseek"},
         })
         with (
             patch("agent.auxiliary_client._read_nous_auth", return_value=None),
             patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
-                "api_key": "glm-key",
-                "base_url": "https://api.z.ai/api/paas/v4",
+                "api_key": "ds-key",
+                "base_url": "https://api.deepseek.com",
             }),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
@@ -230,7 +230,7 @@ class TestResolveVisionProviderClientModelNormalization:
 
             provider, client, model = resolve_vision_provider_client()
 
-        assert provider == "zai"
+        assert provider == "deepseek"
         assert client is not None
         assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
 


### PR DESCRIPTION
## Summary
- The Hindsight cloud client had a hardcoded 30s HTTP timeout, causing `hindsight_reflect` to fail on LLM synthesis that routinely exceeds 30s (#9869)
- The timeout is now configurable via config key `timeout` or `HINDSIGHT_TIMEOUT` env var, defaulting to 120s (matching the `_run_sync` wrapper timeout)

## Test plan
- Existing `hindsight_reflect` calls with slow LLM providers should no longer timeout prematurely
- Setting `HINDSIGHT_TIMEOUT=60` or `"timeout": 60` in config.json should override the default

Closes #9869