### PR TITLE
fix(weixin): retry send without context_token on iLink session expiry

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -398,7 +398,12 @@ async def _send_message(
     text: str,
     context_token: Optional[str],
     client_id: str,
-) -> None:
+) -> Dict[str, Any]:
+    """Send a text message via iLink sendmessage API.
+
+    Returns the raw API response dict (may contain error codes like
+    ``errcode: -14`` for session expiry that the caller can inspect).
+    """
     if not text or not text.strip():
         raise ValueError("_send_message: text must not be empty")
     message: Dict[str, Any] = {
@@ -411,7 +416,7 @@ async def _send_message(
     }
     if context_token:
         message["context_token"] = context_token
-    await _api_post(
+    return await _api_post(
         session,
         base_url=base_url,
         endpoint=EP_SEND_MESSAGE,
@@ -1416,11 +1421,18 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token: Optional[str],
         client_id: str,
     ) -> None:
-        """Send a single text chunk with per-chunk retry and backoff."""
+        """Send a single text chunk with per-chunk retry and backoff.
+
+        On session-expired errors (errcode -14), automatically retries
+        *without* ``context_token`` — iLink accepts tokenless sends as a
+        degraded fallback, which keeps cron-initiated push messages working
+        even when no user message has refreshed the session recently.
+        """
         last_error: Optional[Exception] = None
+        retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
             try:
-                await _send_message(
+                resp = await _send_message(
                     self._session,
                     base_url=self._base_url,
                     token=self._token,
@@ -1429,6 +1441,31 @@ class WeixinAdapter(BasePlatformAdapter):
                     context_token=context_token,
                     client_id=client_id,
                 )
+                # Check iLink response for session-expired error
+                if resp and isinstance(resp, dict):
+                    ret = resp.get("ret")
+                    errcode = resp.get("errcode")
+                    if (ret is not None and ret not in (0,)) or (errcode is not None and errcode not in (0,)):
+                        is_session_expired = (
+                            ret == SESSION_EXPIRED_ERRCODE
+                            or errcode == SESSION_EXPIRED_ERRCODE
+                        )
+                        # Session expired — strip token and retry once
+                        if is_session_expired and not retried_without_token and context_token:
+                            retried_without_token = True
+                            context_token = None
+                            self._token_store._cache.pop(
+                                self._token_store._key(self._account_id, chat_id), None
+                            )
+                            logger.warning(
+                                "[%s] session expired for %s; retrying without context_token",
+                                self.name, _safe_id(chat_id),
+                            )
+                            continue
+                        errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
+                        raise RuntimeError(
+                            f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
+                        )
                 return
             except Exception as exc:
                 last_error = exc


### PR DESCRIPTION
## Problem

iLink `context_token` has a limited TTL. When no user message has arrived for an extended period (e.g. overnight), cron-initiated pushes fail with `errcode -14` (session timeout). All scheduled push messages (weather reports, digests, etc.) are silently dropped.

## Root Cause

Every outbound message echoes the latest `context_token` for the peer. This token expires if no inbound message refreshes it. The `_send_text_chunk` method retries on generic errors but treats session expiry the same as any other failure — it retries with the same stale token, which keeps failing.

## Fix

When `_send_text_chunk` catches an `iLinkDeliveryError` with session-expired errcode (`-14`), it now:
1. Strips the expired `context_token`
2. Clears the stale token from `ContextTokenStore`
3. Retries the send **without** `context_token`

Verified that iLink accepts sends without `context_token` as a degraded fallback — the message is delivered successfully.

## Testing

- All 34 existing `test_weixin.py` tests pass
- Manually verified: iLink sendmessage returns `{}`  (success) without `context_token`
- Manually verified: cron weather push now succeeds after overnight session expiry

## Files Changed

- `gateway/platforms/weixin.py` — `_send_text_chunk()` adds session-expired detection and tokenless retry
