### PR TITLE
fix(run-agent): normalize tool_call_id before matching results

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3290,11 +3290,18 @@ class AIAgent:
     # =========================================================================
 
     @staticmethod
+    def _normalize_tool_call_id(value: Any) -> str:
+        """Normalize tool-call IDs from providers before comparing them."""
+        return value.strip() if isinstance(value, str) else ""
+
+    @staticmethod
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("id", "") or ""
-        return getattr(tc, "id", "") or ""
+            raw = tc.get("id", "") or ""
+        else:
+            raw = getattr(tc, "id", "") or ""
+        return AIAgent._normalize_tool_call_id(raw)
 
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
@@ -3330,7 +3337,7 @@ class AIAgent:
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = AIAgent._normalize_tool_call_id(msg.get("tool_call_id"))
                 if cid:
                     result_call_ids.add(cid)
 
@@ -3339,7 +3346,10 @@ class AIAgent:
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (
+                    m.get("role") == "tool"
+                    and AIAgent._normalize_tool_call_id(m.get("tool_call_id")) in orphaned_results
+                )
             ]
             logger.debug(
                 "Pre-call sanitizer: removed %d orphaned tool result(s)",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1005,6 +1005,17 @@ class TestBuildAssistantMessage:
         assert len(result["tool_calls"]) == 1
         assert result["tool_calls"][0]["function"]["name"] == "web_search"
 
+    def test_with_tool_calls_strips_whitespace_from_ids(self, agent):
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments='{"q":"test"}',
+            call_id=" functions.web_search:24 ",
+        )
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        result = agent._build_assistant_message(msg, "tool_calls")
+        assert result["tool_calls"][0]["id"] == "functions.web_search:24"
+        assert result["tool_calls"][0]["call_id"] == "functions.web_search:24"
+
     def test_with_reasoning_details(self, agent):
         details = [{"type": "reasoning.summary", "text": "step1", "signature": "sig1"}]
         msg = _mock_assistant_msg(content="ans", reasoning_details=details)
@@ -1042,6 +1053,49 @@ class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
         agent.tools = []
         assert agent._format_tools_for_system_message() == "[]"
+
+
+class TestSanitizeApiMessages:
+    def test_preserves_tool_result_when_tool_call_id_has_leading_space(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "functions.cronjob:24",
+                        "function": {"name": "cronjob", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": " functions.cronjob:24",
+                "content": '{"success": true}',
+            },
+        ]
+
+        result = AIAgent._sanitize_api_messages(messages)
+
+        assert len(result) == 2
+        assert result[1]["role"] == "tool"
+        assert result[1]["content"] == '{"success": true}'
+        assert result[1]["tool_call_id"] == " functions.cronjob:24"
+
+    def test_strips_orphaned_tool_result_even_when_id_has_whitespace(self):
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "tool",
+                "tool_call_id": " tc_orphan ",
+                "content": "stale result",
+            },
+            {"role": "user", "content": "Thanks"},
+        ]
+
+        result = AIAgent._sanitize_api_messages(messages)
+
+        assert [msg["role"] for msg in result] == ["user", "user"]
 
     def test_formats_single_tool(self, agent):
         agent.tools = _make_tool_defs("web_search")


### PR DESCRIPTION
## What does this PR do?

Fixes a `run_agent.py` bug where Hermes can replace a real tool result with `[Result unavailable — see context summary above]` if the persisted `tool_call_id` has surrounding whitespace.

The root cause is inconsistent normalization:

- assistant-side tool call IDs are already trimmed in `_build_assistant_message()`
- `_sanitize_api_messages()` was still comparing raw tool-result `tool_call_id` values

That makes these two IDs fail to match even though they are semantically the same:

- `functions.cronjob:24`
- ` functions.cronjob:24`

This PR normalizes `tool_call_id` values before comparing them during the pre-call sanitizer pass.

## Related Issue

Fixes #9999

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - add `AIAgent._normalize_tool_call_id()`
  - normalize assistant/tool call IDs in `_get_tool_call_id_static()`
  - normalize tool-result IDs before building `result_call_ids`
  - normalize tool-result IDs when stripping orphaned tool messages
- `tests/run_agent/test_run_agent.py`
  - add regression test that preserves a valid tool result when `tool_call_id` has leading whitespace
  - add regression test that still strips an orphaned tool result when `tool_call_id` has surrounding whitespace
  - add regression coverage showing `_build_assistant_message()` trims tool call IDs

## How to Test

1. Run:
   ```bash
   uv run pytest tests/run_agent/test_run_agent.py -q -o addopts='' -k 'tool_calls_strips_whitespace or preserves_tool_result_when_tool_call_id_has_leading_space or strips_orphaned_tool_result_even_when_id_has_whitespace'
   ```
2. Confirm all 3 targeted tests pass.
3. Optionally reproduce with a saved session containing:
   - assistant tool call id: `functions.cronjob:24`
   - tool result id: ` functions.cronjob:24`
   and verify Hermes no longer injects the `Result unavailable` stub for that pair.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Python 3.12 via `uv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification:

```text
3 passed, 250 deselected, 1 warning in 7.94s
```

Local full-suite run status:

```text
47 failed, 11321 passed, 95 skipped, 163 warnings, 60 errors in 149.37s
```

The full `pytest tests/ -q` run does not currently pass in my local environment, so that checklist item is intentionally left unchecked.
