### PR TITLE
feat(docker): add docker-cli to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git docker-cli && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime


### PR DESCRIPTION
## What does this PR do?

This allows a Dockerized Hermes agent to use the docker shell backend (with Podman or Docker) by specifying `/var/run/podman/podman.sock:/var/run/docker.sock` or `/var/run/docker.sock:/var/run/docker.sock` as container mounts.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Just adds `docker-cli` to the installaed dependecnies in the container image.

## How to Test

1. Use a Dockerized Hermes agent to use the docker shell backend (with Podman or Docker) with `/var/run/podman/podman.sock:/var/run/docker.sock` or `/var/run/docker.sock:/var/run/docker.sock` specified as container mounts
2. Observe that the docker shell backend functions
3. Profit

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Container on Rocky Linux 10

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A