### PR TITLE
fix(mcp): handle asyncio.CancelledError in reconnect loop on Python 3.11+

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1062,6 +1062,11 @@ class MCPServerTask:
                     await self._run_stdio(config)
                 # Normal exit (shutdown requested) -- break out
                 break
+            except asyncio.CancelledError:
+                # Task was cancelled — expected during shutdown/cancel.
+                # Do NOT treat as a connection failure.
+                self.session = None
+                return
             except Exception as exc:
                 self.session = None
 


### PR DESCRIPTION
## Summary

Fixes a bug where `asyncio.CancelledError` was not caught in `MCPServerTask.run()`'s reconnect loop on Python 3.11+, causing the loop to abort silently when the gateway restarted.

## Root cause

In Python 3.11+, `asyncio.CancelledError` inherits from `BaseException` instead of `Exception`. The reconnect loop only caught `Exception`, so task cancellation during gateway restart escaped the handler and killed the reconnection logic.

## What changed

Added an explicit `except asyncio.CancelledError` block before `except Exception` in the reconnect loop. When cancelled, it clears `self.session` and returns cleanly without treating it as a connection failure. This mirrors the pattern already used in the shutdown handler.

## Related issue

Fixes #9930

## Testing

- Verified Python syntax with `py_compile`
- Logic aligns with existing `CancelledError` handling in the shutdown handler