### PR TITLE
fix(memory_manager): load schemas before mutating state in add_provider()

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -104,12 +104,18 @@ class MemoryManager:
                     provider.name, existing,
                 )
                 return
+
+        # Load schemas before mutating state so a failure doesn't leave
+        # the manager half-registered.
+        schemas = list(provider.get_tool_schemas())
+
+        if not is_builtin:
             self._has_external = True
 
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -125,7 +131,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property


### PR DESCRIPTION
## Summary

Fixes a bug where `MemoryManager.add_provider()` could leave a failed external provider half-registered, blocking all future external providers.

## Root cause

`add_provider()` set `_has_external = True` and appended the provider to `_providers` **before** calling `provider.get_tool_schemas()`. If `get_tool_schemas()` raised an exception, the manager was left in a poisoned state: the failed provider remained in `_providers` and subsequent external providers were rejected.

## What changed

1. Load and cache `provider.get_tool_schemas()` **before** mutating any internal state.
2. Only set `_has_external = True` and append to `_providers` after schemas load successfully.
3. Cache the schema list as `list(...)` so the logger doesn't accidentally consume a generator a second time.

## Related issue

Fixes #9948

## Testing

- Verified Python syntax with `py_compile`
- Logic validated with a standalone regression test confirming that a failed `get_tool_schemas()` no longer leaves the manager in a half-registered state.