### PR TITLE
fix(feishu): handle CARD-type WebSocket frames for interactive card actions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1010,6 +1010,95 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
+
+    # ------------------------------------------------------------------
+    # Monkey-patch: fix lark-oapi SDK silently dropping CARD callbacks.
+    # The SDK's _handle_data_frame returns early for MessageType.CARD
+    # instead of routing it through do_without_validation like EVENT.
+    # This causes Feishu error 200340 for interactive card actions
+    # (e.g. approval buttons) in WebSocket mode.
+    # ------------------------------------------------------------------
+    try:
+        import base64 as _b64
+        import http as _http
+        import time as _time
+
+        from lark_oapi.core.const import UTF_8 as _UTF_8
+        from lark_oapi.core.json import JSON as _JSON
+        from lark_oapi.ws.const import (
+            HEADER_BIZ_RT as _HEADER_BIZ_RT,
+            HEADER_MESSAGE_ID as _HEADER_MESSAGE_ID,
+            HEADER_SEQ as _HEADER_SEQ,
+            HEADER_SUM as _HEADER_SUM,
+            HEADER_TRACE_ID as _HEADER_TRACE_ID,
+            HEADER_TYPE as _HEADER_TYPE,
+        )
+        from lark_oapi.ws.enum import MessageType as _LarkWsMsgType
+        from lark_oapi.ws.model import Response as _WsResponse
+
+        # Keep a reference to the original for non-CARD frames
+        _original_handle = ws_client._handle_data_frame
+
+        # Local helper mirroring SDK's _get_by_key
+        def _get_hdr(headers, key):  # type: ignore[no-untyped-def]
+            for h in headers:
+                if h.key == key:
+                    return h.value
+            return None
+
+        async def _patched_handle_data_frame(frame):  # type: ignore[no-untyped-def]
+            hs = frame.headers
+            type_ = _get_hdr(hs, _HEADER_TYPE)
+            if type_ is None or _LarkWsMsgType(type_) != _LarkWsMsgType.CARD:
+                # Not a CARD frame — delegate to original handler
+                return await _original_handle(frame)
+
+            # --- Handle CARD the same way the SDK handles EVENT ---
+            msg_id = _get_hdr(hs, _HEADER_MESSAGE_ID)
+            trace_id = _get_hdr(hs, _HEADER_TRACE_ID)
+            sum_ = _get_hdr(hs, _HEADER_SUM)
+            seq = _get_hdr(hs, _HEADER_SEQ)
+
+            pl = frame.payload
+            if int(sum_) > 1:
+                pl = ws_client._combine(msg_id, int(sum_), int(seq), pl)
+                if pl is None:
+                    return
+
+            logger.info(
+                "[Feishu] WS card action callback received (message_id=%s, trace_id=%s)",
+                msg_id, trace_id,
+            )
+
+            resp = _WsResponse(code=_http.HTTPStatus.OK)
+            try:
+                start = int(round(_time.time() * 1000))
+                result = ws_client._event_handler.do_without_validation(pl)
+                end = int(round(_time.time() * 1000))
+                header = hs.add()
+                header.key = _HEADER_BIZ_RT
+                header.value = str(end - start)
+                if result is not None:
+                    resp.data = _b64.b64encode(_JSON.marshal(result).encode(_UTF_8))
+            except Exception as exc:
+                logger.error(
+                    "[Feishu] WS card action handler failed (message_id=%s, trace_id=%s): %s",
+                    msg_id, trace_id, exc,
+                )
+                resp = _WsResponse(code=_http.HTTPStatus.INTERNAL_SERVER_ERROR)
+
+            frame.payload = _JSON.marshal(resp).encode(_UTF_8)
+            await ws_client._write_message(frame.SerializeToString())
+
+        ws_client._handle_data_frame = _patched_handle_data_frame
+        logger.debug("[Feishu] Patched WS client _handle_data_frame for CARD callback support")
+    except Exception:
+        logger.warning(
+            "[Feishu] Failed to patch WS client for CARD callbacks; "
+            "interactive card actions may not work in WebSocket mode",
+            exc_info=True,
+        )
+
     try:
         ws_client.start()
     except Exception:

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -1,5 +1,6 @@
 """Tests for Feishu interactive card approval buttons."""
 
+import asyncio
 import importlib.util
 import json
 import sys
@@ -442,3 +443,215 @@ class TestCardActionCallbackResponse:
         card = response.card.data
         assert "Old Name" not in card["elements"][0]["content"]
         assert "ou_expired" in card["elements"][0]["content"]
