### PR TITLE
fix(discord): register native /restart slash command

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1696,6 +1696,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
+        @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
+        async def slash_restart(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/restart", "Restart requested~")
+
         @tree.command(name="approve", description="Approve a pending dangerous command")
         @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
         async def slash_approve(interaction: discord.Interaction, scope: str = ""):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -96,6 +96,7 @@ AUTHOR_MAP = {
     "aryan@synvoid.com": "aryansingh",
     "johnsonblake1@gmail.com": "blakejohnson",
     "kennyx102@gmail.com": "bobashopcashier",
+    "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",
     "hermes@nousresearch.com": "NousResearch",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -117,6 +117,23 @@ async def test_registers_native_thread_slash_command(adapter):
     adapter._handle_thread_create_slash.assert_awaited_once_with(interaction, "Planning", "", 1440)
 
 
+@pytest.mark.asyncio
+async def test_registers_native_restart_slash_command(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    assert "restart" in adapter._client.tree.commands
+
+    interaction = SimpleNamespace()
+    await adapter._client.tree.commands["restart"](interaction)
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction,
+        "/restart",
+        "Restart requested~",
+    )
+
+
 # ------------------------------------------------------------------
 # _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Salvage of PR #9214 by @areu01or00 — cherry-picked onto current main.

Discord's `_register_slash_commands()` was missing `/restart`. The command existed in the central `COMMAND_REGISTRY` and `gateway/run.py` handled it, but Discord users couldn't discover or invoke it from the native slash menu.

## Changes
- Added native Discord `/restart` registration via `@tree.command` in `discord.py`
- Routed through existing `_run_simple_slash(..., "/restart", "Restart requested~")` path
- Added regression test in `test_discord_slash_commands.py`
- Added contributor to AUTHOR_MAP

## Audit
Verified all other platforms already have `/restart`:
- **Telegram** — auto-derived from `COMMAND_REGISTRY` via `telegram_bot_commands()` ✓
- **Slack** — auto-derived via `slack_subcommand_map()` ✓
- **All text-based platforms** (Signal, WhatsApp, Matrix, Mattermost, etc.) — parsed by `gateway/run.py` ✓
- **Discord** — was the only platform missing it

## Test plan
```
pytest tests/gateway/test_discord_slash_commands.py — 21 passed
```

Closes #9214