### PR TITLE
fix: show correct env var name in provider-not-configured error

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2341,9 +2341,15 @@ def call_llm(
             # through OpenRouter (which causes confusing 404s).
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                try:
+                    from hermes_cli.auth import PROVIDER_REGISTRY
+                    _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                    _env_hint = " or ".join(_pconfig.api_key_env_vars) if _pconfig else f"{_explicit.upper()}_API_KEY"
+                except Exception:
+                    _env_hint = f"{_explicit.upper()}_API_KEY"
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             # For auto/custom with no credentials, try the full auto chain
@@ -2546,9 +2552,15 @@ async def async_call_llm(
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                try:
+                    from hermes_cli.auth import PROVIDER_REGISTRY
+                    _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                    _env_hint = " or ".join(_pconfig.api_key_env_vars) if _pconfig else f"{_explicit.upper()}_API_KEY"
+                except Exception:
+                    _env_hint = f"{_explicit.upper()}_API_KEY"
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
-                    f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                    f"was found. Set the {_env_hint} environment "
                     f"variable, or switch to a different provider with `hermes model`."
                 )
             if not resolved_base_url:

--- a/run_agent.py
+++ b/run_agent.py
@@ -937,9 +937,15 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        try:
+                            from hermes_cli.auth import PROVIDER_REGISTRY
+                            _pconfig = PROVIDER_REGISTRY.get(_explicit)
+                            _env_hint = " or ".join(_pconfig.api_key_env_vars) if _pconfig else f"{_explicit.upper()}_API_KEY"
+                        except Exception:
+                            _env_hint = f"{_explicit.upper()}_API_KEY"
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1412,3 +1412,42 @@ def test_named_custom_runtime_no_model_when_absent(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert "model" not in resolved
+
+
+# ---------------------------------------------------------------------------
+# Regression: #9506 — provider error message must use actual env var name
+# ---------------------------------------------------------------------------
+
+def test_alibaba_provider_config_env_var_is_dashscope_not_alibaba():
+    """PROVIDER_REGISTRY for 'alibaba' must list DASHSCOPE_API_KEY, not ALIBABA_API_KEY.
+
+    The no-API-key error message is built from api_key_env_vars, so if the
+    mapping is wrong users are told to set a variable that Hermes never reads.
+    Regression test for #9506.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    pconfig = PROVIDER_REGISTRY.get("alibaba")
+    assert pconfig is not None, "alibaba must be present in PROVIDER_REGISTRY"
+    assert "DASHSCOPE_API_KEY" in pconfig.api_key_env_vars, (
+        "alibaba provider must list DASHSCOPE_API_KEY as its env var"
+    )
+    assert "ALIBABA_API_KEY" not in pconfig.api_key_env_vars, (
+        "ALIBABA_API_KEY is not read by Hermes — listing it would mislead users"
+    )
+
+
+def test_provider_error_message_uses_actual_env_var(monkeypatch):
+    """The no-API-key RuntimeError must mention the real env var, not PROVIDER_API_KEY.
+
+    For 'alibaba' the correct var is DASHSCOPE_API_KEY.  Before the fix the
+    message said ALIBABA_API_KEY, which Hermes never reads.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    provider = "alibaba"
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    env_hint = " or ".join(pconfig.api_key_env_vars) if pconfig else f"{provider.upper()}_API_KEY"
+
+    assert "DASHSCOPE_API_KEY" in env_hint
+    assert "ALIBABA_API_KEY" not in env_hint


### PR DESCRIPTION
## Summary

- When a named provider (e.g. `alibaba`) is set in `config.yaml` but no API key is found, the error message was constructed by blindly uppercasing the provider slug: `ALIBABA_API_KEY`
- For providers whose env var doesn't follow that convention (e.g. alibaba → `DASHSCOPE_API_KEY`), this sent users chasing the wrong variable with no way to fix it
- Fix: look up the provider's actual `api_key_env_vars` from `PROVIDER_REGISTRY` and use those in the error message; falls back to the old slug-based name for unknown providers

## Changes

- `run_agent.py` — fixed 1 location
- `agent/auxiliary_client.py` — fixed 2 locations (sync + async paths)
- `tests/hermes_cli/test_runtime_provider_resolution.py` — added 2 regression tests

## Before / After

**Before:**
> Provider 'alibaba' is set in config.yaml but no API key was found. Set the **ALIBABA_API_KEY** environment variable...

**After:**
> Provider 'alibaba' is set in config.yaml but no API key was found. Set the **DASHSCOPE_API_KEY** environment variable...

Fixes #9506

---
*Developed with [Cursor](https://cursor.com)*