### PR TITLE
security: add read deny list for sensitive credential files

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from tools.file_operations import (
+    _is_read_denied,
     _is_write_denied,
     WRITE_DENIED_PATHS,
     WRITE_DENIED_PREFIXES,
@@ -57,6 +58,58 @@ class TestIsWriteDenied:
     def test_tilde_expansion(self):
         assert _is_write_denied("~/.ssh/authorized_keys") is True
 
+
+# =========================================================================
+# Read deny list — mirrors write deny for credential exfiltration prevention
+# =========================================================================
+
+class TestIsReadDenied:
+    def test_ssh_private_key_denied(self):
+        path = os.path.join(str(Path.home()), ".ssh", "id_ed25519")
+        assert _is_read_denied(path) is True
+
+    def test_ssh_rsa_key_denied(self):
+        path = os.path.join(str(Path.home()), ".ssh", "id_rsa")
+        assert _is_read_denied(path) is True
+
+    def test_aws_credentials_denied(self):
+        path = os.path.join(str(Path.home()), ".aws", "credentials")
+        assert _is_read_denied(path) is True
+
+    def test_kube_config_denied(self):
+        path = os.path.join(str(Path.home()), ".kube", "config")
+        assert _is_read_denied(path) is True
+
+    def test_gnupg_denied(self):
+        path = os.path.join(str(Path.home()), ".gnupg", "private-keys-v1.d", "key.gpg")
+        assert _is_read_denied(path) is True
+
+    def test_docker_config_denied(self):
+        path = os.path.join(str(Path.home()), ".docker", "config.json")
+        assert _is_read_denied(path) is True
+
+    def test_etc_passwd_denied(self):
+        assert _is_read_denied("/etc/passwd") is True
+
+    def test_netrc_denied(self):
+        path = os.path.join(str(Path.home()), ".netrc")
+        assert _is_read_denied(path) is True
+
+    def test_etc_shadow_denied(self):
+        assert _is_read_denied("/etc/shadow") is True
+
+    def test_normal_file_allowed(self, tmp_path):
+        path = str(tmp_path / "readme.md")
+        assert _is_read_denied(path) is False
+
+    def test_project_file_allowed(self):
+        assert _is_read_denied("/tmp/project/main.py") is False
+
+    def test_tilde_expansion(self):
+        assert _is_read_denied("~/.ssh/id_ed25519") is True
+
+    def test_home_directory_itself_allowed(self):
+        assert _is_read_denied(str(Path.home())) is False
 
 
 # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -96,6 +96,22 @@ def _get_safe_write_root() -> Optional[str]:
         return None
 
 
+def _is_read_denied(path: str) -> bool:
+    """Return True if path targets a sensitive credential/key file.
+
+    Mirrors the write deny list for reads.  Without this, an agent can
+    ``read_file("~/.ssh/id_ed25519")`` and exfiltrate the key via any
+    outbound channel (web search query, tool parameter, message send).
+    """
+    resolved = os.path.realpath(os.path.expanduser(str(path)))
+    if resolved in WRITE_DENIED_PATHS:
+        return True
+    for prefix in WRITE_DENIED_PREFIXES:
+        if resolved.startswith(prefix):
+            return True
+    return False
+
+
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
     resolved = os.path.realpath(os.path.expanduser(str(path)))
@@ -468,18 +484,22 @@ class ShellFileOperations(FileOperations):
     def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
-        
+
         Args:
             path: File path (absolute or relative to cwd)
             offset: Line number to start from (1-indexed, default 1)
             limit: Maximum lines to return (default 500, max 2000)
-        
+
         Returns:
             ReadResult with content, metadata, or error info
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
+        # Block reads of sensitive credential/key files
+        if _is_read_denied(path):
+            return ReadResult(error=f"Read denied: '{path}' is a protected credential/key file.")
+
         # Clamp limit
         limit = min(limit, MAX_LINES)
         
@@ -613,6 +633,8 @@ class ShellFileOperations(FileOperations):
         Uses cat so the full file is returned regardless of size.
         """
         path = self._expand_path(path)
+        if _is_read_denied(path):
+            return ReadResult(error=f"Read denied: '{path}' is a protected credential/key file.")
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)
         if stat_result.exit_code != 0:


### PR DESCRIPTION
## Problem

`file_operations.py` has a `WRITE_DENIED_PATHS` deny list that blocks writes to `~/.ssh/`, `~/.aws/`, `~/.gnupg/`, `~/.kube/`, `~/.docker/`, `/etc/shadow`, etc. But there is **no equivalent read guard**.

An agent can:
```
read_file("~/.ssh/id_ed25519")
```
The private key content enters the conversation context and can be exfiltrated via any outbound channel — a web search query parameter, a tool call argument, a message send, or even a skill that phones home.

## Fix

Adds `_is_read_denied(path)` mirroring the existing write deny list. Gates `read_file()` and `read_file_raw()` behind it. Returns `ReadResult(error=...)` for denied paths, consistent with how write denials work.

Same paths, same prefix matching, same `realpath` resolution — just applied symmetrically to reads.

## Files changed

- `tools/file_operations.py` — add `_is_read_denied()`, gate `read_file()` and `read_file_raw()`
- `tests/tools/test_file_operations.py` — 13 new tests for read deny list

No new dependencies. No config changes. Default-on.

## Test plan

- [ ] `pytest tests/tools/test_file_operations.py::TestIsReadDenied` — all 13 pass
- [ ] `read_file("~/.ssh/id_ed25519")` returns error, not content
- [ ] `read_file("/tmp/project/main.py")` still works normally

🤖 Generated with [Claude Code](https://claude.ai/code)