### PR TITLE
fix(discord): replace nested skill subcommands with autocomplete to avoid 8KB limit

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1740,90 +1740,69 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_btw(interaction: discord.Interaction, question: str):
             await self._run_simple_slash(interaction, f"/btw {question}")
 
-        # Register skills under a single /skill command group with category
-        # subcommand groups.  This uses 1 top-level slot instead of N,
-        # supporting up to 25 categories × 25 skills = 625 skills.
-        self._register_skill_group(tree)
+        # Register a single /skill command with autocomplete. Discord applies
+        # an 8 KB max-size limit to a single command definition, so encoding
+        # every installed skill as nested subcommands does not scale.
+        self._register_skill_command(tree)
 
-    def _register_skill_group(self, tree) -> None:
-        """Register a ``/skill`` command group with category subcommand groups.
-
-        Skills are organized by their directory category under ``SKILLS_DIR``.
-        Each category becomes a subcommand group; root-level skills become
-        direct subcommands.  Discord supports 25 subcommand groups × 25
-        subcommands each = 625 skills — well beyond the old 100-command cap.
-        """
+    def _register_skill_command(self, tree) -> None:
+        """Register a compact ``/skill`` command with name autocomplete."""
         try:
-            from hermes_cli.commands import discord_skill_commands_by_category
+            from agent.skill_commands import resolve_skill_command_key
+            from hermes_cli.commands import discord_skill_autocomplete_entries
 
-            existing_names = set()
-            try:
-                existing_names = {cmd.name for cmd in tree.get_commands()}
-            except Exception:
-                pass
-
-            categories, uncategorized, hidden = discord_skill_commands_by_category(
-                reserved_names=existing_names,
-            )
-
-            if not categories and not uncategorized:
+            skill_entries = discord_skill_autocomplete_entries()
+            if not skill_entries:
                 return
 
-            skill_group = discord.app_commands.Group(
-                name="skill",
-                description="Run a Hermes skill",
+            skill_lookup = {
+                display_name: cmd_key
+                for display_name, _desc, cmd_key in skill_entries
+            }
+
+            @tree.command(name="skill", description="Run an installed Hermes skill")
+            @discord.app_commands.describe(
+                name="Skill name",
+                args="Optional arguments for the skill",
             )
-
-            # ── Helper: build a callback for a skill command key ──
-            def _make_handler(_key: str):
-                @discord.app_commands.describe(args="Optional arguments for the skill")
-                async def _handler(interaction: discord.Interaction, args: str = ""):
-                    await self._run_simple_slash(interaction, f"{_key} {args}".strip())
-                _handler.__name__ = f"skill_{_key.lstrip('/').replace('-', '_')}"
-                return _handler
-
-            # ── Uncategorized (root-level) skills → direct subcommands ──
-            for discord_name, description, cmd_key in uncategorized:
-                cmd = discord.app_commands.Command(
-                    name=discord_name,
-                    description=description or f"Run the {discord_name} skill",
-                    callback=_make_handler(cmd_key),
-                )
-                skill_group.add_command(cmd)
-
-            # ── Category subcommand groups ──
-            for cat_name in sorted(categories):
-                cat_desc = f"{cat_name.replace('-', ' ').title()} skills"
-                if len(cat_desc) > 100:
-                    cat_desc = cat_desc[:97] + "..."
-                cat_group = discord.app_commands.Group(
-                    name=cat_name,
-                    description=cat_desc,
-                    parent=skill_group,
-                )
-                for discord_name, description, cmd_key in categories[cat_name]:
-                    cmd = discord.app_commands.Command(
-                        name=discord_name,
-                        description=description or f"Run the {discord_name} skill",
-                        callback=_make_handler(cmd_key),
+            async def slash_skill(interaction: discord.Interaction, name: str, args: str = ""):
+                cmd_key = skill_lookup.get(name) or resolve_skill_command_key(name)
+                if not cmd_key:
+                    await interaction.response.send_message(
+                        f"Unknown skill `{name}`. Use autocomplete to pick an installed skill.",
+                        ephemeral=True,
                     )
-                    cat_group.add_command(cmd)
+                    return
+                await self._run_simple_slash(interaction, f"{cmd_key} {args}".strip())
 
-            tree.add_command(skill_group)
+            @slash_skill.autocomplete("name")
+            async def slash_skill_name_autocomplete(
+                interaction: discord.Interaction,
+                current: str,
+            ):
+                needle = (current or "").strip().lower()
+                matches = []
+                for display_name, description, _cmd_key in skill_entries:
+                    haystack = f"{display_name} {description}".lower()
+                    if needle and needle not in haystack:
+                        continue
+                    choice_name = display_name if not description else f"{display_name} — {description}"
+                    if len(choice_name) > 100:
+                        choice_name = choice_name[:97] + "..."
+                    matches.append(
+                        discord.app_commands.Choice(name=choice_name, value=display_name)
+                    )
+                    if len(matches) >= 25:
+                        break
+                return matches
 
-            total = sum(len(v) for v in categories.values()) + len(uncategorized)
             logger.info(
-                "[%s] Registered /skill group: %d skill(s) across %d categories"
-                " + %d uncategorized",
-                self.name, total, len(categories), len(uncategorized),
+                "[%s] Registered /skill command with autocomplete for %d skill(s)",
+                self.name,
+                len(skill_entries),
             )
-            if hidden:
-                logger.warning(
-                    "[%s] %d skill(s) not registered (Discord subcommand limits)",
-                    self.name, hidden,
-                )
         except Exception as exc:
-            logger.warning("[%s] Failed to register /skill group: %s", self.name, exc)
+            logger.warning("[%s] Failed to register /skill command: %s", self.name, exc)
 
     def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -582,6 +582,62 @@ def discord_skill_commands(
     )
 
 
+def discord_skill_autocomplete_entries() -> list[tuple[str, str, str]]:
+    """Return active Discord skill entries for ``/skill`` autocomplete.
+
+    Discord rejects command definitions larger than 8 KB. Registering every
+    installed skill as nested subcommands quickly breaches that limit, so the
+    Discord gateway uses a single ``/skill`` command with autocomplete instead.
+
+    Returns:
+        ``[(display_name, description, cmd_key), ...]`` sorted by command key.
+        ``display_name`` is the user-facing skill name without a leading slash.
+    """
+    from pathlib import Path as _P
+
+    _platform_disabled: set[str] = set()
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        _platform_disabled = get_disabled_skill_names(platform="discord")
+    except Exception:
+        pass
+
+    entries: list[tuple[str, str, str]] = []
+    try:
+        from agent.skill_commands import get_skill_commands
+        from tools.skills_tool import SKILLS_DIR
+
+        _skills_dir = SKILLS_DIR.resolve()
+        _hub_dir = (SKILLS_DIR / ".hub").resolve()
+        skill_cmds = get_skill_commands()
+
+        for cmd_key in sorted(skill_cmds):
+            info = skill_cmds[cmd_key]
+            skill_path = info.get("skill_md_path", "")
+            if not skill_path:
+                continue
+
+            sp = _P(skill_path).resolve()
+            if not str(sp).startswith(str(_skills_dir)):
+                continue
+            if str(sp).startswith(str(_hub_dir)):
+                continue
+
+            skill_name = info.get("name", "")
+            if skill_name in _platform_disabled:
+                continue
+
+            desc = info.get("description", "")
+            if len(desc) > 100:
+                desc = desc[:97] + "..."
+
+            entries.append((cmd_key.lstrip("/"), desc, cmd_key))
+    except Exception:
+        pass
+
+    return entries
+
+
 def discord_skill_commands_by_category(
     reserved_names: set[str],
 ) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str, str]], int]:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -20,33 +20,10 @@ def _ensure_discord_mock():
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
 
