### PR TITLE
fix(state): repair partial schema migrations before index creation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -83,7 +83,9 @@ CREATE TABLE IF NOT EXISTS messages (
     reasoning_details TEXT,
     codex_reasoning_items TEXT
 );
+"""
 
+INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
@@ -249,6 +251,23 @@ class SessionDB:
                 self._conn.close()
                 self._conn = None
 
+    def _ensure_table_columns(self, cursor, table_name: str, required_columns: List[tuple[str, str]]):
+        """Ensure the given SQLite table has every required column.
+
+        This is a schema-repair guard for partial/broken historical migrations.
+        We inspect the live table shape instead of trusting schema_version alone.
+        """
+        existing = {
+            row["name"] if isinstance(row, sqlite3.Row) else row[1]
+            for row in cursor.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+        }
+        for name, column_type in required_columns:
+            if name in existing:
+                continue
+            safe_name = name.replace('"', '""')
+            cursor.execute(f'ALTER TABLE "{table_name}" ADD COLUMN "{safe_name}" {column_type}')
+            existing.add(name)
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, run migrations."""
         cursor = self._conn.cursor()
@@ -264,17 +283,11 @@ class SessionDB:
             current_version = row["version"] if isinstance(row, sqlite3.Row) else row[0]
             if current_version < 2:
                 # v2: add finish_reason column to messages
-                try:
-                    cursor.execute("ALTER TABLE messages ADD COLUMN finish_reason TEXT")
-                except sqlite3.OperationalError:
-                    pass  # Column already exists
+                self._ensure_table_columns(cursor, "messages", [("finish_reason", "TEXT")])
                 cursor.execute("UPDATE schema_version SET version = 2")
             if current_version < 3:
                 # v3: add title column to sessions
-                try:
-                    cursor.execute("ALTER TABLE sessions ADD COLUMN title TEXT")
-                except sqlite3.OperationalError:
-                    pass  # Column already exists
+                self._ensure_table_columns(cursor, "sessions", [("title", "TEXT")])
                 cursor.execute("UPDATE schema_version SET version = 3")
             if current_version < 4:
                 # v4: add unique index on title (NULLs allowed, only non-NULL must be unique)
@@ -287,28 +300,23 @@ class SessionDB:
                     pass  # Index already exists
                 cursor.execute("UPDATE schema_version SET version = 4")
             if current_version < 5:
-                new_columns = [
-                    ("cache_read_tokens", "INTEGER DEFAULT 0"),
-                    ("cache_write_tokens", "INTEGER DEFAULT 0"),
-                    ("reasoning_tokens", "INTEGER DEFAULT 0"),
-                    ("billing_provider", "TEXT"),
-                    ("billing_base_url", "TEXT"),
-                    ("billing_mode", "TEXT"),
-                    ("estimated_cost_usd", "REAL"),
-                    ("actual_cost_usd", "REAL"),
-                    ("cost_status", "TEXT"),
-                    ("cost_source", "TEXT"),
-                    ("pricing_version", "TEXT"),
-                ]
-                for name, column_type in new_columns:
-                    try:
-                        # name and column_type come from the hardcoded tuple above,
-                        # not user input. Double-quote identifier escaping is applied
-                        # as defense-in-depth; SQLite DDL cannot be parameterized.
-                        safe_name = name.replace('"', '""')
-                        cursor.execute(f'ALTER TABLE sessions ADD COLUMN "{safe_name}" {column_type}')
-                    except sqlite3.OperationalError:
-                        pass
+                self._ensure_table_columns(
+                    cursor,
+                    "sessions",
+                    [
+                        ("cache_read_tokens", "INTEGER DEFAULT 0"),
+                        ("cache_write_tokens", "INTEGER DEFAULT 0"),
+                        ("reasoning_tokens", "INTEGER DEFAULT 0"),
+                        ("billing_provider", "TEXT"),
+                        ("billing_base_url", "TEXT"),
+                        ("billing_mode", "TEXT"),
+                        ("estimated_cost_usd", "REAL"),
+                        ("actual_cost_usd", "REAL"),
+                        ("cost_status", "TEXT"),
+                        ("cost_source", "TEXT"),
+                        ("pricing_version", "TEXT"),
+                    ],
+                )
                 cursor.execute("UPDATE schema_version SET version = 5")
             if current_version < 6:
                 # v6: add reasoning columns to messages table — preserves assistant
@@ -316,19 +324,51 @@ class SessionDB:
                 # session turns.  Without these, reasoning chains are lost on
                 # session reload, breaking multi-turn reasoning continuity for
                 # providers that replay reasoning (OpenRouter, OpenAI, Nous).
