### PR TITLE
fix(insights): count mixed tool usage across sessions

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -212,39 +212,39 @@ class InsightsEngine:
         2. tool_calls JSON on 'assistant' role messages (covers CLI where
            tool_name is not populated on tool responses)
         """
-        tool_counts = Counter()
+        tool_counts_by_session = Counter()
 
         # Source 1: explicit tool_name on tool response messages
         if source:
             cursor = self._conn.execute(
-                """SELECT m.tool_name, COUNT(*) as count
+                """SELECT m.session_id, m.tool_name, COUNT(*) as count
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ? AND s.source = ?
                      AND m.role = 'tool' AND m.tool_name IS NOT NULL
-                   GROUP BY m.tool_name
+                   GROUP BY m.session_id, m.tool_name
                    ORDER BY count DESC""",
                 (cutoff, source),
             )
         else:
             cursor = self._conn.execute(
-                """SELECT m.tool_name, COUNT(*) as count
+                """SELECT m.session_id, m.tool_name, COUNT(*) as count
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ?
                      AND m.role = 'tool' AND m.tool_name IS NOT NULL
-                   GROUP BY m.tool_name
+                   GROUP BY m.session_id, m.tool_name
                    ORDER BY count DESC""",
                 (cutoff,),
             )
         for row in cursor.fetchall():
-            tool_counts[row["tool_name"]] += row["count"]
+            tool_counts_by_session[(row["session_id"], row["tool_name"])] += row["count"]
 
         # Source 2: extract from tool_calls JSON on assistant messages
         # (covers CLI sessions where tool_name is NULL on tool responses)
         if source:
             cursor2 = self._conn.execute(
-                """SELECT m.tool_calls
+                """SELECT m.session_id, m.tool_calls
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ? AND s.source = ?
@@ -253,7 +253,7 @@ class InsightsEngine:
             )
         else:
             cursor2 = self._conn.execute(
-                """SELECT m.tool_calls
+                """SELECT m.session_id, m.tool_calls
                    FROM messages m
                    JOIN sessions s ON s.id = m.session_id
                    WHERE s.started_at >= ?
@@ -261,7 +261,7 @@ class InsightsEngine:
                 (cutoff,),
             )
 
-        tool_calls_counts = Counter()
+        tool_calls_counts_by_session = Counter()
         for row in cursor2.fetchall():
             try:
                 calls = row["tool_calls"]
@@ -272,23 +272,24 @@ class InsightsEngine:
                         func = call.get("function", {}) if isinstance(call, dict) else {}
                         name = func.get("name")
                         if name:
-                            tool_calls_counts[name] += 1
+                            tool_calls_counts_by_session[(row["session_id"], name)] += 1
             except (json.JSONDecodeError, TypeError, AttributeError):
                 continue
 
-        # Merge: prefer tool_name source, supplement with tool_calls source
-        # for tools not already counted
-        if not tool_counts and tool_calls_counts:
-            # No tool_name data at all — use tool_calls exclusively
-            tool_counts = tool_calls_counts
-        elif tool_counts and tool_calls_counts:
-            # Both sources have data — use whichever has the higher count per tool
-            # (they may overlap, so take the max to avoid double-counting)
-            all_tools = set(tool_counts) | set(tool_calls_counts)
-            merged = Counter()
-            for tool in all_tools:
-                merged[tool] = max(tool_counts.get(tool, 0), tool_calls_counts.get(tool, 0))
-            tool_counts = merged
+        # Merge per session/tool so mixed datasets across different sessions add
+        # together, while duplicated representations inside the same session
+        # still collapse to the higher count.
+        merged_by_session = Counter()
+        all_session_tools = set(tool_counts_by_session) | set(tool_calls_counts_by_session)
+        for session_tool in all_session_tools:
+            merged_by_session[session_tool] = max(
+                tool_counts_by_session.get(session_tool, 0),
+                tool_calls_counts_by_session.get(session_tool, 0),
+            )
+
+        tool_counts = Counter()
+        for (_, tool_name), count in merged_by_session.items():
+            tool_counts[tool_name] += count
 
         # Convert to the expected format
         return [

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -630,6 +630,30 @@ class TestEdgeCases:
         sf = next(t for t in tools if t["tool"] == "search_files")
         assert sf["count"] == 2
 
+    def test_tool_usage_sums_disjoint_sessions_across_sources(self, db):
+        """tool_name and tool_calls sources should add across different sessions."""
+        db.create_session(session_id="gateway", source="gateway", model="test")
+        db.append_message("gateway", role="tool", content="results", tool_name="search_files")
+
+        db.create_session(session_id="cli", source="cli", model="test")
+        db.append_message(
+            "cli",
+            role="assistant",
+            content="Let me search",
+            tool_calls=[{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search_files", "arguments": "{}"},
+            }],
+        )
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+
+        search_files = next(t for t in report["tools"] if t["tool"] == "search_files")
+        assert search_files["count"] == 2
+
     def test_overview_pricing_sets_are_lists(self, db):
         """models_with/without_pricing should be JSON-serializable lists."""
         import json as _json


### PR DESCRIPTION
## What does this PR do?

Fixes insights tool-usage undercounting when one session records tools via `tool_name` rows and another records them only via assistant `tool_calls`. The merge now happens per `(session_id, tool_name)` so mixed datasets add across sessions without double-counting duplicate representations inside a single session.

## Related Issue

Fixes #9814

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/insights.py`: aggregate tool usage by `(session_id, tool_name)` before collapsing to repo-wide totals.
- `tests/agent/test_insights.py`: add regression coverage for one `tool_name`-only session plus one `tool_calls`-only session for the same tool.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/agent/test_insights.py -q`.
2. Create one session with a `tool` row containing `tool_name="search_files"`.
3. Create a second session with only assistant `tool_calls` for `search_files` and confirm insights reports a count of `2`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/agent/test_insights.py -q` → `55 passed`
- `uv run --extra dev python -m pytest tests/ -q` is not green in this environment because of unrelated existing failures and missing optional dependencies such as `acp`, `fastapi`, and `faster_whisper`
