### PR TITLE
fix(acp): persist provider snapshot on initial session save

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -302,7 +302,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -170,6 +170,7 @@ AUTHOR_MAP = {
     "oncuevtv@gmail.com": "sprmn24",
     "programming@olafthiele.com": "olafthiele",
     "r2668940489@gmail.com": "r266-tech",
+    "ruzzgarcn@gmail.com": "Ruzzgar",
     "s5460703@gmail.com": "BlackishGreen33",
     "saul.jj.wu@gmail.com": "SaulJWu",
     "shenhaocheng19990111@gmail.com": "hcshen0111",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -140,6 +140,26 @@ class TestPersistence:
         mc = json.loads(row["model_config"])
         assert mc["cwd"] == "/project"
 
+    def test_create_session_persists_provider_snapshot_initially(self, tmp_path):
+        """The first ACP session row should be restorable after an immediate restart."""
+        agent = SimpleNamespace(
+            model="test-model",
+            provider="anthropic",
+            base_url="https://anthropic.example/v1",
+            api_mode="anthropic_messages",
+        )
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(agent_factory=lambda: agent, db=db)
+
+        state = manager.create_session(cwd="/work")
+
+        row = db.get_session(state.session_id)
+        mc = json.loads(row["model_config"])
+        assert mc["cwd"] == "/work"
+        assert mc["provider"] == "anthropic"
+        assert mc["base_url"] == "https://anthropic.example/v1"
+        assert mc["api_mode"] == "anthropic_messages"
+
     def test_get_session_restores_from_db(self, manager):
         """Simulate process restart: create session, drop from memory, get again."""
         state = manager.create_session(cwd="/work")


### PR DESCRIPTION
## Context

ACP session restore expects runtime connection details to be present in the saved session metadata.

That worked after later updates, but not on the very first persist.

What was going wrong

The initial session-create path only saved cwd, even though the persistence flow had already prepared a richer metadata payload containing:

provider
base_url
api_mode

So if a session was restored after its first save but before any later update, the provider snapshot was incomplete.

User-visible effect

A freshly created ACP session could lose its original provider/base URL/API mode snapshot across restart boundaries.

In practice, the first stored row looked like this:

{"cwd": "/work"}

instead of preserving the full runtime config snapshot.

Adjustment

Use the already prepared metadata payload for the initial create_session() call, so the create path matches the update path.

This keeps the fix very small:

no refactor
no new abstraction
no change to restore semantics beyond preserving the intended metadata earlier
Regression coverage

Added coverage for the first-save case to verify that the initial persisted ACP session row includes:

cwd
provider
base_url
api_mode
Verification

Validated with:

python -m pytest tests/acp/test_session.py -q

## Result:

26 passed in 4.25s

Closes #9812