### PR TITLE
fix: left-align banner hero art to preserve braille-based skin symmetry

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -353,7 +353,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             disabled_tools.update(tools_in_ts)
 
     layout_table = Table.grid(padding=(0, 2))
-    layout_table.add_column("left", justify="center")
+    layout_table.add_column("left", justify="left")
     layout_table.add_column("right", justify="left")
 
     # Resolve skin colors once for the entire banner


### PR DESCRIPTION
## Summary
Left-aligns the banner's left column instead of centering it, preventing Rich from injecting ASCII-space padding that distorts braille-based skins.

## Root Cause
The CLI welcome banner centered the left column (`justify="center"`), which caused Rich to add ASCII-space padding around the hero art. For skins using U+2800 braille blank padding for symmetry, this centering changed the apparent silhouette and made symmetric braille-based skins look mangled.

## Fix
Changed `layout_table.add_column("left", justify="center")` to `justify="left"` in `hermes_cli/banner.py`.

## Test Plan
- [ ] Relevant unit tests pass
- [ ] Manual verification: load a braille-based skin and verify hero art renders without extra centering padding

Closes NousResearch/hermes-agent#9879