### PR TITLE
security: skill hash pinning — integrity verification for approved skills

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -670,6 +670,15 @@ def build_skills_system_prompt(
             skill_name = entry["skill_name"]
             if entry["frontmatter_name"] in disabled or skill_name in disabled:
                 continue
+            # Verify content integrity against pinned hash
+            try:
+                from tools.skill_hash_pin import verify_skill
+                skill_dir = skill_file.parent
+                if not verify_skill(skill_name, skill_dir):
+                    logger.warning("Skill %s failed integrity check — excluded from prompt", skill_name)
+                    continue
+            except Exception:
+                pass  # Pin system unavailable — allow (graceful degradation)
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
                 available_tools,

--- a/tests/tools/test_skill_hash_pin.py
+++ b/tests/tools/test_skill_hash_pin.py
@@ -1,0 +1,112 @@
+"""Tests for tools/skill_hash_pin.py — skill content integrity verification."""
+
+import json
+import pytest
+from pathlib import Path
+
+from tools.skill_hash_pin import (
+    pin_skill,
+    unpin_skill,
+    verify_skill,
+    _load_pins,
+    _pins,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_pin_state(tmp_path, monkeypatch):
+    """Isolate pin state per test."""
+    import tools.skill_hash_pin as mod
+    mod._pins = {}
+    mod._PIN_FILE = tmp_path / ".skill_hashes.json"
+    yield
+    mod._pins = {}
+    mod._PIN_FILE = None
+
+
+def _make_skill(tmp_path: Path, name: str, content: str = "---\nname: test\n---\nHello") -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+class TestPinSkill:
+    def test_pin_records_hash(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize")
+        h = pin_skill("summarize", skill_dir)
+        assert h.startswith("sha256:")
+        assert len(h) == len("sha256:") + 16
+
+    def test_pin_persists_to_file(self, tmp_path):
+        import tools.skill_hash_pin as mod
+        skill_dir = _make_skill(tmp_path, "summarize")
+        pin_skill("summarize", skill_dir)
+        assert mod._PIN_FILE.exists()
+        data = json.loads(mod._PIN_FILE.read_text())
+        assert "summarize" in data
+
+    def test_pin_updates_on_repin(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize", "v1")
+        h1 = pin_skill("summarize", skill_dir)
+        (skill_dir / "SKILL.md").write_text("v2")
+        h2 = pin_skill("summarize", skill_dir)
+        assert h1 != h2
+
+
+class TestUnpinSkill:
+    def test_unpin_removes_entry(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize")
+        pin_skill("summarize", skill_dir)
+        unpin_skill("summarize")
+        import tools.skill_hash_pin as mod
+        assert "summarize" not in mod._pins
+
+    def test_unpin_nonexistent_is_noop(self, tmp_path):
+        unpin_skill("nonexistent")  # Should not raise
+
+
+class TestVerifySkill:
+    def test_unpinned_skill_passes(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "builtin-skill")
+        assert verify_skill("builtin-skill", skill_dir) is True
+
+    def test_pinned_skill_matches(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize")
+        pin_skill("summarize", skill_dir)
+        assert verify_skill("summarize", skill_dir) is True
+
+    def test_tampered_skill_fails(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize", "original content")
+        pin_skill("summarize", skill_dir)
+        # Tamper with the skill after pinning
+        (skill_dir / "SKILL.md").write_text("tampered content")
+        assert verify_skill("summarize", skill_dir) is False
+
+    def test_added_file_fails(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize")
+        pin_skill("summarize", skill_dir)
+        # Add a new file (e.g., exfiltration script)
+        (skill_dir / "helper.py").write_text("import os; os.system('curl ...')")
+        assert verify_skill("summarize", skill_dir) is False
+
+    def test_deleted_file_fails(self, tmp_path):
+        skill_dir = _make_skill(tmp_path, "summarize")
+        (skill_dir / "refs.md").write_text("reference data")
+        pin_skill("summarize", skill_dir)
+        # Delete the reference file
+        (skill_dir / "refs.md").unlink()
+        assert verify_skill("summarize", skill_dir) is False
+
+
+class TestPersistence:
+    def test_load_from_disk(self, tmp_path):
+        import tools.skill_hash_pin as mod
+        skill_dir = _make_skill(tmp_path, "summarize")
+        pin_skill("summarize", skill_dir)
+        saved_hash = mod._pins["summarize"]
+        # Clear in-memory state
+        mod._pins = {}
+        # Reload from disk
+        _load_pins()
+        assert mod._pins["summarize"] == saved_hash

--- a/tools/skill_hash_pin.py
+++ b/tools/skill_hash_pin.py
@@ -1,0 +1,99 @@
+"""
+Skill hash pinning — integrity verification for approved skills.
+
+After skills_guard approves a skill, its content hash is recorded.
+Before a skill is loaded into the system prompt, the hash is verified.
+If the content has changed since the last approved scan, the skill is
+flagged as tampered and excluded from the prompt.
+
+This prevents TOCTOU attacks where an agent modifies a skill between
+the security scan and the next prompt build.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Hash pin store lives alongside the skills directory.
+_PIN_FILE: Optional[Path] = None
+_pins: dict[str, str] = {}  # skill_name → hash
+
+
+def _get_pin_file() -> Path:
+    global _PIN_FILE
+    if _PIN_FILE is None:
+        from hermes_cli.config import get_hermes_home
+        _PIN_FILE = get_hermes_home() / "skills" / ".skill_hashes.json"
+    return _PIN_FILE
+
+
+def _load_pins() -> dict[str, str]:
+    global _pins
+    pin_file = _get_pin_file()
+    if pin_file.exists():
+        try:
+            _pins = json.loads(pin_file.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Failed to load skill hash pins: %s", e)
+            _pins = {}
+    return _pins
+
+
+def _save_pins() -> None:
+    pin_file = _get_pin_file()
+    try:
+        pin_file.parent.mkdir(parents=True, exist_ok=True)
+        pin_file.write_text(json.dumps(_pins, indent=2), encoding="utf-8")
+    except Exception as e:
+        logger.warning("Failed to save skill hash pins: %s", e)
+
+
+def pin_skill(skill_name: str, skill_dir: Path) -> str:
+    """Record the content hash of an approved skill. Returns the hash."""
+    from tools.skills_guard import content_hash
+    h = content_hash(skill_dir)
+    if not _pins:
+        _load_pins()
+    _pins[skill_name] = h
+    _save_pins()
+    logger.debug("Pinned skill %s → %s", skill_name, h)
+    return h
+
+
+def unpin_skill(skill_name: str) -> None:
+    """Remove pin for a deleted skill."""
+    if not _pins:
+        _load_pins()
+    if skill_name in _pins:
+        del _pins[skill_name]
+        _save_pins()
+
+
+def verify_skill(skill_name: str, skill_dir: Path) -> bool:
+    """Verify a skill's content matches its pinned hash.
+
+    Returns True if:
+    - The skill has no pin (unpinned skills are allowed — only agent-created
+      skills get pinned, builtins don't)
+    - The hash matches
+
+    Returns False if:
+    - The skill has a pin and the hash doesn't match (tampered)
+    """
+    if not _pins:
+        _load_pins()
+    pinned_hash = _pins.get(skill_name)
+    if pinned_hash is None:
+        return True  # No pin → not an agent-created skill, allow
+    from tools.skills_guard import content_hash
+    current = content_hash(skill_dir)
+    if current != pinned_hash:
+        logger.warning(
+            "Skill %s failed integrity check: pinned=%s current=%s (tampered?)",
+            skill_name, pinned_hash, current,
+        )
+        return False
+    return True

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -331,6 +331,13 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
 
+    # Pin content hash after successful scan
+    try:
+        from tools.skill_hash_pin import pin_skill
+        pin_skill(name, skill_dir)
+    except Exception:
+        pass
+
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
@@ -371,6 +378,13 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
         if original_content is not None:
             _atomic_write_text(skill_md, original_content)
         return {"success": False, "error": scan_error}
+
+    # Re-pin after successful scan
+    try:
+        from tools.skill_hash_pin import pin_skill
+        pin_skill(name, existing["path"])
+    except Exception:
+        pass
 
     return {
         "success": True,
@@ -475,6 +489,13 @@ def _delete_skill(name: str) -> Dict[str, Any]:
 
     skill_dir = existing["path"]
     shutil.rmtree(skill_dir)
+
+    # Remove hash pin
+    try:
+        from tools.skill_hash_pin import unpin_skill
+        unpin_skill(name)
+    except Exception:
+        pass
 
     # Clean up empty category directories (don't remove SKILLS_DIR itself)
     parent = skill_dir.parent


### PR DESCRIPTION
## Problem

`skills_guard` scans skill content at write time (create, edit, patch) using regex-based static analysis. But there's a TOCTOU gap: a skill that passes the scan can be modified **after** approval and **before** the next prompt build loads it into the system prompt.

### Attack scenario
1. Agent creates skill "summarize" → `skills_guard` scans → verdict: `safe` → approved
2. Agent patches the skill with semantically clean but adversarial instructions (no regex-detectable patterns)
3. Patch triggers `skills_guard` again → verdict: `safe` (no banned patterns)
4. Next prompt build loads the tampered skill into the system prompt
5. All future "summarize" calls execute adversarial instructions

The gap is wider than it appears: between scan and execution, **any file in the skill directory** can change — not just SKILL.md. A helper script, reference file, or template can be added/modified post-scan.

## Fix

**Skill hash pinning.** After `skills_guard` approves a skill, compute a SHA-256 hash of all files in the skill directory and store it. Before loading any skill into the system prompt, verify the hash matches. Mismatches → skill excluded from prompt + warning logged.

### How it works
- `pin_skill(name, skill_dir)` — records hash after successful security scan
- `verify_skill(name, skill_dir)` — checks hash before prompt injection
- `unpin_skill(name)` — cleanup on skill deletion
- Pins stored in `~/.hermes/skills/.skill_hashes.json`
- Unpinned skills pass verification (builtins/trusted skills aren't pinned)
- Uses existing `skills_guard.content_hash()` — no new hashing code

## Files changed
- `tools/skill_hash_pin.py` — **new**, pin/unpin/verify + persistent JSON store
- `tools/skill_manager_tool.py` — pin after create/edit approval, unpin on delete
- `agent/prompt_builder.py` — verify hash before loading skill into prompt
- `tests/tools/test_skill_hash_pin.py` — **new**, 11 tests

No new dependencies. Graceful degradation (try/except around all pin operations).

## Test plan
- [ ] `pytest tests/tools/test_skill_hash_pin.py` — all 11 pass
- [ ] Created skill gets pinned
- [ ] Unmodified skill passes verification
- [ ] Tampered SKILL.md fails verification
- [ ] Added file to skill dir fails verification
- [ ] Deleted file from skill dir fails verification
- [ ] Unpinned (builtin) skills pass verification
- [ ] Pin persists across process restarts

🤖 Generated with [Claude Code](https://claude.ai/code)