### PR TITLE
fix: include provider/base_url in initial ACP session snapshot

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -302,7 +302,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.


### PR DESCRIPTION
## Summary
ACP sessions lost provider/base_url/api_mode configuration after the first persist, causing restored sessions to lose provider routing metadata.

## Root Cause
When a new ACP session was first persisted, `db.create_session()` was called with `model_config={"cwd": state.cwd}` — only the working directory. However, the code had already computed a full `session_meta` dict containing `provider`, `base_url`, and `api_mode`. The update path (line 311-315) correctly used `cwd_json` (the full serialized session_meta), but the create path did not.

## Fix
Changed the create_session call to pass `session_meta` instead of `{"cwd": state.cwd}`, ensuring the first persisted snapshot includes all provider routing metadata.

## Test Plan
- [ ] Create a new ACP session with a custom provider/base_url
- [ ] Persist and restore the session — provider/base_url should be preserved
- [ ] Relevant unit tests pass

Closes NousResearch/hermes-agent#9812