### PR TITLE
fix: codex_responses prompt caching — session routing headers + cache_write_tokens field

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -451,7 +451,9 @@ def normalize_usage(
         details = getattr(response_usage, "input_tokens_details", None)
         cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            (getattr(details, "cache_write_tokens", 0)
+             or getattr(details, "cache_creation_tokens", 0))
+            if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1070,6 +1070,20 @@ class AIAgent:
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
         
+        # Codex Responses API: inject session routing headers so the
+        # upstream provider can route requests to the same server that
+        # holds the cached prompt prefix.  Without these, prompt_cache_key
+        # in the request body is useless.
+        if self.api_mode == "codex_responses" and self.session_id:
+            _codex_headers = self._client_kwargs.get("default_headers") or {}
+            _codex_headers["session_id"] = self.session_id
+            _codex_headers["x-client-request-id"] = self.session_id
+            self._client_kwargs["default_headers"] = _codex_headers
+            if self.client:
+                self.client = self._create_openai_client(
+                    self._client_kwargs, reason="codex_session_headers", shared=True,
+                )
+
         # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
         hermes_home = get_hermes_home()
         self.logs_dir = hermes_home / "sessions"
@@ -4645,6 +4659,14 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         else:
             self._client_kwargs.pop("default_headers", None)
+
+        # Codex Responses API: preserve session routing headers after
+        # /model switch so prompt caching continues to work.
+        if self.api_mode == "codex_responses" and getattr(self, "session_id", None):
+            headers = self._client_kwargs.get("default_headers") or {}
+            headers["session_id"] = self.session_id
+            headers["x-client-request-id"] = self.session_id
+            self._client_kwargs["default_headers"] = headers
 
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -101,6 +101,42 @@ def test_estimate_usage_cost_refuses_cache_pricing_without_official_cache_rate(m
     assert result.status == "unknown"
 
 
+def test_codex_responses_reads_cache_write_tokens_field():
+    """codex_responses returns cache_write_tokens, not cache_creation_tokens."""
+    usage = SimpleNamespace(
+        input_tokens=5000,
+        output_tokens=800,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=2000,
+            cache_write_tokens=1500,
+        ),
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
+
+    assert normalized.cache_read_tokens == 2000
+    assert normalized.cache_write_tokens == 1500
+    assert normalized.input_tokens == 1500  # 5000 - 2000 - 1500
+    assert normalized.output_tokens == 800
+
+
+def test_codex_responses_falls_back_to_cache_creation_tokens():
+    """Backward compat: if a provider returns cache_creation_tokens, still works."""
+    usage = SimpleNamespace(
+        input_tokens=3000,
+        output_tokens=400,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=1000,
+            cache_creation_tokens=500,
+        ),
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 500
+    assert normalized.input_tokens == 1500  # 3000 - 1000 - 500
+
+
 def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_endpoint_model_metadata",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -548,6 +548,25 @@ class TestInit:
             )
             assert a.valid_tool_names == {"web_search", "terminal"}
 
+    def test_codex_responses_injects_session_routing_headers(self):
+        """codex_responses mode sets session_id header for cache routing."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        headers = a._client_kwargs.get("default_headers", {})
+        assert headers.get("session_id") == a.session_id
+        assert headers.get("x-client-request-id") == a.session_id
+
     def test_session_id_auto_generated(self):
         """Session ID should be auto-generated in YYYYMMDD_HHMMSS_<hex6> format."""
         with (


### PR DESCRIPTION
## Problem

Prompt caching does not work when using `codex_responses` API mode with OpenAI-compatible providers (e.g. theclawbay). Every request is a cache miss despite `prompt_cache_key` being set in the request body.

## Root cause

Two issues:

### 1. Missing session routing headers (`run_agent.py`)

The OpenAI client is initialized without `session_id` or `x-client-request-id` headers for codex providers. These headers are required for server-side cache routing — they tell the backend to route requests to the same server that holds the cached prompt prefix.

The official Codex CLI sends these unconditionally. Hermes sets `default_headers` for OpenRouter, GitHub Copilot, Kimi, and Qwen — but never for Codex/theclawbay.

### 2. Wrong field name for cache_write_tokens (`agent/usage_pricing.py`)

The `codex_responses` branch reads `cache_creation_tokens` (Anthropic naming convention) instead of `cache_write_tokens` (OpenAI Responses API naming). This means cache write tokens are always reported as 0.

## Fix

### Patch 1: Session routing headers

After `session_id` is assigned during `__init__`, inject `session_id` and `x-client-request-id` into `default_headers` for `codex_responses` mode. Also applied in `_apply_client_headers_for_base_url()` so headers survive `/model` switches.

### Patch 2: cache_write_tokens field

Read `cache_write_tokens` first (OpenAI naming), fall back to `cache_creation_tokens` for backward compatibility.

## Tests

- `test_codex_responses_reads_cache_write_tokens_field` — verifies correct field is read
- `test_codex_responses_falls_back_to_cache_creation_tokens` — backward compat
- `test_codex_responses_injects_session_routing_headers` — verifies headers are set

## Affected files

| File | Change |
|------|--------|
| `run_agent.py` | Inject session routing headers for `codex_responses` mode (+22 lines) |
| `agent/usage_pricing.py` | Read `cache_write_tokens` before `cache_creation_tokens` (+3/-1 lines) |
| `tests/agent/test_usage_pricing.py` | 2 new tests |
| `tests/run_agent/test_run_agent.py` | 1 new test |