### PR TITLE
feat(config): teach _secure_file to honor HERMES_FILE_MODE

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -242,16 +242,34 @@ def _secure_dir(path):
 
 
 def _secure_file(path):
-    """Set file to owner-only read/write (0600). No-op on Windows.
+    """Set file to owner-only read/write (0600 by default). No-op on Windows.
 
     Skipped in managed mode — the NixOS activation script sets
     group-readable permissions (0640) on config files.
+
+    The mode can be overridden via the HERMES_FILE_MODE environment variable
+    (e.g. HERMES_FILE_MODE=0660) for deployments where multiple users in a
+    shared group need to read and write HERMES_HOME state. This is the
+    file-level counterpart to HERMES_HOME_MODE (which governs directory
+    permissions) and is intended to be set alongside it.
+
+    Typical shared-state pairing:
+        HERMES_HOME_MODE=02770   # rwxrwx--- + setgid on dirs
+        HERMES_FILE_MODE=0660    # rw-rw---- on files
+
+    If HERMES_FILE_MODE is unset or invalid, the default 0600 is used —
+    fully backward compatible.
     """
     if is_managed():
         return
     try:
+        mode_str = os.environ.get("HERMES_FILE_MODE", "").strip()
+        mode = int(mode_str, 8) if mode_str else 0o600
+    except ValueError:
+        mode = 0o600
+    try:
         if os.path.exists(str(path)):
-            os.chmod(path, 0o600)
+            os.chmod(path, mode)
     except (OSError, NotImplementedError):
         pass
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -60,6 +60,49 @@ class TestEnsureHermesHome:
             assert soul_path.read_text(encoding="utf-8") == "custom soul"
 
 
+class TestSecureFileMode:
+    """_secure_file honors HERMES_FILE_MODE (paired with HERMES_HOME_MODE)."""
+
+    def test_default_mode_is_0600(self, tmp_path):
+        from hermes_cli.config import _secure_file
+        f = tmp_path / "default.txt"
+        f.write_text("x")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_FILE_MODE", None)
+            _secure_file(f)
+        assert (f.stat().st_mode & 0o777) == 0o600
+
+    def test_env_override_applies_0660(self, tmp_path):
+        from hermes_cli.config import _secure_file
+        f = tmp_path / "shared.txt"
+        f.write_text("x")
+        with patch.dict(os.environ, {"HERMES_FILE_MODE": "0660"}):
+            _secure_file(f)
+        assert (f.stat().st_mode & 0o777) == 0o660
+
+    def test_env_override_applies_0640(self, tmp_path):
+        from hermes_cli.config import _secure_file
+        f = tmp_path / "readable.txt"
+        f.write_text("x")
+        with patch.dict(os.environ, {"HERMES_FILE_MODE": "0640"}):
+            _secure_file(f)
+        assert (f.stat().st_mode & 0o777) == 0o640
+
+    def test_invalid_mode_falls_back_to_default(self, tmp_path):
+        from hermes_cli.config import _secure_file
+        f = tmp_path / "invalid.txt"
+        f.write_text("x")
+        with patch.dict(os.environ, {"HERMES_FILE_MODE": "not-octal"}):
+            _secure_file(f)
+        assert (f.stat().st_mode & 0o777) == 0o600
+
+    def test_nonexistent_path_is_noop(self):
+        from hermes_cli.config import _secure_file
+        # Should not raise, regardless of env.
+        with patch.dict(os.environ, {"HERMES_FILE_MODE": "0660"}):
+            _secure_file(Path("/nonexistent/path/never.txt"))
+
+
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):


### PR DESCRIPTION
## Summary

`_secure_dir` in `hermes_cli/config.py` already reads `HERMES_HOME_MODE` from the environment so deployments with unusual access requirements (reverse-proxy traversal, group-shared state, NixOS-style activation) can relax the default `0700` directory mode. `_secure_file` is the file-level counterpart but hardcodes `0600` with no escape hatch — so even when the surrounding directories are group-accessible, `SOUL.md` and other files stay owner-only and lock out other group members.

This PR adds a paired `HERMES_FILE_MODE` environment variable so operators can opt into group-readable or group-writable files when they've already set `HERMES_HOME_MODE`. Default behavior is unchanged (`0600`).

## Motivation

A shared Hermes state directory where multiple Unix users (in the same group) spawn short-lived `hermes mcp serve` subprocesses against the same SQLite WAL. Today you can:

- Pre-create `~/.hermes` at `2770`
- Set `HERMES_HOME_MODE=02770` so `_secure_dir` preserves directory perms + setgid across every startup

But `SOUL.md` — seeded on first run via `_ensure_default_soul_md` → `_secure_file` — lands at `0600` and stays there forever. Any group member that isn't the owner can't read it, and downstream tools that read `SOUL.md` at session start (agent persona loading, memory setup) silently fail for those users. The current workaround is a one-time `chmod 0660 ~/.hermes/SOUL.md` out-of-band, which is easy to forget when a fresh Hermes install is stood up.

With this PR, setting `HERMES_HOME_MODE=02770 HERMES_FILE_MODE=0660` together produces the exact shared-state perms the docstring on `_secure_dir` already hints at supporting.

## Change

One function, `_secure_file`, now reads `HERMES_FILE_MODE` the same way `_secure_dir` reads `HERMES_HOME_MODE`:

```python
try:
    mode_str = os.environ.get(\"HERMES_FILE_MODE\", \"\").strip()
    mode = int(mode_str, 8) if mode_str else 0o600
except ValueError:
    mode = 0o600
try:
    if os.path.exists(str(path)):
        os.chmod(path, mode)
except (OSError, NotImplementedError):
    pass
```

Docstring updated with the typical pairing example. No API change, no new required config, no migration.

## Backward compatibility

- **Unset env var** → default `0600` (unchanged from today).
- **Invalid octal in env var** → falls back to `0600` (conservative).
- **Windows / managed mode** → same existing short-circuits apply (no-op).
- Callers of `_secure_file` elsewhere in the codebase (`save_env_value_secure`, config persistence, etc.) all inherit the same override, which matches the design intent of `_secure_dir` already.

## Tests

Five new cases in `tests/hermes_cli/test_config.py` → `TestSecureFileMode`:

1. Default mode is `0600` when env var unset.
2. `HERMES_FILE_MODE=0660` applies `0660`.
3. `HERMES_FILE_MODE=0640` applies `0640` (alternate group-readable).
4. Invalid octal falls back to default `0600`.
5. Nonexistent path is a no-op (matches existing `test_secure_file_nonexistent_no_error`).

Full test suite for `test_config.py` passes (52 tests) locally against `main` at SHA `1af2e18d` (v2026.4.13).

## Related

- Complement to existing `HERMES_HOME_MODE` support on `_secure_dir`.
- Downstream consumer: https://github.com/alxpck/intercom — a shared-state MCP broker that motivated this change.

## Out of scope

- Changing the default file mode (still 0600).
- Auto-deriving file mode from `HERMES_HOME_MODE` (e.g. masking execute bits). The explicit paired env var is less magical and mirrors the existing `HERMES_HOME_MODE` pattern; auto-derivation would change default behavior in subtle ways when `HERMES_HOME_MODE` is set without a matching file intent.
- Windows file ACLs (same as existing `_secure_dir`).