### PR TITLE
fix: sort session listing by last activity, not creation time

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -848,7 +848,7 @@ class SessionDB:
                 ) AS last_active
             FROM sessions s
             {where_sql}
-            ORDER BY s.started_at DESC
+            ORDER BY last_active DESC
             LIMIT ? OFFSET ?
         """
         params.extend([limit, offset])


### PR DESCRIPTION
## Summary

- `list_sessions_rich()` ordered by `started_at DESC`, which buried
  long-running interactive sessions (CLI, Telegram) under recently-created
  cron sessions. A cron job running every 5 minutes fills the default fetch
  limit with cron sessions, making active interactive sessions invisible to
  `session_search`.
- Sort by `last_active` instead — the column is already computed in the
  same query. Sessions with recent messages surface regardless of when
  they were created.

## Test plan

- [ ] Run `session_search` with no query while CLI and Telegram sessions
  are active alongside periodic cron jobs — interactive sessions should
  appear in the listing
- [ ] Verify `hermes sessions` CLI command still shows sessions in a
  reasonable order (most recently active first)
- [ ] Verify cron-only workspaces still list sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)