### PR TITLE
feat(provider): support provider-native TTS / image / vision backends

### DIFF
--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -1,0 +1,466 @@
+"""Helpers for chat providers that also serve TTS / image / vision natively.
+
+When a chat provider exposes those non-chat capabilities on the same API
+base and credential, the setup wizard wires them as the default tool
+backends and the tool dispatchers route through this module instead of
+the generic FAL / auxiliary-client paths.
+
+Mirrors the shape of `hermes_cli.nous_subscription`: one apply hook for
+the wizard, plus runtime helpers consumed by the tool files.
+
+Adding a provider:
+
+  1. Add the canonical id to `MINIMAX_PROVIDERS` (or add a new
+     `NATIVE_TOOLS_BY_PROVIDER` row + provider set).
+  2. Implement the request helpers in this file (mirror
+     `_minimax_image_request` / `_minimax_vlm_request`).
+  3. Route to them from `generate_image` / `analyze_image` / etc.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import mimetypes
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+#: Canonical provider id → tool categories the provider serves natively.
+NATIVE_TOOLS_BY_PROVIDER: Dict[str, Tuple[str, ...]] = {
+    "minimax":    ("tts", "image_gen", "vision"),
+    "minimax-cn": ("tts", "image_gen", "vision"),
+}
+
+MINIMAX_PROVIDERS: Set[str] = {"minimax", "minimax-cn"}
+
+
+# ─── Active-provider lookup ──────────────────────────────────────────────
+
+
+def _active_provider_id(config: Dict[str, Any]) -> str:
+    """Canonical id of the active chat provider, or `""`.
+
+    Reads `model.provider` (dict shape) or strips the prefix off the
+    legacy `model: "provider/name"` string.  Normalises through
+    `hermes_cli.providers.normalize_provider` so hand-edited aliases
+    resolve to the canonical id.
+    """
+    model = config.get("model")
+    raw = ""
+    if isinstance(model, dict):
+        raw = str(model.get("provider") or "").strip().lower()
+    elif isinstance(model, str) and "/" in model:
+        raw = model.split("/", 1)[0].strip().lower()
+    if not raw:
+        return ""
+    try:
+        from hermes_cli.providers import normalize_provider
+        return normalize_provider(raw)
+    except Exception:
+        return raw
+
+
+def get_native_tools(config: Dict[str, Any]) -> Tuple[str, ...]:
+    """Native tool categories declared for the active provider, or `()`."""
+    return NATIVE_TOOLS_BY_PROVIDER.get(_active_provider_id(config), ())
+
+
+def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
+    """True when the active chat provider serves `tool` natively."""
+    return tool in get_native_tools(config)
+
+
+def active_provider_api_root(config: Dict[str, Any]) -> str:
+    """API root for the active chat provider, or `""`.
+
+    Reads `model.base_url` and strips the `/anthropic` chat-compat suffix
+    when present, so non-chat endpoints (`/v1/image_generation`,
+    `/v1/t2a_v2`, `/v1/coding_plan/vlm`) hang off the returned root.
+    """
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return ""
+    base = str(model.get("base_url") or "").strip().rstrip("/")
+    if not base:
+        return ""
+    return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
+
+
+# ─── Setup-time defaults ─────────────────────────────────────────────────
+#
+# Mirrors `apply_nous_provider_defaults`: hardcodes the few config slots
+# we touch, only overrides built-in defaults, and returns the set of
+# slots actually changed so the wizard can print a summary.
+
+
+_OVERRIDABLE_TTS    = {"", "edge"}
+_OVERRIDABLE_IMAGE  = {"", "auto", "fal"}
+_OVERRIDABLE_VISION = {"", "auto", "main"}
+
+
+def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
+    """Wire `tts.provider` / `image_gen.provider` for native providers.
+
+    Returns the set of categories newly wired (empty when the provider
+    isn't native or everything is already set).  Vision is reported when
+    something else also changed; no config value is persisted because
+    the dispatcher in `tools/vision_tools.py` activates per session.
+    """
+    native = get_native_tools(config)
+    if not native:
+        return set()
+
+    provider = _active_provider_id(config)
+    changed: Set[str] = set()
+
+    if "tts" in native:
+        cfg = config.setdefault("tts", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_TTS):
+            cfg["provider"] = provider
+            changed.add("tts")
+
+    if "image_gen" in native:
+        cfg = config.setdefault("image_gen", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_IMAGE):
+            cfg["provider"] = provider
+            changed.add("image_gen")
+
+    if "vision" in native and changed:
+        aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
+        v = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
+        if str(v.get("provider") or "").strip().lower() in _OVERRIDABLE_VISION:
+            changed.add("vision")
+
+    if changed:
+        logger.info("Applied provider-native tool defaults for %r: %s",
+                    provider, sorted(changed))
+    return changed
+
+
+_SUMMARY: Dict[str, Dict[str, str]] = {
+    "minimax": {
+        "tts":       "TTS → speech-2.6-hd (30+ voices)",
+        "image_gen": "Image generation → image-01",
+        "vision":    "Vision analysis → MiniMax-VL-01",
+    },
+}
+_SUMMARY["minimax-cn"] = _SUMMARY["minimax"]
+
+
+def describe_changes(changed: Iterable[str], config: Dict[str, Any]) -> str:
+    """Bullet-list summary used by the setup wizard."""
+    items = sorted(changed)
+    if not items:
+        return "No changes — existing tool choices were preserved."
+    phrasing = _SUMMARY.get(_active_provider_id(config), {})
+    return "\n".join(
+        f"  • {phrasing.get(k, k)}" for k in items
+    )
+
+
+# ─── Runtime dispatchers (consumed by tool files) ────────────────────────
+
+
+def generate_image(
+    *,
+    prompt: str,
+    aspect_ratio: str,
+    num_images: int,
+    output_format: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Generate via the active provider's native image backend, or `None`.
+
+    Tool files call this before falling through to their existing path.
+    The return shape matches `image_generate_tool` so callers can return
+    the result verbatim.
+    """
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_image_request(
+            prompt=prompt, aspect_ratio=aspect_ratio,
+            num_images=num_images, output_format=output_format,
+            config=cfg,
+        )
+    return None
+
+
+def analyze_image(
+    image_source: str,
+    user_prompt: str,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Describe via the active provider's native VLM backend, or `None`."""
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_vlm_request(image_source, user_prompt, cfg)
+    return None
+
+
+def native_credential_present(
+    tool: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when the active provider serves `tool` natively *and* its
+    credential is configured.  Used by tool-level `check_fn` gates."""
+    cfg = config if config is not None else _safe_load_config()
+    if not provider_has_native_tool(tool, cfg):
+        return False
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return bool(_minimax_credential(cfg))
+    return False
+
+
+def minimax_endpoint_and_key(
+    subpath: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, str]:
+    """Return ``(url, api_key)`` for a MiniMax subpath (e.g. ``/v1/t2a_v2``)
+    derived from the active provider's ``model.base_url`` + the
+    region-appropriate credential.  Both values are empty strings when
+    the active provider isn't MiniMax, so callers can probe with a
+    single call and fall through.
+    """
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) not in MINIMAX_PROVIDERS:
+        return "", ""
+    root = active_provider_api_root(cfg).rstrip("/")
+    key = _minimax_credential(cfg)
+    if not root or not key:
+        return "", ""
+    return f"{root}{subpath}", key
+
+
+# ─── Internal: shared helpers ────────────────────────────────────────────
+
+
+def _safe_load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception as exc:
+        logger.debug("provider_native_tools: config load failed: %s", exc)
+        return {}
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str, *, timeout: int = 120) -> Dict[str, Any]:
+    """Bearer-auth POST → parsed JSON.  Raises urllib / json errors."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _download(url: str, output_path: Path, *, timeout: int = 120) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(url, timeout=timeout, context=ctx) as resp:
+        with open(output_path, "wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+
+
+# ─── MiniMax bindings ────────────────────────────────────────────────────
+#
+# Per-provider request helpers.  Mirror the per-provider TTS helpers in
+# `tools/tts_tool.py` (`_generate_minimax_tts` etc.).  Adding another
+# provider is parallel: drop helpers below and route to them above.
+
+
+def _minimax_credential(config: Optional[Dict[str, Any]] = None) -> str:
+    """Pick the key matching the active provider's region.
+
+    `minimax-cn` prefers `MINIMAX_CN_API_KEY`; `minimax` (international)
+    prefers `MINIMAX_API_KEY`.  Falls back to the other on absence so a
+    user with only one key still works for both regions (at their own
+    entitlement risk).
+    """
+    cfg = config if config is not None else {}
+    is_cn = _active_provider_id(cfg) == "minimax-cn"
+    order = ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY") if is_cn \
+            else ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")
+    for var in order:
+        v = os.environ.get(var)
+        if v and v.strip():
+            return v.strip()
+    return ""
+
+
+def _minimax_image_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/images", "image_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "image_cache"
+
+
+_MINIMAX_RATIO_ALIAS = {"landscape": "16:9", "portrait": "9:16", "square": "1:1"}
+_MINIMAX_VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"}
+
+
+def _minimax_image_request(
+    *, prompt: str, aspect_ratio: str, num_images: int, output_format: str,
+    config: Dict[str, Any],
+) -> str:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return json.dumps({"success": False,
+            "error": "image_gen.provider=minimax but model.base_url is unset"})
+    key = _minimax_credential(config)
+    if not key:
+        return json.dumps({"success": False,
+            "error": "MINIMAX_API_KEY (or _CN) required"})
+
+    ratio = _MINIMAX_RATIO_ALIAS.get((aspect_ratio or "").lower(), aspect_ratio)
+    if ratio not in _MINIMAX_VALID_RATIOS:
+        ratio = "16:9"
+
+    payload = {
+        "model": "image-01",
+        "prompt": (prompt or "").strip(),
+        "aspect_ratio": ratio,
+        "n": max(1, min(4, int(num_images or 1))),
+        "response_format": "url",
+    }
+    try:
+        body = _post_json(f"{api_root}/v1/image_generation", payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+            "error": f"image API HTTP {exc.code}", "status": exc.code})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+            "error": f"image API error {base.get('status_code')}: "
+                     f"{base.get('status_msg', '')}",
+            "status": base.get("status_code")})
+
+    data = body.get("data") or {}
+    urls: list = []
+    if isinstance(data, dict):
+        for k in ("image_urls", "urls"):
+            v = data.get(k)
+            if isinstance(v, list):
+                urls = [u for u in v if isinstance(u, str) and u.startswith("http")]
+                break
+    if not urls:
+        return json.dumps({"success": False, "error": "image API returned no URL(s)"})
+
+    out_dir = _minimax_image_cache_dir()
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    ext = "jpeg" if (output_format or "").lower() in ("jpeg", "jpg") else "png"
+    saved: list = []
+    for i, url in enumerate(urls):
+        path = out_dir / (f"image_{ts}.{ext}" if i == 0 else f"image_{ts}_{i + 1}.{ext}")
+        try:
+            _download(url, path)
+            saved.append(str(path))
+        except Exception as exc:
+            logger.warning("image download failed for %s: %s", url, exc)
+    if not saved:
+        return json.dumps({"success": False, "error": "all image downloads failed"})
+    return json.dumps({
+        "success": True,
+        "provider": _active_provider_id(config),
+        "model": "image-01",
+        "aspect_ratio": ratio,
+        "paths": saved,
+        "urls": urls,
+    }, ensure_ascii=False)
+
+
+_VLM_SUPPORTED_MIME = {"image/jpeg", "image/png", "image/webp"}
+_VLM_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff",      "image/jpeg"),
+)
+
+
+def _coerce_vlm_image_url(image_source: str) -> Optional[str]:
+    """Normalise into a value the VLM endpoint accepts (data URI / URL),
+    or `None` for unsupported / missing files."""
+    src = (image_source or "").strip()
+    if not src:
+        return None
+    if src.startswith(("data:", "http://", "https://")):
+        return src
+    if src.startswith("file://"):
+        src = src[len("file://"):]
+    path = Path(src).expanduser()
+    if not path.is_file():
+        return None
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime:
+        head = path.read_bytes()[:12]
+        mime = next((m for magic, m in _VLM_MAGIC if head.startswith(magic)), None)
+        if mime is None and head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+            mime = "image/webp"
+    if mime not in _VLM_SUPPORTED_MIME:
+        return None
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}"
+
+
+def _minimax_vlm_request(image_source: str, user_prompt: str,
+                         config: Dict[str, Any]) -> Optional[str]:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return None
+    key = _minimax_credential(config)
+    if not key:
+        return None
+    image_url = _coerce_vlm_image_url(image_source)
+    if not image_url:
+        return None
+
+    try:
+        body = _post_json(
+            f"{api_root}/v1/coding_plan/vlm",
+            {"prompt": user_prompt, "image_url": image_url},
+            key,
+            timeout=60,
+        )
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        logger.debug("VLM call failed: %s", exc)
+        return None
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        # Surface provider-side errors verbatim (e.g. 1008 insufficient
+        # balance) instead of masking them as fallback triggers.
+        return json.dumps({
+            "success": False,
+            "error": f"VLM error {base.get('status_code')}: {base.get('status_msg', '')}",
+            "status": base.get("status_code"),
+        }, ensure_ascii=False)
+
+    content = body.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return json.dumps({
+        "success": True,
+        "analysis": content,
+        "provider": _active_provider_id(config),
+        "model": "MiniMax-VL-01",
+        "endpoint": "/v1/coding_plan/vlm",
+    }, ensure_ascii=False)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -24,6 +24,11 @@ from hermes_cli.nous_subscription import (
     apply_nous_provider_defaults,
     get_nous_subscription_features,
 )
