### PR TITLE
fix(batch_runner): add discarded prompts to completed set on resume

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -444,6 +444,7 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
             if not reasoning.get("has_any_reasoning", True):
                 print(f"   🚫 Prompt {prompt_index} discarded (no reasoning in any turn)")
                 discarded_no_reasoning += 1
+                completed_in_batch.append(prompt_index)
                 continue
             
             # Get and normalize tool stats for consistent schema across all entries


### PR DESCRIPTION
## Summary

Fixes a bug where prompts discarded for having no reasoning (`has_any_reasoning=False`) were not added to `completed_in_batch`, causing `--resume` to retry them indefinitely.

## What changed

In `_process_batch_worker()`, when a prompt is discarded due to zero reasoning across all turns, we now append its `prompt_index` to `completed_in_batch` before continuing. This ensures the checkpoint records the prompt as dispositioned and `resume` will not re-run it.

## Related issue

Fixes #9950

## Testing

- Verified Python syntax with `py_compile`
- Wrote a standalone regression test confirming the discarded prompt is now included in `completed_prompts`

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Minimal, focused change
- [x] Verified with standalone test logic