### PR TITLE
fix(provider): show DashScope env var for Alibaba

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -252,6 +252,10 @@ _DESTRUCTIVE_PATTERNS = re.compile(
 # Output redirects that overwrite files (> but not >>)
 _REDIRECT_OVERWRITE = re.compile(r'[^>]>[^>]|^>[^>]')
 
+_PROVIDER_API_KEY_ENV_HINTS = {
+    "alibaba": "DASHSCOPE_API_KEY",
+}
+
 
 def _is_destructive_command(cmd: str) -> bool:
     """Heuristic: does this terminal command look like it modifies/deletes files?"""
@@ -262,6 +266,12 @@ def _is_destructive_command(cmd: str) -> bool:
     if _REDIRECT_OVERWRITE.search(cmd):
         return True
     return False
+
+
+def _missing_provider_api_key_env(provider: str) -> str:
+    """Return the actual env var users should set for a provider."""
+    provider_id = (provider or "").strip().lower()
+    return _PROVIDER_API_KEY_ENV_HINTS.get(provider_id, f"{provider_id.upper()}_API_KEY")
 
 
 def _should_parallelize_tool_batch(tool_calls) -> bool:
@@ -939,7 +949,7 @@ class AIAgent:
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_missing_provider_api_key_env(_explicit)} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -448,6 +448,25 @@ class TestMaskApiKey:
 
 
 class TestInit:
+    def test_explicit_alibaba_provider_missing_key_mentions_dashscope_env(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                AIAgent(
+                    provider="alibaba",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+
+        message = str(exc_info.value)
+        assert "DASHSCOPE_API_KEY" in message
+        assert "ALIBABA_API_KEY" not in message
+
     def test_anthropic_base_url_accepted(self):
         """Anthropic base URLs should route to native Anthropic client."""
         with (


### PR DESCRIPTION
## What does this PR do?

Fixes the missing-credentials error hint for the Alibaba provider.

When users explicitly configure `provider: alibaba` but do not have valid credentials available, Hermes raised a runtime error telling them to set `ALIBABA_API_KEY`. The actual supported env var in Hermes is `DASHSCOPE_API_KEY`, so the message was misleading and sent users toward a non-working configuration.

This change keeps credential resolution behavior unchanged and only corrects the error hint to point at the real env var Hermes expects.

## Related Issue

Fixes #9506

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a small provider-to-env-var hint map in [run_agent.py](run_agent.py) so explicit provider errors can reference the correct credential name
- Use `DASHSCOPE_API_KEY` for the Alibaba/DashScope provider instead of synthesizing `ALIBABA_API_KEY`
- Add a regression test in [tests/run_agent/test_run_agent.py](tests/run_agent/test_run_agent.py) that asserts the runtime error mentions `DASHSCOPE_API_KEY` and not `ALIBABA_API_KEY`

## How to Test

1. Run `source .venv/bin/activate && python -m pytest tests/run_agent/test_run_agent.py -q`
2. Confirm the suite passes, including `test_explicit_alibaba_provider_missing_key_mentions_dashscope_env`
3. Optionally instantiate `AIAgent(provider="alibaba", ...)` without DashScope credentials and confirm the error message points to `DASHSCOPE_API_KEY`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted verification: `tests/run_agent/test_run_agent.py -q` → `251 passed`
- I left the full-suite checkbox unchecked because local `pytest tests/ -q` currently has unrelated pre-existing failures on `main`
