### PR TITLE
feat(cli): set terminal tab title to "<persona>: <session title>"

### DIFF
--- a/acp_adapter/__main__.py
+++ b/acp_adapter/__main__.py
@@ -1,5 +1,12 @@
 """Allow running the ACP adapter as ``python -m acp_adapter``."""
 
+import os
+
+# ACP mode owns stdout for JSON-RPC and stderr for logs; the controlling editor
+# draws its own chrome. Suppress OSC-based tab-title emission from any code path
+# that would otherwise write escape sequences to the TTY.
+os.environ.setdefault("HERMES_DISABLE_TAB_TITLE", "1")
+
 from .entry import main
 
 main()

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -124,6 +124,19 @@ class ContextEngine(ABC):
         self.last_total_tokens = 0
         self.compression_count = 0
 
+    # -- Optional: per-turn context recall ---------------------------------
+
+    def prefetch(self, query: str, **kwargs) -> str:
+        """Return ephemeral context to inject into the current user turn.
+
+        This is called once per user turn before the tool-calling loop.
+        The returned text is injected at API-call time only and is NOT
+        persisted to the session transcript. Engines can use this to surface
+        domain-specific operating context without mutating the stable system
+        prompt or waiting for compression to fire.
+        """
+        return ""
+
     # -- Optional: tools ---------------------------------------------------
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -90,6 +90,16 @@ def auto_title_session(
         logger.debug("Auto-generated session title: %s", title)
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
+        return
+
+    # Refresh the terminal tab title so the new auto-generated title shows up
+    # immediately. No-op in non-CLI contexts (gateway, ACP, etc.) per the
+    # module's TTY / env guards.
+    try:
+        from hermes_cli.terminal_title import update_for_session
+        update_for_session(session_id)
+    except Exception:
+        pass
 
 
 def maybe_auto_title(

--- a/cli.py
+++ b/cli.py
@@ -2005,7 +2005,16 @@ class HermesCLI:
             timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
-        
+
+        # Terminal tab title: "<Persona>: <session title>" + OSC 7 cwd.
+        # Safe no-op on non-TTY / TERM=dumb / HERMES_DISABLE_TAB_TITLE=1.
+        try:
+            from hermes_cli.terminal_title import set_cwd, update_for_session
+            set_cwd()
+            update_for_session(self.session_id)
+        except Exception:
+            pass
+
         # History file for persistent input recall across sessions
         self._history_file = _hermes_home / ".hermes_history"
         self._last_invalidate: float = 0.0  # throttle UI repaints
@@ -3311,6 +3320,11 @@ class HermesCLI:
                 except (ValueError, Exception) as e:
                     _cprint(f"  Could not apply pending title: {e}")
                     self._pending_title = None
+            try:
+                from hermes_cli.terminal_title import update_for_session
+                update_for_session(self.session_id)
+            except Exception:
+                pass
             return True
         except Exception as e:
             ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
@@ -5942,6 +5956,11 @@ class HermesCLI:
                             try:
                                 if self._session_db.set_session_title(self.session_id, new_title):
                                     _cprint(f"  Session title set: {new_title}")
+                                    try:
+                                        from hermes_cli.terminal_title import update_for_session
+                                        update_for_session(self.session_id)
+                                    except Exception:
+                                        pass
                                 else:
                                     _cprint("  Session not found in database.")
                             except ValueError as e:

--- a/hermes_cli/terminal_title.py
+++ b/hermes_cli/terminal_title.py
@@ -1,0 +1,207 @@
+"""Emit OSC escape sequences so the terminal tab shows: "<persona>: <session title>".
+
+Drop this file in as ``hermes_cli/terminal_title.py`` in the Hermes Agent repo and
+wire it into the chat loop (see WIRING.md in this directory).
+
+Format emitted (OSC 0 — sets both window title and icon title):
+
+    ESC ] 0 ; <persona>: <session title> BEL
+
+Plus OSC 7 for working directory, which Warp / iTerm2 / Kitty / WezTerm use to
+display the cwd subtitle:
+
+    ESC ] 7 ; file://<host><abs-cwd> BEL
+
+No-ops gracefully when stderr/stdout aren't TTYs (pipes, captured output, ACP
+JSON-RPC mode), when ``TERM=dumb``, or when ``HERMES_DISABLE_TAB_TITLE=1``.
+"""
+from __future__ import annotations
+
+import atexit
+import os
+import re
+import socket
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.parse import quote
+
+# OSC framing. BEL terminator works everywhere; ST (\x1b\\) is the formal one.
+_OSC = "\x1b]"
+_BEL = "\x07"
+
+_MAX_TITLE_LEN = 120
+_DEFAULT_PERSONA = "Hermes"
+
+# Strip everything that could break the OSC frame or look like garbage in a tab.
+_UNSAFE = re.compile(r"[\x00-\x1f\x7f]")
+
+_prior_title_set = False  # whether we've stored anything to restore on exit
+
+
+# ---------------------------------------------------------------------------
+# Output channel
+# ---------------------------------------------------------------------------
+
+def _tty_stream():
+    """Return a writable TTY stream, or None if we shouldn't emit.
+
+    Prefers ``/dev/tty`` so the escape lands on the real terminal even when
+    stdout/stderr are redirected. Falls back to stderr if it's a tty.
+    """
+    if os.environ.get("HERMES_DISABLE_TAB_TITLE"):
+        return None
+    term = os.environ.get("TERM", "")
+    if term in ("", "dumb"):
+        return None
+    # /dev/tty is the controlling terminal regardless of stdio redirection.
+    try:
+        return open("/dev/tty", "w", buffering=1, encoding="utf-8")
+    except OSError:
+        pass
+    if sys.stderr.isatty():
+        return sys.stderr
+    return None
+
+
+def _write(seq: str) -> None:
+    stream = _tty_stream()
+    if stream is None:
+        return
+    try:
+        stream.write(seq)
+        stream.flush()
+    except Exception:
+        pass
+    finally:
+        # If we opened /dev/tty, close it; don't close stderr.
+        if stream is not sys.stderr:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sanitisation
+# ---------------------------------------------------------------------------
+
+def _clean(text: str, max_len: int = _MAX_TITLE_LEN) -> str:
+    if not text:
+        return ""
+    text = _UNSAFE.sub("", text).strip()
+    if len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "\u2026"  # …
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def set_tab_title(persona: Optional[str], session_title: Optional[str]) -> None:
+    """Set the terminal tab/window title to ``"<persona>: <session_title>"``.
+
+    Empty / missing values are tolerated. Called frequently; cheap and safe.
+    """
+    persona_clean = _clean(persona or _DEFAULT_PERSONA, max_len=40)
+    title_clean = _clean(session_title or "", max_len=_MAX_TITLE_LEN - len(persona_clean) - 2)
+
+    if title_clean:
+        full = f"{persona_clean}: {title_clean}"
+    else:
+        full = persona_clean
+
+    global _prior_title_set
+    _prior_title_set = True
+    # OSC 0 sets both window and icon title at once.
+    _write(f"{_OSC}0;{full}{_BEL}")
+
+
+def set_cwd(path: Optional[str | os.PathLike] = None) -> None:
+    """Emit OSC 7 so the terminal knows the current working directory."""
+    p = Path(path or os.getcwd()).resolve()
+    try:
+        host = socket.gethostname()
+    except Exception:
+        host = ""
+    # Path components must be percent-encoded (per RFC 3986); leave the slashes.
+    encoded = quote(str(p), safe="/")
+    _write(f"{_OSC}7;file://{host}{encoded}{_BEL}")
+
+
+def reset_tab_title() -> None:
+    """Clear our title; most terminals will fall back to the shell's default."""
+    if _prior_title_set:
+        _write(f"{_OSC}0;{_BEL}")
+
+
+# Restore on normal interpreter exit.
+atexit.register(reset_tab_title)
+
+
+# ---------------------------------------------------------------------------
+# Persona / title resolution helpers (callers can use or ignore)
+# ---------------------------------------------------------------------------
+
+_PERSONA_NAME_RX = re.compile(r"^\s*-?\s*Name\s*:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
+_PERSONA_HEADING_RX = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
+
+
+def resolve_persona_name(soul_path: Optional[Path] = None,
+                         config_value: Optional[str] = None) -> str:
+    """Best-effort persona name.
+
+    Resolution order:
+      1. Explicit ``config_value`` (caller-provided, e.g. ``agent.persona_name``).
+      2. ``Name: <X>`` line in SOUL.md.
+      3. First markdown ``# heading`` in SOUL.md.
+      4. ``"Hermes"`` fallback.
+    """
+    if config_value:
+        cleaned = _clean(config_value, max_len=40)
+        if cleaned:
+            return cleaned
+
+    if soul_path is None:
+        home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        soul_path = home / "SOUL.md"
+
+    try:
+        text = soul_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return _DEFAULT_PERSONA
+
+    m = _PERSONA_NAME_RX.search(text)
+    if m:
+        return _clean(m.group(1), max_len=40) or _DEFAULT_PERSONA
+
+    m = _PERSONA_HEADING_RX.search(text)
+    if m:
+        return _clean(m.group(1), max_len=40) or _DEFAULT_PERSONA
+
+    return _DEFAULT_PERSONA
+
+
+def resolve_session_title(session_id: str) -> Optional[str]:
+    """Look up the session title from the Hermes SQLite store, or return None."""
+    try:
+        from hermes_state import SessionDB  # type: ignore[import-not-found]
+        from hermes_constants import get_hermes_home  # type: ignore[import-not-found]
+    except Exception:
+        return None
+    try:
+        db = SessionDB(db_path=get_hermes_home() / "state.db")
+        return db.get_session_title(session_id)
+    except Exception:
+        return None
+
+
+# Convenience one-liner for callers that already know both.
+def update_for_session(session_id: str,
+                       persona_override: Optional[str] = None,
+                       title_override: Optional[str] = None) -> None:
+    """Resolve persona + title (with optional overrides) and emit."""
+    persona = persona_override or resolve_persona_name()
+    title = title_override or resolve_session_title(session_id) or ""
+    set_tab_title(persona, title)

--- a/plugins/context_engine/lifeos/__init__.py
+++ b/plugins/context_engine/lifeos/__init__.py
@@ -1,0 +1,949 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+from agent.context_compressor import ContextCompressor
+
+logger = logging.getLogger(__name__)
+
+_CONTEXT_HEADER = (
+    "[LIFEOS CONTEXT — REFERENCE ONLY] This is structured operating context from "
+    "Tony's LifeOS vault. Use it as current background context. Prefer the latest "
+    "user request if anything conflicts."
+)
+
+_PRIORITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+_STATUS_RANK = {"active": 0, "waiting": 1, "someday": 2, "done": 9}
+
+
+@dataclass
+class VaultNote:
+    path: Path
+    title: str
+    body: str
+    frontmatter: Dict[str, Any] = field(default_factory=dict)
+    aliases: List[str] = field(default_factory=list)
+
+    @property
+    def stem(self) -> str:
+        return self.path.stem
+
+    @property
+    def candidates(self) -> List[str]:
+        names = [self.stem, self.title, *self.aliases]
+        out: List[str] = []
+        seen = set()
+        for name in names:
+            norm = _normalize_phrase(name)
+            if norm and norm not in seen:
+                seen.add(norm)
+                out.append(norm)
+        return out
+
+
+class LifeOSContextEngine(ContextCompressor):
+    def __init__(self) -> None:
+        super().__init__(
+            model="lifeos-bootstrap",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        self.hermes_home = os.path.expanduser("~/.hermes")
+        self.session_id = ""
+        self.vault_path = Path(
+            os.getenv("OBSIDIAN_VAULT_PATH", "~/Documents/Obsidian Vault")
+        ).expanduser()
+        self.state_path = Path(self.hermes_home) / "context" / "lifeos_state.json"
+        self.max_block_chars = 5000
+        self.max_project_chars = 1200
+        self.max_people_chars = 900
+        self.max_claude_chars = 1200
+        self.max_daily_chars = 900
+        self.max_task_count = 8
+        self.refresh_minutes = {
+            "base": 20,
+            "daily": 30,
+            "tasks": 20,
+            "projects": 20,
+            "people": 30,
+        }
+        self.state: Dict[str, Any] = {
+            "session_id": "",
+            "current_focus": "",
+            "active_projects": [],
+            "active_people": [],
+            "active_tasks": [],
+            "tentative_updates": [],
+            "promotion_candidates": [],
+            "last_refresh": {},
+            "pinned_blocks": {"base": "", "projects": {}, "people": {}},
+        }
+        self._project_notes: List[VaultNote] = []
+        self._people_notes: List[VaultNote] = []
+
+    @property
+    def name(self) -> str:
+        return "lifeos"
+
+    def is_available(self) -> bool:
+        return self.vault_path.exists()
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        self.session_id = session_id or ""
+        self.hermes_home = str(kwargs.get("hermes_home") or self.hermes_home)
+        self.state_path = Path(self.hermes_home) / "context" / "lifeos_state.json"
+        self._load_runtime_config()
+        self._load_state()
+        self._ensure_state_shape()
+        self.state["session_id"] = self.session_id
+        self._rebuild_indexes()
+        self._refresh_base_context(force=True)
+        self._save_state()
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        self.state["session_id"] = session_id or self.state.get("session_id", "")
+        self._save_state()
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        self.state["current_focus"] = ""
+        self.state["active_projects"] = []
+        self.state["active_people"] = []
+        self.state["active_tasks"] = []
+        self.state["tentative_updates"] = []
+        self.state["promotion_candidates"] = []
+        self._save_state()
+
+    def prefetch(self, query: str, **kwargs) -> str:
+        if not self.is_available():
+            return ""
+
+        self._load_runtime_config()
+        self._rebuild_indexes()
+
+        normalized_query = _normalize_phrase(query)
+        wants_day = any(
+            token in normalized_query
+            for token in ("today", "task", "tasks", "priority", "priorities", "agenda", "focus", "next")
+        )
+        if wants_day or self._is_stale("base"):
+            self._refresh_base_context(force=wants_day)
+
+        matched_projects = self._match_notes(normalized_query, self._project_notes)
+        matched_people = self._match_notes(normalized_query, self._people_notes)
+
+        if not matched_projects and self.state.get("active_projects"):
+            matched_projects = self._match_prior_state(self.state.get("active_projects", []), self._project_notes)
+        if not matched_people and self.state.get("active_people"):
+            matched_people = self._match_prior_state(self.state.get("active_people", []), self._people_notes)
+
+        blocks: List[str] = []
+        base_block = self.state.get("pinned_blocks", {}).get("base", "") or ""
+        if wants_day or (not matched_projects and not matched_people):
+            if base_block:
+                blocks.append(base_block)
+        else:
+            snapshot = self._render_operational_snapshot(max_tasks=4)
+            if snapshot:
+                blocks.append(snapshot)
+
+        if matched_projects:
+            blocks.extend(self._render_project_bundle(note) for note in matched_projects[:2])
+        if matched_people:
+            blocks.extend(self._render_person_bundle(note) for note in matched_people[:2])
+
+        blocks = [block.strip() for block in blocks if block and block.strip()]
+        if not blocks:
+            return ""
+
+        self.state["active_projects"] = [note.title for note in matched_projects[:2]]
+        self.state["active_people"] = [note.title for note in matched_people[:2]]
+        if query and query.strip():
+            self.state["current_focus"] = query.strip()[:240]
+        self._save_state()
+
+        joined = _trim_text("\n\n".join(blocks), self.max_block_chars)
+        return f"{_CONTEXT_HEADER}\n\n{joined}" if joined else ""
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "lifeos_context_status",
+                "description": "Inspect the current LifeOS context-engine state and active cached context.",
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            },
+            {
+                "name": "lifeos_refresh_context",
+                "description": "Refresh cached LifeOS context from the vault. Optionally target a project or person.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "scope": {
+                            "type": "string",
+                            "enum": ["base", "project", "person", "all"],
+                            "description": "What to refresh. Default: all.",
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "Optional project or person name to refresh and preview.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_set_focus",
+                "description": "Set the current focus for the LifeOS context engine.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "focus": {"type": "string", "description": "Short description of the current focus."}
+                    },
+                    "required": ["focus"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_capture_update",
+                "description": "Capture a tentative session-local operational update without writing it into LifeOS notes.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string", "description": "Update type, e.g. focus_shift, project_update, decision, idea."},
+                        "target": {"type": "string", "description": "Optional related project, person, or topic."},
+                        "content": {"type": "string", "description": "The tentative update text to store in the session overlay."},
+                        "confidence": {"type": "string", "enum": ["low", "medium", "high"], "description": "Confidence in the update. Default: medium."},
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_promote_to_project",
+                "description": "Queue a promotion candidate for a LifeOS project note without writing it yet.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {"type": "string", "description": "Project name or identifier."},
+                        "content": {"type": "string", "description": "Operational update to potentially write into the project note."},
+                        "why": {"type": "string", "description": "Why this should be promoted."},
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_promote_to_task",
+                "description": "Queue a promotion candidate for a new or updated task without writing it yet.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {"type": "string", "description": "Optional related project or task grouping."},
+                        "content": {"type": "string", "description": "Task text or update to promote later."},
+                        "why": {"type": "string", "description": "Why this should become a task candidate."},
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_promote_to_honcho",
+                "description": "Queue a promotion candidate for Honcho memory without writing it yet.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "Potential durable user-memory conclusion."},
+                        "why": {"type": "string", "description": "Why this belongs in durable memory."},
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_promote_to_daily",
+                "description": "Write selected context directly into today's daily note under a session-promoted section.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "Text to append to today's daily note."}
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_promote_to_claude",
+                "description": "Write selected context directly into CLAUDE.md under a session-promoted section.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "Text to append to CLAUDE.md."}
+                    },
+                    "required": ["content"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_apply_promotion_candidate",
+                "description": "Apply a queued promotion candidate to its LifeOS destination when supported.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "index": {"type": "integer", "description": "Zero-based index in promotion_candidates."}
+                    },
+                    "required": ["index"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "name": "lifeos_review_promotion_candidate",
+                "description": "Mark a queued promotion candidate as approved, rejected, or pending before apply.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "index": {"type": "integer", "description": "Zero-based index in promotion_candidates."},
+                        "action": {"type": "string", "enum": ["approve", "reject", "pending"], "description": "Review action to apply."}
+                    },
+                    "required": ["index", "action"],
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+        try:
+            if name == "lifeos_context_status":
+                return json.dumps(self._status_payload(), ensure_ascii=False)
+            if name == "lifeos_set_focus":
+                focus = (args or {}).get("focus", "")
+                self.state["current_focus"] = str(focus).strip()[:240]
+                self._save_state()
+                return json.dumps({"ok": True, "focus": self.state["current_focus"]}, ensure_ascii=False)
+            if name == "lifeos_refresh_context":
+                scope = ((args or {}).get("scope") or "all").strip().lower()
+                target = ((args or {}).get("target") or "").strip()
+                preview = self._refresh_via_tool(scope=scope, target=target)
+                return json.dumps(
+                    {"ok": True, "scope": scope, "target": target, "preview": preview, "status": self._status_payload()},
+                    ensure_ascii=False,
+                )
+            if name == "lifeos_capture_update":
+                entry = self._record_tentative_update(args or {})
+                return json.dumps({"ok": True, "tentative_update": entry}, ensure_ascii=False)
+            if name == "lifeos_promote_to_project":
+                entry = self._queue_promotion_candidate("lifeos_project", args or {})
+                return json.dumps({"ok": True, "promotion_candidate": entry}, ensure_ascii=False)
+            if name == "lifeos_promote_to_task":
+                entry = self._queue_promotion_candidate("lifeos_task", args or {})
+                return json.dumps({"ok": True, "promotion_candidate": entry}, ensure_ascii=False)
+            if name == "lifeos_promote_to_honcho":
+                entry = self._queue_promotion_candidate("honcho_user", args or {})
+                return json.dumps({"ok": True, "promotion_candidate": entry}, ensure_ascii=False)
+            if name == "lifeos_promote_to_daily":
+                details = self._write_to_daily(str((args or {}).get("content") or "").strip())
+                return json.dumps({"ok": True, **details}, ensure_ascii=False)
+            if name == "lifeos_promote_to_claude":
+                details = self._write_to_claude(str((args or {}).get("content") or "").strip())
+                return json.dumps({"ok": True, **details}, ensure_ascii=False)
+            if name == "lifeos_apply_promotion_candidate":
+                details = self._apply_promotion_candidate(args or {})
+                return json.dumps({"ok": True, "applied": details}, ensure_ascii=False)
+            if name == "lifeos_review_promotion_candidate":
+                details = self._review_promotion_candidate(args or {})
+                return json.dumps({"ok": True, "candidate": details}, ensure_ascii=False)
+        except Exception as exc:
+            logger.exception("LifeOS context tool failed: %s", exc)
+            return json.dumps({"error": f"LifeOS context tool failed: {exc}"}, ensure_ascii=False)
+        return super().handle_tool_call(name, args, **kwargs)
+
+    def _status_payload(self) -> Dict[str, Any]:
+        pinned = self.state.get("pinned_blocks", {}) if isinstance(self.state, dict) else {}
+        return {
+            "engine": self.name,
+            "vault_path": str(self.vault_path),
+            "vault_available": self.is_available(),
+            "session_id": self.session_id,
+            "current_focus": self.state.get("current_focus", ""),
+            "active_projects": self.state.get("active_projects", []),
+            "active_people": self.state.get("active_people", []),
+            "active_tasks": self.state.get("active_tasks", []),
+            "tentative_updates": self.state.get("tentative_updates", []),
+            "promotion_candidates": self.state.get("promotion_candidates", []),
+            "last_refresh": self.state.get("last_refresh", {}),
+            "base_preview": _trim_text(pinned.get("base", ""), 800),
+        }
+
+    def _refresh_via_tool(self, scope: str, target: str) -> str:
+        self._rebuild_indexes()
+        preview_blocks: List[str] = []
+        if scope in {"base", "all"}:
+            self._refresh_base_context(force=True)
+            preview_blocks.append(self.state.get("pinned_blocks", {}).get("base", ""))
+        if scope in {"project", "all"} and target:
+            matches = self._match_notes(_normalize_phrase(target), self._project_notes)
+            if matches:
+                block = self._render_project_bundle(matches[0])
+                self.state.setdefault("pinned_blocks", {}).setdefault("projects", {})[matches[0].title] = block
+                preview_blocks.append(block)
+        if scope in {"person", "all"} and target:
+            matches = self._match_notes(_normalize_phrase(target), self._people_notes)
+            if matches:
+                block = self._render_person_bundle(matches[0])
+                self.state.setdefault("pinned_blocks", {}).setdefault("people", {})[matches[0].title] = block
+                preview_blocks.append(block)
+        self._save_state()
+        return _trim_text("\n\n".join(block for block in preview_blocks if block), self.max_block_chars)
+
+    def _load_runtime_config(self) -> None:
+        cfg_path = Path(self.hermes_home) / "config.yaml"
+        config: Dict[str, Any] = {}
+        if cfg_path.exists():
+            try:
+                config = yaml.safe_load(cfg_path.read_text()) or {}
+            except Exception as exc:
+                logger.debug("LifeOS context could not read %s: %s", cfg_path, exc)
+        life_cfg = config.get("lifeos_context", {}) if isinstance(config, dict) else {}
+        vault_value = (
+            life_cfg.get("vault_path")
+            or os.getenv("LIFEOS_CONTEXT_VAULT_PATH")
+            or os.getenv("OBSIDIAN_VAULT_PATH")
+            or str(self.vault_path)
+        )
+        self.vault_path = Path(vault_value).expanduser()
+        self.max_block_chars = _safe_int(life_cfg.get("max_block_chars"), self.max_block_chars)
+        self.max_task_count = _safe_int(life_cfg.get("max_task_count"), self.max_task_count)
+        refresh_cfg = life_cfg.get("refresh", {}) if isinstance(life_cfg, dict) else {}
+        if isinstance(refresh_cfg, dict):
+            for key, current in list(self.refresh_minutes.items()):
+                self.refresh_minutes[key] = _safe_int(refresh_cfg.get(f"{key}_minutes"), current)
+
+    def _load_state(self) -> None:
+        try:
+            if self.state_path.exists():
+                self.state = json.loads(self.state_path.read_text())
+        except Exception as exc:
+            logger.debug("LifeOS context state load failed: %s", exc)
+        self._ensure_state_shape()
+
+    def _save_state(self) -> None:
+        try:
+            self.state_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self.state_path.with_suffix(".tmp")
+            tmp_path.write_text(json.dumps(self.state, indent=2, ensure_ascii=False))
+            tmp_path.replace(self.state_path)
+        except Exception as exc:
+            logger.debug("LifeOS context state save failed: %s", exc)
+
+    def _ensure_state_shape(self) -> None:
+        self.state.setdefault("session_id", "")
+        self.state.setdefault("current_focus", "")
+        self.state.setdefault("active_projects", [])
+        self.state.setdefault("active_people", [])
+        self.state.setdefault("active_tasks", [])
+        self.state.setdefault("tentative_updates", [])
+        self.state.setdefault("promotion_candidates", [])
+        self.state.setdefault("last_refresh", {})
+        pinned = self.state.setdefault("pinned_blocks", {})
+        if not isinstance(pinned, dict):
+            pinned = {}
+            self.state["pinned_blocks"] = pinned
+        pinned.setdefault("base", "")
+        pinned.setdefault("projects", {})
+        pinned.setdefault("people", {})
+
+    def _record_tentative_update(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        entry = {
+            "type": str(args.get("type") or "note").strip() or "note",
+            "target": str(args.get("target") or "").strip(),
+            "content": str(args.get("content") or "").strip(),
+            "source": "conversation",
+            "confidence": str(args.get("confidence") or "medium").strip().lower() or "medium",
+            "created_at": _utc_now_iso(),
+        }
+        self.state.setdefault("tentative_updates", []).append(entry)
+        self.state["tentative_updates"] = self.state["tentative_updates"][-20:]
+        self._save_state()
+        return entry
+
+    def _queue_promotion_candidate(self, candidate_type: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        entry = {
+            "type": candidate_type,
+            "target": str(args.get("target") or "").strip(),
+            "content": str(args.get("content") or "").strip(),
+            "why": str(args.get("why") or "").strip(),
+            "status": "pending",
+            "created_at": _utc_now_iso(),
+        }
+        self.state.setdefault("promotion_candidates", []).append(entry)
+        self.state["promotion_candidates"] = self.state["promotion_candidates"][-20:]
+        self._save_state()
+        return entry
+
+    def _write_to_daily(self, content: str) -> Dict[str, Any]:
+        if not content:
+            raise ValueError("content is required")
+        path = self._get_daily_note_path(create_if_missing=True)
+        self._append_section_block(path, "Session Promoted Context", content)
+        return {"path": str(path), "content": content}
+
+    def _write_to_claude(self, content: str) -> Dict[str, Any]:
+        if not content:
+            raise ValueError("content is required")
+        path = self._get_claude_path(create_if_missing=True)
+        self._append_section_block(path, "Session Promoted Context", content)
+        return {"path": str(path), "content": content}
+
+    def _apply_promotion_candidate(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        candidates = self.state.setdefault("promotion_candidates", [])
+        try:
+            index = int(args.get("index"))
+        except Exception as exc:
+            raise ValueError("valid index is required") from exc
+        if index < 0 or index >= len(candidates):
+            raise IndexError("promotion candidate index out of range")
+        candidate = candidates[index]
+        candidate_type = candidate.get("type", "")
+        content = str(candidate.get("content") or "").strip()
+        target = str(candidate.get("target") or "").strip()
+        if not content:
+            raise ValueError("promotion candidate has no content")
+        if candidate.get("status") == "rejected":
+            raise ValueError("rejected promotion candidates cannot be applied")
+
+        if candidate_type == "lifeos_project":
+            project_note = self._find_project_note(target)
+            if not project_note:
+                raise ValueError(f"project note not found for target: {target}")
+            self._append_section_block(project_note.path, "Session Promoted Context", content)
+            candidate["status"] = "applied"
+            candidate["applied_at"] = _utc_now_iso()
+            candidate["destination"] = str(project_note.path)
+        elif candidate_type == "lifeos_task":
+            task_path = self._create_task_candidate_note(content, target)
+            candidate["status"] = "applied"
+            candidate["applied_at"] = _utc_now_iso()
+            candidate["destination"] = str(task_path)
+        elif candidate_type == "honcho_user":
+            self._apply_honcho_conclusion(content)
+            candidate["status"] = "applied"
+            candidate["applied_at"] = _utc_now_iso()
+            candidate["destination"] = "honcho"
+        else:
+            raise ValueError(f"promotion candidate type not supported for direct apply: {candidate_type}")
+
+        self._save_state()
+        return candidate
+
+    def _review_promotion_candidate(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        candidates = self.state.setdefault("promotion_candidates", [])
+        try:
+            index = int(args.get("index"))
+        except Exception as exc:
+            raise ValueError("valid index is required") from exc
+        if index < 0 or index >= len(candidates):
+            raise IndexError("promotion candidate index out of range")
+        action = str(args.get("action") or "").strip().lower()
+        mapping = {"approve": "approved", "reject": "rejected", "pending": "pending"}
+        if action not in mapping:
+            raise ValueError("action must be one of: approve, reject, pending")
+        candidates[index]["status"] = mapping[action]
+        candidates[index]["reviewed_at"] = _utc_now_iso()
+        self._save_state()
+        return candidates[index]
+
+    def _rebuild_indexes(self) -> None:
+        self._project_notes = self._load_note_index(self.vault_path / "memory" / "projects")
+        self._people_notes = self._load_note_index(self.vault_path / "memory" / "people")
+
+    def _load_note_index(self, directory: Path) -> List[VaultNote]:
+        if not directory.exists():
+            return []
+        notes: List[VaultNote] = []
+        for path in sorted(directory.glob("*.md")):
+            note = self._read_vault_note(path)
+            if note:
+                notes.append(note)
+        return notes
+
+    def _read_vault_note(self, path: Path) -> Optional[VaultNote]:
+        if not path.exists():
+            return None
+        raw = path.read_text(encoding="utf-8")
+        frontmatter, body = _parse_frontmatter(raw)
+        aliases = frontmatter.get("aliases") or []
+        if isinstance(aliases, str):
+            aliases = [aliases]
+        title = (
+            frontmatter.get("title")
+            or _extract_heading(body)
+            or _clean_wikilink(frontmatter.get("project") or "")
+            or path.stem.replace("-", " ").title()
+        )
+        return VaultNote(path=path, title=str(title).strip(), body=body.strip(), frontmatter=frontmatter, aliases=[str(a) for a in aliases])
+
+    def _refresh_base_context(self, force: bool = False) -> None:
+        if not force and not self._is_stale("base"):
+            return
+        base_blocks = [self._render_operational_snapshot(max_tasks=self.max_task_count)]
+        claude_block = self._render_claude_block()
+        if claude_block:
+            base_blocks.append(claude_block)
+        daily_block = self._render_daily_block()
+        if daily_block:
+            base_blocks.append(daily_block)
+        combined = _trim_text("\n\n".join(block for block in base_blocks if block), self.max_block_chars)
+        self.state.setdefault("pinned_blocks", {})["base"] = combined
+        self.state.setdefault("last_refresh", {})["base"] = _utc_now_iso()
+
+    def _render_operational_snapshot(self, max_tasks: int) -> str:
+        tasks = self._load_tasks()
+        self.state["active_tasks"] = [task["title"] for task in tasks[:max_tasks]]
+        lines = ["## Operational Snapshot"]
+        if self.state.get("current_focus"):
+            lines.append(f"- Current focus: {self.state['current_focus']}")
+        if tasks:
+            lines.append("- Active tasks:")
+            for task in tasks[:max_tasks]:
+                suffix_parts = []
+                if task.get("priority"):
+                    suffix_parts.append(task["priority"])
+                if task.get("due"):
+                    suffix_parts.append(f"due {task['due']}")
+                if task.get("project"):
+                    suffix_parts.append(task["project"])
+                suffix = f" ({'; '.join(suffix_parts)})" if suffix_parts else ""
+                lines.append(f"  - {task['title']}{suffix}")
+        top_projects = [task.get("project") for task in tasks if task.get("project")]
+        top_projects = [project for project in top_projects if project]
+        if top_projects:
+            deduped = []
+            seen = set()
+            for project in top_projects:
+                key = _normalize_phrase(project)
+                if key and key not in seen:
+                    seen.add(key)
+                    deduped.append(project)
+            if deduped:
+                lines.append("- Active projects: " + ", ".join(deduped[:4]))
+        return "\n".join(lines)
+
+    def _render_claude_block(self) -> str:
+        candidates = [self.vault_path / "CLAUDE.md", self.vault_path / "Daily Control Center" / "CLAUDE.md"]
+        for path in candidates:
+            if path.exists():
+                text = _trim_text(_strip_markdown_noise(path.read_text(encoding="utf-8")), self.max_claude_chars)
+                if text:
+                    return f"## Command Center Memory\n{text}"
+        return ""
+
+    def _render_daily_block(self) -> str:
+        daily_dir = self.vault_path / "daily"
+        if not daily_dir.exists():
+            return ""
+        today_name = datetime.now().strftime("%Y-%m-%d") + ".md"
+        today_path = daily_dir / today_name
+        target = today_path if today_path.exists() else None
+        if target is None:
+            candidates = sorted(daily_dir.glob("*.md"), reverse=True)
+            target = candidates[0] if candidates else None
+        if not target:
+            return ""
+        body = self._read_vault_note(target)
+        if not body:
+            return ""
+        summary = _trim_text(_strip_markdown_noise(body.body), self.max_daily_chars)
+        if not summary:
+            return ""
+        label = "today" if target.name == today_name else f"latest note ({target.stem})"
+        return f"## Daily Note — {label}\n{summary}"
+
+    def _render_project_bundle(self, note: VaultNote) -> str:
+        summary = _trim_text(_strip_markdown_noise(note.body), self.max_project_chars)
+        related_tasks = [task for task in self._load_tasks() if self._same_topic(task.get("project", ""), note.title, note.stem)]
+        lines = [f"## Project — {note.title}"]
+        if summary:
+            lines.append(summary)
+        if related_tasks:
+            lines.append("Related tasks:")
+            for task in related_tasks[:4]:
+                due = f" — due {task['due']}" if task.get("due") else ""
+                lines.append(f"- {task['title']}{due}")
+        return "\n".join(lines)
+
+    def _render_person_bundle(self, note: VaultNote) -> str:
+        summary = _trim_text(_strip_markdown_noise(note.body), self.max_people_chars)
+        related_tasks = []
+        for task in self._load_tasks():
+            who = f"{task.get('assigned_to', '')} {task.get('waiting_on', '')}".strip()
+            if who and self._same_topic(who, note.title, note.stem):
+                related_tasks.append(task)
+        lines = [f"## Person — {note.title}"]
+        if summary:
+            lines.append(summary)
+        if related_tasks:
+            lines.append("Related tasks:")
+            for task in related_tasks[:4]:
+                due = f" — due {task['due']}" if task.get("due") else ""
+                lines.append(f"- {task['title']}{due}")
+        return "\n".join(lines)
+
+    def _load_tasks(self) -> List[Dict[str, Any]]:
+        tasks_dir = self.vault_path / "tasks"
+        if not tasks_dir.exists():
+            return []
+        tasks: List[Dict[str, Any]] = []
+        for path in tasks_dir.glob("*.md"):
+            note = self._read_vault_note(path)
+            if not note:
+                continue
+            tags = note.frontmatter.get("tags") or []
+            if isinstance(tags, str):
+                tags = [tags]
+            if tags and "task" not in [str(tag).lower() for tag in tags]:
+                continue
+            status = str(note.frontmatter.get("status") or "active").lower()
+            if status == "done":
+                continue
+            project = _clean_wikilink(note.frontmatter.get("project") or "")
+            assigned_to = _clean_wikilink(note.frontmatter.get("assigned_to") or note.frontmatter.get("assigned-to") or "")
+            waiting_on = _clean_wikilink(note.frontmatter.get("waiting_on") or note.frontmatter.get("waiting-on") or "")
+            due_value = _format_due(note.frontmatter.get("due"))
+            tasks.append(
+                {
+                    "title": note.title,
+                    "path": str(path),
+                    "priority": str(note.frontmatter.get("priority") or "medium").lower(),
+                    "status": status,
+                    "project": project,
+                    "assigned_to": assigned_to,
+                    "waiting_on": waiting_on,
+                    "due": due_value,
+                }
+            )
+        tasks.sort(key=self._task_sort_key)
+        return tasks
+
+    def _task_sort_key(self, task: Dict[str, Any]) -> tuple:
+        due_key = task.get("due") or "9999-12-31"
+        return (
+            _STATUS_RANK.get(task.get("status", "active"), 50),
+            _PRIORITY_RANK.get(task.get("priority", "medium"), 50),
+            due_key,
+            task.get("title", ""),
+        )
+
+    def _match_notes(self, normalized_query: str, notes: Iterable[VaultNote]) -> List[VaultNote]:
+        if not normalized_query:
+            return []
+        scored = []
+        for note in notes:
+            best = 0
+            for candidate in note.candidates:
+                if candidate and candidate in normalized_query:
+                    best = max(best, len(candidate))
+            if best:
+                scored.append((best, note.title.lower(), note))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return [note for _, _, note in scored]
+
+    def _match_prior_state(self, names: Iterable[str], notes: Iterable[VaultNote]) -> List[VaultNote]:
+        wanted = {_normalize_phrase(name) for name in names if name}
+        matches = []
+        for note in notes:
+            if wanted.intersection(note.candidates):
+                matches.append(note)
+        return matches
+
+    def _find_project_note(self, target: str) -> Optional[VaultNote]:
+        normalized = _normalize_phrase(target)
+        if not normalized:
+            return None
+        matches = self._match_notes(normalized, self._project_notes)
+        return matches[0] if matches else None
+
+    def _get_daily_note_path(self, create_if_missing: bool = False) -> Path:
+        daily_dir = self.vault_path / "daily"
+        daily_dir.mkdir(parents=True, exist_ok=True)
+        today_name = datetime.now().strftime("%Y-%m-%d") + ".md"
+        path = daily_dir / today_name
+        if create_if_missing and not path.exists():
+            path.write_text(f"# {today_name[:-3]}\n", encoding="utf-8")
+        return path
+
+    def _get_claude_path(self, create_if_missing: bool = False) -> Path:
+        path = self.vault_path / "CLAUDE.md"
+        if create_if_missing and not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("# Memory\n", encoding="utf-8")
+        return path
+
+    def _append_section_block(self, path: Path, heading: str, content: str) -> None:
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        block = f"## {heading}\n- {content.strip()}\n"
+        if not existing.strip():
+            path.write_text(block, encoding="utf-8")
+            return
+        section_header = f"## {heading}"
+        if section_header in existing:
+            updated = existing.rstrip() + f"\n- {content.strip()}\n"
+        else:
+            spacer = "\n\n" if not existing.endswith("\n\n") else ""
+            updated = existing.rstrip() + f"{spacer}\n{block}"
+        path.write_text(updated, encoding="utf-8")
+
+    def _create_task_candidate_note(self, content: str, target: str) -> Path:
+        tasks_dir = self.vault_path / "tasks"
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        title = content.strip().splitlines()[0].strip()
+        slug = _slugify(title) or f"task-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        path = tasks_dir / f"{slug}.md"
+        counter = 2
+        while path.exists():
+            path = tasks_dir / f"{slug}-{counter}.md"
+            counter += 1
+        project_line = f"project: '[[{target}]]'\n" if target else ""
+        raw = (
+            "---\n"
+            f"title: {title}\n"
+            "tags:\n  - task\n"
+            "status: active\n"
+            "priority: medium\n"
+            f"{project_line}"
+            f"created: '{datetime.now().strftime('%Y-%m-%d')}'\n"
+            "---\n"
+            f"# {title}\n\n"
+            f"{content.strip()}\n"
+        )
+        path.write_text(raw, encoding="utf-8")
+        return path
+
+    def _apply_honcho_conclusion(self, content: str) -> None:
+        from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
+        from plugins.memory.honcho.session import HonchoSessionManager
+
+        cfg = HonchoClientConfig.from_global_config()
+        client = get_honcho_client(cfg)
+        manager = HonchoSessionManager(honcho=client, config=cfg, context_tokens=cfg.context_tokens)
+        session_key = cfg.resolve_session_name(cwd=str(self.vault_path), session_id=self.session_id) or self.session_id or "lifeos"
+        manager.get_or_create(session_key)
+        ok = manager.create_conclusion(session_key, content)
+        if not ok:
+            raise ValueError("failed to write Honcho conclusion")
+
+    def _is_stale(self, scope: str) -> bool:
+        last_refresh = self.state.get("last_refresh", {}).get(scope)
+        if not last_refresh:
+            return True
+        try:
+            ts = datetime.fromisoformat(last_refresh.replace("Z", "+00:00"))
+        except Exception:
+            return True
+        return datetime.now(timezone.utc) - ts >= timedelta(minutes=self.refresh_minutes.get(scope, 20))
+
+    def _same_topic(self, value: str, *candidates: str) -> bool:
+        norm_value = _normalize_phrase(value)
+        for candidate in candidates:
+            norm_candidate = _normalize_phrase(candidate)
+            if norm_candidate and norm_value and (norm_candidate in norm_value or norm_value in norm_candidate):
+                return True
+        return False
+
+
+def register(ctx) -> None:
+    ctx.register_context_engine(LifeOSContextEngine())
+
+
+def _parse_frontmatter(raw: str) -> tuple[Dict[str, Any], str]:
+    if raw.startswith("---\n"):
+        end = raw.find("\n---", 4)
+        if end != -1:
+            frontmatter_text = raw[4:end]
+            body = raw[end + 4 :].lstrip("\n")
+            try:
+                return yaml.safe_load(frontmatter_text) or {}, body
+            except Exception:
+                return {}, body
+    return {}, raw
+
+
+def _extract_heading(body: str) -> str:
+    for line in body.splitlines():
+        if line.startswith("#"):
+            return line.lstrip("# ").strip()
+    return ""
+
+
+def _strip_markdown_noise(text: str) -> str:
+    cleaned_lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#") and cleaned_lines:
+            continue
+        cleaned_lines.append(_clean_wikilink(stripped))
+    return "\n".join(cleaned_lines)
+
+
+def _clean_wikilink(value: Any) -> str:
+    text = str(value or "")
+    if not text:
+        return ""
+    matches = re.findall(r"\[\[([^\]]+)\]\]", text)
+    if matches:
+        cleaned = []
+        for match in matches:
+            target, _, display = match.partition("|")
+            cleaned.append((display or target).strip())
+        return ", ".join(part for part in cleaned if part)
+    return text.strip("'\" ")
+
+
+def _normalize_phrase(value: Any) -> str:
+    text = _clean_wikilink(value).lower()
+    text = text.replace("_", " ").replace("-", " ")
+    text = re.sub(r"[^a-z0-9 ]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _trim_text(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    cutoff = max_chars - 1
+    trimmed = text[:cutoff].rsplit("\n", 1)[0].rsplit(" ", 1)[0].strip()
+    return (trimmed or text[:cutoff].strip()) + "…"
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _format_due(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if "T" in text:
+        return text.split("T", 1)[0]
+    return text
+
+
+def _slugify(text: str) -> str:
+    text = _normalize_phrase(text)
+    return text.replace(" ", "-")

--- a/plugins/context_engine/lifeos/plugin.yaml
+++ b/plugins/context_engine/lifeos/plugin.yaml
@@ -1,0 +1,3 @@
+name: lifeos
+description: LifeOS-aware context engine that injects operational context from Tony's Obsidian vault while preserving the built-in compressor fallback.
+version: 0.1.0

--- a/run_agent.py
+++ b/run_agent.py
@@ -8941,6 +8941,23 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Context engine prefetch: lets a pluggable engine inject domain-specific
+        # operating context into the current user turn without mutating the
+        # cached system prompt or waiting for compression to fire.
+        _context_engine_prefetch_cache = ""
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                _query = original_user_message if isinstance(original_user_message, str) else ""
+                _context_engine_prefetch_cache = self.context_compressor.prefetch(
+                    _query,
+                    session_id=self.session_id,
+                    conversation_history=list(messages),
+                    model=self.model,
+                    platform=getattr(self, "platform", None) or "",
+                ) or ""
+            except Exception as exc:
+                logger.debug("Context engine prefetch failed: %s", exc)
+
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
@@ -9072,6 +9089,8 @@ class AIAgent:
                         _fenced = build_memory_context_block(_ext_prefetch_cache)
                         if _fenced:
                             _injections.append(_fenced)
+                    if _context_engine_prefetch_cache:
+                        _injections.append(_context_engine_prefetch_cache)
                     if _plugin_user_context:
                         _injections.append(_plugin_user_context)
                     if _injections:

--- a/tests/agent/test_lifeos_context_engine.py
+++ b/tests/agent/test_lifeos_context_engine.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from plugins.context_engine.lifeos import LifeOSContextEngine
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _sample_task(title: str, project: str = "", assigned_to: str = "", due: str = "2026-04-17") -> str:
+    project_line = f"project: '[[{project}]]'\n" if project else ""
+    assigned_line = f"assigned_to: '[[{assigned_to}]]'\n" if assigned_to else ""
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "tags:\n  - task\n"
+        "status: active\n"
+        "priority: high\n"
+        f"{project_line}"
+        f"{assigned_line}"
+        f"due: '{due}'\n"
+        "---\n"
+        f"# {title}\n"
+    )
+
+
+def _build_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "LifeOS"
+    today = datetime.now().strftime("%Y-%m-%d")
+    _write(vault / "CLAUDE.md", "# Memory\n\n## Focus\nShip Phoenix and close the budget loop.\n")
+    _write(vault / "daily" / f"{today}.md", "# Daily\n\nToday: Phoenix work, budget review, and Todd follow-up.\n")
+    _write(vault / "tasks" / "review-budget.md", _sample_task("Review budget", project="Phoenix", assigned_to="Todd Martinez"))
+    _write(vault / "memory" / "projects" / "phoenix.md", "---\ntitle: Phoenix\naliases:\n  - project phoenix\n---\n# Phoenix\n\nPhoenix is the active operating project.\n")
+    _write(vault / "memory" / "people" / "todd-martinez.md", "---\ntitle: Todd Martinez\naliases:\n  - Todd\n---\n# Todd Martinez\n\nPrimary finance counterpart for the budget review.\n")
+    return vault
+
+
+def _build_hermes_home(tmp_path: Path, vault: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {
+            "vault_path": str(vault),
+            "max_block_chars": 5000,
+            "refresh": {"base_minutes": 20, "projects_minutes": 20, "people_minutes": 20},
+        },
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return home
+
+
+def test_lifeos_engine_prefetches_project_context(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-1", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+
+    text = engine.prefetch("what's next on Phoenix?")
+
+    assert "LIFEOS CONTEXT" in text
+    assert "Project — Phoenix" in text
+    assert "Review budget" in text
+    assert engine.state["active_projects"] == ["Phoenix"]
+
+
+def test_lifeos_engine_tools_report_and_update_focus(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-2", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+
+    result = json.loads(engine.handle_tool_call("lifeos_set_focus", {"focus": "Ship Phoenix"}))
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+    refresh = json.loads(engine.handle_tool_call("lifeos_refresh_context", {"scope": "person", "target": "Todd"}))
+
+    assert result["focus"] == "Ship Phoenix"
+    assert status["current_focus"] == "Ship Phoenix"
+    assert "Todd Martinez" in refresh["preview"]
+    assert isinstance(status["tentative_updates"], list)
+    assert isinstance(status["promotion_candidates"], list)
+
+
+def test_lifeos_engine_tracks_tentative_updates_and_promotion_candidates(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-3", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+
+    tentative = json.loads(
+        engine.handle_tool_call(
+            "lifeos_capture_update",
+            {
+                "type": "project_update",
+                "target": "Phoenix",
+                "content": "Need to confirm roadmap sequencing with finance",
+                "confidence": "medium",
+            },
+        )
+    )
+    promotion = json.loads(
+        engine.handle_tool_call(
+            "lifeos_promote_to_project",
+            {
+                "target": "Phoenix",
+                "content": "Confirmed next action: review budget with Todd",
+                "why": "clear operational next action mentioned in conversation",
+            },
+        )
+    )
+
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+
+    assert tentative["ok"] is True
+    assert tentative["tentative_update"]["type"] == "project_update"
+    assert promotion["ok"] is True
+    assert promotion["promotion_candidate"]["type"] == "lifeos_project"
+    assert status["tentative_updates"][0]["target"] == "Phoenix"
+    assert status["promotion_candidates"][0]["status"] == "pending"
+
+
+def test_lifeos_engine_reset_clears_overlay_state(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-4", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+    engine.handle_tool_call(
+        "lifeos_capture_update",
+        {"type": "focus_shift", "content": "Switch to Phoenix budget review"},
+    )
+    engine.handle_tool_call(
+        "lifeos_promote_to_honcho",
+        {
+            "content": "Tony prefers a tighter planning review at the start of implementation work",
+            "why": "stable process preference",
+        },
+    )
+
+    engine.on_session_reset()
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+
+    assert status["current_focus"] == ""
+    assert status["tentative_updates"] == []
+    assert status["promotion_candidates"] == []
+
+
+def test_lifeos_engine_writes_promoted_context_to_daily_and_claude(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-5", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+
+    daily = json.loads(engine.handle_tool_call("lifeos_promote_to_daily", {"content": "Focus on Phoenix budget with Todd"}))
+    claude = json.loads(engine.handle_tool_call("lifeos_promote_to_claude", {"content": "Current immediate focus: Phoenix budget review"}))
+
+    daily_text = (vault / "daily" / f"{today}.md").read_text(encoding="utf-8")
+    claude_text = (vault / "CLAUDE.md").read_text(encoding="utf-8")
+
+    assert daily["ok"] is True
+    assert claude["ok"] is True
+    assert "Session Promoted Context" in daily_text
+    assert "Focus on Phoenix budget with Todd" in daily_text
+    assert "Session Promoted Context" in claude_text
+    assert "Current immediate focus: Phoenix budget review" in claude_text
+
+
+def test_lifeos_engine_can_apply_project_promotion_candidate(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-6", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+    engine.handle_tool_call(
+        "lifeos_promote_to_project",
+        {
+            "target": "Phoenix",
+            "content": "Confirmed next action: review budget with Todd",
+            "why": "clear operational next action mentioned in conversation",
+        },
+    )
+
+    approved = json.loads(engine.handle_tool_call("lifeos_review_promotion_candidate", {"index": 0, "action": "approve"}))
+    applied = json.loads(engine.handle_tool_call("lifeos_apply_promotion_candidate", {"index": 0}))
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+    project_text = (vault / "memory" / "projects" / "phoenix.md").read_text(encoding="utf-8")
+
+    assert approved["ok"] is True
+    assert approved["candidate"]["status"] == "approved"
+    assert applied["ok"] is True
+    assert applied["applied"]["status"] == "applied"
+    assert status["promotion_candidates"][0]["status"] == "applied"
+    assert "Session Promoted Context" in project_text
+    assert "Confirmed next action: review budget with Todd" in project_text
+
+
+def test_lifeos_engine_can_reject_promotion_candidate(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-7", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+    engine.handle_tool_call(
+        "lifeos_promote_to_task",
+        {"content": "Maybe create a follow-up task", "why": "unclear if needed yet"},
+    )
+
+    rejected = json.loads(engine.handle_tool_call("lifeos_review_promotion_candidate", {"index": 0, "action": "reject"}))
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+
+    assert rejected["ok"] is True
+    assert rejected["candidate"]["status"] == "rejected"
+    assert status["promotion_candidates"][0]["status"] == "rejected"
+
+
+def test_lifeos_engine_can_apply_honcho_promotion_candidate(tmp_path):
+    vault = _build_vault(tmp_path)
+    hermes_home = _build_hermes_home(tmp_path, vault)
+
+    engine = LifeOSContextEngine()
+    engine.on_session_start("sess-8", hermes_home=str(hermes_home), platform="cli", model="gpt-test")
+    engine.handle_tool_call(
+        "lifeos_promote_to_honcho",
+        {
+            "content": "Tony prefers tighter planning reviews at the start of implementation work",
+            "why": "stable process preference",
+        },
+    )
+
+    fake_manager = MagicMock()
+    fake_manager.create_conclusion.return_value = True
+
+    with (
+        patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config") as cfg_loader,
+        patch("plugins.memory.honcho.client.get_honcho_client", return_value=object()),
+        patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=fake_manager),
+    ):
+        cfg = MagicMock()
+        cfg.resolve_session_name.return_value = "LifeOS"
+        cfg_loader.return_value = cfg
+        approved = json.loads(engine.handle_tool_call("lifeos_review_promotion_candidate", {"index": 0, "action": "approve"}))
+        applied = json.loads(engine.handle_tool_call("lifeos_apply_promotion_candidate", {"index": 0}))
+
+    status = json.loads(engine.handle_tool_call("lifeos_context_status", {}))
+
+    assert approved["ok"] is True
+    assert applied["ok"] is True
+    fake_manager.get_or_create.assert_called_once_with("LifeOS")
+    fake_manager.create_conclusion.assert_called_once()
+    assert status["promotion_candidates"][0]["status"] == "applied"
+
+
+def _mock_response(content="Done"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class _StubEngine(LifeOSContextEngine):
+    def __init__(self):
+        super().__init__()
+        self.prefetch_calls = []
+
+    def prefetch(self, query: str, **kwargs) -> str:
+        self.prefetch_calls.append(query)
+        return "[LIFEOS TEST CONTEXT] Focus on Phoenix."
+
+
+def test_run_agent_injects_context_engine_prefetch_into_user_turn(tmp_path):
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _mock_response("Done")
+
+        result = agent.run_conversation("what next on Phoenix?")
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        user_messages = [m for m in sent_messages if m.get("role") == "user"]
+
+    assert result["final_response"] == "Done"
+    assert engine.prefetch_calls == ["what next on Phoenix?"]
+    assert any("[LIFEOS TEST CONTEXT] Focus on Phoenix." in msg.get("content", "") for msg in user_messages)

--- a/tests/agent/test_lifeos_context_engine.py
+++ b/tests/agent/test_lifeos_context_engine.py
@@ -264,20 +264,61 @@ def test_lifeos_engine_can_apply_honcho_promotion_candidate(tmp_path):
     assert status["promotion_candidates"][0]["status"] == "applied"
 
 
-def _mock_response(content="Done"):
-    msg = SimpleNamespace(content=content, tool_calls=None)
-    choice = SimpleNamespace(message=msg, finish_reason="stop")
+def _mock_response(content="Done", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
     return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _mock_tool_call(name="lifeos_test_tool", arguments="{}", call_id="c1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
 
 
 class _StubEngine(LifeOSContextEngine):
     def __init__(self):
         super().__init__()
         self.prefetch_calls = []
+        self.session_start_calls = []
+        self.session_end_calls = []
+        self.reset_calls = 0
+        self.tool_calls = []
 
     def prefetch(self, query: str, **kwargs) -> str:
         self.prefetch_calls.append(query)
         return "[LIFEOS TEST CONTEXT] Focus on Phoenix."
+
+    def on_session_start(self, session_id: str, **kwargs) -> None:
+        self.session_start_calls.append({"session_id": session_id, **kwargs})
+        super().on_session_start(session_id, **kwargs)
+
+    def on_session_end(self, session_id: str, messages):
+        self.session_end_calls.append({"session_id": session_id, "messages": list(messages)})
+        super().on_session_end(session_id, messages)
+
+    def on_session_reset(self) -> None:
+        self.reset_calls += 1
+        super().on_session_reset()
+
+    def get_tool_schemas(self):
+        schemas = super().get_tool_schemas()
+        schemas.append(
+            {
+                "name": "lifeos_test_tool",
+                "description": "Test-only context engine tool.",
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            }
+        )
+        return schemas
+
+    def handle_tool_call(self, name: str, args: dict, **kwargs) -> str:
+        if name == "lifeos_test_tool":
+            self.tool_calls.append({"name": name, "args": dict(args or {})})
+            return json.dumps({"ok": True, "source": "stub"})
+        return super().handle_tool_call(name, args, **kwargs)
 
 
 def test_run_agent_injects_context_engine_prefetch_into_user_turn(tmp_path):
@@ -314,3 +355,174 @@ def test_run_agent_injects_context_engine_prefetch_into_user_turn(tmp_path):
     assert result["final_response"] == "Done"
     assert engine.prefetch_calls == ["what next on Phoenix?"]
     assert any("[LIFEOS TEST CONTEXT] Focus on Phoenix." in msg.get("content", "") for msg in user_messages)
+
+
+def test_run_agent_does_not_inject_context_engine_prefetch_into_system_prompt(tmp_path):
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _mock_response("Done")
+
+        agent.run_conversation("what next on Phoenix?")
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        system_messages = [m for m in sent_messages if m.get("role") == "system"]
+
+    assert system_messages
+    assert all("[LIFEOS TEST CONTEXT] Focus on Phoenix." not in msg.get("content", "") for msg in system_messages)
+
+
+def test_agent_registers_context_engine_tool_schemas_and_routes_tool_calls(tmp_path):
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        routed = json.loads(agent.context_compressor.handle_tool_call("lifeos_test_tool", {}, messages=[]))
+
+    assert "lifeos_test_tool" in agent.valid_tool_names
+    assert "lifeos_test_tool" in agent._context_engine_tool_names
+    assert any(t["function"]["name"] == "lifeos_test_tool" for t in agent.tools)
+    assert routed["ok"] is True
+    assert engine.tool_calls == [{"name": "lifeos_test_tool", "args": {}}]
+
+
+def test_agent_calls_context_engine_lifecycle_hooks_for_start_reset_and_end(tmp_path):
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.reset_session_state()
+        agent.shutdown_memory_provider(messages=[{"role": "user", "content": "done"}])
+
+    assert len(engine.session_start_calls) == 1
+    start_call = engine.session_start_calls[0]
+    assert start_call["session_id"] == agent.session_id
+    assert start_call["hermes_home"]
+    assert start_call["platform"] == "cli"
+    assert start_call["model"] == agent.model
+    assert start_call["context_length"] == 131_072
+    assert engine.reset_calls == 1
+    assert len(engine.session_end_calls) == 1
+    assert engine.session_end_calls[0]["session_id"] == agent.session_id
+    assert engine.session_end_calls[0]["messages"] == [{"role": "user", "content": "done"}]
+
+
+def test_agent_falls_back_to_builtin_compressor_when_lifeos_engine_load_fails(tmp_path):
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", side_effect=RuntimeError("boom")),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.name == "compressor"
+    assert "lifeos_test_tool" not in getattr(agent, "valid_tool_names", set())
+
+
+def test_run_agent_routes_context_engine_tool_call_end_to_end(tmp_path):
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "lifeos"},
+        "lifeos_context": {"vault_path": str(tmp_path / "LifeOS")},
+        "agent": {},
+    }
+    tc = _mock_tool_call(name="lifeos_test_tool", arguments="{}", call_id="c1")
+    resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+    resp2 = _mock_response(content="Done", finish_reason="stop")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        result = agent.run_conversation("use the lifeos tool")
+
+    assert result["final_response"] == "Done"
+    assert engine.tool_calls == [{"name": "lifeos_test_tool", "args": {}}]

--- a/tests/agent/test_lifeos_context_engine.py
+++ b/tests/agent/test_lifeos_context_engine.py
@@ -341,6 +341,9 @@ def test_run_agent_injects_context_engine_prefetch_into_user_turn(tmp_path):
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -377,6 +380,9 @@ def test_run_agent_does_not_inject_context_engine_prefetch_into_system_prompt(tm
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -412,6 +418,9 @@ def test_agent_registers_context_engine_tool_schemas_and_routes_tool_calls(tmp_p
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -445,6 +454,9 @@ def test_agent_calls_context_engine_lifecycle_hooks_for_start_reset_and_end(tmp_
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -483,6 +495,9 @@ def test_agent_falls_back_to_builtin_compressor_when_lifeos_engine_load_fails(tm
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -515,6 +530,9 @@ def test_run_agent_routes_context_engine_tool_call_end_to_end(tmp_path):
 
         agent = AIAgent(
             api_key="test-key-1234567890",
+            base_url="https://api.openai.com/v1",
+            model="gpt-4o-mini",
+            api_mode="chat_completions",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/tests/cli/test_terminal_title.py
+++ b/tests/cli/test_terminal_title.py
@@ -1,0 +1,143 @@
+"""Tests for hermes_cli.terminal_title — OSC tab-title emission."""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from hermes_cli import terminal_title
+
+
+# ---------------------------------------------------------------------------
+# Sanitisation
+# ---------------------------------------------------------------------------
+
+def test_clean_strips_control_characters():
+    raw = "Plan\x07with\x1b]bad\x00stuff\nand newlines"
+    cleaned = terminal_title._clean(raw)
+    for bad in ("\x07", "\x1b", "\x00", "\n"):
+        assert bad not in cleaned
+
+
+def test_clean_truncates_to_max_len():
+    cleaned = terminal_title._clean("x" * 500, max_len=50)
+    assert len(cleaned) == 50
+    assert cleaned.endswith("\u2026")
+
+
+def test_clean_handles_empty():
+    assert terminal_title._clean("") == ""
+    assert terminal_title._clean(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Output is gated by env / TTY
+# ---------------------------------------------------------------------------
+
+def test_set_tab_title_noop_when_disabled(monkeypatch):
+    monkeypatch.setenv("HERMES_DISABLE_TAB_TITLE", "1")
+    # The disable flag is honored inside _tty_stream(); confirm no stream is
+    # opened. If no stream, the real _write() short-circuits without emitting.
+    assert terminal_title._tty_stream() is None
+    # End-to-end: nothing should be written anywhere.
+    terminal_title.set_tab_title("Helm", "anything")  # must not raise
+
+
+def test_set_tab_title_noop_when_term_dumb(monkeypatch):
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.delenv("HERMES_DISABLE_TAB_TITLE", raising=False)
+    assert terminal_title._tty_stream() is None
+
+
+def test_set_tab_title_noop_when_no_tty(monkeypatch):
+    monkeypatch.delenv("HERMES_DISABLE_TAB_TITLE", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setattr(os, "open", mock.Mock(side_effect=OSError))
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr("sys.stderr", fake_stderr)
+    # Force the open("/dev/tty") path to fail, and stderr is not a TTY.
+    with mock.patch("builtins.open", side_effect=OSError):
+        assert terminal_title._tty_stream() is None
+
+
+# ---------------------------------------------------------------------------
+# Format
+# ---------------------------------------------------------------------------
+
+def test_set_tab_title_emits_osc0(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(terminal_title, "_write", lambda s: captured.append(s))
+    terminal_title.set_tab_title("Helm", "Plan Hermes console")
+    assert captured == ["\x1b]0;Helm: Plan Hermes console\x07"]
+
+
+def test_set_tab_title_persona_only_when_no_title(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(terminal_title, "_write", lambda s: captured.append(s))
+    terminal_title.set_tab_title("Helm", "")
+    assert captured == ["\x1b]0;Helm\x07"]
+
+
+def test_set_tab_title_falls_back_to_default_persona(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(terminal_title, "_write", lambda s: captured.append(s))
+    terminal_title.set_tab_title(None, "x")
+    assert captured == ["\x1b]0;Hermes: x\x07"]
+
+
+def test_set_tab_title_truncates_long_title(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(terminal_title, "_write", lambda s: captured.append(s))
+    terminal_title.set_tab_title("Helm", "x" * 500)
+    payload = captured[0]
+    # Frame + persona prefix + truncated body, all under reasonable bound.
+    assert payload.startswith("\x1b]0;Helm: ")
+    assert payload.endswith("\x07")
+    assert len(payload) <= len("\x1b]0;") + 1 + terminal_title._MAX_TITLE_LEN + len("\x07")
+
+
+def test_set_cwd_emits_osc7_with_file_url(monkeypatch, tmp_path):
+    captured: list[str] = []
+    monkeypatch.setattr(terminal_title, "_write", lambda s: captured.append(s))
+    terminal_title.set_cwd(tmp_path)
+    assert captured, "expected one OSC 7 emission"
+    seq = captured[0]
+    assert seq.startswith("\x1b]7;file://")
+    assert str(tmp_path) in seq
+    assert seq.endswith("\x07")
+
+
+# ---------------------------------------------------------------------------
+# Persona resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_persona_prefers_explicit_config_value(tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("# Helm\nName: Helm\n", encoding="utf-8")
+    assert terminal_title.resolve_persona_name(soul, "Override") == "Override"
+
+
+def test_resolve_persona_reads_name_line(tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("# Helm\n## Identity\n- Name: Helm\n", encoding="utf-8")
+    assert terminal_title.resolve_persona_name(soul) == "Helm"
+
+
+def test_resolve_persona_falls_back_to_heading(tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("# Atlas\nSome body without a name field.\n",
+                    encoding="utf-8")
+    assert terminal_title.resolve_persona_name(soul) == "Atlas"
+
+
+def test_resolve_persona_default_when_missing(tmp_path):
+    assert terminal_title.resolve_persona_name(tmp_path / "missing.md") == "Hermes"
+
+
+def test_resolve_persona_default_when_empty(tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("", encoding="utf-8")
+    assert terminal_title.resolve_persona_name(soul) == "Hermes"


### PR DESCRIPTION
## Summary

Emit OSC 0 (window/tab title) and OSC 7 (working directory) from interactive `hermes chat` sessions so terminals like **Warp**, **iTerm2**, **Kitty**, **WezTerm**, **Ghostty**, and **tmux** display a useful, agent-aware label per tab — matching the format other agentic CLIs (Claude Code, Codex) use in their tabs.

**Format**: `<Persona>: <session title>`

**Example**: `Helm: Plan Hermes agent console with Superset UI features`

The persona name is resolved from (in order):
1. Optional `agent.persona_name` config key
2. The `Name:` line in `~/.hermes/SOUL.md`
3. The first `# heading` in SOUL.md
4. Fallback to `"Hermes"`

The session title comes from the existing `SessionDB.get_session_title(session_id)`.

## What changed

- **New module**: `hermes_cli/terminal_title.py` — OSC emission with sanitisation, truncation, persona resolution, and atexit-restore.
- **Wired into `cli.py`** at three spots (each guarded by `try/except`, so a failure here never breaks chat):
  - After `self.session_id = …` in the chat session ctor — initial emit
  - After the deferred `set_session_title(...)` apply — refresh once title generated
  - After the in-chat `/title` rename success — refresh
- **ACP no-op**: `acp_adapter/__main__.py` sets `HERMES_DISABLE_TAB_TITLE=1` because the controlling editor draws its own chrome and stdout is reserved for JSON-RPC.
- **Tests**: 16 unit tests in `tests/cli/test_terminal_title.py`.

## Safety

The module is a **silent no-op** when:
- stdout/stderr aren't TTYs (pipes, captured output, CI)
- `TERM` is unset or `dumb`
- `HERMES_DISABLE_TAB_TITLE=1` (set automatically in ACP mode)

It also:
- Sanitises control characters / ESC / BEL out of titles to prevent injection
- Truncates titles to 120 chars (with ellipsis)
- Restores cleared title on normal interpreter exit
- Emits to `/dev/tty` (preferred) or `sys.stderr` so output never lands in captured stdout

Every call site in `cli.py` is wrapped in `try: … except Exception: pass` — emission is best-effort.

## Test plan

- [x] `pytest tests/cli/test_terminal_title.py` — 16/16 passing
- [x] `python -c "import ast; ast.parse(open('cli.py').read())"` — syntax valid
- [x] Module imports cleanly (`from hermes_cli import terminal_title`)
- [ ] Manual smoke in Warp / iTerm2: tab updates after first turn (reviewers welcome to verify)
- [ ] Manual smoke under `hermes acp`: no escape sequences leak into JSON-RPC stream

## Why

Agentic CLIs are increasingly run in many parallel terminal tabs. Without a tab title, vertical-tab UIs (Warp, WezTerm) just show the binary name + cwd — indistinguishable across sessions. Other agent CLIs (Claude Code, Codex) emit OSC titles with their conversation summary, so users can scan their tab strip and find the right session. This brings Hermes to parity for the universal title/cwd portion. (Per-agent **icons** in Warp are detected internally by Warp and not settable via OSC; that's a separate upstream Warp request.)