### PR TITLE
fix(memory): discover external memory provider plugins

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -58,9 +58,15 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
-    from pathlib import Path as _Path
 
-    plugin_dir = _Path(__file__).parent.parent / "plugins" / "memory" / provider_name
+    try:
+        from plugins.memory import find_memory_provider_dir
+    except Exception:
+        find_memory_provider_dir = None  # type: ignore[assignment]
+
+    plugin_dir = find_memory_provider_dir(provider_name) if callable(find_memory_provider_dir) else None
+    if plugin_dir is None:
+        plugin_dir = Path(__file__).parent.parent / "plugins" / "memory" / provider_name
     yaml_path = plugin_dir / "plugin.yaml"
     if not yaml_path.exists():
         return

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -22,11 +22,56 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
+
+
+def _user_memory_plugins_dir() -> Path:
+    """Return the user-installed memory plugin directory.
+
+    Memory providers can be installed via ``hermes plugins install`` into
+    ``$HERMES_HOME/plugins/<name>/``. Those directories are not nested under a
+    dedicated ``memory`` subdirectory, so discovery must scan the user plugin
+    root and then filter to plugins that implement the MemoryProvider contract.
+    """
+    return get_hermes_home() / "plugins"
+
+
+def _iter_provider_dirs() -> Iterable[Path]:
+    """Yield bundled providers first, then user-installed providers.
+
+    Bundled providers win if the same provider name exists in both places.
+    """
+    seen: set[str] = set()
+    for base in (_MEMORY_PLUGINS_DIR, _user_memory_plugins_dir()):
+        if not base.is_dir():
+            continue
+        for child in sorted(base.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name in seen:
+                continue
+            if not (child / "__init__.py").exists():
+                continue
+            seen.add(child.name)
+            yield child
+
+
+def find_memory_provider_dir(name: str) -> Optional[Path]:
+    """Resolve a provider name to its directory.
+
+    Search order is bundled plugins first, then user-installed plugins under
+    ``$HERMES_HOME/plugins``.
+    """
+    for provider_dir in _iter_provider_dirs():
+        if provider_dir.name == name:
+            return provider_dir
+    return None
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
@@ -37,16 +82,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     and does a lightweight availability check.
     """
     results = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
-
-    for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-        if not child.is_dir() or child.name.startswith(("_", ".")):
-            continue
-        init_file = child / "__init__.py"
-        if not init_file.exists():
-            continue
-
+    for child in _iter_provider_dirs():
         # Read description from plugin.yaml if available
         desc = ""
         yaml_file = child / "plugin.yaml"
@@ -80,9 +116,12 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
 
     Returns None if the provider is not found or fails to load.
     """
-    provider_dir = _MEMORY_PLUGINS_DIR / name
-    if not provider_dir.is_dir():
-        logger.debug("Memory provider '%s' not found in %s", name, _MEMORY_PLUGINS_DIR)
+    provider_dir = find_memory_provider_dir(name)
+    if provider_dir is None:
+        logger.debug(
+            "Memory provider '%s' not found in bundled or user plugin directories",
+            name,
+        )
         return None
 
     try:
@@ -249,16 +288,13 @@ def discover_plugin_cli_commands() -> List[dict]:
     any provider is loaded.
     """
     results: List[dict] = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
-        return results
 
     active_provider = _get_active_memory_provider()
     if not active_provider:
         return results
 
-    # Only look at the active provider's directory
-    plugin_dir = _MEMORY_PLUGINS_DIR / active_provider
-    if not plugin_dir.is_dir():
+    plugin_dir = find_memory_provider_dir(active_provider)
+    if plugin_dir is None:
         return results
 
     cli_file = plugin_dir / "cli.py"

--- a/tests/agent/test_external_memory_provider_discovery.py
+++ b/tests/agent/test_external_memory_provider_discovery.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _write_memory_plugin(path: Path, *, description: str = "User plugin", cli: bool = False) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "plugin.yaml").write_text(f'name: {path.name}\ndescription: "{description}"\n')
+    (path / "__init__.py").write_text(
+        "from agent.memory_provider import MemoryProvider\n\n"
+        "class DemoMemoryProvider(MemoryProvider):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        f"        return '{path.name}'\n\n"
+        "    def is_available(self):\n"
+        "        return True\n\n"
+        "    def initialize(self, session_id, **kwargs):\n"
+        "        return None\n\n"
+        "    def get_tool_schemas(self):\n"
+        "        return []\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(DemoMemoryProvider())\n"
+    )
+    if cli:
+        (path / "cli.py").write_text(
+            "def demo_command(args):\n"
+            "    return None\n\n"
+            "def register_cli(subparser):\n"
+            "    subparser.set_defaults(func=demo_command)\n"
+        )
+
+
+def test_discover_memory_providers_includes_user_plugins(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    user_plugins = hermes_home / "plugins"
+    bundled = tmp_path / "bundled_memory"
+    _write_memory_plugin(user_plugins / "user-memory", description="User-scoped provider")
+    bundled.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from plugins import memory as memory_plugins
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", bundled)
+
+    providers = memory_plugins.discover_memory_providers()
+    names = [name for name, _, _ in providers]
+
+    assert "user-memory" in names
+
+
+def test_load_memory_provider_falls_back_to_user_plugin_dir(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    user_plugins = hermes_home / "plugins"
+    bundled = tmp_path / "bundled_memory"
+    _write_memory_plugin(user_plugins / "user-memory")
+    bundled.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from plugins import memory as memory_plugins
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", bundled)
+
+    provider = memory_plugins.load_memory_provider("user-memory")
+
+    assert provider is not None
+    assert provider.name == "user-memory"
+
+
+def test_load_memory_provider_prefers_bundled_plugin_over_user_plugin(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    user_plugins = hermes_home / "plugins"
+    bundled = tmp_path / "bundled_memory"
+    _write_memory_plugin(user_plugins / "shared-memory", description="user copy")
+    _write_memory_plugin(bundled / "shared-memory", description="bundled copy")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from plugins import memory as memory_plugins
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", bundled)
+
+    provider = memory_plugins.load_memory_provider("shared-memory")
+
+    assert provider is not None
+    assert provider.name == "shared-memory"
+    providers = memory_plugins.discover_memory_providers()
+    descriptions = {name: desc for name, desc, _ in providers}
+    assert descriptions["shared-memory"] == "bundled copy"
+
+
+def test_discover_plugin_cli_commands_uses_active_user_memory_plugin(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    user_plugins = hermes_home / "plugins"
+    bundled = tmp_path / "bundled_memory"
+    _write_memory_plugin(user_plugins / "user-memory", cli=True)
+    bundled.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("memory:\n  provider: user-memory\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from plugins import memory as memory_plugins
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", bundled)
+
+    commands = memory_plugins.discover_plugin_cli_commands()
+
+    assert len(commands) == 1
+    assert commands[0]["name"] == "user-memory"
+
+
+def test_install_dependencies_reads_user_plugin_manifest(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    user_plugin = hermes_home / "plugins" / "user-memory"
+    _write_memory_plugin(user_plugin)
+    (user_plugin / "plugin.yaml").write_text(
+        'name: user-memory\npip_dependencies:\n  - fake-dep\n'
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import memory_setup
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fake_dep":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(memory_setup, "__import__", fake_import, raising=False)
+
+    with patch("shutil.which", return_value="/usr/bin/uv"), \
+         patch("subprocess.run") as mock_run:
+        memory_setup._install_dependencies("user-memory")
+
+    assert mock_run.called
+    args = mock_run.call_args[0][0]
+    assert args[:5] == ["/usr/bin/uv", "pip", "install", "--python", memory_setup.sys.executable]
+    assert "fake-dep" in args


### PR DESCRIPTION
## Summary
- discover memory providers from user-installed plugin directories under `$HERMES_HOME/plugins`
- resolve active memory-plugin CLI commands from the same external plugin locations
- let `hermes memory setup` find `plugin.yaml` and dependency declarations for user-installed memory providers
- add regression tests covering user-plugin discovery, loading, CLI resolution, and dependency install lookup

## Why
Memory providers currently require an awkward symlink into `plugins/memory/` even after `hermes plugins install owner/repo` succeeds. General plugins already support user plugin directories and pip entry points; memory providers were the odd one out.

This closes the gap for the user-plugin path and makes the normal install flow much less cursed.

## Test Plan
- `python3 -m pytest tests/agent/test_memory_provider.py tests/agent/test_external_memory_provider_discovery.py -q -o addopts=''`

## Notes
- Bundled memory providers still take precedence if the same provider name exists in both places.
- I did not change pip entry-point discovery for memory providers in this PR; this targets the immediate `~/.hermes/plugins/` install path first.
