### PR TITLE
fix(install): quote PYTHON_PATH in version checks to handle spaces on macOS

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -255,7 +255,7 @@ check_python() {
         if command -v python >/dev/null 2>&1; then
             PYTHON_PATH="$(command -v python)"
             if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
-                PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+                PYTHON_FOUND_VERSION="$($PYTHON_PATH --version 2>/dev/null)"
                 log_success "Python found: $PYTHON_FOUND_VERSION"
                 return 0
             fi
@@ -264,7 +264,7 @@ check_python() {
         log_info "Installing Python via pkg..."
         pkg install -y python >/dev/null
         PYTHON_PATH="$(command -v python)"
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION="$($PYTHON_PATH --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -275,7 +275,7 @@ check_python() {
     # First check if a suitable Python is already available
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION="$($PYTHON_PATH --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -284,7 +284,7 @@ check_python() {
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION="$($PYTHON_PATH --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"


### PR DESCRIPTION
## Summary
Wrap all `$PYTHON_FOUND_VERSION` assignments in double quotes to prevent word splitting when the Python path contains spaces (e.g. on macOS with uv-managed Python in `~/Library/Application Support/uv/...`).

## Root Cause
Lines 258, 267, 278, 287 used unquoted `$PYTHON_PATH --version`:
```bash
PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)   # broken
```
When `$PYTHON_PATH` contains a space, bash word-splits it and `set -e` silently aborts the install script.

## Fix
```bash
PYTHON_FOUND_VERSION="$($PYTHON_PATH --version 2>/dev/null)"  # correct
```

## Testing
- Verified on macOS with uv Python path containing spaces
- install.sh no longer aborts prematurely

Closes #10009
