### PR TITLE
docs(cli): document --all flag for gateway start/restart

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -157,6 +157,14 @@ Subcommands:
 | `uninstall` | Remove the installed service. |
 | `setup` | Interactive messaging-platform setup. |
 
+The `start`, `stop`, and `restart` subcommands accept `--all` for multi-profile environments:
+
+| Option | Subcommands | Description |
+|--------|-------------|-------------|
+| `--all` | `start` | Kill all stale gateway processes across all profiles before starting the current profile's service. |
+| `--all` | `stop` | Stop gateway processes across all profiles, not just the current one. |
+| `--all` | `restart` | Stop all gateway processes across all profiles, then start the current profile's service fresh. |
+
 :::tip WSL users
 Use `hermes gateway run` instead of `hermes gateway start` — WSL's systemd support is unreliable. Wrap it in tmux for persistence: `tmux new -s hermes 'hermes gateway run'`. See [WSL FAQ](/docs/reference/faq#wsl-gateway-keeps-disconnecting-or-hermes-gateway-start-fails) for details.
 :::


### PR DESCRIPTION
## Summary

Fixes #10062.

PR #10043 added `--all` flag support to `hermes gateway start` and `hermes gateway restart` but the CLI reference was not updated. This adds an options table documenting `--all` behavior for `start`, `stop`, and `restart` subcommands.

## Changes

- `website/docs/reference/cli-commands.md` — Added options table after the gateway subcommands table showing `--all` behavior for each applicable subcommand.

## Test plan

- Verified the added table matches the actual `--all` behavior described in #10043.
- No code changes, docs only.