### PR TITLE
fix: normalize tool_call_id whitespace in sanitizer

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3293,8 +3293,8 @@ class AIAgent:
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("id", "") or ""
-        return getattr(tc, "id", "") or ""
+            return (tc.get("id", "") or "").strip()
+        return (getattr(tc, "id", "") or "").strip()
 
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
@@ -3330,7 +3330,7 @@ class AIAgent:
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = (msg.get("tool_call_id") or "").strip()
                 if cid:
                     result_call_ids.add(cid)
 
@@ -3339,7 +3339,7 @@ class AIAgent:
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (m.get("role") == "tool" and (m.get("tool_call_id") or "").strip() in orphaned_results)
             ]
             logger.debug(
                 "Pre-call sanitizer: removed %d orphaned tool result(s)",

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -108,6 +108,30 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_tool_result_with_leading_whitespace_preserved(self):
+        """Tool result IDs with leading/trailing whitespace should match assistant call IDs."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("functions.cronjob:24")]},
+            tool_result(" functions.cronjob:24"),  # leading whitespace
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Should NOT inject a stub — the tool result is valid after stripping
+        assert len(out) == 2
+        assert out[1]["role"] == "tool"
+        assert out[1]["content"] == "ok"
+
+    def test_truly_orphaned_with_whitespace_still_removed(self):
+        """Truly orphaned tool results with whitespace should still be removed."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c_valid")]},
+            tool_result(" c_ORPHAN "),  # whitespace + no matching call
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2  # assistant + stub for c_valid, orphan removed
+        tool_msgs = [m for m in out if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "c_valid"
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## Summary
Fixes tool result misclassification when tool_call_id has leading/trailing whitespace.

## Root Cause
`_sanitize_api_messages()` compared raw tool_call_id strings without stripping whitespace. When assistant-side IDs (via `_get_tool_call_id_static`) and tool-result IDs diverged due to surrounding whitespace, valid tool results were treated as orphaned and replaced with stub placeholders.

## Fix
- Strip whitespace in `_get_tool_call_id_static()` for both dict and object tool_calls
- Strip whitespace when collecting `result_call_ids` from tool messages
- Strip whitespace when filtering orphaned results

## Test Plan
- [x] Relevant unit tests pass (9/9 in test_agent_guardrails.py)
- [x] New regression tests: whitespace-preserved tool results, orphaned whitespace still removed

Closes NousResearch/hermes-agent#9999