### PR TITLE
fix: constrain persisted tool result filenames

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -17,6 +17,7 @@ from tools.tool_result_storage import (
     _build_persisted_message,
     _heredoc_marker,
     _resolve_storage_dir,
+    _safe_result_filename,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
@@ -161,6 +162,19 @@ class TestResolveStorageDir:
         env = MagicMock()
         env.get_temp_dir.return_value = "/data/data/com.termux/files/usr/tmp"
         assert _resolve_storage_dir(env) == "/data/data/com.termux/files/usr/tmp/hermes-results"
+
+
+class TestSafeResultFilename:
+    def test_preserves_normal_tool_call_id(self):
+        assert _safe_result_filename("tc_456") == "tc_456.txt"
+
+    def test_replaces_path_and_shell_metacharacters(self):
+        filename = _safe_result_filename("../outside/$(whoami);x")
+        assert filename.startswith("outside_whoami_x_")
+        assert filename.endswith(".txt")
+        assert "/" not in filename
+        assert "$" not in filename
+        assert ";" not in filename
 
 
 # ── _build_persisted_message ──────────────────────────────────────────
@@ -373,6 +387,28 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         assert "unique_id_abc.txt" in result
+
+    def test_tool_use_id_cannot_escape_storage_dir(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        env.get_temp_dir.return_value = ""
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="../outside/$(whoami);x",
+            env=env,
+            threshold=30_000,
+        )
+        cmd = env.execute.call_args[0][0]
+        target = cmd.split("cat > ", 1)[1].split(" <<", 1)[0]
+
+        assert "Full output saved to: /tmp/hermes-results/outside_whoami_x_" in result
+        assert "/tmp/hermes-results/../" not in result
+        assert target.startswith("/tmp/hermes-results/outside_whoami_x_")
+        assert "/../" not in target
+        assert "$(whoami)" not in target
+        assert ";" not in target
 
     def test_preview_included_in_persisted_output(self):
         env = MagicMock()

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -22,8 +22,10 @@ Defense against context-window overflow operates at three levels:
    where many medium-sized results combine to overflow context.
 """
 
+import hashlib
 import logging
 import os
+import re
 import shlex
 import uuid
 
@@ -39,6 +41,8 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+_UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_RESULT_FILENAME_STEM = 120
 
 
 def _resolve_storage_dir(env) -> str:
@@ -55,6 +59,24 @@ def _resolve_storage_dir(env) -> str:
                     temp_dir = temp_dir.rstrip("/") or "/"
                     return f"{temp_dir}/hermes-results"
     return STORAGE_DIR
+
+
+def _safe_result_filename(tool_use_id: str) -> str:
+    """Return a single safe filename for a tool result id."""
+    raw_id = str(tool_use_id or "tool_result")
+    safe_stem = _UNSAFE_RESULT_FILENAME_CHARS.sub("_", raw_id).strip("._-")
+    changed = safe_stem != raw_id
+
+    if not safe_stem:
+        safe_stem = "tool_result"
+        changed = True
+
+    if changed or len(safe_stem) > _MAX_RESULT_FILENAME_STEM:
+        digest = hashlib.sha256(raw_id.encode("utf-8")).hexdigest()[:12]
+        safe_stem = safe_stem[:_MAX_RESULT_FILENAME_STEM].rstrip("._-") or "tool_result"
+        safe_stem = f"{safe_stem}_{digest}"
+
+    return f"{safe_stem}.txt"
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -147,7 +169,7 @@ def maybe_persist_tool_result(
         return content
 
     storage_dir = _resolve_storage_dir(env)
-    remote_path = f"{storage_dir}/{tool_use_id}.txt"
+    remote_path = f"{storage_dir}/{_safe_result_filename(tool_use_id)}"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
     if env is not None:


### PR DESCRIPTION
## What does this PR do?

Persisted large tool results are saved under `hermes-results` using the tool call id as the filename stem. The existing shell quoting protects metacharacters, but it does not force the id to remain a single path segment; an id such as `../outside` can still resolve outside the result storage directory.

This PR converts tool call ids into safe filename stems before building the persisted-result path. Normal ids such as `tc_456` keep the same filename, while ids with path separators, shell metacharacters, empty stems, or excessive length are normalized and get a short hash suffix to reduce collisions.

Related: #7912 covers shell quoting in `_write_to_sandbox`; this PR covers path-segment containment for the generated result filename.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tool_result_storage.py`: add `_safe_result_filename()` and use it when creating persisted tool-result paths.
- `tests/tools/test_tool_result_storage.py`: add regression coverage for preserving normal ids and blocking traversal/metacharacter ids from escaping `/tmp/hermes-results`.

## How to Test

1. `source /Users/peter/hermes-agent/venv/bin/activate && pytest tests/tools/test_tool_result_storage.py -q`
2. `source /Users/peter/hermes-agent/venv/bin/activate && python -m compileall tools/tool_result_storage.py tests/tools/test_tool_result_storage.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

`pytest tests/tools/test_tool_result_storage.py -q`:

```text
51 passed in 0.79s
```