### PR TITLE
fix: validate bot token format in gateway and setup wizards

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -1626,6 +1627,42 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
 # Gateway Setup (Interactive Messaging Platform Configuration)
 # =============================================================================
 
+# Bot token format validators — used by gateway setup to reject invalid tokens
+# before they are saved to .env.
+_TELEGRAM_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]{25,50}$")
+_DISCORD_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}$")
+_SLACK_BOT_TOKEN_RE = re.compile(r"^xoxb-[A-Za-z0-9-]+$")
+_SLACK_APP_TOKEN_RE = re.compile(r"^xapp-[A-Za-z0-9-]+$")
+
+
+def _validate_bot_token(token: str, var_name: str) -> tuple[bool, str]:
+    """Validate a bot token format. Returns (is_valid, error_message)."""
+    if var_name == "TELEGRAM_BOT_TOKEN":
+        if not _TELEGRAM_TOKEN_RE.match(token):
+            return False, (
+                "Invalid Telegram bot token format. Expected: <numeric_id>:<alphanumeric_token>\n"
+                "  Example: 123456789:ABCdefGHI-jklMNOpqrSTUvwxYZ"
+            )
+    elif var_name == "DISCORD_BOT_TOKEN":
+        if not _DISCORD_TOKEN_RE.match(token):
+            return False, (
+                "Invalid Discord bot token format. Expected: three dot-separated segments\n"
+                "  Example: MTIzNDU2Nzg5.MmY3Zg.ABCdefGHIjklMNOpqrSTUvwxYZ"
+            )
+    elif var_name == "SLACK_BOT_TOKEN":
+        if not _SLACK_BOT_TOKEN_RE.match(token):
+            return False, (
+                "Invalid Slack bot token. Expected: xoxb- prefix\n"
+                "  Example: see Slack docs for xoxb- token format"
+            )
+    elif var_name == "SLACK_APP_TOKEN":
+        if not _SLACK_APP_TOKEN_RE.match(token):
+            return False, (
+                "Invalid Slack app token. Expected: xapp- prefix\n"
+                "  Example: see Slack docs for xapp- token format"
+            )
+    return True, ""
+
 # Per-platform config: each entry defines the env vars, setup instructions,
 # and prompts needed to configure a messaging platform.
 _PLATFORMS = [
@@ -2158,6 +2195,27 @@ def _setup_standard_platform(platform: dict):
 
         value = prompt(f"  {var['prompt']}", password=var.get("password", False))
         if value:
+            # Validate bot token format for known token fields
+            is_valid, error_msg = _validate_bot_token(value, var["name"])
+            if not is_valid:
+                print_error(f"  {error_msg}")
+                print_warning("  Please re-enter the correct token, or press Enter to skip.")
+                value = prompt(f"  {var['prompt']}", password=var.get("password", False))
+                if value:
+                    is_valid2, error_msg2 = _validate_bot_token(value, var["name"])
+                    if not is_valid2:
+                        print_error(f"  {error_msg2}")
+                        print_warning("  Saving anyway — you will need to fix this before the gateway can connect.")
+                    else:
+                        save_env_value(var["name"], value)
+                        print_success(f"  Saved {var['name']}")
+                        continue
+                if not value:
+                    if var["name"] == token_var:
+                        print_warning(f"  Skipped — {label} won't work without this.")
+                        return
+                    print_info("  Skipped (can configure later)")
+                    continue
             save_env_value(var["name"], value)
             print_success(f"  Saved {var['name']}")
         elif var["name"] == token_var:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import re
 import shutil
 import sys
 import copy
@@ -1611,9 +1612,17 @@ def _setup_telegram():
             return
 
     print_info("Create a bot via @BotFather on Telegram")
-    token = prompt("Telegram bot token", password=True)
-    if not token:
-        return
+    while True:
+        token = prompt("Telegram bot token", password=True)
+        if not token:
+            return
+        if re.match(r"^\d+:[A-Za-z0-9_-]{25,50}$", token):
+            break
+        print_error("Invalid Telegram bot token format. Expected: <numeric_id>:<alphanumeric_token>")
+        print_info("  Example: 123456789:ABCdefGHI-jklMNOpqrSTUvwxYZ")
+        if not prompt_yes_no("Re-enter the token?", True):
+            print_warning("Saving anyway — you will need to fix this before the gateway can connect.")
+            break
     save_env_value("TELEGRAM_BOT_TOKEN", token)
     print_success("Telegram token saved")
 
@@ -1672,9 +1681,17 @@ def _setup_discord():
             return
 
     print_info("Create a bot at https://discord.com/developers/applications")
-    token = prompt("Discord bot token", password=True)
-    if not token:
-        return
+    while True:
+        token = prompt("Discord bot token", password=True)
+        if not token:
+            return
+        if re.match(r"^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}$", token):
+            break
+        print_error("Invalid Discord bot token format. Expected: three dot-separated segments")
+        print_info("  Example: MTIzNDU2Nzg5.MmY3Zg.ABCdefGHIjklMNOpqrSTUvwxYZ")
+        if not prompt_yes_no("Re-enter the token?", True):
+            print_warning("Saving anyway — you will need to fix this before the gateway can connect.")
+            break
     save_env_value("DISCORD_BOT_TOKEN", token)
     print_success("Discord token saved")
 
@@ -1753,10 +1770,24 @@ def _setup_slack():
     bot_token = prompt("Slack Bot Token (xoxb-...)", password=True)
     if not bot_token:
         return
-    save_env_value("SLACK_BOT_TOKEN", bot_token)
+    if not re.match(r"^xoxb-[A-Za-z0-9-]+$", bot_token):
+        print_error("Invalid Slack bot token format. Expected: xoxb- prefix")
+        print_info("  Example: see Slack docs for xoxb- token format")
+        if prompt_yes_no("Save anyway?", False):
+            save_env_value("SLACK_BOT_TOKEN", bot_token)
+        else:
+            return
+    else:
+        save_env_value("SLACK_BOT_TOKEN", bot_token)
     app_token = prompt("Slack App Token (xapp-...)", password=True)
     if app_token:
-        save_env_value("SLACK_APP_TOKEN", app_token)
+        if not re.match(r"^xapp-[A-Za-z0-9-]+$", app_token):
+            print_error("Invalid Slack app token format. Expected: xapp- prefix")
+            print_info("  Example: see Slack docs for xapp- token format")
+            if prompt_yes_no("Save anyway?", False):
+                save_env_value("SLACK_APP_TOKEN", app_token)
+        else:
+            save_env_value("SLACK_APP_TOKEN", app_token)
     print_success("Slack tokens saved")
 
     print()


### PR DESCRIPTION
## Summary
`hermes gateway setup` and `hermes setup` accepted any string as a bot token without format validation. Invalid tokens were only discovered at runtime when the gateway failed to connect.

## Root Cause
The setup prompts in both `gateway.py` (`_setup_standard_platform`) and `setup.py` (`_setup_telegram`, `_setup_discord`, `_setup_slack`) saved token values directly without checking format.

## Fix
Added regex-based format validation for:
- **Telegram**: `<numeric_id>:<alphanumeric_token>` (e.g., `123456789:ABCdefGHI-jklMNO`)
- **Discord**: three dot-separated base64 segments
- **Slack bot token**: `xoxb-` prefix
- **Slack app token**: `xapp-` prefix

Invalid tokens trigger a re-prompt with a helpful error message. If the user still wants to save an invalid token, a warning is shown.

## Test Plan
- [ ] Run `hermes gateway setup` → Telegram → enter invalid token → should reject
- [ ] Run `hermes gateway setup` → Discord → enter invalid token → should reject
- [ ] Run `hermes gateway setup` → Slack → enter invalid xoxb token → should reject
- [ ] Valid tokens should pass validation and save normally

Closes NousResearch/hermes-agent#9843