-    # Lightweight mock for app_commands.Group and Command used by
-    # _register_skill_group.
-    class _FakeGroup:
-        def __init__(self, *, name, description, parent=None):
-            self.name = name
-            self.description = description
-            self.parent = parent
-            self._children: dict[str, object] = {}
-            if parent is not None:
-                parent.add_command(self)
-
-        def add_command(self, cmd):
-            self._children[cmd.name] = cmd
-
-    class _FakeCommand:
-        def __init__(self, *, name, description, callback, parent=None):
-            self.name = name
-            self.description = description
-            self.callback = callback
-            self.parent = parent
-
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),
         Choice=lambda **kwargs: SimpleNamespace(**kwargs),
-        Group=_FakeGroup,
-        Command=_FakeCommand,
     )
 
     ext_mod = MagicMock()
@@ -70,16 +47,20 @@ class FakeTree:
 
     def command(self, *, name, description):
         def decorator(fn):
+            fn._autocomplete_handlers = {}
+
+            def _autocomplete(param_name):
+                def _register(callback):
+                    fn._autocomplete_handlers[param_name] = callback
+                    return callback
+
+                return _register
+
+            fn.autocomplete = _autocomplete
             self.commands[name] = fn
             return fn
 
         return decorator
-
-    def add_command(self, cmd):
-        self.commands[cmd.name] = cmd
-
-    def get_commands(self):
-        return [SimpleNamespace(name=n) for n in self.commands]
 
 
 @pytest.fixture
@@ -548,51 +529,33 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
 
 
 # ------------------------------------------------------------------
-# /skill group registration
+# /skill command registration
 # ------------------------------------------------------------------
 
 