-                for col_name, col_type in [
-                    ("reasoning", "TEXT"),
-                    ("reasoning_details", "TEXT"),
-                    ("codex_reasoning_items", "TEXT"),
-                ]:
-                    try:
-                        safe = col_name.replace('"', '""')
-                        cursor.execute(
-                            f'ALTER TABLE messages ADD COLUMN "{safe}" {col_type}'
-                        )
-                    except sqlite3.OperationalError:
-                        pass  # Column already exists
+                self._ensure_table_columns(
+                    cursor,
+                    "messages",
+                    [
+                        ("reasoning", "TEXT"),
+                        ("reasoning_details", "TEXT"),
+                        ("codex_reasoning_items", "TEXT"),
+                    ],
+                )
                 cursor.execute("UPDATE schema_version SET version = 6")
+
+        # Repair any partial historical migration regardless of recorded version.
+        self._ensure_table_columns(
+            cursor,
+            "sessions",
+            [
+                ("parent_session_id", "TEXT"),
+                ("title", "TEXT"),
+                ("cache_read_tokens", "INTEGER DEFAULT 0"),
+                ("cache_write_tokens", "INTEGER DEFAULT 0"),
+                ("reasoning_tokens", "INTEGER DEFAULT 0"),
+                ("billing_provider", "TEXT"),
+                ("billing_base_url", "TEXT"),
+                ("billing_mode", "TEXT"),
+                ("estimated_cost_usd", "REAL"),
+                ("actual_cost_usd", "REAL"),
+                ("cost_status", "TEXT"),
+                ("cost_source", "TEXT"),
+                ("pricing_version", "TEXT"),
+            ],
+        )
+        self._ensure_table_columns(
+            cursor,
+            "messages",
+            [
+                ("finish_reason", "TEXT"),
+                ("reasoning", "TEXT"),
+                ("reasoning_details", "TEXT"),
+                ("codex_reasoning_items", "TEXT"),
+            ],
+        )
+
+        # Create secondary indexes only after repair/migration so historical
+        # partial schemas do not fail to open before missing columns are added.
+        cursor.executescript(INDEX_SQL)
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1010,6 +1010,153 @@ class TestSchemaInit:
 
         migrated_db.close()
 
+    def test_repairs_partial_v5_migration_when_schema_version_is_already_6(self, tmp_path):
+        """A DB that claims v6 but is missing one v5 column should self-heal."""
+        import sqlite3
+        from agent.insights import InsightsEngine
+
+        db_path = tmp_path / "partial_v6.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                title TEXT,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, input_tokens, output_tokens) VALUES (?, ?, ?, ?, ?)",
+            ("existing", "cli", time.time(), 12, 7),
+        )
+        conn.commit()
+        conn.close()
+
+        repaired_db = SessionDB(db_path=db_path)
+        cursor = repaired_db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "cache_read_tokens" in columns
+
+        report = InsightsEngine(repaired_db).generate(days=30)
+        assert report["empty"] is False
+        assert report["overview"]["total_sessions"] == 1
+
+        repaired_db.close()
+
+    def test_repairs_missing_parent_session_id_before_creating_indexes(self, tmp_path):
+        """A broken DB missing parent_session_id should repair before idx_sessions_parent is created."""
+        import sqlite3
+
+        db_path = tmp_path / "partial_missing_parent.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                title TEXT,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("existing", "cli", time.time()),
+        )
+        conn.commit()
+        conn.close()
+
+        repaired_db = SessionDB(db_path=db_path)
+        columns = {
+            row[1] for row in repaired_db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert "parent_session_id" in columns
+
+        index_names = {
+            row[1] for row in repaired_db._conn.execute("PRAGMA index_list('sessions')").fetchall()
+        }
+        assert "idx_sessions_parent" in index_names
+
+        repaired_db.close()
+
 
 class TestTitleUniqueness:
     """Tests for unique title enforcement and title-based lookups."""


### PR DESCRIPTION
## Summary
- repair partial historical `SessionDB` schemas by inspecting actual columns on open
- add any missing required `sessions` columns even when `schema_version` already reports current
- create secondary indexes only after repair so broken historical DBs can open successfully

## Problem
A database can end up with `schema_version` set to a newer value even though one or more `ALTER TABLE` steps did not actually land. Current startup logic trusts the version too much, so later queries can fail with errors like:

- `sqlite3.OperationalError: no such column: cache_read_tokens`
- index creation failures when `parent_session_id` is missing

## Fix
This change adds a schema repair pass based on `PRAGMA table_info(...)` for the `sessions` table and defers secondary index creation until after that repair pass. That makes startup self-heal partial historical migrations instead of treating them as permanently current.

## Tests
- `./.venv/bin/python -m pytest -q -n0 tests/test_hermes_state.py::TestSchemaInit`

Includes regressions for:
- a DB claiming schema version 6 while missing `cache_read_tokens`
- a DB missing `parent_session_id` before `idx_sessions_parent` creation
