### PR TITLE
[codex] fix plugin manifest locale-dependent decoding

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -85,6 +85,13 @@ def _get_disabled_plugins() -> set:
         return set()
 
 
+def load_plugin_manifest(manifest_file: Path) -> Any:
+    """Load a plugin manifest using UTF-8 instead of the host locale."""
+    if yaml is None:
+        raise RuntimeError("PyYAML not installed")
+    return yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -394,7 +401,7 @@ class PluginManager:
                 if yaml is None:
                     logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                     continue
-                data = yaml.safe_load(manifest_file.read_text()) or {}
+                data = load_plugin_manifest(manifest_file)
                 manifest = PluginManifest(
                     name=data.get("name", child.name),
                     version=str(data.get("version", "")),

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from hermes_cli.plugins import load_plugin_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +119,8 @@ def _read_manifest(plugin_dir: Path) -> dict:
     if not manifest_file.exists():
         return {}
     try:
-        import yaml
-
-        with open(manifest_file) as f:
-            return yaml.safe_load(f) or {}
+        data = load_plugin_manifest(manifest_file)
+        return data if isinstance(data, dict) else {}
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
@@ -539,11 +538,6 @@ def cmd_list() -> None:
     from rich.console import Console
     from rich.table import Table
 
-    try:
-        import yaml
-    except ImportError:
-        yaml = None
-
     console = Console()
     plugins_dir = _plugins_dir()
 
@@ -563,21 +557,16 @@ def cmd_list() -> None:
     table.add_column("Source", style="dim")
 
     for d in dirs:
-        manifest_file = d / "plugin.yaml"
         name = d.name
         version = ""
         description = ""
         source = "local"
 
-        if manifest_file.exists() and yaml:
-            try:
-                with open(manifest_file) as f:
-                    manifest = yaml.safe_load(f) or {}
-                name = manifest.get("name", d.name)
-                version = manifest.get("version", "")
-                description = manifest.get("description", "")
-            except Exception:
-                pass
+        manifest = _read_manifest(d)
+        if manifest:
+            name = manifest.get("name", d.name)
+            version = manifest.get("version", "")
+            description = manifest.get("description", "")
 
         # Check if it's a git repo (installed via hermes plugins install)
         if (d / ".git").exists():
@@ -742,11 +731,6 @@ def cmd_toggle() -> None:
     """Interactive composite UI — general plugins + provider plugin categories."""
     from rich.console import Console
 
-    try:
-        import yaml
-    except ImportError:
-        yaml = None
-
     console = Console()
     plugins_dir = _plugins_dir()
 
@@ -759,18 +743,13 @@ def cmd_toggle() -> None:
     plugin_selected = set()
 
     for i, d in enumerate(dirs):
-        manifest_file = d / "plugin.yaml"
         name = d.name
         description = ""
 
-        if manifest_file.exists() and yaml:
-            try:
-                with open(manifest_file) as f:
-                    manifest = yaml.safe_load(f) or {}
-                name = manifest.get("name", d.name)
-                description = manifest.get("description", "")
-            except Exception:
-                pass
+        manifest = _read_manifest(d)
+        if manifest:
+            name = manifest.get("name", d.name)
+            description = manifest.get("description", "")
 
         plugin_names.append(name)
         label = f"{name} \u2014 {description}" if description else name

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -62,6 +62,33 @@ class TestPluginDiscovery:
         assert "hello_plugin" in mgr._plugins
         assert mgr._plugins["hello_plugin"].enabled
 
+    def test_discover_user_plugins_reads_utf8_manifest(self, tmp_path, monkeypatch):
+        """UTF-8 plugin manifests load correctly regardless of host locale."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "utf8_plugin"
+        plugin_dir.mkdir(parents=True)
+        description = "UTF-8 manifest — loaded across locales"
+        (plugin_dir / "plugin.yaml").write_text(
+            (
+                'name: utf8_plugin\n'
+                'version: "0.1.0"\n'
+                f'description: "{description}"\n'
+            ),
+            encoding="utf-8",
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n    pass\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "utf8_plugin" in mgr._plugins
+        assert mgr._plugins["utf8_plugin"].enabled
+        assert mgr._plugins["utf8_plugin"].manifest.description == description
+
     def test_discover_project_plugins(self, tmp_path, monkeypatch):
         """Plugins in ./.hermes/plugins/ are discovered."""
         project_dir = tmp_path / "project"

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -192,6 +192,19 @@ class TestReadManifest:
         assert result["name"] == "cool-plugin"
         assert result["version"] == "1.0.0"
 
+    def test_utf8_manifest_with_non_ascii_text(self, tmp_path):
+        description = "Recent state-transition awareness plugin — protects overrides"
+        (tmp_path / "plugin.yaml").write_text(
+            (
+                "name: temporal-guard\n"
+                'version: "1.0.0"\n'
+                f'description: "{description}"\n'
+            ),
+            encoding="utf-8",
+        )
+        result = _read_manifest(tmp_path)
+        assert result["description"] == description
+
     def test_missing_file_returns_empty(self, tmp_path):
         result = _read_manifest(tmp_path)
         assert result == {}
@@ -609,7 +622,7 @@ class TestProviderDiscovery:
         config_file.write_text("memory:\n  provider: ''\n")
         from hermes_cli.plugins_cmd import _save_memory_provider
         _save_memory_provider("honcho")
-        content = yaml.safe_load(config_file.read_text())
+        content = yaml.safe_load(config_file.read_text(encoding="utf-8"))
         assert content["memory"]["provider"] == "honcho"
 
     def test_save_context_engine(self, tmp_path, monkeypatch):
@@ -619,7 +632,7 @@ class TestProviderDiscovery:
         config_file.write_text("context:\n  engine: compressor\n")
         from hermes_cli.plugins_cmd import _save_context_engine
         _save_context_engine("lcm")
-        content = yaml.safe_load(config_file.read_text())
+        content = yaml.safe_load(config_file.read_text(encoding="utf-8"))
         assert content["context"]["engine"] == "lcm"
 
     def test_discover_memory_providers_empty(self):
@@ -651,7 +664,7 @@ class TestNoAutoActivation:
         # This tests the run_agent.py logic indirectly by checking that the
         # code path for default config doesn't call get_plugin_context_engine.
         import run_agent as ra_module
-        source = open(ra_module.__file__).read()
+        source = Path(ra_module.__file__).read_text(encoding="utf-8")
         # The old code had: "Even with default config, check if a plugin registered one"
         # The fix removes this. Verify it's gone.
         assert "Even with default config, check if a plugin registered one" not in source


### PR DESCRIPTION
## What does this PR do?

This PR makes plugin manifest loading deterministic across platforms by reading `plugin.yaml` as UTF-8 instead of relying on the host locale.

On Windows 11 with a `cp950` locale, plugin discovery and `hermes plugins` CLI paths failed to parse manifests containing non-ASCII UTF-8 text such as an em dash (`—`). That caused valid plugins to be skipped even though the manifest itself was well-formed YAML.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a shared UTF-8 manifest loader in `hermes_cli/plugins.py`
- Updated plugin discovery in `hermes_cli/plugins.py` to use the shared loader
- Updated manifest reads in `hermes_cli/plugins_cmd.py` so CLI listing/toggling uses the same UTF-8 path
- Added regression tests covering UTF-8 manifest text with non-ASCII characters
- Updated three Windows-sensitive test reads in `tests/hermes_cli/test_plugins_cmd.py` so the plugin test suite is stable under non-UTF-8 locales

## How to Test

1. On Windows with a non-UTF-8 locale, create or use a plugin manifest whose description contains a UTF-8 character such as `—`
2. Run plugin discovery or `hermes plugins` commands before this change and observe the manifest parse failure
3. With this branch, run:
   - `pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py -q`
4. Verify the manifest loads successfully and the plugin appears in discovery / CLI output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction before the fix on Windows 11 (`cp950` locale):

```text
Failed to parse C:\Users\linkl\AppData\Local\hermes\plugins\temporal-guard\plugin.yaml: 'cp950' codec can't decode byte 0xe2 in position 92: illegal multibyte sequence
```

Validation run on this branch:

```text
pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py -q
91 passed
```