### PR TITLE
[codex] fix interrupt race for pre-start terminal runs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -754,6 +754,7 @@ class AIAgent:
         self._interrupt_requested = False
         self._interrupt_message = None  # Optional message that triggered interrupt
         self._execution_thread_id: int | None = None  # Set at run_conversation() start
+        self._interrupt_thread_signal_pending = False
         self._client_lock = threading.RLock()
         
         # Subagent delegation state
@@ -2923,7 +2924,15 @@ class AIAgent:
         # Signal all tools to abort any in-flight operations immediately.
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.
-        _set_interrupt(True, self._execution_thread_id)
+        if self._execution_thread_id is not None:
+            _set_interrupt(True, self._execution_thread_id)
+            self._interrupt_thread_signal_pending = False
+        else:
+            # The interrupt arrived before run_conversation() finished
+            # binding the agent to its execution thread. Defer the tool-level
+            # interrupt signal until startup completes instead of targeting
+            # the caller thread by mistake.
+            self._interrupt_thread_signal_pending = True
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -2939,7 +2948,9 @@ class AIAgent:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
         self._interrupt_message = None
-        _set_interrupt(False, self._execution_thread_id)
+        self._interrupt_thread_signal_pending = False
+        if self._execution_thread_id is not None:
+            _set_interrupt(False, self._execution_thread_id)
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe)."""
@@ -8079,11 +8090,19 @@ class AIAgent:
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
-        # Must be set before clear_interrupt() which uses it.
+        # Must be set before any thread-scoped interrupt syncing.
         self._execution_thread_id = threading.current_thread().ident
 
-        # Clear any stale interrupt state at start
-        self.clear_interrupt()
+        # Always clear stale per-thread state from a previous turn. If an
+        # interrupt arrived before startup finished, preserve it and bind it
+        # to this execution thread now instead of dropping it on the floor.
+        _set_interrupt(False, self._execution_thread_id)
+        if self._interrupt_requested:
+            _set_interrupt(True, self._execution_thread_id)
+            self._interrupt_thread_signal_pending = False
+        else:
+            self._interrupt_message = None
+            self._interrupt_thread_signal_pending = False
 
         # External memory provider: prefetch once before the tool loop.
         # Reuse the cached result on every iteration to avoid re-calling

--- a/tests/run_agent/test_interrupt_propagation.py
+++ b/tests/run_agent/test_interrupt_propagation.py
@@ -28,7 +28,8 @@ class TestInterruptPropagationToChild(unittest.TestCase):
         agent = AIAgent.__new__(AIAgent)
         agent._interrupt_requested = False
         agent._interrupt_message = None
-        agent._execution_thread_id = None  # defaults to current thread in set_interrupt
+        agent._execution_thread_id = None
+        agent._interrupt_thread_signal_pending = False
         agent._active_children = []
         agent._active_children_lock = threading.Lock()
         agent.quiet_mode = True
@@ -46,15 +47,17 @@ class TestInterruptPropagationToChild(unittest.TestCase):
         assert parent._interrupt_requested is True
         assert child._interrupt_requested is True
         assert child._interrupt_message == "new user message"
-        assert is_interrupted() is True
+        assert is_interrupted() is False
+        assert parent._interrupt_thread_signal_pending is True
 
     def test_child_clear_interrupt_at_start_clears_thread(self):
         """child.clear_interrupt() at start of run_conversation clears the
-        per-thread interrupt flag for the current thread.
+        bound execution thread's interrupt flag.
         """
         child = self._make_bare_agent()
         child._interrupt_requested = True
         child._interrupt_message = "msg"
+        child._execution_thread_id = threading.current_thread().ident
 
         # Interrupt for current thread is set
         set_interrupt(True)
@@ -127,6 +130,36 @@ class TestInterruptPropagationToChild(unittest.TestCase):
         assert detected, "Child never detected the interrupt!"
         child_thread.join(timeout=1)
         set_interrupt(False)
+
+    def test_prestart_interrupt_binds_to_execution_thread(self):
+        """An interrupt that arrives before startup should bind to the agent thread."""
+        agent = self._make_bare_agent()
+        barrier = threading.Barrier(2)
+        result = {}
+
+        agent.interrupt("stop before start")
+        assert agent._interrupt_requested is True
+        assert agent._interrupt_thread_signal_pending is True
+        assert is_interrupted() is False
+
+        def run_thread():
+            from tools.interrupt import set_interrupt as _set_interrupt_for_test
+
+            agent._execution_thread_id = threading.current_thread().ident
+            _set_interrupt_for_test(False, agent._execution_thread_id)
+            if agent._interrupt_requested:
+                _set_interrupt_for_test(True, agent._execution_thread_id)
+                agent._interrupt_thread_signal_pending = False
+            barrier.wait(timeout=5)
+            result["thread_interrupted"] = is_interrupted()
+
+        t = threading.Thread(target=run_thread)
+        t.start()
+        barrier.wait(timeout=5)
+        t.join(timeout=2)
+
+        assert result["thread_interrupted"] is True
+        assert agent._interrupt_thread_signal_pending is False
 
 
 class TestPerThreadInterruptIsolation(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Fixes a race in the interrupt path where a user interrupt can arrive before `run_conversation()` has bound the agent to its execution thread.

In that startup window, Hermes was marking the interrupt on the wrong thread and then clearing state during startup, which meant the CLI could print `New message detected, interrupting...` while a foreground terminal launch kept running anyway. This is the path that matches the reproduced "freeze when launching a complex Python command and interrupting immediately" report.

The fix keeps that early interrupt pending until the execution thread is known, then binds the tool-level interrupt signal to the correct thread instead of dropping it.

## Related Issue

Support-driven fix for the "Freezing chat when launching cli commands" report.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `run_agent.py` so `AIAgent.interrupt()` defers thread-scoped interrupt signaling when the execution thread has not been registered yet.
- Updated `run_agent.py` startup flow in `run_conversation()` to preserve and rebind pre-start interrupts to the agent execution thread instead of clearing them during initialization.
- Added regression coverage in `tests/run_agent/test_interrupt_propagation.py` for the pre-start interrupt race and adjusted the existing expectations to match the corrected thread-scoped behavior.

## How to Test

1. Start a foreground terminal-heavy run from the CLI, especially one that launches a complex Python command.
2. Interrupt immediately while the launch is still starting up.
3. Expected: the interrupt is preserved and delivered to the correct agent thread instead of wedging the chat while the foreground terminal call keeps running.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run results:

- `python -m pytest tests/run_agent/test_interrupt_propagation.py -q`
- `python -m pytest tests/run_agent/test_run_agent.py -q -k interrupt`
- `python -m pytest tests/run_agent/test_real_interrupt_subagent.py -q`
- `python -m pytest tests/cli/test_cli_interrupt_subagent.py -q`
- `python -m pytest tests/ -q -n 4` currently finishes red with unrelated pre-existing failures and errors outside this change set, including Discord reply-mode setup, Google Workspace API dependency coverage, browser backend expectations, and other unrelated test groups.
