### PR TITLE
feat(web): add verbose dashboard toggle with thinking & memory observability

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -81,7 +81,8 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT,
     reasoning TEXT,
     reasoning_details TEXT,
-    codex_reasoning_items TEXT
+    codex_reasoning_items TEXT,
+    memory_context TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -329,6 +330,14 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add memory_context column to messages — stores the Hindsight
+                # auto-recall context injected before each LLM call for dashboard visibility
+                try:
+                    cursor.execute("ALTER TABLE messages ADD COLUMN memory_context TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -801,6 +810,7 @@ class SessionDB:
         reasoning: str = None,
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
+        memory_context: str = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -828,8 +838,8 @@ class SessionDB:
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_details, codex_reasoning_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   reasoning, reasoning_details, codex_reasoning_items, memory_context)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -843,6 +853,7 @@ class SessionDB:
                     reasoning,
                     reasoning_details_json,
                     codex_items_json,
+                    memory_context,
                 ),
             )
             msg_id = cursor.lastrowid

--- a/run_agent.py
+++ b/run_agent.py
@@ -2319,7 +2319,7 @@ class AIAgent:
             )
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
-            for msg in messages[flush_from:]:
+            for _db_i, msg in enumerate(messages[flush_from:], start=flush_from):
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 tool_calls_data = None
@@ -2330,6 +2330,10 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                # Check if this is the user message that had memory context injected
+                _memory_ctx = None
+                if role == "user" and _db_i == self._persist_user_message_idx:
+                    _memory_ctx = getattr(self, "_current_memory_context", None)
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -2341,6 +2345,7 @@ class AIAgent:
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    memory_context=_memory_ctx,
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -8090,6 +8095,7 @@ class AIAgent:
         # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
+        self._current_memory_context = None
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
@@ -8097,6 +8103,7 @@ class AIAgent:
                 _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
