### PR TITLE
docs: note session continuity for previous_response_id chains

### DIFF
--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -130,7 +130,7 @@ Chain responses to maintain full context (including tool calls) across turns:
 }
 ```
 
-The server reconstructs the full conversation from the stored response chain — all previous tool calls and results are preserved.
+The server reconstructs the full conversation from the stored response chain — all previous tool calls and results are preserved. Chained requests also share the same session, so multi-turn conversations appear as a single entry in the dashboard and session history.
 
 #### Named conversations
 


### PR DESCRIPTION
Follow-up to #10059. Adds a sentence to the API server docs noting that chained requests via `previous_response_id` now share the same session in the dashboard.