### PR TITLE
fix(security): tag untrusted senders in Slack threads

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1457,7 +1457,19 @@ class SlackAdapter(BasePlatformAdapter):
                 is_parent = msg_ts == thread_ts
                 prefix = "[thread parent] " if is_parent else ""
                 name = await self._resolve_user_name(msg_user, chat_id=channel_id)
-                context_parts.append(f"{prefix}{name}: {msg_text}")
+
+                # Tag messages from users not on the allowlist
+                trust_tag = ""
+                allow_all = os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or \
+                    os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+                if not allow_all:
+                    allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+                    if allowed_csv:
+                        allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+                        if "*" not in allowed_ids and msg_user not in allowed_ids:
+                            trust_tag = "[Message from untrusted user] "
+
+                context_parts.append(f"{prefix}{trust_tag}{name}: {msg_text}")
 
             content = ""
             if context_parts:


### PR DESCRIPTION
## What does this PR do?

Fix indirect prompt injection vulnerability (CWE-863, MEDIUM) in Slack thread context.

`_fetch_thread_context()` includes all non-bot thread replies as context for the LLM
without distinguishing between authorized and unauthorized senders. An unauthorized user
can post crafted messages in a public thread to inject instructions into the LLM context,
potentially manipulating the bot's behavior for authorized users in the same thread.

This PR labels messages from non-allowlisted users with `[Message from untrusted user]`
prefix in thread context, preserving thread functionality while making the trust boundary
visible to the LLM.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- Added trust tagging in `SlackAdapter._fetch_thread_context()` in `gateway/platforms/slack.py`
  — checks `SLACK_ALLOW_ALL_USERS`, `GATEWAY_ALLOW_ALL_USERS`, and `SLACK_ALLOWED_USERS`
  env vars, consistent with existing auth patterns in the adapter.
- Messages from users not on the allowlist get `[Message from untrusted user]` prefix.
- When no allowlist is configured, all users are treated as trusted (backward compatible).

## How to Test

1. `pytest tests/ -q` — all existing tests pass
2. Configure `SLACK_ALLOWED_USERS` with specific user IDs
3. Verify thread replies from allowlisted users appear without prefix
4. Verify thread replies from non-allowlisted users get `[Message from untrusted user]` prefix