### PR TITLE
feat(cron): parallel job execution within a single tick

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -11,6 +11,7 @@ import logging
 import tempfile
 import os
 import re
+import threading
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -36,6 +37,10 @@ CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+
+# Protects load_jobs → modify → save_jobs cycles from concurrent threads
+# (e.g. parallel cron job execution in tick()).
+_jobs_file_lock = threading.Lock()
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -581,13 +586,21 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
     Mark a job as having been run.
-    
+
     Updates last_run_at, last_status, increments completed count,
     computes next_run_at, and auto-deletes if repeat limit reached.
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+
+    Thread-safe: holds ``_jobs_file_lock`` for the read-modify-write cycle.
     """
+    with _jobs_file_lock:
+        _mark_job_run_unlocked(job_id, success, error, delivery_error)
+
+
+def _mark_job_run_unlocked(job_id: str, success: bool, error: Optional[str] = None,
+                           delivery_error: Optional[str] = None):
     jobs = load_jobs()
     for i, job in enumerate(jobs):
         if job["id"] == job_id:
@@ -638,7 +651,14 @@ def advance_next_run(job_id: str) -> bool:
     One-shot jobs are left unchanged so they can still retry on restart.
 
     Returns True if next_run_at was advanced, False otherwise.
+
+    Thread-safe: holds ``_jobs_file_lock`` for the read-modify-write cycle.
     """
+    with _jobs_file_lock:
+        return _advance_next_run_unlocked(job_id)
+
+
+def _advance_next_run_unlocked(job_id: str) -> bool:
     jobs = load_jobs()
     for job in jobs:
         if job["id"] == job_id:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -48,6 +49,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "qqbot",
 })
 
+from gateway.session_context import set_session_vars, clear_session_vars, get_session_env
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -61,6 +63,10 @@ _hermes_home = get_hermes_home()
 # File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
 _LOCK_DIR = _hermes_home / "cron"
 _LOCK_FILE = _LOCK_DIR / ".tick.lock"
+
+# Serializes load_dotenv() calls — all jobs load the same .env file, but
+# load_dotenv mutates os.environ and is not thread-safe.
+_dotenv_lock = threading.Lock()
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -601,28 +607,41 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
 
+    _ctx_tokens = []
+    _cron_deliver_tokens = []
     try:
-        # Inject origin context so the agent's send_message tool knows the chat.
-        # Must be INSIDE the try block so the finally cleanup always runs.
+        # Inject origin context via ContextVars (thread-safe for parallel jobs).
+        # Falls back to os.environ reads via get_session_env() in tools.
         if origin:
-            os.environ["HERMES_SESSION_PLATFORM"] = origin["platform"]
-            os.environ["HERMES_SESSION_CHAT_ID"] = str(origin["chat_id"])
-            if origin.get("chat_name"):
-                os.environ["HERMES_SESSION_CHAT_NAME"] = origin["chat_name"]
+            _ctx_tokens = set_session_vars(
+                platform=origin["platform"],
+                chat_id=str(origin["chat_id"]),
+                chat_name=origin.get("chat_name", ""),
+            )
+
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
-        try:
-            load_dotenv(str(_hermes_home / ".env"), override=True, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(str(_hermes_home / ".env"), override=True, encoding="latin-1")
+        with _dotenv_lock:
+            try:
+                load_dotenv(str(_hermes_home / ".env"), override=True, encoding="utf-8")
+            except UnicodeDecodeError:
+                load_dotenv(str(_hermes_home / ".env"), override=True, encoding="latin-1")
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            os.environ["HERMES_CRON_AUTO_DELIVER_PLATFORM"] = delivery_target["platform"]
-            os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
-            if delivery_target.get("thread_id") is not None:
-                os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+            from gateway.session_context import (
+                _CRON_AUTO_DELIVER_PLATFORM,
+                _CRON_AUTO_DELIVER_CHAT_ID,
+                _CRON_AUTO_DELIVER_THREAD_ID,
+            )
+            _cron_deliver_tokens = [
+                _CRON_AUTO_DELIVER_PLATFORM.set(delivery_target["platform"]),
+                _CRON_AUTO_DELIVER_CHAT_ID.set(str(delivery_target["chat_id"])),
+                _CRON_AUTO_DELIVER_THREAD_ID.set(
+                    str(delivery_target["thread_id"]) if delivery_target.get("thread_id") is not None else ""
+                ),
+            ]
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -768,7 +787,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        _cron_future = _cron_pool.submit(agent.run_conversation, prompt)
+        # Copy the current context so ContextVars (session platform, delivery
+        # target) are visible inside the worker thread on Python <3.12.
+        import contextvars
+        _ctx = contextvars.copy_context()
+        _cron_future = _cron_pool.submit(_ctx.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -875,16 +898,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
-        # Clean up injected env vars so they don't leak to other jobs
-        for key in (
-            "HERMES_SESSION_PLATFORM",
-            "HERMES_SESSION_CHAT_ID",
-            "HERMES_SESSION_CHAT_NAME",
-            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
-            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
-            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
-        ):
-            os.environ.pop(key, None)
+        # Reset ContextVars (thread-safe cleanup — no cross-job leakage)
+        clear_session_vars(_ctx_tokens)
+        if _cron_deliver_tokens:
+            from gateway.session_context import (
+                _CRON_AUTO_DELIVER_PLATFORM,
+                _CRON_AUTO_DELIVER_CHAT_ID,
+                _CRON_AUTO_DELIVER_THREAD_ID,
+            )
+            for var, token in zip(
+                [_CRON_AUTO_DELIVER_PLATFORM, _CRON_AUTO_DELIVER_CHAT_ID, _CRON_AUTO_DELIVER_THREAD_ID],
+                _cron_deliver_tokens,
+            ):
+                var.reset(token)
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
@@ -927,6 +953,8 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             lock_fd.close()
         return 0
 
+    # Phase 1: Collect due jobs and advance schedules (under lock)
+    due_jobs = []
     try:
         due_jobs = get_due_jobs()
 
@@ -937,55 +965,73 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
-        executed = 0
         for job in due_jobs:
-            try:
-                # For recurring jobs (cron/interval), advance next_run_at to the
-                # next future occurrence BEFORE execution.  This way, if the
-                # process crashes mid-run, the job won't re-fire on restart.
-                # One-shot jobs are left alone so they can retry on restart.
-                advance_next_run(job["id"])
-
-                success, output, final_response, error = run_job(job)
-
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
-
-                # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
-
-                delivery_error = None
-                if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-                executed += 1
-
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
-
-        return executed
+            advance_next_run(job["id"])
     finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
+        try:
+            if fcntl:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
+        except Exception:
+            pass
+
+    # Phase 2: Execute jobs OUTSIDE the lock, in parallel.
+    # mark_job_run and save_job_output are thread-safe (jobs.json writes
+    # are serialized by _jobs_file_lock; output goes to per-job directories).
+    max_workers = int(os.getenv("HERMES_CRON_MAX_WORKERS", "4"))
+    max_workers = max(1, max_workers)
+
+    def _execute_one(job):
+        """Run a single job: agent execution → output save → delivery → state update."""
+        try:
+            success, output, final_response, error = run_job(job)
+
+            output_file = save_job_output(job["id"], output)
+            if verbose:
+                logger.info("Output saved to: %s", output_file)
+
+            deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+            should_deliver = bool(deliver_content)
+            if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                should_deliver = False
+
+            delivery_error = None
+            if should_deliver:
+                try:
+                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                except Exception as de:
+                    delivery_error = str(de)
+                    logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            return True
+
+        except Exception as e:
+            logger.error("Error processing job %s: %s", job['id'], e)
+            mark_job_run(job["id"], False, str(e))
+            return False
+
+    if max_workers == 1 or len(due_jobs) <= 1:
+        return sum(1 for job in due_jobs if _execute_one(job))
+
+    executed = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_execute_one, job): job for job in due_jobs}
+        for future in concurrent.futures.as_completed(futures):
             try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+                if future.result():
+                    executed += 1
+            except Exception as e:
+                job = futures[future]
+                logger.error("Unexpected error for job %s: %s", job["id"], e)
+
+    return executed
 
 
 if __name__ == "__main__":

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -50,6 +50,12 @@ _SESSION_USER_ID: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID", default
 _SESSION_USER_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_USER_NAME", default="")
 _SESSION_KEY: ContextVar[str] = ContextVar("HERMES_SESSION_KEY", default="")
 