+from hermes_cli.provider_native_tools import (
+    apply_provider_native_tool_defaults,
+    describe_changes as describe_native_tool_changes,
+    get_native_tools as _provider_native_tools,
+)
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from hermes_constants import get_optional_skills_dir
 
@@ -843,9 +848,28 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         else:
             print_info(f"Keeping your existing TTS provider: {current_tts}")
 
+    # Wire tool defaults for chat providers that serve TTS / image / vision
+    # natively on the same credential.  Self-gates on the active provider;
+    # a no-op for providers not registered in
+    # `hermes_cli.provider_native_tools.NATIVE_TOOLS_BY_PROVIDER`.
+    native_changes = apply_provider_native_tool_defaults(config)
+    if native_changes:
+        print()
+        print_success(
+            "The same credential also unlocks the following — wired automatically:"
+        )
+        print(describe_native_tool_changes(native_changes, config))
+
     save_config(config)
 
-    if not quick and selected_provider != "nous":
+    # Skip the interactive TTS selector when the active provider already
+    # owns it (nous via subscription defaults, or any provider that
+    # declares `tts` in its native-tools registry).
+    if (
+        not quick
+        and selected_provider != "nous"
+        and "tts" not in _provider_native_tools(config)
+    ):
         _setup_tts_provider(config)
 
 

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -1,0 +1,286 @@
+"""Tests for hermes_cli/provider_native_tools.py.
+
+Covers the registry shape, active-provider lookup (incl. alias
+normalisation), URL derivation, the setup-time defaults hook (override
+preservation, idempotency), and the user-facing summary.
+
+Uses MiniMax (the first registered provider) as the live fixture.
+Adding another provider to ``NATIVE_TOOLS_BY_PROVIDER`` should let the
+generic suite continue to pass — the only provider-specific assertions
+are on the MiniMax phrasing in ``describe_changes``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.provider_native_tools import (
+    NATIVE_TOOLS_BY_PROVIDER,
+    _active_provider_id,
+    active_provider_api_root,
+    apply_provider_native_tool_defaults,
+    describe_changes,
+    get_native_tools,
+    minimax_endpoint_and_key,
+    native_credential_present,
+    provider_has_native_tool,
+)
+
+
+class TestRegistryShape:
+    def test_minimax_registered(self):
+        assert "minimax" in NATIVE_TOOLS_BY_PROVIDER
+        assert "minimax-cn" in NATIVE_TOOLS_BY_PROVIDER
+
+    def test_minimax_capabilities(self):
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax"]) == {"tts", "image_gen", "vision"}
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax-cn"]) == {"tts", "image_gen", "vision"}
+
+    def test_no_unknown_tool_categories(self):
+        valid = {"tts", "image_gen", "vision"}
+        for provider, tools in NATIVE_TOOLS_BY_PROVIDER.items():
+            unknown = set(tools) - valid
+            assert not unknown, (
+                f"provider {provider!r} declares unknown tool categories {unknown}"
+            )
+
+
+class TestActiveProviderId:
+    def test_dict_shape(self):
+        assert _active_provider_id({"model": {"provider": "minimax"}}) == "minimax"
+
+    def test_dict_shape_cn(self):
+        assert _active_provider_id({"model": {"provider": "minimax-cn"}}) == "minimax-cn"
+
+    def test_case_insensitive(self):
+        assert _active_provider_id({"model": {"provider": "MiniMax"}}) == "minimax"
+
+    def test_alias_normalised(self):
+        assert _active_provider_id({"model": {"provider": "minimax-china"}}) == "minimax-cn"
+        assert _active_provider_id({"model": {"provider": "minimax_cn"}}) == "minimax-cn"
+
+    def test_legacy_string_shape(self):
+        assert _active_provider_id({"model": "minimax/MiniMax-M2.7"}) == "minimax"
+
+    def test_unset(self):
+        assert _active_provider_id({}) == ""
+        assert _active_provider_id({"model": {}}) == ""
+        assert _active_provider_id({"model": {"default": "M2.7"}}) == ""
+
+
+class TestQueryHelpers:
+    def test_get_native_tools_minimax(self):
+        out = get_native_tools({"model": {"provider": "minimax"}})
+        assert set(out) == {"tts", "image_gen", "vision"}
+
+    def test_get_native_tools_unregistered(self):
+        assert get_native_tools({"model": {"provider": "anthropic"}}) == ()
+
+    def test_get_native_tools_unset(self):
+        assert get_native_tools({}) == ()
+
+    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision"])
+    def test_provider_has_native_tool_minimax(self, tool):
+        assert provider_has_native_tool(tool, {"model": {"provider": "minimax"}}) is True
+
+    def test_provider_has_native_tool_unregistered(self):
+        assert provider_has_native_tool("tts", {"model": {"provider": "anthropic"}}) is False
+
+    def test_unknown_tool(self):
+        assert provider_has_native_tool("music_gen", {"model": {"provider": "minimax"}}) is False
+
+
+class TestApiRoot:
+    def test_strips_anthropic_suffix(self):
+        cfg = {"model": {"base_url": "https://api.minimax.io/anthropic"}}
+        assert active_provider_api_root(cfg) == "https://api.minimax.io"
+
+    def test_strips_anthropic_suffix_with_trailing_slash(self):
+        cfg = {"model": {"base_url": "https://api.minimax.io/anthropic/"}}
+        assert active_provider_api_root(cfg) == "https://api.minimax.io"
+
+    def test_cn_endpoint(self):
+        cfg = {"model": {"base_url": "https://api.minimaxi.com/anthropic"}}
+        assert active_provider_api_root(cfg) == "https://api.minimaxi.com"
+
+    def test_no_anthropic_suffix(self):
+        cfg = {"model": {"base_url": "https://api.openai.com/v1"}}
+        assert active_provider_api_root(cfg) == "https://api.openai.com/v1"
+
+    def test_unset(self):
+        assert active_provider_api_root({}) == ""
+        assert active_provider_api_root({"model": {}}) == ""
+
+
+class TestApplyDefaults:
+    def test_noop_when_provider_not_native(self):
+        config = {"model": {"provider": "anthropic"}}
+        assert apply_provider_native_tool_defaults(config) == set()
+        assert "tts" not in config
+
+    def test_noop_when_no_provider(self):
+        assert apply_provider_native_tool_defaults({}) == set()
+
+    def test_minimax_writes_tts_image_reports_vision(self):
+        config = {"model": {"provider": "minimax"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision"}
+        assert config["tts"]["provider"] == "minimax"
+        assert config["image_gen"]["provider"] == "minimax"
+        # Vision is reported but no value persists — runtime dispatch handles it.
+        assert config.get("auxiliary", {}).get("vision") in (None, {})
+
+    def test_explicit_tts_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "tts": {"provider": "elevenlabs"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" not in changed
+        assert config["tts"]["provider"] == "elevenlabs"
+        assert "image_gen" in changed
+
+    def test_edge_default_overridden(self):
+        config = {"model": {"provider": "minimax"}, "tts": {"provider": "edge"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax"
+
+    def test_explicit_fal_overridden(self):
+        config = {"model": {"provider": "minimax"}, "image_gen": {"provider": "fal"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" in changed
+        assert config["image_gen"]["provider"] == "minimax"
+
+    def test_explicit_third_party_image_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "image_gen": {"provider": "stability"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" not in changed
+        assert config["image_gen"]["provider"] == "stability"
+
+    def test_explicit_vision_provider_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "auxiliary": {"vision": {"provider": "openrouter"}},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["auxiliary"]["vision"]["provider"] == "openrouter"
+
+    def test_idempotent(self):
+        config = {"model": {"provider": "minimax"}}
+        first = apply_provider_native_tool_defaults(config)
+        assert first == {"tts", "image_gen", "vision"}
+        second = apply_provider_native_tool_defaults(config)
+        assert second == set()
+
+    def test_cn_provider_same_behaviour(self):
+        config = {"model": {"provider": "minimax-cn"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision"}
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_alias_provider_resolved(self):
+        config = {"model": {"provider": "minimax-china"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_other_auxiliary_keys_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "auxiliary": {"compression": {"provider": "openai"}},
+        }
+        apply_provider_native_tool_defaults(config)
+        assert config["auxiliary"]["compression"]["provider"] == "openai"
+
+
+class TestDescribeChanges:
+    def test_empty_set(self):
+        out = describe_changes(set(), {"model": {"provider": "minimax"}})
+        assert "No changes" in out
+
+    def test_minimax_three_tools(self):
+        out = describe_changes(
+            {"tts", "image_gen", "vision"},
+            {"model": {"provider": "minimax"}},
+        )
+        # Provider name omitted from values (wizard's success line names it).
+        assert "TTS" in out and "image-01" in out and "MiniMax-VL-01" in out
+        assert out.count("•") == 3
+
+    def test_minimax_cn_shares_minimax_phrasing(self):
+        out_int = describe_changes({"tts"}, {"model": {"provider": "minimax"}})
+        out_cn = describe_changes({"tts"}, {"model": {"provider": "minimax-cn"}})
+        assert out_int == out_cn
+
+    def test_unknown_provider_falls_back_to_generic(self):
+        out = describe_changes({"tts"}, {"model": {"provider": "imaginary"}})
+        assert "tts" in out
+
+
+class TestNativeCredentialPresent:
+    def test_false_when_provider_not_native(self):
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "anthropic"}},
+        ) is False
+
+    def test_false_when_tool_not_served_by_provider(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert native_credential_present(
+            "search", {"model": {"provider": "minimax"}},
+        ) is False  # minimax declares tts/image_gen/vision — not "search"
+
+    def test_true_when_provider_native_and_key_set(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "minimax"}},
+        ) is True
+
+    def test_false_when_provider_native_but_no_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "minimax"}},
+        ) is False
+
+
+class TestMinimaxEndpointAndKey:
+    def test_non_minimax_returns_empty_tuple(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert minimax_endpoint_and_key(
+            "/v1/t2a_v2", {"model": {"provider": "anthropic"}},
+        ) == ("", "")
+
+    def test_derives_url_and_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax", "base_url": "https://api.minimax.io/anthropic"},
+        })
+        assert url == "https://api.minimax.io/v1/t2a_v2"
+        assert key == "sk-intl"
+
+    def test_cn_picks_cn_host_and_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax-cn", "base_url": "https://api.minimaxi.com/anthropic"},
+        })
+        assert url == "https://api.minimaxi.com/v1/t2a_v2"
+        assert key == "sk-cn"
+
+    def test_empty_when_base_url_missing(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert minimax_endpoint_and_key(
+            "/v1/t2a_v2", {"model": {"provider": "minimax"}},
+        ) == ("", "")
+
+    def test_empty_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax", "base_url": "https://api.minimax.io/anthropic"},
+        }) == ("", "")

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -381,6 +381,22 @@ def image_generate_tool(
                  "image": str or None  # URL of the upscaled image, or None if failed
              }
     """
