### PR TITLE
Add moving Codex latest model alias

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1457,17 +1457,14 @@ class HermesCLI:
 
         # 2. Replace untouched default with a Codex model
         if self._model_is_default:
-            fallback_model = "gpt-5.3-codex"
             try:
-                from hermes_cli.codex_models import get_codex_model_ids
+                from hermes_cli.codex_models import get_latest_codex_model_id
 
-                available = get_codex_model_ids(
+                fallback_model = get_latest_codex_model_id(
                     access_token=self.api_key if self.api_key else None,
                 )
-                if available:
-                    fallback_model = available[0]
             except Exception:
-                pass
+                fallback_model = "gpt-5.3-codex"
 
             if current_model != fallback_model:
                 self.model = fallback_model

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -18,6 +18,8 @@ DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.1-codex-mini",
 ]
 
+CODEX_LATEST_MODEL_CHOICES = {"latest", "codex-latest"}
+
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
@@ -47,6 +49,33 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
             seen.add(synthetic_model)
 
     return ordered
+
+
+def is_codex_latest_choice(model_id: Optional[str]) -> bool:
+    """Return True when the user requested the moving Codex latest alias."""
+    return (model_id or "").strip().lower() in CODEX_LATEST_MODEL_CHOICES
+
+
+def get_latest_codex_model_id(access_token: Optional[str] = None) -> str:
+    """Return the best current Codex model slug.
+
+    Prefers the live catalog when available, then falls back to the curated
+    defaults. The first entry is always the newest/most preferred model.
+    """
+    models = get_codex_model_ids(access_token=access_token)
+    return models[0] if models else DEFAULT_CODEX_MODELS[0]
+
+
+def resolve_codex_model_id(model_id: Optional[str], access_token: Optional[str] = None) -> str:
+    """Resolve Codex aliases like ``latest`` to a concrete model slug."""
+    requested = (model_id or "").strip()
+    if ":" in requested:
+        prefix, remainder = requested.split(":", 1)
+        if prefix.strip().lower() in {"openai-codex", "codex"}:
+            requested = remainder.strip()
+    if is_codex_latest_choice(requested):
+        return get_latest_codex_model_id(access_token=access_token)
+    return requested
 
 
 def _fetch_models_from_api(access_token: str) -> List[str]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1072,7 +1072,7 @@ def _model_flow_openai_codex(config, current_model=""):
         _update_config_for_provider, _login_openai_codex,
         PROVIDER_REGISTRY, DEFAULT_CODEX_BASE_URL,
     )
-    from hermes_cli.codex_models import get_codex_model_ids
+    from hermes_cli.codex_models import get_codex_model_ids, is_codex_latest_choice
     from hermes_cli.config import get_env_value, save_env_value
     import argparse
 
@@ -1099,9 +1099,14 @@ def _model_flow_openai_codex(config, current_model=""):
         pass
 
     codex_models = get_codex_model_ids(access_token=_codex_token)
+    codex_latest_choice = "Latest available (auto)"
+    codex_choices = codex_models + [codex_latest_choice]
+    current_choice = codex_latest_choice if is_codex_latest_choice(current_model) else current_model
 
-    selected = _prompt_model_selection(codex_models, current_model=current_model)
+    selected = _prompt_model_selection(codex_choices, current_model=current_choice)
     if selected:
+        if selected == codex_latest_choice:
+            selected = "codex-latest"
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         # Clear custom endpoint env vars that would otherwise override Codex.

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1677,7 +1677,7 @@ def setup_model_provider(config: dict):
             if custom:
                 _set_default_model(config, custom)
         elif selected_provider == "openai-codex":
-            from hermes_cli.codex_models import get_codex_model_ids
+            from hermes_cli.codex_models import get_codex_model_ids, is_codex_latest_choice
 
             codex_token = None
             try:
@@ -1688,9 +1688,12 @@ def setup_model_provider(config: dict):
 
             codex_models = get_codex_model_ids(access_token=codex_token)
 
