### PR TITLE
fix: remove excessive markdown escaping in Feishu text element rendering

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -367,7 +367,11 @@ def _render_text_element(element: Dict[str, Any]) -> str:
     if _is_style_enabled(style_dict, "code"):
         return _wrap_inline_code(text)
 
-    rendered = _escape_markdown_text(text)
+    # Feishu rich text elements provide raw text + separate style metadata.
+    # Do NOT escape the text before applying style wrappers — Feishu already
+    # separates content from formatting, and escaping breaks markdown rendering
+    # when the text is sent back through a post message with tag=md.
+    rendered = text
     if not rendered:
         return ""
     if _is_style_enabled(style_dict, "bold"):


### PR DESCRIPTION
## Summary
Feishu/Lark messages were poorly formatted because the `\_escape_markdown_text` function escaped every Markdown special character, breaking rendering when content was sent through post messages with `tag=md`.

## Root Cause
In `\_render_text_element()`, all text was passed through `\_escape_markdown_text()` before style wrappers were applied. Feishu's rich text elements already separate content from formatting metadata — escaping the raw text before wrapping it with style markers caused double-escaping that broke Markdown rendering.

## Fix
Removed the `\_escape_markdown_text()` call in `\_render_text_element()`. Feishu rich text provides raw text + separate style metadata, so the text should be used directly without pre-escaping. Style wrappers (bold, italic, etc.) are applied on top of the raw text.

## Test Plan
- [ ] Send formatted messages (bold, italic, code) to Feishu — should render correctly
- [ ] Send code blocks to Feishu — should render properly
- [ ] Verify inbound rich text parsing still works for styled messages

Closes NousResearch/hermes-agent#9816