+# Cron auto-delivery context — thread-safe alternative to os.environ for
+# parallel job execution (each worker thread gets its own copy).
+_CRON_AUTO_DELIVER_PLATFORM: ContextVar[str] = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default="")
+_CRON_AUTO_DELIVER_CHAT_ID: ContextVar[str] = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default="")
+_CRON_AUTO_DELIVER_THREAD_ID: ContextVar[str] = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default="")
+
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
@@ -58,6 +64,9 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
 }
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import threading
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -1162,6 +1163,159 @@ class TestTickAdvanceBeforeRun:
         adv_mock.assert_called_once_with("test-advance")
         # advance must happen before run
         assert call_order == [("advance", "test-advance"), ("run", "test-advance")]
+
+
+class TestTickParallelExecution:
+    """Verify tick() runs due jobs in parallel when HERMES_CRON_MAX_WORKERS > 1."""
+
+    def test_jobs_run_in_parallel(self, tmp_path, monkeypatch):
+        """With max_workers=4, two slow jobs should overlap in time."""
+        import time
+        import threading
+
+        timestamps = {}  # job_id → (start, end)
+        lock = threading.Lock()
+
+        def slow_run_job(job):
+            start = time.monotonic()
+            time.sleep(0.3)
+            end = time.monotonic()
+            with lock:
+                timestamps[job["id"]] = (start, end)
+            return True, "output", "response", None
+
+        jobs = [
+            {"id": f"par-{i}", "name": f"job-{i}", "prompt": "hi",
+             "enabled": True, "schedule": {"kind": "interval", "seconds": 3600}}
+            for i in range(3)
+        ]
+
+        monkeypatch.setenv("HERMES_CRON_MAX_WORKERS", "4")
+
+        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.advance_next_run", return_value=True), \
+             patch("cron.scheduler.run_job", side_effect=slow_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=tmp_path / "out.md"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            from cron.scheduler import tick
+            executed = tick(verbose=False)
+
+        assert executed == 3
+        # With parallel execution, at least two jobs should have overlapping time ranges
+        intervals = list(timestamps.values())
+        overlap_found = False
+        for i in range(len(intervals)):
+            for j in range(i + 1, len(intervals)):
+                s1, e1 = intervals[i]
+                s2, e2 = intervals[j]
+                if s1 < e2 and s2 < e1:
+                    overlap_found = True
+                    break
+        assert overlap_found, "Expected parallel overlap but jobs ran serially"
+
+    def test_serial_with_max_workers_1(self, tmp_path, monkeypatch):
+        """HERMES_CRON_MAX_WORKERS=1 runs jobs serially (backward compat)."""
+        import time
+
+        call_times = []
+
+        def tracking_run_job(job):
+            call_times.append(time.monotonic())
+            time.sleep(0.1)
+            call_times.append(time.monotonic())
+            return True, "output", "response", None
+
+        jobs = [
+            {"id": f"ser-{i}", "name": f"job-{i}", "prompt": "hi",
+             "enabled": True, "schedule": {"kind": "interval", "seconds": 3600}}
+            for i in range(2)
+        ]
+
+        monkeypatch.setenv("HERMES_CRON_MAX_WORKERS", "1")
+
+        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.advance_next_run", return_value=True), \
+             patch("cron.scheduler.run_job", side_effect=tracking_run_job), \
+             patch("cron.scheduler.save_job_output", return_value=tmp_path / "out.md"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            from cron.scheduler import tick
+            executed = tick(verbose=False)
+
+        assert executed == 2
+        # Job 2 should start after job 1 ends (serial)
+        assert call_times[2] >= call_times[1], "Expected serial execution"
+
+    def test_default_max_workers(self, monkeypatch):
+        """Default max_workers is 4 when env var is unset."""
+        monkeypatch.delenv("HERMES_CRON_MAX_WORKERS", raising=False)
+
+        with patch("cron.scheduler.get_due_jobs", return_value=[]):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        # No crash = env var parsing works with default
+
+    def test_failed_job_does_not_block_others(self, tmp_path, monkeypatch):
+        """A failing job should not prevent other jobs from completing."""
+        call_count = {"ok": 0, "fail": 0}
+        lock = threading.Lock()
+
+        def sometimes_fail(job):
+            if job["id"] == "fail-job":
+                raise RuntimeError("boom")
+            with lock:
+                call_count["ok"] += 1
+            return True, "output", "response", None
+
+        jobs = [
+            {"id": "fail-job", "name": "bad", "prompt": "hi",
+             "enabled": True, "schedule": {"kind": "interval", "seconds": 3600}},
+            {"id": "ok-job", "name": "good", "prompt": "hi",
+             "enabled": True, "schedule": {"kind": "interval", "seconds": 3600}},
+        ]
+
+        monkeypatch.setenv("HERMES_CRON_MAX_WORKERS", "4")
+
+        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.advance_next_run", return_value=True), \
+             patch("cron.scheduler.run_job", side_effect=sometimes_fail), \
+             patch("cron.scheduler.save_job_output", return_value=tmp_path / "out.md"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            from cron.scheduler import tick
+            executed = tick(verbose=False)
+
+        assert executed == 1
+        assert call_count["ok"] == 1
+
+    def test_mark_job_run_called_for_each_job(self, tmp_path, monkeypatch):
+        """Every job gets mark_job_run called, even in parallel."""
+
+        def fake_run(job):
+            return True, "output", "response", None
+
+        jobs = [
+            {"id": f"mark-{i}", "name": f"job-{i}", "prompt": "hi",
+             "enabled": True, "schedule": {"kind": "interval", "seconds": 3600}}
+            for i in range(3)
+        ]
+
+        monkeypatch.setenv("HERMES_CRON_MAX_WORKERS", "4")
+
+        with patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.advance_next_run", return_value=True), \
+             patch("cron.scheduler.run_job", side_effect=fake_run), \
+             patch("cron.scheduler.save_job_output", return_value=tmp_path / "out.md"), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            from cron.scheduler import tick
+            executed = tick(verbose=False)
+
+        assert executed == 3
+        assert mock_mark.call_count == 3
+        marked_ids = {call.args[0] for call in mock_mark.call_args_list}
+        assert marked_ids == {"mark-0", "mark-1", "mark-2"}
 
 
 class TestSendMediaViaAdapter:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -272,11 +272,12 @@ def _describe_media_for_mirror(media_files):
 
 def _get_cron_auto_delivery_target():
     """Return the cron scheduler's auto-delivery target for the current run, if any."""
