### PR TITLE
feat(xai): add xAI/Grok to provider prefix stripping

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -36,6 +36,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
     "mimo", "xiaomi-mimo",
     "arcee-ai", "arceeai",
+    "xai", "x-ai", "x.ai", "grok",
     "qwen-portal",
 })
 


### PR DESCRIPTION
## Summary

Salvaged from PR #9184 by @Julientalbot — adds xAI provider identifiers (`xai`, `x-ai`, `x.ai`, `grok`) to `_PROVIDER_PREFIXES` in `model_metadata.py` so that colon-prefixed model names (e.g. `xai:grok-4.20`) are stripped correctly for context length lookups.

The other two changes from #9184 were not included:
- `auxiliary_client.py` mapping: unnecessary per main-model-first design (xAI is a non-aggregator)
- `setup.py` model list: `_DEFAULT_PROVIDER_MODELS` is dead code (defined but never referenced)

## Test plan
- `strip_provider_prefix('xai:grok-4.20-0309-reasoning')` → `'grok-4.20-0309-reasoning'` ✓
- Ollama tags preserved: `'grok:latest'` → `'grok:latest'` ✓
- 80 model_metadata tests passing