+
+
+# ===========================================================================
+# _run_official_feishu_ws_client — CARD monkey-patch
+# ===========================================================================
+
+
+class _FakeHeader:
+    """Minimal protobuf-like header for testing."""
+    def __init__(self, key: str = "", value: str = ""):
+        self.key = key
+        self.value = value
+
+
+class _FakeHeaders(list):
+    """Minimal protobuf-like repeated headers container."""
+    def add(self):
+        h = _FakeHeader()
+        self.append(h)
+        return h
+
+
+class _FakeFrame:
+    """Minimal protobuf-like Frame for testing _patched_handle_data_frame."""
+    def __init__(self, headers=None, payload=b"{}"):
+        self.headers = headers if headers is not None else _FakeHeaders()
+        self.payload = payload
+
+    def SerializeToString(self):
+        return self.payload
+
+
+def _make_card_frame(
+    msg_type: str = "card",
+    msg_id: str = "msg_card_001",
+    trace_id: str = "trace_001",
+    sum_: str = "1",
+    seq: str = "0",
+    payload: bytes = b'{"test": "data"}',
+) -> _FakeFrame:
+    """Build a fake WS frame with CARD type headers."""
+    headers = _FakeHeaders()
+    for k, v in [
+        ("type", msg_type),
+        ("message_id", msg_id),
+        ("trace_id", trace_id),
+        ("sum", sum_),
+        ("seq", seq),
+    ]:
+        headers.append(_FakeHeader(k, v))
+    return _FakeFrame(headers=headers, payload=payload)
+
+
+def _ensure_ws_mocks():
+    """Provide deeper lark_oapi.ws.* stubs needed by _run_official_feishu_ws_client."""
+    import enum as _enum
+
+    class _MockMessageType(_enum.Enum):
+        EVENT = "event"
+        CARD = "card"
+        PING = "ping"
+        PONG = "pong"
+
+    class _MockFrameType(_enum.Enum):
+        CONTROL = 0
+        DATA = 1
+
+    class _MockResponse:
+        def __init__(self, code=None):
+            self.code = code
+            self.data = None
+
+    ws_client_mod = MagicMock()
+    ws_client_mod.websockets = MagicMock()
+
+    ws_enum_mod = MagicMock()
+    ws_enum_mod.MessageType = _MockMessageType
+    ws_enum_mod.FrameType = _MockFrameType
+
+    ws_const_mod = MagicMock()
+    ws_const_mod.HEADER_TYPE = "type"
+    ws_const_mod.HEADER_MESSAGE_ID = "message_id"
+    ws_const_mod.HEADER_TRACE_ID = "trace_id"
+    ws_const_mod.HEADER_SUM = "sum"
+    ws_const_mod.HEADER_SEQ = "seq"
+    ws_const_mod.HEADER_BIZ_RT = "biz_rt"
+
+    ws_model_mod = MagicMock()
+    ws_model_mod.Response = _MockResponse
+
+    core_const_mod = MagicMock()
+    core_const_mod.UTF_8 = "utf-8"
+
+    core_json_mod = MagicMock()
+    core_json_mod.JSON = MagicMock()
+    core_json_mod.JSON.marshal = MagicMock(side_effect=lambda x: json.dumps({"code": 200}))
+
+    mods = {
+        "lark_oapi.ws": MagicMock(),
+        "lark_oapi.ws.client": ws_client_mod,
+        "lark_oapi.ws.enum": ws_enum_mod,
+        "lark_oapi.ws.const": ws_const_mod,
+        "lark_oapi.ws.model": ws_model_mod,
+        "lark_oapi.core": MagicMock(),
+        "lark_oapi.core.const": core_const_mod,
+        "lark_oapi.core.json": core_json_mod,
+    }
+    return mods, _MockMessageType
+
+
+def _run_ws_client_with_patch():
+    """Execute _run_official_feishu_ws_client to install the monkey-patch,
+    returning (ws_client, original_handle, MessageType)."""
+    ws_mods, msg_type_cls = _ensure_ws_mocks()
+
+    ws_client = MagicMock()
+    original_handle = AsyncMock()
+    ws_client._handle_data_frame = original_handle
+    ws_client._event_handler = MagicMock()
+    ws_client._event_handler.do_without_validation = MagicMock(return_value=None)
+    ws_client._combine = MagicMock()
+    ws_client._write_message = AsyncMock()
+    ws_client.start = MagicMock()
+
+    adapter = MagicMock()
+    adapter._ws_reconnect_nonce = 0
+    adapter._ws_reconnect_interval = 10
+    adapter._ws_ping_interval = None
+    adapter._ws_ping_timeout = None
+
+    with patch.dict("sys.modules", ws_mods):
+        feishu_module._run_official_feishu_ws_client(ws_client, adapter)
+
+    return ws_client, original_handle, msg_type_cls
+
+
+class TestWSCardMonkeyPatch:
+    """Test the _handle_data_frame monkey-patch for CARD messages."""
+
+    def test_patch_replaces_handle_data_frame(self):
+        """After _run_official_feishu_ws_client, _handle_data_frame should be patched."""
+        ws_client, original_handle, _ = _run_ws_client_with_patch()
+        ws_client.start.assert_called_once()
+        assert ws_client._handle_data_frame is not original_handle
+
+    @pytest.mark.asyncio
+    async def test_card_frame_calls_event_handler(self):
+        """A CARD frame should be routed through do_without_validation."""
+        ws_client, original_handle, _ = _run_ws_client_with_patch()
+        patched = ws_client._handle_data_frame
+
+        frame = _make_card_frame()
+        await patched(frame)
+
+        ws_client._event_handler.do_without_validation.assert_called_once_with(
+            b'{"test": "data"}'
+        )
+        ws_client._write_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_event_frame_delegates_to_original(self):
+        """A non-CARD frame should delegate to the original handler."""
+        ws_client, original_handle, _ = _run_ws_client_with_patch()
+        patched = ws_client._handle_data_frame
+
+        frame = _make_card_frame(msg_type="event")
+        await patched(frame)
+
+        original_handle.assert_called_once_with(frame)
+        ws_client._event_handler.do_without_validation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_card_frame_handler_error_returns_500(self):
+        """If the card handler raises, the response should still be written."""
+        ws_client, _, _ = _run_ws_client_with_patch()
+        ws_client._event_handler.do_without_validation = MagicMock(
+            side_effect=RuntimeError("handler boom")
+        )
+        patched = ws_client._handle_data_frame
+
+        frame = _make_card_frame()
+        await patched(frame)
+
+        ws_client._write_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_card_frame_multipart_combines(self):
+        """Multi-part CARD frames should be combined via _combine."""
+        combined_payload = b'{"combined": true}'
+        ws_client, _, _ = _run_ws_client_with_patch()
+        ws_client._combine = MagicMock(return_value=combined_payload)
+        patched = ws_client._handle_data_frame
+
+        original_payload = b'{"test": "data"}'
+        frame = _make_card_frame(sum_="3", seq="1", payload=original_payload)
+        await patched(frame)
+
+        ws_client._combine.assert_called_once_with("msg_card_001", 3, 1, original_payload)
+        ws_client._event_handler.do_without_validation.assert_called_once_with(combined_payload)
+
+    @pytest.mark.asyncio
+    async def test_card_frame_multipart_incomplete_returns_early(self):
+        """If _combine returns None (waiting for more parts), handler returns early."""
+        ws_client, _, _ = _run_ws_client_with_patch()
+        ws_client._combine = MagicMock(return_value=None)
+        patched = ws_client._handle_data_frame
+
+        frame = _make_card_frame(sum_="3", seq="1")
+        await patched(frame)
+
+        ws_client._event_handler.do_without_validation.assert_not_called()
+        ws_client._write_message.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the Feishu mobile interactive card approval buttons returning error code 200340 when clicked.

