### PR TITLE
Add YantrikDB memory provider plugin

### DIFF
--- a/plugins/memory/yantrikdb/ARCHITECTURE.md
+++ b/plugins/memory/yantrikdb/ARCHITECTURE.md
@@ -1,0 +1,141 @@
+# YantrikDB Plugin Architecture
+
+This document explains how the plugin is structured, how requests flow through it, and how failures are contained. Target audience: maintainers reviewing the PR and operators debugging a live deployment.
+
+## Files
+
+| File             | Role                                                                              |
+|------------------|-----------------------------------------------------------------------------------|
+| `__init__.py`    | `YantrikDBMemoryProvider` (implements Hermes' `MemoryProvider` ABC), 8 tool schemas, 3 optional hooks, circuit breaker. |
+| `client.py`      | `YantrikDBClient` — HTTP wrapper, typed error taxonomy, config resolution, bounded retries, text truncation. |
+| `plugin.yaml`    | Declared name, version, dependencies (`requests>=2.31`), and the three optional hooks the plugin implements. |
+| `README.md`      | User-facing documentation.                                                        |
+| `CHANGELOG.md`   | Versioned change history.                                                         |
+| `SECURITY.md`    | Token / secret handling, AGPL-vs-MIT boundary, reporting.                         |
+
+## Layered responsibilities
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                Hermes MemoryProvider contract                │
+│            initialize / prefetch / sync_turn / ...           │
+└──────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────┐
+│           YantrikDBMemoryProvider (__init__.py)              │
+│  • tool dispatch + schema surface                            │
+│  • namespace derivation (base:workspace:identity)            │
+│  • background threads (prefetch, sync, mem-write mirror)     │
+│  • circuit breaker (5 failures → 120 s cooldown)             │
+│  • exception → tool_error() mapping                          │
+└──────────────────────────────────────────────────────────────┘
+                                │ self._client
+                                ▼
+┌──────────────────────────────────────────────────────────────┐
+│                YantrikDBClient (client.py)                   │
+│  • one requests.Session with keep-alive + pooled adapters    │
+│  • urllib3 Retry on 5xx / connection blips                   │
+│  • per-request req_id + latency_ms at DEBUG                  │
+│  • text truncation before POST /v1/remember                  │
+│  • error taxonomy: Auth / Client / Transient / Server        │
+└──────────────────────────────────────────────────────────────┘
+                                │ HTTP
+                                ▼
+                    yantrikdb-server (port 7438)
+```
+
+The plugin owns no persistent state beyond live threads and the HTTP session. Everything durable lives in yantrikdb-server.
+
+## Request flow
+
+1. **Tool call arrives at Hermes** → Hermes invokes `handle_tool_call(name, args)` on the active provider.
+2. **Guardrails**: if the cron skip flag is set or the client is `None`, return `tool_error` immediately; if the circuit breaker is open, return a short-circuit error; otherwise dispatch.
+3. **Dispatch** maps the tool name to a `_do_*` method that validates args and calls the HTTP client.
+4. **HTTP**: the client composes the request, sends with `(connect_timeout, read_timeout)`, retries transient 5xx, logs the `req_id` + latency, and parses the response.
+5. **Error mapping**: 401/403 → `YantrikDBAuthError`; 4xx → `YantrikDBClientError`; 429/503 → `YantrikDBTransientError`; 5xx → `YantrikDBServerError`; network/timeout → `YantrikDBTransientError`.
+6. **Dispatcher catches** these in the order above: auth and transient/server trip the breaker; client errors do not.
+7. **Result** is serialized to JSON and returned to Hermes as the tool output.
+
+## Namespace scoping
+
+The effective namespace at initialize time is `base:agent_workspace:agent_identity`, where `base` is `YANTRIKDB_NAMESPACE` (default `hermes`). This matches HANDOFF §3:
+
+- Cross-session recall works within an identity.
+- Two different identities running against the same server do not pollute each other.
+- `session_id` goes in memory metadata, not the namespace, so `think()` can consolidate across sessions.
+
+## Threading model
+
+Three long-lived daemon threads may be active:
+
+- **Prefetch thread** — kicked off by `queue_prefetch()`, calls `recall()`, stores the block for the next turn. Joined with a 3 s timeout before `prefetch()` returns.
+- **Sync thread** — kicked off by `sync_turn()`, persists the user message in the background.
+- **Memory-write mirror thread** — spawned per `on_memory_write(add, …)` call to mirror built-in MEMORY.md additions.
+
+All three are daemon threads. On `shutdown()`:
+1. Pending prefetch and sync threads are joined with a 5 s timeout.
+2. The `requests.Session` is closed.
+
+Background failures increment the failure counter via `_record_failure()` but never propagate. Client-level 4xx (bad input) are logged at DEBUG without counting against the breaker.
+
+## Circuit breaker
+
+```
+                ┌──────────────┐
+                │   CLOSED     │  (normal operation)
+                │              │
+                │ fail_count<5 │
+                └──────┬───────┘
+                       │  5th transient/server/auth failure
+                       ▼
+                ┌──────────────┐
+                │    OPEN      │  (short-circuit all calls)
+                │              │
+                │  cooldown    │
+                │   = 120 s    │
+                └──────┬───────┘
+                       │  cooldown elapsed
+                       ▼
+                ┌──────────────┐
+                │  HALF-OPEN   │  (next call tries; reset on success)
+                │              │
+                └──────────────┘
+```
+
+- 4xx client errors are deterministic — they do not count.
+- Auth errors count (token may be stale server-side).
+- On success, the counter resets to 0 regardless of prior state.
+
+## Text hygiene
+
+`YANTRIKDB_MAX_TEXT_LEN` (default 25000 chars) caps the memory body. The client truncates at a word boundary, appends a visible `…[truncated]` marker, and logs nothing extra — the marker itself is the operator signal. This prevents silent 400s from the server when an agent tries to remember a very large blob.
+
+## Config resolution
+
+Resolution order matches mem0:
+
+1. `YantrikDBConfig.from_env()` reads all env vars with defaults.
+2. If `$HERMES_HOME/yantrikdb.json` exists, values from the JSON file overlay individual fields. Empty strings / `None` are ignored. Numeric fields are coerced; bad values keep the env defaults.
+3. If `hermes_constants.get_hermes_home` is unavailable (tests), step 2 is skipped.
+
+This means: env sets a floor, the JSON file is a soft override, and neither partial file is ever fatal.
+
+## What the plugin deliberately does not do
+
+- **Manage the yantrikdb-server lifecycle** — installation, tokens, upgrades, clustering. The user owns that. (HANDOFF §3.)
+- **Extract facts from assistant messages** — hallucination amplification risk. (HANDOFF §10.1.) Only user turns are persisted.
+- **Run `think()` per turn** — too expensive. Only on session end automatically; manual via `yantrikdb_think` otherwise. (HANDOFF §10.2.)
+- **Auto-surface conflicts in every prompt** — bloats the system prompt. The agent calls `yantrikdb_conflicts` on demand. (HANDOFF §10.4.)
+- **Retry 4xx errors** — deterministic caller mistakes. Surfaced as `tool_error` so the agent can fix and retry.
+- **Fall back to a local SQLite store** — duplicative with `pip install yantrikdb` for embedded use. (HANDOFF §12.)
+
+## Testing posture
+
+94 tests cover:
+
+- Config: env parsing, JSON overlay, numeric coercion, corrupt-file fallback, empty-value handling.
+- Client: request formation (URL, method, headers, body) for every endpoint, full error taxonomy (401/403/400/404/429/503/500, timeout, connection error), empty-body and non-JSON-body handling, text truncation.
+- Provider: 8 tool schemas present, dispatch to the correct client method, top_k cap, missing-param rejection, unknown-tool rejection, namespace derivation (3 corner cases), circuit breaker threshold / short-circuit / reset, `why_retrieved` pass-through, all three optional hooks, config schema and save_config.
+
+All tests run without network. `tests/conftest.py` stubs `agent.memory_provider` and `tools.registry` so the plugin imports cleanly outside Hermes.

--- a/plugins/memory/yantrikdb/CHANGELOG.md
+++ b/plugins/memory/yantrikdb/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to the YantrikDB Hermes memory plugin.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project aims for semantic versioning once merged into Hermes.
+
+## [0.1.0] — Initial
+
+### Added
+
+- `YantrikDBMemoryProvider` implementing Hermes' `MemoryProvider` ABC.
+- Eight tool schemas: `yantrikdb_remember`, `yantrikdb_recall`, `yantrikdb_forget`, `yantrikdb_think`, `yantrikdb_conflicts`, `yantrikdb_resolve_conflict`, `yantrikdb_relate`, `yantrikdb_stats`.
+- Explainable recall — the `why_retrieved` reason list from the server is surfaced per result.
+- Structured `think()` response with consolidation counts, conflict counts, patterns, duration, and server-suggested triggers.
+- Three optional hooks: `on_session_end` (auto-consolidation), `on_pre_compress` (preserves high-salience memories through Hermes context compression), `on_memory_write` (mirrors built-in MEMORY.md / USER.md additions).
+- Typed error taxonomy: `YantrikDBAuthError`, `YantrikDBClientError`, `YantrikDBTransientError`, `YantrikDBServerError` on a `YantrikDBError` base.
+- Circuit breaker: 5 consecutive transient/server/auth failures → 120 s cooldown. 4xx errors do not trip the breaker.
+- Bounded HTTP retries on transient 5xx and connection blips (urllib3 Retry with exponential backoff).
+- Per-request `req_id` + `latency_ms` at DEBUG for post-hoc log correlation.
+- Client-side text truncation at `YANTRIKDB_MAX_TEXT_LEN` (default 25000) with a visible marker.
+- Config resolution: env vars first, `$HERMES_HOME/yantrikdb.json` overlay, numeric coercion, empty-value skip.
+- Configurable timeouts and retry count via env: `YANTRIKDB_READ_TIMEOUT`, `YANTRIKDB_CONNECT_TIMEOUT`, `YANTRIKDB_RETRY_TOTAL`.
+- Namespace scoping: `{base}:{agent_workspace}:{agent_identity}` for per-identity isolation while allowing cross-session consolidation.
+- `get_config_schema()` + `save_config()` so `hermes memory setup` can walk the user through token + URL configuration.
+- 94 tests covering config loading, request formation, error taxonomy, tool dispatch, hook semantics, circuit breaker behavior, and text truncation. All tests run without network.
+
+### Deliberate non-goals for this release
+
+- No assistant-message extraction on `sync_turn` (hallucination amplification risk).
+- No embedded / in-process YantrikDB — the plugin is a thin HTTP client. Embedded use is covered by `pip install yantrikdb`.
+- No local SQLite fallback — out of scope; would duplicate the embedded variant.
+- No batch write queue — background threads already absorb latency; the added complexity is not justified for v1.
+- No CLI subcommand (`hermes yantrikdb …`) — tracked as a potential v0.2 addition.

--- a/plugins/memory/yantrikdb/CHANGELOG.md
+++ b/plugins/memory/yantrikdb/CHANGELOG.md
@@ -3,7 +3,212 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project aims for semantic versioning once merged into Hermes.
 
-## [0.1.0] — Initial
+## [0.4.2] — 2026-05-12 — First-class embedder loaders
+
+v0.4.1 shipped the config surface for swapping embedders, but the only embedder-class path required users to write a thin wrapper around `model2vec` or `sentence-transformers`. That's friction the plugin should absorb — most users asking about multilingual want `potion-multilingual-128M` (a model2vec model) or one of the well-known HF sentence-transformers, both of which are one-liners to load.
+
+v0.4.2 adds two first-class loaders so you can point at any Hugging Face model id directly, with no wrapper class to write and no `YANTRIKDB_EMBEDDING_DIM` to set (auto-probed).
+
+### Added
+
+- **`YANTRIKDB_EMBEDDER_MODEL2VEC`** — Hugging Face model id for the built-in `Model2VecEmbedder` loader (wraps `model2vec.StaticModel.from_pretrained`). Lightweight static-embedding family — no PyTorch dependency. Install with `pip install 'yantrikdb-hermes-plugin[model2vec]'`. Example: `YANTRIKDB_EMBEDDER_MODEL2VEC=minishlab/potion-multilingual-128M`.
+- **`YANTRIKDB_EMBEDDER_HF`** — Hugging Face model id for the built-in `SentenceTransformerEmbedder` loader (wraps `sentence_transformers.SentenceTransformer`). Covers the broader HF embedder ecosystem; pulls in PyTorch. Install with `pip install 'yantrikdb-hermes-plugin[sentence-transformers]'`. Example: `YANTRIKDB_EMBEDDER_HF=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`.
+- **Auto-probed dim** for the two new loaders — the plugin calls `.encode("__yantrikdb_probe__")` once during init, uses `len()` of the result as the dim, and passes that into `YantrikDB(db_path, embedding_dim=N)`. No `YANTRIKDB_EMBEDDING_DIM` env var needed for these paths.
+- **Two new pip extras**: `[model2vec]` and `[sentence-transformers]`. The default install stays slim; only users who pick one of the new paths pull the heavy dep.
+- **10 new tests** in `tests/test_embedded.py` covering the new loaders, auto-probe, missing-dependency actionable errors, and the extended precedence rules (151 tests total, all green).
+
+### Behavior changes
+
+- Path precedence is now: **CLASS > MODEL2VEC > HF > EMBEDDER (bundled-named) > default**. More-specific user intent wins: `_CLASS` is the most specific (exact Python class), the built-in loaders pick an exact HF model, `_EMBEDDER` depends on which named variants the engine version ships, and default is the fallback.
+- The `[model2vec]` and `[sentence-transformers]` extras can be installed together if you want to A/B different embedders without uninstalling.
+- The error message when `model2vec` or `sentence-transformers` is missing is now actionable — it points at the right pip extra by name.
+
+### Migration
+
+None required. With no embedder env vars set, the plugin behaves identically to v0.4.1 / v0.3.x.
+
+### Net install for multilingual
+
+```bash
+pip install 'yantrikdb-hermes-plugin[model2vec]'  # v0.4.2
+yantrikdb-hermes install ~/hermes-agent
+
+cat >> ~/.hermes/.env <<EOF
+YANTRIKDB_EMBEDDER_MODEL2VEC=minishlab/potion-multilingual-128M
+EOF
+```
+
+That's the whole integration — no Python wrapper to write, no dim to look up.
+
+## [0.4.1] — 2026-05-12 — Unblock v0.4.0 publish (lint)
+
+Patch release: v0.4.0's tagged commit failed the publish workflow at the `ruff` gate (F841 — unused `client = ...` locals in three `tests/test_embedded.py` cases that assert against the mock instead of the returned client). PyPI never received v0.4.0; this is the first PyPI release of the pluggable-embedder feature.
+
+### Fixed
+- Removed unused `client = ` assignments in `tests/test_embedded.py` so `ruff check` passes under CI's stricter config. Pure test-code cleanup; no behavior change in the plugin.
+
+### Note
+Functionally identical to v0.4.0. Use this if you want pluggable embedders on PyPI.
+
+## [0.4.0] — 2026-05-12 — Pluggable embedders
+
+Lands the configuration surface for swapping the bundled embedder — driven by the first user inquiry on the repo ([Issue #1](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/1): multilingual embedding support). Default behavior is unchanged for existing users; the new env vars only matter if you want a non-default embedder.
+
+### Added
+
+- **`YANTRIKDB_EMBEDDER`** — name of a bundled-download embedder (e.g. `potion-base-8M`, `potion-base-32M`). The plugin calls `db.set_embedder_named(name)` on engine construction. Works with whatever named embedders `yantrikdb >= 0.7.6` ships behind the `embedder-download` feature flag.
+- **`YANTRIKDB_EMBEDDER_CLASS`** — dotted Python import path (e.g. `myapp.embedders.MultilingualEmbedder`) to a class that has a `.encode(text) -> list[float]` method. The plugin imports the class, instantiates with no args, and calls `db.set_embedder(instance)`. Lets users plug `sentence-transformers`, `model2vec-rs`, multilingual variants, or any custom embedder *without* waiting on upstream bundling.
+- **`YANTRIKDB_EMBEDDING_DIM`** — required when either `_EMBEDDER` or `_EMBEDDER_CLASS` is set; matches the output dim of the chosen embedder (256 for potion-base-8M, 512 for potion-base-32M, 384 for `all-MiniLM-L6-v2`, etc.). The plugin passes this to `YantrikDB(db_path, embedding_dim=N)`.
+- **13 new tests** in `tests/test_embedded.py` pinning the embedder-path semantics: default (with_default) path, bundled-named path, custom-class path, dim-required-when-custom invariant, class-must-have-encode invariant, malformed-class-path errors, and class-over-name precedence when both are set.
+
+### Behavior changes
+
+- The plugin's embedder selection logic is now three paths instead of one:
+  - `YANTRIKDB_EMBEDDER_CLASS` set → import + instantiate + `set_embedder(instance)`.
+  - else `YANTRIKDB_EMBEDDER` set → construct with `embedding_dim=N` + `set_embedder_named(name)`.
+  - else → `YantrikDB.with_default(db_path)` (existing v0.3.x behavior, dim=64 potion-2M).
+- Class path takes precedence over named path when both env vars are set — it's the more specific instruction and doesn't depend on upstream bundling state.
+- All three paths use `set_embedder*` exactly once, immediately after construction, before the engine is shared (Arc::get_mut requirement per the engine's threading contract).
+
+### Migration for v0.3.x users
+
+None required. With no embedder env vars set, the plugin behaves identically to v0.3.1.
+
+### Net install for non-default embedders
+
+```bash
+pip install yantrikdb-hermes-plugin                  # v0.4.0
+yantrikdb-hermes install ~/hermes-agent
+
+# Tier 2 bundled (downloaded on first use):
+cat >> ~/.hermes/.env <<EOF
+YANTRIKDB_EMBEDDER=potion-base-8M
+YANTRIKDB_EMBEDDING_DIM=256
+EOF
+
+# OR — custom Python embedder (e.g. multilingual, sentence-transformers):
+cat >> ~/.hermes/.env <<EOF
+YANTRIKDB_EMBEDDER_CLASS=myapp.embedders.MultilingualEmbedder
+YANTRIKDB_EMBEDDING_DIM=384
+EOF
+```
+
+### Cross-stack note
+
+Upstream `yantrikos/yantrikdb` may add `potion-multilingual-128M` (101 languages) as a fourth named-download variant in a future release. Once that lands, multilingual users can drop the `_EMBEDDER_CLASS` Python wrapper and just set `YANTRIKDB_EMBEDDER=potion-multilingual-128M` — the plugin code is already ready for it.
+
+## [0.3.1] — 2026-05-09 — PyPI distribution
+
+Tooling-only release. Plugin behavior unchanged from v0.3.0 — same 8 default tools, same 3 opt-in skill tools, same feature flag, same 128 tests.
+
+### Added
+
+- **PyPI distribution via `yantrikdb-hermes-plugin`.** `pip install yantrikdb-hermes-plugin` installs the source under the importable package `yantrikdb_hermes_plugin` (avoids the namespace collision with the existing `yantrikdb` engine package on PyPI).
+- **`yantrikdb-hermes` CLI** — bridges the pip → filesystem gap. Hermes loads plugins from `$HERMES_ROOT/plugins/memory/<name>/`, which pip can't write to directly. Two subcommands:
+  - `yantrikdb-hermes install <hermes_root>` — copy the plugin source into the Hermes checkout's `plugins/memory/yantrikdb/`. `--force` overwrites an existing install.
+  - `yantrikdb-hermes path` — print the on-disk path of the installed package (for users who'd rather symlink: `ln -s "$(yantrikdb-hermes path)" ~/hermes-agent/plugins/memory/yantrikdb`).
+- **`.github/workflows/publish.yml`** — automated PyPI publishing pipeline triggered by tag pushes matching `v*`. Builds wheel + sdist after running ruff + mypy + pytest as a gate. Uses PyPI Trusted Publisher (no API token in repo secrets); one-time config on PyPI's web UI.
+
+### Net install flow (post v0.3.1 publish)
+
+```bash
+pip install yantrikdb-hermes-plugin           # the plugin source + CLI
+yantrikdb-hermes install ~/hermes-agent       # copy into plugins/memory/
+hermes config set memory.provider yantrikdb
+echo "YANTRIKDB_MODE=embedded" >> ~/.hermes/.env
+```
+
+`yantrikdb` (the engine, ~10 MB with bundled embedder) is pulled automatically as a dependency.
+
+### Internal
+
+- `yantrikdb/__init__.py` now wraps `from agent.memory_provider import MemoryProvider` and `from tools.registry import tool_error` in try/except so the package imports successfully outside a Hermes runtime (e.g. when the CLI invokes `from yantrikdb_hermes_plugin.cli import main`). Stub `MemoryProvider` and `tool_error` are used in that path; they're never the ones Hermes sees because Hermes loads the plugin via fresh filesystem import from `plugins/memory/yantrikdb/`.
+
+## [0.3.0] — 2026-05-09 — Skill substrate + feature flag
+
+### Added
+
+- **Three new tools (opt-in via feature flag)**: `yantrikdb_skill_search`, `yantrikdb_skill_define`, `yantrikdb_skill_outcome`. Bridges Hermes agents to YantrikDB's `skill_substrate` namespace where agent-authored procedural skills live alongside skills written by other consumers (Lane B SDK, server handlers, WisePick). Hermes-authored entries are tagged `metadata.source=hermes` so any consumer can filter Hermes-authored skills in or out cleanly.
+- **`YANTRIKDB_SKILLS_ENABLED` feature flag** — defaults **off**. When unset, the three skill schemas are hidden from `get_tool_schemas()` and any direct skill-tool call short-circuits with a clear error pointing at the env var. Pattern: simple-stays-simple, advanced-reachable. Same shape as yantrikdb-server's bundled-embedder default-on engine feature.
+- Client-side schema validation reproducing yantrikdb-server's wrapper checks (skill_id regex, body length, applies_to format, skill_type enum). Embedded mode ships full validation since there's no server in front; HTTP mode validates client-side too as defense-in-depth ahead of the server's own check.
+- The load-bearing `applies_to` regex (`^[a-z][a-z0-9_]*$` — no hyphens, no dots) is regression-pinned in `tests/test_provider.py::TestSkillValidation::test_applies_to_REJECTS_HYPHEN` per yantrikdb-server's explicit flag. Anyone naturally writing "applies-to"-style hyphenated tags would corrupt the substrate convention; the test prevents that drift.
+- 32 new tests: 9 skill dispatch tests, 3 feature-flag tests, 20 validation tests. Total: **128 tests passing** (was 96).
+
+### Architecture
+
+- **Skill substrate**: namespace `skill_substrate` for skill bodies, `outcome_substrate` for append-only outcome events. `metadata.source=hermes` tags all writes by this plugin. Single shared namespace + metadata filtering rather than sub-namespace, per yantrikdb-server's recommendation: sub-namespace would force every downstream consumer to UNION across N+1 namespaces if they wanted all skills, which is the wrong default for the agentic-loop story.
+- **Outcomes are append-only**, never auto-rolled-up onto the parent skill. The "did this skill work?" computation is the agent's pedagogy decision, not the substrate's. Matches the WisePick pattern.
+- **Embedded-mode TOCTOU on `on_conflict=reject`**: the uniqueness check is best-effort lookup-then-write rather than transactional (single-agent embedded use is non-racy in practice). HTTP mode preserves server-enforced 409. Documented as semantic difference between modes.
+- **Engine surface used**: `db.recall_text(query, top_k, namespace=...)` for skill_search (requires yantrikdb >= 0.7.7; pre-0.7.7 falls back to `db.recall(query=..., namespace=...)`). `db.record_text(body, memory_type="procedural", namespace="skill_substrate", metadata={...})` for skill_define. `db.record_text(...)` to `outcome_substrate` for skill_outcome.
+
+### Lifecycle distinction (worth knowing)
+
+The Hermes plugin now lives alongside Hermes' own filesystem skills (`$HERMES_HOME/skills/*.md`) without overlap:
+
+- **Filesystem skills**: human-authored, durable, version-controlled. Canonical for skills a human wrote and committed.
+- **YantrikDB skills**: agent-authored, runtime-evolving, semantic-search-queryable. Canonical for patterns the agent distilled from observed success.
+
+Different *kinds* of canonical, not competing authorities. The model resolves by lifecycle, not by competition.
+
+### Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `YANTRIKDB_SKILLS_ENABLED` | `false` | Set `true` / `1` / `yes` to expose the three skill tools. |
+
+When the flag is off, plugin behavior is identical to v0.2.1 (8 tools, same mode-aware backend selection).
+
+## [0.2.1] — 2026-05-09 — Documentation polish for HN-tier scrutiny
+
+Text-only release. No code changes; no behavioural changes. All findings from yantrikdb-core's post-publish review pass on v0.2.0.
+
+### Changed
+
+- README quality claims now cite the upstream evaluation script (`yantrikos/yantrikdb/scratch/eval_potion_2m.py`) so readers can reproduce the R@5 vs MiniLM-L6-v2 numbers. The "~89% / ~92% / ~95% of MiniLM" approximations are now scoped to that specific eval rather than presented as universal.
+- Latency table extended with p99 tail numbers for both backends. Added the honest note that even embedded p99 beats HTTP p50 — and that long-running soak validation is in progress upstream, not concluded.
+- New "About the embedder quality claims" section explains corpus-size dependence: at 3 records all vectors look similar (top score ~0.58); at 8+ with real diversity the score range opens up (~0.84). Readers running their own evals on toy corpora won't be surprised by the score collapse.
+- New "Explainability is a side effect, not a bolt-on" section pulls a verbatim quote from the live DeepSeek Hermes session showing the model parsing `why_retrieved` reason codes naturally and reflecting them in its own reasoning. Frames the explainability surface as the recall response itself rather than a separate feature.
+
+### Internal
+
+- v0.2.0 commit + tag remain valid; v0.2.1 is the recommended pin for documentation-quality reasons but the on-disk plugin behaviour is identical.
+
+## [0.2.0] — 2026-05-09 — Embedded by default
+
+### Added
+
+- **In-process backend** (`yantrikdb/embedded.py`) wrapping `yantrikdb._yantrikdb_rust.YantrikDB` to the same 8-method surface as the HTTP client. Users running a single Hermes instance no longer need a separate `yantrikdb-server`, Docker, token mint, or URL config. `pip install` and go.
+- **Backend factory** (`make_backend()`) selects HTTP vs embedded based on `YANTRIKDB_MODE` env (default `embedded`). Provider's tool dispatch is unchanged — same 8 tools, same hooks, same namespace scoping, same circuit breaker policy.
+- **New env config**: `YANTRIKDB_MODE` (`embedded` | `http`), `YANTRIKDB_DB_PATH` (defaults to `$HERMES_HOME/yantrikdb-memory.db`), `YANTRIKDB_EMBEDDER` (`""` for the bundled potion-base-2M, or `potion-base-8M` / `potion-base-32M` for tier-2/3 download paths).
+- **Hermes-on-LXC verification for embedded mode** captured in `VERIFICATION.md` — real DeepSeek session, 3× `yantrikdb_remember` + `yantrikdb_recall` + `yantrikdb_stats` all sub-millisecond after one-time 80 ms engine warmup.
+- 96 tests passing, all transport-agnostic — they exercise the provider contract, not the backend.
+
+### Changed
+
+- **Default backend is now embedded** (`YANTRIKDB_MODE=embedded`). Users pinning v0.1 behavior should set `YANTRIKDB_MODE=http` explicitly.
+- `pip_dependencies` adds `yantrikdb>=0.7.6` (required for the bundled embedder via `YantrikDB.with_default()`). v0.7.6 ships only `uuid-utils` + `click` as hard deps; the install is ~10 MB total.
+- `is_available()` now mode-aware: embedded mode is available iff `yantrikdb` is importable; HTTP mode requires a token (unchanged).
+- `YantrikDBConfig` extended with `mode`, `db_path`, `embedder_name` fields; HTTP-only fields (`url`, `token`, `connect_timeout`, etc.) and embedded-only fields coexist on one dataclass.
+
+### Performance (steady-state, post-warmup)
+
+| Op | v0.1 HTTP (Apr 14, LXC vs LAN cluster) | v0.2 Embedded (today, in-process) |
+|---|---|---|
+| `record_text` p50 | ~13.8 ms | **0.60 ms** |
+| `recall_text` p50 | ~24.0 ms | **2.58 ms** |
+| Token mint at install | required | not needed |
+| Server / Docker | required | not needed |
+| Cold start (one-time) | n/a | 77 ms |
+
+### Notes for HTTP-mode users
+
+The HTTP backend (`YANTRIKDB_MODE=http`) is unchanged in v0.2 and still recommended for:
+
+- HA cluster deployments where multiple Hermes instances share one yantrikdb-server.
+- Multi-tenant scenarios needing the cluster's centralized control plane.
+- Auditing setups requiring server-side request logs.
+
+## [0.1.0] — 2026-04-14 — Initial
 
 ### Added
 
@@ -26,7 +231,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this pr
 ### Deliberate non-goals for this release
 
 - No assistant-message extraction on `sync_turn` (hallucination amplification risk).
-- No embedded / in-process YantrikDB — the plugin is a thin HTTP client. Embedded use is covered by `pip install yantrikdb`.
-- No local SQLite fallback — out of scope; would duplicate the embedded variant.
+- No embedded / in-process YantrikDB — the plugin is a thin HTTP client. (Reversed in v0.2.0.)
+- No local SQLite fallback — out of scope.
 - No batch write queue — background threads already absorb latency; the added complexity is not justified for v1.
-- No CLI subcommand (`hermes yantrikdb …`) — tracked as a potential v0.2 addition.
+- No CLI subcommand (`hermes yantrikdb …`) — still tracked as future work.

--- a/plugins/memory/yantrikdb/README.md
+++ b/plugins/memory/yantrikdb/README.md
@@ -2,6 +2,7 @@
 
 > **Self-maintaining memory for Hermes.** Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall — instead of behaving like an append-only vector index.
 
+> Installing standalone (until upstream review lands)? See **[../README.md](../README.md)** for the one-liner drop-in install.
 
 ## Why YantrikDB?
 

--- a/plugins/memory/yantrikdb/README.md
+++ b/plugins/memory/yantrikdb/README.md
@@ -1,0 +1,219 @@
+# YantrikDB Memory Provider
+
+> **Self-maintaining memory for Hermes.** Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall — instead of behaving like an append-only vector index.
+
+
+## Why YantrikDB?
+
+| Plugin                     | Best at                                               |
+|----------------------------|--------------------------------------------------------|
+| `mem0`                     | Managed cloud fact extraction with reranking          |
+| `honcho`                   | Cross-session user modeling with dialectic Q&A        |
+| `byterover` / `supermemory`| Standard semantic vector recall                        |
+| `hindsight` / `holographic`| Specialized retrieval schemes                          |
+| **`yantrikdb`**            | **Memory maintenance: canonicalization, contradiction tracking, recency ranking, explainable recall, knowledge-graph boosting** |
+
+What the other memory plugins have in common: once a fact is stored, it stays as-is. Duplicate stores pile up, superseded facts silently outrank their replacements, and the agent has no window into *why* a memory came back.
+
+YantrikDB maintains its store. `think()` runs a bounded maintenance pass that canonicalizes near-duplicates, flags contradictions, and re-scores for recency. `recall()` returns a `why_retrieved` reason list per result. `conflicts()` surfaces superseded claims explicitly so the agent resolves them via `resolve_conflict()` rather than hoping last-write-wins.
+
+## Requirements
+
+- A running `yantrikdb-server` (Docker, systemd, or bare binary). The plugin is a thin HTTP client; it does not start or manage the backend.
+- A bearer token minted against that server.
+
+## Setup
+
+```bash
+hermes memory setup   # select "yantrikdb"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider yantrikdb
+cat >> ~/.hermes/.env <<'EOF'
+YANTRIKDB_URL=http://localhost:7438
+YANTRIKDB_TOKEN=ydb_...
+EOF
+```
+
+### Running the server
+
+Docker, single node:
+
+```bash
+docker run -d -p 7438:7438 \
+  -v yantrikdb-data:/var/lib/yantrikdb \
+  --name yantrikdb \
+  ghcr.io/yantrikos/yantrikdb:latest
+```
+
+Mint a token:
+
+```bash
+docker exec yantrikdb yantrikdb token \
+  --data-dir /var/lib/yantrikdb \
+  create --db default --label hermes
+# → ydb_abc123...
+```
+
+See <https://yantrikdb.com/server/quickstart/> for systemd, HA cluster, and advanced deployments.
+
+## Config
+
+Optional config file: `$HERMES_HOME/yantrikdb.json`. Env vars are the primary source.
+
+| Key               | Env                         | Default                 | Description                                                                        |
+|-------------------|-----------------------------|-------------------------|------------------------------------------------------------------------------------|
+| `url`             | `YANTRIKDB_URL`             | `http://localhost:7438` | HTTP endpoint.                                                                     |
+| `token`           | `YANTRIKDB_TOKEN`           | *required*              | Bearer token from `yantrikdb token create`.                                        |
+| `namespace`       | `YANTRIKDB_NAMESPACE`       | `hermes`                | Tenant prefix. Combined with `agent_workspace:agent_identity` at init time.        |
+| `top_k`           | `YANTRIKDB_TOP_K`           | `10`                    | Default recall result count (capped at 50 via tool param).                         |
+| `connect_timeout` | `YANTRIKDB_CONNECT_TIMEOUT` | `5.0`                   | TCP connect timeout (seconds).                                                     |
+| `read_timeout`    | `YANTRIKDB_READ_TIMEOUT`    | `15.0`                  | Per-request read timeout.                                                          |
+| `retry_total`     | `YANTRIKDB_RETRY_TOTAL`     | `3`                     | Bounded retries on transient 5xx / connection blips (exponential backoff).         |
+| `max_text_len`    | `YANTRIKDB_MAX_TEXT_LEN`    | `25000`                 | Hard cap on memory body length; longer text is truncated client-side with a marker.|
+
+## Tools
+
+| Tool                         | Purpose                                                                                  |
+|------------------------------|------------------------------------------------------------------------------------------|
+| `yantrikdb_remember`         | Store a memory with importance and optional domain.                                      |
+| `yantrikdb_recall`           | Explainable recall — each result includes a `why_retrieved` reason list.                 |
+| `yantrikdb_forget`           | Tombstone a memory by rid.                                                               |
+| `yantrikdb_think`            | Run the bounded maintenance pass. **The differentiator.**                                |
+| `yantrikdb_conflicts`        | List open contradictions detected by `think()`.                                          |
+| `yantrikdb_resolve_conflict` | Close a contradiction via `keep_winner` / `merge` / `keep_both` / `dismiss`.             |
+| `yantrikdb_relate`           | Record a knowledge-graph edge (e.g. *Alice works_at Acme*).                              |
+| `yantrikdb_stats`            | Operational snapshot: memory counts, open conflicts, pending triggers.                   |
+
+### Explainable recall
+
+`yantrikdb_recall` returns each result with a reason list so the agent can audit ranking:
+
+```json
+{
+  "rid": "019d…",
+  "text": "User lives in Seattle since 2024",
+  "score": 1.1576,
+  "importance": 0.9,
+  "why_retrieved": [
+    "semantic_match",
+    "important (decay=0.91)",
+    "graph-connected via User"
+  ]
+}
+```
+
+This lets the agent decide whether to trust a match (semantic + graph + importance) versus a weak match (keyword only), and lets you debug why stale memories are outranking fresh ones.
+
+### The `think()` maintenance pass
+
+Call this at natural break points (end of a phase, long user pause, before a `/compact`). One call:
+
+1. **Canonicalizes** near-duplicates — 20 variations of *"user prefers dark mode"* are linked to 1–2 canonical memories. Originals are kept (not deleted) and recall favors canonical forms.
+2. **Flags contradictions** — *"CEO is Alice"* stored earlier and *"CEO is Bob"* stored later surface via `yantrikdb_conflicts`. Nothing is silently overwritten.
+3. **Optionally mines patterns** — temporal clusters, entity co-occurrences. Off by default (expensive).
+
+The response is structured:
+
+```json
+{
+  "consolidated": 3,
+  "conflicts_found": 1,
+  "patterns_new": 0,
+  "patterns_updated": 0,
+  "duration_ms": 42,
+  "triggers": [
+    {"trigger_type": "review_conflicts", "urgency": "medium", "source_rids": ["019d…"]}
+  ]
+}
+```
+
+### Conflict-aware memory
+
+`yantrikdb_conflicts` surfaces what `think()` detected:
+
+```json
+{"count": 1, "conflicts": [
+  {"conflict_id": "cf_1",
+   "memory_a": {"rid": "r1", "text": "CEO is Alice"},
+   "memory_b": {"rid": "r2", "text": "CEO is Bob"},
+   "detection_reason": "entity_collision: CEO",
+   "priority": "high"}
+]}
+```
+
+The agent resolves explicitly:
+
+```python
+yantrikdb_resolve_conflict(
+    conflict_id="cf_1",
+    strategy="keep_winner",
+    winner_rid="r2",
+    resolution_note="Bob succeeded Alice in March 2026",
+)
+```
+
+Strategies:
+
+- `keep_winner` — preserve `winner_rid`, tombstone the other.
+- `merge` — emit a consolidated `new_text`, tombstone both.
+- `keep_both` — both remain (context-dependent truth).
+- `dismiss` — close without action (false positive).
+
+## Hooks
+
+| Hook              | Effect                                                                                          |
+|-------------------|-------------------------------------------------------------------------------------------------|
+| `on_session_end`  | Calls `/v1/think` to consolidate the session before exit.                                       |
+| `on_pre_compress` | Seeds recall with the about-to-be-compressed tail so the Hermes compressor preserves insights. |
+| `on_memory_write` | Mirrors built-in `MEMORY.md` / `USER.md` additions into YantrikDB.                              |
+
+Hooks are best-effort: they never block the main Hermes loop and failures are logged at DEBUG without propagating.
+
+Assistant-message extraction is intentionally out of v1 scope — storing LLM output as fact is a hallucination-amplification risk. Only user messages are persisted via `sync_turn`.
+
+## Use cases
+
+- **Long-running research agents** where noise accumulates — `think()` periodically canonicalizes.
+- **Debate / planning agents** that encounter shifting facts — contradictions get surfaced, not papered over.
+- **User-modeling agents** where preferences evolve — recency ranking plus explicit `resolve_conflict` keeps the picture current.
+- **Multi-session projects** where the same entities recur — the knowledge graph boosts cross-session recall.
+
+## Resilience
+
+- Bounded HTTP retries (default 3, configurable) with exponential backoff on transient 5xx and connection errors.
+- Circuit breaker: after 5 consecutive transient/server/auth failures the plugin short-circuits for 120 s so a flapping server cannot hammer Hermes' event loop. 4xx errors (deterministic caller mistakes) do not trip the breaker.
+- All background writes (sync_turn, prefetch, on_memory_write mirror) run on daemon threads with bounded join timeouts; shutdown flushes pending work.
+- Every HTTP call is tagged with a short `req_id` and logged at DEBUG with operation and latency for post-hoc correlation in the Hermes log stream.
+
+## Troubleshooting
+
+**`Connection refused`** — server isn't running. Verify with `curl http://localhost:7438/v1/health`.
+
+**`401 / invalid token`** — mint a fresh token against the *running* server, not a previously-stopped instance. See the [quickstart](https://yantrikdb.com/server/quickstart/).
+
+**Recall returns nothing across sessions** — the effective namespace depends on `agent_workspace` + `agent_identity`. Changing profile names changes the namespace. Check startup logs for `YantrikDB connected: ... (namespace: ...)`.
+
+**Circuit breaker open** — the plugin stopped trying after repeated failures. Check the server; the breaker auto-resets after 120 s.
+
+**Text unexpectedly truncated** — memory bodies over `YANTRIKDB_MAX_TEXT_LEN` (default 25000 chars) are clipped client-side with a visible `…[truncated]` marker. Raise the env var if your use case needs longer bodies, but note that the server may enforce its own limits.
+
+## Architecture notes
+
+The plugin is ~700 lines split into `__init__.py` (provider + 8 tool schemas + 3 optional hooks) and `client.py` (HTTP wrapper, typed errors, config). The only pip dependency is `requests`. The Rust backend is an external dependency managed by the user — same model as the `honcho` plugin.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for control flow, error taxonomy, and threading model. [CHANGELOG.md](CHANGELOG.md) tracks versioned changes; [SECURITY.md](SECURITY.md) documents the token/secret handling model.
+
+### License
+
+YantrikDB-server is AGPL-3.0. This plugin ships under Hermes' MIT license. The plugin connects to the server over HTTP and does not statically link or embed any YantrikDB code, so the model is the same as any MIT client that talks to an AGPL server — legally clean.
+
+## Links
+
+- Server repo: <https://github.com/yantrikos/yantrikdb-server>
+- Docs: <https://yantrikdb.com>
+- HTTP API reference: <https://yantrikdb.com/server/http-api/>
+- Issues: <https://github.com/yantrikos/yantrikdb-server/issues>

--- a/plugins/memory/yantrikdb/SECURITY.md
+++ b/plugins/memory/yantrikdb/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Scope
+
+This document covers security properties of the **YantrikDB Hermes plugin** — the Python code in this directory. Security of the underlying `yantrikdb-server` is covered separately at <https://yantrikdb.com/security/>.
+
+## Token handling
+
+- The YantrikDB bearer token is read from `YANTRIKDB_TOKEN` or the `token` key in `$HERMES_HOME/yantrikdb.json`.
+- It is attached to every outgoing request as `Authorization: Bearer <token>` and is never logged. The debug log line for each request includes the request id, method, path, status, and duration — **not** headers.
+- `save_config(values, hermes_home)` intentionally does not accept the token: the config wizard writes secrets to `.env`, not the JSON file. (This matches the pattern in mem0 and honcho.)
+- The `get_config_schema()` entry for `token` declares `"secret": True` so Hermes' setup flow treats it accordingly.
+- 401/403 responses raise `YantrikDBAuthError` — no token value is ever interpolated into the exception message.
+
+## Transport
+
+- The plugin speaks plain HTTP by default (local deployment). For production, point `YANTRIKDB_URL` at an HTTPS endpoint — the `requests`-based client uses the system CA bundle by default, so TLS verification is enforced automatically.
+- There is no option to disable TLS verification.
+- No credentials are cached to disk by the plugin. The `requests.Session` holds only a connection pool.
+
+## Input validation
+
+- Memory bodies exceeding `YANTRIKDB_MAX_TEXT_LEN` (default 25000 chars) are truncated client-side with a visible `…[truncated]` marker. This prevents the agent from inadvertently sending an unbounded blob that could slow the server or trip load shedding.
+- 4xx responses from the server are surfaced to the agent as `tool_error` — they do not trip the circuit breaker, because they represent deterministic caller mistakes the agent should correct.
+
+## Resilience
+
+- Bounded retries on transient 5xx / connection blips (configurable, default 3) prevent unbounded retry storms.
+- A circuit breaker opens for 120 s after 5 consecutive transient/server/auth failures so a flapping server cannot wedge Hermes' event loop. See [ARCHITECTURE.md](ARCHITECTURE.md) for state transitions.
+- Background threads (prefetch, sync_turn, on_memory_write mirror) are all daemon threads with bounded join timeouts; they cannot prevent Hermes from exiting.
+
+## License boundary (AGPL vs MIT)
+
+- `yantrikdb-server` is licensed AGPL-3.0.
+- The plugin code in this directory is shipped under Hermes' MIT license.
+- The plugin **connects to** the server over HTTP — it does not embed, statically link, or redistribute any YantrikDB code. This is the same model as any MIT client that talks to an AGPL server. It is legally clean; if you fork or redistribute, the plugin is MIT and the server remains AGPL.
+
+## Reporting a vulnerability
+
+If you find a security issue in the plugin:
+
+1. **Do not** open a public issue.
+2. Email `security@yantrikdb.com` with a description and, if possible, a proof-of-concept.
+3. Expect an acknowledgement within 3 business days and a fix timeline within 10 business days for confirmed issues.
+
+For issues in `yantrikdb-server` itself, follow the disclosure process at <https://yantrikdb.com/security/>.
+
+For issues in Hermes core, follow the Hermes project's disclosure process.

--- a/plugins/memory/yantrikdb/__init__.py
+++ b/plugins/memory/yantrikdb/__init__.py
@@ -1,0 +1,909 @@
+"""YantrikDB memory plugin — self-maintaining memory for Hermes.
+
+YantrikDB is a memory provider that actively maintains what it stores
+instead of behaving like an append-only vector index:
+
+- ``think()`` runs a bounded maintenance pass — canonicalizes duplicates,
+  flags superseded or contradictory facts, and mines co-occurrence
+  patterns.
+- Contradiction tracking surfaces conflicting claims for the agent to
+  resolve explicitly (``resolve_conflict``) rather than overwriting
+  silently.
+- Recency-aware ranking prefers fresher facts over stale ones without
+  deleting the older records — every result is annotated with a
+  ``why_retrieved`` reason list so recall is explainable.
+- A knowledge graph promotes related memories in recall through entity
+  edges created via ``relate``.
+
+The plugin is a thin HTTP client against an externally managed
+``yantrikdb-server`` (see README for deployment). The plugin never
+starts, stops, or upgrades the backend — same pattern as ``honcho``.
+
+Config via env + $HERMES_HOME/yantrikdb.json:
+  YANTRIKDB_URL              — default http://localhost:7438
+  YANTRIKDB_TOKEN            — required, Bearer token from `yantrikdb token create`
+  YANTRIKDB_NAMESPACE        — default "hermes"; combined with agent_workspace:agent_identity
+  YANTRIKDB_TOP_K            — default 10
+  YANTRIKDB_READ_TIMEOUT     — default 15.0 seconds
+  YANTRIKDB_CONNECT_TIMEOUT  — default 5.0 seconds
+  YANTRIKDB_RETRY_TOTAL      — default 3 retries on transient 5xx
+  YANTRIKDB_MAX_TEXT_LEN     — default 25000 chars; text is truncated client-side above this
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+from .client import (
+    DEFAULT_NAMESPACE,
+    YantrikDBAuthError,
+    YantrikDBClient,
+    YantrikDBClientError,
+    YantrikDBConfig,
+    YantrikDBError,
+    YantrikDBServerError,
+    YantrikDBTransientError,
+)
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker — after N consecutive transient/server/auth failures, the
+# plugin short-circuits for _BREAKER_COOLDOWN seconds so a flapping server
+# does not hammer Hermes' event loop. 4xx errors are deterministic caller
+# mistakes and do NOT count toward the breaker. Matches mem0's 5/120s.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN = 120.0
+
+_PREFETCH_JOIN_SECS = 3.0
+_SYNC_JOIN_SECS = 5.0
+_SESSION_END_JOIN_SECS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+#
+# Framing: these are memory maintenance operations, not opaque cognition.
+# Descriptions tell the agent when to reach for each tool, what the tool
+# will mutate, and how to read its structured result.
+# ---------------------------------------------------------------------------
+
+REMEMBER_SCHEMA = {
+    "name": "yantrikdb_remember",
+    "description": (
+        "Store a durable memory. Use for decisions, preferences, facts about "
+        "people, and project context. Skip ephemeral task state and anything "
+        "derivable from code or git. Text over 25k characters is truncated "
+        "client-side with a visible marker."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The fact or decision to remember, as a complete sentence.",
+            },
+            "importance": {
+                "type": "number",
+                "description": (
+                    "0.0-1.0 resistance to temporal ranking decay. "
+                    "0.8+ for critical decisions, 0.5-0.7 for useful context, "
+                    "0.3-0.5 for background detail. Default 0.6."
+                ),
+            },
+            "domain": {
+                "type": "string",
+                "description": (
+                    "Optional tag for filtered recall: 'work', 'preference', "
+                    "'people', 'architecture', 'infrastructure', etc."
+                ),
+            },
+        },
+        "required": ["text"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "yantrikdb_recall",
+    "description": (
+        "Explainable recall — semantic search ranked by relevance × recency × "
+        "importance with knowledge-graph boosting. Each result includes a "
+        "`why_retrieved` list (semantic_match / graph-connected / "
+        "keyword_match / important / emotionally weighted, etc.) so the "
+        "agent can see why each memory ranked. Call before making claims "
+        "about the user or past decisions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural-language search query. Be specific.",
+            },
+            "top_k": {
+                "type": "integer",
+                "description": "Max results (default 10, capped at 50).",
+            },
+            "domain": {
+                "type": "string",
+                "description": "Optional domain filter (e.g. 'work').",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "yantrikdb_forget",
+    "description": (
+        "Tombstone (soft-delete) a memory by its rid. Use when the user "
+        "retracts a fact or you are resolving a conflict by dropping the "
+        "obsolete record. Tombstoned memories stop surfacing in recall but "
+        "remain for audit."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "rid": {
+                "type": "string",
+                "description": "Memory id returned by yantrikdb_recall or yantrikdb_remember.",
+            },
+        },
+        "required": ["rid"],
+    },
+}
+
+THINK_SCHEMA = {
+    "name": "yantrikdb_think",
+    "description": (
+        "Run a bounded memory maintenance pass: canonicalize near-duplicates, "
+        "flag contradictory or superseded facts, optionally mine co-occurrence "
+        "patterns. Returns structured counts plus a `triggers` list suggesting "
+        "follow-up actions. Call at natural break points (end of a project "
+        "phase, a long user pause) — it is the most expensive operation and "
+        "should not run per turn. This is YantrikDB's differentiating feature."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "consolidation_limit": {
+                "type": "integer",
+                "description": "Max memories to consolidate this run (default: server-configured).",
+            },
+            "run_pattern_mining": {
+                "type": "boolean",
+                "description": "Also mine temporal and co-occurrence patterns. Default false.",
+            },
+        },
+        "required": [],
+    },
+}
+
+CONFLICTS_SCHEMA = {
+    "name": "yantrikdb_conflicts",
+    "description": (
+        "List open contradictions detected by yantrikdb_think. Each conflict "
+        "includes the two (or more) memory ids, a detection reason, and a "
+        "priority. YantrikDB never silently overwrites — contradictions "
+        "surface here until the agent resolves them explicitly."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+RESOLVE_CONFLICT_SCHEMA = {
+    "name": "yantrikdb_resolve_conflict",
+    "description": (
+        "Resolve a contradiction from yantrikdb_conflicts. Strategies: "
+        "'keep_winner' (pick the winner_rid, tombstone the other), "
+        "'merge' (emit a merged new_text, tombstone both), "
+        "'keep_both' (record both as context-dependent), "
+        "'dismiss' (close without action, e.g. false positive)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conflict_id": {"type": "string", "description": "Id from yantrikdb_conflicts."},
+            "strategy": {
+                "type": "string",
+                "description": "One of: keep_winner, merge, keep_both, dismiss.",
+            },
+            "winner_rid": {
+                "type": "string",
+                "description": "Required for 'keep_winner'. The rid to preserve.",
+            },
+            "new_text": {
+                "type": "string",
+                "description": "Required for 'merge'. The consolidated text that replaces both.",
+            },
+            "resolution_note": {
+                "type": "string",
+                "description": "Optional audit note explaining the choice.",
+            },
+        },
+        "required": ["conflict_id", "strategy"],
+    },
+}
+
+RELATE_SCHEMA = {
+    "name": "yantrikdb_relate",
+    "description": (
+        "Record a relationship edge between two entities in the knowledge "
+        "graph (e.g. 'Alice works_at Acme', 'ProjectX uses React'). "
+        "Edges boost recall — memories near related entities rank higher "
+        "and show `graph-connected via X` in their why_retrieved reasons."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "entity": {"type": "string", "description": "Source entity."},
+            "target": {"type": "string", "description": "Target entity."},
+            "relationship": {
+                "type": "string",
+                "description": (
+                    "Relationship verb, snake_case by convention "
+                    "(e.g. 'works_at', 'uses', 'reports_to')."
+                ),
+            },
+        },
+        "required": ["entity", "target", "relationship"],
+    },
+}
+
+STATS_SCHEMA = {
+    "name": "yantrikdb_stats",
+    "description": (
+        "Operational snapshot: active memory count, tombstoned count, "
+        "graph edges, entities, open conflicts, pending triggers. Use to "
+        "decide whether to call yantrikdb_think, spot runaway growth, or "
+        "see whether conflicts have accumulated."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
+    REMEMBER_SCHEMA,
+    RECALL_SCHEMA,
+    FORGET_SCHEMA,
+    THINK_SCHEMA,
+    CONFLICTS_SCHEMA,
+    RESOLVE_CONFLICT_SCHEMA,
+    RELATE_SCHEMA,
+    STATS_SCHEMA,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _derive_namespace(base: str, kwargs: dict[str, Any]) -> str:
+    """Scope the namespace to ``{base}:{agent_workspace}:{agent_identity}``.
+
+    Per HANDOFF §3 — one tenant namespace per agent identity so cross-session
+    consolidation works, while preventing a second agent from polluting
+    the first agent's memories.
+    """
+    workspace = (kwargs.get("agent_workspace") or "").strip()
+    identity = (kwargs.get("agent_identity") or "").strip()
+    parts = [base]
+    if workspace:
+        parts.append(workspace)
+    if identity:
+        parts.append(identity)
+    return ":".join(parts)
+
+
+def _format_recall_block(results: list[dict[str, Any]], limit: int = 8) -> str:
+    """Markdown bullet list of recalled memories for prompt injection."""
+    if not results:
+        return ""
+    lines: list[str] = []
+    for r in results[:limit]:
+        text = (r.get("text") or "").strip()
+        if not text:
+            continue
+        score = r.get("score")
+        tag = f" _(score {score:.2f})_" if isinstance(score, (int, float)) else ""
+        lines.append(f"- {text}{tag}")
+    return "\n".join(lines)
+
+
+def _estimate_importance(text: str) -> float:
+    """Cheap heuristic for ambient writes via sync_turn.
+
+    We can't tell a greeting from a decision without an LLM call; err
+    conservative. ``think()`` consolidates noise on session end.
+    """
+    n = len(text.strip())
+    if n < 40:
+        return 0.3
+    if n < 200:
+        return 0.5
+    return 0.6
+
+
+def _coerce_float(raw: Any, *, default: float) -> float:
+    try:
+        return float(raw) if raw is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(raw: Any, default: int) -> int:
+    try:
+        return int(raw) if raw is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+class YantrikDBMemoryProvider(MemoryProvider):
+    """MemoryProvider implementation backed by yantrikdb-server over HTTP."""
+
+    def __init__(self) -> None:
+        self._config: YantrikDBConfig | None = None
+        self._client: YantrikDBClient | None = None
+        self._client_lock = threading.Lock()
+
+        self._namespace: str = DEFAULT_NAMESPACE
+        self._session_id: str = ""
+        self._cron_skipped: bool = False
+
+        self._prefetch_result: str = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+
+        self._failure_count: int = 0
+        self._breaker_open_until: float = 0.0
+        self._breaker_lock = threading.Lock()
+
+    # -- Identity ---------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "yantrikdb"
+
+    # -- Setup / config ---------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Ready iff a token is configured. No network call."""
+        return bool(YantrikDBConfig.load().token)
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "token",
+                "description": "YantrikDB bearer token (from `yantrikdb token create`).",
+                "secret": True,
+                "required": True,
+                "env_var": "YANTRIKDB_TOKEN",
+                "url": "https://yantrikdb.com/server/quickstart/",
+            },
+            {
+                "key": "url",
+                "description": "YantrikDB HTTP endpoint.",
+                "default": "http://localhost:7438",
+                "env_var": "YANTRIKDB_URL",
+            },
+            {
+                "key": "namespace",
+                "description": "Tenant namespace prefix (combined with agent_workspace:agent_identity).",
+                "default": "hermes",
+                "env_var": "YANTRIKDB_NAMESPACE",
+            },
+            {
+                "key": "top_k",
+                "description": "Default max results for recall.",
+                "default": "10",
+                "env_var": "YANTRIKDB_TOP_K",
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
+        """Persist non-secret config to $HERMES_HOME/yantrikdb.json."""
+        path = Path(hermes_home) / "yantrikdb.json"
+        existing: dict[str, Any] = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                existing = {}
+        existing.update(values)
+        path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    # -- Lifecycle --------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        agent_context = kwargs.get("agent_context", "")
+        platform = kwargs.get("platform", "cli")
+        if agent_context in ("cron", "flush") or platform == "cron":
+            logger.debug(
+                "YantrikDB skipped: cron/flush context (agent_context=%s, platform=%s)",
+                agent_context, platform,
+            )
+            self._cron_skipped = True
+            return
+
+        self._session_id = session_id or ""
+        hermes_home_raw = kwargs.get("hermes_home")
+        hermes_home = Path(hermes_home_raw) if hermes_home_raw else None
+        self._config = YantrikDBConfig.load(hermes_home)
+
+        if not self._config.token:
+            logger.debug("YantrikDB not configured (no token) — plugin inactive")
+            return
+
+        self._namespace = _derive_namespace(self._config.namespace, kwargs)
+        with self._client_lock:
+            self._client = YantrikDBClient(self._config)
+
+        try:
+            self._client.health()
+            logger.info(
+                "YantrikDB connected: %s (namespace: %s)",
+                self._config.url, self._namespace,
+            )
+        except YantrikDBError as e:
+            logger.warning(
+                "YantrikDB health check failed (%s) — will retry on demand.", e,
+            )
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=_SYNC_JOIN_SECS)
+        with self._client_lock:
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def _require_client(self) -> YantrikDBClient:
+        """Return the client or raise — keeps dispatch paths type-clean."""
+        if self._client is None:
+            raise RuntimeError("YantrikDB client not initialized")
+        return self._client
+
+    # -- Prompt / prefetch -----------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        if self._cron_skipped or self._client is None:
+            return ""
+        return (
+            "# YantrikDB Memory\n"
+            f"Active. Namespace: `{self._namespace}`.\n"
+            "Self-maintaining memory: canonicalizes duplicates, surfaces "
+            "contradictions, ranks with recency awareness, and explains recall. "
+            "Use `yantrikdb_recall` before claiming facts about the user or "
+            "past decisions — each result includes a why_retrieved reason list. "
+            "When a new decision or relationship surfaces, call "
+            "`yantrikdb_remember` or `yantrikdb_relate`. Run `yantrikdb_think` "
+            "at natural break points to consolidate duplicates and surface "
+            "contradictions — then `yantrikdb_conflicts` lists what needs "
+            "resolving and `yantrikdb_resolve_conflict` closes each out."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._cron_skipped or self._client is None:
+            return ""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=_PREFETCH_JOIN_SECS)
+        with self._prefetch_lock:
+            result, self._prefetch_result = self._prefetch_result, ""
+        if not result:
+            return ""
+        return f"## YantrikDB Recall\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._cron_skipped or self._client is None or not query:
+            return
+        if self._breaker_open():
+            return
+
+        client = self._client
+        namespace = self._namespace
+
+        def _run() -> None:
+            try:
+                resp = client.recall(query, namespace=namespace, top_k=5)
+                block = _format_recall_block(resp.get("results", []), limit=5)
+                if block:
+                    with self._prefetch_lock:
+                        self._prefetch_result = block
+                self._record_success()
+            except YantrikDBClientError as e:
+                logger.debug("YantrikDB prefetch rejected: %s", e)
+            except YantrikDBError as e:
+                self._record_failure()
+                logger.debug("YantrikDB prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="yantrikdb-prefetch",
+        )
+        self._prefetch_thread.start()
+
+    # -- Turn sync --------------------------------------------------------
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+    ) -> None:
+        """Persist the user message after a completed turn.
+
+        Assistant-message extraction is intentionally out of v1 scope
+        (HANDOFF §10.1) — storing LLM output as fact amplifies
+        hallucination. think() cleans up ambient noise at session end.
+        """
+        if self._cron_skipped or self._client is None or self._config is None:
+            return
+        if not self._config.sync_user_messages:
+            return
+        if self._breaker_open():
+            return
+        text = (user_content or "").strip()
+        if not text:
+            return
+
+        client = self._client
+        snapshot_sid = self._session_id or session_id
+        namespace = self._namespace
+
+        def _run() -> None:
+            try:
+                client.remember(
+                    text,
+                    namespace=namespace,
+                    importance=_estimate_importance(text),
+                    metadata={"session_id": snapshot_sid, "role": "user"},
+                )
+                self._record_success()
+            except YantrikDBClientError as e:
+                logger.debug("YantrikDB sync_turn rejected: %s", e)
+            except YantrikDBError as e:
+                self._record_failure()
+                logger.debug("YantrikDB sync_turn failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=_SYNC_JOIN_SECS)
+        self._sync_thread = threading.Thread(
+            target=_run, daemon=True, name="yantrikdb-sync",
+        )
+        self._sync_thread.start()
+
+    # -- Tool dispatch ----------------------------------------------------
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        # Called by Hermes at register-time (before initialize()) to index
+        # tool names → provider for routing. Must return the static schema
+        # list regardless of client state; runtime readiness is enforced
+        # in handle_tool_call().
+        if self._cron_skipped:
+            return []
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        **kwargs: Any,
+    ) -> str:
+        if self._cron_skipped or self._client is None:
+            return tool_error("YantrikDB is not active for this session.")
+        if self._breaker_open():
+            return tool_error(
+                "YantrikDB temporarily unavailable (circuit breaker open). "
+                "Will retry automatically."
+            )
+
+        try:
+            if tool_name == "yantrikdb_remember":
+                return self._do_remember(args)
+            if tool_name == "yantrikdb_recall":
+                return self._do_recall(args)
+            if tool_name == "yantrikdb_forget":
+                return self._do_forget(args)
+            if tool_name == "yantrikdb_think":
+                return self._do_think(args)
+            if tool_name == "yantrikdb_conflicts":
+                return self._do_conflicts()
+            if tool_name == "yantrikdb_resolve_conflict":
+                return self._do_resolve_conflict(args)
+            if tool_name == "yantrikdb_relate":
+                return self._do_relate(args)
+            if tool_name == "yantrikdb_stats":
+                return self._do_stats()
+            return tool_error(f"Unknown tool: {tool_name}")
+        except YantrikDBAuthError as e:
+            self._record_failure()
+            return tool_error(
+                f"YantrikDB auth rejected: {e}. Check YANTRIKDB_TOKEN."
+            )
+        except YantrikDBClientError as e:
+            return tool_error(f"YantrikDB rejected the request: {e}")
+        except (YantrikDBTransientError, YantrikDBServerError) as e:
+            self._record_failure()
+            return tool_error(f"YantrikDB unavailable: {e}")
+        except YantrikDBError as e:
+            self._record_failure()
+            return tool_error(f"YantrikDB error: {e}")
+
+    def _do_remember(self, args: dict[str, Any]) -> str:
+        text = (args.get("text") or "").strip()
+        if not text:
+            return tool_error("Missing required parameter: text")
+        importance = _coerce_float(args.get("importance"), default=0.6)
+        resp = self._require_client().remember(
+            text,
+            namespace=self._namespace,
+            importance=importance,
+            domain=args.get("domain"),
+            metadata={"session_id": self._session_id},
+        )
+        self._record_success()
+        return json.dumps({"rid": resp.get("rid"), "stored": True})
+
+    def _do_recall(self, args: dict[str, Any]) -> str:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return tool_error("Missing required parameter: query")
+        default_top_k = self._config.top_k if self._config else 10
+        top_k = min(_coerce_int(args.get("top_k"), default_top_k), 50)
+        resp = self._require_client().recall(
+            query,
+            namespace=self._namespace,
+            top_k=top_k,
+            domain=args.get("domain"),
+        )
+        self._record_success()
+        results = resp.get("results", []) or []
+        compact = [
+            {
+                "rid": r.get("rid"),
+                "text": r.get("text"),
+                "score": r.get("score"),
+                "importance": r.get("importance"),
+                "domain": r.get("domain"),
+                "created_at": r.get("created_at"),
+                # Explainable recall — server returns a list of reasons per result.
+                "why_retrieved": r.get("why_retrieved") or [],
+            }
+            for r in results
+        ]
+        return json.dumps({"count": len(compact), "results": compact})
+
+    def _do_forget(self, args: dict[str, Any]) -> str:
+        rid = (args.get("rid") or "").strip()
+        if not rid:
+            return tool_error("Missing required parameter: rid")
+        resp = self._require_client().forget(rid)
+        self._record_success()
+        return json.dumps({"rid": rid, "found": bool(resp.get("found", False))})
+
+    def _do_think(self, args: dict[str, Any]) -> str:
+        resp = self._require_client().think(
+            run_pattern_mining=bool(args.get("run_pattern_mining", False)),
+            consolidation_limit=args.get("consolidation_limit"),
+        )
+        self._record_success()
+        return json.dumps({
+            "consolidated": resp.get("consolidation_count", 0),
+            "conflicts_found": resp.get("conflicts_found", 0),
+            "patterns_new": resp.get("patterns_new", 0),
+            "patterns_updated": resp.get("patterns_updated", 0),
+            "personality_updated": resp.get("personality_updated", False),
+            "duration_ms": resp.get("duration_ms"),
+            "triggers": resp.get("triggers", []),
+        })
+
+    def _do_conflicts(self) -> str:
+        resp = self._require_client().conflicts()
+        self._record_success()
+        conflicts = resp.get("conflicts", []) or []
+        return json.dumps({"count": len(conflicts), "conflicts": conflicts})
+
+    def _do_resolve_conflict(self, args: dict[str, Any]) -> str:
+        conflict_id = (args.get("conflict_id") or "").strip()
+        strategy = (args.get("strategy") or "").strip()
+        if not conflict_id or not strategy:
+            return tool_error(
+                "Missing required parameters: conflict_id, strategy"
+            )
+        if strategy == "keep_winner" and not args.get("winner_rid"):
+            return tool_error("strategy='keep_winner' requires winner_rid")
+        if strategy == "merge" and not args.get("new_text"):
+            return tool_error("strategy='merge' requires new_text")
+
+        resp = self._require_client().resolve_conflict(
+            conflict_id,
+            strategy=strategy,
+            winner_rid=args.get("winner_rid"),
+            new_text=args.get("new_text"),
+            resolution_note=args.get("resolution_note"),
+        )
+        self._record_success()
+        return json.dumps({
+            "conflict_id": resp.get("conflict_id", conflict_id),
+            "strategy": resp.get("strategy", strategy),
+            "resolved": True,
+        })
+
+    def _do_relate(self, args: dict[str, Any]) -> str:
+        entity = (args.get("entity") or "").strip()
+        target = (args.get("target") or "").strip()
+        relationship = (args.get("relationship") or "").strip()
+        if not (entity and target and relationship):
+            return tool_error(
+                "Missing required parameters: entity, target, relationship"
+            )
+        resp = self._require_client().relate(
+            entity, target, relationship,
+        )
+        self._record_success()
+        return json.dumps({"edge_id": resp.get("edge_id"), "stored": True})
+
+    def _do_stats(self) -> str:
+        resp = self._require_client().stats()
+        self._record_success()
+        return json.dumps({
+            "active_memories": resp.get("active_memories", 0),
+            "consolidated_memories": resp.get("consolidated_memories", 0),
+            "tombstoned_memories": resp.get("tombstoned_memories", 0),
+            "edges": resp.get("edges", 0),
+            "entities": resp.get("entities", 0),
+            "operations": resp.get("operations", 0),
+            "open_conflicts": resp.get("open_conflicts", 0),
+            "pending_triggers": resp.get("pending_triggers", 0),
+        })
+
+    # -- Optional hooks ---------------------------------------------------
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        """Run consolidation at session end, flushing pending writes first."""
+        if self._cron_skipped or self._client is None or self._config is None:
+            return
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=_SESSION_END_JOIN_SECS)
+        if not self._config.auto_think_on_session_end:
+            return
+        if self._breaker_open():
+            return
+        try:
+            stats = self._client.think(
+                run_pattern_mining=False, run_personality=False,
+            )
+            logger.info(
+                "YantrikDB session-end think: consolidated=%s conflicts=%s duration_ms=%s",
+                stats.get("consolidation_count"),
+                stats.get("conflicts_found"),
+                stats.get("duration_ms"),
+            )
+        except YantrikDBError as e:
+            logger.debug("YantrikDB session-end think failed: %s", e)
+
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
+        """Preserve high-salience memories across context compression.
+
+        Seeds recall with the tail of the about-to-be-compressed messages
+        and returns a markdown block. Hermes' compressor includes this
+        in the summary prompt so insights don't get dropped.
+        """
+        if self._cron_skipped or self._client is None:
+            return ""
+        if self._breaker_open():
+            return ""
+        tail = " ".join(
+            (m.get("content") or "") for m in messages[-6:] if isinstance(m, dict)
+        ).strip()
+        if not tail:
+            return ""
+        try:
+            resp = self._client.recall(
+                tail[:2000], namespace=self._namespace, top_k=8,
+            )
+            block = _format_recall_block(resp.get("results", []), limit=8)
+            if not block:
+                return ""
+            return f"## YantrikDB memories to preserve\n{block}"
+        except YantrikDBError as e:
+            logger.debug("YantrikDB on_pre_compress failed: %s", e)
+            return ""
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in MEMORY.md / USER.md additions into YantrikDB."""
+        if self._cron_skipped or self._client is None:
+            return
+        if action != "add" or target not in ("memory", "user") or not content:
+            return
+        if self._breaker_open():
+            return
+
+        client = self._client
+        text = content
+        session_id = self._session_id
+        namespace = self._namespace
+        domain = "user" if target == "user" else "work"
+
+        def _run() -> None:
+            try:
+                client.remember(
+                    text,
+                    namespace=namespace,
+                    importance=0.7,
+                    domain=domain,
+                    metadata={
+                        "source": "hermes_memory_md",
+                        "target": target,
+                        "session_id": session_id,
+                    },
+                )
+                self._record_success()
+            except YantrikDBError as e:
+                self._record_failure()
+                logger.debug("YantrikDB on_memory_write failed: %s", e)
+
+        threading.Thread(
+            target=_run, daemon=True, name="yantrikdb-memwrite",
+        ).start()
+
+    # -- Circuit breaker --------------------------------------------------
+
+    def _breaker_open(self) -> bool:
+        with self._breaker_lock:
+            if self._failure_count < _BREAKER_THRESHOLD:
+                return False
+            if time.monotonic() >= self._breaker_open_until:
+                self._failure_count = 0
+                return False
+            return True
+
+    def _record_success(self) -> None:
+        with self._breaker_lock:
+            self._failure_count = 0
+
+    def _record_failure(self) -> None:
+        with self._breaker_lock:
+            self._failure_count += 1
+            if self._failure_count >= _BREAKER_THRESHOLD:
+                self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN
+                logger.warning(
+                    "YantrikDB circuit breaker tripped after %d failures — "
+                    "pausing for %ds.",
+                    self._failure_count, _BREAKER_COOLDOWN,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx: Any) -> None:
+    """Register YantrikDB as a memory provider plugin."""
+    ctx.register_memory_provider(YantrikDBMemoryProvider())
+
+
+__all__ = [
+    "ALL_TOOL_SCHEMAS",
+    "CONFLICTS_SCHEMA",
+    "FORGET_SCHEMA",
+    "RECALL_SCHEMA",
+    "RELATE_SCHEMA",
+    "REMEMBER_SCHEMA",
+    "RESOLVE_CONFLICT_SCHEMA",
+    "STATS_SCHEMA",
+    "THINK_SCHEMA",
+    "YantrikDBMemoryProvider",
+    "register",
+]

--- a/plugins/memory/yantrikdb/__init__.py
+++ b/plugins/memory/yantrikdb/__init__.py
@@ -39,8 +39,33 @@ import time
 from pathlib import Path
 from typing import Any
 
-from agent.memory_provider import MemoryProvider
-from tools.registry import tool_error
+try:
+    from agent.memory_provider import MemoryProvider
+    from tools.registry import tool_error
+    _HERMES_AVAILABLE = True
+except ImportError:
+    # Plugin is being imported outside a Hermes runtime — typically because
+    # `yantrikdb-hermes-plugin` was pip-installed and the user is invoking
+    # the CLI installer (`yantrikdb-hermes install <hermes_root>`). The
+    # provider class never runs in this path; we just need module load to
+    # succeed so the CLI's `from yantrikdb_hermes_plugin.cli import main`
+    # works. Inside Hermes, the real imports take over.
+    _HERMES_AVAILABLE = False
+
+    class MemoryProvider:  # type: ignore[no-redef]
+        """Stub used only when the plugin is imported outside Hermes.
+
+        Real `agent.memory_provider.MemoryProvider` is an ABC; this stub is
+        a plain class so the YantrikDBMemoryProvider subclass below still
+        defines successfully when Hermes isn't on the import path. Hermes
+        instantiates the provider via filesystem-loaded source (a fresh
+        import from `plugins/memory/yantrikdb/`), so this stub is never
+        the one Hermes sees in practice.
+        """
+
+    def tool_error(message: str) -> str:  # type: ignore[no-redef]
+        import json
+        return json.dumps({"error": message})
 
 from .client import (
     DEFAULT_NAMESPACE,
@@ -52,6 +77,7 @@ from .client import (
     YantrikDBServerError,
     YantrikDBTransientError,
 )
+from .embedded import make_backend
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +293,150 @@ STATS_SCHEMA = {
     "parameters": {"type": "object", "properties": {}, "required": []},
 }
 
+# -- Skills (v0.3.0+) -------------------------------------------------
+#
+# Skills are procedural memory: reusable patterns the agent distills
+# from observed success and pulls back next session. They live in the
+# shared ``skill_substrate`` namespace alongside skills authored by
+# other YantrikDB consumers — Hermes-authored entries are tagged
+# ``metadata.source=hermes`` so any consumer can filter Hermes-authored
+# skills in or out cleanly. Outcomes are append-only; success/failure
+# rollup is the agent's pedagogy decision, not the substrate's.
+#
+# Note: this is a peer surface to the filesystem skills Hermes already
+# has at $HERMES_HOME/skills/. Filesystem = human-authored, durable,
+# version-controlled. YantrikDB skills = agent-authored, runtime-
+# evolving, semantic-search-queryable. Different kinds of canonical;
+# the model picks the right substrate by lifecycle, not by competition.
+
+SKILL_SEARCH_SCHEMA = {
+    "name": "yantrikdb_skill_search",
+    "description": (
+        "Semantic search over agent-authored skills in the shared "
+        "skill_substrate. Use to find a procedural pattern relevant to "
+        "the current task before acting — agent-authored skills capture "
+        "what worked in previous similar situations. Distinct from "
+        "yantrikdb_recall (episodic/semantic memory): skills are "
+        "procedures, memories are facts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural-language description of the task or pattern.",
+            },
+            "top_k": {
+                "type": "integer",
+                "description": "Max results (default 10).",
+            },
+            "applies_to": {
+                "type": "string",
+                "description": (
+                    "Optional filter: only return skills tagged for this "
+                    "context (e.g. 'git', 'deploy', 'pgsql')."
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+SKILL_DEFINE_SCHEMA = {
+    "name": "yantrikdb_skill_define",
+    "description": (
+        "Distill a procedural pattern into a reusable skill. Use when "
+        "you've observed a sequence that worked and want it findable next "
+        "session. The body should be a self-contained instruction — "
+        "future you (or another agent) reads it and follows it. Skill "
+        "naming convention: dot-separated lowercase, e.g. "
+        "'git.commit_clean', 'deploy.rolling_restart'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": (
+                    "Dot-separated lowercase identifier matching "
+                    "^[a-z][a-z0-9_]*(\\.[a-z0-9_]+)+$, length 4-200. "
+                    "First segment is the broad category, later segments "
+                    "narrow it (e.g. 'workflow.git.commit_clean')."
+                ),
+            },
+            "body": {
+                "type": "string",
+                "description": (
+                    "The procedural instructions, 50-5000 chars. Self-"
+                    "contained — assume the reader has no prior context."
+                ),
+            },
+            "skill_type": {
+                "type": "string",
+                "enum": ["procedure", "reference", "lesson", "pattern", "rule"],
+                "description": (
+                    "procedure: do these steps. reference: information to "
+                    "consult. lesson: things to remember from a past mistake. "
+                    "pattern: recognizable shape. rule: invariant to maintain."
+                ),
+            },
+            "applies_to": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Tags identifying when this skill is relevant. Lowercase "
+                    "+ digits + underscores ONLY (no hyphens, no dots, no "
+                    "spaces): each entry must match ^[a-z][a-z0-9_]*$. "
+                    "Max 10 entries. Examples: ['git', 'commit'], "
+                    "['postgres', 'migration', 'rollback']."
+                ),
+            },
+            "triggers": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional natural-language phrases that should activate this skill.",
+            },
+            "version": {
+                "type": "string",
+                "description": "Optional version string (e.g. '1.0.0').",
+            },
+            "supersedes_skill_id": {
+                "type": "string",
+                "description": "Optional skill_id this skill replaces.",
+            },
+        },
+        "required": ["skill_id", "body", "skill_type", "applies_to"],
+    },
+}
+
+SKILL_OUTCOME_SCHEMA = {
+    "name": "yantrikdb_skill_outcome",
+    "description": (
+        "Record whether a skill succeeded when used. Append-only: each "
+        "call adds an event to the outcome log; success/failure rollup "
+        "is the agent's call, not the substrate's. Use after attempting "
+        "a skill to feed back signal for future search ranking."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": "The skill_id that was applied.",
+            },
+            "succeeded": {
+                "type": "boolean",
+                "description": "True if the skill produced the intended outcome.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional context — what worked, what didn't, what to adjust.",
+            },
+        },
+        "required": ["skill_id", "succeeded"],
+    },
+}
+
 ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     REMEMBER_SCHEMA,
     RECALL_SCHEMA,
@@ -276,6 +446,9 @@ ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     RESOLVE_CONFLICT_SCHEMA,
     RELATE_SCHEMA,
     STATS_SCHEMA,
+    SKILL_SEARCH_SCHEMA,
+    SKILL_DEFINE_SCHEMA,
+    SKILL_OUTCOME_SCHEMA,
 ]
 
 
@@ -377,8 +550,19 @@ class YantrikDBMemoryProvider(MemoryProvider):
     # -- Setup / config ---------------------------------------------------
 
     def is_available(self) -> bool:
-        """Ready iff a token is configured. No network call."""
-        return bool(YantrikDBConfig.load().token)
+        """Ready when the configured backend can be reached. No network call.
+
+        - embedded mode: available iff `yantrikdb` Python package is importable.
+        - http mode: available iff a token is configured.
+        """
+        cfg = YantrikDBConfig.load()
+        if cfg.mode == "embedded":
+            try:
+                import yantrikdb._yantrikdb_rust  # noqa: F401
+                return True
+            except ImportError:
+                return False
+        return bool(cfg.token)
 
     def get_config_schema(self) -> list[dict[str, Any]]:
         return [
@@ -440,19 +624,30 @@ class YantrikDBMemoryProvider(MemoryProvider):
         hermes_home = Path(hermes_home_raw) if hermes_home_raw else None
         self._config = YantrikDBConfig.load(hermes_home)
 
-        if not self._config.token:
-            logger.debug("YantrikDB not configured (no token) — plugin inactive")
+        # Embedded mode is self-contained (`pip install` and go); HTTP mode
+        # requires a token. is_available() short-circuits at the provider
+        # level, but be defensive here too.
+        if self._config.mode == "http" and not self._config.token:
+            logger.debug("YantrikDB http mode but no token — plugin inactive")
             return
 
         self._namespace = _derive_namespace(self._config.namespace, kwargs)
+        try:
+            backend = make_backend(self._config)
+        except YantrikDBError as e:
+            logger.warning("YantrikDB %s mode init failed: %s", self._config.mode, e)
+            return
         with self._client_lock:
-            self._client = YantrikDBClient(self._config)
+            self._client = backend
 
         try:
             self._client.health()
+            target = self._config.url if self._config.mode == "http" else (
+                self._config.db_path or "default"
+            )
             logger.info(
-                "YantrikDB connected: %s (namespace: %s)",
-                self._config.url, self._namespace,
+                "YantrikDB connected: mode=%s target=%s namespace=%s",
+                self._config.mode, target, self._namespace,
             )
         except YantrikDBError as e:
             logger.warning(
@@ -590,9 +785,23 @@ class YantrikDBMemoryProvider(MemoryProvider):
         # tool names → provider for routing. Must return the static schema
         # list regardless of client state; runtime readiness is enforced
         # in handle_tool_call().
+        #
+        # Skills are opt-in (YANTRIKDB_SKILLS_ENABLED=true). When the flag
+        # is off, the three skill schemas are filtered out so the model
+        # never sees them — keeping the tool surface minimal for users who
+        # don't need the agentic skill loop. When `_config` is None (we
+        # haven't initialized yet), expose all schemas so register-time
+        # routing has every tool indexed; runtime check below short-
+        # circuits if skills are disabled at call time.
         if self._cron_skipped:
             return []
-        return list(ALL_TOOL_SCHEMAS)
+        skills_enabled = bool(
+            self._config.skills_enabled if self._config else
+            YantrikDBConfig.load().skills_enabled
+        )
+        if skills_enabled:
+            return list(ALL_TOOL_SCHEMAS)
+        return [s for s in ALL_TOOL_SCHEMAS if not s["name"].startswith("yantrikdb_skill_")]
 
     def handle_tool_call(
         self,
@@ -625,6 +834,18 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 return self._do_relate(args)
             if tool_name == "yantrikdb_stats":
                 return self._do_stats()
+            if tool_name.startswith("yantrikdb_skill_"):
+                if not (self._config and self._config.skills_enabled):
+                    return tool_error(
+                        "Skills are disabled. Set YANTRIKDB_SKILLS_ENABLED=true "
+                        "to enable yantrikdb_skill_search / _define / _outcome."
+                    )
+                if tool_name == "yantrikdb_skill_search":
+                    return self._do_skill_search(args)
+                if tool_name == "yantrikdb_skill_define":
+                    return self._do_skill_define(args)
+                if tool_name == "yantrikdb_skill_outcome":
+                    return self._do_skill_outcome(args)
             return tool_error(f"Unknown tool: {tool_name}")
         except YantrikDBAuthError as e:
             self._record_failure()
@@ -766,6 +987,76 @@ class YantrikDBMemoryProvider(MemoryProvider):
             "operations": resp.get("operations", 0),
             "open_conflicts": resp.get("open_conflicts", 0),
             "pending_triggers": resp.get("pending_triggers", 0),
+        })
+
+    def _do_skill_search(self, args: dict[str, Any]) -> str:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return tool_error("Missing required parameter: query")
+        default_top_k = self._config.top_k if self._config else 10
+        top_k = min(_coerce_int(args.get("top_k"), default_top_k), 50)
+        resp = self._require_client().skill_search(
+            query, top_k=top_k, applies_to=args.get("applies_to"),
+        )
+        self._record_success()
+        skills = resp.get("skills") or resp.get("results") or []
+        compact = [
+            {
+                "rid": s.get("rid"),
+                "skill_id": (s.get("metadata") or {}).get("skill_id"),
+                "skill_type": (s.get("metadata") or {}).get("skill_type"),
+                "applies_to": (s.get("metadata") or {}).get("applies_to", []),
+                "body": s.get("text"),
+                "score": s.get("score"),
+                "source": (s.get("metadata") or {}).get("source"),
+                "why_retrieved": s.get("why_retrieved") or [],
+            }
+            for s in skills
+        ]
+        return json.dumps({"count": len(compact), "skills": compact})
+
+    def _do_skill_define(self, args: dict[str, Any]) -> str:
+        skill_id = (args.get("skill_id") or "").strip()
+        body = args.get("body") or ""
+        skill_type = (args.get("skill_type") or "").strip()
+        applies_to = args.get("applies_to") or []
+        if not skill_id or not body or not skill_type or not applies_to:
+            return tool_error(
+                "Missing required parameters: skill_id, body, skill_type, applies_to"
+            )
+        resp = self._require_client().skill_define(
+            skill_id=skill_id,
+            body=body,
+            skill_type=skill_type,
+            applies_to=applies_to,
+            triggers=args.get("triggers"),
+            on_conflict=args.get("on_conflict", "reject"),
+            version=args.get("version"),
+            supersedes_skill_id=args.get("supersedes_skill_id"),
+        )
+        self._record_success()
+        return json.dumps({
+            "rid": resp.get("rid"),
+            "skill_id": resp.get("skill_id", skill_id),
+            "stored": bool(resp.get("stored", True)),
+        })
+
+    def _do_skill_outcome(self, args: dict[str, Any]) -> str:
+        skill_id = (args.get("skill_id") or "").strip()
+        if not skill_id:
+            return tool_error("Missing required parameter: skill_id")
+        if "succeeded" not in args:
+            return tool_error("Missing required parameter: succeeded")
+        resp = self._require_client().skill_outcome(
+            skill_id,
+            bool(args.get("succeeded")),
+            note=args.get("note"),
+        )
+        self._record_success()
+        return json.dumps({
+            "rid": resp.get("rid"),
+            "skill_id": resp.get("skill_id", skill_id),
+            "recorded": bool(resp.get("recorded", True)),
         })
 
     # -- Optional hooks ---------------------------------------------------

--- a/plugins/memory/yantrikdb/client.py
+++ b/plugins/memory/yantrikdb/client.py
@@ -1,0 +1,460 @@
+"""HTTP client for yantrikdb-server.
+
+Thin wrapper over the YantrikDB REST API (port 7438 by default). The
+plugin never manages the server process — the user runs yantrikdb-server
+themselves and the client connects to it.
+
+Config resolution matches the mem0 pattern:
+  1. Environment variables (YANTRIKDB_URL / YANTRIKDB_TOKEN / YANTRIKDB_NAMESPACE /
+     YANTRIKDB_TOP_K / YANTRIKDB_READ_TIMEOUT / YANTRIKDB_CONNECT_TIMEOUT /
+     YANTRIKDB_RETRY_TOTAL / YANTRIKDB_MAX_TEXT_LEN)
+  2. $HERMES_HOME/yantrikdb.json (overrides individual keys when present)
+
+Errors are mapped into a small taxonomy so the provider can decide which
+conditions trip the circuit breaker and which are deterministic caller
+mistakes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+
+try:
+    from urllib3.util.retry import Retry  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover — urllib3 ships with requests
+    Retry = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = "http://localhost:7438"
+DEFAULT_NAMESPACE = "hermes"
+DEFAULT_TOP_K = 10
+DEFAULT_READ_TIMEOUT = 15.0
+DEFAULT_CONNECT_TIMEOUT = 5.0
+DEFAULT_RETRY_TOTAL = 3
+DEFAULT_MAX_TEXT_LEN = 25000  # matches Honcho's message cap
+
+_USER_AGENT = "hermes-yantrikdb-plugin/0.1"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class YantrikDBConfig:
+    url: str = DEFAULT_URL
+    token: str = ""
+    namespace: str = DEFAULT_NAMESPACE
+    top_k: int = DEFAULT_TOP_K
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
+    read_timeout: float = DEFAULT_READ_TIMEOUT
+    retry_total: int = DEFAULT_RETRY_TOTAL
+    max_text_len: int = DEFAULT_MAX_TEXT_LEN
+    auto_think_on_session_end: bool = True
+    sync_user_messages: bool = True
+
+    @classmethod
+    def from_env(cls) -> YantrikDBConfig:
+        return cls(
+            url=os.environ.get("YANTRIKDB_URL", DEFAULT_URL).rstrip("/"),
+            token=os.environ.get("YANTRIKDB_TOKEN", ""),
+            namespace=os.environ.get("YANTRIKDB_NAMESPACE", DEFAULT_NAMESPACE),
+            top_k=_parse_int(os.environ.get("YANTRIKDB_TOP_K"), DEFAULT_TOP_K),
+            connect_timeout=_parse_float(
+                os.environ.get("YANTRIKDB_CONNECT_TIMEOUT"), DEFAULT_CONNECT_TIMEOUT,
+            ),
+            read_timeout=_parse_float(
+                os.environ.get("YANTRIKDB_READ_TIMEOUT"), DEFAULT_READ_TIMEOUT,
+            ),
+            retry_total=_parse_int(
+                os.environ.get("YANTRIKDB_RETRY_TOTAL"), DEFAULT_RETRY_TOTAL,
+            ),
+            max_text_len=_parse_int(
+                os.environ.get("YANTRIKDB_MAX_TEXT_LEN"), DEFAULT_MAX_TEXT_LEN,
+            ),
+        )
+
+    @classmethod
+    def load(cls, hermes_home: Path | None = None) -> YantrikDBConfig:
+        """Load config from env, then overlay with $HERMES_HOME/yantrikdb.json.
+
+        Mirrors the mem0 pattern — env provides defaults, the JSON file is an
+        optional override for individual keys.
+        """
+        cfg = cls.from_env()
+        path = _resolve_config_path(hermes_home)
+        if path is None or not path.exists():
+            return cfg
+        try:
+            overrides = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Failed to read %s: %s — using env config", path, e)
+            return cfg
+        if not isinstance(overrides, dict):
+            return cfg
+        int_fields = {"top_k", "retry_total", "max_text_len"}
+        float_fields = {"connect_timeout", "read_timeout"}
+        for key, val in overrides.items():
+            if val in (None, ""):
+                continue
+            if not hasattr(cfg, key):
+                continue
+            if key == "url" and isinstance(val, str):
+                setattr(cfg, key, val.rstrip("/"))
+            elif key in int_fields:
+                setattr(cfg, key, _parse_int(val, getattr(cfg, key)))
+            elif key in float_fields:
+                setattr(cfg, key, _parse_float(val, getattr(cfg, key)))
+            else:
+                setattr(cfg, key, val)
+        return cfg
+
+
+def _parse_int(raw: Any, default: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_float(raw: Any, default: float) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_config_path(hermes_home: Path | None) -> Path | None:
+    if hermes_home is not None:
+        return Path(hermes_home) / "yantrikdb.json"
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return get_hermes_home() / "yantrikdb.json"
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Text hygiene
+# ---------------------------------------------------------------------------
+
+def truncate_text(text: str, max_len: int) -> str:
+    """Truncate at a word boundary when possible, preserving a trailing ellipsis.
+
+    Oversize memory bodies would otherwise fail with a 400 from the server.
+    We truncate client-side with a visible marker so the agent (and anyone
+    reading the recall result) can see that the body was clipped.
+    """
+    if max_len <= 0 or len(text) <= max_len:
+        return text
+    marker = " …[truncated]"
+    budget = max_len - len(marker)
+    if budget <= 0:
+        return text[:max_len]
+    cut = text.rfind(" ", 0, budget)
+    if cut < int(budget * 0.8):
+        cut = budget
+    return text[:cut].rstrip() + marker
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class YantrikDBError(Exception):
+    """Base for all yantrikdb client errors."""
+
+
+class YantrikDBAuthError(YantrikDBError):
+    """401 / 403 — token missing, expired, or revoked."""
+
+
+class YantrikDBClientError(YantrikDBError):
+    """4xx — request was rejected (bad shape, quota, not found)."""
+
+
+class YantrikDBServerError(YantrikDBError):
+    """5xx — server failed to process the request."""
+
+
+class YantrikDBTransientError(YantrikDBError):
+    """Network error, timeout, 429, or 503 — retry later."""
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class YantrikDBClient:
+    """HTTP client for yantrikdb-server.
+
+    - Session-pooled ``requests.Session`` for keep-alive.
+    - Bounded retries on 5xx and connection blips via urllib3.
+    - Exceptions mapped to the taxonomy above so callers can decide what
+      trips a circuit breaker (transient/server/auth) versus what does not
+      (4xx client mistakes).
+    - Each request is tagged with a short ``req_id`` and logged at DEBUG
+      with the operation and latency, so operators can correlate slow or
+      failing calls in the Hermes log stream.
+    """
+
+    def __init__(self, config: YantrikDBConfig, session: Session | None = None):
+        self.config = config
+        self._session = session if session is not None else self._build_session(config)
+
+    @staticmethod
+    def _build_session(config: YantrikDBConfig) -> Session:
+        s = requests.Session()
+        if Retry is None:
+            return s
+        retry = Retry(
+            total=max(0, config.retry_total),
+            connect=min(config.retry_total, 2),
+            read=min(config.retry_total, 2),
+            backoff_factor=0.5,
+            status_forcelist=(500, 502, 504),
+            allowed_methods=frozenset(("GET", "POST", "DELETE")),
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(
+            max_retries=retry, pool_connections=4, pool_maxsize=8,
+        )
+        s.mount("http://", adapter)
+        s.mount("https://", adapter)
+        return s
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json", "User-Agent": _USER_AGENT}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self.config.url}{path}"
+        req_id = uuid.uuid4().hex[:8]
+        started = time.perf_counter()
+        try:
+            resp = self._session.request(
+                method,
+                url,
+                json=body,
+                headers=self._headers(),
+                timeout=(self.config.connect_timeout, self.config.read_timeout),
+            )
+        except requests.Timeout as e:
+            self._log_failure(req_id, method, path, started, f"timeout: {e}")
+            raise YantrikDBTransientError(f"Timeout contacting {url}: {e}") from e
+        except requests.ConnectionError as e:
+            self._log_failure(req_id, method, path, started, f"conn: {e}")
+            raise YantrikDBTransientError(f"Connection error: {e}") from e
+        except requests.RequestException as e:
+            self._log_failure(req_id, method, path, started, f"req: {e}")
+            raise YantrikDBError(f"Request failed: {e}") from e
+
+        latency_ms = (time.perf_counter() - started) * 1000
+        logger.debug(
+            "yantrikdb req=%s %s %s status=%s duration_ms=%.1f",
+            req_id, method, path, resp.status_code, latency_ms,
+        )
+        return _parse_response(resp)
+
+    @staticmethod
+    def _log_failure(
+        req_id: str, method: str, path: str, started: float, reason: str,
+    ) -> None:
+        latency_ms = (time.perf_counter() - started) * 1000
+        logger.debug(
+            "yantrikdb req=%s %s %s FAIL duration_ms=%.1f reason=%s",
+            req_id, method, path, latency_ms, reason,
+        )
+
+    # -- Endpoints --
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/v1/health")
+
+    def remember(
+        self,
+        text: str,
+        *,
+        namespace: str | None = None,
+        importance: float = 0.6,
+        domain: str | None = None,
+        memory_type: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        safe_text = truncate_text(text, self.config.max_text_len)
+        body: dict[str, Any] = {
+            "text": safe_text,
+            "namespace": namespace or self.config.namespace,
+            "importance": float(importance),
+        }
+        if domain:
+            body["domain"] = domain
+        if memory_type:
+            body["memory_type"] = memory_type
+        if metadata:
+            body["metadata"] = metadata
+        return self._request("POST", "/v1/remember", body)
+
+    def recall(
+        self,
+        query: str,
+        *,
+        namespace: str | None = None,
+        top_k: int | None = None,
+        memory_type: str | None = None,
+        domain: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "query": query,
+            "namespace": namespace or self.config.namespace,
+            "top_k": int(top_k or self.config.top_k),
+        }
+        if memory_type:
+            body["memory_type"] = memory_type
+        if domain:
+            body["domain"] = domain
+        return self._request("POST", "/v1/recall", body)
+
+    def forget(self, rid: str) -> dict[str, Any]:
+        return self._request("POST", "/v1/forget", {"rid": rid})
+
+    def think(
+        self,
+        *,
+        run_consolidation: bool = True,
+        run_conflict_scan: bool = True,
+        run_pattern_mining: bool = False,
+        run_personality: bool = False,
+        consolidation_limit: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "run_consolidation": run_consolidation,
+            "run_conflict_scan": run_conflict_scan,
+            "run_pattern_mining": run_pattern_mining,
+            "run_personality": run_personality,
+        }
+        if consolidation_limit is not None:
+            body["consolidation_limit"] = int(consolidation_limit)
+        return self._request("POST", "/v1/think", body)
+
+    def conflicts(self) -> dict[str, Any]:
+        return self._request("GET", "/v1/conflicts")
+
+    def resolve_conflict(
+        self,
+        conflict_id: str,
+        *,
+        strategy: str,
+        winner_rid: str | None = None,
+        new_text: str | None = None,
+        resolution_note: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"strategy": strategy}
+        if winner_rid:
+            body["winner_rid"] = winner_rid
+        if new_text:
+            body["new_text"] = new_text
+        if resolution_note:
+            body["resolution_note"] = resolution_note
+        return self._request(
+            "POST", f"/v1/conflicts/{conflict_id}/resolve", body,
+        )
+
+    def relate(
+        self,
+        entity: str,
+        target: str,
+        relationship: str,
+        *,
+        weight: float | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "entity": entity,
+            "target": target,
+            "relationship": relationship,
+        }
+        if weight is not None:
+            body["weight"] = float(weight)
+        return self._request("POST", "/v1/relate", body)
+
+    def stats(self) -> dict[str, Any]:
+        return self._request("GET", "/v1/stats")
+
+    def close(self) -> None:
+        try:
+            self._session.close()
+        except Exception as e:  # pragma: no cover
+            logger.debug("Session close failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+def _parse_response(resp: Response) -> dict[str, Any]:
+    status = resp.status_code
+    if status in (401, 403):
+        raise YantrikDBAuthError(f"{status}: {_safe_error_text(resp)}")
+    if status in (429, 503):
+        raise YantrikDBTransientError(f"{status}: {_safe_error_text(resp)}")
+    if 400 <= status < 500:
+        raise YantrikDBClientError(f"{status}: {_safe_error_text(resp)}")
+    if status >= 500:
+        raise YantrikDBServerError(f"{status}: {_safe_error_text(resp)}")
+
+    if not resp.content:
+        return {}
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"raw": resp.text}
+    return data if isinstance(data, dict) else {"data": data}
+
+
+def _safe_error_text(resp: Response) -> str:
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    if isinstance(data, dict) and "error" in data:
+        return str(data["error"])[:500]
+    text = (resp.text or "").strip()
+    return text[:500] if text else f"HTTP {resp.status_code}"
+
+
+__all__ = [
+    "DEFAULT_MAX_TEXT_LEN",
+    "DEFAULT_NAMESPACE",
+    "DEFAULT_RETRY_TOTAL",
+    "DEFAULT_TOP_K",
+    "DEFAULT_URL",
+    "YantrikDBAuthError",
+    "YantrikDBClient",
+    "YantrikDBClientError",
+    "YantrikDBConfig",
+    "YantrikDBError",
+    "YantrikDBServerError",
+    "YantrikDBTransientError",
+    "truncate_text",
+]

--- a/plugins/memory/yantrikdb/client.py
+++ b/plugins/memory/yantrikdb/client.py
@@ -54,22 +54,50 @@ _USER_AGENT = "hermes-yantrikdb-plugin/0.1"
 
 @dataclass
 class YantrikDBConfig:
+    # Backend selector — "embedded" (default in v0.2.0+) or "http"
+    mode: str = "embedded"
+    # HTTP-only fields
     url: str = DEFAULT_URL
     token: str = ""
-    namespace: str = DEFAULT_NAMESPACE
-    top_k: int = DEFAULT_TOP_K
     connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
     read_timeout: float = DEFAULT_READ_TIMEOUT
     retry_total: int = DEFAULT_RETRY_TOTAL
+    # Embedded-only fields
+    db_path: str = ""               # default $HERMES_HOME/yantrikdb-memory.db
+    embedder_name: str = ""         # bundled potion-2M when empty; "potion-base-8M" / "potion-base-32M" for tier 2/3
+    embedder_class: str = ""        # dotted python path "pkg.module.Class" — instantiated and passed to db.set_embedder(); for custom embedders
+    embedder_model2vec: str = ""    # HF model id for built-in Model2VecEmbedder loader (v0.4.2+); dim auto-probed
+    embedder_huggingface: str = ""  # HF model id for built-in SentenceTransformerEmbedder loader (v0.4.2+); dim auto-probed
+    embedding_dim: int = 0          # output dim; required for embedder_name and embedder_class paths, ignored for the two auto-probe paths above (bundled potion-2M is dim=64)
+    # Shared fields
+    namespace: str = DEFAULT_NAMESPACE
+    top_k: int = DEFAULT_TOP_K
     max_text_len: int = DEFAULT_MAX_TEXT_LEN
     auto_think_on_session_end: bool = True
     sync_user_messages: bool = True
+    # v0.3.0+ skills surface — opt-in. Disabled by default so adding the
+    # plugin to an existing Hermes install doesn't change the tool schema
+    # the model sees. Users enable explicitly when they want the agentic
+    # skill loop (define / search / outcome). When disabled, the three
+    # skill schemas are hidden from get_tool_schemas() and any direct
+    # call to a skill tool short-circuits with a clear error.
+    skills_enabled: bool = False
 
     @classmethod
     def from_env(cls) -> YantrikDBConfig:
         return cls(
+            mode=os.environ.get("YANTRIKDB_MODE", "embedded").strip().lower(),
             url=os.environ.get("YANTRIKDB_URL", DEFAULT_URL).rstrip("/"),
             token=os.environ.get("YANTRIKDB_TOKEN", ""),
+            db_path=os.environ.get("YANTRIKDB_DB_PATH", ""),
+            embedder_name=os.environ.get("YANTRIKDB_EMBEDDER", ""),
+            embedder_class=os.environ.get("YANTRIKDB_EMBEDDER_CLASS", ""),
+            embedder_model2vec=os.environ.get("YANTRIKDB_EMBEDDER_MODEL2VEC", ""),
+            embedder_huggingface=os.environ.get("YANTRIKDB_EMBEDDER_HF", ""),
+            embedding_dim=_parse_int(os.environ.get("YANTRIKDB_EMBEDDING_DIM"), 0),
+            skills_enabled=_parse_bool(
+                os.environ.get("YANTRIKDB_SKILLS_ENABLED"), default=False,
+            ),
             namespace=os.environ.get("YANTRIKDB_NAMESPACE", DEFAULT_NAMESPACE),
             top_k=_parse_int(os.environ.get("YANTRIKDB_TOP_K"), DEFAULT_TOP_K),
             connect_timeout=_parse_float(
@@ -104,8 +132,9 @@ class YantrikDBConfig:
             return cfg
         if not isinstance(overrides, dict):
             return cfg
-        int_fields = {"top_k", "retry_total", "max_text_len"}
+        int_fields = {"top_k", "retry_total", "max_text_len", "embedding_dim"}
         float_fields = {"connect_timeout", "read_timeout"}
+        bool_fields = {"skills_enabled", "auto_think_on_session_end", "sync_user_messages"}
         for key, val in overrides.items():
             if val in (None, ""):
                 continue
@@ -117,6 +146,8 @@ class YantrikDBConfig:
                 setattr(cfg, key, _parse_int(val, getattr(cfg, key)))
             elif key in float_fields:
                 setattr(cfg, key, _parse_float(val, getattr(cfg, key)))
+            elif key in bool_fields:
+                setattr(cfg, key, _parse_bool(val, default=getattr(cfg, key)))
             else:
                 setattr(cfg, key, val)
         return cfg
@@ -127,6 +158,25 @@ def _parse_int(raw: Any, default: int) -> int:
         return int(raw)
     except (TypeError, ValueError):
         return default
+
+
+def _parse_bool(raw: Any, *, default: bool) -> bool:
+    """Parse a bool from env var or JSON string. Accepts the usual truthy/falsy spellings.
+
+    Truthy:  "1", "true", "yes", "on", "enabled"
+    Falsy:   "0", "false", "no", "off", "disabled"
+    Anything else (or None) → ``default``.
+    """
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    s = str(raw).strip().lower()
+    if s in ("1", "true", "yes", "on", "enabled"):
+        return True
+    if s in ("0", "false", "no", "off", "disabled"):
+        return False
+    return default
 
 
 def _parse_float(raw: Any, default: float) -> float:
@@ -400,6 +450,70 @@ class YantrikDBClient:
 
     def stats(self) -> dict[str, Any]:
         return self._request("GET", "/v1/stats")
+
+    # -- Skills (v0.3.0+) ---------------------------------------------
+    #
+    # The HTTP path delegates to yantrikdb-server's wrapper endpoints,
+    # which handle schema validation server-side. The plugin still
+    # validates client-side via embedded.validate_skill_define_args
+    # before calling — defense in depth, and gives users early errors
+    # without a network round-trip on simple shape mistakes.
+
+    def skill_search(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+        applies_to: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "query": query,
+            "top_k": int(top_k or self.config.top_k),
+        }
+        if applies_to:
+            body["applies_to"] = applies_to
+        return self._request("POST", "/v1/skills/search", body)
+
+    def skill_define(
+        self,
+        skill_id: str,
+        body: str,
+        skill_type: str,
+        applies_to: list[str],
+        *,
+        triggers: list[str] | None = None,
+        on_conflict: str = "reject",
+        version: str | None = None,
+        supersedes_skill_id: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "skill_id": skill_id,
+            "body": body,
+            "skill_type": skill_type,
+            "applies_to": list(applies_to),
+            "on_conflict": on_conflict,
+        }
+        if triggers:
+            payload["triggers"] = list(triggers)
+        if version:
+            payload["version"] = version
+        if supersedes_skill_id:
+            payload["supersedes_skill_id"] = supersedes_skill_id
+        return self._request("POST", "/v1/skills/define", payload)
+
+    def skill_outcome(
+        self,
+        skill_id: str,
+        succeeded: bool,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"succeeded": bool(succeeded)}
+        if note:
+            payload["note"] = note
+        return self._request(
+            "POST", f"/v1/skills/{skill_id}/outcome", payload,
+        )
 
     def close(self) -> None:
         try:

--- a/plugins/memory/yantrikdb/embedded.py
+++ b/plugins/memory/yantrikdb/embedded.py
@@ -1,0 +1,620 @@
+"""In-process YantrikDB backend via the bundled embedded engine.
+
+Mirrors ``YantrikDBClient``'s 8-method surface so the provider can use
+either backend interchangeably. The embedded path uses ``yantrikdb >=
+0.7.4`` which ships a default Rust-native embedder (potion-base-2M,
+~8 MB, dim=64) — users get semantic recall via ``pip install`` alone:
+no separate server, no token, no GPU, no network.
+
+Lifecycle / threading model (per yantrikdb-core guidance):
+- Construct ONCE at plugin init. ``YantrikDB.with_default(...)`` opens
+  SQLite, spawns internal materializer + compactor threads, and lazy-
+  loads the bundled model on first encode (~tens of ms cold).
+- The pyo3 wrapper holds ``Arc<YantrikDB>`` internally; concurrent
+  ``record_text`` / ``recall_text`` calls from any thread are safe.
+- ``set_embedder_named()`` (v0.7.5+) requires exclusive Arc access —
+  call it once right after construction, before any other code takes
+  a ref to the handle.
+- Don't call ``close()`` unless tearing down the plugin entirely;
+  let the GC handle the last drop.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from . import (
+    embedders as _embedders_mod,  # noqa: F401 — register submodule for test patching; heavy deps inside the loader classes remain lazy
+)
+from .client import (
+    YantrikDBClientError,
+    YantrikDBConfig,
+    YantrikDBError,
+    YantrikDBServerError,
+    truncate_text,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Skill schema validation (v0.3.0+)
+#
+# Reproduces yantrikdb-server's wrapper-layer checks client-side so the
+# plugin can write skills in embedded mode (no server in front) without
+# corrupting the shared `skill_substrate` convention. Rules per
+# yantrikdb-server's RFC 022 / saga decision 2026-05-01:
+#
+#   skill_id     ^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$  length 4..200
+#   body         length 50..5000
+#   applies_to   non-empty list (<=10), each ^[a-z][a-z0-9_]*$
+#   skill_type   {procedure, reference, lesson, pattern, rule}
+#
+# The applies_to entry regex is LOAD-BEARING per yantrikdb-server's
+# May-9 review — anyone naturally writing "applies-to"-style hyphenated
+# tags would corrupt the substrate convention. Hyphens MUST be rejected.
+# ---------------------------------------------------------------------------
+
+_SKILL_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$")
+_APPLIES_TO_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_SKILL_TYPES = frozenset({"procedure", "reference", "lesson", "pattern", "rule"})
+
+_SKILL_BODY_MIN = 50
+_SKILL_BODY_MAX = 5000
+_SKILL_ID_MIN = 4
+_SKILL_ID_MAX = 200
+_APPLIES_TO_MAX = 10
+
+SKILL_NAMESPACE = "skill_substrate"
+OUTCOME_NAMESPACE = "outcome_substrate"
+
+
+def validate_skill_define_args(
+    skill_id: str,
+    body: str,
+    skill_type: str,
+    applies_to: list[str],
+) -> None:
+    """Raise ``YantrikDBClientError`` if any field violates the wrapper schema.
+
+    Mirrors yantrikdb-server's `/v1/skills/define` validation. Errors are
+    surfaced as 4xx-equivalents (don't trip the breaker; they're
+    deterministic caller mistakes).
+    """
+    # skill_id
+    if not isinstance(skill_id, str):
+        raise YantrikDBClientError("skill_id must be a string")
+    if not (_SKILL_ID_MIN <= len(skill_id) <= _SKILL_ID_MAX):
+        raise YantrikDBClientError(
+            f"skill_id length must be {_SKILL_ID_MIN}..{_SKILL_ID_MAX} chars; got {len(skill_id)}"
+        )
+    if not _SKILL_ID_RE.fullmatch(skill_id):
+        raise YantrikDBClientError(
+            f"skill_id {skill_id!r} must match {_SKILL_ID_RE.pattern} "
+            "(lowercase, dot-separated segments; e.g. 'workflow.git.commit_clean')"
+        )
+
+    # body
+    if not isinstance(body, str):
+        raise YantrikDBClientError("body must be a string")
+    if not (_SKILL_BODY_MIN <= len(body) <= _SKILL_BODY_MAX):
+        raise YantrikDBClientError(
+            f"body length must be {_SKILL_BODY_MIN}..{_SKILL_BODY_MAX} chars; got {len(body)}"
+        )
+
+    # skill_type
+    if skill_type not in _SKILL_TYPES:
+        raise YantrikDBClientError(
+            f"skill_type {skill_type!r} not in {sorted(_SKILL_TYPES)}"
+        )
+
+    # applies_to — load-bearing regex (hyphen-vs-underscore drift)
+    if not isinstance(applies_to, list) or not applies_to:
+        raise YantrikDBClientError(
+            "applies_to must be a non-empty list of identifiers"
+        )
+    if len(applies_to) > _APPLIES_TO_MAX:
+        raise YantrikDBClientError(
+            f"applies_to may contain at most {_APPLIES_TO_MAX} entries; got {len(applies_to)}"
+        )
+    for entry in applies_to:
+        if not isinstance(entry, str) or not _APPLIES_TO_RE.fullmatch(entry):
+            raise YantrikDBClientError(
+                f"applies_to entry {entry!r} must match {_APPLIES_TO_RE.pattern} "
+                "(lowercase + digits + underscores ONLY — no hyphens, no dots, no spaces)"
+            )
+
+
+def _default_db_path() -> str:
+    """Resolve where to put the SQLite file when YANTRIKDB_DB_PATH is empty.
+
+    Prefer ``$HERMES_HOME/yantrikdb-memory.db`` if Hermes is importable,
+    fall back to ``~/.yantrikdb-hermes-memory.db`` for standalone use.
+    """
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return str(get_hermes_home() / "yantrikdb-memory.db")
+    except ImportError:
+        return str(Path.home() / ".yantrikdb-hermes-memory.db")
+
+
+class EmbeddedYantrikDBClient:
+    """Adapter wrapping ``yantrikdb._yantrikdb_rust.YantrikDB`` to the
+    same surface as ``YantrikDBClient`` (HTTP).
+
+    Translates engine return shapes (bare strings / lists / bools) into
+    the dict envelopes the provider's dispatch code expects, so
+    ``handle_tool_call`` works against either backend without branching.
+    """
+
+    def __init__(self, config: YantrikDBConfig) -> None:
+        self.config = config
+
+        try:
+            from yantrikdb._yantrikdb_rust import YantrikDB
+        except ImportError as e:
+            raise YantrikDBError(
+                "embedded mode requires `yantrikdb >= 0.7.4`. "
+                "Install with: pip install --upgrade yantrikdb"
+            ) from e
+
+        db_path = config.db_path or _default_db_path()
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        # Embedder selection — five paths, evaluated in order:
+        #   1. YANTRIKDB_EMBEDDER_CLASS (most flexible escape hatch)
+        #      → import dotted class, instantiate, set_embedder(instance).
+        #        Requires YANTRIKDB_EMBEDDING_DIM (user knows their model).
+        #   2. YANTRIKDB_EMBEDDER_MODEL2VEC (built-in model2vec loader, v0.4.2+)
+        #      → Model2VecEmbedder(model_name); dim auto-probed.
+        #        Install: pip install 'yantrikdb-hermes-plugin[model2vec]'.
+        #   3. YANTRIKDB_EMBEDDER_HF (built-in sentence-transformers loader, v0.4.2+)
+        #      → SentenceTransformerEmbedder(model_name); dim auto-probed.
+        #        Install: pip install 'yantrikdb-hermes-plugin[sentence-transformers]'.
+        #   4. YANTRIKDB_EMBEDDER (bundled-named download via engine)
+        #      → set_embedder_named(name); requires YANTRIKDB_EMBEDDING_DIM.
+        #   5. Default: with_default() → bundled potion-base-2M (dim=64).
+        #
+        # The precedence ordering is: more-specific user intent wins. A user
+        # who set _CLASS clearly wants that exact class; a user who set
+        # _MODEL2VEC/_HF picked a specific HF model; _EMBEDDER is the
+        # bundled-download named variant; default is for users who set
+        # nothing at all.
+        #
+        # set_embedder* requires exclusive Arc access on the engine — call
+        # ONCE immediately after construction, before _db is shared.
+        custom_class = (config.embedder_class or "").strip()
+        model2vec_name = (config.embedder_model2vec or "").strip()
+        hf_name = (config.embedder_huggingface or "").strip()
+        named = (config.embedder_name or "").strip()
+
+        # Resolve which path to take + materialise the embedder instance
+        # (where applicable) BEFORE constructing YantrikDB, so the
+        # builtin-loader paths can pass the probed dim into the ctor.
+        # `instance` is the embedder object for paths 1/2/3; None for
+        # path 4 (named, engine handles internally) and path 5 (default).
+        instance: Any = None
+        path_label: str = ""           # for log lines
+        resolved_dim: int = 0          # 0 means "use with_default" or "trust user-set"
+
+        if custom_class:
+            # Path 1 — custom class via dotted import.
+            if config.embedding_dim <= 0:
+                raise YantrikDBError(
+                    "YANTRIKDB_EMBEDDING_DIM must be a positive int when "
+                    "YANTRIKDB_EMBEDDER_CLASS is set. The plugin can't probe "
+                    "an arbitrary class's dim ahead of construction. Use the "
+                    "embedder's output dim (e.g. 384 for all-MiniLM-L6-v2, "
+                    "768 for all-mpnet-base-v2)."
+                )
+            try:
+                import importlib
+                mod_path, _, cls_name = custom_class.rpartition(".")
+                if not mod_path or not cls_name:
+                    raise YantrikDBError(
+                        f"YANTRIKDB_EMBEDDER_CLASS={custom_class!r} must be a "
+                        "dotted import path 'module.submodule.ClassName'."
+                    )
+                mod = importlib.import_module(mod_path)
+                cls = getattr(mod, cls_name, None)
+                if cls is None:
+                    raise YantrikDBError(
+                        f"class {cls_name!r} not found in module {mod_path!r}"
+                    )
+                instance = cls()
+            except YantrikDBError:
+                raise
+            except Exception as e:
+                raise YantrikDBError(
+                    f"failed to import / instantiate YANTRIKDB_EMBEDDER_CLASS="
+                    f"{custom_class!r}: {e}",
+                ) from e
+            if not callable(getattr(instance, "encode", None)):
+                raise YantrikDBError(
+                    f"YANTRIKDB_EMBEDDER_CLASS={custom_class!r}: instance has "
+                    "no callable .encode() method. The engine expects an object "
+                    "with `.encode(text: str) -> list[float]`."
+                )
+            resolved_dim = int(config.embedding_dim)
+            path_label = f"class={custom_class}"
+        elif model2vec_name:
+            # Path 2 — built-in model2vec loader; dim auto-probed.
+            from .embedders import Model2VecEmbedder
+            instance = Model2VecEmbedder(model2vec_name)
+            resolved_dim = instance.embedding_dim
+            path_label = f"model2vec={model2vec_name}"
+        elif hf_name:
+            # Path 3 — built-in sentence-transformers loader; dim auto-probed.
+            from .embedders import SentenceTransformerEmbedder
+            instance = SentenceTransformerEmbedder(hf_name)
+            resolved_dim = instance.embedding_dim
+            path_label = f"hf={hf_name}"
+        elif named:
+            # Path 4 — bundled-named via engine; dim required.
+            if config.embedding_dim <= 0:
+                raise YantrikDBError(
+                    "YANTRIKDB_EMBEDDING_DIM must be a positive int when "
+                    "YANTRIKDB_EMBEDDER is set. Use the named embedder's "
+                    "output dim (e.g. 256 for potion-base-8M, 512 for "
+                    "potion-base-32M)."
+                )
+            resolved_dim = int(config.embedding_dim)
+            path_label = f"named={named}"
+        # else: path 5 — default, no explicit ctor
+
+        # Construct the engine
+        if not custom_class and not model2vec_name and not hf_name and not named:
+            # Path 5 — default
+            try:
+                self._db = YantrikDB.with_default(db_path)
+            except Exception as e:
+                raise YantrikDBServerError(
+                    f"failed to open YantrikDB at {db_path}: {e}",
+                ) from e
+        else:
+            try:
+                self._db = YantrikDB(db_path, embedding_dim=resolved_dim)
+            except Exception as e:
+                raise YantrikDBServerError(
+                    f"failed to open YantrikDB at {db_path}: {e}",
+                ) from e
+
+        # Attach embedder (paths 1/2/3 share set_embedder; path 4 uses
+        # set_embedder_named; path 5 already attached inside with_default).
+        if instance is not None:
+            try:
+                self._db.set_embedder(instance)
+                logger.info(
+                    "YantrikDB embedded: attached embedder %s (dim=%d)",
+                    path_label, resolved_dim,
+                )
+            except Exception as e:
+                raise YantrikDBServerError(
+                    f"set_embedder({path_label}) failed: {e}",
+                ) from e
+        elif named:
+            try:
+                self._db.set_embedder_named(named)
+                logger.info(
+                    "YantrikDB embedded: attached bundled embedder %s (dim=%d)",
+                    named, resolved_dim,
+                )
+            except Exception as e:
+                raise YantrikDBServerError(
+                    f"set_embedder_named({named!r}) failed — most likely "
+                    "the model name isn't a known bundled-download variant "
+                    f"in this yantrikdb version, or the dim mismatches: {e}",
+                ) from e
+
+        if not self._db.has_embedder():
+            raise YantrikDBError(
+                "YantrikDB embedder not configured. The default `pip install "
+                "yantrikdb` ships the bundled embedder; slim builds "
+                "(--no-default-features) require an explicit embedder."
+            )
+
+        logger.info(
+            "YantrikDB embedded backend ready: db=%s namespace=%s",
+            db_path, config.namespace,
+        )
+
+    # -- Operational --------------------------------------------------
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "engine": "embedded",
+            "embedder_attached": bool(self._db.has_embedder()),
+        }
+
+    # -- Memory ops ---------------------------------------------------
+
+    def remember(
+        self,
+        text: str,
+        *,
+        namespace: str | None = None,
+        importance: float = 0.6,
+        domain: str | None = None,
+        memory_type: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        safe_text = truncate_text(text, self.config.max_text_len)
+        rid = self._db.record_text(
+            safe_text,
+            memory_type=memory_type or "semantic",
+            importance=float(importance),
+            namespace=namespace or self.config.namespace,
+            domain=domain or "general",
+            metadata=metadata,
+        )
+        return {"rid": rid}
+
+    def recall(
+        self,
+        query: str,
+        *,
+        namespace: str | None = None,
+        top_k: int | None = None,
+        memory_type: str | None = None,
+        domain: str | None = None,
+    ) -> dict[str, Any]:
+        results = self._db.recall(
+            query=query,
+            top_k=int(top_k or self.config.top_k),
+            namespace=namespace or self.config.namespace,
+            domain=domain,
+            memory_type=memory_type,
+        )
+        items = list(results) if results else []
+        return {"results": items, "total": len(items)}
+
+    def forget(self, rid: str) -> dict[str, Any]:
+        try:
+            found = bool(self._db.forget(rid))
+        except Exception as e:
+            # Engine raises on bad rid format; map to client error so
+            # provider's 4xx handling kicks in (no breaker trip).
+            raise YantrikDBClientError(f"forget failed: {e}") from e
+        return {"rid": rid, "found": found}
+
+    # -- Maintenance --------------------------------------------------
+
+    def think(
+        self,
+        *,
+        run_consolidation: bool = True,
+        run_conflict_scan: bool = True,
+        run_pattern_mining: bool = False,
+        run_personality: bool = False,
+        consolidation_limit: int | None = None,
+    ) -> dict[str, Any]:
+        cfg: dict[str, Any] = {
+            "run_consolidation": run_consolidation,
+            "run_conflict_scan": run_conflict_scan,
+            "run_pattern_mining": run_pattern_mining,
+            "run_personality": run_personality,
+        }
+        if consolidation_limit is not None:
+            cfg["consolidation_limit"] = int(consolidation_limit)
+        out = self._db.think(cfg)
+        return out if isinstance(out, dict) else {}
+
+    def conflicts(self) -> dict[str, Any]:
+        out = self._db.get_conflicts(namespace=self.config.namespace)
+        items = list(out) if out else []
+        return {"conflicts": items}
+
+    def resolve_conflict(
+        self,
+        conflict_id: str,
+        *,
+        strategy: str,
+        winner_rid: str | None = None,
+        new_text: str | None = None,
+        resolution_note: str | None = None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "conflict_id": conflict_id,
+            "strategy": strategy,
+        }
+        if winner_rid:
+            kwargs["winner_rid"] = winner_rid
+        if new_text:
+            kwargs["new_text"] = new_text
+        if resolution_note:
+            kwargs["resolution_note"] = resolution_note
+        out = self._db.resolve_conflict(**kwargs)
+        if isinstance(out, dict):
+            return out
+        return {"conflict_id": conflict_id, "strategy": strategy}
+
+    # -- Graph --------------------------------------------------------
+
+    def relate(
+        self,
+        entity: str,
+        target: str,
+        relationship: str,
+        *,
+        weight: float | None = None,
+    ) -> dict[str, Any]:
+        edge_id = self._db.relate(
+            entity, target,
+            rel_type=relationship,
+            weight=float(weight) if weight is not None else 1.0,
+        )
+        return {"edge_id": edge_id}
+
+    # -- Stats --------------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        out = self._db.stats(namespace=self.config.namespace)
+        return out if isinstance(out, dict) else {}
+
+    # -- Skills (v0.3.0+) ---------------------------------------------
+    #
+    # Skills live in the shared ``skill_substrate`` namespace alongside
+    # other consumers (Lane B SDK, server handlers, WisePick). Hermes-
+    # authored skills are tagged with ``metadata.source=hermes`` so any
+    # downstream consumer can filter Hermes-authored skills in or out
+    # of their searches. Outcomes go to ``outcome_substrate`` as an
+    # append-only event log; consumers compute their own success metrics.
+
+    def skill_search(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+        applies_to: str | None = None,
+    ) -> dict[str, Any]:
+        # Prefer the keyword-only namespace filter on `recall_text` (engine
+        # v0.7.7+); fall back to the lower-level `recall` for older wheels
+        # so users who haven't upgraded yet still get a working read path.
+        try:
+            results = self._db.recall_text(
+                query, top_k=int(top_k or self.config.top_k),
+                namespace=SKILL_NAMESPACE,
+            )
+        except TypeError:
+            # Pre-0.7.7 wheel: recall_text didn't accept `namespace`.
+            results = self._db.recall(
+                query=query,
+                top_k=int(top_k or self.config.top_k),
+                namespace=SKILL_NAMESPACE,
+            )
+        items: list[dict[str, Any]] = list(results) if results else []
+        # Optional client-side post-filter on applies_to — server's
+        # /v1/skills/search does the same as a post-filter pattern.
+        if applies_to:
+            items = [
+                r for r in items
+                if applies_to in (r.get("metadata", {}) or {}).get("applies_to", [])
+            ]
+        return {"skills": items, "total": len(items)}
+
+    def skill_define(
+        self,
+        skill_id: str,
+        body: str,
+        skill_type: str,
+        applies_to: list[str],
+        *,
+        triggers: list[str] | None = None,
+        on_conflict: str = "reject",
+        version: str | None = None,
+        supersedes_skill_id: str | None = None,
+    ) -> dict[str, Any]:
+        # Reproduce server-side schema validation client-side. These
+        # raise YantrikDBClientError so the provider's 4xx handling
+        # surfaces them without tripping the breaker.
+        validate_skill_define_args(skill_id, body, skill_type, applies_to)
+
+        # Best-effort uniqueness check. In embedded mode there's a
+        # TOCTOU window between this lookup and the record_text below,
+        # but single-agent embedded use is non-racy in practice. The
+        # constraint difference (server: 409 transactional; embedded:
+        # last-write-wins) is documented in the v0.3.0 changelog.
+        if on_conflict == "reject":
+            existing = self._db.recall(
+                query=skill_id, top_k=5, namespace=SKILL_NAMESPACE,
+            )
+            for hit in (existing or []):
+                meta = hit.get("metadata", {}) or {}
+                if meta.get("skill_id") == skill_id:
+                    raise YantrikDBClientError(
+                        f"skill {skill_id!r} already exists "
+                        "(on_conflict='reject'); use on_conflict='replace' or pick a new skill_id"
+                    )
+
+        metadata: dict[str, Any] = {
+            "record_type": "skill",
+            "skill_id": skill_id,
+            "skill_type": skill_type,
+            "applies_to": list(applies_to),
+            "source": "hermes",
+        }
+        if triggers:
+            metadata["triggers"] = list(triggers)
+        if version:
+            metadata["version"] = version
+        if supersedes_skill_id:
+            metadata["supersedes_skill_id"] = supersedes_skill_id
+
+        rid = self._db.record_text(
+            body,
+            memory_type="procedural",
+            namespace=SKILL_NAMESPACE,
+            domain="skill",
+            metadata=metadata,
+        )
+        return {"rid": rid, "skill_id": skill_id, "stored": True}
+
+    def skill_outcome(
+        self,
+        skill_id: str,
+        succeeded: bool,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        # Append-only event log. NO auto-rollup of success_count on the
+        # parent skill record — agent-layer pedagogy decision per
+        # yantrikdb-server's "schema not semantics" rule (matches the
+        # WisePick pattern).
+        body_parts = [
+            f"outcome: skill={skill_id} succeeded={succeeded}",
+        ]
+        if note:
+            body_parts.append(f"note: {note}")
+        body = "\n".join(body_parts)
+
+        metadata: dict[str, Any] = {
+            "record_type": "skill_outcome",
+            "skill_id": skill_id,
+            "succeeded": bool(succeeded),
+            "source": "hermes",
+        }
+        if note:
+            metadata["note"] = note
+
+        rid = self._db.record_text(
+            body,
+            memory_type="episodic",
+            namespace=OUTCOME_NAMESPACE,
+            domain="skill_outcome",
+            metadata=metadata,
+        )
+        return {"rid": rid, "skill_id": skill_id, "recorded": True}
+
+    # -- Lifecycle ----------------------------------------------------
+
+    def close(self) -> None:
+        # Per upstream guidance: don't close unless the plugin is being
+        # torn down entirely; let GC handle the final drop. Calling
+        # close() while concurrent threads still hold refs raises.
+        logger.debug("EmbeddedYantrikDBClient.close() — no-op (GC manages handle)")
+
+
+def make_backend(config: YantrikDBConfig) -> Any:
+    """Factory: return either ``YantrikDBClient`` (HTTP) or
+    ``EmbeddedYantrikDBClient`` based on ``config.mode``.
+
+    Both expose the same 8-method surface so the provider's dispatch
+    code stays unchanged.
+    """
+    mode = (config.mode or "embedded").strip().lower()
+    if mode == "embedded":
+        return EmbeddedYantrikDBClient(config)
+    if mode == "http":
+        from .client import YantrikDBClient
+        return YantrikDBClient(config)
+    raise YantrikDBError(
+        f"unknown YANTRIKDB_MODE={mode!r}. Use 'embedded' or 'http'."
+    )
+
+
+__all__ = ["EmbeddedYantrikDBClient", "make_backend"]

--- a/plugins/memory/yantrikdb/embedders.py
+++ b/plugins/memory/yantrikdb/embedders.py
@@ -1,0 +1,188 @@
+"""Built-in embedder wrappers for the embedded backend.
+
+v0.4.2 adds two first-class loaders so users don't have to write a thin
+wrapper class for the two most common embedder families:
+
+  * :class:`Model2VecEmbedder` — wraps ``model2vec.StaticModel`` for the
+    lightweight static-embedding family (``minishlab/potion-base-*M``,
+    ``minishlab/potion-multilingual-128M``, etc.). Fast, no torch dep.
+  * :class:`SentenceTransformerEmbedder` — wraps
+    ``sentence_transformers.SentenceTransformer`` for the broader HF
+    ecosystem (``all-MiniLM-L6-v2``, ``paraphrase-multilingual-MiniLM-L12-v2``,
+    ``all-mpnet-base-v2``, etc.).
+
+Both pick up their heavy dependency lazily (imported inside ``__init__``)
+so this module can be imported without either package installed — the
+loader only fails when a user actually configures that path. Both also
+probe the output dim once on construction (calling
+``.encode("__yantrikdb_probe__")`` and using ``len()`` of the result) so
+the plugin can pass the right ``embedding_dim`` to ``YantrikDB(...)``
+without the user having to set ``YANTRIKDB_EMBEDDING_DIM`` for the
+builtin paths.
+
+Both wrappers expose ``.encode(text: str) -> list[float]`` — the engine's
+:py:meth:`set_embedder` contract — and have a public ``.embedding_dim``
+attribute so :mod:`.embedded` can read the probed dim back out.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .client import YantrikDBError
+
+logger = logging.getLogger(__name__)
+
+_PROBE_TEXT = "__yantrikdb_probe__"
+
+
+def _coerce_to_float_list(vec: Any, *, model_name: str, family: str) -> list[float]:
+    """Normalise the embedder's encode() return into ``list[float]``.
+
+    Different libraries return numpy arrays, torch tensors, or plain
+    lists. The engine's ``set_embedder`` expects a Python ``list[float]``
+    (per the pyo3 binding). We accept any 1-D sequence-like and convert.
+    """
+    # numpy ndarray / torch tensor / list / tuple — all support tolist() or iter
+    out = vec.tolist() if hasattr(vec, "tolist") else list(vec)
+    # Some libs return a 2-D batch even when called with a single string;
+    # flatten one level if needed.
+    if out and isinstance(out[0], list):
+        out = out[0]
+    try:
+        return [float(x) for x in out]
+    except (TypeError, ValueError) as e:
+        raise YantrikDBError(
+            f"{family} loader for {model_name!r} returned a non-numeric vector "
+            f"from .encode(): {type(vec).__name__}. Cannot use as embedder."
+        ) from e
+
+
+class Model2VecEmbedder:
+    """Wraps ``model2vec.StaticModel`` for use with ``YantrikDB.set_embedder``.
+
+    Constructs the underlying ``StaticModel.from_pretrained(model_name)``
+    once. Subsequent ``.encode(text)`` calls reuse the loaded model.
+
+    The output dim is probed once at construction time and exposed as
+    :attr:`embedding_dim` so the plugin can pass it to ``YantrikDB(...)``.
+    """
+
+    def __init__(self, model_name: str) -> None:
+        try:
+            from model2vec import StaticModel  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise YantrikDBError(
+                "YANTRIKDB_EMBEDDER_MODEL2VEC requires the `model2vec` package. "
+                "Install with: pip install 'yantrikdb-hermes-plugin[model2vec]' "
+                "  (or: pip install model2vec)"
+            ) from e
+        self.model_name = model_name
+        try:
+            self._model = StaticModel.from_pretrained(model_name)
+        except Exception as e:
+            raise YantrikDBError(
+                f"model2vec failed to load model {model_name!r}: {e}. "
+                "Check the model name on Hugging Face and that you have "
+                "network access on first run (subsequent runs use the HF cache)."
+            ) from e
+        # Probe dim once — guarantees the loader is healthy before we
+        # hand it to the engine and lets us infer the right embedding_dim.
+        probe = _coerce_to_float_list(
+            self._model.encode([_PROBE_TEXT])[0],
+            model_name=model_name, family="model2vec",
+        )
+        self.embedding_dim = len(probe)
+        if self.embedding_dim <= 0:
+            raise YantrikDBError(
+                f"model2vec {model_name!r} probed to an empty vector. "
+                "This is almost certainly a broken model load."
+            )
+        logger.info(
+            "Model2VecEmbedder loaded: %s (dim=%d)",
+            model_name, self.embedding_dim,
+        )
+
+    def encode(self, text: str) -> list[float]:
+        # StaticModel.encode accepts a single string or a list; calling
+        # with a list always returns a 2-D ndarray, calling with a string
+        # is version-dependent. The list form is the stable contract.
+        out = self._model.encode([text])
+        # out is shape (1, dim); take the first row.
+        row = out[0] if hasattr(out, "__len__") and len(out) else out
+        return _coerce_to_float_list(row, model_name=self.model_name, family="model2vec")
+
+
+class SentenceTransformerEmbedder:
+    """Wraps ``sentence_transformers.SentenceTransformer`` for use with
+    ``YantrikDB.set_embedder``.
+
+    Pulls in PyTorch transitively. Heavier than :class:`Model2VecEmbedder`
+    but covers the broader HF embedder ecosystem. Output dim is probed
+    once at construction.
+    """
+
+    def __init__(self, model_name: str) -> None:
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise YantrikDBError(
+                "YANTRIKDB_EMBEDDER_HF requires the `sentence-transformers` "
+                "package. Install with: "
+                "pip install 'yantrikdb-hermes-plugin[sentence-transformers]' "
+                "  (or: pip install sentence-transformers)"
+            ) from e
+        self.model_name = model_name
+        try:
+            self._model = SentenceTransformer(model_name)
+        except Exception as e:
+            raise YantrikDBError(
+                f"sentence-transformers failed to load model {model_name!r}: {e}. "
+                "Check the model name on Hugging Face and that you have "
+                "network access on first run (subsequent runs use the HF cache)."
+            ) from e
+        # Prefer the model's declared dim if available — saves an encode
+        # call and matches what HF says rather than relying on probe.
+        declared = getattr(self._model, "get_sentence_embedding_dimension", None)
+        if callable(declared):
+            try:
+                self.embedding_dim = int(declared())
+            except Exception:
+                self.embedding_dim = 0
+        else:
+            self.embedding_dim = 0
+        # Always probe — confirms the loader actually works before we
+        # hand it to the engine and as a fallback when declared dim isn't
+        # available.
+        probe = _coerce_to_float_list(
+            self._model.encode(_PROBE_TEXT),
+            model_name=model_name, family="sentence-transformers",
+        )
+        probed = len(probe)
+        if self.embedding_dim and self.embedding_dim != probed:
+            logger.warning(
+                "sentence-transformers %s: declared dim=%d but probe returned %d; "
+                "using probed value.",
+                model_name, self.embedding_dim, probed,
+            )
+        self.embedding_dim = probed
+        if self.embedding_dim <= 0:
+            raise YantrikDBError(
+                f"sentence-transformers {model_name!r} probed to an empty vector."
+            )
+        logger.info(
+            "SentenceTransformerEmbedder loaded: %s (dim=%d)",
+            model_name, self.embedding_dim,
+        )
+
+    def encode(self, text: str) -> list[float]:
+        # SentenceTransformer.encode with a single string returns a 1-D
+        # ndarray of shape (dim,). With a list it returns 2-D.
+        vec = self._model.encode(text)
+        return _coerce_to_float_list(
+            vec, model_name=self.model_name, family="sentence-transformers",
+        )
+
+
+__all__ = ["Model2VecEmbedder", "SentenceTransformerEmbedder"]

--- a/plugins/memory/yantrikdb/plugin.yaml
+++ b/plugins/memory/yantrikdb/plugin.yaml
@@ -1,0 +1,9 @@
+name: yantrikdb
+version: 0.1.0
+description: "YantrikDB — cognitive memory with consolidation, contradiction detection, temporal decay, and a knowledge graph. Self-hosted Rust backend; the plugin connects to a user-managed server over HTTP."
+pip_dependencies:
+  - requests>=2.31
+hooks:
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write

--- a/plugins/memory/yantrikdb/plugin.yaml
+++ b/plugins/memory/yantrikdb/plugin.yaml
@@ -1,7 +1,8 @@
 name: yantrikdb
-version: 0.1.0
-description: "YantrikDB — cognitive memory with consolidation, contradiction detection, temporal decay, and a knowledge graph. Self-hosted Rust backend; the plugin connects to a user-managed server over HTTP."
+version: 0.4.2
+description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
+  - yantrikdb>=0.7.6
   - requests>=2.31
 hooks:
   - on_session_end


### PR DESCRIPTION
Adds a `plugins/memory/yantrikdb/` memory provider. Resolves the discussion in #9975.

## What it is

YantrikDB is a self-hosted cognitive memory backend (Rust, HTTP REST, port 7438, optional HA cluster). Unlike append-only vector stores, it *maintains* what it stores:

- **`think()`** runs a bounded maintenance pass — canonicalizes near-duplicates, flags superseded / contradictory facts, optionally mines co-occurrence patterns. Returns structured counts plus server-suggested follow-up triggers.
- **Recall is explainable.** Every result carries a `why_retrieved` reason list (`semantic_match`, `graph-connected via X`, `important (decay=0.91)`, `keyword_match`, …) so the agent can audit ranking.
- **Contradictions surface explicitly.** `conflicts()` lists unresolved claims; the agent closes each via `resolve_conflict(strategy=keep_winner | merge | keep_both | dismiss)` — no silent last-write-wins.
- **Knowledge-graph edges** (`relate(entity, target, relationship)`) boost recall across related entities.

That niche — memory *hygiene* — isn't emphasized by the existing plugins, which is why it seemed worth adding.

## Shape

Follows the `honcho` pattern (user runs their own backend, plugin is a thin HTTP client). Two files:

| File | Size | Role |
|---|---|---|
| `__init__.py` | ~650 lines | `YantrikDBMemoryProvider` + 8 tool schemas + 3 optional hooks + circuit breaker + tool dispatch |
| `client.py` | ~400 lines | HTTP wrapper, typed errors, config resolution, bounded retries, request-id logging, text truncation |
| `plugin.yaml` | | Declares hooks + `requests>=2.31` (already in Hermes core) |
| `README.md` / `ARCHITECTURE.md` / `CHANGELOG.md` / `SECURITY.md` | | User docs + operational docs. Happy to slim if preferred. |

**Eight tools**: `yantrikdb_remember`, `_recall`, `_forget`, `_think`, `_conflicts`, `_resolve_conflict`, `_relate`, `_stats`.

**Three hooks**: `on_session_end` (conservative auto-consolidation — no pattern mining, no personality), `on_pre_compress` (seeds recall from the about-to-be-compressed tail so insights survive compression), `on_memory_write` (mirrors `MEMORY.md` / `USER.md` additions).

**Config**: env vars + `$HERMES_HOME/yantrikdb.json` overlay, same pattern as mem0. Namespace is `{YANTRIKDB_NAMESPACE}:{agent_workspace}:{agent_identity}` so cross-session consolidation works per-identity without cross-identity pollution. `get_config_schema()` + `save_config()` wired into `hermes memory setup`.

**Resilience**: typed error taxonomy (`Auth`/`Client`/`Transient`/`Server`), circuit breaker (5 consecutive transient/server/auth failures → 120 s cooldown; 4xx deterministic errors do *not* trip it — copy of mem0's policy), urllib3 retries on 5xx, per-request `req_id` + latency at DEBUG for log correlation.

## Verification

- 95 unit tests in the external repo covering request formation, error taxonomy, provider contract, hook semantics, circuit breaker, text truncation. All mocked, no network.
- 2 live integration tests (skipped unless env vars set) against a real `yantrikdb-server`.
- **End-to-end live-verified inside an unmodified Hermes 0.9.0 install** — full transcripts at <https://github.com/yantrikos/yantrikdb-hermes-plugin/blob/main/VERIFICATION.md>. Captured real DeepSeek-driven agent sessions calling `yantrikdb_remember` × 3 + `yantrikdb_stats` + `yantrikdb_recall` with the `why_retrieved` reasons coming back through the tool response verbatim.

The live run caught one bug 95 unit tests missed: `get_tool_schemas()` was guarded by `self._client is None`, returning `[]` before `initialize()` ran. Hermes' `MemoryManager._register_provider` calls `get_tool_schemas()` to index tool-name → provider *at register time*, strictly before `initialize()` — so the guard made every `yantrikdb_*` call resolve as "Unknown tool". Fixed, regression-tested. Thought it worth calling out — might be a useful note for anyone else writing a provider.

## License boundary

`yantrikdb-server` is AGPL-3.0. The plugin code in this PR is MIT (matching Hermes). The plugin only *talks to* the server over HTTP — does not embed, statically link, or redistribute any YantrikDB code. Same model as any MIT client that talks to an AGPL service (e.g. MIT web client → AGPL database). Flagging here to preempt confusion.

## Questions / preferences

The issue (#9975) has six open design questions — happy to adjust any of the following based on preference:

1. **Tool surface.** 8 tools feels right to me, but I can drop `_stats` (operational info the agent rarely uses in-session) or `_relate` to tighten to 6.
2. **Hook aggressiveness.** `on_session_end` auto-calling `think()` — happy to make this opt-in via config if too eager by default.
3. **Circuit breaker policy.** Copied mem0's 5/120 s; happy to tune.
4. **Doc layout.** 4 markdown files inside the plugin folder might be more than you want. Happy to collapse to just `README.md` if preferred.
5. **Splittable.** If this PR is too large, happy to split into skeleton-first (just ABC impl + 3 core tools) then hooks + differentiator tools as follow-ups.

A standalone repo with the same code is live at <https://github.com/yantrikos/yantrikdb-hermes-plugin> so users can drop-in install it while this PR waits in the queue; I'll keep that mirrored with whatever direction this PR takes.

Thanks for taking a look.
