### PR TITLE
[codex] fix Copilot runtime base URL and gpt-5-mini routing

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1162,6 +1162,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             if token:
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
                 active_sources.add(source_name)
+                pconfig = PROVIDER_REGISTRY.get(provider)
                 changed |= _upsert_entry(
                     entries,
                     provider,
@@ -1170,6 +1171,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "source": source_name,
                         "auth_type": AUTH_TYPE_API_KEY,
                         "access_token": token,
+                        "base_url": pconfig.inference_base_url if pconfig else "",
                         "label": source,
                     },
                 )

--- a/run_agent.py
+++ b/run_agent.py
@@ -705,12 +705,13 @@ class AIAgent:
         except Exception:
             pass
 
-        # GPT-5.x models require the Responses API path — they are rejected
-        # on /v1/chat/completions by both OpenAI and OpenRouter.  Also
-        # auto-upgrade for direct OpenAI URLs (api.openai.com) since all
-        # newer tool-calling models prefer Responses there.
-        # ACP runtimes are excluded: CopilotACPClient handles its own
-        # routing and does not implement the Responses API surface.
+        # GPT-5.x models usually require the Responses API path, but some
+        # providers have exceptions (for example Copilot's gpt-5-mini still
+        # uses chat completions). Also auto-upgrade for direct OpenAI URLs
+        # (api.openai.com) since all newer tool-calling models prefer
+        # Responses there. ACP runtimes are excluded: CopilotACPClient
+        # handles its own routing and does not implement the Responses API
+        # surface.
         if (
             self.api_mode == "chat_completions"
             and self.provider != "copilot-acp"
@@ -718,7 +719,10 @@ class AIAgent:
             and not str(self.base_url or "").lower().startswith("acp+tcp://")
             and (
                 self._is_direct_openai_url()
-                or self._model_requires_responses_api(self.model)
+                or self._provider_model_requires_responses_api(
+                    self.model,
+                    provider=self.provider,
+                )
             )
         ):
             self.api_mode = "codex_responses"
@@ -1910,6 +1914,24 @@ class AIAgent:
         if "/" in m:
             m = m.rsplit("/", 1)[-1]
         return m.startswith("gpt-5")
+
+    @staticmethod
+    def _provider_model_requires_responses_api(
+        model: str,
+        *,
+        provider: Optional[str] = None,
+    ) -> bool:
+        """Return True when this provider/model pair should use Responses API."""
+        normalized_provider = (provider or "").strip().lower()
+        if normalized_provider == "copilot":
+            try:
+                from hermes_cli.models import _should_use_copilot_responses_api
+                return _should_use_copilot_responses_api(model)
+            except Exception:
+                # Fall back to the generic GPT-5 rule if Copilot-specific
+                # logic is unavailable for any reason.
+                pass
+        return AIAgent._model_requires_responses_api(model)
 
     def _max_tokens_param(self, value: int) -> dict:
         """Return the correct max tokens kwarg for the current provider.
@@ -5633,9 +5655,13 @@ class AIAgent:
                 fb_api_mode = "anthropic_messages"
             elif self._is_direct_openai_url(fb_base_url):
                 fb_api_mode = "codex_responses"
-            elif self._model_requires_responses_api(fb_model):
-                # GPT-5.x models need Responses API on every provider
-                # (OpenRouter, Copilot, direct OpenAI, etc.)
+            elif self._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
                 fb_api_mode = "codex_responses"
 
             old_model = self.model

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1091,6 +1091,7 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
     assert len(entries) == 1
     assert entries[0].source == "gh_cli"
     assert entries[0].access_token == "gho_fake_token_abc123"
+    assert entries[0].base_url == "https://api.githubcopilot.com"
 
 
 def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -259,6 +259,23 @@ def test_copilot_acp_stays_on_chat_completions_for_gpt_5_models(monkeypatch):
     assert agent.api_mode == "chat_completions"
 
 
+def test_copilot_gpt_5_mini_stays_on_chat_completions(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5-mini",
+        base_url="https://api.githubcopilot.com",
+        provider="copilot",
+        api_key="gh-token",
+        api_mode="chat_completions",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "copilot"
+    assert agent.api_mode == "chat_completions"
+
+
 def test_build_api_kwargs_codex(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = agent._build_api_kwargs(


### PR DESCRIPTION
## What does this PR do?

Fixes two GitHub Copilot runtime regressions that showed up during local validation.

First, when Hermes seeded Copilot credentials from `gh auth token`, the synthesized credential-pool entry did not carry a base URL. That let runtime provider resolution return a valid Copilot token with an empty `base_url`, which surfaced as the generic "Provider resolver returned an empty base URL" error.

Second, Hermes had a generic GPT-5 override in `run_agent.py` that forced all `gpt-5*` models onto the Responses API path. That is correct for many providers, but not for Copilot's `gpt-5-mini`, which is the exception and should stay on chat completions. This patch makes the Responses API upgrade provider-aware in both the main path and fallback path.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve the default Copilot base URL when `_seed_from_singletons()` creates a Copilot pool entry from `gh auth token` in `agent/credential_pool.py`
- Replace the blunt GPT-5 Responses API override in `run_agent.py` with a provider-aware check so Copilot keeps `gpt-5-mini` on chat completions
- Apply the same provider-aware routing rule in the fallback provider reroute path in `run_agent.py`
- Extend the existing Copilot credential-pool test to assert the seeded base URL in `tests/agent/test_credential_pool.py`
- Add a regression test covering direct Copilot `gpt-5-mini` initialization staying on chat completions in `tests/run_agent/test_run_agent_codex_responses.py`

## How to Test

1. Configure Hermes to use GitHub Copilot with a valid `gh auth token` and verify runtime provider resolution no longer returns an empty Copilot base URL.
2. Start Hermes with Copilot `gpt-5-mini` and verify it stays on chat completions instead of being forced onto the Responses API path.
3. Run the focused regression tests:
   `python -m pytest tests/agent/test_credential_pool.py -q -k copilot`
   `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests passed:

- `python -m pytest tests/agent/test_credential_pool.py -q -k copilot`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`

Full suite result on this checkout:

- `python -m pytest tests/ -q -n 5`
- `19 failed, 11548 passed, 34 skipped, 10 errors`

The full-suite failures were not triaged as part of this PR and include unrelated failures in Discord gateway reply-mode tests, CLI init tests, browser tests, Tirith tests, plugin skill tests, and a Copilot auto-provider selection test.
