### PR TITLE
gateway: allow hooks to mutate prompt and response

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -17,6 +17,12 @@ Events:
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.
+
+The ``context`` object passed to handlers is mutable. Event emitters may choose
+to re-read specific fields after ``emit()`` returns. Gateway currently supports
+this for:
+  - ``agent:start`` → ``context_prompt``
+  - ``agent:end``   → ``response``
 """
 
 import asyncio

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3559,9 +3559,14 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
+                "session_key": session_key,
                 "message": message_text[:500],
+                "message_full": message_text,
+                "context_prompt": context_prompt,
             }
             await self.hooks.emit("agent:start", hook_ctx)
+            if "context_prompt" in hook_ctx:
+                context_prompt = str(hook_ctx["context_prompt"] or "")
 
             # Run the agent
             agent_result = await self._run_agent(
@@ -3649,11 +3654,26 @@ class GatewayRunner:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Emit agent:end hook
-            await self.hooks.emit("agent:end", {
+            # Emit agent:end hook. Hooks may mutate context["response"] in place.
+            hook_end_ctx = {
                 **hook_ctx,
-                "response": (response or "")[:500],
-            })
+                "response": response or "",
+                "response_preview": (response or "")[:500],
+                "messages": agent_messages,
+                "history_offset": agent_result.get("history_offset", len(history)),
+                "api_calls": agent_result.get("api_calls", 0),
+                "max_iterations": int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+            }
+            await self.hooks.emit("agent:end", hook_end_ctx)
+            if "response" in hook_end_ctx:
+                response = str(hook_end_ctx["response"] or "")
+            if agent_messages:
+                for msg in reversed(agent_messages):
+                    if msg.get("role") != "assistant":
+                        continue
+                    if isinstance(msg.get("content"), str):
+                        msg["content"] = response
+                        break
             
             # Check for pending process watchers (check_interval on background processes)
             try:

--- a/tests/gateway/test_hook_mutation.py
+++ b/tests/gateway/test_hook_mutation.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.LOCAL,
+        user_id="u1",
+        chat_id="local-chat",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.LOCAL: PlatformConfig(enabled=True)}
+    )
+    runner.adapters = {Platform.LOCAL: MagicMock()}
+    runner._voice_mode = {}
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._session_db = None
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._restart_requested = False
+    runner._restart_task_started = False
+    runner._restart_detached = False
+    runner._restart_via_service = False
+    runner._restart_drain_timeout = 0.0
+    runner._stop_task = None
+    runner._exit_code = None
+    runner._clear_session_env = MagicMock()
+    runner._set_session_env = MagicMock(return_value={})
+    runner._should_send_voice_reply = MagicMock(return_value=False)
+    runner._send_voice_reply = AsyncMock()
+    runner._update_runtime_status = MagicMock()
+
+    session_entry = SessionEntry(
+        session_key="local:local-chat:u1",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.LOCAL,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.config = MagicMock()
+    runner.session_store.config.get_reset_policy.return_value = SimpleNamespace(
+        notify=False,
+        notify_exclude_platforms=[],
+        idle_minutes=0,
+        at_hour=0,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_agent_hooks_can_mutate_context_prompt_and_response(monkeypatch):
+    runner = _make_runner()
+    event = _make_event("hello")
+    captured_contexts: list[str] = []
+
+    async def _emit(event_type: str, context: dict) -> None:
+        if event_type == "agent:start":
+            context["context_prompt"] = "hooked context"
+        if event_type == "agent:end":
+            context["response"] = "hooked response"
+
+    runner.hooks = SimpleNamespace(emit=AsyncMock(side_effect=_emit), loaded_hooks=True)
+    runner._prepare_inbound_message_text = AsyncMock(return_value="hello")
+
+    async def _run_agent(**kwargs):
+        captured_contexts.append(kwargs["context_prompt"])
+        return {
+            "final_response": "original response",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "original response"},
+            ],
+            "history_offset": 0,
+            "api_calls": 1,
+            "last_prompt_tokens": 12,
+        }
+
+    runner._run_agent = AsyncMock(side_effect=_run_agent)
+
+    monkeypatch.setattr("gateway.run.build_session_context", lambda *_a, **_kw: {})
+    monkeypatch.setattr("gateway.run.build_session_context_prompt", lambda *_a, **_kw: "base context")
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.4")
+
+    response = await runner._handle_message_with_agent(event, event.source, "quick-key")
+
+    assert captured_contexts == ["hooked context"]
+    assert response == "hooked response"
+    assert any(
+        call.args[0] == "sess-1"
+        and call.args[1].get("role") == "assistant"
+        and call.args[1].get("content") == "hooked response"
+        for call in runner.session_store.append_to_transcript.call_args_list
+    )

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -68,6 +68,9 @@ async def handle(event_type: str, context: dict):
 - Receives `event_type` (string) and `context` (dict)
 - Can be `async def` or regular `def` — both work
 - Errors are caught and logged, never crashing the agent
+- `context` is mutable. For most events this is only useful for sharing state
+  between hooks, but `agent:start` and `agent:end` support specific in-place
+  mutations described below.
 
 ### Available Events
 
@@ -77,10 +80,36 @@ async def handle(event_type: str, context: dict):
 | `session:start` | New messaging session created | `platform`, `user_id`, `session_id`, `session_key` |
 | `session:end` | Session ended (before reset) | `platform`, `user_id`, `session_key` |
 | `session:reset` | User ran `/new` or `/reset` | `platform`, `user_id`, `session_key` |
-| `agent:start` | Agent begins processing a message | `platform`, `user_id`, `session_id`, `message` |
+| `agent:start` | Agent begins processing a message | `platform`, `user_id`, `session_id`, `session_key`, `message`, `message_full`, `context_prompt` |
 | `agent:step` | Each iteration of the tool-calling loop | `platform`, `user_id`, `session_id`, `iteration`, `tool_names` |
-| `agent:end` | Agent finishes processing | `platform`, `user_id`, `session_id`, `message`, `response` |
+| `agent:end` | Agent finishes processing | `platform`, `user_id`, `session_id`, `session_key`, `message`, `message_full`, `context_prompt`, `response`, `response_preview`, `messages`, `history_offset`, `api_calls`, `max_iterations` |
 | `command:*` | Any slash command executed | `platform`, `user_id`, `command`, `args` |
+
+### Mutable Context Fields
+
+Gateway hooks are still primarily observer hooks, but two lifecycle points
+support targeted in-place mutation:
+
+- `agent:start`: if your handler updates `context["context_prompt"]`, Hermes
+  uses the modified prompt for the upcoming agent run.
+- `agent:end`: if your handler updates `context["response"]`, Hermes sends the
+  modified reply to the user and persists the same final text to the session
+  transcript.
+
+All other context keys should be treated as read-only snapshots unless a
+specific event documents otherwise.
+
+Example — append a postscript before the reply is sent:
+
+```python
+def handle(event_type: str, context: dict):
+    if event_type != "agent:end":
+        return
+    response = str(context.get("response") or "").strip()
+    if not response:
+        return
+    context["response"] = f"{response}\n\nP.S. Generated via hook."
+```
 
 #### Wildcard Matching
 


### PR DESCRIPTION
# PR: Gateway hooks can mutate prompt and response

## Branch

- `dh/upstream-gateway-hook-mutable-context`

## Commit

- `35553540` `gateway: allow hooks to mutate prompt and response`

## Suggested title

`gateway: allow hooks to mutate prompt and response`

## Suggested body

### Summary

This PR makes gateway hooks useful for targeted pre/post-processing without
embedding product-specific logic in `gateway/run.py`.

It adds a small mutable hook contract for two lifecycle events:

- `agent:start`: hooks may update `context["context_prompt"]` before the agent run
- `agent:end`: hooks may update `context["response"]` before the reply is sent

When an `agent:end` hook rewrites the response, the same final text is also
written back to the transcript so user-visible output and stored history stay in
sync.

### Why

Before this change, gateway hooks could observe these lifecycle events but could
not reliably influence the actual prompt or final reply. That forced downstream
customizations into `gateway/run.py` itself.

This change keeps the core generic while enabling:

- response post-processing
- session-scoped prompt injection
- cleaner downstream extensions via hooks instead of source patches

### Scope

- documents the mutable context contract in `gateway/hooks.py`
- extends gateway hook payloads for `agent:start` and `agent:end`
- re-reads `context_prompt` and `response` after hook execution
- keeps transcript content aligned with the final reply text
- adds regression coverage for prompt mutation, response mutation, and transcript consistency

### Tests

```bash
python -m pytest -q tests/gateway/test_hook_mutation.py tests/gateway/test_hooks.py
```

## Reviewer notes

- This does not introduce arbitrary mutable hook semantics for every event.
- The contract is intentionally narrow and explicitly documented.
- The gateway remains resilient to hook failures; hooks are still best-effort observers/processors.
