### PR TITLE
fix: mark discarded-no-reasoning prompts as completed to prevent infinite retry (#9950)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -444,6 +444,7 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
             if not reasoning.get("has_any_reasoning", True):
                 print(f"   🚫 Prompt {prompt_index} discarded (no reasoning in any turn)")
                 discarded_no_reasoning += 1
+                completed_in_batch.append(prompt_index)
                 continue
             
             # Get and normalize tool stats for consistent schema across all entries


### PR DESCRIPTION
## Summary

Fixes #9950. Prompts discarded for having no reasoning (`has_any_reasoning == False`) were not added to `completed_in_batch`, causing `--resume` to retry them indefinitely.

## Root Cause

In `_process_batch_worker()`, when a prompt is discarded (line 444-447), the code increments `discarded_no_reasoning` and `continue`s — skipping the `completed_in_batch.append()` that happens later. On resume, these prompts appear unfinished and get re-processed forever.

## Fix

Add `completed_in_batch.append(prompt_index)` before the `continue` in the discard branch. Discard is a terminal disposition, not a retryable failure.

1 file changed, 1 insertion.
