### PR TITLE
fix: recognize Claude Code OAuth tokens (cc- prefix) in _is_oauth_token

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -168,8 +168,9 @@ def _is_oauth_token(key: str) -> bool:
     Positively identifies Anthropic OAuth tokens by their key format:
     - ``sk-ant-`` prefix (but NOT ``sk-ant-api``) → setup tokens, managed keys
     - ``eyJ`` prefix → JWTs from the Anthropic OAuth flow
+    - ``cc-`` prefix → Claude Code OAuth access tokens (from CLAUDE_CODE_OAUTH_TOKEN)
 
-    Non-Anthropic keys (MiniMax, Alibaba, etc.) don't match either pattern
+    Non-Anthropic keys (MiniMax, Alibaba, etc.) don't match any pattern
     and correctly return False.
     """
     if not key:
@@ -182,6 +183,9 @@ def _is_oauth_token(key: str) -> bool:
         return True
     # JWTs from Anthropic OAuth flow
     if key.startswith("eyJ"):
+        return True
+    # Claude Code OAuth access tokens (opaque, from CLAUDE_CODE_OAUTH_TOKEN)
+    if key.startswith("cc-"):
         return True
     return False
 


### PR DESCRIPTION
## Summary
`CLAUDE_CODE_OAUTH_TOKEN` tokens were being misclassified as API keys instead of OAuth tokens, causing them to be sent with `x-api-key` semantics instead of Bearer/OAuth semantics.

## Root Cause
`_is_oauth_token()` in `agent/anthropic_adapter.py` only recognized `sk-ant-*` (non-api) and `eyJ*` (JWT) patterns. Claude Code OAuth access tokens use the `cc-` prefix, which was not covered, so they fell through to the API-key path.

## Fix
Added `cc-` prefix detection to `_is_oauth_token()`. Claude Code OAuth tokens starting with `cc-` are now correctly identified and routed through Bearer auth with Claude Code identity headers.

## Test Plan
- [ ] Set CLAUDE_CODE_OAUTH_TOKEN to a cc- prefixed token
- [ ] Verify the token is routed through auth_token (Bearer) not api_key (x-api-key)
- [ ] Existing sk-ant-* and eyJ* tokens still work correctly
- [ ] Third-party API keys still use x-api-key

Closes NousResearch/hermes-agent#9813