### PR TITLE
skills-hub: hash binary skill bundle files correctly

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -695,6 +695,22 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_accepts_binary_files(self):
+        bundle = SkillBundle(
+            name="demo-binary-skill",
+            files={
+                "SKILL.md": "# Demo\n",
+                "assets/logo.png": b"\x89PNG\r\n\x1a\nbinary",
+            },
+            source="github",
+            identifier="owner/repo/demo-binary-skill",
+            trust_level="community",
+        )
+
+        digest = bundle_content_hash(bundle)
+
+        assert digest.startswith("sha256:")
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
# PR: Fix binary skill bundle hashing in skills check

## Branch

- `dh/upstream-skills-hub-binary-hash`

## Commit

- `0af486f9` `skills-hub: hash binary skill bundle files correctly`

## Suggested title

`skills-hub: hash binary skill bundle files correctly`

## Suggested body

### Summary

This PR fixes `hermes skills check` for skill bundles that include binary files.

`SkillBundle.files` can contain either `str` or `bytes`, but
`bundle_content_hash()` always called `.encode("utf-8")`. That crashes when a
bundle contains assets like images.

This change hashes `bytes` directly and only encodes text files.

### Why

The current implementation works for text-only skills, but fails on valid skill
bundles with binary assets. That breaks update checks for installed hub skills
even though the bundle format already allows binary content.

### Scope

- fixes `bundle_content_hash()` to accept both `str` and `bytes`
- adds a regression test that covers binary files in a `SkillBundle`

### Tests

```bash
python -m pytest -q tests/tools/test_skills_hub.py -k "bundle_content_hash or reports_update_when_remote_hash_differs or reports_up_to_date_when_hash_matches"
```

## Reviewer notes

- This is a targeted bugfix with no behavior change for existing text-only skills.
- The new test matches the declared `SkillBundle.files` type and covers the real failure mode seen in `hermes skills check`.
