### PR TITLE
fix: validate Telegram bot token format during gateway setup (#9843)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1611,9 +1611,19 @@ def _setup_telegram():
             return
 
     print_info("Create a bot via @BotFather on Telegram")
-    token = prompt("Telegram bot token", password=True)
-    if not token:
-        return
+    import re
+
+    while True:
+        token = prompt("Telegram bot token", password=True)
+        if not token:
+            return
+        if not re.match(r"^\d+:[A-Za-z0-9_-]{30,}$", token):
+            print_error(
+                "Invalid token format. Expected: <numeric_id>:<alphanumeric_hash> "
+                "(e.g., 123456789:ABCdefGHI-jklMNOpqrSTUvwxYZ)"
+            )
+            continue
+        break
     save_env_value("TELEGRAM_BOT_TOKEN", token)
     print_success("Telegram token saved")
 


### PR DESCRIPTION
## Summary

Fixes #9843. The setup wizard accepts any string as a Telegram bot token without validation. Invalid tokens are only caught at runtime when the gateway fails to connect.

## Changes

- \hermes_cli/setup.py\: Add regex validation for Telegram bot token format (\<numeric_id>:<alphanumeric_hash>\)
- Loop until valid token entered or user cancels
- Clear error message with expected format example

## Before
Any string accepted silently. User discovers bad token only when gateway crashes.

## After
\\\
Telegram bot token: ***
✗ Invalid token format. Expected: <numeric_id>:<alphanumeric_hash> (e.g., 123456789:ABCdefGHI-jklMNOpqrSTUvwxYZ)
Telegram bot token: ***
✓ Telegram token saved
\\\

1 file changed, 13 insertions, 3 deletions.