### PR TITLE
fix(security): auth check before Telegram media download

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -791,6 +791,7 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._auth_check: Optional[Callable[[Any], bool]] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
@@ -924,6 +925,10 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_auth_check(self, checker: Callable[[Any], bool]) -> None:
+        """Set an authorization checker (receives SessionSource, returns bool)."""
+        self._auth_check = checker
 
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2344,9 +2344,19 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(update.message):
             return
-        
+
+        # Check authorization before downloading media
         msg = update.message
-        
+        if self._auth_check and msg.from_user:
+            source = self.build_source(
+                chat_id=str(msg.chat.id),
+                user_id=str(msg.from_user.id),
+                user_name=msg.from_user.full_name,
+            )
+            if not self._auth_check(source):
+                logger.debug("[Telegram] Skipping media download for unauthorized user %s", msg.from_user.id)
+                return
+
         # Determine media type
         if msg.sticker:
             msg_type = MessageType.STICKER

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1747,6 +1747,7 @@ class GatewayRunner:
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_auth_check(self._is_user_authorized)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -2091,6 +2092,7 @@ class GatewayRunner:
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter.set_auth_check(self._is_user_authorized)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)


### PR DESCRIPTION
## What does this PR do?

Fix authorization bypass vulnerability (CWE-862, MEDIUM) in Telegram media handling.

`_handle_media_message()` downloads media files (photos, videos, documents, voice) from
Telegram's servers before user authorization is checked. The auth check only happens
later in `GatewayRunner._handle_message()`. An unauthorized user can send media messages
to trigger file downloads, consuming server bandwidth, disk space, and API quota without
ever being authorized to interact with the bot.

This PR adds an `auth_check` callback to `BasePlatformAdapter` and wires it to the existing
`_is_user_authorized()` in `GatewayRunner`. `TelegramAdapter._handle_media_message()` now
checks authorization before downloading any media.

## Related Issue

N/A

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- Added `set_auth_check()` callback to `BasePlatformAdapter` in `gateway/platforms/base.py`
- Registered `_is_user_authorized` as the auth callback in `GatewayRunner` in `gateway/run.py`
- Added early auth check in `TelegramAdapter._handle_media_message()` before media download

## How to Test

1. `pytest tests/ -q` — all existing tests pass
2. Configure `TELEGRAM_ALLOWED_USERS` with specific user IDs
3. Verify authorized users can still send media normally
4. Verify unauthorized users' media messages are silently skipped (no download)