### PR TITLE
fix(dingtalk): accept oapi.dingtalk.com webhook domain for stream mode reply routing

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
-_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
+_DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 
 
 def check_dingtalk_requirements() -> bool:


### PR DESCRIPTION
## Summary

- DingTalk Stream SDK returns `sessionWebhook` URLs using `oapi.dingtalk.com` domain, but the SSRF validation regex only accepted `api.dingtalk.com`, causing all reply routing via session webhooks to silently fail in stream mode
- Updated regex to accept both `api.dingtalk.com` and `oapi.dingtalk.com` domains

## Test plan

- [ ] Verify regex matches both `https://api.dingtalk.com/...` and `https://oapi.dingtalk.com/...`
- [ ] Verify regex rejects non-DingTalk domains (SSRF protection intact)
- [ ] Test DingTalk stream mode end-to-end: bot receives messages and replies successfully via `oapi.dingtalk.com` session webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)