### PR TITLE
fix terminal workdir validation for Windows paths

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -75,6 +75,7 @@ AUTHOR_MAP = {
     "abdullahfarukozden@gmail.com": "Farukest",
     "lovre.pesut@gmail.com": "rovle",
     "hakanerten02@hotmail.com": "teyrebaz33",
+    "ruzzgarcn@gmail.com": "Ruzzgar",
     "alireza78.crypto@gmail.com": "alireza78a",
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",
     "gpickett00@gmail.com": "gpickett00",

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -88,3 +88,18 @@ def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+
+
+def test_validate_workdir_allows_windows_drive_paths():
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
+    assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None
+
+
+def test_validate_workdir_allows_windows_unc_paths():
+    assert terminal_tool._validate_workdir(r"\\server\share\project") is None
+
+
+def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
+    assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -148,9 +148,10 @@ def _check_all_guards(command: str, env_type: str) -> dict:
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
-# Covers alphanumeric, path separators, tilde, dot, hyphen, underscore, space,
-# plus, at, equals, and comma.  Everything else is rejected.
-_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/_\-.~ +@=,]+$')
+# Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
+# dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
+# else is rejected.
+_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
 
 
 def _validate_workdir(workdir: str) -> str | None:


### PR DESCRIPTION
## Summary

Fixes terminal `workdir` validation so normal Windows paths are accepted while shell metacharacters remain blocked.

Previously, `_validate_workdir()` rejected valid Windows drive and UNC paths because the allowlist did not include `:` or `\`. That meant calls such as `terminal(..., workdir="C:\\Users\\Alice\\project")` were blocked before execution, even though the path itself was valid.

This change expands the path-character allowlist narrowly for Windows path syntax and adds regression coverage for both accepted Windows paths and rejected shell metacharacter cases.

## Changes

- Allow Windows drive paths such as `C:\Users\Alice\project`
- Allow Windows forward-slash drive paths such as `C:/Users/Alice/project`
- Allow UNC paths such as `\\server\share\project`
- Keep blocking dangerous shell metacharacters in `workdir`, including `;`, `$()`, and newlines
- Add contributor attribution mapping for `ruzzgarcn@gmail.com`

## Tests

Ran:

```bash
uv run pytest tests/tools/test_terminal_tool.py -q

Result:
10 passed, 10 warnings

Ran:

uv run pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_none_command_guard.py tests/tools/test_terminal_foreground_timeout_cap.py

Result:
20 passed, 20 warnings
