### PR TITLE
fix(security): add SSRF checks to Skills Hub fetches

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -32,6 +32,7 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 import yaml
 
+from tools.url_safety import is_safe_url
 from tools.skills_guard import (
     ScanResult, content_hash, TRUSTED_REPOS,
 )
@@ -886,6 +887,9 @@ class WellKnownSkillSource(SkillSource):
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
             return cached
 
+        if not is_safe_url(index_url):
+            logger.warning("Blocked SSRF: unsafe index URL %s", index_url)
+            return None
         try:
             resp = httpx.get(index_url, timeout=20, follow_redirects=True)
             if resp.status_code != 200:
@@ -917,6 +921,9 @@ class WellKnownSkillSource(SkillSource):
 
     @staticmethod
     def _fetch_text(url: str) -> Optional[str]:
+        if not is_safe_url(url):
+            logger.warning("Blocked SSRF: unsafe fetch URL %s", url)
+            return None
         try:
             resp = httpx.get(url, timeout=20, follow_redirects=True)
             if resp.status_code == 200:
@@ -1822,11 +1829,15 @@ class ClawHubSource(SkillSource):
         import zipfile
 
         files: Dict[str, str] = {}
+        download_url = f"{self.BASE_URL}/download"
+        if not is_safe_url(download_url):
+            logger.warning("Blocked SSRF: unsafe download URL %s", download_url)
+            return files
         max_retries = 3
         for attempt in range(max_retries):
             try:
                 resp = httpx.get(
-                    f"{self.BASE_URL}/download",
+                    download_url,
                     params={"slug": slug, "version": version},
                     timeout=30,
                     follow_redirects=True,
@@ -1880,6 +1891,9 @@ class ClawHubSource(SkillSource):
         return files
 
     def _fetch_text(self, url: str) -> Optional[str]:
+        if not is_safe_url(url):
+            logger.warning("Blocked SSRF: unsafe fetch URL %s", url)
+            return None
         try:
             resp = httpx.get(url, timeout=20)
             if resp.status_code == 200:


### PR DESCRIPTION
## What does this PR do?

Fix SSRF vulnerability (CWE-918, HIGH) in Skills Hub HTTP request handling.

Skills Hub fetch methods (`_parse_index()`, `_fetch_text()`, `_download_zip()`) use
`httpx.get()` with `follow_redirects=True` but do not validate whether the target URL
resolves to a private/internal network address. A malicious skill source index could
contain URLs pointing to internal services (e.g. `http://169.254.169.254/`,
`http://localhost:8080/`), allowing an attacker to probe or exfiltrate data from
the internal network.

This PR adds `is_safe_url()` checks before outbound requests in the affected methods.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- Added `is_safe_url()` guard in `WellKnownSkillSource._parse_index()` — validates index URL before fetch
- Added `is_safe_url()` guard in `WellKnownSkillSource._fetch_text()` — validates arbitrary text fetch URLs
- Added `is_safe_url()` guard in `SkillsShSource._download_zip()` — validates download URL before ZIP fetch
- Added `is_safe_url()` guard in `SkillsShSource._fetch_text()` — validates text fetch URLs

## How to Test

1. `pytest tests/ -q` — all existing tests pass
2. Verify skill installation from public sources still works
3. Verify URLs resolving to private IPs are blocked (logged as warning)