### PR TITLE
[codex] Fix gateway status ps fallback on WSL

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -221,12 +221,26 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                             pass
                     current_cmd = ""
         else:
-            result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
+            result = None
+            # procps on Ubuntu/WSL accepts `-eww`, while the mixed BSD-style
+            # `eww -ax` form can fail and make status checks report false
+            # negatives even when the gateway is running.
+            for ps_cmd in (
+                ["ps", "-eww", "-ax", "-o", "pid=,command="],
+                ["ps", "-ax", "-o", "pid=,command="],
+            ):
+                result = subprocess.run(
+                    ps_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    break
+
+            if result is None or result.returncode != 0:
+                return pids
+
             for line in result.stdout.split('\n'):
                 stripped = line.strip()
                 if not stripped or 'grep' in stripped:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -799,6 +799,34 @@ class TestFindGatewayPidsExclude:
 
         assert pids == [100]
 
+    def test_falls_back_when_primary_ps_flags_fail(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "")
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["ps", "-eww", "-ax"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="unsupported")
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="100 python gateway/run.py\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert pids == [100]
+        assert calls == [
+            ["ps", "-eww", "-ax", "-o", "pid=,command="],
+            ["ps", "-ax", "-o", "pid=,command="],
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)


### PR DESCRIPTION
## Summary
Fix `hermes gateway status` / `hermes status` process detection on WSL and Ubuntu variants where `ps eww -ax -o ...` is rejected by procps.

## Root Cause
The non-Windows gateway PID scan used a mixed BSD-style `ps eww -ax -o pid=,command=` invocation. On the reporter's WSL/Ubuntu environment, that command failed, so gateway process discovery returned no manual gateway PIDs and status commands incorrectly reported that the gateway was not running.

## What Changed
- Prefer `ps -eww -ax -o pid=,command=` for Linux/WSL process scans.
- Fall back to `ps -ax -o pid=,command=` if the extended-environment form is unsupported.
- Return the already-known service-managed PIDs if both process scans fail instead of crashing or misparsing.
- Add a regression test covering primary `ps` failure followed by fallback success.

## Impact
`hermes gateway status` and `hermes status` now correctly detect manually running gateways on more Linux/WSL procps variants instead of producing false negatives.

## Validation
- `python -m pytest tests/hermes_cli/test_update_gateway_restart.py -q -k "falls_back_when_primary_ps_flags_fail or filters_to_current_profile or no_exclude_returns_all or excludes_specified_pids"`
- `python -m pytest tests/hermes_cli/test_gateway_wsl.py -q -k "test_status_wsl_running_manual or test_status_wsl_not_running"`

## Notes
Broader gateway suites still have pre-existing Windows-environment failures in this checkout around `launchd/systemd` paths and missing async pytest support; they are unrelated to this change.