### PR TITLE
fix(gateway,cli,tui): pass user arguments to exec quick_commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8956,6 +8956,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Append user arguments to the command
+                            from hermes_cli._subprocess_compat import shell_quote
+                            user_args = cmd_original[len(base_cmd):].strip()
+                            if user_args:
+                                exec_cmd = f"{exec_cmd} {shell_quote(user_args)}"
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.
                             # Sanitize env to prevent credential leakage —

--- a/cli.py
+++ b/cli.py
@@ -4662,9 +4662,14 @@ class HermesCLI:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":
                     import subprocess
+                    import shlex
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Append user arguments to the command
+                            user_args = cmd_original[len(base_cmd):].strip()
+                            if user_args:
+                                exec_cmd = f"{exec_cmd} {shlex.quote(user_args)}"
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
                                 text=True, timeout=30

--- a/cli.py
+++ b/cli.py
@@ -3273,6 +3273,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         if not exec_cmd:
             self._console_print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
             return True
+        # Forward user arguments (e.g. `/poly white sox` → `poly.sh 'white sox'`).
+        # Split-then-quote per token so `--foo bar` stays two argv entries;
+        # quoting the blob would collapse it into one (see quote_args).
+        args = (user_args or "").strip()
+        if args:
+            from hermes_cli._subprocess_compat import quote_args
+            exec_cmd = f"{exec_cmd} {quote_args(args)}"
         try:
             # shell=True is intentional (user-authored config snippets, never LLM controlled);
             # the env is sanitized because this process holds every API key.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2180,6 +2180,11 @@ class GatewayRunner:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Append user arguments to the command