-            model_choices = codex_models + [f"Keep current ({current_model})"]
+            codex_latest_choice = "Latest available (auto)"
+            model_choices = codex_models + [codex_latest_choice, f"Keep current ({current_model})"]
             default_codex = 0
-            if current_model in codex_models:
+            if is_codex_latest_choice(current_model):
+                default_codex = len(codex_models)
+            elif current_model in codex_models:
                 default_codex = codex_models.index(current_model)
             elif current_model:
                 default_codex = len(model_choices) - 1
@@ -1701,6 +1704,8 @@ def setup_model_provider(config: dict):
             if model_idx < len(codex_models):
                 _set_default_model(config, codex_models[model_idx])
             elif model_idx == len(codex_models):
+                _set_default_model(config, "codex-latest")
+            elif model_idx == len(codex_models) + 1:
                 custom = prompt("Enter model name")
                 if custom:
                     _set_default_model(config, custom)

--- a/run_agent.py
+++ b/run_agent.py
@@ -518,6 +518,17 @@ class AIAgent:
         if self.api_mode == "chat_completions" and self._is_direct_openai_url():
             self.api_mode = "codex_responses"
 
+        if self.provider == "openai-codex":
+            try:
+                from hermes_cli.auth import resolve_codex_runtime_credentials
+                from hermes_cli.codex_models import resolve_codex_model_id
+
+                codex_creds = resolve_codex_runtime_credentials()
+                codex_token = str(codex_creds.get("api_key") or "").strip() if codex_creds else None
+                self.model = resolve_codex_model_id(self.model, access_token=codex_token or None)
+            except Exception:
+                pass
+
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.

--- a/tests/test_codex_models.py
+++ b/tests/test_codex_models.py
@@ -5,7 +5,13 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
+from hermes_cli.codex_models import (
+    DEFAULT_CODEX_MODELS,
+    get_codex_model_ids,
+    get_latest_codex_model_id,
+    is_codex_latest_choice,
+    resolve_codex_model_id,
+)
 
 
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
@@ -34,6 +40,21 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
     # Non-codex-suffixed models are included when the cache says they're available
     assert "gpt-5.4" in models
     assert "gpt-5-hidden-codex" not in models
+
+
+def test_get_latest_codex_model_id_and_alias_resolution(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.4", "gpt-5.3-codex"],
+    )
+
+    assert is_codex_latest_choice("codex-latest") is True
+    assert is_codex_latest_choice("latest") is True
+    assert is_codex_latest_choice("gpt-5.4") is False
+    assert get_latest_codex_model_id(access_token="codex-token") == "gpt-5.4"
+    assert resolve_codex_model_id("codex-latest", access_token="codex-token") == "gpt-5.4"
+    assert resolve_codex_model_id("openai-codex:latest", access_token="codex-token") == "gpt-5.4"
+    assert resolve_codex_model_id("gpt-5.3-codex") == "gpt-5.3-codex"
 
 
 def test_setup_wizard_codex_import_resolves():
@@ -102,7 +123,7 @@ def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     _model_flow_openai_codex({}, current_model="openai/gpt-5.4")
 
     assert captured["access_token"] == "codex-access-token"
-    assert captured["model_ids"] == ["gpt-5.2-codex", "gpt-5.2"]
+    assert captured["model_ids"] == ["gpt-5.2-codex", "gpt-5.2", "Latest available (auto)"]
     assert captured["current_model"] == "openai/gpt-5.4"
 
 


### PR DESCRIPTION
Adds a Codex-specific "Latest available (auto)" choice that stores a moving alias (codex-latest) and resolves it to the newest Codex model at runtime.

Changes:
- Add Codex latest alias helpers
- Use latest Codex model as the fallback for untouched defaults
- Add the auto-latest choice to /model and setup flows
- Resolve the alias in AIAgent initialization
- Add unit coverage for alias resolution and picker wiring

Validation:
- python3 -m py_compile hermes_cli/codex_models.py cli.py run_agent.py hermes_cli/main.py hermes_cli/setup.py tests/test_codex_models.py
- pytest not available in this environment