-    platform = os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
-    chat_id = os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
+    from gateway.session_context import get_session_env
+    platform = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
+    chat_id = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
     if not platform or not chat_id:
         return None
-    thread_id = os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
+    thread_id = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
     return {
         "platform": platform,
         "chat_id": chat_id,


### PR DESCRIPTION
## Problem

Currently all due jobs in `tick()` run serially in a for-loop. If one job takes 9 minutes (e.g. a daily data fetch), all other due jobs are blocked until it finishes.

## Solution

Split `tick()` into two phases:
1. **Phase 1 (under file lock):** advance `next_run_at` for all due jobs
2. **Phase 2 (outside lock):** execute jobs in parallel via `ThreadPoolExecutor`

### Key changes

- **`HERMES_CRON_MAX_WORKERS` env var** (default 4) controls max parallel jobs
- **`os.environ` → `contextvars`** for session/delivery injection (thread-safe, no cross-job leakage)
- **`load_dotenv()`** serialized with a threading lock
- **Backward compatible:** `HERMES_CRON_MAX_WORKERS=1` = serial behavior (identical to current code)
- **155 lines of new tests** for parallel execution

### Files changed

| File | Change |
|------|--------|
| `cron/scheduler.py` | Parallel tick + ContextVars |
| `cron/jobs.py` | Thread-safe jobs.json writes |
| `gateway/session_context.py` | New ContextVars for session state |
| `tools/send_message_tool.py` | Read from ContextVars with os.environ fallback |
| `tests/cron/test_scheduler.py` | 155 lines of new tests |

### Safety

- Each job already creates its own `AIAgent` instance — no shared state
- File lock still prevents concurrent ticks (gateway + daemon + systemd)
- `save_job_output()` writes to per-job directories — no conflicts
- `mark_job_run()` uses file-level locking for jobs.json updates