### PR TITLE
fix(transcription): reject symlinked audio inputs

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -6,12 +6,19 @@ end-to-end dispatch.  All external dependencies are mocked.
 """
 
 import os
+import sys
 import struct
 import subprocess
+import types
 import wave
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+if "faster_whisper" not in sys.modules:
+    faster_whisper_stub = types.ModuleType("faster_whisper")
+    faster_whisper_stub.WhisperModel = MagicMock(name="WhisperModel")
+    sys.modules["faster_whisper"] = faster_whisper_stub
 
 
 # ============================================================================

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -754,6 +754,23 @@ class TestValidateAudioFileEdgeCases:
         assert result is not None
         assert "not a file" in result["error"]
 
+    def test_symlink_with_supported_extension_is_rejected(self, tmp_path):
+        if not hasattr(os, "symlink"):
+            pytest.skip("symlinks are not supported on this platform")
+
+        target = tmp_path / "target.txt"
+        target.write_bytes(b"not audio")
+        link = tmp_path / "linked.wav"
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        from tools.transcription_tools import _validate_audio_file
+        result = _validate_audio_file(str(link))
+        assert result is not None
+        assert "symbolic link" in result["error"]
+
     def test_stat_oserror(self, tmp_path):
         f = tmp_path / "test.ogg"
         f.write_bytes(b"data")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -659,6 +659,23 @@ class TestValidateAudioFileEdgeCases:
         assert result is not None
         assert "not a file" in result["error"]
 
+    def test_symlink_with_supported_extension_is_rejected(self, tmp_path):
+        if not hasattr(os, "symlink"):
+            pytest.skip("symlinks are not supported on this platform")
+
+        target = tmp_path / "target.txt"
+        target.write_bytes(b"not audio")
+        link = tmp_path / "linked.wav"
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        from tools.transcription_tools import _validate_audio_file
+        result = _validate_audio_file(str(link))
+        assert result is not None
+        assert "symbolic link" in result["error"]
+
     def test_stat_oserror(self, tmp_path):
         f = tmp_path / "test.ogg"
         f.write_bytes(b"data")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -285,6 +285,8 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
+    if os.path.islink(audio_path):
+        return {"success": False, "transcript": "", "error": f"Path is a symbolic link: {file_path}"}
     if not audio_path.exists():
         return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
     if not audio_path.is_file():

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -251,6 +251,8 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
+    if os.path.islink(audio_path):
+        return {"success": False, "transcript": "", "error": f"Path is a symbolic link: {file_path}"}
     if not audio_path.exists():
         return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
     if not audio_path.is_file():


### PR DESCRIPTION
## Summary
- reject symbolic-link audio paths during validation before provider dispatch
- add a platform-safe regression test for supported-extension symlink inputs

## Tests
- source venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py::TestValidateAudioFileEdgeCases -q
- source venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py::TestValidateAudioFileEdgeCases tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_invalid_file_short_circuits -q
- source venv/bin/activate && python -m compileall -q tools/transcription_tools.py tests/tools/test_transcription_tools.py
- git diff --check

## Note
- Full `tests/tools/test_transcription_tools.py -q` under the dev extra is still blocked by the optional local STT dependency `faster_whisper` not being installed.