### PR TITLE
fix(run_agent): salvage streamed text for malformed final responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -845,6 +845,14 @@ class AIAgent:
         # Internal stream callback (set during streaming TTS).
         # Initialized here so _vprint can reference it before run_conversation.
         self._stream_callback = None
+        # Visible text that was already streamed to the user during the current
+        # API attempt. Lets us salvage a response if the provider later returns a
+        # malformed final object after successful text delivery.
+        self._streamed_visible_text_parts: List[str] = []
+        # Track whether the current streamed attempt observed tool call deltas.
+        # Text salvage is only safe for pure text turns; if tool calls were seen,
+        # a malformed final response must not be converted into a completed answer.
+        self._streamed_visible_text_had_tool_calls = False
         # Deferred paragraph break flag — set after tool iterations so a
         # single "\n\n" is prepended to the next real text delta.
         self._stream_needs_break = False
@@ -4949,6 +4957,13 @@ class AIAgent:
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
 
+    def _reset_streamed_visible_text(self) -> None:
+        self._streamed_visible_text_parts = []
+        self._streamed_visible_text_had_tool_calls = False
+
+    def _get_streamed_visible_text(self) -> str:
+        return "".join(getattr(self, "_streamed_visible_text_parts", [])).strip()
+
     def _fire_stream_delta(self, text: str) -> None:
         """Fire all registered stream delta callbacks (display + TTS)."""
         # If a tool iteration set the break flag, prepend a single paragraph
@@ -4958,6 +4973,8 @@ class AIAgent:
         if getattr(self, "_stream_needs_break", False) and text and text.strip():
             self._stream_needs_break = False
             text = "\n\n" + text
+        if isinstance(text, str) and text:
+            self._streamed_visible_text_parts.append(text)
         callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
         delivered = False
         for cb in callbacks:
@@ -5154,6 +5171,7 @@ class AIAgent:
 
                 # Accumulate tool call deltas — notify display on first name
                 if delta and delta.tool_calls:
+                    self._streamed_visible_text_had_tool_calls = True
                     for tc_delta in delta.tool_calls:
                         raw_idx = tc_delta.index if tc_delta.index is not None else 0
                         delta_id = tc_delta.id or ""
@@ -7819,6 +7837,7 @@ class AIAgent:
 
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback
+        self._reset_streamed_visible_text()
         self._persist_user_message_idx = None
         self._persist_user_message_override = persist_user_message
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
@@ -8382,6 +8401,7 @@ class AIAgent:
                         if isinstance(getattr(self, "client", None), Mock):
                             _use_streaming = False
 
