### PR TITLE
fix(cli): restore messaging toolset for gateway platforms

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
+    ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
 ]

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -8,6 +8,7 @@ from hermes_cli.tools_config import (
     _platform_toolset_summary,
     _save_platform_tools,
     _toolset_has_keys,
+    CONFIGURABLE_TOOLSETS,
     TOOL_CATEGORIES,
     _visible_providers,
     tools_command,
@@ -20,6 +21,15 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled
+
+
+def test_configurable_toolsets_include_messaging():
+    assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+def test_get_platform_tools_default_telegram_includes_messaging():
+    enabled = _get_platform_tools({}, "telegram")
+
+    assert "messaging" in enabled
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():


### PR DESCRIPTION
## Summary
Salvage of PR #8934 by @abutbul (cherry-picked onto current main).

Adds `messaging` to `CONFIGURABLE_TOOLSETS` so that `send_message` is available on all gateway platforms (Telegram, Discord, Matrix, etc.). Without this, the toolset was silently dropped during platform tool resolution.

## What changed
- `hermes_cli/tools_config.py`: Added `("messaging", "📨 Cross-Platform Messaging", "send_message")` to `CONFIGURABLE_TOOLSETS`
- `tests/hermes_cli/test_tools_config.py`: 2 regression tests

Also addresses PRs #6140 and #6007 which fix the same issue.
Fixes #5991, #8616.

## Test plan
- All 24 tools_config tests pass
- E2E verified: `_get_platform_tools({}, 'matrix')` now includes `messaging`