### PR TITLE
fix(security): strip MCP auth on cross-origin redirect

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -975,9 +975,22 @@ class MCPServerTask:
             # matching the SDK's own create_mcp_http_client defaults.
             import httpx
 
+            _original_url = httpx.URL(url)
+
+            async def _strip_auth_on_cross_origin_redirect(response):
+                """Strip Authorization headers when redirected to a different origin."""
+                if response.is_redirect and response.next_request:
+                    target = response.next_request.url
+                    if (target.scheme, target.host, target.port) != (
+                        _original_url.scheme, _original_url.host, _original_url.port,
+                    ):
+                        response.next_request.headers.pop("authorization", None)
+                        response.next_request.headers.pop("Authorization", None)
+
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
+                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
             }
             if headers:
                 client_kwargs["headers"] = headers


### PR DESCRIPTION
## What does this PR do?

Fix credential leakage vulnerability (CWE-522, MEDIUM) in MCP HTTP transport.

The MCP HTTP client uses `httpx.AsyncClient` with `follow_redirects=True` and
passes `Authorization` headers (or OAuth auth) for server authentication. When
the MCP server responds with a redirect to a different origin, httpx forwards
the credentials to the redirect target. A malicious or compromised MCP server
could redirect to an attacker-controlled endpoint to capture the auth token.

This PR adds an httpx event hook that strips `Authorization` headers when a
redirect crosses origin boundaries (different scheme, host, or port).

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- Added `_strip_auth_on_cross_origin_redirect()` event hook in `tools/mcp_tool.py`
  `_run_http()` method — compares redirect target origin against the original URL
  and removes `Authorization` headers on mismatch.
- Wired the hook into `httpx.AsyncClient` via `event_hooks` parameter.

## How to Test

1. `pytest tests/ -q` — all existing tests pass
2. Verify MCP HTTP connections to same-origin servers still authenticate normally
3. Verify cross-origin redirects no longer carry Authorization headers