### PR TITLE
Fix gateway shutdown notifications for grouped sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1411,15 +1411,43 @@ class GatewayRunner:
         )
         msg = f"⚠️ Gateway {action} — {hint}"
 
+        def _source_for_session_key(session_key: str) -> Optional[SessionSource]:
+            """Return persisted origin metadata for *session_key*, if available."""
+            try:
+                entries = getattr(getattr(self, "session_store", None), "_entries", None)
+                if isinstance(entries, dict):
+                    entry = entries.get(session_key)
+                    origin = getattr(entry, "origin", None) if entry else None
+                    if isinstance(origin, SessionSource):
+                        return origin
+            except Exception:
+                pass
+            return None
+
         notified: set = set()
         for session_key in active:
-            # Parse platform + chat_id from the session key.
-            # Format: agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]
-            parts = session_key.split(":")
-            if len(parts) < 5:
-                continue
-            platform_str = parts[2]
-            chat_id = parts[4]
+            origin = _source_for_session_key(session_key)
+            if origin is not None:
+                platform_str = origin.platform.value
+                chat_id = origin.chat_id
+                thread_id = origin.thread_id
+            else:
+                # Fallback for legacy/in-memory entries without origin metadata.
+                # Format: agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]
+                # For group/channel sessions the extra field may be a user_id
+                # rather than a thread_id, so only infer thread metadata for
+                # key shapes where the suffix is unambiguous.
+                parts = session_key.split(":")
+                if len(parts) < 5:
+                    continue
+                platform_str = parts[2]
+                chat_type = parts[3]
+                chat_id = parts[4]
+                thread_id = (
+                    parts[5]
+                    if chat_type in ("dm", "thread") and len(parts) > 5
+                    else None
+                )
 
             # Deduplicate: one notification per chat, even if multiple
             # sessions (different users/threads) share the same chat.
@@ -1435,7 +1463,6 @@ class GatewayRunner:
 
                 # Include thread_id if present so the message lands in the
                 # correct forum topic / thread.
-                thread_id = parts[5] if len(parts) > 5 else None
                 metadata = {"thread_id": thread_id} if thread_id else None
 
                 await adapter.send(chat_id, msg, metadata=metadata)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -171,6 +171,7 @@ AUTHOR_MAP = {
     "oncuevtv@gmail.com": "sprmn24",
     "programming@olafthiele.com": "olafthiele",
     "r2668940489@gmail.com": "r266-tech",
+    "ruzzgarcn@gmail.com": "Ruzzgar",
     "s5460703@gmail.com": "BlackishGreen33",
     "saul.jj.wu@gmail.com": "SaulJWu",
     "shenhaocheng19990111@gmail.com": "hcshen0111",

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -12,6 +12,7 @@ class RestartTestAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
         self.sent: list[str] = []
+        self.sent_metadata: list[object] = []
 
     async def connect(self):
         return True
@@ -21,6 +22,7 @@ class RestartTestAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
         self.sent.append(content)
+        self.sent_metadata.append(metadata)
         return SendResult(success=True, message_id="1")
 
     async def send_typing(self, chat_id, metadata=None):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,14 +1,16 @@
 import asyncio
 import shutil
 import subprocess
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
+from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-from gateway.session import build_session_key
+from gateway.session import SessionEntry, SessionSource, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
@@ -207,6 +209,47 @@ async def test_shutdown_notification_deduplicates_per_chat():
     await runner._notify_active_sessions_of_shutdown()
 
     assert len(adapter.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_does_not_treat_group_user_id_as_thread():
+    """A per-user group session suffix is a user_id, not a thread_id."""
+    runner, adapter = make_restart_runner()
+    runner._running_agents["agent:main:telegram:group:chat1:u1"] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent_metadata == [None]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_uses_origin_thread_metadata():
+    """Persisted session origin provides reliable thread routing metadata."""
+    runner, adapter = make_restart_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat1",
+        chat_type="group",
+        thread_id="topic-42",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = MagicMock()
+    runner.session_store._entries = {
+        session_key: SessionEntry(
+            session_key=session_key,
+            session_id="session-1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=source,
+        )
+    }
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent_metadata == [{"thread_id": "topic-42"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Use persisted `SessionSource` origin metadata when routing gateway shutdown notifications.
- Avoid treating the extra suffix in group/channel session keys as a `thread_id`.
- Keep legacy session-key parsing as a fallback for in-memory or older entries.
- Add regression coverage for grouped sessions and threaded origin metadata.
- Add my author email to `AUTHOR_MAP` so the attribution check can resolve the commit author.

## Problem

Gateway shutdown notifications currently parse routing metadata directly from the session key:

`agent:main:{platform}:{chat_type}:{chat_id}[:extra...]`

That fallback is ambiguous for group sessions. In a key such as:

`agent:main:telegram:group:chat1:u1`

the final suffix is a user id, not a thread id. Treating it as `thread_id` can send shutdown notifications with incorrect metadata, which may route the message to the wrong place or fail on platforms that distinguish group users from thread/topic ids.

Persisted session entries already carry authoritative `SessionSource` origin metadata, including `platform`, `chat_id`, and `thread_id`, so shutdown notification routing should prefer that instead of guessing from the key shape.

## Fix

This change updates shutdown notification routing to:

- Prefer `SessionEntry.origin` when available.
- Use `origin.thread_id` only when the session source actually has thread metadata.
- Fall back to parsing the session key only for legacy/in-memory entries.
- In fallback mode, only infer `thread_id` for unambiguous chat types such as `dm` and `thread`.
- Avoid inferring `thread_id` from group/channel suffixes, where the suffix may represent a user id.

## Tests

Added regression coverage for:

- Group session keys where the suffix is a user id and must not be passed as `thread_id`.
- Persisted origin metadata where a real `thread_id` should still be used for routing.
- Existing shutdown notification behavior remains covered by the restart drain tests.

Tested with:

```bash
python -m pytest tests/gateway/test_restart_drain.py -q
python -m pytest tests/gateway/test_restart_drain.py tests/gateway/test_gateway_shutdown.py -q

15 passed
21 passed