-def test_register_skill_group_creates_group(adapter):
-    """_register_skill_group should register a '/skill' Group on the tree."""
-    mock_categories = {
-        "creative": [
+def test_register_skill_command_creates_command(adapter):
+    """_register_skill_command should register a '/skill' command on the tree."""
+    with patch(
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=[
             ("ascii-art", "Generate ASCII art", "/ascii-art"),
-            ("excalidraw", "Hand-drawn diagrams", "/excalidraw"),
-        ],
-        "media": [
             ("gif-search", "Search for GIFs", "/gif-search"),
         ],
-    }
-    mock_uncategorized = [
-        ("dogfood", "Exploratory QA testing", "/dogfood"),
-    ]
-
-    with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(mock_categories, mock_uncategorized, 0),
     ):
         adapter._register_slash_commands()
 
     tree = adapter._client.tree
-    assert "skill" in tree.commands, "Expected /skill group to be registered"
-    skill_group = tree.commands["skill"]
-    assert skill_group.name == "skill"
-    # Should have 2 category subgroups + 1 uncategorized subcommand
-    children = skill_group._children
-    assert "creative" in children
-    assert "media" in children
-    assert "dogfood" in children
-    # Category groups should have their skills
-    assert "ascii-art" in children["creative"]._children
-    assert "excalidraw" in children["creative"]._children
-    assert "gif-search" in children["media"]._children
+    assert "skill" in tree.commands, "Expected /skill command to be registered"
+    skill_cmd = tree.commands["skill"]
+    assert callable(skill_cmd)
+    assert "name" in skill_cmd._autocomplete_handlers
 
 
-def test_register_skill_group_empty_skills_no_group(adapter):
-    """No /skill group should be added when there are zero skills."""
+def test_register_skill_command_empty_skills_no_command(adapter):
+    """No /skill command should be added when there are zero skills."""
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=({}, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=[],
     ):
         adapter._register_slash_commands()
 
@@ -600,24 +563,43 @@ def test_register_skill_group_empty_skills_no_group(adapter):
     assert "skill" not in tree.commands
 
 
-def test_register_skill_group_handler_dispatches_command(adapter):
-    """Skill subcommand handlers should dispatch the correct /cmd-key text."""
-    mock_categories = {
-        "media": [
-            ("gif-search", "Search for GIFs", "/gif-search"),
-        ],
-    }
-
+@pytest.mark.asyncio
+async def test_register_skill_command_handler_dispatches_command(adapter):
+    """The /skill handler should dispatch the selected /cmd-key text."""
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(mock_categories, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=[("gif-search", "Search for GIFs", "/gif-search")],
     ):
         adapter._register_slash_commands()
 
-    skill_group = adapter._client.tree.commands["skill"]
-    media_group = skill_group._children["media"]
-    gif_cmd = media_group._children["gif-search"]
-    assert gif_cmd.callback is not None
-    # The callback name should reflect the skill
-    assert "gif_search" in gif_cmd.callback.__name__
+    adapter._run_simple_slash = AsyncMock()
+    skill_cmd = adapter._client.tree.commands["skill"]
+    interaction = SimpleNamespace()
 
+    await skill_cmd(interaction, name="gif-search", args="cats")
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction,
+        "/gif-search cats",
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_skill_command_autocomplete_filters_matches(adapter):
+    """Autocomplete should filter skill matches and return Discord choices."""
+    with patch(
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=[
+            ("gif-search", "Search for GIFs", "/gif-search"),
+            ("ascii-art", "Generate ASCII art", "/ascii-art"),
+        ],
+    ):
+        adapter._register_slash_commands()
+
+    skill_cmd = adapter._client.tree.commands["skill"]
+    autocomplete = skill_cmd._autocomplete_handlers["name"]
+
+    choices = await autocomplete(SimpleNamespace(), "gif")
+
+    assert len(choices) == 1
+    assert choices[0].value == "gif-search"


### PR DESCRIPTION
## Summary

Fix Discord slash command sync failure caused by the `/skill` command group exceeding Discord's 8KB command definition limit.

**Before:** Every installed skill was registered as a nested subcommand under `/skill` → category groups. With 28+ bundled skills, the serialized command tree exceeded 8KB and Discord rejected it with:
```
CommandSyncFailure: Command exceeds maximum size (8000)
In group 'skill' defined in module 'gateway.platforms.discord'
```

**After:** A single `/skill` command with name autocomplete. Users type `/skill` and get an autocomplete dropdown of all installed skills. This stays well under the 8KB limit regardless of how many skills are installed.

## Changes

| File | What |
|---|---|
| `gateway/platforms/discord.py` | Replace `_register_skill_group()` (nested subcommands) with `_register_skill_command()` (single command + autocomplete) |
| `hermes_cli/commands.py` | Add `discord_skill_autocomplete_entries()` — returns flat list of skills for autocomplete |
| `tests/gateway/test_discord_slash_commands.py` | Update tests for new autocomplete approach |

## How it works

- `/skill name:archive-session args:my notes` — autocomplete on `name` shows all installed skills with descriptions
- Autocomplete searches both skill name and description, returns up to 25 matches
- Skill descriptions truncated to 100 chars (Discord limit)
- Hub skills and platform-disabled skills are filtered out

## Test Results

- Discord gateway starts without slash command sync error
- `/skill` autocomplete shows installed skills
- Skill execution works through the new command path