## Root Cause

The `lark-oapi` SDK's WebSocket client (`lark_oapi.ws.client.Client._handle_data_frame`) silently drops messages with `MessageType.CARD`:

```python
# In lark_oapi/ws/client.py:
async def _handle_data_frame(self, frame):
    ...
    if message_type == MessageType.EVENT:
        result = self._event_handler.do_without_validation(pl)
    elif message_type == MessageType.CARD:
        return  # ← silently dropped!
```

Feishu sends card action callbacks (e.g., approval button clicks) as `CARD`-type WebSocket frames, not `EVENT`. Since the SDK ignores these, the registered `card.action.trigger` handler is never invoked, and no response is sent back to Feishu — resulting in error 200340 on the client.

## Fix

Monkey-patches the SDK's `_handle_data_frame` on the WS client instance to route `MessageType.CARD` frames through `do_without_validation`, mirroring the existing `EVENT` handling path. The response (including any card update from the callback handler) is serialized and written back through the WebSocket.

The patch is applied at runtime in `_run_official_feishu_ws_client` and falls back gracefully with a warning if the SDK internals change.

## Tests

Added 6 new tests in `test_feishu_approval_buttons.py`:
- `test_patch_replaces_handle_data_frame` — verifies the patch is installed
- `test_card_frame_calls_event_handler` — CARD frames route through `do_without_validation`
- `test_event_frame_delegates_to_original` — non-CARD frames still use the original handler
- `test_card_frame_handler_error_returns_500` — errors produce 500 response (not silent drop)
- `test_card_frame_multipart_combines` — multi-part CARD frames are combined correctly
- `test_card_frame_multipart_incomplete_returns_early` — incomplete multi-part waits for more

All 24 tests in `test_feishu_approval_buttons.py` pass. Full suite: 11350 passed.

Closes #10073
Closes #8764