### PR TITLE
fix: remove @staticmethod from _context_completions that references self

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -844,8 +844,7 @@ class SlashCommandCompleter(Completer):
             return None
         return word
 
-    @staticmethod
-    def _context_completions(word: str, limit: int = 30):
+    def _context_completions(self, word: str, limit: int = 30):
         """Yield Claude Code-style @ context completions.
 
         Bare ``@`` or ``@partial`` shows static references and matching


### PR DESCRIPTION
## Summary
Fix crash when typing `@` in CLI input — the autocompletion system threw `NameError: name 'self' is not defined`.

## Root Cause
`_context_completions` (line 848) was decorated with `@staticmethod` but the method body called `self._fuzzy_file_completions()` on line 916, which is an instance method requiring `self`. This was introduced in PR #9467 when fuzzy file completion code was added into what was previously a static method.

## Fix
Removed the `@staticmethod` decorator and added `self` as the first parameter. The caller on line 1085 already invokes it as `self._context_completions(ctx_word)`, so the instance is passed correctly.

## Test Plan
- [ ] Type `@` in CLI input — no more crash
- [ ] Context completion still works for `@diff`, `@staged`, `@file:`, etc.

Closes NousResearch/hermes-agent#9817