### PR TITLE
fix(agent): time out slow context file reads

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import queue
 import re
 import threading
 from collections import OrderedDict
@@ -50,6 +51,36 @@ _CONTEXT_INVISIBLE_CHARS = {
     '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
     '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
 }
+
+# Read deadlines for context files. These are intentionally short because
+# network-backed filesystems (like iCloud Drive) can fault-in evicted files and
+# block indefinitely on a cold read.
+_CONTEXT_FILE_READ_TIMEOUT_SECS = 5.0
+
+
+def _read_text_with_timeout(path: Path, timeout: float | None = None) -> str | None:
+    """Read a text file on a daemon thread so slow files can't stall startup."""
+    if timeout is None:
+        timeout = _CONTEXT_FILE_READ_TIMEOUT_SECS
+    result: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
+
+    def _reader():
+        try:
+            result.put((True, path.read_text(encoding="utf-8")))
+        except Exception as exc:
+            result.put((False, exc))
+
+    thread = threading.Thread(target=_reader, daemon=True, name=f"context-read:{path.name}")
+    thread.start()
+    try:
+        ok, value = result.get(timeout=timeout)
+    except queue.Empty:
+        logger.warning("Context file %s read timed out after %.1fs; skipping", path, timeout)
+        return None
+    if ok:
+        return value  # type: ignore[return-value]
+    logger.debug("Failed to read context file %s: %s", path, value)
+    return None
 
 
 def _scan_context_content(content: str, filename: str) -> str:
@@ -904,16 +935,15 @@ def load_soul_md() -> Optional[str]:
     soul_path = get_hermes_home() / "SOUL.md"
     if not soul_path.exists():
         return None
-    try:
-        content = soul_path.read_text(encoding="utf-8").strip()
-        if not content:
-            return None
-        content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
-        return content
-    except Exception as e:
-        logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
+    content = _read_text_with_timeout(soul_path)
+    if content is None:
         return None
+    content = content.strip()
+    if not content:
+        return None
+    content = _scan_context_content(content, "SOUL.md")
+    content = _truncate_content(content, "SOUL.md")
+    return content
 
 
 def _load_hermes_md(cwd_path: Path) -> str:
@@ -922,7 +952,10 @@ def _load_hermes_md(cwd_path: Path) -> str:
     if not hermes_md_path:
         return ""
     try:
-        content = hermes_md_path.read_text(encoding="utf-8").strip()
+        content = _read_text_with_timeout(hermes_md_path)
+        if content is None:
+            return ""
+        content = content.strip()
         if not content:
             return ""
         content = _strip_yaml_frontmatter(content)
@@ -945,7 +978,10 @@ def _load_agents_md(cwd_path: Path) -> str:
         candidate = cwd_path / name
         if candidate.exists():
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = _read_text_with_timeout(candidate)
+                if content is None:
+                    continue
+                content = content.strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
@@ -961,7 +997,10 @@ def _load_claude_md(cwd_path: Path) -> str:
         candidate = cwd_path / name
         if candidate.exists():
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = _read_text_with_timeout(candidate)
+                if content is None:
+                    continue
+                content = content.strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
@@ -977,7 +1016,10 @@ def _load_cursorrules(cwd_path: Path) -> str:
     cursorrules_file = cwd_path / ".cursorrules"
     if cursorrules_file.exists():
         try:
-            content = cursorrules_file.read_text(encoding="utf-8").strip()
+            content = _read_text_with_timeout(cursorrules_file)
+            if content is None:
+                content = ""
+            content = content.strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
@@ -989,7 +1031,10 @@ def _load_cursorrules(cwd_path: Path) -> str:
         mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
         for mdc_file in mdc_files:
             try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
+                content = _read_text_with_timeout(mdc_file)
+                if content is None:
+                    content = ""
+                content = content.strip()
                 if content:
                     content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
                     cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -19,7 +19,7 @@ import shlex
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
-from agent.prompt_builder import _scan_context_content
+from agent.prompt_builder import _scan_context_content, _read_text_with_timeout, _CONTEXT_FILE_READ_TIMEOUT_SECS
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,10 @@ class SubdirectoryHintTracker:
             except OSError:
                 continue
             try:
