### PR TITLE
[codex] Fix codex quota rotation handling

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2665,7 +2665,7 @@ class AIAgent:
         if isinstance(body, dict):
             payload = body.get("error") if isinstance(body.get("error"), dict) else body
         if isinstance(payload, dict):
-            reason = payload.get("code") or payload.get("error")
+            reason = payload.get("code") or payload.get("type") or payload.get("error")
             if isinstance(reason, str) and reason.strip():
                 context["reason"] = reason.strip()
             message = payload.get("message") or payload.get("error_description")
@@ -4722,6 +4722,25 @@ class AIAgent:
             return False, has_retried_429
 
         if effective_reason == FailoverReason.rate_limit:
+            quota_reason = str((error_context or {}).get("reason") or "").strip().lower()
+            quota_message = str((error_context or {}).get("message") or "").strip().lower()
+            has_reset_at = bool((error_context or {}).get("reset_at") or (error_context or {}).get("resets_at"))
+            is_quota_exhausted = (
+                quota_reason == "usage_limit_reached"
+                or (has_reset_at and ("usage limit" in quota_message or "quota" in quota_message))
+            )
+            if is_quota_exhausted:
+                rotate_status = status_code if status_code is not None else 429
+                next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+                if next_entry is not None:
+                    logger.info(
+                        "Credential %s (quota exhausted) — rotated to pool entry %s",
+                        rotate_status,
+                        getattr(next_entry, "id", "?"),
+                    )
+                    self._swap_credential(next_entry)
+                    return True, False
+                return False, has_retried_429
             if not has_retried_429:
                 return False, True
             rotate_status = status_code if status_code is not None else 429
@@ -4735,6 +4754,32 @@ class AIAgent:
                 self._swap_credential(next_entry)
                 return True, False
             return False, True
+
+        if (
+            effective_reason in (FailoverReason.timeout, FailoverReason.unknown)
+            and self.api_mode == "codex_responses"
+            and (self.provider or "").strip().lower() == "openai-codex"
+        ):
+            quota_message = str((error_context or {}).get("message") or "").strip().lower()
+            is_codex_quota_proxy = (
+                quota_message.startswith("[errno 2] no such file or directory")
+                and "'" not in quota_message
+            )
+            if is_codex_quota_proxy:
+                synthesized_context = dict(error_context or {})
+                synthesized_context.setdefault("reason", "codex_file_not_found_quota_proxy")
+                next_entry = pool.mark_exhausted_and_rotate(
+                    status_code=429,
+                    error_context=synthesized_context,
+                )
+                if next_entry is not None:
+                    logger.info(
+                        "Credential 429 (codex file-not-found quota proxy) — rotated to pool entry %s",
+                        getattr(next_entry, "id", "?"),
+                    )
+                    self._swap_credential(next_entry)
+                    return True, False
+                return False, has_retried_429
 
         if effective_reason == FailoverReason.auth:
             refreshed = pool.try_refresh_current()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2731,6 +2731,25 @@ class TestCredentialPoolRecovery:
         assert context["message"] == "Weekly credits exhausted."
         assert context["reset_at"] == "2026-04-12T10:30:00Z"
 
+    def test_extract_api_error_context_uses_type_when_code_missing(self, agent):
+        response = SimpleNamespace(headers={})
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "resets_at": 1776740799,
+                }
+            },
+            response=response,
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "usage_limit_reached"
+        assert context["message"] == "The usage limit has been reached"
+        assert context["reset_at"] == 1776740799
+
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")
         captured = {}
@@ -2757,6 +2776,87 @@ class TestCredentialPoolRecovery:
         assert retry_same is False
         assert captured["status_code"] == 429
         assert captured["error_context"]["reason"] == "device_code_exhausted"
+
+    def test_recover_with_pool_rotates_immediately_on_usage_limit_429(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        captured = {}
+
+        class _Pool:
+            def current(self):
+                return SimpleNamespace(label="primary")
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                captured["status_code"] = status_code
+                captured["error_context"] = error_context
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "reset_at": 1776740799,
+            },
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert captured["status_code"] == 429
+        assert captured["error_context"]["reason"] == "usage_limit_reached"
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_recover_with_pool_rotates_on_codex_file_not_found_quota_proxy(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        captured = {}
+
+        class _Pool:
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                captured["status_code"] = status_code
+                captured["error_context"] = error_context
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=FailoverReason.timeout,
+            error_context={"message": "[Errno 2] No such file or directory"},
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert captured["status_code"] == 429
+        assert captured["error_context"]["reason"] == "codex_file_not_found_quota_proxy"
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_recover_with_pool_does_not_rotate_on_named_file_not_found(self, agent):
+        class _Pool:
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                raise AssertionError("should not rotate for explicit local file path errors")
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+        agent.provider = "openai-codex"
+        agent.api_mode = "codex_responses"
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=FailoverReason.timeout,
+            error_context={"message": "[Errno 2] No such file or directory: '/tmp/missing.txt'"},
+        )
+
+        assert recovered is False
+        assert retry_same is False
+        agent._swap_credential.assert_not_called()
 
 
 class TestMaxTokensParam:


### PR DESCRIPTION
## What changed

- parse `error.type` when `error.code` is missing in provider error bodies
- rotate the credential pool immediately for Codex quota exhaustion signaled as `usage_limit_reached`
- rotate the credential pool for the observed Codex quota incident that surfaced as generic `[Errno 2] No such file or directory` without a named file path
- add regression tests for the new success and negative cases

## Why

On this runtime, `openai-codex` quota exhaustion did not always surface as a normal `429 usage_limit_reached` code path. In the observed incident, the backend sometimes returned a generic `FileNotFoundError` message, so Hermes retried/fell back instead of rotating to the next credential.

## Impact

- Hermes can rotate away from exhausted Codex credentials sooner
- the fix is narrowly scoped to `openai-codex` + `codex_responses` for the generic file-not-found incident pattern
- explicit local file path errors still do not trigger credential rotation

## Validation

- `.venv/bin/pytest tests/run_agent/test_run_agent.py -k "extract_api_error_context_uses_type_when_code_missing or rotates_immediately_on_usage_limit_429 or rotates_on_codex_file_not_found_quota_proxy or does_not_rotate_on_named_file_not_found"`
