### PR TITLE
fix(gateway): suppress silent placeholder replies in live chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -71,6 +71,65 @@ def _ensure_ssl_certs() -> None:
 
 _ensure_ssl_certs()
 
+
+_LIVE_GATEWAY_SILENT_MARKERS = {
+    "[silent]",
+    "silent",
+    "no message",
+    "no reply",
+    "no response",
+    "no response generated",
+    "empty",
+}
+
+
+def _normalize_live_gateway_response(response: Optional[str], *, failed: bool = False) -> str:
+    """Suppress placeholder silence markers before live message delivery.
+
+    Live gateway chats should not send placeholder strings such as
+    ``(No message)`` or ``[SILENT]`` into Discord/Telegram/etc.  Only exact
+    silence markers are suppressed; real error text and normal responses are
+    preserved.
+    """
+    if response is None:
+        return ""
+
+    text = str(response).strip()
+    if not text or failed:
+        return text
+
+    normalized = text
+    for _ in range(6):
+        updated = normalized.strip()
+        changed = False
+
+        for wrapper in ("**", "__", "~~", "`"):
+            if updated.startswith(wrapper) and updated.endswith(wrapper):
+                inner = updated[len(wrapper):-len(wrapper)].strip()
+                if inner:
+                    normalized = inner
+                    changed = True
+                    break
+        if changed:
+            continue
+
+        for left, right in (("(", ")"), ("[", "]"), ("{", "}"), ('"', '"'), ("'", "'")):
+            if updated.startswith(left) and updated.endswith(right):
+                inner = updated[len(left):-len(right)].strip()
+                if inner:
+                    normalized = inner
+                    changed = True
+                    break
+        if not changed:
+            normalized = updated
+            break
+
+    canonical = re.sub(r"[\s\-_]+", " ", normalized).strip(" .!?:;").casefold()
+    if canonical in _LIVE_GATEWAY_SILENT_MARKERS:
+        return ""
+
+    return text
+
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -3565,12 +3624,6 @@ class GatewayRunner:
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
-            _resp_len = len(response)
-            logger.info(
-                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
-                _platform_name, source.chat_id or "unknown",
-                _response_time, _api_calls, _resp_len,
-            )
 
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
@@ -3627,6 +3680,17 @@ class GatewayRunner:
                     else:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+
+            response = _normalize_live_gateway_response(
+                response,
+                failed=bool(agent_result.get("failed")),
+            )
+            _resp_len = len(response)
+            logger.info(
+                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
+                _platform_name, source.chat_id or "unknown",
+                _response_time, _api_calls, _resp_len,
+            )
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -8475,7 +8539,10 @@ class GatewayRunner:
                             )
                         )
                     )
-                    first_response = result.get("final_response", "")
+                    first_response = _normalize_live_gateway_response(
+                        result.get("final_response", ""),
+                        failed=bool(result.get("failed")),
+                    )
                     if first_response and not _already_streamed:
                         try:
                             await adapter.send(

--- a/tests/gateway/test_live_silent_responses.py
+++ b/tests/gateway/test_live_silent_responses.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _normalize_live_gateway_response
+from gateway.session import SessionSource
+
+
+@pytest.mark.parametrize(
+    ("raw_text", "expected"),
+    [
+        ("(No message)", ""),
+        ("[SILENT]", ""),
+        ("`(No reply)`", ""),
+        ("**(No response generated)**", ""),
+        ("(empty)", ""),
+        ("[SILENT] means stay quiet", "[SILENT] means stay quiet"),
+        ("No message received from Discord", "No message received from Discord"),
+    ],
+)
+def test_normalize_live_gateway_response(raw_text, expected):
+    assert _normalize_live_gateway_response(raw_text) == expected
+
+
+def test_normalize_live_gateway_response_preserves_failed_output():
+    assert _normalize_live_gateway_response("[SILENT]", failed=True) == "[SILENT]"
+
+
+def _make_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner.adapters = {}
+    runner._show_reasoning = False
+    runner._session_db = None
+    runner._set_session_env = MagicMock(return_value=[])
+    runner._clear_session_env = MagicMock()
+    runner._should_send_voice_reply = MagicMock(return_value=False)
+    runner._deliver_media_from_response = AsyncMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_suppresses_placeholder(monkeypatch):
+    runner = _make_runner()
+
+    session_entry = SimpleNamespace(
+        session_id="sess-1",
+        session_key="key-1",
+        created_at=1,
+        updated_at=2,
+        was_auto_reset=False,
+        last_prompt_tokens=0,
+    )
+    history = [{"role": "assistant", "content": "Earlier reply"}]
+
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "(No message)",
+            "messages": history,
+            "api_calls": 1,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr("gateway.run.build_session_context", lambda *_a, **_kw: {})
+    monkeypatch.setattr("gateway.run.build_session_context_prompt", lambda *_a, **_kw: "")
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="chat-1",
+        user_id="user-1",
+        user_name="tester",
+    )
+    event = MessageEvent(text="test", message_type=MessageType.TEXT, source=source)
+
+    result = await runner._handle_message_with_agent(event, source, "key-1")
+
+    assert result == ""
+    appended = [call.args[1] for call in runner.session_store.append_to_transcript.call_args_list]
+    assert any(entry["role"] == "user" for entry in appended)
+    assert not any(entry.get("content") == "(No message)" for entry in appended)


### PR DESCRIPTION
## Summary
- suppress placeholder silent replies in the live gateway response path
- prevent `(No message)`, `(No reply)`, `[SILENT]`, and similar exact silence markers from being sent to Discord and other live messaging platforms
- add focused regression coverage for silent-response normalization

## Problem
In live gateway chats, the model can decide it should stay silent but still emit placeholder text such as `(No message)`, `(No reply)`, or `[SILENT]`.

The gateway was treating those placeholders as normal text and delivering them to Discord instead of suppressing delivery entirely.

## Root Cause
The live messaging response path had no normalization step for silence markers before adapter delivery. As a result, placeholder "no reply" outputs were forwarded like ordinary assistant messages.

## Changes
- add `_normalize_live_gateway_response()` in `gateway/run.py`
- suppress exact silence markers before normal live response delivery
- suppress the same markers in the queued follow-up first-response path
- preserve real errors and non-placeholder content
- add regression tests covering placeholder and non-placeholder cases

## Testing
- `venv\\Scripts\\python -m pytest tests/gateway/test_live_silent_responses.py -q -n 0`

Closes #9840