+        self._current_memory_context = _ext_prefetch_cache or None
 
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -935,7 +935,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -991,12 +991,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to latest version
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -213,6 +213,7 @@ export interface SessionInfo {
   source: string | null;
   model: string | null;
   title: string | null;
+  system_prompt: string | null;
   started_at: number;
   ended_at: number | null;
   last_active: number;
@@ -221,6 +222,9 @@ export interface SessionInfo {
   tool_call_count: number;
   input_tokens: number;
   output_tokens: number;
+  reasoning_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
   preview: string | null;
 }
 
@@ -252,6 +256,10 @@ export interface SessionMessage {
   tool_name?: string;
   tool_call_id?: string;
   timestamp?: number;
+  reasoning?: string | null;
+  reasoning_details?: any;
+  codex_reasoning_items?: any;
+  memory_context?: string | null;
 }
 
 export interface SessionMessagesResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -12,6 +12,10 @@ import {
   MessageCircle,
   Hash,
   X,
+  BrainCircuit,
+  FileText,
+  Sparkles,
+  Database,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type { SessionInfo, SessionMessage, SessionSearchResult } from "@/lib/api";
@@ -20,6 +24,7 @@ import { Markdown } from "@/components/Markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { useI18n } from "@/i18n";
 
 const SOURCE_CONFIG: Record<string, { icon: typeof Terminal; color: string }> = {
@@ -92,7 +97,66 @@ function ToolCallBlock({ toolCall }: { toolCall: { id: string; function: { name:
   );
 }
 
-function MessageBubble({ msg, highlight }: { msg: SessionMessage; highlight?: string }) {
+/** Collapsible section with a header button. */
+function CollapsibleSection({
+  title,
+  icon,
+  children,
+  defaultOpen = false,
+  className = "",
+}: {
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={`rounded-md border border-border bg-background ${className}`}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground cursor-pointer hover:bg-secondary/30 transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {icon}
+        <span className="font-medium">{title}</span>
+      </button>
+      {open && (
+        <div className="border-t border-border px-3 py-2 text-xs overflow-x-auto whitespace-pre-wrap font-mono leading-relaxed">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders a thinking/reasoning block for assistant messages. */
+function ThinkingBlock({ reasoning }: { reasoning: string }) {
+  // Try to pretty-print if it's JSON
+  let display = reasoning;
+  try {
+    const parsed = JSON.parse(reasoning);
+    display = JSON.stringify(parsed, null, 2);
+  } catch {
+    // keep as-is — likely plain text reasoning
+  }
+
+  return (
+    <CollapsibleSection
+      title="Thinking"
+      icon={<BrainCircuit className="h-3 w-3 text-purple-400" />}
+      className="mt-2 border-purple-500/20 bg-purple-500/5"
+    >
+      <div className="text-purple-300/90 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto">
+        {display}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+function MessageBubble({ msg, highlight, verbose }: { msg: SessionMessage; highlight?: string; verbose?: boolean }) {
   const { t } = useI18n();
 
   const ROLE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
@@ -118,6 +182,8 @@ function MessageBubble({ msg, highlight }: { msg: SessionMessage; highlight?: st
     ? highlight.split(/\s+/).filter(Boolean)
     : undefined;
 
+  const hasReasoning = !!(msg.reasoning || msg.reasoning_details || msg.codex_reasoning_items);
+
   return (
     <div className={`${style.bg} p-3 ${isHit ? "ring-1 ring-warning/40" : ""}`} data-search-hit={isHit || undefined}>
       <div className="flex items-center gap-2 mb-1">
@@ -128,11 +194,50 @@ function MessageBubble({ msg, highlight }: { msg: SessionMessage; highlight?: st
         {msg.timestamp && (
           <span className="text-[10px] text-muted-foreground">{timeAgo(msg.timestamp)}</span>
         )}
+        {verbose && hasReasoning && (
+          <Badge variant="outline" className="text-[9px] py-0 px-1.5 border-purple-500/30 text-purple-400">
+            <BrainCircuit className="h-2.5 w-2.5 mr-0.5" />
+            thinking
+          </Badge>
+        )}
+        {verbose && msg.memory_context && (
+          <Badge variant="outline" className="text-[9px] py-0 px-1.5 border-emerald-500/30 text-emerald-400">
+            <Database className="h-2.5 w-2.5 mr-0.5" />
+            memory
+          </Badge>
+        )}
       </div>
       {msg.content && (
         msg.role === "system"
           ? <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">{msg.content}</div>
           : <Markdown content={msg.content} highlightTerms={highlightTerms} />
+      )}
+      {verbose && msg.memory_context && (
+        <CollapsibleSection
+          title="Memory Context"
+          icon={<Database className="h-3 w-3 text-emerald-400" />}
+          className="mt-2 border-emerald-500/20 bg-emerald-500/5"
+        >
+          <div className="text-emerald-300/90 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto text-xs">
+            {msg.memory_context}
+          </div>
+        </CollapsibleSection>
+      )}
+      {verbose && msg.reasoning && (
+        <ThinkingBlock reasoning={msg.reasoning} />
+      )}
+      {verbose && msg.reasoning_details && !msg.reasoning && (
+        <CollapsibleSection
+          title="Reasoning Details"
+          icon={<Sparkles className="h-3 w-3 text-purple-400" />}
+          className="mt-2 border-purple-500/20 bg-purple-500/5"
+        >
+          <div className="text-purple-300/90 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto">
+            {typeof msg.reasoning_details === "string"
+              ? msg.reasoning_details
+              : JSON.stringify(msg.reasoning_details, null, 2)}
+          </div>
+        </CollapsibleSection>
       )}
       {msg.tool_calls && msg.tool_calls.length > 0 && (
         <div className="mt-1">
@@ -146,7 +251,7 @@ function MessageBubble({ msg, highlight }: { msg: SessionMessage; highlight?: st
 }
 
 /** Message list with auto-scroll to first search hit. */
-function MessageList({ messages, highlight }: { messages: SessionMessage[]; highlight?: string }) {
+function MessageList({ messages, highlight, verbose }: { messages: SessionMessage[]; highlight?: string; verbose?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -164,7 +269,7 @@ function MessageList({ messages, highlight }: { messages: SessionMessage[]; high
   return (
     <div ref={containerRef} className="flex flex-col gap-3 max-h-[600px] overflow-y-auto pr-2">
       {messages.map((msg, i) => (
-        <MessageBubble key={i} msg={msg} highlight={highlight} />
+        <MessageBubble key={i} msg={msg} highlight={highlight} verbose={verbose} />
       ))}
     </div>
   );
@@ -177,6 +282,7 @@ function SessionRow({
   isExpanded,
   onToggle,
   onDelete,
+  verbose,
 }: {
   session: SessionInfo;
   snippet?: string;
@@ -184,6 +290,7 @@ function SessionRow({
   isExpanded: boolean;
   onToggle: () => void;
   onDelete: () => void;
+  verbose: boolean;
 }) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -204,6 +311,14 @@ function SessionRow({
   const sourceInfo = (session.source ? SOURCE_CONFIG[session.source] : null) ?? { icon: Globe, color: "text-muted-foreground" };
   const SourceIcon = sourceInfo.icon;
   const hasTitle = session.title && session.title !== "Untitled";
+
+  // Format token counts for display
+  const fmtTokens = (n: number) => n > 0 ? (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)) : null;
+  const inputT = fmtTokens(session.input_tokens);
+  const outputT = fmtTokens(session.output_tokens);
+  const reasoningT = fmtTokens(session.reasoning_tokens);
+  const cacheReadT = fmtTokens(session.cache_read_tokens);
+  const cacheWriteT = fmtTokens(session.cache_write_tokens);
 
   return (
     <div className={`border overflow-hidden transition-colors ${
@@ -241,6 +356,18 @@ function SessionRow({
                   <span>{session.tool_call_count} {t.common.tools}</span>
                 </>
               )}
+              {(inputT || outputT) && (
+                <>
+                  <span className="text-border">&#183;</span>
+                  <span>{inputT}↑ {outputT}↓</span>
+                  {reasoningT && verbose && (
+                    <span className="text-purple-400">&#183;{reasoningT}🧠</span>
+                  )}
+                  {cacheReadT && verbose && (
+                    <span className="text-blue-400">&#183;{cacheReadT}📦</span>
+                  )}
+                </>
+              )}
               <span className="text-border">&#183;</span>
               <span>{timeAgo(session.last_active)}</span>
             </div>
@@ -271,6 +398,32 @@ function SessionRow({
 
       {isExpanded && (
         <div className="border-t border-border bg-background/50 p-4">
+          {/* Verbose: System Prompt */}
+          {verbose && session.system_prompt && (
+            <div className="mb-3">
+              <CollapsibleSection
+                title="System Prompt"
+                icon={<FileText className="h-3 w-3 text-blue-400" />}
+                className="border-blue-500/20 bg-blue-500/5"
+              >
+                <div className="text-blue-200/90 whitespace-pre-wrap break-words max-h-[500px] overflow-y-auto">
+                  {session.system_prompt}
+                </div>
+              </CollapsibleSection>
+            </div>
+          )}
+
+          {/* Verbose: Token Breakdown */}
+          {verbose && (inputT || outputT) && (
+            <div className="mb-3 flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-muted-foreground">
+              {inputT && <span>Input: <span className="text-foreground">{inputT}</span></span>}
+              {outputT && <span>Output: <span className="text-foreground">{outputT}</span></span>}
+              {reasoningT && <span>Reasoning: <span className="text-purple-400">{reasoningT}</span></span>}
+              {cacheReadT && <span>Cache Read: <span className="text-blue-400">{cacheReadT}</span></span>}
+              {cacheWriteT && <span>Cache Write: <span className="text-blue-400">{cacheWriteT}</span></span>}
+            </div>
+          )}
+
           {loading && (
             <div className="flex items-center justify-center py-8">
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
@@ -283,7 +436,7 @@ function SessionRow({
             <p className="text-sm text-muted-foreground py-4 text-center">{t.sessions.noMessages}</p>
           )}
           {messages && messages.length > 0 && (
-            <MessageList messages={messages} highlight={searchQuery} />
+            <MessageList messages={messages} highlight={searchQuery} verbose={verbose} />
           )}
         </div>
       )}
@@ -301,6 +454,7 @@ export default function SessionsPage() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<SessionSearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
+  const [verbose, setVerbose] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const { t } = useI18n();
 
@@ -388,7 +542,13 @@ export default function SessionsPage() {
             {total}
           </Badge>
         </div>
-        <div className="relative w-full sm:w-64">
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-1.5 cursor-pointer text-xs text-muted-foreground select-none">
+            <BrainCircuit className="h-3.5 w-3.5" />
+            <span>Verbose</span>
+            <Switch checked={verbose} onCheckedChange={setVerbose} />
+          </label>
+          <div className="relative w-full sm:w-64">
           {searching ? (
             <div className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
           ) : (
@@ -409,6 +569,7 @@ export default function SessionsPage() {
               <X className="h-3 w-3" />
             </button>
           )}
+          </div>
         </div>
       </div>
 
@@ -436,6 +597,7 @@ export default function SessionsPage() {
                   setExpandedId((prev) => (prev === s.id ? null : s.id))
                 }
                 onDelete={() => handleDelete(s.id)}
+                verbose={verbose}
               />
             ))}
           </div>

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -207,22 +207,6 @@ function MessageBubble({ msg, highlight, verbose }: { msg: SessionMessage; highl
           </Badge>
         )}
       </div>
-      {msg.content && (
-        msg.role === "system"
-          ? <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">{msg.content}</div>
-          : <Markdown content={msg.content} highlightTerms={highlightTerms} />
-      )}
-      {verbose && msg.memory_context && (
-        <CollapsibleSection
-          title="Memory Context"
-          icon={<Database className="h-3 w-3 text-emerald-400" />}
-          className="mt-2 border-emerald-500/20 bg-emerald-500/5"
-        >
-          <div className="text-emerald-300/90 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto text-xs">
-            {msg.memory_context}
-          </div>
-        </CollapsibleSection>
-      )}
       {verbose && msg.reasoning && (
         <ThinkingBlock reasoning={msg.reasoning} />
       )}
@@ -238,6 +222,22 @@ function MessageBubble({ msg, highlight, verbose }: { msg: SessionMessage; highl
               : JSON.stringify(msg.reasoning_details, null, 2)}
           </div>
         </CollapsibleSection>
+      )}
+      {verbose && msg.memory_context && (
+        <CollapsibleSection
+          title="Memory Context"
+          icon={<Database className="h-3 w-3 text-emerald-400" />}
+          className="mt-2 border-emerald-500/20 bg-emerald-500/5"
+        >
+          <div className="text-emerald-300/90 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto text-xs">
+            {msg.memory_context}
+          </div>
+        </CollapsibleSection>
+      )}
+      {msg.content && (
+        msg.role === "system"
+          ? <div className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">{msg.content}</div>
+          : <Markdown content={msg.content} highlightTerms={highlightTerms} />
       )}
       {msg.tool_calls && msg.tool_calls.length > 0 && (
         <div className="mt-1">


### PR DESCRIPTION
## What does this PR do?

Adds a **verbose mode** toggle to the dashboard sessions view that reveals agent reasoning, memory context, and system prompt information — making agent behavior observable and debuggable.

When verbose mode is off, the dashboard looks exactly as before. When toggled on, assistant messages display:
- **Thinking/reasoning blocks** — collapsible sections showing the model's reasoning process (purple brain icon)
- **Memory context** — collapsible section showing what the agent recalled before responding (green memory badge + emerald section)
- **Reasoning details** — collapsible for extended reasoning data

This is useful for debugging why an agent made a decision, understanding what context it had, and auditing agent behavior.

## Related Issue

No existing issue — this emerged from local development needs for agent observability.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `web/src/pages/SessionsPage.tsx` — Added `CollapsibleSection` and `ThinkingBlock` components, verbose toggle switch in `MessageList`, memory context/reasoning display in `MessageBubble`, and reordered thinking blocks above message content
- `web/src/lib/api.ts` — Added `memory_context`, `reasoning`, `reasoning_details`, `codex_reasoning_items` fields to `SessionMessage` type
- `hermes_state.py` — Added `memory_context` column to session messages schema (migration v5→v7), `append_message()` method, and API endpoint to serve memory context
- `run_agent.py` — Captured Hindsight/memory recall context on the agent instance and flushes it with user messages
- `tests/test_hermes_state.py` — Updated schema version test for migration

## How to Test

1. Start the dashboard: `hermes dashboard`
2. Open a session with an agent that uses memory (Hindsight) or produces reasoning/thinking output
3. Toggle the **Verbose** switch at the top of the session messages view
4. Verify:
   - Purple "thinking" badge appears on messages with reasoning
   - Green "memory" badge appears on messages with memory context
   - Thinking block renders **above** the assistant response text
   - Memory context section renders above the response text
   - Collapsible sections expand/collapse correctly
   - Toggling verbose off hides all reasoning/memory UI

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(web):`, `fix(web):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_state.py tests/test_model_tools.py tests/test_toolsets.py -q` and all tests pass
- [x] I've tested on my platform: Ubuntu Server (NUC)
- [ ] ~~I've added tests for my changes~~ — frontend UI component tests are not yet in the test suite

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A (web UI feature, no docs changes needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] N/A for architecture/workflow changes
- [x] N/A for cross-platform impact (web UI is platform-agnostic)
- [x] N/A for tool descriptions/schemas

## Screenshots

_N/A — will add screenshots if requested during review_