+                    self._reset_streamed_visible_text()
                     if _use_streaming:
                         response = self._interruptible_streaming_api_call(
                             api_kwargs, on_first_delta=_stop_spinner
@@ -8473,11 +8493,43 @@ class AIAgent:
                             thinking_spinner = None
                         if self.thinking_callback:
                             self.thinking_callback("")
-                        
+
                         # Invalid response — could be rate limiting, provider timeout,
                         # upstream server error, or malformed response.
+                        streamed_visible_text = self._get_streamed_visible_text()
+                        streamed_turn_had_tool_calls = getattr(
+                            self, "_streamed_visible_text_had_tool_calls", False
+                        )
+                        if (
+                            self.api_mode == "chat_completions"
+                            and streamed_visible_text
+                            and not streamed_turn_had_tool_calls
+                        ):
+                            logger.warning(
+                                "Salvaging malformed chat_completions final response from %d streamed chars.",
+                                len(streamed_visible_text),
+                            )
+                            response = SimpleNamespace(
+                                choices=[
+                                    SimpleNamespace(
+                                        message=SimpleNamespace(
+                                            role="assistant",
+                                            content=streamed_visible_text,
+                                            tool_calls=None,
+                                            reasoning_content=None,
+                                        ),
+                                        finish_reason="stop",
+                                    )
+                                ],
+                                model=getattr(response, "model", None) if response is not None else None,
+                                usage=getattr(response, "usage", None) if response is not None else None,
+                            )
+                            response_invalid = False
+
+                    if response_invalid:
+                        # This is often rate limiting or provider returning malformed response
                         retry_count += 1
-                        
+
                         # Eager fallback: empty/malformed responses are a common
                         # rate-limit symptom.  Switch to fallback immediately
                         # rather than retrying with extended backoff.
@@ -8499,18 +8551,18 @@ class AIAgent:
                                 provider_name = response.error.metadata.get('provider_name', 'Unknown')
                         elif response and hasattr(response, 'message') and response.message:
                             error_msg = str(response.message)
-                        
+
                         # Try to get provider from model field (OpenRouter often returns actual model used)
                         if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
                             provider_name = f"model={response.model}"
-                        
+
                         # Check for x-openrouter-provider or similar metadata
                         if provider_name == "Unknown" and response:
                             # Log all response attributes for debugging
                             resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
                             if self.verbose_logging:
                                 logging.debug(f"Response attributes for invalid response: {resp_attrs}")
-                        
+
                         # Extract error code from response for contextual diagnostics
                         _resp_error_code = None
                         if response and hasattr(response, 'error') and response.error:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1685,6 +1685,60 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_streamed_text_salvaged_when_final_response_is_malformed(self, agent):
+        """If streaming already produced visible text, don't retry and duplicate it."""
+        self._setup_agent(agent)
+        deltas = []
+        agent.stream_delta_callback = lambda text: deltas.append(text)
+
+        def _bad_streaming_call(_api_kwargs, on_first_delta=None):
+            if on_first_delta:
+                on_first_delta()
+            agent._fire_stream_delta("Good morning! How can I help today?")
+            return SimpleNamespace(choices=[], model="test/model", usage=None)
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_streaming_api_call", side_effect=_bad_streaming_call),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 1
+        assert result["final_response"] == "Good morning! How can I help today?"
+        assert deltas == ["Good morning! How can I help today?"]
+
+    def test_streamed_text_not_salvaged_when_tool_calls_were_seen(self, agent):
+        """A malformed final response must not turn a tool turn into a completed text answer."""
+        self._setup_agent(agent)
+        deltas = []
+        agent.stream_delta_callback = lambda text: deltas.append(text)
+        agent._fallback_chain = []
+
+        def _bad_streaming_call(_api_kwargs, on_first_delta=None):
+            if on_first_delta:
+                on_first_delta()
+            agent._fire_stream_delta("Let me check that for you.")
+            agent._streamed_visible_text_had_tool_calls = True
+            return SimpleNamespace(choices=[], model="test/model", usage=None)
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_streaming_api_call", side_effect=_bad_streaming_call),
+            patch("run_agent.jittered_backoff", return_value=0.0),
+            patch("run_agent.time.sleep", return_value=None),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert "final_response" not in result
+        assert len(deltas) >= 1
+        assert all(delta == "Let me check that for you." for delta in deltas)
+
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary
- salvage already-streamed visible text when a `chat_completions` call returns a malformed final response object
- track whether tool-call deltas were seen during the attempt
- only salvage for text-only streamed turns, never for tool turns

## Problem
There is already nearby recovery logic for partial streamed content when a connection fails, but a different failure mode still falls through: the provider can stream visible assistant text successfully and then return a malformed final response object (for example `choices=[]`). In that case the current path retries / falls back even though the user already saw the text, which can duplicate output and waste additional API calls.

## Fix
This extends recovery to the malformed-final-response case by synthesizing the final assistant response from the already-streamed visible text. To keep the behavior narrow and safe, the salvage path is disabled if any tool-call deltas were observed during the attempt.

## Tests
- `./.venv/bin/python -m pytest -q -n0 tests/run_agent/test_run_agent.py::TestRunConversation::test_streamed_text_salvaged_when_final_response_is_malformed tests/run_agent/test_run_agent.py::TestRunConversation::test_streamed_text_not_salvaged_when_tool_calls_were_seen tests/run_agent/test_run_agent.py::TestRunConversation::test_partial_stream_recovery_on_empty_stub`
