### PR TITLE
fix: make Hindsight cloud client timeout configurable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -11,6 +11,7 @@ Config via environment variables:
   HINDSIGHT_BUDGET    — recall budget: low/mid/high (default: mid)
   HINDSIGHT_API_URL   — API endpoint
   HINDSIGHT_MODE      — cloud or local (default: cloud)
+  HINDSIGHT_TIMEOUT   — HTTP client timeout in seconds (default: 300)
 
 Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 ~/.hindsight/config.json (legacy, shared) for backward compatibility.
@@ -458,7 +459,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
-                kwargs = {"base_url": self._api_url, "timeout": 30.0}
+                kwargs = {
+                    "base_url": self._api_url,
+                    "timeout": float(os.environ.get("HINDSIGHT_TIMEOUT", "300.0")),
+                }
                 if self._api_key:
                     kwargs["api_key"] = self._api_key
                 logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s)",


### PR DESCRIPTION
## Summary
The `hindsight_reflect` tool was failing intermittently because the Hindsight cloud client had a hardcoded 30-second HTTP timeout, while LLM synthesis across the memory graph routinely takes longer — especially with larger memory banks or slower providers.

## Root Cause
Line 461 of `plugins/memory/hindsight/__init__.py` hardcoded `timeout: 30.0` when creating the Hindsight cloud client. The outer `\_run_sync()` wrapper has a 120s timeout, but the inner HTTP client enforces its own 30s limit, so requests never get a chance to complete.

## Fix
Made the timeout configurable via the `HINDSIGHT_TIMEOUT` environment variable, with a default of 300 seconds to match the outer wrapper and other Hermes timeouts.

## Test Plan
- [ ] Run hindsight_reflect with a large memory bank — should no longer timeout at 30s
- [ ] Set HINDSIGHT_TIMEOUT=60 to override the default
- [ ] Verify hindsight_retain and hindsight_recall are unaffected

Closes NousResearch/hermes-agent#9869