### PR TITLE
fix: make Hindsight cloud client timeout configurable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -11,6 +11,7 @@ Config via environment variables:
   HINDSIGHT_BUDGET    — recall budget: low/mid/high (default: mid)
   HINDSIGHT_API_URL   — API endpoint
   HINDSIGHT_MODE      — cloud or local (default: cloud)
+  HINDSIGHT_CLIENT_TIMEOUT — cloud client timeout in seconds (default: 120)
 
 Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 ~/.hindsight/config.json (legacy, shared) for backward compatibility.
@@ -225,6 +226,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
         self._retain_async = True
+        self._client_timeout = 120.0
 
     @property
     def name(self) -> str:
@@ -434,6 +436,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
+            {"key": "client_timeout", "description": "Timeout in seconds for the Hindsight cloud client", "default": 120.0, "env_var": "HINDSIGHT_CLIENT_TIMEOUT"},
         ]
 
     def _get_client(self):
@@ -458,7 +461,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
-                kwargs = {"base_url": self._api_url, "timeout": 30.0}
+                kwargs = {"base_url": self._api_url, "timeout": self._client_timeout}
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
                 logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s)",
@@ -537,6 +540,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
         self._retain_async = self._config.get("retain_async", True)
+        self._client_timeout = float(
+            os.environ.get("HINDSIGHT_CLIENT_TIMEOUT")
+            or self._config.get("client_timeout", 120.0)
+        )
 
         _client_version = "unknown"
         try:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -32,6 +32,7 @@ def _clean_env(monkeypatch):
     for key in (
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_CLIENT_TIMEOUT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -203,6 +204,53 @@ class TestConfig:
         assert cfg["apiKey"] == "env-key"
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
+
+    def test_default_client_timeout(self, provider):
+        """Default client_timeout should be 120.0."""
+        assert provider._client_timeout == 120.0
+
+    def test_custom_client_timeout_from_config(self, provider_with_config):
+        """client_timeout should be configurable via config."""
+        p = provider_with_config(client_timeout=60.0)
+        assert p._client_timeout == 60.0
+
+    def test_client_timeout_from_env_var(self, tmp_path, monkeypatch):
+        """HINDSIGHT_CLIENT_TIMEOUT env var should override config."""
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "client_timeout": 60.0,
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setenv("HINDSIGHT_CLIENT_TIMEOUT", "90.0")
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        assert p._client_timeout == 90.0
+
+    def test_get_client_passes_configured_timeout(self, provider_with_config):
+        """_get_client() should pass the configured timeout to Hindsight constructor."""
+        import sys
+
+        p = provider_with_config(client_timeout=45.0)
+        p._client = None  # force re-creation
+
+        mock_cls = MagicMock()
+        mock_module = MagicMock()
+        mock_module.Hindsight = mock_cls
+        with patch.dict(sys.modules, {"hindsight_client": mock_module}):
+            p._get_client()
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args
+            assert call_kwargs[1]["timeout"] == 45.0
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +609,7 @@ class TestConfigSchema:
             "retain_context",
             "recall_max_tokens", "recall_max_input_chars",
             "recall_prompt_preamble",
+            "client_timeout",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
 


### PR DESCRIPTION
## Summary

The Hindsight cloud client constructor hardcodes `timeout: 30.0` (line 461 in `plugins/memory/hindsight/__init__.py`), but `hindsight_reflect` routinely takes longer due to LLM synthesis across the memory graph. The `_run_sync()` wrapper already uses 120s, so the inner client timeout is the actual bottleneck.

## Changes

- Add `client_timeout` config key and `HINDSIGHT_CLIENT_TIMEOUT` env var to control the cloud client timeout
- Default to `120.0` seconds (matching `_run_sync`'s default)
- Env var takes precedence over config file value
- Added to `get_config_schema()` for discoverability
- 4 new tests covering default value, config override, env var precedence, and constructor passthrough

## Configuration

```json
// $HERMES_HOME/hindsight/config.json
{
  "client_timeout": 120.0
}
```

Or via environment variable:
```bash
export HINDSIGHT_CLIENT_TIMEOUT=120
```

## Test Results

All 50 hindsight provider tests pass. Full suite: 11311 passed (pre-existing failures in `test_web_server.py` are unrelated).

Fixes #9869