### PR TITLE
diag: log hermes processes on unexpected gateway shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9273,6 +9273,29 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         nonlocal _signal_initiated_shutdown
         _signal_initiated_shutdown = True
         logger.info("Received SIGTERM/SIGINT — initiating shutdown")
+        # Diagnostic: log all hermes-related processes so we can identify
+        # what triggered the signal (hermes update, hermes gateway restart,
+        # a stale detached subprocess, etc.).
+        try:
+            import subprocess as _sp
+            _ps = _sp.run(
+                ["ps", "aux"],
+                capture_output=True, text=True, timeout=3,
+            )
+            _hermes_procs = [
+                line for line in _ps.stdout.splitlines()
+                if ("hermes" in line.lower() or "gateway" in line.lower())
+                and str(os.getpid()) not in line.split()[1:2]  # exclude self
+            ]
+            if _hermes_procs:
+                logger.warning(
+                    "Shutdown diagnostic — other hermes processes running:\n  %s",
+                    "\n  ".join(_hermes_procs),
+                )
+            else:
+                logger.info("Shutdown diagnostic — no other hermes processes found")
+        except Exception:
+            pass
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():


### PR DESCRIPTION
## Context

Follow-up to #9850, #9875, #9895. We traced a user's gateway restarts to deliberate `systemctl restart` commands (confirmed via journalctl), but could not determine **what** is issuing them. The user says they're not restarting manually, no `/update` or `/restart` appears in the agent logs, and there's no auto-update mechanism.

## Change

When the gateway receives SIGTERM/SIGINT, the shutdown handler now runs `ps aux` and logs every hermes/gateway-related process (excluding itself) at WARNING level. Next time the mystery restart happens, agent.log will show:

```
WARNING: Shutdown diagnostic — other hermes processes running:
  hermes  1234 ... hermes update --gateway
  hermes  5678 ... hermes gateway restart
```

Or if nothing is found:
```
INFO: Shutdown diagnostic — no other hermes processes found
```

The second case would prove the signal came from outside our codebase (systemd itself, WSL2 VM management, a cron job, etc.).

Best-effort: subprocess call is wrapped in try/except with a 3-second timeout so it never blocks shutdown.

## Test plan
- All 13 restart drain tests pass
- py_compile OK