+                            import shlex
+                            user_args = event.get_command_args().strip()
+                            if user_args:
+                                exec_cmd = f"{exec_cmd} {shlex.quote(user_args)}"
                             proc = await asyncio.create_subprocess_shell(
                                 exec_cmd,
                                 stdout=asyncio.subprocess.PIPE,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10422,6 +10422,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Append user arguments to the command
+                            from hermes_cli._subprocess_compat import shell_quote
+                            user_args = event.get_command_args().strip()
+                            if user_args:
+                                exec_cmd = f"{exec_cmd} {shell_quote(user_args)}"
                             # Sanitize env to prevent credential leakage —
                             # quick commands run in the gateway process which
                             # has all API keys in os.environ.

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -922,9 +922,15 @@ class GatewayInboundMixin:
             return await getattr(self, f"_hm_cmd_{canonical}")(event, source, _quick_key)
         return False, None
 
-    async def _hm_run_exec_quick_command(self, command: str, exec_cmd: str) -> str:
+    async def _hm_run_exec_quick_command(self, command: Optional[str], exec_cmd: str, user_args: str = "") -> str:
         """Run a ``type: exec`` quick command in the gateway process (30 s cap, sanitized env — the
         gateway process has every API key in os.environ; output is redacted too)."""
+        # Forward user arguments (e.g. `/poly white sox`): split-then-quote per
+        # token so boundaries survive (see hermes_cli._subprocess_compat.quote_args).
+        args = (user_args or "").strip()
+        if args:
+            from hermes_cli._subprocess_compat import quote_args
+            exec_cmd = f"{exec_cmd} {quote_args(args)}"
         try:
             from tools.environments.local import build_subprocess_env
             proc = await asyncio.create_subprocess_shell(
@@ -966,7 +972,9 @@ class GatewayInboundMixin:
                 exec_cmd = qcmd.get("command", "")
                 if not exec_cmd:
                     return True, f"Quick command '/{command}' has no command defined.", command
-                return True, await self._hm_run_exec_quick_command(command, exec_cmd), command
+                return True, await self._hm_run_exec_quick_command(
+                    command, exec_cmd, event.get_command_args().strip()
+                ), command
             if qtype != "alias":
                 return True, f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias').", command
             new_command = self._hm_expand_alias_quick_command(event, qcmd)

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -38,6 +38,7 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "shell_quote",
 ]
 
 
@@ -232,3 +233,35 @@ def windows_detach_popen_kwargs() -> dict:
     if IS_WINDOWS:
         return {"creationflags": windows_detach_flags()}
     return {"start_new_session": True}
+
+
+# -----------------------------------------------------------------------------
+# Cross-platform shell quoting
+# -----------------------------------------------------------------------------
+
+
+def shell_quote(value: str) -> str:
+    """Shell-quote a string for the current platform's default shell.
+
+    Uses ``mslex.quote`` on Windows (cmd.exe-compatible) and
+    ``shlex.quote`` on POSIX.  Falls back to a minimal double-quote
+    escape if ``mslex`` is not installed on Windows.
+
+    This is intended for quoting a single blob of user-supplied arguments
+    that will be appended to a user-defined shell command and executed via
+    ``shell=True`` / ``create_subprocess_shell``.
+    """
+    import shlex
+
+    if IS_WINDOWS:
+        try:
+            import mslex  # type: ignore[import-not-found]
+
+            return mslex.quote(value)
+        except ImportError:
+            # Minimal cmd.exe escape: wrap in double quotes, escape embedded
+            # double quotes.  Not as robust as mslex but better than
+            # shlex's single-quote style which cmd.exe doesn't understand.
+            return '"' + value.replace('"', '\\"') + '"'
+
+    return shlex.quote(value)

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -27,6 +27,8 @@ __all__ = [
     "bounded_git_probe",
     "bounded_probe_run",
     "noninteractive_git_env",
+    "shell_quote",
+    "quote_args",
     "NO_DRIVER_DIFF_FLAGS",
     "pid_is_hermes",
 ]
@@ -461,3 +463,73 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
         return ""
     return (result.stdout or "").strip()
 
+
+
+def shell_quote(value: str) -> str:
+    """Shell-quote a single token for the current platform's default shell.
+
+    Uses ``mslex.quote`` on Windows (cmd.exe-compatible) and
+    ``shlex.quote`` on POSIX.  Falls back to cmd.exe's ``""`` doubling
+    rule if ``mslex`` is not installed on Windows.
+
+    Quote ONE token at a time.  For a whole argument string use
+    :func:`quote_args`, which splits into tokens first — quoting a blob
+    destroys argv boundaries (``--foo bar`` would arrive as one argument).
+    """
+    import shlex
+
+    if IS_WINDOWS:
+        try:
+            import mslex  # type: ignore[import-not-found]
+
+            return mslex.quote(value)
+        except ImportError:
+            # Minimal cmd.exe escape: wrap in double quotes and double any
+            # embedded double quote.  cmd.exe's quoting rule is doubling,
+            # NOT backslash-escaping (backslash is not an escape character
+            # there) — backslash escapes both break the token and leave it
+            # injectable.  Percent signs are doubled as well: cmd.exe expands
+            # %VAR% *inside* double quotes, so a bare % in user input is an
+            # expansion vector; %% renders literally with no variable lookup.
+            # (!VAR! delayed expansion is off under plain cmd /c and cannot be
+            # escaped inside quotes, so it is intentionally left alone.)
+            return '"' + value.replace('"', '""').replace('%', '%%') + '"'
+
+    return shlex.quote(value)
+
+
+def quote_args(args: str) -> str:
+    """Split a user-supplied argument string into tokens and quote each one.
+
+    Appending a shell-quoted *blob* to a command collapses ``--foo bar``
+    into a single argv entry; this helper preserves token boundaries so
+    the appended arguments reach the wrapped tool the way the user typed
+    them.  On POSIX it is ``shlex.split`` + ``shlex.quote`` per token; on
+    Windows it uses ``mslex.split``/``mslex.quote`` when available and
+    falls back to :func:`split_command_line` with cmd-safe quoting.
+
+    Returns ``""`` for empty input.  If the input has unbalanced quotes
+    and cannot be tokenized, the whole string is quoted as one token
+    rather than raising.
+    """
+    import shlex
+
+    text = args.strip()
+    if not text:
+        return ""
+    if IS_WINDOWS:
+        try:
+            import mslex  # type: ignore[import-not-found]
+
+            return " ".join(mslex.quote(tok) for tok in mslex.split(text))
+        except ImportError:
+            try:
+                tokens = split_command_line(text)
+            except ValueError:
+                return shell_quote(text)
+            return " ".join(shell_quote(tok) for tok in tokens)
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return shell_quote(text)
+    return " ".join(shell_quote(tok) for tok in tokens)

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -245,3 +245,35 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+
+class TestExecQuickCommandArgs:
+    """Test that exec quick commands receive user arguments."""
+
+    def test_exec_command_receives_args(self):
+        """Exec quick commands should pass user arguments to the shell command."""
+        from unittest.mock import patch
+        import subprocess
+
+        cli = TestCLIQuickCommands()._make_cli({
+            "search": {"type": "exec", "command": "echo"}
+        })
+
+        # Process command with arguments
+        result = cli.process_command("/search hello world")
+        assert result is True
+
+        # Verify the command was called with arguments
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "hello world" in printed
+
+    def test_exec_command_no_args_still_works(self):
+        """Exec quick commands without arguments should still execute."""
+        cli = TestCLIQuickCommands()._make_cli({
+            "test": {"type": "exec", "command": "echo ok"}
+        })
+
+        result = cli.process_command("/test")
+        assert result is True
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "ok" in printed

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -186,3 +186,35 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+
+class TestExecQuickCommandArgs:
+    """Test that exec quick commands receive user arguments."""
+
+    def test_exec_command_receives_args(self):
+        """Exec quick commands should pass user arguments to the shell command."""
+        from unittest.mock import patch
+        import subprocess
+
+        cli = TestCLIQuickCommands()._make_cli({
+            "search": {"type": "exec", "command": "echo"}
+        })
+
+        # Process command with arguments
+        result = cli.process_command("/search hello world")
+        assert result is True
+
+        # Verify the command was called with arguments
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "hello world" in printed
+
+    def test_exec_command_no_args_still_works(self):
+        """Exec quick commands without arguments should still execute."""
+        cli = TestCLIQuickCommands()._make_cli({
+            "test": {"type": "exec", "command": "echo ok"}
+        })
+
+        result = cli.process_command("/test")
+        assert result is True
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "ok" in printed

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -175,3 +175,187 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+
+# ── Exec arg-forwarding (PR #9942) ──────────────────────────────────────
+# Gateway/CLI/TUI exec quick commands must forward user args with argv
+# boundaries preserved (split-then-quote, never blob-quote).
+
+class TestGatewayExecArgsForwarding(TestGatewayQuickCommands):
+    """Gateway exec quick commands append args with boundaries preserved."""
+
+    @pytest.mark.asyncio
+    async def test_exec_command_passes_args_tokenized(self):
+        """Gateway exec quick commands append args with boundaries preserved."""
+        import shlex
+        from unittest.mock import AsyncMock
+
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"search": {"type": "exec", "command": "echo"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        captured: dict[str, str] = {}
+        fake_proc = AsyncMock()
+        fake_proc.communicate.return_value = (b"ok", b"")
+
+        async def fake_shell(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return fake_proc
+
+        with patch("asyncio.create_subprocess_shell", side_effect=fake_shell):
+            result = await runner._handle_message(self._make_event("search", args="--foo bar"))
+
+        assert result == "ok"
+        assert shlex.split(captured["cmd"]) == ["echo", "--foo", "bar"]
+
+    @pytest.mark.asyncio
+    async def test_exec_command_metachars_stay_boundary_safe(self):
+        """Gateway: shell metacharacters must stay inside quoted tokens."""
+        import shlex
+        from unittest.mock import AsyncMock
+
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"search": {"type": "exec", "command": "echo"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        captured: dict[str, str] = {}
+        fake_proc = AsyncMock()
+        fake_proc.communicate.return_value = (b"ok", b"")
+
+        async def fake_shell(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return fake_proc
+
+        for dangerous in ["'; rm -rf /'", "a && id", "x | cat", "%PATH%"]:
+            with patch("asyncio.create_subprocess_shell", side_effect=fake_shell):
+                await runner._handle_message(self._make_event("search", args=dangerous))
+            assert shlex.split(captured["cmd"]) == ["echo"] + shlex.split(dangerous)
+
+
+
+
+
+# ── TUI tests ──────────────────────────────────────────────────────────────
+
+class TestTUIQuickCommands:
+    """Test TUI command.dispatch exec quick commands (arg forwarding)."""
+
+    @staticmethod
+    def _dispatch(name, arg):
+        # Handlers are registered on tui_gateway.server's _methods registry
+        # (method_ctx rebinds at install); methods_tools itself has no dict.
+        import tui_gateway.server as server
+
+        return server._methods["command.dispatch"](None, {"name": name, "arg": arg, "session_id": ""})
+
+    @staticmethod
+    def _patch_cfg(quick_commands):
+        # _load_cfg is lazily imported from tui_gateway.server at call time —
+        # patch the source module, not the consumer.
+        return patch("tui_gateway.server._load_cfg", return_value={"quick_commands": quick_commands})
+
+    def test_tui_exec_forwards_args_tokenized(self):
+        import shlex
+        import subprocess as sp
+        from unittest.mock import patch
+
+        captured: dict[str, str] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return sp.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        with self._patch_cfg({"search": {"type": "exec", "command": "echo"}}):
+            with patch("subprocess.run", side_effect=fake_run):
+                self._dispatch("/search", "--foo bar")
+
+        assert shlex.split(captured["cmd"]) == ["echo", "--foo", "bar"]
+
+    def test_tui_exec_no_args_unchanged(self):
+        import subprocess as sp
+        from unittest.mock import patch
+
+        captured: dict[str, str] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return sp.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        with self._patch_cfg({"limits": {"type": "exec", "command": "echo ok"}}):
+            with patch("subprocess.run", side_effect=fake_run):
+                self._dispatch("/limits", "")
+
+        assert captured["cmd"] == "echo ok"
+
+
+class TestExecQuickCommandArgs:
+    """Test that exec quick commands receive user arguments."""
+
+    def test_exec_command_receives_args(self):
+        """Exec quick commands should pass user arguments to the shell command."""
+        from unittest.mock import patch
+        import subprocess
+
+        cli = TestCLIQuickCommands()._make_cli({
+            "search": {"type": "exec", "command": "echo"}
+        })
+
+        # Process command with arguments
+        result = cli.process_command("/search hello world")
+        assert result is True
+
+        # Verify the command was called with arguments
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "hello world" in printed
+
+    def test_exec_command_passes_args_tokenized(self):
+        """User args must be appended per-token so argv boundaries survive."""
+        import shlex
+
+        cli = TestCLIQuickCommands()._make_cli({"search": {"type": "exec", "command": "echo"}})
+        captured: dict[str, str] = {}
+
+        def fake_run(args, **kwargs):
+            captured["cmd"] = args
+            return subprocess.CompletedProcess(args, 0, stdout="ok", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = cli.process_command("/search --foo bar")
+
+        assert result is True
+        assert shlex.split(captured["cmd"]) == ["echo", "--foo", "bar"]
+
+    def test_exec_command_metachars_stay_boundary_safe(self):
+        """Shell metacharacters in user args must arrive quoted, not as operators."""
+        import shlex
+
+        cli = TestCLIQuickCommands()._make_cli({"search": {"type": "exec", "command": "echo"}})
+        captured: dict[str, str] = {}
+
+        def fake_run(args, **kwargs):
+            captured["cmd"] = args
+            return subprocess.CompletedProcess(args, 0, stdout="ok", stderr="")
+
+        for dangerous in ["'; rm -rf /'", "a && id", "x | cat", "%PATH%", "a; touch /tmp/pwned"]:
+            with patch("subprocess.run", side_effect=fake_run):
+                cli.process_command(f"/search {dangerous}")
+            assert shlex.split(captured["cmd"]) == ["echo"] + shlex.split(dangerous)
+
+    def test_exec_command_no_args_still_works(self):
+        """Exec quick commands without arguments should still execute."""
+        cli = TestCLIQuickCommands()._make_cli({
+            "test": {"type": "exec", "command": "echo ok"}
+        })
+
+        result = cli.process_command("/test")
+        assert result is True
+        printed = TestCLIQuickCommands._printed_plain(cli.console.print.call_args[0][0])
+        assert "ok" in printed

--- a/tests/hermes_cli/test_subprocess_compat_shell_quote.py
+++ b/tests/hermes_cli/test_subprocess_compat_shell_quote.py
@@ -1,0 +1,99 @@
+"""Tests for cross-platform shell_quote() in _subprocess_compat."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch, Mock
+
+import pytest
+
+
+@pytest.fixture
+def compat_module():
+    """Import (or re-import) the module fresh so IS_WINDOWS patching works."""
+    import hermes_cli._subprocess_compat as mod
+    importlib.reload(mod)
+    return mod
+
+
+class TestShellQuotePOSIX:
+    """Test shell_quote() on POSIX (the real platform in CI)."""
+
+    def test_simple_space(self, compat_module):
+        result = compat_module.shell_quote("hello world")
+        assert "hello world" in result
+        assert result.startswith("'") or result.startswith('"')
+
+    def test_no_space_unchanged(self, compat_module):
+        assert compat_module.shell_quote("hello") == "hello"
+
+    def test_semicolon_metachar(self, compat_module):
+        result = compat_module.shell_quote("a; rm -rf /")
+        assert "a; rm -rf /" in result
+        assert not result.startswith("a;")
+
+    def test_pipe_metachar(self, compat_module):
+        result = compat_module.shell_quote("foo | bar")
+        assert "foo | bar" in result
+        assert not result.startswith("foo |")
+
+    def test_ampersand_metachar(self, compat_module):
+        result = compat_module.shell_quote("foo & bar")
+        assert "foo & bar" in result
+        assert not result.startswith("foo &")
+
+    def test_single_quote_inside(self, compat_module):
+        result = compat_module.shell_quote("it's fine")
+        assert "it" in result and "fine" in result
+
+    def test_empty_string(self, compat_module):
+        assert compat_module.shell_quote("") == "''"
+
+
+class TestShellQuoteWindows:
+    """Test shell_quote() Windows branch via monkeypatch (no real Windows needed)."""
+
+    def test_windows_uses_mslex(self, compat_module, monkeypatch):
+        """When IS_WINDOWS=True and mslex is available, mslex.quote is used."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        fake_mslex = Mock()
+        fake_mslex.quote = lambda s: f"[MSLEX]{s}[MSLEX]"
+
+        with patch.dict(sys.modules, {"mslex": fake_mslex}):
+            result = compat_module.shell_quote("hello world")
+        assert result == "[MSLEX]hello world[MSLEX]"
+
+    def test_windows_fallback_no_mslex(self, compat_module, monkeypatch):
+        """When IS_WINDOWS=True and mslex is not installed, fallback to double-quote."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        # Setting mslex to None in sys.modules causes ImportError on import
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.shell_quote("hello world")
+
+        assert result.startswith('"') and result.endswith('"')
+        assert "hello world" in result
+
+    def test_windows_fallback_escapes_embedded_quotes(self, compat_module, monkeypatch):
+        """Fallback should escape embedded double quotes."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.shell_quote('say "hi"')
+
+        assert '\\"' in result
+        assert result.startswith('"') and result.endswith('"')
+
+    def test_windows_metachar_semicolon(self, compat_module, monkeypatch):
+        """Windows quoting should handle semicolons (via mslex)."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        fake_mslex = Mock()
+        fake_mslex.quote = lambda s: f"[Q]{s}[Q]"
+
+        with patch.dict(sys.modules, {"mslex": fake_mslex}):
+            result = compat_module.shell_quote("a; rm -rf \\")
+
+        assert result == "[Q]a; rm -rf \\[Q]"

--- a/tests/hermes_cli/test_subprocess_compat_shell_quote.py
+++ b/tests/hermes_cli/test_subprocess_compat_shell_quote.py
@@ -1,0 +1,155 @@
+"""Tests for cross-platform shell_quote() in _subprocess_compat."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch, Mock
+
+import pytest
+
+
+@pytest.fixture
+def compat_module():
+    """Import (or re-import) the module fresh so IS_WINDOWS patching works."""
+    import hermes_cli._subprocess_compat as mod
+    importlib.reload(mod)
+    return mod
+
+
+class TestShellQuotePOSIX:
+    """Test shell_quote() on POSIX (the real platform in CI)."""
+
+    def test_simple_space(self, compat_module):
+        result = compat_module.shell_quote("hello world")
+        assert "hello world" in result
+        assert result.startswith("'") or result.startswith('"')
+
+    def test_no_space_unchanged(self, compat_module):
+        assert compat_module.shell_quote("hello") == "hello"
+
+    def test_semicolon_metachar(self, compat_module):
+        result = compat_module.shell_quote("a; rm -rf /")
+        assert "a; rm -rf /" in result
+        assert not result.startswith("a;")
+
+    def test_pipe_metachar(self, compat_module):
+        result = compat_module.shell_quote("foo | bar")
+        assert "foo | bar" in result
+        assert not result.startswith("foo |")
+
+    def test_ampersand_metachar(self, compat_module):
+        result = compat_module.shell_quote("foo & bar")
+        assert "foo & bar" in result
+        assert not result.startswith("foo &")
+
+    def test_single_quote_inside(self, compat_module):
+        result = compat_module.shell_quote("it's fine")
+        assert "it" in result and "fine" in result
+
+    def test_empty_string(self, compat_module):
+        assert compat_module.shell_quote("") == "''"
+
+
+class TestShellQuoteWindows:
+    """Test shell_quote() Windows branch via monkeypatch (no real Windows needed)."""
+
+    def test_windows_uses_mslex(self, compat_module, monkeypatch):
+        """When IS_WINDOWS=True and mslex is available, mslex.quote is used."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        fake_mslex = Mock()
+        fake_mslex.quote = lambda s: f"[MSLEX]{s}[MSLEX]"
+
+        with patch.dict(sys.modules, {"mslex": fake_mslex}):
+            result = compat_module.shell_quote("hello world")
+        assert result == "[MSLEX]hello world[MSLEX]"
+
+    def test_windows_fallback_no_mslex(self, compat_module, monkeypatch):
+        """When IS_WINDOWS=True and mslex is not installed, fallback to double-quote."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        # Setting mslex to None in sys.modules causes ImportError on import
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.shell_quote("hello world")
+
+        assert result.startswith('"') and result.endswith('"')
+        assert "hello world" in result
+
+    def test_windows_fallback_doubles_embedded_quotes(self, compat_module, monkeypatch):
+        """cmd.exe quoting doubles double quotes; backslash is NOT an escape."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.shell_quote('say "hi"')
+
+        assert result == '"say ""hi"""'
+        assert '\\"' not in result
+
+    def test_windows_fallback_neutralizes_percent_expansion(self, compat_module, monkeypatch):
+        """cmd.exe expands %VAR% inside quotes — percents must be doubled."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.shell_quote("%PATH%")
+
+        assert result == '"%%PATH%%"'
+        assert result.count("%") == 4
+
+    def test_windows_metachar_semicolon(self, compat_module, monkeypatch):
+        """Windows quoting should handle semicolons (via mslex)."""
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        fake_mslex = Mock()
+        fake_mslex.quote = lambda s: f"[Q]{s}[Q]"
+
+        with patch.dict(sys.modules, {"mslex": fake_mslex}):
+            result = compat_module.shell_quote("a; rm -rf \\")
+
+        assert result == "[Q]a; rm -rf \\[Q]"
+
+
+class TestQuoteArgs:
+    """quote_args() must preserve argv boundaries, not quote the whole blob."""
+
+    def test_token_boundaries_preserved(self, compat_module):
+        import shlex
+
+        for sample in ["--foo bar", "a b c", "-n 3 --verbose out.txt", "--name 'John Doe'"]:
+            assert shlex.split(compat_module.quote_args(sample)) == shlex.split(sample)
+
+    def test_empty_string(self, compat_module):
+        assert compat_module.quote_args("") == ""
+        assert compat_module.quote_args("   ") == ""
+
+    def test_metachars_quoted_per_token(self, compat_module):
+        import shlex
+
+        result = compat_module.quote_args("a; rm -rf / b")
+        assert not result.startswith("a;")  # the metachar token must be quoted
+        assert shlex.split(result) == ["a;", "rm", "-rf", "/", "b"]
+
+    def test_unbalanced_quotes_fall_back_to_single_blob(self, compat_module):
+        result = compat_module.quote_args('say "unbalanced')
+        assert result.startswith("'") and result.endswith("'")
+
+    def test_windows_mslex_path(self, compat_module, monkeypatch):
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        fake_mslex = Mock()
+        fake_mslex.split = lambda s: ["--foo", "bar baz"]
+        fake_mslex.quote = lambda s: f"[{s}]"
+
+        with patch.dict(sys.modules, {"mslex": fake_mslex}):
+            result = compat_module.quote_args("--foo bar baz")
+
+        assert result == "[--foo] [bar baz]"
+
+    def test_windows_fallback_path(self, compat_module, monkeypatch):
+        monkeypatch.setattr(compat_module, "IS_WINDOWS", True)
+
+        with patch.dict(sys.modules, {"mslex": None}):
+            result = compat_module.quote_args('--name "John Doe"')
+
+        # Two tokens, each cmd-safe double-quote wrapped: "--name" "John Doe"
+        assert result == '"--name" "John Doe"'

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -469,7 +469,14 @@ def _dispatch_quick(rid, params, session, name, arg):
     if qc.get("type") == "exec":
         # Sanitized env: the TUI server process holds every API key in os.environ.
         env = _tools_mod("tools.environments.local").build_subprocess_env()
-        r = subprocess.run(qc.get("command", ""), shell=True, env=env, **_capture_run_kwargs(30))
+        exec_cmd = qc.get("command", "")
+        # Forward user arguments (e.g. `/poly white sox`): split-then-quote per
+        # token so boundaries survive (see hermes_cli._subprocess_compat).
+        args = (arg or "").strip()
+        if args:
+            quote_args = _tools_mod("hermes_cli._subprocess_compat").quote_args
+            exec_cmd = f"{exec_cmd} {quote_args(args)}"
+        r = subprocess.run(exec_cmd, shell=True, env=env, **_capture_run_kwargs(30))
         output = _joined_output(r)[:4000]
         output = _tools_mod("agent.redact").redact_sensitive_text(output) if output else output
         if r.returncode != 0:


### PR DESCRIPTION
## Problem

The gateway, CLI, and TUI gateway `type: exec` quick_commands all silently dropped user arguments. Any slash command wrapping a CLI tool would fail to receive the query.

**Root cause:** `exec_cmd` was used directly without appending user arguments. The alias type handler already forwarded args, but all three exec dispatch paths were missing the same logic.

## Real-World Example

```yaml
quick_commands:
  poly:
    type: exec
    command: "polymarket markets search"
```

**User types in Telegram:** `/poly white sox`

- **Before fix:** Gateway runs `polymarket markets search` (no query) — script returns usage message
- **After fix:** Gateway runs `polymarket markets search white sox` — returns market results

## Changes

All three exec dispatch paths now extract user args, `shlex.quote()` them for shell injection safety, and append to `exec_cmd` before spawning the subprocess. The append is gated on non-empty args so zero-arg commands are unaffected.

- **gateway/run.py** (~line 10016): `event.get_command_args()` + `shlex.quote()`
- **cli.py** (~line 8929): `cmd_original[len(base_cmd):]` + `shlex.quote()`
- **tui_gateway/server.py** (~line 11823): `arg` from `command.dispatch` params + `shlex.quote()`

## Tests (7 new)

**Gateway (`tests/cli/test_quick_commands.py`):**
- Multi-word arg forwarding (`/echo hello world foo` → output contains all words)
- No-args regression (no trailing space added to command)
- Shell injection prevention (`; echo INJECTED` treated as literal text, not executed)

**CLI (`tests/cli/test_quick_commands.py`):**
- Multi-word arg forwarding
- No-args regression

**TUI Gateway (`tests/test_tui_gateway_server.py`):**
- Multi-word arg forwarding (captures the actual command string passed to subprocess)
- No-args regression

## Reviewer Feedback Addressed

Per @teknium1's review on #62717:
- ✅ Added `tui_gateway/server.py` exec path (was missing)
- ✅ Added multi-word argument regression test
- ✅ Added empty-argument regression test (confirms no regression for zero-arg commands)