### PR TITLE
feat(scheduler): add Chinese platform names to delivery fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -92,7 +92,7 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             }
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in ("matrix", "telegram", "discord", "slack", "bluebubbles"):
+        for platform_name in ("feishu", "weixin", "wecom", "matrix", "telegram", "discord", "slack", "bluebubbles"):
             chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
             if chat_id:
                 logger.info(


### PR DESCRIPTION
## Summary

- Add `feishu`, `weixin`, and `wecom` to the delivery target fallback list in `_resolve_delivery_target()`
- Jobs created via API/script without an origin can now fall back to Chinese platform home channels

## Context

Extracted from #8824 as suggested by @teknium1 in [this comment](https://github.com/NousResearch/hermes-agent/pull/8824#issuecomment-4236190784):

> The cron/scheduler.py change (adding Chinese platform names to delivery fallback) would be welcome as a separate PR.

## Changes

- `cron/scheduler.py`: Prepend `("feishu", "weixin", "wecom")` to the platform fallback tuple so these are checked first (matching the project's existing Chinese-first priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)