### PR TITLE
fix(cli): preserve ${VAR} env refs in config.yaml across save_config()

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2612,6 +2612,60 @@ _COMMENTED_SECTIONS = """
 """
 
 
+def _restore_env_refs(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Restore ${VAR} references that load_config() expanded.
+
+    When load_config() resolves ``${VAR}`` to the literal env value, any
+    subsequent ``save_config()`` call would bake that value into the file.
+    This function reads the *existing* raw config and, wherever the raw file
+    has a ``${VAR}`` that matches the expanded value, restores the reference
+    so the YAML stays portable across environments.
+    """
+    config_path = get_config_path()
+    if not config_path.exists():
+        return config
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except Exception:
+        return config
+
+    import copy
+    result = copy.deepcopy(config)
+    _do_restore(result, raw)
+    return result
+
+
+def _do_restore(target: dict, raw: dict):
+    """Recursively walk target, restoring ${VAR} from raw where values match."""
+    for key, raw_val in raw.items():
+        if key not in target:
+            continue
+        target_val = target[key]
+        if isinstance(raw_val, str) and re.fullmatch(r"\$\{[^}]+\}", raw_val):
+            # raw has a ${VAR} reference — only restore if the target still
+            # holds the value that the env var resolved to.  If the target
+            # was intentionally changed to something else, leave it alone.
+            var_name = raw_val[2:-1]  # strip ${ and }
+            expanded = os.environ.get(var_name)
+            if isinstance(target_val, str) and expanded is not None and target_val == expanded:
+                target[key] = raw_val
+        elif isinstance(raw_val, dict) and isinstance(target_val, dict):
+            _do_restore(target_val, raw_val)
+        elif isinstance(raw_val, list) and isinstance(target_val, list):
+            for i, rv in enumerate(raw_val):
+                if i < len(target_val):
+                    tv = target_val[i]
+                    if isinstance(rv, str) and re.fullmatch(r"\$\{[^}]+\}", rv):
+                        var_name = rv[2:-1]
+                        expanded = os.environ.get(var_name)
+                        if isinstance(tv, str) and expanded is not None and tv == expanded:
+                            target_val[i] = rv
+                    elif isinstance(rv, dict) and isinstance(tv, dict):
+                        _do_restore(tv, rv)
+
+
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
     if is_managed():
@@ -2622,6 +2676,9 @@ def save_config(config: Dict[str, Any]):
     ensure_hermes_home()
     config_path = get_config_path()
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    # Restore ${VAR} references that load_config() may have expanded, so we
+    # don't bake env values into the YAML file on every save.
+    normalized = _restore_env_refs(normalized)
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -1,8 +1,9 @@
 """Tests for ${ENV_VAR} substitution in config.yaml values."""
 
 import os
+import re
 import pytest
-from hermes_cli.config import _expand_env_vars, load_config
+from hermes_cli.config import _expand_env_vars, _restore_env_refs, load_config, save_config
 from unittest.mock import patch as mock_patch
 
 
@@ -130,3 +131,159 @@ class TestLoadCliConfigExpansion:
         config = load_cli_config()
 
         assert config["auxiliary"]["vision"]["api_key"] == "${UNSET_CLI_VAR_ABC}"
+
+
+class TestRestoreEnvRefs:
+    """Tests for _restore_env_refs — inverse of _expand_env_vars."""
+
+    def test_restores_expanded_value_to_var_ref(self, tmp_path, monkeypatch):
+        """When raw file has ${VAR} and target has the expanded value, restore it."""
+        monkeypatch.setenv("TEST_API_KEY", "sk-secret-123")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        # Write a raw config with ${VAR}
+        (tmp_path / "config.yaml").write_text("model:\n  api_key: ${TEST_API_KEY}\n")
+
+        # Simulate what load_config produces (expanded)
+        config = {"model": {"api_key": "sk-secret-123"}}
+        restored = _restore_env_refs(config)
+
+        assert restored["model"]["api_key"] == "${TEST_API_KEY}"
+
+    def test_no_restore_when_value_changed(self, tmp_path, monkeypatch):
+        """If target has a different value than what ${VAR} resolved to, keep target."""
+        monkeypatch.setenv("MY_KEY", "old-value")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text("model:\n  api_key: ${MY_KEY}\n")
+
+        config = {"model": {"api_key": "new-value"}}
+        restored = _restore_env_refs(config)
+
+        assert restored["model"]["api_key"] == "new-value"
+
+    def test_no_restore_when_raw_has_literal(self, tmp_path, monkeypatch):
+        """If raw file has a literal value (not ${VAR}), don't touch it."""
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text("model:\n  api_key: literal-value\n")
+
+        config = {"model": {"api_key": "literal-value"}}
+        restored = _restore_env_refs(config)
+
+        assert restored["model"]["api_key"] == "literal-value"
+
+    def test_no_restore_when_config_file_missing(self, tmp_path, monkeypatch):
+        """If no config file exists, return config unchanged."""
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "nonexistent.yaml")
+
+        config = {"model": {"api_key": "sk-expanded"}}
+        restored = _restore_env_refs(config)
+
+        assert restored["model"]["api_key"] == "sk-expanded"
+
+    def test_restores_multiple_vars(self, tmp_path, monkeypatch):
+        """Multiple ${VAR} refs across different sections are all restored."""
+        monkeypatch.setenv("VENICE_KEY", "vk-abc")
+        monkeypatch.setenv("TAVILY_KEY", "tk-xyz")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text(
+            "auxiliary:\n"
+            "  vision:\n"
+            "    api_key: ${VENICE_KEY}\n"
+            "  web_extract:\n"
+            "    api_key: ${TAVILY_KEY}\n"
+            "environment:\n"
+            "  TAVILY_API_KEY: ${TAVILY_KEY}\n"
+        )
+
+        config = {
+            "auxiliary": {
+                "vision": {"api_key": "vk-abc"},
+                "web_extract": {"api_key": "tk-xyz"},
+            },
+            "environment": {"TAVILY_API_KEY": "tk-xyz"},
+        }
+        restored = _restore_env_refs(config)
+
+        assert restored["auxiliary"]["vision"]["api_key"] == "${VENICE_KEY}"
+        assert restored["auxiliary"]["web_extract"]["api_key"] == "${TAVILY_KEY}"
+        assert restored["environment"]["TAVILY_API_KEY"] == "${TAVILY_KEY}"
+
+    def test_restores_refs_in_list_of_dicts(self, tmp_path, monkeypatch):
+        """${VAR} inside list items (e.g. providers list) is restored."""
+        monkeypatch.setenv("PROVIDER_KEY", "pk-123")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n"
+            "- name: venice\n"
+            "  api_key: ${PROVIDER_KEY}\n"
+            "- name: local\n"
+            "  api_key: local\n"
+        )
+
+        config = {
+            "providers": [
+                {"name": "venice", "api_key": "pk-123"},
+                {"name": "local", "api_key": "local"},
+            ]
+        }
+        restored = _restore_env_refs(config)
+
+        assert restored["providers"][0]["api_key"] == "${PROVIDER_KEY}"
+        assert restored["providers"][1]["api_key"] == "local"
+
+    def test_does_not_mutate_original_config(self, tmp_path, monkeypatch):
+        """_restore_env_refs returns a new dict, doesn't mutate the input."""
+        monkeypatch.setenv("KEY", "val")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+        (tmp_path / "config.yaml").write_text("x: ${KEY}\n")
+
+        original = {"x": "val"}
+        restored = _restore_env_refs(original)
+
+        assert original["x"] == "val"          # unchanged
+        assert restored["x"] == "${KEY}"       # restored
+
+
+class TestSaveConfigPreservesEnvRefs:
+    """Round-trip: load_config() → save_config() keeps ${VAR} refs in YAML."""
+
+    def test_roundtrip_preserves_env_refs(self, tmp_path, monkeypatch):
+        """After load_config + save_config, the YAML file still has ${VAR}."""
+        monkeypatch.setenv("ROUNDTRIP_KEY", "rt-secret-456")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  api_key: ${ROUNDTRIP_KEY}\n"
+            "  default: test-model\n"
+        )
+
+        # Load (expands ${VAR}) then save
+        config = load_config()
+        config["model"]["default"] = "updated-model"
+        save_config(config)
+
+        # Read raw file back
+        raw = (tmp_path / "config.yaml").read_text()
+
+        assert "${ROUNDTRIP_KEY}" in raw
+        assert "rt-secret-456" not in raw
+        assert "updated-model" in raw
+
+    def test_new_literal_value_written_when_set(self, tmp_path, monkeypatch):
+        """Setting a new api_key value writes the literal (no ${VAR} invented)."""
+        monkeypatch.delenv("BRAND_NEW_KEY", raising=False)
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+
+        (tmp_path / "config.yaml").write_text("model:\n  default: test\n")
+
+        config = load_config()
+        config["model"]["api_key"] = "brand-new-key"
+        save_config(config)
+
+        raw = (tmp_path / "config.yaml").read_text()
+        assert "brand-new-key" in raw


### PR DESCRIPTION
load_config() expands ${VAR} references to literal values from os.environ. Any subsequent save_config() call then writes those expanded values back, permanently replacing environment variable references with secrets in the YAML file.

This affects any config value using ${VAR} syntax that doesn't have a dedicated auth/setup flow reading directly from .env — provider api_keys, auxiliary tool keys, custom environment sections, etc. Migration steps trigger it by calling load_config() then save_config().

Fix: _restore_env_refs() runs inside save_config() before writing. It reads the existing raw YAML and restores any ${VAR} where:
  - the raw file has a ${VAR} reference
  - the to-save value matches what os.environ resolves the var to This preserves env refs across round-trips while still writing intentionally-changed values as literals (no false restorations).

Security: prevents accidental secret exposure in config.yaml.

9 tests added covering restore, round-trip, edge cases, and mutation safety. All 47 existing config tests still pass.