### PR TITLE
fix: support ${ENV_VAR} syntax in custom provider api_key

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -389,9 +389,18 @@ def _resolve_named_custom_runtime(
             pool_result["model"] = model_name
         return pool_result
 
+    # Expand env vars in api_key field (e.g., "${QIANFAN_API_KEY}")
+    raw_api_key = str(custom_provider.get("api_key", "") or "").strip()
+    if raw_api_key.startswith("${") and raw_api_key.endswith("}"):
+        # Extract variable name and get from environment
+        var_name = raw_api_key[2:-1]
+        expanded_api_key = os.getenv(var_name, "").strip()
+    else:
+        expanded_api_key = raw_api_key
+
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        expanded_api_key,
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),


### PR DESCRIPTION
## What

Support `${ENV_VAR}` syntax in the `api_key` field of `custom_providers` config.

## Why

1. **Reduce configuration errors from common AI patterns**  
   When users ask AI assistants to configure custom providers, models often suggest `api_key: ${ENV_VAR}` based on common conventions (docker-compose, GitHub Actions, Kubernetes, etc.). This previously failed silently, requiring debugging to discover the correct `key_env` field.

2. **Support intuitive syntax**  
   `${ENV_VAR}` is widely recognized. Users should not need to learn a field-specific convention (`key_env`) for a common task.

3. **Consistency with ecosystem**  
   Aligns with syntax used in docker-compose, Kubernetes, GitHub Actions, and many other configuration formats.

## Example

```yaml
custom_providers:
  - name: my-provider
    base_url: https://api.example.com/v1
    api_key: ${MY_API_KEY}  # Now works!
```

## Before

Users had to use the `key_env` field:
```yaml
custom_providers:
  - name: my-provider
    base_url: https://api.example.com/v1
    key_env: MY_API_KEY  # Less intuitive
```

## Testing

Tested with custom provider configuration using `${ENV_VAR}` syntax - API key correctly expanded from environment variable.