### PR TITLE
fix: block agent from self-destructing gateway via terminal (#6666)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -550,11 +550,12 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
-    def test_systemctl_restart_not_flagged(self):
-        """Using systemctl to manage the gateway is the correct approach."""
+    def test_systemctl_restart_flagged(self):
+        """systemctl restart kills running agents and should require approval."""
         cmd = "systemctl --user restart hermes-gateway"
         dangerous, key, desc = detect_dangerous_command(cmd)
-        assert dangerous is False
+        assert dangerous is True
+        assert "stop/restart" in desc
 
     def test_pkill_hermes_detected(self):
         """pkill targeting hermes/gateway processes must be caught."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -87,7 +87,7 @@ DANGEROUS_PATTERNS = [
     (r'\bDELETE\s+FROM\b(?!.*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
     (r'>\s*/etc/', "overwrite system config"),
-    (r'\bsystemctl\s+(stop|disable|mask)\b', "stop/disable system service"),
+    (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
@@ -101,6 +101,11 @@ DANGEROUS_PATTERNS = [
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     (r'\bfind\b.*-exec\s+(/\S*/)?rm\b', "find -exec rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),
+    # Gateway lifecycle protection: prevent the agent from killing its own
+    # gateway process.  These commands trigger a gateway restart/stop that
+    # terminates all running agents mid-work.
+    (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
+    (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),


### PR DESCRIPTION
## Summary

Fixes #6666 — agents running `hermes gateway restart`, `hermes update`, or `systemctl restart hermes-gateway` via the terminal tool kill the gateway process mid-work. Users see the agent suddenly stop responding.

### Changes

**tools/approval.py** (+8/-2):
- Added `hermes gateway stop/restart` pattern — requires approval
- Added `hermes update` pattern — requires approval (triggers gateway restart)
- Extended `systemctl` pattern to match flags between command and action: `systemctl --user restart` was previously undetected because the regex expected the action immediately after `systemctl`
- `restart` added to the existing `stop|disable|mask` systemctl pattern

**tests/tools/test_approval.py** (+2/-2):
- Updated `test_systemctl_restart_not_flagged` → `test_systemctl_restart_flagged` (intentional behavior change)

### What gets blocked vs allowed

| Command | Blocked? | Why |
|---------|----------|-----|
| `hermes gateway restart` | ✓ Requires approval | Kills running agents |
| `hermes gateway stop` | ✓ Requires approval | Kills running agents |
| `hermes update` | ✓ Requires approval | Restarts gateway |
| `systemctl restart hermes-gateway` | ✓ Requires approval | Kills running agents |
| `systemctl --user restart hermes-gateway` | ✓ Requires approval | Kills running agents |
| `hermes gateway status` | Safe | Read-only |
| `hermes gateway setup` | Safe | Configuration only |
| `systemctl status hermes-gateway` | Safe | Read-only |

In YOLO mode, these commands still execute without approval (by design).

## Test plan
- All 119 approval tests pass
- E2E verified pattern detection for all new commands
