### PR TITLE
fix(dingtalk): close session websocket on disconnect

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -154,12 +154,19 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._running = False
         self._mark_disconnected()
 
+        websocket = getattr(self._stream_client, "websocket", None)
+        if websocket is not None:
+            try:
+                await websocket.close()
+            except Exception as e:
+                logger.debug("[%s] websocket close during disconnect failed: %s", self.name, e)
+
         if self._stream_task:
             self._stream_task.cancel()
             try:
-                await self._stream_task
-            except asyncio.CancelledError:
-                pass
+                await asyncio.wait_for(self._stream_task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
             self._stream_task = None
 
         if self._http_client:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
@@ -229,6 +230,29 @@ class TestSend:
 
 
 class TestConnect:
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_session_websocket(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        websocket = AsyncMock()
+        blocker = asyncio.Event()
+
+        async def _run_forever():
+            try:
+                await blocker.wait()
+            except asyncio.CancelledError:
+                return
+
+        adapter._stream_client = SimpleNamespace(websocket=websocket)
+        adapter._stream_task = asyncio.create_task(_run_forever())
+        adapter._running = True
+
+        await adapter.disconnect()
+
+        websocket.close.assert_awaited_once()
+        assert adapter._stream_task is None
 
     @pytest.mark.asyncio
     async def test_connect_fails_without_sdk(self, monkeypatch):


### PR DESCRIPTION
## Summary
- close the active DingTalk session websocket before awaiting adapter shutdown
- bound the wait on the stream task during disconnect so gateway stop/restart does not hang indefinitely
- add a regression test covering websocket cleanup during `disconnect()`

## Why
In local verification on WSL, `hermes-gateway.service` could get stuck in `stop-sigterm` and be SIGKILLed during restart while DingTalk was configured. Closing the SDK websocket explicitly gives the stream loop a clean shutdown path instead of waiting for the remote side to time out.

This PR is intentionally scoped to shutdown behavior only. Existing open DingTalk PRs already cover CallbackMessage parsing, async SDK compatibility, and `oapi.dingtalk.com` webhook routing.

Related: #7562

## Test plan
- [x] `pytest tests/gateway/test_dingtalk.py::TestConnect::test_disconnect_closes_session_websocket -v`
- [x] `pytest tests/gateway/test_dingtalk.py -q`
- [x] manually verified local `systemctl --user restart hermes-gateway` no longer hangs in the idle DingTalk case after applying the patch
