### PR TITLE
feat(dashboard): add chat interface via API server proxy

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2022,6 +2022,116 @@ async def get_usage_analytics(days: int = 30):
         db.close()
 
 
+
+# ---------------------------------------------------------------------------
+# Chat proxy — thin relay to the API server's /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+_API_SERVER_PORT = int(os.getenv("API_SERVER_PORT", "8642"))
+
+
+class ChatRequest(BaseModel):
+    messages: List[Dict[str, Any]]
+    session_id: Optional[str] = None
+
+
+@app.post("/api/chat/send")
+async def chat_send(body: ChatRequest):
+    """Proxy a chat message to the gateway's API server with SSE streaming."""
+    try:
+        import httpx
+    except ImportError:
+        raise HTTPException(status_code=501, detail="httpx not installed")
+
+    api_url = f"http://127.0.0.1:{_API_SERVER_PORT}/v1/chat/completions"
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    api_key = os.getenv("API_SERVER_KEY", "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if body.session_id:
+        headers["X-Hermes-Session-Id"] = body.session_id
+
+    from starlette.responses import StreamingResponse
+
+    async def stream_proxy():
+        got_content = False
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+                async with client.stream(
+                    "POST", api_url,
+                    json={"messages": body.messages, "stream": True},
+                    headers=headers,
+                ) as resp:
+                    if resp.status_code != 200:
+                        error_body = await resp.aread()
+                        yield f"data: {json.dumps({'error': error_body.decode()})}\n\n"
+                        return
+                    async for line in resp.aiter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+                        data = line[6:]
+                        if data == "[DONE]":
+                            yield f"{line}\n\n"
+                            break
+                        try:
+                            chunk = json.loads(data)
+                            delta = chunk.get("choices", [{}])[0].get("delta", {})
+                            finish = chunk.get("choices", [{}])[0].get("finish_reason")
+                            if delta.get("content"):
+                                got_content = True
+                            yield f"{line}\n\n"
+                            # Stream ended without content (agent error) - break early
+                            if finish and not got_content:
+                                break
+                        except (json.JSONDecodeError, IndexError):
+                            yield f"{line}\n\n"
+
+                # Empty stream fallback: non-streaming request to surface errors
+                if not got_content:
+                    try:
+                        fb = await client.post(
+                            api_url,
+                            json={"messages": body.messages, "stream": False},
+                            headers=headers,
+                            timeout=httpx.Timeout(120.0),
+                        )
+                        if fb.status_code == 200:
+                            content = fb.json().get("choices", [{}])[0].get("message", {}).get("content", "")
+                            if content:
+                                yield f"data: {json.dumps({'choices': [{'index': 0, 'delta': {'content': content}, 'finish_reason': 'stop'}]})}\n\n"
+                                yield "data: [DONE]\n\n"
+                    except Exception:
+                        pass
+
+        except httpx.ConnectError:
+            yield f"data: {json.dumps({'error': 'API server not reachable. Start the gateway with the api_server platform enabled.'})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
+    return StreamingResponse(
+        stream_proxy(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@app.get("/api/chat/status")
+async def chat_status():
+    """Check whether the API server is reachable for chat."""
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=httpx.Timeout(3.0)) as client:
+            resp = await client.get(f"http://127.0.0.1:{_API_SERVER_PORT}/health")
+            if resp.status_code == 200:
+                return {"available": True}
+    except Exception:
+        pass
+    return {
+        "available": False,
+        "message": "API server not reachable. Start the gateway with the api_server platform enabled.",
+    }
+
+
 def mount_spa(application: FastAPI):
     """Mount the built SPA. Falls back to index.html for client-side routing.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, NavLink, Navigate } from "react-router-dom";
-import { Activity, BarChart3, Clock, FileText, KeyRound, MessageSquare, Package, Settings } from "lucide-react";
+import { Activity, BarChart3, Clock, FileText, KeyRound, MessageCircle, MessageSquare, Package, Settings } from "lucide-react";
 import StatusPage from "@/pages/StatusPage";
 import ConfigPage from "@/pages/ConfigPage";
 import EnvPage from "@/pages/EnvPage";
@@ -8,11 +8,13 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import CronPage from "@/pages/CronPage";
 import SkillsPage from "@/pages/SkillsPage";
+import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { useI18n } from "@/i18n";
 
 const NAV_ITEMS = [
   { path: "/", labelKey: "status" as const, icon: Activity },
+  { path: "/chat", labelKey: "chat" as const, icon: MessageCircle },
   { path: "/sessions", labelKey: "sessions" as const, icon: MessageSquare },
   { path: "/analytics", labelKey: "analytics" as const, icon: BarChart3 },
   { path: "/logs", labelKey: "logs" as const, icon: FileText },
@@ -78,6 +80,7 @@ export default function App() {
       <main className="relative z-2 mx-auto w-full max-w-[1400px] flex-1 px-3 sm:px-6 pt-16 sm:pt-20 pb-4 sm:pb-8">
         <Routes>
           <Route path="/" element={<StatusPage />} />
+          <Route path="/chat" element={<ChatPage />} />
           <Route path="/sessions" element={<SessionsPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/logs" element={<LogsPage />} />

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -54,6 +54,7 @@ export const en: Translations = {
     },
     nav: {
       status: "Status",
+      chat: "Chat",
       sessions: "Sessions",
       analytics: "Analytics",
       logs: "Logs",
@@ -270,6 +271,13 @@ export const en: Translations = {
       external: "External CLI",
     },
     expiresIn: "expires in {time}",
+  },
+
+  chat: {
+    unavailable: "Chat unavailable",
+    unavailableDesc: "The API server platform is not running. Start the gateway with the API server platform enabled to use chat.",
+    placeholder: "Send a message to start chatting with Hermes",
+    inputPlaceholder: "Message Hermes...",
   },
 
   language: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -56,6 +56,7 @@ export interface Translations {
     };
     nav: {
       status: string;
+      chat: string;
       sessions: string;
       analytics: string;
       logs: string;
@@ -281,6 +282,14 @@ export interface Translations {
       external: string;
     };
     expiresIn: string;
+  };
+
+  // ── Chat page ──
+  chat: {
+    unavailable: string;
+    unavailableDesc: string;
+    placeholder: string;
+    inputPlaceholder: string;
   };
 
   // ── Language switcher ──

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -54,6 +54,7 @@ export const zh: Translations = {
     },
     nav: {
       status: "状态",
+      chat: "聊天",
       sessions: "会话",
       analytics: "分析",
       logs: "日志",
@@ -270,6 +271,13 @@ export const zh: Translations = {
       external: "外部 CLI",
     },
     expiresIn: "{time}后过期",
+  },
+
+  chat: {
+    unavailable: "聊天不可用",
+    unavailableDesc: "API 服务器平台未运行。请启动网关并启用 API 服务器平台以使用聊天。",
+    placeholder: "发送消息开始与 Hermes 聊天",
+    inputPlaceholder: "给 Hermes 发消息...",
   },
 
   language: {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -182,6 +182,10 @@ export const api = {
       },
     );
   },
+
+  // Chat
+  checkChatStatus: () =>
+    fetchJSON<{ available: boolean; message?: string }>("/api/chat/status"),
 };
 
 export interface PlatformStatus {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,0 +1,212 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Send, Loader2, AlertCircle, Bot, User } from "lucide-react";
+import { api } from "@/lib/api";
+import { Markdown } from "@/components/Markdown";
+import { useI18n } from "@/i18n";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [unavailableMsg, setUnavailableMsg] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const { t } = useI18n();
+
+  useEffect(() => {
+    api.checkChatStatus().then((resp) => {
+      setAvailable(resp.available);
+      if (!resp.available) setUnavailableMsg(resp.message || "");
+    }).catch(() => setAvailable(false));
+  }, []);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    const el = e.target;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 160) + "px";
+  };
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || streaming) return;
+
+    const userMsg: Message = { role: "user", content: text };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput("");
+    setStreaming(true);
+
+    if (inputRef.current) inputRef.current.style.height = "auto";
+
+    const apiMessages = newMessages.map((m) => ({ role: m.role, content: m.content }));
+
+    try {
+      const token = window.__HERMES_SESSION_TOKEN__;
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
+      const resp = await fetch("/api/chat/send", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ messages: apiMessages, session_id: sessionId }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        const errText = await resp.text().catch(() => "Unknown error");
+        setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${errText}` }]);
+        setStreaming(false);
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let assistantContent = "";
+      let buffer = "";
+
+      setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6);
+          if (data === "[DONE]") continue;
+
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.error) {
+              assistantContent += parsed.error;
+              setMessages((prev) => {
+                const updated = [...prev];
+                updated[updated.length - 1] = { role: "assistant", content: assistantContent };
+                return updated;
+              });
+              continue;
+            }
+            const delta = parsed.choices?.[0]?.delta?.content;
+            if (delta) {
+              assistantContent += delta;
+              setMessages((prev) => {
+                const updated = [...prev];
+                updated[updated.length - 1] = { role: "assistant", content: assistantContent };
+                return updated;
+              });
+            }
+            if (!sessionId && parsed.id) {
+              setSessionId(parsed.id);
+            }
+          } catch {
+            // skip
+          }
+        }
+      }
+    } catch (err) {
+      setMessages((prev) => [...prev, { role: "assistant", content: `Connection error: ${err}` }]);
+    } finally {
+      setStreaming(false);
+      inputRef.current?.focus();
+    }
+  }, [input, messages, streaming, sessionId]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  if (available === false) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-muted-foreground gap-3">
+        <AlertCircle className="h-8 w-8 opacity-40" />
+        <p className="text-sm font-medium">{t.chat?.unavailable ?? "Chat unavailable"}</p>
+        <p className="text-xs text-center max-w-sm leading-relaxed">
+          {unavailableMsg || (t.chat?.unavailableDesc ?? "The API server platform is not running. Start the gateway with the API server platform enabled to use chat.")}
+        </p>
+        <code className="text-xs bg-muted/50 px-3 py-1.5 font-mono">hermes gateway start</code>
+      </div>
+    );
+  }
+
+  if (available === null) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-8rem)] sm:h-[calc(100vh-10rem)]">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto space-y-1 pb-4">
+        {messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
+            <Bot className="h-8 w-8 opacity-30" />
+            <p className="text-sm">{t.chat?.placeholder ?? "Send a message to start chatting with Hermes"}</p>
+          </div>
+        )}
+        {messages.map((msg, i) => (
+          <div key={i} className={`flex gap-3 px-2 py-3 ${msg.role === "user" ? "" : "bg-muted/20"}`}>
+            <div className="shrink-0 mt-0.5">
+              {msg.role === "user" ? (
+                <User className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <Bot className="h-5 w-5 text-foreground" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0 text-sm leading-relaxed">
+              {msg.role === "assistant" ? (
+                <Markdown content={msg.content || (streaming && i === messages.length - 1 ? "..." : "")} />
+              ) : (
+                <p className="whitespace-pre-wrap">{msg.content}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="border-t border-border bg-background/80 backdrop-blur-sm pt-3 pb-1">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            placeholder={t.chat?.inputPlaceholder ?? "Message Hermes..."}
+            rows={1}
+            disabled={streaming}
+            className="flex-1 resize-none bg-muted/30 border border-border px-3 py-2.5 text-sm placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/30 min-h-[40px] max-h-[160px]"
+          />
+          <button
+            type="button"
+            onClick={sendMessage}
+            disabled={streaming || !input.trim()}
+            className="h-10 w-10 flex items-center justify-center bg-foreground text-background shrink-0 disabled:opacity-30 cursor-pointer disabled:cursor-not-allowed"
+          >
+            {streaming ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Chat tab to the dashboard. Proxies to the gateway's existing API server (`/v1/chat/completions`) — no new agent lifecycle code, no new dependencies.

## Backend — 2 endpoints, 110 lines

**`POST /api/chat/send`** — SSE streaming proxy to `localhost:8642/v1/chat/completions`
- Forwards messages + optional `X-Hermes-Session-Id` for session continuity
- Passes `API_SERVER_KEY` to the API server when set
- Handles empty stream (agent internal errors): detects `finish_reason` without content, falls back to a non-streaming request to surface the actual error message
- Respects `API_SERVER_PORT` env var

**`GET /api/chat/status`** — health check, hits the API server's `/health` endpoint

Both are protected by the existing auth middleware (#9800).

## Frontend — ChatPage.tsx, 212 lines

- SSE stream parsing (OpenAI-compatible `choices[0].delta.content` chunks)
- Markdown rendering via existing `Markdown` component
- Session continuity (stores session ID from first response, sends on subsequent messages)
- Auto-scroll to bottom on new content
- Auto-resize textarea, Enter to send, Shift+Enter for newline
- When gateway isn't running: "Chat unavailable" with `hermes gateway start` instruction
- i18n: English + Chinese translations

## Requires

The gateway must be running with the `api_server` platform enabled:
```yaml
# ~/.hermes/config.yaml
platforms:
  api_server:
    enabled: true
```
Then `hermes gateway start`. The Chat tab detects this automatically and shows setup instructions if not configured.

## Files changed

| File | Lines | What |
|------|-------|------|
| `hermes_cli/web_server.py` | +110 | Chat proxy endpoints |
| `web/src/pages/ChatPage.tsx` | +212 | Chat UI (new file) |
| `web/src/App.tsx` | +4 | Add Chat route + nav item |
| `web/src/lib/api.ts` | +4 | `checkChatStatus()` method |
| `web/src/i18n/types.ts` | +9 | Chat string types |
| `web/src/i18n/en.ts` | +8 | English strings |
| `web/src/i18n/zh.ts` | +8 | Chinese strings |