### PR TITLE
fix: harden traversal checks for Windows separators

### DIFF
--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -1,0 +1,13 @@
+from tools.path_security import has_traversal_component
+
+
+def test_has_traversal_component_detects_posix_separator():
+    assert has_traversal_component("scripts/../secret.py") is True
+
+
+def test_has_traversal_component_detects_windows_separator_on_posix():
+    assert has_traversal_component(r"scripts\..\secret.py") is True
+
+
+def test_has_traversal_component_allows_non_traversal_windows_separator_path():
+    assert has_traversal_component(r"scripts\safe\secret.py") is False

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -6,7 +6,7 @@ skills_hub, cronjob_tools, and credential_files.
 """
 
 import logging
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -39,5 +39,4 @@ def has_traversal_component(path_str: str) -> bool:
 
     Quick check for obvious traversal attempts before doing full resolution.
     """
-    parts = Path(path_str).parts
-    return ".." in parts
+    return ".." in Path(path_str).parts or ".." in PureWindowsPath(path_str).parts


### PR DESCRIPTION
## Summary
- detect `..` traversal components when paths use Windows-style separators on POSIX
- preserve the existing native Path traversal behavior
- add focused coverage for POSIX traversal, Windows-style traversal, and a safe Windows-style path

## Tests
- source venv/bin/activate && python -m pytest tests/tools/test_path_security.py -q
- source venv/bin/activate && python -m compileall -q tools/path_security.py tests/tools/test_path_security.py
- git diff --check