### PR TITLE
fix: remove @staticmethod from _context_completions to fix @ crash (#9817)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -844,8 +844,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Summary

Fixes #9817. Typing \@\ in the CLI crashes with \NameError: name 'self' is not defined\.

## Root Cause

\_context_completions\ is decorated as \@staticmethod\ but its body calls \self._fuzzy_file_completions()\, which requires an instance reference. Introduced in PR #9467.

## Fix

Remove the \@staticmethod\ decorator and add \self\ as the first parameter. The caller on line 1086 already invokes it as \self._context_completions(ctx_word)\, so the instance is passed correctly.

## Changes

- \hermes_cli/commands.py\: Remove \@staticmethod\ decorator, add \self\ parameter to \_context_completions\

1 file changed, 1 insertion, 2 deletions.