### PR TITLE
fix(doctor): stop false warning for OpenCode Go provider

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -733,7 +733,8 @@ def run_doctor(args):
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),
-        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         "https://opencode.ai/zen/go/v1/models", "OPENCODE_GO_BASE_URL", True),
+        # OpenCode Go has no shared /models endpoint; skip the health check.
+        ("OpenCode Go",      ("OPENCODE_GO_API_KEY",),                         None,                                  "OPENCODE_GO_BASE_URL", False),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
         _key = ""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -343,3 +343,57 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
     assert "Kimi / Moonshot (China)" in out
     assert "str expected, not NoneType" not in out
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
+
+
+@pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
+def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("OPENCODE_GO_API_KEY=***\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-test")
+    if base_url:
+        monkeypatch.setenv("OPENCODE_GO_BASE_URL", base_url)
+    else:
+        monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert any(
+        "OpenCode Go" in line and "(key configured)" in line
+        for line in out.splitlines()
+    )
+    assert not any(url == "https://opencode.ai/zen/go/v1/models" for url, _, _ in calls)
+    assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)


### PR DESCRIPTION
`hermes doctor` was falsely warning users about OpenCode Go connectivity because it tried to probe a `/models` endpoint that this provider does not expose. Unlike OpenCode Zen and other providers, OpenCode Go has no shared models listing route, so the health-check HTTP call always failed.

## Summary

- Set the default health-check URL for OpenCode Go to `None` and mark `supports_health_check` as `False`, so the doctor skips the unreachable probe while still detecting whether the API key is configured.
- Added a parametrized test (`test_run_doctor_opencode_go_skips_invalid_models_probe`) that verifies:
  - The provider is still listed as configured when `OPENCODE_GO_API_KEY` is set.
  - No HTTP request is made to any OpenCode Go `/models` URL, regardless of whether `OPENCODE_GO_BASE_URL` is set.

## Testing

- `source /Users/me/c/mine/hermes-agent/.venv/bin/activate && python -m pytest tests/hermes_cli/test_doctor.py -q`
