### PR TITLE
fix: reset retry counters after compression and stop poisoning conversation history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8012,6 +8012,15 @@ class AIAgent:
                     # skipping them because conversation_history is still the
                     # pre-compression length.
                     conversation_history = None
+                    # Fix: reset retry counters after compression so the model
+                    # gets a fresh budget on the compressed context.  Without
+                    # this, pre-compression retries carry over and the model
+                    # hits "(empty)" immediately after compression-induced
+                    # context loss.
+                    self._empty_content_retries = 0
+                    self._thinking_prefill_retries = 0
+                    self._last_content_with_tools = None
+                    self._mute_post_response = False
                     # Re-estimate after compression
                     _preflight_tokens = estimate_request_tokens_rough(
                         messages,
@@ -10202,6 +10211,13 @@ class AIAgent:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
                     
+                    # Fix: unmute output when entering the no-tool-call branch
+                    # so the user can see empty-response warnings and recovery
+                    # status messages.  _mute_post_response was set during a
+                    # prior housekeeping tool turn and should not silence the
+                    # final response path.
+                    self._mute_post_response = False
+                    
                     # Check if response only has think block with no actual content after it
                     if not self._has_content_after_think_block(final_response):
                         # ── Partial stream recovery ─────────────────────
@@ -10239,16 +10255,10 @@ class AIAgent:
                             self._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
                             self._last_content_with_tools = None
                             self._empty_content_retries = 0
-                            for i in range(len(messages) - 1, -1, -1):
-                                msg = messages[i]
-                                if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                                    tool_names = []
-                                    for tc in msg["tool_calls"]:
-                                        if not tc or not isinstance(tc, dict): continue
-                                        fn = tc.get("function", {})
-                                        tool_names.append(fn.get("name", "unknown"))
-                                    msg["content"] = f"Calling the {', '.join(tool_names)} tool{'s' if len(tool_names) > 1 else ''}..."
-                                    break
+                            # Do NOT modify the assistant message content — the
+                            # old code injected "Calling the X tools..." which
+                            # poisoned the conversation history.  Just use the
+                            # fallback text as the final response and break.
                             final_response = self._strip_think_blocks(fallback).strip()
                             self._response_was_previewed = True
                             break

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "balyan.sid@gmail.com": "balyansid",
     "oluwadareab12@gmail.com": "bennytimz",
     "simon@simonmarcus.org": "simon-marcus",
+    "1243352777@qq.com": "zons-zhaozhy",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──
     "1115117931@qq.com": "aaronagent",


### PR DESCRIPTION
## Summary

Salvage of PR #9544 by @zons-zhaozhy — cherry-picked onto current main.

Three targeted fixes in the agent loop (`run_agent.py`):

### 1. Reset retry counters after compression
After preflight compression succeeds, reset `_empty_content_retries`, `_thinking_prefill_retries`, `_last_content_with_tools`, and `_mute_post_response` to zero/None/False. Without this, pre-compression retry counts carry over into the compressed context — if the model had 2 empty retries before compression, it would only get 1 more attempt before hitting the empty-response terminal.

### 2. Unmute output in final response path
Explicitly clear `_mute_post_response = False` when entering the no-tool-call branch. A stale True value from a prior housekeeping tool turn was silencing status messages and recovery output in the final response path.

### 3. Stop poisoning conversation history with synthetic content
Removes a 10-line loop that walked backward through messages and injected fabricated `"Calling the X tools..."` text into prior assistant messages. This synthetic content was never produced by the model and poisoned the conversation history on subsequent turns. The fix uses the fallback text directly as `final_response` without mutating history.

## Test plan
- `python3 -m pytest tests/run_agent/ -o 'addopts=' -q` — 756 passed (1 pre-existing skip for missing anthropic pkg)
- `python3 -m pytest tests/run_agent/test_compression_feasibility.py tests/run_agent/test_1630_context_overflow_loop.py -o 'addopts=' -q` — 28 passed
- py_compile passes

## Attribution
Original commit by @zons-zhaozhy, cherry-picked with authorship preserved. AUTHOR_MAP updated.