### PR TITLE
feat: add camofox browser takeover tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -396,6 +396,10 @@ DEFAULT_CONFIG = {
             # Requires Camofox server to be configured with CAMOFOX_PROFILE_DIR.
             # When false (default), each session gets a random userId (ephemeral).
             "managed_persistence": False,
+            "takeover": {
+                "mint_url": "",
+                "default_ttl_seconds": 900,
+            },
         },
     },
 
@@ -703,7 +707,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -719,6 +723,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    18: ["CAMOFOX_TAKEOVER_MINT_URL", "CAMOFOX_TAKEOVER_DEFAULT_TTL"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1083,7 +1088,23 @@ OPTIONAL_ENV_VARS = {
         "description": "Camofox browser server URL for local anti-detection browsing (e.g. http://localhost:9377)",
         "prompt": "Camofox server URL",
         "url": "https://github.com/jo-inc/camofox-browser",
-        "tools": ["browser_navigate", "browser_click"],
+        "tools": ["browser_navigate", "browser_click", "browser_takeover"],
+        "password": False,
+        "category": "tool",
+    },
+    "CAMOFOX_TAKEOVER_MINT_URL": {
+        "description": "HTTP endpoint that mints temporary takeover links for the live Camofox browser session",
+        "prompt": "Camofox takeover mint URL",
+        "url": None,
+        "tools": ["browser_takeover"],
+        "password": False,
+        "category": "tool",
+    },
+    "CAMOFOX_TAKEOVER_DEFAULT_TTL": {
+        "description": "Default lifetime for Camofox takeover links in seconds (optional, default 900)",
+        "prompt": "Camofox takeover TTL (seconds)",
+        "url": None,
+        "tools": ["browser_takeover"],
         "password": False,
         "category": "tool",
     },

--- a/model_tools.py
+++ b/model_tools.py
@@ -212,7 +212,7 @@ _LEGACY_TOOLSET_MAP = {
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",
         "browser_press", "browser_get_images",
-        "browser_vision", "browser_console"
+        "browser_vision", "browser_console", "browser_takeover"
     ],
     "cronjob_tools": ["cronjob"],
     "rl_tools": [

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -393,6 +393,15 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_camofox_takeover_env_vars_in_env_vars_by_version(self):
+        """Camofox takeover env vars are listed for config migration prompts."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+        assert "CAMOFOX_TAKEOVER_MINT_URL" in all_vars
+        assert "CAMOFOX_TAKEOVER_DEFAULT_TTL" in all_vars
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""
@@ -459,7 +468,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,6 +615,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -16,6 +16,7 @@ from tools.browser_camofox import (
     camofox_press,
     camofox_scroll,
     camofox_snapshot,
+    camofox_takeover,
     camofox_type,
     camofox_vision,
     check_camofox_available,
@@ -100,6 +101,42 @@ class TestCamofoxSnapshot:
     def test_no_session_returns_error(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         result = json.loads(camofox_snapshot(task_id="no_such_task"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_reattaches_existing_tab_for_snapshot(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+
+        mock_get.side_effect = [
+            _mock_response(json_data={
+                "tabs": [{"tabId": "tab_existing", "url": "https://example.com"}],
+            }),
+            _mock_response(json_data={
+                "snapshot": '- heading "Test" [e1]',
+                "refsCount": 1,
+            }),
+        ]
+
+        result = json.loads(camofox_snapshot(task_id="reattach_task"))
+        assert result["success"] is True
+        assert result["element_count"] == 1
+        tabs_call = mock_get.call_args_list[0]
+        assert tabs_call.args[0].endswith("/tabs")
+        assert tabs_call.kwargs["params"]["userId"].startswith("hermes_")
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_does_not_reattach_when_multiple_tabs_exist(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+
+        mock_get.return_value = _mock_response(json_data={
+            "tabs": [
+                {"tabId": "tab_a", "url": "https://a.example"},
+                {"tabId": "tab_b", "url": "https://b.example"},
+            ],
+        })
+
+        result = json.loads(camofox_snapshot(task_id="ambiguous_task"))
         assert result["success"] is False
         assert "browser_navigate" in result["error"]
 
@@ -205,6 +242,53 @@ class TestCamofoxClose:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         result = json.loads(camofox_close(task_id="nonexistent"))
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Takeover
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxTakeover:
+    @patch("tools.browser_camofox.requests.post")
+    def test_mints_takeover_link(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("CAMOFOX_TAKEOVER_MINT_URL", "http://helper.test/api/mint")
+        mock_post.side_effect = [
+            _mock_response(json_data={"tabId": "tab_takeover", "url": "https://x.com"}),
+            _mock_response(json_data={
+                "url": "https://takeover.test/session",
+                "expiresAt": "2026-04-15T00:00:00Z",
+                "agent": "test-agent",
+            }),
+        ]
+
+        camofox_navigate("https://x.com", task_id="takeover")
+        result = json.loads(camofox_takeover(reason="captcha", ttl_seconds=600, task_id="takeover"))
+        assert result["success"] is True
+        assert result["backend"] == "camofox"
+        assert result["url"] == "https://takeover.test/session"
+        assert result["ttl_seconds"] == 600
+        assert "instructions" in result
+        mint_call = mock_post.call_args
+        assert mint_call.args[0] == "http://helper.test/api/mint"
+        assert mint_call.kwargs["json"]["ttlSeconds"] == 600
+        assert mint_call.kwargs["json"]["reason"] == "captcha"
+        assert mint_call.kwargs["json"]["tabId"] == "tab_takeover"
+
+    def test_requires_existing_session(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("CAMOFOX_TAKEOVER_MINT_URL", "http://helper.test/api/mint")
+        result = json.loads(camofox_takeover(task_id="takeover_missing_session"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+    def test_requires_takeover_mint_url(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.delenv("CAMOFOX_TAKEOVER_MINT_URL", raising=False)
+        result = json.loads(camofox_takeover(task_id="takeover_missing"))
+        assert result["success"] is False
+        assert "mint" in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -59,9 +59,16 @@ class TestCamofoxConfigDefaults:
         browser_cfg = DEFAULT_CONFIG["browser"]
         assert browser_cfg["camofox"]["managed_persistence"] is False
 
+    def test_default_config_includes_takeover_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        takeover_cfg = DEFAULT_CONFIG["browser"]["camofox"]["takeover"]
+        assert takeover_cfg["mint_url"] == ""
+        assert takeover_cfg["default_ttl_seconds"] == 900
+
     def test_config_version_matches_current_schema(self):
         from hermes_cli.config import DEFAULT_CONFIG
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 17
+        assert DEFAULT_CONFIG["_config_version"] == 18

--- a/tests/tools/test_browser_takeover.py
+++ b/tests/tools/test_browser_takeover.py
@@ -1,0 +1,83 @@
+"""Tests for the browser_takeover tool wiring and gating."""
+
+import json
+from unittest.mock import patch
+
+
+class TestBrowserTakeoverSchema:
+    def test_schema_in_browser_schemas(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+        names = [s["name"] for s in BROWSER_TOOL_SCHEMAS]
+        assert "browser_takeover" in names
+
+    def test_schema_has_reason_and_ttl(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_takeover")
+        props = schema["parameters"]["properties"]
+        assert props["reason"]["type"] == "string"
+        assert props["ttl_seconds"]["type"] == "integer"
+
+
+class TestBrowserTakeoverToolsetWiring:
+    def test_in_browser_toolset(self):
+        from toolsets import TOOLSETS
+
+        assert "browser_takeover" in TOOLSETS["browser"]["tools"]
+
+    def test_in_hermes_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "browser_takeover" in _HERMES_CORE_TOOLS
+
+    def test_in_legacy_toolset_map(self):
+        from model_tools import _LEGACY_TOOLSET_MAP
+
+        assert "browser_takeover" in _LEGACY_TOOLSET_MAP["browser_tools"]
+
+    def test_in_registry(self):
+        from tools.registry import registry
+        from tools import browser_tool  # noqa: F401
+
+        assert "browser_takeover" in registry._tools
+
+
+class TestBrowserTakeoverBehavior:
+    @patch("tools.browser_tool._is_camofox_mode", return_value=True)
+    @patch("tools.browser_tool.check_browser_takeover_requirements", return_value=True)
+    @patch("tools.browser_tool.camofox_takeover")
+    def test_routes_to_camofox_backend(self, mock_takeover, _mock_requirements, _mock_mode):
+        from tools.browser_tool import browser_takeover
+
+        mock_takeover.return_value = json.dumps({
+            "success": True,
+            "backend": "camofox",
+            "url": "https://takeover.test/session",
+        })
+
+        result = json.loads(browser_takeover(reason="captcha", ttl_seconds=900, task_id="takeover-task"))
+        assert result["success"] is True
+        assert result["backend"] == "camofox"
+        mock_takeover.assert_called_once_with(reason="captcha", ttl_seconds=900, task_id="takeover-task")
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=True)
+    @patch("tools.browser_tool.check_camofox_takeover_available", return_value=False)
+    def test_requirement_check_verifies_helper_reachability(self, _mock_reachable, _mock_mode):
+        from tools.browser_tool import check_browser_takeover_requirements
+
+        assert check_browser_takeover_requirements() is False
+
+    @patch("tools.browser_tool._is_camofox_mode", return_value=False)
+    def test_errors_when_backend_does_not_support_takeover(self, _mock_mode):
+        from tools.browser_tool import browser_takeover
+
+        result = json.loads(browser_takeover(task_id="no-backend"))
+        assert result["success"] is False
+        assert "currently supported only" in result["error"]
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_not_available_without_camofox_and_mint_url(self):
+        from tools.browser_tool import check_browser_takeover_requirements
+
+        assert check_browser_takeover_requirements() is False

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
+_DEFAULT_TAKEOVER_TTL = 900
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
@@ -90,6 +91,56 @@ def get_vnc_url() -> Optional[str]:
     return _vnc_url
 
 
+def _get_takeover_config() -> dict:
+    """Return the browser.camofox.takeover config block, or {}."""
+    try:
+        return load_config().get("browser", {}).get("camofox", {}).get("takeover", {}) or {}
+    except Exception as exc:
+        logger.debug("Could not load Camofox takeover config: %s", exc)
+        return {}
+
+
+def get_camofox_takeover_mint_url() -> str:
+    """Return the configured takeover mint endpoint, or empty string."""
+    env_url = os.getenv("CAMOFOX_TAKEOVER_MINT_URL", "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+    cfg_url = str(_get_takeover_config().get("mint_url") or "").strip()
+    return cfg_url.rstrip("/")
+
+
+def get_camofox_takeover_default_ttl() -> int:
+    """Return the default TTL in seconds for takeover links."""
+    raw = os.getenv("CAMOFOX_TAKEOVER_DEFAULT_TTL", "").strip()
+    if not raw:
+        raw = str(_get_takeover_config().get("default_ttl_seconds") or "").strip()
+    try:
+        ttl = int(raw) if raw else _DEFAULT_TAKEOVER_TTL
+    except (TypeError, ValueError):
+        ttl = _DEFAULT_TAKEOVER_TTL
+    return max(60, min(ttl, 3600))
+
+
+def check_camofox_takeover_available() -> bool:
+    """Return True when Camofox takeover is configured and helper looks reachable."""
+    if not get_camofox_url() or not get_camofox_takeover_mint_url():
+        return False
+
+    mint_url = get_camofox_takeover_mint_url()
+    probe_url = None
+    if mint_url.endswith("/api/mint"):
+        probe_url = mint_url[:-len("/api/mint")] + "/health"
+
+    if not probe_url:
+        return True
+
+    try:
+        resp = requests.get(probe_url, timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
 def _managed_persistence_enabled() -> bool:
     """Return whether Hermes-managed persistence is enabled for Camofox.
 
@@ -115,6 +166,32 @@ _sessions: Dict[str, Dict[str, Any]] = {}
 _sessions_lock = threading.Lock()
 
 
+def _try_reattach_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
+    """Bind *session* to an existing server-side tab when local state is missing."""
+    if session.get("tab_id"):
+        return session
+    try:
+        tabs_data = _get("/tabs", params={"userId": session["user_id"]}, timeout=5)
+        tabs = tabs_data.get("tabs", []) or []
+        if len(tabs) == 1:
+            reused_tab = tabs[0]
+            session["tab_id"] = reused_tab.get("tabId") or reused_tab.get("targetId")
+            logger.info(
+                "Auto-reattached to existing Camofox tab %s (url: %s)",
+                session["tab_id"],
+                reused_tab.get("url", "?"),
+            )
+        elif len(tabs) > 1:
+            logger.warning(
+                "Skipping Camofox auto-reattach for user %s because %d tabs exist; refusing to guess.",
+                session["user_id"],
+                len(tabs),
+            )
+    except Exception as exc:
+        logger.debug("Auto-reattach check failed: %s", exc)
+    return session
+
+
 def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
     """Get or create a camofox session for the given task.
 
@@ -124,25 +201,25 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
     """
     task_id = task_id or "default"
     with _sessions_lock:
-        if task_id in _sessions:
-            return _sessions[task_id]
-        if _managed_persistence_enabled():
-            identity = get_camofox_identity(task_id)
-            session = {
-                "user_id": identity["user_id"],
-                "tab_id": None,
-                "session_key": identity["session_key"],
-                "managed": True,
-            }
-        else:
-            session = {
-                "user_id": f"hermes_{uuid.uuid4().hex[:10]}",
-                "tab_id": None,
-                "session_key": f"task_{task_id[:16]}",
-                "managed": False,
-            }
-        _sessions[task_id] = session
-        return session
+        session = _sessions.get(task_id)
+        if session is None:
+            if _managed_persistence_enabled():
+                identity = get_camofox_identity(task_id)
+                session = {
+                    "user_id": identity["user_id"],
+                    "tab_id": None,
+                    "session_key": identity["session_key"],
+                    "managed": True,
+                }
+            else:
+                session = {
+                    "user_id": f"hermes_{uuid.uuid4().hex[:10]}",
+                    "tab_id": None,
+                    "session_key": f"task_{task_id[:16]}",
+                    "managed": False,
+                }
+            _sessions[task_id] = session
+    return _try_reattach_existing_tab(session)
 
 
 def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
@@ -570,6 +647,85 @@ def camofox_vision(question: str, annotate: bool = False,
         })
     except Exception as e:
         return tool_error(str(e), success=False)
+
+
+def camofox_takeover(
+    reason: str = "",
+    ttl_seconds: Optional[int] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Mint a temporary live-browser takeover link for the current Camofox session."""
+    mint_url = get_camofox_takeover_mint_url()
+    if not mint_url:
+        return tool_error(
+            "Camofox browser takeover is not configured. Set CAMOFOX_TAKEOVER_MINT_URL "
+            "or browser.camofox.takeover.mint_url.",
+            success=False,
+        )
+
+    task_id = task_id or "default"
+    with _sessions_lock:
+        existing = _sessions.get(task_id)
+    if existing is None:
+        return tool_error(
+            "No browser session. Call browser_navigate first before requesting takeover.",
+            success=False,
+        )
+
+    session = _try_reattach_existing_tab(existing)
+    if not session.get("tab_id"):
+        return tool_error(
+            "No live browser tab found for takeover. Call browser_navigate first.",
+            success=False,
+        )
+
+    ttl = ttl_seconds if ttl_seconds is not None else get_camofox_takeover_default_ttl()
+    try:
+        ttl = max(60, min(int(ttl), 3600))
+    except (TypeError, ValueError):
+        ttl = get_camofox_takeover_default_ttl()
+
+    payload: Dict[str, Any] = {
+        "ttlSeconds": ttl,
+        "userId": session.get("user_id"),
+        "tabId": session.get("tab_id"),
+    }
+    if reason:
+        payload["reason"] = reason
+
+    try:
+        data = requests.post(mint_url, json=payload, timeout=_DEFAULT_TIMEOUT)
+        data.raise_for_status()
+        body = data.json()
+    except Exception as exc:
+        return tool_error(f"Failed to mint Camofox takeover link: {exc}", success=False)
+
+    takeover_url = body.get("url") or body.get("takeoverUrl") or body.get("link")
+    if not takeover_url:
+        return tool_error(
+            f"Takeover mint endpoint did not return a URL: {body}",
+            success=False,
+        )
+
+    result: Dict[str, Any] = {
+        "success": True,
+        "backend": "camofox",
+        "url": takeover_url,
+        "ttl_seconds": ttl,
+        "instructions": "Share this link with the user so they can view and control the live browser.",
+    }
+    expires_at = body.get("expiresAt") or body.get("expires_at")
+    if expires_at:
+        result["expires_at"] = expires_at
+    if body.get("agent"):
+        result["agent"] = body["agent"]
+    if body.get("containerName") or body.get("container"):
+        result["container"] = body.get("containerName") or body.get("container")
+    if body.get("target"):
+        result["target"] = body["target"]
+    if reason:
+        result["reason"] = reason
+    return json.dumps(result)
 
 
 def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -87,9 +87,19 @@ from tools.tool_backend_helpers import normalize_browser_cloud_provider
 # When CAMOFOX_URL is set, all browser operations route through the
 # camofox REST API instead of the agent-browser CLI.
 try:
-    from tools.browser_camofox import is_camofox_mode as _is_camofox_mode
+    from tools.browser_camofox import (
+        check_camofox_takeover_available,
+        camofox_takeover,
+        is_camofox_mode as _is_camofox_mode,
+    )
 except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
+
+    def check_camofox_takeover_available() -> bool:
+        return False
+
+    def camofox_takeover(*args, **kwargs):
+        return json.dumps({"success": False, "error": "Camofox backend not available"})
 
 logger = logging.getLogger(__name__)
 
@@ -758,12 +768,30 @@ BROWSER_TOOL_SCHEMAS = [
             "properties": {
                 "clear": {
                     "type": "boolean",
-                    "default": False,
-                    "description": "If true, clear the message buffers after reading"
+                    "description": "If true, clear the message buffers after reading",
+                    "default": False
                 },
                 "expression": {
                     "type": "string",
                     "description": "JavaScript expression to evaluate in the page context. Runs in the browser like DevTools console — full access to DOM, window, document. Return values are serialized to JSON. Example: 'document.title' or 'document.querySelectorAll(\"a\").length'"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "browser_takeover",
+        "description": "Mint a temporary live-browser takeover link so a human can view and control the current browser session. Use this when browser automation is blocked by login, CAPTCHA, MFA, or a step that needs manual intervention.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Optional short reason for requesting takeover, such as 'captcha' or 'finish login'."
+                },
+                "ttl_seconds": {
+                    "type": "integer",
+                    "description": "Optional link lifetime in seconds. Defaults to the configured Camofox takeover TTL."
                 }
             },
             "required": []
@@ -1702,6 +1730,20 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     }, ensure_ascii=False)
 
 
+def browser_takeover(
+    reason: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Mint a temporary live-browser takeover link for human intervention."""
+    if _is_camofox_mode():
+        return camofox_takeover(reason=reason or "", ttl_seconds=ttl_seconds, task_id=task_id)
+    return json.dumps({
+        "success": False,
+        "error": "Browser takeover is currently supported only for the Camofox backend.",
+    }, ensure_ascii=False)
+
+
 def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
     if _is_camofox_mode():
@@ -2254,6 +2296,13 @@ def check_browser_requirements() -> bool:
     return True
 
 
+def check_browser_takeover_requirements() -> bool:
+    """Return whether the browser_takeover tool should be exposed."""
+    if not _is_camofox_mode():
+        return False
+    return check_camofox_takeover_available()
+
+
 # ============================================================================
 # Module Test
 # ============================================================================
@@ -2384,4 +2433,16 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+)
+registry.register(
+    name="browser_takeover",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_takeover"],
+    handler=lambda args, **kw: browser_takeover(
+        reason=args.get("reason"),
+        ttl_seconds=args.get("ttl_seconds"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_takeover_requirements,
+    emoji="🛟",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -43,7 +43,7 @@ _HERMES_CORE_TOOLS = [
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_get_images",
-    "browser_vision", "browser_console",
+    "browser_vision", "browser_console", "browser_takeover",
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
@@ -115,7 +115,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "web_search"
+            "browser_vision", "browser_console", "browser_takeover", "web_search"
         ],
         "includes": []
     },


### PR DESCRIPTION
## Summary
- add a first-class `browser_takeover` tool to Hermes browser tools
- add Camofox takeover config/env wiring and registry/toolset integration
- make Camofox reattach to an existing live tab when local task state is missing, but refuse to guess when multiple tabs exist
- add regression coverage for takeover wiring, config migration metadata, and safe reattach behavior

## Testing
- `env -u CAMOFOX_URL -u CAMOFOX_TAKEOVER_MINT_URL -u CAMOFOX_TAKEOVER_DEFAULT_TTL python -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_takeover.py tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_camofox_state.py tests/hermes_cli/test_config.py tests/gateway/test_api_server_toolset.py tests/test_model_tools.py -o addopts= -q`
- manual Docker validation on a fresh test container: navigated to `https://example.com`, minted a takeover link with the new built-in tool, then verified the noVNC websocket bridge returned the VNC banner `RFB 003.008\n`

## Notes
- Camofox-only for now; other browser backends return unsupported for `browser_takeover`
- drafted for review because the helper-side agent-mapping/defaulting UX still deserves discussion before marking ready
