### PR TITLE
fix: reject malformed MCP OAuth server URLs

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -169,6 +169,43 @@ class TestBuildOAuthAuth:
         assert provider is not None
         assert provider.context.client_metadata.scope == "read write admin"
 
+    @pytest.mark.parametrize("server_url", ["", "localhost:8000", "ftp://example.com/mcp"])
+    def test_rejects_malformed_server_url_before_provider(self, tmp_path, monkeypatch, server_url):
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = MagicMock(side_effect=AssertionError("provider should not be constructed"))
+        monkeypatch.setattr(mod, "OAuthClientProvider", provider)
+
+        with pytest.raises(ValueError, match="absolute http\\(s\\) URL"):
+            build_oauth_auth("bad-server", server_url)
+
+        provider.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("server_url", "expected_provider_url"),
+        [
+            ("http://localhost:8000/mcp", "http://localhost:8000/mcp"),
+            (
+                "https://example.com/mcp?transport=streamable",
+                "https://example.com/mcp?transport=streamable",
+            ),
+        ],
+    )
+    def test_valid_server_url_preserves_provider_url(
+        self, tmp_path, monkeypatch, server_url, expected_provider_url
+    ):
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = MagicMock(return_value=object())
+        monkeypatch.setattr(mod, "OAuthClientProvider", provider)
+
+        result = build_oauth_auth("valid-server", server_url)
+
+        assert result is provider.return_value
+        assert provider.call_args.kwargs["server_url"] == expected_provider_url
+
 
 # ---------------------------------------------------------------------------
 # Utility functions
@@ -522,5 +559,4 @@ def test_build_oauth_auth_preserves_server_url_path():
         )
 
     assert captured["server_url"] == "https://mcp.notion.com/mcp"
-
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -168,6 +168,18 @@ def _write_json(path: Path, data: dict) -> None:
         raise
 
 
+def _validated_oauth_provider_url(server_name: str, server_url: str) -> str:
+    """Return a validated MCP server URL for OAuth provider construction."""
+    url = server_url.strip() if isinstance(server_url, str) else ""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            f"MCP OAuth server URL for '{server_name}' must be an absolute "
+            f"http(s) URL with a host, got {server_url!r}"
+        )
+    return url
+
+
 # ---------------------------------------------------------------------------
 # HermesTokenStorage -- persistent token/client-info on disk
 # ---------------------------------------------------------------------------
@@ -539,6 +551,8 @@ def build_oauth_auth(
         An ``OAuthClientProvider`` instance, or None if the MCP SDK lacks
         OAuth support.
     """
+    provider_url = _validated_oauth_provider_url(server_name, server_url)
+
     if not _OAUTH_AVAILABLE:
         logger.warning(
             "MCP OAuth requested for '%s' but SDK auth types are not available. "
@@ -564,7 +578,7 @@ def build_oauth_auth(
     _maybe_preregister_client(storage, cfg, client_metadata)
 
     return OAuthClientProvider(
-        server_url=server_url,
+        server_url=provider_url,
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,


### PR DESCRIPTION
## Summary
- validate MCP OAuth server URLs before constructing the OAuth provider
- reject empty, schemeless, and non-http(s) inputs before provider setup
- preserve valid http/https provider URLs, including path-scoped MCP endpoints

## Tests
- source venv/bin/activate && python -m pytest tests/tools/test_mcp_oauth.py -q