### PR TITLE
fix(copilot): fall back to gh hosts.yml credentials

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -14,6 +14,7 @@ Credential search order (matching Copilot CLI behaviour):
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
   4. gh auth token  CLI fallback
+  5. ~/.config/gh/hosts.yml fallback when gh isn't installed
 """
 
 from __future__ import annotations
@@ -26,6 +27,8 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Optional
+
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +95,16 @@ def resolve_copilot_token() -> tuple[str, str]:
             )
         return token, "gh auth token"
 
+    # 3. Fall back to the persisted gh hosts.yml credential store
+    token = _try_gh_hosts_yml_token()
+    if token:
+        valid, msg = validate_copilot_token(token)
+        if not valid:
+            raise ValueError(
+                f"Token from gh hosts.yml is a classic PAT (ghp_*). {msg}"
+            )
+        return token, "gh hosts.yml"
+
     return "", ""
 
 
@@ -150,7 +163,64 @@ def _try_gh_cli_token() -> Optional[str]:
     return None
 
 
-# ─── OAuth Device Code Flow ────────────────────────────────────────────────
+def _gh_hosts_config_paths() -> list[Path]:
+    """Return likely gh hosts.yml locations without invoking the gh binary."""
+    candidates: list[Path] = []
+    xdg_config_home = os.getenv("XDG_CONFIG_HOME", "").strip()
+    if xdg_config_home:
+        candidates.append(Path(xdg_config_home) / "gh" / "hosts.yml")
+    candidates.append(Path.home() / ".config" / "gh" / "hosts.yml")
+    return candidates
+
+
+def _extract_gh_hosts_token(data: object, hostname: str = "") -> Optional[str]:
+    """Extract an oauth token from parsed gh hosts.yml content."""
+    if not isinstance(data, dict):
+        return None
+
+    candidate_hosts = []
+    if hostname:
+        candidate_hosts.append(hostname)
+    candidate_hosts.append("github.com")
+
+    for host in candidate_hosts:
+        host_entry = data.get(host)
+        if isinstance(host_entry, dict):
+            token = host_entry.get("oauth_token")
+            if isinstance(token, str) and token.strip():
+                return token.strip()
+
+    token = data.get("oauth_token")
+    if isinstance(token, str) and token.strip():
+        return token.strip()
+
+    # Some gh config variants nest host data deeper; search one level down.
+    for value in data.values():
+        if isinstance(value, dict):
+            token = value.get("oauth_token")
+            if isinstance(token, str) and token.strip():
+                return token.strip()
+    return None
+
+
+def _try_gh_hosts_yml_token() -> Optional[str]:
+    """Return a GitHub token from gh's hosts.yml without requiring gh to exist."""
+    hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+
+    for hosts_path in _gh_hosts_config_paths():
+        try:
+            if not hosts_path.is_file():
+                continue
+            with hosts_path.open("r", encoding="utf-8") as handle:
+                parsed = yaml.safe_load(handle) or {}
+        except Exception as exc:
+            logger.debug("gh hosts.yml token lookup failed (%s): %s", hosts_path, exc)
+            continue
+
+        token = _extract_gh_hosts_token(parsed, hostname=hostname)
+        if token:
+            return token
+    return None
 
 def copilot_device_code_login(
     *,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -519,7 +519,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
-    ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
+    ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN, gh auth token, or gh hosts.yml)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -25,7 +25,7 @@ from hermes_cli.auth import (
     KIMI_CODE_BASE_URL,
     _resolve_kimi_base_url,
 )
-from hermes_cli.copilot_auth import _try_gh_cli_token
+from hermes_cli.copilot_auth import _try_gh_cli_token, resolve_copilot_token
 
 
 # =============================================================================
@@ -405,6 +405,25 @@ class TestResolveApiKeyProviderCredentials:
 
         assert _try_gh_cli_token() == "gh-cli-secret"
         assert calls == [["/opt/homebrew/bin/gh", "auth", "token"]]
+
+    def test_resolve_copilot_prefers_hosts_yml_when_gh_binary_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
+        monkeypatch.setattr("hermes_cli.copilot_auth.shutil.which", lambda command: None)
+        monkeypatch.setattr("hermes_cli.copilot_auth.Path.home", lambda: tmp_path)
+
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        (gh_dir / "hosts.yml").write_text(
+            "github.com:\n  oauth_token: gho_hosts_secret\n  user: test-user\n", encoding="utf-8"
+        )
+
+        token, source = resolve_copilot_token()
+
+        assert token == "gho_hosts_secret"
+        assert source == "gh hosts.yml"
 
     def test_resolve_copilot_acp_with_local_cli(self, monkeypatch):
         monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio")


### PR DESCRIPTION
Closes #10022

## Summary
- Resolve Copilot credentials from `~/.config/gh/hosts.yml` when `gh` is unavailable.
- Keep `gh auth token` as the preferred CLI-based path and document the fallback in the provider listing.
- Add regression coverage for the hosts.yml fallback and existing gh CLI lookup paths.

## Testing
- pytest -q tests/hermes_cli/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_resolve_copilot_with_gh_cli_fallback tests/hermes_cli/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_resolve_copilot_prefers_hosts_yml_when_gh_binary_missing tests/hermes_cli/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_try_gh_cli_token_uses_homebrew_path_when_not_on_path
