### PR TITLE
Add manual sleep memory consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Change model | `/model [provider:model]` | `/model [provider:model]` |
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
+| Consolidate memory manually | `/sleep [quick|deep] [--apply]` | Not available |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
 | Browse skills | `/skills` or `/<skill-name>` | `/skills` or `/<skill-name>` |
 | Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |
+
+`/sleep` is a manual memory-consolidation pass for the CLI. It analyzes prior session history to learn which conversations tend to matter for a given user, scores curated memory entries against those learned patterns, and proposes low-value entries for removal from `MEMORY.md` while leaving `USER.md` untouched. By default it runs in preview mode; add `--apply` to persist the suggested changes. `quick` uses the default threshold; `deep` is more aggressive.
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
 

--- a/agent/sleep_engine.py
+++ b/agent/sleep_engine.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""
+Sleep Engine - Memory consolidation and cleaning system for Hermes Agent.
+
+Implements a sleep mode that filters redundant memories based on session usage patterns.
+Inspired by human sleep-memory consolidation mechanisms.
+
+Key concepts:
+1. Session importance scoring: Based on duration, message count, recency
+2. Adaptive vocabulary learning: Extracts important vs unimportant words from sessions
+3. Memory scoring: Evaluates memories based on learned vocabulary
+4. Cleaning: Removes low-scoring memories, consolidates important ones
+"""
+
+import logging
+import re
+import sqlite3
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional, Any
+
+from hermes_constants import get_hermes_home
+from tools.memory_tool import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionStats:
+    """Statistics for a single session."""
+    session_id: str
+    started_at: float
+    ended_at: Optional[float]
+    message_count: int
+    tool_call_count: int
+    title: Optional[str]
+    source: str
+    duration_hours: float = 0.0
+    importance_score: float = 0.0
+
+
+class SleepEngine:
+    """Core engine for memory consolidation during sleep."""
+    
+    def __init__(self, memory_store: MemoryStore, db_path: Optional[Path] = None):
+        """
+        Initialize the sleep engine.
+        
+        Args:
+            memory_store: The MemoryStore instance to clean
+            db_path: Path to state.db (default: ~/.hermes/state.db)
+        """
+        self.memory_store = memory_store
+        self.db_path = db_path or (get_hermes_home() / "state.db")
+        
+        # Vocabulary caches
+        self.important_words: Dict[str, float] = {}  # word -> positive weight
+        self.unimportant_words: Dict[str, float] = {}  # word -> negative weight
+        
+        # Configuration
+        self.importance_threshold = 0.5  # Sessions with score > 0.5 are important
+        self.memory_delete_threshold = 0.4  # Memories with score < 0.4 are deleted
+        self.min_word_length = 2  # Minimum word length to consider
+        self.max_words_to_keep = 100  # Max number of words to track
+        
+        # For progress reporting
+        self.progress_callback = None
+    
+    def set_progress_callback(self, callback):
+        """Set a callback for progress updates."""
+        self.progress_callback = callback
+    
+    def _update_progress(self, stage: str, progress: float, message: str = ""):
+        """Update progress if callback is set."""
+        if self.progress_callback:
+            self.progress_callback(stage, progress, message)
+    
+    # -------------------------------------------------------------------------
+    # Session Analysis
+    # -------------------------------------------------------------------------
+    
+    def _get_all_sessions(self) -> List[SessionStats]:
+        """Retrieve all sessions from the database."""
+        if not self.db_path.exists():
+            logger.warning(f"Database not found at {self.db_path}")
+            return []
+        
+        try:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            
+            # Get all sessions with basic stats
+            cursor.execute("""
+                SELECT 
+                    id, source, started_at, ended_at, message_count, 
+                    tool_call_count, title
+                FROM sessions 
+                WHERE ended_at IS NOT NULL 
+                ORDER BY started_at DESC
+            """)
+            
+            sessions = []
+            for row in cursor.fetchall():
+                # Calculate duration in hours
+                duration = 0.0
+                if row['ended_at']:
+                    duration = (row['ended_at'] - row['started_at']) / 3600.0  # hours
+                
+                session = SessionStats(
+                    session_id=row['id'],
+                    started_at=row['started_at'],
+                    ended_at=row['ended_at'],
+                    message_count=row['message_count'],
+                    tool_call_count=row['tool_call_count'],
+                    title=row['title'],
+                    source=row['source'],
+                    duration_hours=max(0.0, duration)
+                )
+                sessions.append(session)
+            
+            conn.close()
+            logger.info(f"Retrieved {len(sessions)} sessions from database")
+            return sessions
+            
+        except sqlite3.Error as e:
+            logger.error(f"Database error: {e}")
+            return []
+    
+    def _calculate_session_importance(self, session: SessionStats) -> float:
+        """
+        Calculate importance score for a session (0-1).
+        
+        Factors:
+        1. Duration: Longer sessions are more important
+        2. Message density: More messages per hour = more engagement
+        3. Tool usage: Tool calls indicate serious work
+        4. Recency: Recent sessions are more relevant
+        """
+        score = 0.0
+        
+        # 1. Duration factor (0-0.3)
+        # Sessions longer than 1 hour get max points, shorter get proportional
+        duration_score = min(session.duration_hours / 1.0, 1.0) * 0.3
+        score += duration_score
+        
+        # 2. Message density factor (0-0.3)
+        if session.duration_hours > 0.1:  # At least 6 minutes
+            messages_per_hour = session.message_count / session.duration_hours
+            density_score = min(messages_per_hour / 20.0, 1.0) * 0.3  # 20 msgs/hour = max
+            score += density_score
+        
+        # 3. Tool usage factor (0-0.2)
+        if session.tool_call_count > 0:
+            tool_score = min(session.tool_call_count / 10.0, 1.0) * 0.2  # 10 tools = max
+            score += tool_score
+        
+        # 4. Recency factor (0-0.2)
+        # Sessions from last 7 days get full points, older decay
+        days_ago = (time.time() - session.started_at) / (24 * 3600)
+        recency_score = max(0.0, 1.0 - (days_ago / 7.0)) * 0.2
+        score += recency_score
+        
+        return min(1.0, max(0.0, score))
+    
+    def _extract_words_from_session(self, session_id: str) -> List[str]:
+        """Extract words from session messages."""
+        if not self.db_path.exists():
+            return []
+        
+        try:
+            conn = sqlite3.connect(str(self.db_path))
+            cursor = conn.cursor()
+            
+            # Get all messages for this session
+            cursor.execute("""
+                SELECT content FROM messages 
+                WHERE session_id = ? AND content IS NOT NULL
+            """, (session_id,))
+            
+            all_text = " ".join(row[0] for row in cursor.fetchall() if row[0])
+            conn.close()
+            
+            # Simple word extraction: split by non-alphanumeric, filter short words
+            words = re.findall(r'\b\w+\b', all_text.lower())
+            words = [w for w in words if len(w) >= self.min_word_length]
+            
+            return words
+            
+        except sqlite3.Error as e:
+            logger.error(f"Error extracting words from session {session_id}: {e}")
+            return []
+    
+    # -------------------------------------------------------------------------
+    # Vocabulary Learning
+    # -------------------------------------------------------------------------
+    
+    def learn_vocabulary(self, sessions: List[SessionStats]) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """
+        Learn important and unimportant words from sessions.
+        
+        Important words come from important sessions.
+        Unimportant words come from unimportant sessions.
+        """
+        self._update_progress("vocabulary", 0.1, "Analyzing session importance...")
+        
+        # Calculate importance for all sessions
+        for i, session in enumerate(sessions):
+            session.importance_score = self._calculate_session_importance(session)
+            if i % 10 == 0:
+                progress = 0.1 + (i / len(sessions)) * 0.3 if sessions else 0.4
+                self._update_progress("vocabulary", progress, f"Scoring sessions...")
+        
+        # Separate sessions by importance
+        important_sessions = [s for s in sessions if s.importance_score > self.importance_threshold]
+        unimportant_sessions = [s for s in sessions if s.importance_score < 0.3]
+        
+        logger.info(f"Found {len(important_sessions)} important sessions, {len(unimportant_sessions)} unimportant sessions")
+        
+        # Extract words from important sessions
+        self._update_progress("vocabulary", 0.5, "Extracting important words...")
+        important_word_counts = Counter()
+        for i, session in enumerate(important_sessions):
+            words = self._extract_words_from_session(session.session_id)
+            important_word_counts.update(words)
+            
+            if i % 5 == 0 and important_sessions:
+                progress = 0.5 + (i / len(important_sessions)) * 0.2
+                self._update_progress("vocabulary", progress, f"Processing important sessions...")
+        
+        # Extract words from unimportant sessions
+        self._update_progress("vocabulary", 0.7, "Extracting unimportant words...")
+        unimportant_word_counts = Counter()
+        for i, session in enumerate(unimportant_sessions):
+            words = self._extract_words_from_session(session.session_id)
+            unimportant_word_counts.update(words)
+            
+            if i % 5 == 0 and unimportant_sessions:
+                progress = 0.7 + (i / len(unimportant_sessions)) * 0.2
+                self._update_progress("vocabulary", progress, f"Processing unimportant sessions...")
+        
+        # Calculate word weights
+        self._update_progress("vocabulary", 0.9, "Calculating word weights...")
+        important_words = {}
+        unimportant_words = {}
+        
+        # Common stopwords to ignore (English and Chinese)
+        stopwords = {
+            'the', 'and', 'for', 'with', 'this', 'that', 'have', 'from', 'what',
+            '的', '了', '在', '是', '我', '有', '和', '就', '不', '人', '都', '一',
+            '一个', '一些', '可以', '可能', '应该', '需要', '现在', '今天', '明天',
+            'weather', 'time', 'today', 'now', 'query', 'search', 'find', 'look'
+        }
+        
+        # Important words: weight = log(frequency) * session_importance_avg
+        for word, count in important_word_counts.most_common(self.max_words_to_keep):
+            if word in stopwords or len(word) < self.min_word_length:
+                continue
+            # Weight based on frequency (log scale to reduce dominance of very common words)
+            weight = (1.0 + 0.5 * (count ** 0.5))  # 1.0 to ~6.0 for very frequent words
+            important_words[word] = weight
+        
+        # Unimportant words: negative weight
+        for word, count in unimportant_word_counts.most_common(self.max_words_to_keep):
+            if word in stopwords or len(word) < self.min_word_length:
+                continue
+            # Negative weight for unimportant words
+            weight = -0.5 * (1.0 + 0.3 * (count ** 0.5))  # -0.5 to ~-3.0
+            unimportant_words[word] = weight
+        
+        self._update_progress("vocabulary", 1.0, "Vocabulary learned!")
+        logger.info(f"Learned {len(important_words)} important words, {len(unimportant_words)} unimportant words")
+        
+        return important_words, unimportant_words
+    
+    # -------------------------------------------------------------------------
+    # Memory Scoring
+    # -------------------------------------------------------------------------
+    
+    def _score_memory(self, memory_text: str) -> Tuple[float, Dict[str, float]]:
+        """
+        Score a memory based on learned vocabulary.
+        
+        Returns:
+            Tuple of (total_score, word_contributions)
+        """
+        text_lower = memory_text.lower()
+        words = re.findall(r'\b\w+\b', text_lower)
+        
+        score = 1.0  # Base score
+        contributions = {}
+        
+        # Check for important words
+        for word, weight in self.important_words.items():
+            if word in text_lower:
+                score += weight * 0.1  # Scale down contribution
+                contributions[word] = weight * 0.1
+        
+        # Check for unimportant words
+        for word, weight in self.unimportant_words.items():
+            if word in text_lower:
+                score += weight * 0.15  # Slightly stronger negative impact
+                contributions[word] = weight * 0.15
+        
+        # Length factor: very short memories might be fragments
+        if len(memory_text) < 20:
+            score -= 0.3
+            contributions["length_short"] = -0.3
+        elif len(memory_text) > 100:
+            score += 0.1  # Longer memories often more substantial
+            contributions["length_long"] = 0.1
+        
+        return max(0.0, score), contributions
+    
+    # -------------------------------------------------------------------------
+    # Main Sleep Function
+    # -------------------------------------------------------------------------
+    
+    def sleep(self, mode: str = "quick", apply_changes: bool = False) -> Dict[str, Any]:
+        """
+        Perform memory consolidation (sleep mode).
+        
+        Args:
+            mode: "quick" for fast filtering, "deep" for thorough analysis
+            apply_changes: When True, persist deletions to MEMORY.md. Otherwise preview only.
+        
+        Returns:
+            Dictionary with results and statistics
+        """
+        if mode not in {"quick", "deep"}:
+            return {
+                "success": False,
+                "error": f"Unsupported sleep mode: {mode}. Expected 'quick' or 'deep'.",
+            }
+
+        start_time = time.time()
+        logger.info(f"Starting sleep mode: {mode}")
+        
+        # Get all sessions
+        self._update_progress("sleep", 0.1, "Loading sessions...")
+        sessions = self._get_all_sessions()
+        
+        if not sessions:
+            return {
+                "success": False,
+                "error": "No sessions found in database. Sleep requires historical session data.",
+                "stats": {"sessions_analyzed": 0}
+            }
+        
+        # Learn vocabulary from sessions
+        self._update_progress("sleep", 0.2, "Learning vocabulary from sessions...")
+        self.important_words, self.unimportant_words = self.learn_vocabulary(sessions)
+        
+        # Load current memories
+        self._update_progress("sleep", 0.6, "Loading memories...")
+        memory_entries = self.memory_store.memory_entries.copy()
+
+        if not memory_entries:
+            return {
+                "success": True,
+                "mode": mode,
+                "applied": False,
+                "elapsed_seconds": round(time.time() - start_time, 2),
+                "stats": {
+                    "sessions_analyzed": len(sessions),
+                    "important_sessions": len(
+                        [s for s in sessions if s.importance_score > self.importance_threshold]
+                    ),
+                    "avg_session_duration_hours": round(
+                        sum(s.duration_hours for s in sessions) / len(sessions), 2
+                    ) if sessions else 0,
+                    "memories_before": 0,
+                    "memories_after": 0,
+                    "memories_deleted": 0,
+                    "chars_before": 0,
+                    "chars_after": 0,
+                    "chars_saved": 0,
+                    "char_reduction_pct": 0,
+                },
+                "vocabulary": {
+                    "important_words_count": len(self.important_words),
+                    "unimportant_words_count": len(self.unimportant_words),
+                    "top_important_words": [],
+                    "top_unimportant_words": [],
+                },
+                "deleted_memories_preview": [],
+                "top_kept_memories": [],
+            }
+        
+        # Score all memories
+        self._update_progress("sleep", 0.7, "Scoring memories...")
+        scored_memories = []
+        deleted_memories = []
+        kept_memories = []
+        
+        for i, memory in enumerate(memory_entries):
+            score, contributions = self._score_memory(memory)
+            scored_memories.append({
+                "text": memory,
+                "score": score,
+                "contributions": contributions
+            })
+            
+            if i % 10 == 0 and memory_entries:
+                progress = 0.7 + (i / len(memory_entries)) * 0.2
+                self._update_progress("sleep", progress, f"Scoring memory {i+1}/{len(memory_entries)}...")
+        
+        # Sort by score
+        scored_memories.sort(key=lambda x: x["score"], reverse=True)
+        
+        # Determine which memories to delete
+        delete_threshold = self.memory_delete_threshold
+        if mode == "deep":
+            delete_threshold = 0.6  # More aggressive in deep mode
+        
+        for mem in scored_memories:
+            if mem["score"] < delete_threshold:
+                deleted_memories.append(mem)
+            else:
+                kept_memories.append(mem)
+        
+        applied = False
+
+        # Apply changes if there are memories to delete
+        if deleted_memories and apply_changes:
+            self._update_progress("sleep", 0.9, "Applying changes...")
+            # Create new memory list with only kept memories
+            new_memories = [mem["text"] for mem in kept_memories]
+            
+            # Update memory store
+            self.memory_store.memory_entries = new_memories
+            self.memory_store.save_to_disk("memory")
+            applied = True
+            
+            logger.info(f"Deleted {len(deleted_memories)} memories, kept {len(kept_memories)}")
+        elif deleted_memories:
+            logger.info("Sleep preview found %d memories below threshold; no changes applied", len(deleted_memories))
+        else:
+            logger.info("No memories met deletion threshold")
+        
+        # Generate report
+        elapsed = time.time() - start_time
+        report = self._generate_report(
+            sessions, scored_memories, deleted_memories, kept_memories, 
+            mode, elapsed, applied
+        )
+        
+        self._update_progress("sleep", 1.0, "Sleep complete!")
+        return report
+    
+    def _generate_report(self, sessions: List[SessionStats], 
+                        all_memories: List[Dict], 
+                        deleted: List[Dict], 
+                        kept: List[Dict],
+                        mode: str,
+                        elapsed_seconds: float,
+                        applied: bool) -> Dict[str, Any]:
+        """Generate a detailed sleep report."""
+        
+        # Calculate session statistics
+        important_sessions = [s for s in sessions if s.importance_score > self.importance_threshold]
+        avg_session_duration = sum(s.duration_hours for s in sessions) / len(sessions) if sessions else 0
+        
+        # Memory statistics
+        total_chars_before = sum(len(m["text"]) for m in all_memories)
+        total_chars_after = sum(len(m["text"]) for m in kept)
+        char_savings = total_chars_before - total_chars_after
+        
+        # Top important words
+        top_important = sorted(self.important_words.items(), key=lambda x: x[1], reverse=True)[:10]
+        top_unimportant = sorted(self.unimportant_words.items(), key=lambda x: x[1])[:10]
+        
+        return {
+            "success": True,
+            "mode": mode,
+            "applied": applied,
+            "elapsed_seconds": round(elapsed_seconds, 2),
+            "stats": {
+                "sessions_analyzed": len(sessions),
+                "important_sessions": len(important_sessions),
+                "avg_session_duration_hours": round(avg_session_duration, 2),
+                "memories_before": len(all_memories),
+                "memories_after": len(kept),
+                "memories_deleted": len(deleted),
+                "chars_before": total_chars_before,
+                "chars_after": total_chars_after,
+                "chars_saved": char_savings,
+                "char_reduction_pct": round((char_savings / total_chars_before * 100) if total_chars_before > 0 else 0, 1)
+            },
+            "vocabulary": {
+                "important_words_count": len(self.important_words),
+                "unimportant_words_count": len(self.unimportant_words),
+                "top_important_words": [{"word": w, "weight": round(v, 2)} for w, v in top_important],
+                "top_unimportant_words": [{"word": w, "weight": round(v, 2)} for w, v in top_unimportant]
+            },
+            "deleted_memories_preview": [
+                {
+                    "text": m["text"][:100] + ("..." if len(m["text"]) > 100 else ""),
+                    "score": round(m["score"], 2)
+                }
+                for m in deleted[:5]  # Preview first 5
+            ],
+            "top_kept_memories": [
+                {
+                    "text": m["text"][:100] + ("..." if len(m["text"]) > 100 else ""),
+                    "score": round(m["score"], 2)
+                }
+                for m in kept[:5]  # Top 5 highest scoring
+            ]
+        }
+    
+# -----------------------------------------------------------------------------
+# Helper functions for CLI integration
+# -----------------------------------------------------------------------------
+
+def format_sleep_report(report: Dict[str, Any]) -> str:
+    """Format the sleep report for CLI display."""
+    if not report.get("success"):
+        return f"❌ Sleep failed: {report.get('error', 'Unknown error')}"
+    
+    stats = report["stats"]
+    vocab = report["vocabulary"]
+    
+    lines = []
+    lines.append("🌙 Hermes Sleep Mode Complete!")
+    lines.append("═══════════════════════════════════════════")
+    action = "applied" if report.get("applied") else "preview"
+    lines.append(f"Mode: {report['mode']} | Result: {action} | Time: {report['elapsed_seconds']}s")
+    lines.append("")
+    
+    # Session analysis
+    lines.append("📊 Session Analysis:")
+    lines.append(f"  • Sessions analyzed: {stats['sessions_analyzed']}")
+    lines.append(f"  • Important sessions: {stats['important_sessions']}")
+    lines.append(f"  • Avg duration: {stats['avg_session_duration_hours']} hours")
+    lines.append("")
+    
+    # Memory consolidation
+    lines.append("💾 Memory Consolidation:")
+    lines.append(f"  • Memories before: {stats['memories_before']}")
+    lines.append(f"  • Memories after: {stats['memories_after']}")
+    lines.append(f"  • Memories deleted: {stats['memories_deleted']}")
+    lines.append(f"  • Space saved: {stats['chars_saved']:,} chars ({stats['char_reduction_pct']}%)")
+    if not report.get("applied"):
+        lines.append("  • Preview only: rerun with --apply to persist these changes")
+    lines.append("")
+    
+    # Vocabulary learned
+    lines.append("📚 Vocabulary Learned:")
+    lines.append(f"  • Important words: {vocab['important_words_count']}")
+    lines.append(f"  • Unimportant words: {vocab['unimportant_words_count']}")
+    
+    if vocab['top_important_words']:
+        lines.append("  • Top important words: " + ", ".join(
+            f"{w['word']}({w['weight']})" for w in vocab['top_important_words'][:5]
+        ))
+    
+    if vocab['top_unimportant_words']:
+        lines.append("  • Top unimportant words: " + ", ".join(
+            f"{w['word']}({w['weight']})" for w in vocab['top_unimportant_words'][:5]
+        ))
+    lines.append("")
+    
+    # Deleted memories preview
+    if report.get('deleted_memories_preview'):
+        lines.append("🗑️ Deleted Memories (preview):")
+        for i, mem in enumerate(report['deleted_memories_preview']):
+            lines.append(f"  {i+1}. [{mem['score']}] {mem['text']}")
+        lines.append("")
+    
+    # Top kept memories
+    if report.get('top_kept_memories'):
+        lines.append("💾 Top Kept Memories:")
+        for i, mem in enumerate(report['top_kept_memories']):
+            lines.append(f"  {i+1}. [{mem['score']}] {mem['text']}")
+        lines.append("")
+    
+    lines.append("🛌 Sleep complete! Memory has been consolidated.")
+    return "\n".join(lines)

--- a/cli.py
+++ b/cli.py
@@ -5519,6 +5519,8 @@ class HermesCLI:
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":
             self._handle_voice_command(cmd_original)
+        elif canonical == "sleep":
+            self._handle_sleep_command(cmd_original)
         else:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
@@ -6168,6 +6170,89 @@ class HermesCLI:
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")
 
+    def _handle_sleep_command(self, cmd: str):
+        """Handle /sleep [deep|quick] [--apply] — preview or apply memory consolidation."""
+        try:
+            from agent.sleep_engine import SleepEngine, format_sleep_report
+        except ImportError as e:
+            print(f"  Sleep engine not available: {e}")
+            return
+        
+        # Parse mode / flags
+        parts = cmd.strip().split()
+        mode = "quick"
+        apply_changes = False
+        for raw_arg in parts[1:]:
+            arg = raw_arg.strip().lower()
+            if arg in ("deep", "深度", "彻底"):
+                mode = "deep"
+            elif arg in ("quick", "快速", "快"):
+                mode = "quick"
+            elif arg == "--apply":
+                apply_changes = True
+            else:
+                print(f"  Unknown argument: {raw_arg}. Use 'deep', 'quick', or '--apply'.")
+                return
+        
+        print(f"\n🌙 Hermes is entering sleep mode ({mode})...")
+        print("  This may take 30-60 seconds while I analyze your session history.")
+        if apply_changes:
+            print("  Changes will be written to MEMORY.md after the analysis completes.")
+        else:
+            print("  This run is a preview only. Re-run with --apply to persist changes.")
+        print("  During sleep, I will clean redundant memories and consolidate important information.")
+        print("")
+        
+        # Get memory store from agent or create a new one
+        memory_store = None
+        if hasattr(self, 'agent') and self.agent:
+            # Try to get memory store from AIAgent
+            if hasattr(self.agent, '_memory_store'):
+                memory_store = self.agent._memory_store
+            elif hasattr(self.agent, 'memory_store'):
+                memory_store = self.agent.memory_store
+        
+        # If not available from agent, create a new one
+        if memory_store is None:
+            try:
+                from tools.memory_tool import MemoryStore
+                memory_store = MemoryStore()
+                memory_store.load_from_disk()
+            except ImportError as e:
+                print(f"  Cannot access memory system: {e}")
+                return
+        
+        # Create sleep engine
+        engine = SleepEngine(memory_store)
+        
+        # Progress callback for visual feedback
+        def progress_callback(stage: str, progress: float, message: str = ""):
+            bar_length = 20
+            filled = int(bar_length * progress)
+            bar = "█" * filled + "░" * (bar_length - filled)
+            percent = int(progress * 100)
+            stage_display = stage.capitalize()
+            msg_display = f": {message}" if message else ""
+            print(f"\r  [{bar}] {stage_display} {percent}%{msg_display}", end="", flush=True)
+        
+        engine.set_progress_callback(progress_callback)
+        
+        try:
+            # Run sleep
+            print("  Starting memory consolidation...")
+            report = engine.sleep(mode, apply_changes=apply_changes)
+            
+            # Clear progress line
+            print("\r" + " " * 80 + "\r", end="")
+            
+            # Display results
+            print(format_sleep_report(report))
+            
+        except Exception as e:
+            print(f"\n  ❌ Sleep failed with error: {e}")
+            import traceback
+            traceback.print_exc()
+    
     def _toggle_verbose(self):
         """Cycle tool progress mode: off → new → all → verbose → off."""
         cycle = ["off", "new", "all", "verbose"]

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -165,6 +165,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",
                cli_only=True, aliases=("exit", "q")),
+    # Sleep
+    CommandDef("sleep", "Enter sleep mode to clean redundant memories and consolidate important information", "Session",
+               aliases=("休眠", "休息"), args_hint="[deep|quick] [--apply]"),
 ]
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -150,6 +150,7 @@ def _discover_tools():
         "tools.tts_tool",
         "tools.todo_tool",
         "tools.memory_tool",
+        "tools.sleep_tool",
         "tools.session_search_tool",
         "tools.clarify_tool",
         "tools.code_execution_tool",

--- a/tests/cli/test_sleep_command.py
+++ b/tests/cli/test_sleep_command.py
@@ -1,0 +1,40 @@
+"""Tests for CLI /sleep command registration and dispatch."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {"quick_commands": {}}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj._app = None
+    return cli_obj
+
+
+def test_sleep_command_is_registered():
+    names = [cmd.name for cmd in COMMAND_REGISTRY]
+    assert "sleep" in names
+
+
+def test_sleep_alias_resolves():
+    cmd = resolve_command("休眠")
+    assert cmd is not None
+    assert cmd.name == "sleep"
+
+
+def test_dream_command_is_not_registered():
+    assert resolve_command("dream") is None
+    assert resolve_command("做梦") is None
+
+
+def test_process_command_dispatches_sleep_handler():
+    cli_obj = _make_cli()
+
+    with patch.object(cli_obj, "_handle_sleep_command") as mock_sleep:
+        assert cli_obj.process_command("/sleep deep --apply") is True
+
+    mock_sleep.assert_called_once_with("/sleep deep --apply")

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1,0 +1,115 @@
+"""Tests for agent.sleep_engine."""
+
+from pathlib import Path
+
+from agent.sleep_engine import SessionStats, SleepEngine
+
+
+class _FakeMemoryStore:
+    def __init__(self, entries):
+        self.memory_entries = list(entries)
+        self.saved_targets = []
+
+    def save_to_disk(self, target: str):
+        self.saved_targets.append(target)
+
+
+def _session(session_id: str = "s1", importance_score: float = 0.0):
+    return SessionStats(
+        session_id=session_id,
+        started_at=0.0,
+        ended_at=3600.0,
+        message_count=20,
+        tool_call_count=3,
+        title="test",
+        source="cli",
+        duration_hours=1.0,
+        importance_score=importance_score,
+    )
+
+
+def test_sleep_rejects_unknown_mode():
+    engine = SleepEngine(_FakeMemoryStore([]), db_path=Path("/tmp/missing.db"))
+
+    result = engine.sleep("nap")
+
+    assert result["success"] is False
+    assert "Unsupported sleep mode" in result["error"]
+
+
+def test_sleep_succeeds_when_no_memories_exist(monkeypatch):
+    engine = SleepEngine(_FakeMemoryStore([]), db_path=Path("/tmp/missing.db"))
+    sessions = [_session(importance_score=0.8), _session("s2", importance_score=0.2)]
+
+    monkeypatch.setattr(engine, "_get_all_sessions", lambda: sessions)
+    monkeypatch.setattr(
+        engine,
+        "learn_vocabulary",
+        lambda _sessions: ({"project": 1.4}, {"weather": -0.8}),
+    )
+
+    result = engine.sleep("quick")
+
+    assert result["success"] is True
+    assert result["applied"] is False
+    assert result["stats"]["sessions_analyzed"] == 2
+    assert result["stats"]["memories_before"] == 0
+    assert result["stats"]["memories_deleted"] == 0
+    assert result["vocabulary"]["important_words_count"] == 1
+
+
+def test_sleep_preview_does_not_persist_changes(monkeypatch):
+    store = _FakeMemoryStore(["important project note", "weather lookup"])
+    engine = SleepEngine(store, db_path=Path("/tmp/missing.db"))
+    sessions = [_session(importance_score=0.9), _session("s2", importance_score=0.1)]
+
+    monkeypatch.setattr(engine, "_get_all_sessions", lambda: sessions)
+    monkeypatch.setattr(engine, "learn_vocabulary", lambda _sessions: ({}, {}))
+    monkeypatch.setattr(
+        engine,
+        "_score_memory",
+        lambda text: (0.9, {}) if "important" in text else (0.1, {}),
+    )
+
+    result = engine.sleep("quick")
+
+    assert result["success"] is True
+    assert result["applied"] is False
+    assert store.memory_entries == ["important project note", "weather lookup"]
+    assert store.saved_targets == []
+    assert result["stats"]["memories_before"] == 2
+    assert result["stats"]["memories_deleted"] == 1
+
+
+def test_sleep_apply_persists_deletions(monkeypatch):
+    store = _FakeMemoryStore(["important project note", "weather lookup"])
+    engine = SleepEngine(store, db_path=Path("/tmp/missing.db"))
+    sessions = [_session(importance_score=0.9), _session("s2", importance_score=0.1)]
+
+    monkeypatch.setattr(engine, "_get_all_sessions", lambda: sessions)
+    monkeypatch.setattr(engine, "learn_vocabulary", lambda _sessions: ({}, {}))
+    monkeypatch.setattr(
+        engine,
+        "_score_memory",
+        lambda text: (0.9, {}) if "important" in text else (0.1, {}),
+    )
+
+    result = engine.sleep("quick", apply_changes=True)
+
+    assert result["success"] is True
+    assert result["applied"] is True
+    assert store.memory_entries == ["important project note"]
+    assert store.saved_targets == ["memory"]
+    assert result["stats"]["memories_before"] == 2
+    assert result["stats"]["memories_deleted"] == 1
+
+
+def test_sleep_feature_is_exposed_through_tooling():
+    from model_tools import get_all_tool_names
+    from toolsets import resolve_toolset
+
+    all_tools = get_all_tool_names()
+
+    assert "sleep_memory" in all_tools
+    assert "dream_memory" not in all_tools
+    assert "sleep_memory" in resolve_toolset("memory")

