### PR TITLE
Fix NameError: missing import os in web_server.py

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import asyncio
+import os
 import hmac
 import json
 import logging

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1176,3 +1176,23 @@ class TestStatusRemoteGateway:
         assert data["gateway_running"] is True
         assert data["gateway_pid"] is None
         assert data["gateway_state"] == "running"
+
+
+def test_anthropic_oauth_status_env_var_fallback(monkeypatch):
+    """Regression test for #9936: _anthropic_oauth_status uses os.getenv
+    when no stored credentials are present. Without ``import os`` in
+    web_server.py this raises NameError.
+    """
+    import agent.anthropic_adapter as aa
+    from hermes_cli.web_server import _anthropic_oauth_status
+
+    monkeypatch.setattr(aa, "read_hermes_oauth_credentials", lambda: None)
+    monkeypatch.setattr(aa, "read_claude_code_credentials", lambda: None)
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-test-regression-token")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    status = _anthropic_oauth_status()
+
+    assert status["logged_in"] is True
+    assert status["source"] == "env_var"
+    assert status["source_label"] == "ANTHROPIC_TOKEN environment variable"


### PR DESCRIPTION
## What does this PR do?

Fixes a `NameError: name 'os' is not defined` that breaks the dashboard when resolving env-var credentials — most visibly when users try to configure OpenAI auth through the UI.

`hermes_cli/web_server.py` calls `os.getenv` in four places but never imports `os`.

## Related Issue

Fixes #9936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: add `import os`
- `tests/hermes_cli/test_web_server.py`: add regression test `test_anthropic_oauth_status_env_var_fallback`

Existing `os.getenv` callsites in the file:
- L806: `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` (in `_anthropic_oauth_status`)
- L1247–1248: `HERMES_PORTAL_BASE_URL` / `NOUS_PORTAL_BASE_URL`
- L1516: `HERMES_CODEX_BASE_URL`

## How to Test

Automated: `pytest tests/hermes_cli/test_web_server.py -q` — 68 passed (67 existing + 1 new). The new test exercises `_anthropic_oauth_status()` with no stored creds and `ANTHROPIC_TOKEN` set; it fails on `main` with `NameError` and passes with the import added.

Manual:
1. `hermes dashboard`
2. Open the dashboard, go to auth / providers
3. Attempt to configure OpenAI — before the fix: `NameError` surfaces in the browser. After: loads normally.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(web_server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_web_server.py -q` and all tests pass (68 passed)
- [x] I've added a regression test that fails without the fix
- [x] I've tested on my platform: Ubuntu 24.04 LTS (VM, Python 3.11.15)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no docs describe the missing-import behavior)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `import os` is stdlib, no platform concern
- [x] I've updated tool descriptions/schemas — N/A