### PR TITLE
fix(codex): force codex_responses api_mode for openai-codex provider

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -676,13 +676,19 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        # openai-codex MUST use /responses — /chat/completions is now blocked by
+        # Cloudflare managed challenge (observed 2026-04-14). Force the required
+        # api_mode before honoring any caller-passed override, because stale
+        # api_mode="chat_completions" can leak in via delegate_tool inheritance
+        # (see tools/delegate_tool.py:325) or resolve_runtime_provider() cache.
+        if self.provider == "openai-codex" or (
+            (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower
+        ):
+            self.api_mode = "codex_responses"
+            if self.provider != "openai-codex":
+                self.provider = "openai-codex"
+        elif api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             self.api_mode = api_mode
-        elif self.provider == "openai-codex":
-            self.api_mode = "codex_responses"
-        elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
-            self.api_mode = "codex_responses"
-            self.provider = "openai-codex"
         elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
             self.api_mode = "anthropic_messages"
             self.provider = "anthropic"


### PR DESCRIPTION
## Summary

- `openai-codex` provider targets `chatgpt.com/backend-api/codex/*`, but Cloudflare started issuing managed challenges (403) on `/chat/completions` on 2026-04-14.
- The correct path (`/responses`, aka `api_mode="codex_responses"`) is not yet challenged, and is already the documented transport for this provider in `hermes_cli/providers.py:57`.
- However, `AIAgent.__init__` honored a caller-passed `api_mode` before applying the provider requirement. A stale `api_mode="chat_completions"` could leak in via `tools/delegate_tool.py:325` (subagent inherits parent's post-switch api_mode) or `resolve_runtime_provider()` cache from a previous OpenRouter/etc. session, routing `openai-codex` to the blocked endpoint.
- **Fix**: flip the resolution order so `provider == "openai-codex"` (or base_url = `chatgpt.com/backend-api/codex`) always forces `api_mode="codex_responses"` before considering caller overrides.

Verified symptom in local logs: 111+ CF challenge pages captured on `/backend-api/codex/chat/completions?__cf_chl_tk=…` in a 24h window.

Upstream references: [openclaw/openclaw#66633](https://github.com/openclaw/openclaw/issues/66633), [#62142](https://github.com/openclaw/openclaw/issues/62142), [#62087](https://github.com/openclaw/openclaw/issues/62087) — parallel Cloudflare blocker across ecosystems.

## Test plan

- [ ] Unit: existing `test_auth_codex_provider.py` / `test_codex_models.py` pass
- [ ] Integration: run a gpt-5.4 turn; verify request URL = `.../codex/responses`, not `/chat/completions`
- [ ] Regression: confirm `anthropic_messages` / `chat_completions` still selectable for non-codex providers when caller explicitly passes `api_mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)