### PR TITLE
fix: align zai model catalogs with live provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -139,7 +139,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-5v-turbo",
         "glm-5-turbo",
         "glm-4.7",
+        "glm-4.6",
         "glm-4.5",
+        "glm-4.5-air",
         "glm-4.5-flash",
     ],
     "xai": [

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -96,7 +96,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
         "gemma-4-31b-it", "gemma-4-26b-it",
     ],
-    "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.1", "glm-5", "glm-5-turbo", "glm-4.7", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "arcee": ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -6,7 +6,7 @@ from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     filter_nous_free_models, _NOUS_ALLOWED_FREE_MODELS,
     is_nous_free_tier, partition_nous_models_by_tier,
-    check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    check_nous_free_tier, _FREE_TIER_CACHE_TTL, provider_model_ids,
 )
 import hermes_cli.models as _models_mod
 
@@ -114,6 +114,16 @@ class TestFindOpenrouterSlug:
 
 
 class TestDetectProviderForModel:
+    def test_zai_provider_catalog_includes_current_zai_models(self):
+        models = provider_model_ids("zai")
+        assert "glm-5.1" in models
+        assert "glm-5" in models
+        assert "glm-5-turbo" in models
+        assert "glm-4.7" in models
+        assert "glm-4.6" in models
+        assert "glm-4.5" in models
+        assert "glm-4.5-air" in models
+
     def test_anthropic_model_detected(self):
         """claude-opus-4-6 should resolve to anthropic provider."""
         with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):


### PR DESCRIPTION
## Summary
- add missing live Z.AI models to the static provider catalog
- keep `hermes model` / setup menus aligned with the current Z.AI endpoint
- add a regression test covering the expected Z.AI provider model list

## Why
Live Z.AI account/model discovery currently exposes additional models beyond the older static picker lists, including `glm-4.6` and `glm-4.5-air`. Without updating the static catalogs, users can have working credentials for these models but still miss them in provider-specific menus and setup flows.

## Test Plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/ashsokke/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_models.py -q`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/ashsokke/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_setup_model_provider.py -q`
- [x] `hermes --profile default chat --provider zai -m glm-4.6 -q "Reply with exactly DEFAULT_GLM46_OK" --quiet`
- [x] `hermes --profile default chat --provider zai -m glm-4.5-air -q "Reply with exactly DEFAULT_GLM45AIR_OK" --quiet`