--- a/tools/sleep_tool.py
+++ b/tools/sleep_tool.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Sleep Memory Tool - Memory consolidation and cleaning for Hermes Agent.
+
+Provides tools to clean and consolidate memories based on session usage patterns.
+Inspired by human sleep-memory consolidation mechanisms.
+
+Key features:
+1. Session analysis: Analyzes historical sessions to identify important vs unimportant content
+2. Adaptive vocabulary learning: Learns important/unimportant words from user's own session patterns
+3. Memory scoring: Scores memories based on learned vocabulary and length
+4. Intelligent cleaning: Removes low-scoring memories while preserving important information
+
+The tool is self-adaptive — it learns from each user's unique interaction patterns,
+avoiding hardcoded rules that might not generalize across different users.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Core tool functions
+# -----------------------------------------------------------------------------
+
+def check_sleep_requirements() -> bool:
+    """Check if sleep tool requirements are met."""
+    # No external dependencies required
+    return True
+
+def sleep_memory(
+    mode: str = "quick",
+    apply_changes: bool = False,
+    task_id: Optional[str] = None,
+) -> str:
+    """
+    Perform memory consolidation (sleep mode).
+    
+    Args:
+        mode: "quick" for fast filtering, "deep" for thorough analysis
+        apply_changes: When True, persist deletions instead of previewing them
+        task_id: Optional task ID for context
+    
+    Returns:
+        JSON string with results and statistics
+    """
+    try:
+        # Import here to avoid circular dependencies
+        from agent.sleep_engine import SleepEngine
+        from tools.memory_tool import MemoryStore
+        
+        # Load memory store
+        memory_store = MemoryStore()
+        memory_store.load_from_disk()
+        
+        # Create sleep engine
+        engine = SleepEngine(memory_store)
+        
+        # Run sleep
+        report = engine.sleep(mode, apply_changes=apply_changes)
+        
+        # Convert to JSON string
+        return json.dumps(report, ensure_ascii=False, indent=2)
+        
+    except Exception as e:
+        logger.error(f"Sleep memory failed: {e}")
+        return tool_error(f"Sleep memory failed: {e}")
+
+SLEEP_MEMORY_SCHEMA = {
+    "name": "sleep_memory",
+    "description": (
+        "Perform memory consolidation (sleep mode) to clean redundant memories "
+        "based on session usage patterns. Analyzes historical sessions to learn "
+        "important vs unimportant vocabulary, then scores and filters memories. "
+        "Mode: 'quick' for fast filtering, 'deep' for thorough analysis. "
+        "By default this is a dry run; set apply_changes=true to write the filtered "
+        "memory set back to MEMORY.md. "
+        "Returns detailed statistics including sessions analyzed, memories deleted, "
+        "vocabulary learned, and space saved."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "mode": {
+                "type": "string",
+                "description": "Sleep mode: 'quick' (fast filtering) or 'deep' (thorough analysis)",
+                "enum": ["quick", "deep"],
+                "default": "quick"
+            },
+            "apply_changes": {
+                "type": "boolean",
+                "description": "When true, persist the filtered memory set to MEMORY.md. When false, preview only.",
+                "default": False,
+            }
+        },
+        "required": []
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Tool registration
+# -----------------------------------------------------------------------------
+
+registry.register(
+    name="sleep_memory",
+    toolset="memory",
+    schema=SLEEP_MEMORY_SCHEMA,
+    handler=lambda args, **kw: sleep_memory(
+        mode=args.get("mode", "quick"),
+        apply_changes=args.get("apply_changes", False),
+        task_id=kw.get("task_id")
+    ),
+    check_fn=check_sleep_requirements,
+    emoji="🌙",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -47,7 +47,7 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "memory", "sleep_memory",
     # Session history search
     "session_search",
     # Clarifying questions
@@ -164,7 +164,7 @@ TOOLSETS = {
     
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
-        "tools": ["memory"],
+        "tools": ["memory", "sleep_memory"],
         "includes": []
     },
     


### PR DESCRIPTION
## What does this PR do?

This PR adds a first-pass manual `sleep` capability for Hermes CLI.

It introduces a `/sleep [quick|deep] [--apply]` command and a corresponding `sleep_memory` tool that perform curated memory consolidation based on prior session usage patterns. The feature analyzes historical sessions, learns which conversations tend to matter for a given user, scores existing `MEMORY.md` entries against those learned patterns, and proposes low-value entries for removal.

The first version is intentionally conservative:

- it only operates on `MEMORY.md`
- it never modifies `USER.md`
- it is manual, not automatic
- it defaults to preview mode
- changes are only persisted when `--apply` is passed

This keeps the initial version safe, inspectable, and easy to review.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `SleepEngine` in `agent/sleep_engine.py` for session-informed memory consolidation
- added `sleep_memory` in `tools/sleep_tool.py` and exposed it through the `memory` toolset
- added `/sleep [quick|deep] [--apply]` to the CLI command registry and dispatcher
- documented the new command in `README.md`
- added focused tests for command registration, tool exposure, preview/apply behavior, invalid mode handling, and empty-memory behavior
- intentionally removed `/dream` from this PR scope so the first contribution stays small and reviewable

## How to Test

1. Activate the environment:
   `source venv/bin/activate`
2. Run the focused tests for this change:
   `python -m pytest tests/cli/test_sleep_command.py tests/test_sleep_engine.py tests/test_toolsets.py tests/test_model_tools.py -q`
3. In Hermes CLI, run:
   `hermes`
4. Preview consolidation:
   `/sleep`
5. Apply consolidation:
   `/sleep quick --apply`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Python 3.11.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests added for this PR pass locally:

```bash
python -m pytest tests/cli/test_sleep_command.py tests/test_sleep_engine.py tests/test_toolsets.py tests/test_model_tools.py -q
# 47 passed
```

I also ran the full suite locally:

```bash
python -m pytest tests/ -q
```

In my current environment the repository is not green at baseline. The full run ended with:

- `11087 passed`
- `326 failed`
- `124 errors`
- `40 skipped`

The failures were concentrated in existing areas such as Discord gateway tests, `run_agent`, `file_tools_live`, and MCP OAuth tests, and did not appear to be caused by this `/sleep` change set.
