### PR TITLE
feat(model_metadata): backfill context length from LiteLLM /model/info endpoint

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -472,6 +472,87 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
         return _model_metadata_cache or {}
 
 
+def _backfill_from_litellm_model_info(
+    candidate_url: str,
+    headers: Dict[str, str],
+    cache: Dict[str, Dict[str, Any]],
+) -> None:
+    """Backfill context_length and max_completion_tokens from LiteLLM's /model/info.
+
+    LiteLLM proxy's standard /v1/models returns only {id, object, created, owned_by}
+    without token limits.  The /v1/model/info (or /model/info) endpoint returns richer
+    metadata including max_tokens, max_input_tokens, max_output_tokens in model_info.
+
+    This function queries that endpoint and merges token limit data into *cache*
+    entries that are still missing context_length.
+    """
+    base = candidate_url.rstrip("/")
+    # Try both /v1/model/info and /model/info (LiteLLM accepts both)
+    urls_to_try = []
+    if base.endswith("/v1"):
+        urls_to_try.append(base + "/model/info")
+        urls_to_try.append(base[:-3].rstrip("/") + "/model/info")
+    else:
+        urls_to_try.append(base + "/v1/model/info")
+        urls_to_try.append(base + "/model/info")
+
+    for info_url in urls_to_try:
+        try:
+            resp = requests.get(info_url, headers=headers, timeout=10)
+            if not resp.ok:
+                continue
+            payload = resp.json()
+            info_models = payload.get("data", [])
+            if not isinstance(info_models, list):
+                continue
+
+            # Build a lookup: model_name -> model_info dict
+            info_lookup: Dict[str, Dict[str, Any]] = {}
+            for item in info_models:
+                if not isinstance(item, dict):
+                    continue
+                model_name = item.get("model_name", "")
+                model_info = item.get("model_info", {})
+                if model_name and isinstance(model_info, dict):
+                    info_lookup[model_name] = model_info
+
+            if not info_lookup:
+                continue
+
+            # Merge into cache entries that lack context_length
+            for model_id, entry in cache.items():
+                if "context_length" in entry:
+                    continue  # already resolved
+                # Try exact match, then substring match in both directions
+                mi = info_lookup.get(model_id)
+                if not mi:
+                    for info_name, info_data in info_lookup.items():
+                        if model_id in info_name or info_name in model_id:
+                            mi = info_data
+                            break
+                if not mi:
+                    continue
+
+                # Prefer max_input_tokens (total context window),
+                # fall back to max_tokens
+                ctx = mi.get("max_input_tokens") or mi.get("max_tokens")
+                if isinstance(ctx, int) and ctx > 0:
+                    entry["context_length"] = ctx
+
+                max_out = mi.get("max_output_tokens") or mi.get("max_tokens")
+                if isinstance(max_out, int) and max_out > 0 and "max_completion_tokens" not in entry:
+                    entry["max_completion_tokens"] = max_out
+
+            logger.debug(
+                "Backfilled model metadata from LiteLLM /model/info at %s (%d models)",
+                info_url, len(info_lookup),
+            )
+            return  # success — no need to try the other URL
+
+        except Exception as exc:
+            logger.debug("LiteLLM /model/info query failed at %s: %s", info_url, exc)
+
+
 def fetch_endpoint_model_metadata(
     base_url: str,
     api_key: str = "",
@@ -549,6 +630,17 @@ def fetch_endpoint_model_metadata(
                             cache[model_alias]["context_length"] = n_ctx
                 except Exception:
                     pass
+
+            # LiteLLM proxy: /v1/models returns only {id, object, created, owned_by}
+            # without token limits.  The /v1/model/info (or /model/info) endpoint
+            # exposes max_tokens, max_input_tokens, max_output_tokens via model_info.
+            # Backfill any models in cache that are still missing context_length.
+            models_missing_ctx = [
+                mid for mid, entry in cache.items()
+                if "context_length" not in entry
+            ]
+            if models_missing_ctx:
+                _backfill_from_litellm_model_info(candidate, headers, cache)
 
             _endpoint_model_metadata_cache[normalized] = cache
             _endpoint_model_metadata_cache_time[normalized] = time.time()

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -709,3 +709,172 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# LiteLLM /model/info backfill
+# =========================================================================
+
+class TestLiteLLMModelInfoBackfill:
+    """Tests for _backfill_from_litellm_model_info — enriches endpoint metadata
+    cache with token limits from LiteLLM proxy's /v1/model/info endpoint."""
+
+    def _make_litellm_response(self, models):
+        """Build a mock LiteLLM /model/info JSON payload."""
+        return {"data": models}
+
+    def _mock_ok_response(self, payload):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = payload
+        return resp
+
+    def _mock_404(self):
+        resp = MagicMock()
+        resp.ok = False
+        resp.status_code = 404
+        return resp
+
+    def test_backfills_missing_context_length(self):
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {
+            "my-model": {"name": "my-model"},
+        }
+        payload = self._make_litellm_response([{
+            "model_name": "my-model",
+            "model_info": {
+                "max_input_tokens": 200000,
+                "max_output_tokens": 8192,
+                "max_tokens": 8192,
+            },
+        }])
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_ok_response(payload)):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert cache["my-model"]["context_length"] == 200000
+        assert cache["my-model"]["max_completion_tokens"] == 8192
+
+    def test_prefers_max_input_tokens_over_max_tokens(self):
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+        payload = self._make_litellm_response([{
+            "model_name": "m",
+            "model_info": {
+                "max_input_tokens": 1000000,
+                "max_tokens": 128000,
+                "max_output_tokens": 128000,
+            },
+        }])
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_ok_response(payload)):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert cache["m"]["context_length"] == 1000000
+
+    def test_does_not_overwrite_existing_context_length(self):
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m", "context_length": 8192}}
+        payload = self._make_litellm_response([{
+            "model_name": "m",
+            "model_info": {"max_input_tokens": 1000000},
+        }])
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_ok_response(payload)):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert cache["m"]["context_length"] == 8192  # unchanged
+
+    def test_substring_matching(self):
+        """LiteLLM model_name may differ from /v1/models id — substring match."""
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {
+            "provider/vendor/my-large-model-v2": {"name": "my-model"},
+        }
+        payload = self._make_litellm_response([{
+            "model_name": "provider/vendor/my-large-model-v2",
+            "model_info": {"max_input_tokens": 1000000, "max_output_tokens": 128000},
+        }])
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_ok_response(payload)):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert cache["provider/vendor/my-large-model-v2"]["context_length"] == 1000000
+
+    def test_handles_404_gracefully(self):
+        """Non-LiteLLM endpoints return 404 — should not crash."""
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_404()):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert "context_length" not in cache["m"]
+
+    def test_handles_network_error_gracefully(self):
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+
+        with patch("agent.model_metadata.requests.get", side_effect=Exception("timeout")):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert "context_length" not in cache["m"]
+
+    def test_null_values_ignored(self):
+        """Models with null max_input_tokens should not get a context_length."""
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+        payload = self._make_litellm_response([{
+            "model_name": "m",
+            "model_info": {
+                "max_input_tokens": None,
+                "max_output_tokens": None,
+                "max_tokens": None,
+            },
+        }])
+
+        with patch("agent.model_metadata.requests.get", return_value=self._mock_ok_response(payload)):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert "context_length" not in cache["m"]
+
+    def test_url_construction_with_v1_suffix(self):
+        """When candidate URL ends with /v1, tries /v1/model/info first."""
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+        call_urls = []
+
+        def track_calls(url, **kwargs):
+            call_urls.append(url)
+            return self._mock_404()
+
+        with patch("agent.model_metadata.requests.get", side_effect=track_calls):
+            _backfill_from_litellm_model_info("https://example.com/v1", {}, cache)
+
+        assert "https://example.com/v1/model/info" in call_urls
+        assert "https://example.com/model/info" in call_urls
+
+    def test_url_construction_without_v1_suffix(self):
+        """When candidate URL has no /v1, tries /v1/model/info first."""
+        from agent.model_metadata import _backfill_from_litellm_model_info
+
+        cache = {"m": {"name": "m"}}
+        call_urls = []
+
+        def track_calls(url, **kwargs):
+            call_urls.append(url)
+            return self._mock_404()
+
+        with patch("agent.model_metadata.requests.get", side_effect=track_calls):
+            _backfill_from_litellm_model_info("https://example.com", {}, cache)
+
+        assert "https://example.com/v1/model/info" in call_urls
+        assert "https://example.com/model/info" in call_urls


