### PR TITLE
test: lock active Hermes env write denial

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -24,6 +24,12 @@ class TestStaticDenyList:
     def test_etc_shadow_is_denied(self):
         assert _is_write_denied("/etc/shadow") is True
 
+    def test_current_hermes_home_env_is_denied(self, tmp_path: Path, monkeypatch):
+        hermes_home = tmp_path / "profiles" / "coder"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _is_write_denied(str(hermes_home / ".env")) is True
+
 
 class TestSafeWriteRoot:
     """HERMES_WRITE_SAFE_ROOT should sandbox writes to a specific subtree."""


### PR DESCRIPTION
## Summary
- rebase onto current main after write-deny logic moved into shared agent.file_safety
- keep the PR focused on regression coverage for profile/custom HERMES_HOME changes
- verify active HERMES_HOME/.env stays denied after env switches

## Tests
- source venv/bin/activate && python -m pytest tests/tools/test_file_write_safety.py -q