### PR TITLE
fix: mark discarded no-reasoning prompts completed on resume

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -444,6 +444,7 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
             if not reasoning.get("has_any_reasoning", True):
                 print(f"   🚫 Prompt {prompt_index} discarded (no reasoning in any turn)")
                 discarded_no_reasoning += 1
+                completed_in_batch.append(prompt_index)
                 continue
             
             # Get and normalize tool stats for consistent schema across all entries

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -12,7 +12,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from batch_runner import BatchRunner
+from batch_runner import BatchRunner, _process_batch_worker
 
 
 @pytest.fixture
@@ -157,3 +157,32 @@ class TestResumePreservesProgress:
 
         assert checkpoint_data["completed_prompts"] == []
         assert checkpoint_data["run_name"] == "test_run"
+
+
+class TestBatchWorkerResumeBehavior:
+    def test_discarded_no_reasoning_prompts_are_marked_completed(self, tmp_path, monkeypatch):
+        batch_file = tmp_path / "batch_1.jsonl"
+        prompt_result = {
+            "success": True,
+            "trajectory": [{"role": "assistant", "content": "x"}],
+            "reasoning_stats": {"has_any_reasoning": False},
+            "tool_stats": {},
+            "metadata": {},
+            "completed": True,
+            "api_calls": 1,
+            "toolsets_used": [],
+        }
+
+        monkeypatch.setattr("batch_runner._process_single_prompt", lambda *args, **kwargs: prompt_result)
+
+        result = _process_batch_worker((
+            1,
+            [(0, {"prompt": "hi"})],
+            tmp_path,
+            set(),
+            {"verbose": False},
+        ))
+
+        assert result["discarded_no_reasoning"] == 1
+        assert result["completed_prompts"] == [0]
+        assert not batch_file.exists() or batch_file.read_text() == ""


### PR DESCRIPTION
## Summary
- mark prompts discarded for missing reasoning as completed in batch checkpoints
- prevent `--resume` from re-running prompts that were intentionally discarded
- add a regression test covering the worker return value used by checkpoint updates

## Test Plan
- `uv run --extra dev python -m pytest tests/test_batch_runner_checkpoint.py -q`
- `uv run --extra dev --extra web python -m pytest tests/test_batch_runner_checkpoint.py::TestBatchWorkerResumeBehavior::test_discarded_no_reasoning_prompts_are_marked_completed tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status -q`

Closes #9950