### PR DESCRIPTION
## Summary

The OpenAI standard `/v1/models` endpoint only returns `{id, object, created, owned_by}` — it does not include token limit metadata like `context_length`. While some providers (e.g., OpenRouter) extend this endpoint with additional fields, LiteLLM proxy follows the OpenAI standard and does not include token limits in `/v1/models`.

However, LiteLLM provides a separate `/model/info` endpoint that exposes rich model metadata including `max_tokens`, `max_input_tokens`, `max_output_tokens`, and cost information (see [LiteLLM docs: Model Management](https://docs.litellm.ai/docs/proxy/model_management)).

This PR adds `_backfill_from_litellm_model_info()` as a fallback in `fetch_endpoint_model_metadata()`. When models are missing `context_length` after querying `/v1/models`, it automatically queries `/model/info` to fill in the gaps.

## Changes

- **`agent/model_metadata.py`**: New `_backfill_from_litellm_model_info()` function + integration into `fetch_endpoint_model_metadata()`
- **`tests/agent/test_model_metadata.py`**: 9 unit tests covering backfill logic, priority, error handling, and URL construction

## How it works

1. After querying `/v1/models`, checks if any cached models are still missing `context_length`
2. If so, queries `/v1/model/info` (tries both URL variants: `/v1/model/info` and `/model/info`)
3. Uses `max_input_tokens` for `context_length` (falls back to `max_tokens`)
4. Uses `max_output_tokens` for `max_completion_tokens`
5. Does **not** overwrite existing values
6. Handles 404 and network errors gracefully — non-LiteLLM servers simply skip this step
7. Uses substring matching for model name resolution (LiteLLM model names may differ from `/v1/models` IDs)