### PR TITLE
fix: resolve external skill dirs from config path

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -201,6 +201,7 @@ def get_external_skills_dirs() -> List[Path]:
         return []
 
     local_skills = get_skills_dir().resolve()
+    config_dir = config_path.parent.resolve()
     seen: Set[Path] = set()
     result: List[Path] = []
 
@@ -208,9 +209,11 @@ def get_external_skills_dirs() -> List[Path]:
         entry = str(entry).strip()
         if not entry:
             continue
-        # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded).resolve()
+        # Expand ~ and environment variables, then resolve relative paths from config.yaml.
+        expanded = Path(os.path.expanduser(os.path.expandvars(entry)))
+        if not expanded.is_absolute():
+            expanded = config_dir / expanded
+        p = expanded.resolve()
         if p == local_skills:
             continue
         if p in seen:

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from agent.skill_utils import get_external_skills_dirs
+
+
+def test_external_skill_dirs_resolve_relative_to_config_path(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    shared_skills = tmp_path / "shared-skills"
+    other_cwd = tmp_path / "unrelated" / "other-cwd"
+
+    hermes_home.mkdir()
+    shared_skills.mkdir()
+    other_cwd.mkdir(parents=True)
+
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n  external_dirs:\n    - ../shared-skills\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(other_cwd)
+
+    assert get_external_skills_dirs() == [shared_skills.resolve()]


### PR DESCRIPTION
## Summary
- resolve relative `skills.external_dirs` entries relative to the active `config.yaml` location instead of the process working directory
- preserve existing handling for absolute paths, environment expansion, deduplication, and missing directories
- add a regression test proving cwd changes no longer break relative external skill directories

## Test Plan
- `uv run --extra dev python -m pytest tests/agent/test_skill_utils.py -q`

Closes #9949

