### PR TITLE
fix(docker): repair config.yaml permissions on startup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,6 +51,13 @@ if [ ! -f "$HERMES_HOME/config.yaml" ]; then
     cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
 fi
 
+# Ensure the main config file remains accessible to the hermes runtime user
+# even if it was edited on the host after initial ownership setup.
+if [ -f "$HERMES_HOME/config.yaml" ]; then
+    chown hermes:hermes "$HERMES_HOME/config.yaml"
+    chmod 640 "$HERMES_HOME/config.yaml"
+fi
+
 # SOUL.md
 if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
     cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"


### PR DESCRIPTION
## What does this PR do?

This PR fixes a startup issue where `/opt/data/config.yaml` can become unreadable
to the `hermes` runtime user after being edited on the host as `root`.

Currently, the entrypoint only performs a recursive ownership fix when the
top-level `$HERMES_HOME` directory is not owned by the expected runtime user.
This misses the case where the directory ownership is already correct, but
`config.yaml` itself has drifted to `root:root` with restrictive permissions.

This change adds a small targeted repair step during startup to ensure
`$HERMES_HOME/config.yaml` remains owned by `hermes:hermes` and readable by
the runtime user if the file exists.

This approach is intentionally minimal and scoped only to the main config file,
rather than recursively resetting the entire data directory on every startup.

## Related Issue

Fixes #<在这里填你的issue编号>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `docker/entrypoint.sh`
- Added a startup-time ownership and permission repair step for `$HERMES_HOME/config.yaml`
- Ensures `config.yaml` is accessible to the `hermes` runtime user even if it was edited on the host after initial ownership setup

## How to Test

1. Start Hermes with `/opt/data` bind-mounted from the host
2. Let the container initialize ownership normally
3. Change `/opt/data/config.yaml` on the host so it becomes owned by `root:root`
4. Set restrictive permissions, for example: `chmod 600 /opt/data/config.yaml`
5. Restart the container
6. Confirm Hermes starts without `Permission denied: '/opt/data/config.yaml'`
7. Confirm the file ownership/permissions are repaired on startup

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Docker)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix:

```text
WARNING gateway.config: Failed to process config.yaml — falling back to .env / gateway.json values.
Error: [Errno 13] Permission denied: '/opt/data/config.yaml'