+    # Provider-native dispatch: when the active chat provider serves image
+    # generation natively (via its registry entry in
+    # `hermes_cli.provider_native_tools`), route there first.  Returns
+    # `None` when no native backend applies, in which case the FAL flow
+    # below runs unchanged.
+    try:
+        from hermes_cli.provider_native_tools import generate_image as _native_generate_image
+        _native_result = _native_generate_image(
+            prompt=prompt, aspect_ratio=aspect_ratio,
+            num_images=num_images, output_format=output_format,
+        )
+        if _native_result is not None:
+            return _native_result
+    except Exception as _exc:
+        logger.debug("provider-native image dispatch skipped: %s", _exc)
+
     # Validate and map aspect_ratio to actual image_size
     aspect_ratio_lower = aspect_ratio.lower().strip() if aspect_ratio else DEFAULT_ASPECT_RATIO
     if aspect_ratio_lower not in ASPECT_RATIO_MAP:
@@ -550,6 +566,14 @@ def check_image_generation_requirements() -> bool:
     Returns:
         bool: True if requirements are met, False otherwise
     """
+    # Active chat provider's native image backend counts as "requirements
+    # met" without needing FAL_KEY.  See `hermes_cli.provider_native_tools`.
+    try:
+        from hermes_cli.provider_native_tools import native_credential_present
+        if native_credential_present("image_gen"):
+            return True
+    except Exception:
+        pass
     try:
         # Check API key
         if not check_fal_api_key():

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -317,7 +317,19 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     """
     import requests
 
