### PR TITLE
fix: preserve clean Slack thread input and soften session_search timeouts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -661,6 +661,9 @@ class MessageEvent:
     """
     # Message content
     text: str
+    # Optional clean text to persist in transcripts/history when `text`
+    # contains API-only synthetic context (e.g. injected thread history).
+    persist_text: Optional[str] = None
     message_type: MessageType = MessageType.TEXT
     
     # Source information

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1014,6 +1014,7 @@ class SlackAdapter(BasePlatformAdapter):
         is_mentioned = bot_uid and f"<@{bot_uid}>" in text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        persist_text = None
 
         if not is_dm and bot_uid:
             if channel_id in self._slack_free_response_channels():
@@ -1064,6 +1065,11 @@ class SlackAdapter(BasePlatformAdapter):
                 team_id=team_id,
             )
             if thread_context:
+                # Keep the original user utterance for transcript/history
+                # persistence. The prepended thread scaffold is only for the
+                # live model call so the agent can orient itself in a fresh
+                # thread without polluting stored exchanges.
+                persist_text = text
                 text = thread_context + text
 
         # Determine message type
@@ -1169,6 +1175,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         msg_event = MessageEvent(
             text=text,
+            persist_text=persist_text,
             message_type=msg_type,
             source=source,
             raw_message=event,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3561,6 +3561,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                persist_user_message=getattr(event, "persist_text", None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -7402,6 +7403,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -8094,7 +8096,12 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                    persist_user_message=persist_user_message,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -178,14 +178,17 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
 
     _CapturingAgent.last_init = None
     result = await runner._run_agent(
-        message="hi",
+        message="[Thread context]\n\nhi",
         context_prompt="",
         history=[],
         source=_make_source(),
         session_id="session-1",
         session_key="agent:main:telegram:dm:12345",
+        persist_user_message="hi",
     )
 
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+    assert _CapturingAgent.last_run["user_message"] == "[Thread context]\n\nhi"
+    assert _CapturingAgent.last_run["persist_user_message"] == "hi"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1258,6 +1258,34 @@ class TestAssistantThreadLifecycle:
         assert msg_event.source.thread_id == "171.000"
         assert msg_event.source.user_name == "Tyler"
 
+    @pytest.mark.asyncio
+    async def test_first_thread_reply_preserves_clean_persist_text(self, assistant_adapter):
+        assistant_adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Tyler"}}
+        })
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._fetch_thread_context = AsyncMock(
+            return_value="[Thread context — prior messages in this thread]\nfoo\n[End of thread context]\n\n"
+        )
+        assistant_adapter._has_active_session_for_thread = MagicMock(return_value=False)
+
+        event = {
+            "text": "hello from thread",
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": "im",
+            "thread_ts": "171.000",
+            "ts": "171.111",
+            "team": "T_TEAM",
+        }
+
+        await assistant_adapter._handle_slack_message(event)
+
+        msg_event = assistant_adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("[Thread context — prior messages in this thread]")
+        assert msg_event.persist_text == "hello from thread"
+
     def test_assistant_threads_cache_eviction(self, assistant_adapter):
         """Cache should evict oldest entries when exceeding the size limit."""
         assistant_adapter._ASSISTANT_THREADS_MAX = 10

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1,5 +1,6 @@
 """Tests for tools/session_search_tool.py — helper functions and search dispatcher."""
 
+import concurrent.futures
 import json
 import time
 import pytest
@@ -318,3 +319,39 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_timeout_degrades_to_raw_preview(self):
+        """A top-level summarization timeout should fall back to raw previews."""
+        from unittest.mock import MagicMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "other_sid",
+                "content": "match",
+                "source": "cli",
+                "session_started": 1709500000,
+                "model": "test",
+            },
+        ]
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        mock_db.get_session.return_value = {"parent_session_id": None}
+
+        def _raise_timeout(coro):
+            coro.close()
+            raise concurrent.futures.TimeoutError()
+
+        with _patch(
+            "model_tools._run_async",
+            side_effect=_raise_timeout,
+        ):
+            result = json.loads(session_search(query="test", db=mock_db))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "other_sid"
+        assert "[Raw preview — summarization unavailable]" in result["results"][0]["summary"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -413,14 +413,36 @@ def session_search(
                     exc_info=True,
                 )
 
-        # Summarize all sessions in parallel
+        # Summarize all sessions in parallel, but don't let one hung summary
+        # kill the whole tool call. Timed-out summaries fall back to raw previews.
         async def _summarize_all() -> List[Union[str, Exception]]:
-            """Summarize all sessions in parallel."""
-            coros = [
-                _summarize_session(text, query, meta)
-                for _, _, text, meta in tasks
-            ]
-            return await asyncio.gather(*coros, return_exceptions=True)
+            """Summarize all sessions in parallel with per-task degradation."""
+            task_map = {
+                asyncio.create_task(_summarize_session(text, query, meta)): idx
+                for idx, (_, _, text, meta) in enumerate(tasks)
+            }
+            if not task_map:
+                return []
+
+            done, pending = await asyncio.wait(task_map.keys(), timeout=60)
+            results: List[Union[str, Exception, None]] = [None] * len(tasks)
+
+            for finished in done:
+                idx = task_map[finished]
+                try:
+                    results[idx] = finished.result()
+                except Exception as exc:  # pragma: no cover - defensive
+                    results[idx] = exc
+
+            for pending_task in pending:
+                pending_task.cancel()
+                idx = task_map[pending_task]
+                results[idx] = TimeoutError("session summarization timed out")
+
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+            return [result if result is not None else RuntimeError("missing summary result") for result in results]
 
         try:
             # Use _run_async() which properly manages event loops across
@@ -436,10 +458,7 @@ def session_search(
                 "Session summarization timed out after 60 seconds",
                 exc_info=True,
             )
-            return json.dumps({
-                "success": False,
-                "error": "Session summarization timed out. Try a more specific query or reduce the limit.",
-            }, ensure_ascii=False)
+            results = [TimeoutError("session summarization timed out")] * len(tasks)
 
         summaries = []
         for (session_id, match_info, conversation_text, _), result in zip(tasks, results):


### PR DESCRIPTION
## Summary
This PR addresses two failure modes that both surfaced around agent robustness at the gateway/tool boundary:

1. **Slack thread bootstrap context was being treated like a real user utterance during persistence**
   - On a first reply in a Slack thread, the adapter prepends synthetic thread history so the live model call can orient itself.
   - That injected wrapper text could then flow through transcript/session persistence and downstream memory capture as though the user had actually typed it.

2. **`session_search` could fail hard when summarization timed out**
   - A hung or slow summarization path could surface a timeout as a tool failure.
   - In practice that means the agent can lose the turn instead of returning partial recall.

## What changed

### 1) Keep synthetic Slack thread context out of persisted exchanges
- add `MessageEvent.persist_text` to carry a clean persisted form when `text` contains API-only scaffolding
- in the Slack adapter, preserve the original user message before prepending thread context
- thread `persist_user_message` through `GatewayRunner._run_agent()` into `agent.run_conversation(...)`
- add regression coverage proving the live model input can include thread context while the persisted payload stays clean

### 2) Make `session_search` fail soft on summarization timeout
- run session summaries in parallel with `asyncio.wait(..., timeout=60)`
- cancel pending summarization tasks and preserve task ordering
- convert timeout/failure cases into raw-preview fallbacks instead of aborting the entire tool call
- add regression coverage for top-level `_run_async` timeout handling

## Why this is the right fix
- The Slack issue is best fixed **at the gateway boundary**, where synthetic context is introduced, instead of trying to scrub it later in memory providers.
- The `session_search` issue is best fixed by **degrading gracefully**: recall should remain usable even when summarization is unavailable.

## Test plan
- `python3 -m py_compile gateway/platforms/base.py gateway/platforms/slack.py gateway/run.py tools/session_search_tool.py tests/gateway/test_slack.py tests/gateway/test_fast_command.py tests/tools/test_session_search.py`
- `python3 -m pytest tests/gateway/test_slack.py -q tests/gateway/test_fast_command.py -q tests/tools/test_session_search.py -q`
- `python3 -m build`

## Commits
- `f840e657` — `fix(slack): persist clean user text when thread context is injected`
- `f8b1d4e4` — `fix(session_search): degrade summarization timeouts to raw previews`