-                content = hint_path.read_text(encoding="utf-8").strip()
+                content = _read_text_with_timeout(hint_path, timeout=_CONTEXT_FILE_READ_TIMEOUT_SECS)
+                if content is None:
+                    continue
+                content = content.strip()
                 if not content:
                     continue
                 # Same security scan as startup context loading

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,8 @@ import builtins
 import importlib
 import logging
 import sys
+import time
+from pathlib import Path
 
 import pytest
 
@@ -521,6 +523,31 @@ class TestBuildContextFilesPrompt:
         (hermes_home / "SOUL.md").write_text("\n\n", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
+
+    def test_timeout_skips_slow_hermes_md_and_falls_back(self, tmp_path, monkeypatch, caplog):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".hermes.md").write_text("Hermes project rules.")
+        (tmp_path / "AGENTS.md").write_text("Agent fallback rules.")
+        monkeypatch.setattr("agent.prompt_builder._CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+
+        original_read_text = Path.read_text
+
+        def slow_read_text(self, *args, **kwargs):
+            if self.name == ".hermes.md":
+                time.sleep(0.2)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", slow_read_text)
+
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.15
+        assert "Agent fallback rules" in result
+        assert "Hermes project rules" not in result
+        assert "timed out" in caplog.text.lower()
 
     def test_blocks_injection_in_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text(

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -1,6 +1,7 @@
 """Tests for progressive subdirectory hint discovery."""
 
 import os
+import time
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -183,6 +184,33 @@ class TestSubdirectoryHintTracker:
         assert tracker.check_tool_call("read_file", {}) is None
         assert tracker.check_tool_call("terminal", {"command": ""}) is None
 
+    def test_timeout_skips_slow_hint_files(self, project, monkeypatch, caplog):
+        """Slow hint reads should time out instead of blocking the turn."""
+        backend = project / "backend"
+        (backend / "AGENTS.md").write_text("Backend-specific instructions")
+        monkeypatch.setattr("agent.subdirectory_hints._CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+
+        original_read_text = Path.read_text
+
+        def slow_read_text(self, *args, **kwargs):
+            if self.name == "AGENTS.md" and self.parent == backend:
+                time.sleep(0.2)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", slow_read_text)
+
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        start = time.monotonic()
+        with caplog.at_level("WARNING", logger="agent.prompt_builder"):
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+            )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.15
+        assert result is None
+        assert "timed out" in caplog.text.lower()
+
     def test_url_in_command_ignored(self, project):
         """URLs in shell commands should not be treated as paths."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))
@@ -209,10 +237,12 @@ class TestPermissionErrorHandling:
         restricted = tmp_path / "restricted"
         restricted.mkdir()
         original_is_file = Path.is_file
+
         def patched_is_file(self):
             if "restricted" in str(self):
                 raise PermissionError("Permission denied")
             return original_is_file(self)
+
         with patch.object(Path, "is_file", patched_is_file):
             result = tracker._load_hints_for_directory(restricted)
         assert result is None
@@ -221,10 +251,12 @@ class TestPermissionErrorHandling:
         """Full check_tool_call should not crash when a path is inaccessible."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))
         original_is_dir = Path.is_dir
+
         def patched_is_dir(self):
             if "backend" in str(self) and "src" not in str(self):
                 raise PermissionError("Permission denied")
             return original_is_dir(self)
+
         with patch.object(Path, "is_dir", patched_is_dir):
             # Should not raise — gracefully skip the inaccessible directory
             result = tracker.check_tool_call(


### PR DESCRIPTION
## Summary\n- Added a daemon-thread read helper with a timeout for context files loaded at startup and during subdirectory hint discovery\n- Applied it to SOUL.md, .hermes.md/HERMES.md, AGENTS.md, CLAUDE.md, .cursorrules, and .cursor/rules/*.mdc\n- Added regression tests proving slow reads fall back instead of blocking\n\n## Testing\n- pytest tests/agent/test_prompt_builder.py tests/agent/test_subdirectory_hints.py -q