### PR TITLE
fix: add SMS to PLATFORMS registry to fix KeyError on inbound message (#9789)

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -38,6 +38,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),
+    ("sms",            PlatformInfo(label="📲 SMS",             default_toolset="hermes-sms")),
 ])
 
 


### PR DESCRIPTION
## Summary

Fixes #9789. The SMS gateway crashes with `KeyError: 'sms'` when receiving inbound messages because the SMS platform is missing from the `PLATFORMS` registry.

## Root Cause

`hermes_cli/platforms.py` defines all platform entries but omits `sms`. When `tools_config.py` looks up `PLATFORMS['sms']` to get the default toolset, it raises `KeyError`.

## Fix

Add the SMS entry to the `PLATFORMS` OrderedDict with the existing `hermes-sms` toolset.

1 file changed, 1 insertion.
