### PR TITLE
fix(gateway): prevent /btw from interrupting running agent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2606,6 +2606,14 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
+            # /btw must bypass the running-agent guard — it spawns its own
+            # ephemeral agent in a background task and should never interrupt
+            # the active conversation.  Without this bypass, sending /btw
+            # while the agent is running triggers running_agent.interrupt()
+            # on line 2640, killing the in-progress response.  (#btw-interrupt)
+            if _cmd_def_inner and _cmd_def_inner.name == "btw":
+                return await self._handle_btw_command(event)
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)


### PR DESCRIPTION
## Problem

When an agent is actively processing a request, sending `/btw` (with or without arguments) triggers `running_agent.interrupt()`, killing the in-progress response and producing `(No response generated)`.

### Reproduction

1. Start a conversation that takes several seconds (e.g., ask a question that triggers tool calls)
2. While the agent is running, send `/btw` with no arguments
3. The active agent is interrupted and returns empty → user sees `(No response generated)`

### Root Cause

In `_handle_message()`, the running-agent priority handling section (line ~2521) has explicit bypasses for `/background`, `/stop`, `/new`, `/reset`, `/approve`, `/deny`, `/queue`, `/model`, and photo messages. `/btw` is missing from this list, so it falls through to line 2640 `running_agent.interrupt(event.text)`.

`/btw` already spawns its own ephemeral background agent via `asyncio.create_task()`, so it never needs to interrupt the main agent.

## Fix

Add `/btw` to the running-agent guard bypass list (alongside `/background`) so it routes directly to `_handle_btw_command()` without interrupting the active conversation.

## Changes

- `gateway/run.py`: Add 8-line bypass block for `/btw` in the running-agent priority section