### PR TITLE
fix: increase API retry limit from 3 to 10

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7858,7 +7858,7 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            max_retries = 10
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted=False


### PR DESCRIPTION
Improve resilience against transient API errors in run_agent conversation loop.

Increase max_retries from 3 to 10 in the API call retry loop.