+    # Derive URL + key from the active chat provider so CN users
+    # (minimax-cn → api.minimaxi.com) hit the correct host with the
+    # correct key.  Falls back to the international defaults when the
+    # active provider isn't MiniMax.
+    derived_base = ""
     api_key = os.getenv("MINIMAX_API_KEY", "")
+    try:
+        from hermes_cli.provider_native_tools import minimax_endpoint_and_key
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2")
+        derived_base = url or derived_base
+        api_key = key or api_key
+    except Exception:
+        pass
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 
@@ -327,7 +339,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     speed = mm_config.get("speed", tts_config.get("speed", 1))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
-    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
+    base_url = mm_config.get("base_url") or derived_base or DEFAULT_MINIMAX_BASE_URL
 
     # Determine audio format from output extension
     if output_path.endswith(".wav"):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -466,6 +466,34 @@ async def vision_analyze_tool(
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
         
+        # Provider-native dispatch: when the active chat provider serves
+        # vision natively (via its registry entry in
+        # `hermes_cli.provider_native_tools`) and the user hasn't pinned
+        # `auxiliary.vision.provider` to a different backend, route there
+        # first.  Returns `None` when no native backend applies, in which
+        # case the auxiliary-client flow below runs unchanged.
+        try:
+            from hermes_cli.provider_native_tools import (
+                analyze_image as _native_analyze_image,
+                provider_has_native_tool as _native_has,
+            )
+            from hermes_cli.config import load_config as _load_config_for_vision
+            _vision_cfg = _load_config_for_vision()
+            _aux_vision = _vision_cfg.get("auxiliary", {}).get("vision", {}) \
+                if isinstance(_vision_cfg.get("auxiliary"), dict) else {}
+            _explicit_vision = str(_aux_vision.get("provider") or "").strip().lower()
+            if (
+                _native_has("vision", _vision_cfg)
+                and _explicit_vision in ("", "auto", "main")
+            ):
+                _native_result = _native_analyze_image(
+                    image_url, user_prompt, config=_vision_cfg,
+                )
+                if _native_result is not None:
+                    return _native_result
+        except Exception as _exc:
+            logger.debug("provider-native vision dispatch skipped: %s", _exc)
+
         # Determine if this is a local file path or a remote URL
         # Strip file:// scheme so file URIs resolve as local paths.
         resolved_url = image_url


### PR DESCRIPTION
## Summary

Adds a provider-agnostic hook that wires TTS / image / vision tool defaults to the active chat provider when it serves those capabilities natively on the same credential.  Mirrors `apply_nous_provider_defaults`.

MiniMax is the first registered consumer (international + CN).  Adding another provider is one row in `NATIVE_TOOLS_BY_PROVIDER` plus a set of request helpers.

## Files Changed

| File | Changes |
|------|---------|
| `hermes_cli/provider_native_tools.py` | **new (+466)** — registry, `apply_provider_native_tool_defaults`, runtime dispatchers (`generate_image`, `analyze_image`), shared helpers (`active_provider_api_root`, `native_credential_present`, `minimax_endpoint_and_key`), MiniMax request bindings |
| `hermes_cli/setup.py` | **+26 / −1** — call the generic hook beside the existing Nous branch; skip the interactive TTS prompt when the active provider already owns `tts` |
| `tools/image_generation_tool.py` | **+24** — early-call the native dispatcher; fall through on `None`.  Zero MiniMax mentions |
| `tools/vision_tools.py` | **+28** — early-call when user hasn't pinned `auxiliary.vision.provider`.  Zero MiniMax mentions |
| `tools/tts_tool.py` | **+13 / −1** — existing `_generate_minimax_tts` derives URL + key from `minimax_endpoint_and_key` so `minimax-cn` users hit `api.minimaxi.com` with the CN key automatically |
| `tests/hermes_cli/test_provider_native_tools.py` | **new (+286)** — 47 cases |

## Design Notes

- **URL derivation** reuses `model.base_url`, stripping the `/anthropic` chat-compat suffix.  CN users who pick `minimax-cn` get `api.minimaxi.com` automatically — no separate env var.
- **Credential selection** flips on region: `minimax-cn` → `MINIMAX_CN_API_KEY` first, falls back to `MINIMAX_API_KEY`.
- **Provider detection** uses `hermes_cli.providers.normalize_provider` so hand-edited aliases (`minimax-china`, `minimax_cn`) resolve to the canonical id.
- **Vision** uses runtime dispatch (no persisted config) because chat models on `/anthropic/v1/messages` don't accept multimodal content; vision is served by `/v1/coding_plan/vlm`, the same endpoint MiniMax's official `mmx vision` CLI targets.

## Test Plan

```
python -m pytest tests/hermes_cli/test_provider_native_tools.py -q
# 47 passed
```

Live end-to-end on both `api.minimax.io` and `api.minimaxi.com` with Token Plan keys: TTS, image, vision all return correctly.

Zero new pip dependencies (stdlib only).  Zero behaviour change for chat providers not in `NATIVE_TOOLS_BY_PROVIDER`.