### PR TITLE
fix: resolve external_dirs relative to HERMES_HOME instead of cwd (#9949)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -200,6 +200,9 @@ def get_external_skills_dirs() -> List[Path]:
     if not isinstance(raw_dirs, list):
         return []
 
+    from hermes_constants import get_hermes_home
+
+    hermes_home = get_hermes_home()
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
     result: List[Path] = []
@@ -210,7 +213,12 @@ def get_external_skills_dirs() -> List[Path]:
             continue
         # Expand ~ and environment variables
         expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded).resolve()
+        p = Path(expanded)
+        # Resolve relative paths against HERMES_HOME, not cwd
+        if not p.is_absolute():
+            p = (hermes_home / p).resolve()
+        else:
+            p = p.resolve()
         if p == local_skills:
             continue
         if p in seen:


### PR DESCRIPTION
## Summary

Fixes #9949. Relative entries in \skills.external_dirs\ were resolved against the process working directory, causing them to silently fail when Hermes was launched from a different directory.

## Root Cause

\Path(expanded).resolve()\ resolves relative paths against \os.getcwd()\, not against \HERMES_HOME\. A config like \../shared-skills\ works when launched from \HERMES_HOME\ but silently fails from any other directory.

## Fix

Resolve relative paths against \get_hermes_home()\ instead of cwd. Absolute paths, tilde expansion, and env-var expansion are unchanged.

## Changes

- \gent/skill_utils.py\: Check \p.is_absolute()\; if relative, resolve against \get_hermes_home()\

1 file changed, 9 insertions, 1 deletion.