### PR TITLE
fix: prevent agent hang when backgrounding processes via terminal tool

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -322,7 +322,7 @@ class ProcessRegistry:
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", command],
+                    [user_shell, "-lic", f"set +m; {command}"],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -363,7 +363,7 @@ class ProcessRegistry:
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
         proc = subprocess.Popen(
-            [user_shell, "-lic", command],
+            [user_shell, "-lic", f"set +m; {command}"],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
## Summary

- When the agent runs a command that backgrounds a process (e.g.
  `python3 -m http.server 8000 &>/dev/null &`), the terminal tool hangs
  forever. `bash -lic` with a PTY enables job control (`set -m`), which
  makes bash wait for all background jobs before the shell exits.
- Prefix `set +m;` to the command string to disable job control while
  keeping `-i` (for `.bashrc` sourcing) and the PTY (for interactive tools).

## Test plan

- [ ] `hermes chat` → run `python3 -m http.server 9999 &>/dev/null &` — should return immediately
- [ ] Verify server is running: `curl localhost:9999` — should respond
- [ ] Run an interactive command (e.g. `python3` REPL) — should still work with full terminal support
- [ ] Run a command that uses nvm/pyenv — should still resolve correctly (`.bashrc` still sourced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)