### PR TITLE
fix(memory): rollback add_provider state on schema load failure

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -104,12 +104,19 @@ class MemoryManager:
                     provider.name, existing,
                 )
                 return
+
+        # Collect schemas BEFORE mutating state so a failure in
+        # get_tool_schemas() doesn't leave half-registered state.
+        schemas = provider.get_tool_schemas()
+
+        # -- All fallible work done; mutate state -------------------------
+        if not is_builtin:
             self._has_external = True
 
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -125,7 +132,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property

--- a/tests/agent/test_memory_manager_rollback.py
+++ b/tests/agent/test_memory_manager_rollback.py
@@ -1,0 +1,138 @@
+"""Tests for add_provider() rollback on schema load failure (#9948).
+
+Verifies that a broken external provider that raises in get_tool_schemas()
+does NOT leave MemoryManager in a half-registered (poisoned) state.
+"""
+
+import json
+import pytest
+
+from agent.memory_provider import MemoryProvider
+from agent.memory_manager import MemoryManager
+
+
+# ---------------------------------------------------------------------------
+# Test providers
+# ---------------------------------------------------------------------------
+
+class _StableProvider(MemoryProvider):
+    """Minimal working provider."""
+
+    def __init__(self, name="stable", tools=None):
+        self._name = name
+        self._tools = tools or []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return self._tools
+
+    def handle_tool_call(self, tool_name, args, **kwargs):
+        return json.dumps({"handled": tool_name})
+
+
+class _BrokenSchemaProvider(MemoryProvider):
+    """Provider whose get_tool_schemas() always raises."""
+
+    def __init__(self, name="broken"):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        raise RuntimeError("schema load exploded")
+
+    def handle_tool_call(self, tool_name, args, **kwargs):
+        return json.dumps({"handled": tool_name})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestAddProviderRollback:
+    """Regression tests for #9948: add_provider must not mutate state if
+    get_tool_schemas() raises."""
+
+    def test_broken_provider_does_not_register(self):
+        """A provider that fails in get_tool_schemas() must not appear in
+        _providers, _has_external, or _tool_to_provider."""
+        mgr = MemoryManager()
+        builtin = _StableProvider("builtin")
+        mgr.add_provider(builtin)
+
+        broken = _BrokenSchemaProvider("broken_ext")
+
+        with pytest.raises(RuntimeError, match="schema load exploded"):
+            mgr.add_provider(broken)
+
+        # State must be clean — no trace of the broken provider
+        assert [p.name for p in mgr.providers] == ["builtin"]
+        assert mgr._has_external is False
+        assert mgr.get_all_tool_names() == set()
+
+    def test_valid_provider_succeeds_after_broken_one(self):
+        """After a failed add, a subsequent valid external provider must
+        register successfully — _has_external must not be stuck True."""
+        mgr = MemoryManager()
+        builtin = _StableProvider("builtin")
+        mgr.add_provider(builtin)
+
+        broken = _BrokenSchemaProvider("broken_ext")
+        with pytest.raises(RuntimeError):
+            mgr.add_provider(broken)
+
+        good = _StableProvider("good_ext", tools=[
+            {"name": "ext_tool", "description": "Works", "parameters": {}},
+        ])
+        mgr.add_provider(good)
+
+        assert [p.name for p in mgr.providers] == ["builtin", "good_ext"]
+        assert mgr._has_external is True
+        assert mgr.has_tool("ext_tool")
+
+    def test_normal_add_provider_still_works(self):
+        """Sanity check: the happy path is unaffected by the fix."""
+        mgr = MemoryManager()
+        builtin = _StableProvider("builtin", tools=[
+            {"name": "mem_read", "description": "Read", "parameters": {}},
+        ])
+        ext = _StableProvider("external", tools=[
+            {"name": "ext_recall", "description": "Recall", "parameters": {}},
+        ])
+        mgr.add_provider(builtin)
+        mgr.add_provider(ext)
+
+        assert [p.name for p in mgr.providers] == ["builtin", "external"]
+        assert mgr._has_external is True
+        assert mgr.has_tool("mem_read")
+        assert mgr.has_tool("ext_recall")
+        result = json.loads(mgr.handle_tool_call("ext_recall", {}))
+        assert result["handled"] == "ext_recall"
+
+    def test_broken_builtin_does_not_register(self):
+        """Even a builtin provider must not half-register on schema failure."""
+        mgr = MemoryManager()
+        broken_builtin = _BrokenSchemaProvider("builtin")
+
+        with pytest.raises(RuntimeError):
+            mgr.add_provider(broken_builtin)
+
+        assert mgr.providers == []
+        assert mgr.get_all_tool_names() == set()


### PR DESCRIPTION
## Summary

Fixes a race condition in `MemoryManager.add_provider()` where a failing external provider leaves the manager in a half-registered (poisoned) state, permanently blocking future external provider registrations.

## Problem

`add_provider()` mutated internal state (`_has_external`, `_providers`) **before** calling `provider.get_tool_schemas()`. If `get_tool_schemas()` raised an exception:

- `_has_external` was stuck at `True`
- The broken provider was left in `_providers`
- Any subsequent valid external provider was rejected with *"external provider already registered"*

This made the memory subsystem permanently degraded for the rest of the process lifetime.

## Root Cause

`agent/memory_manager.py` lines 94–129 — state mutations happen before the fallible `get_tool_schemas()` call:

```python
# Before fix (buggy):
self._has_external = True          # ← mutates state
self._providers.append(provider)   # ← mutates state
for schema in provider.get_tool_schemas():  # ← can raise!
```

## Fix

Defer all state mutations until after `get_tool_schemas()` succeeds:

```python
# After fix:
schemas = provider.get_tool_schemas()  # ← fallible call first
self._has_external = True              # ← only on success
self._providers.append(provider)       # ← only on success
for schema in schemas:                 # ← iterate cached result
```

Also eliminates a redundant second `get_tool_schemas()` call in the log statement by reusing the cached result.

## Test Coverage

Added `tests/agent/test_memory_manager_rollback.py` with 4 regression tests:

| Test | Verifies |
|------|----------|
| `test_broken_provider_does_not_register` | Failed provider leaves no trace in state |
| `test_valid_provider_succeeds_after_broken_one` | Recovery works — next valid provider registers fine |
| `test_normal_add_provider_still_works` | Happy path unaffected |
| `test_broken_builtin_does_not_register` | Even builtin providers don't half-register |

All 4 new tests pass. Full test suite: 11311 passed (pre-existing failures unaffected).

Closes #9948