### PR TITLE
docs(cli): add --all and --system flags to gateway start/stop/restart

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -157,6 +157,27 @@ Subcommands:
 | `uninstall` | Remove the installed service. |
 | `setup` | Interactive messaging-platform setup. |
 
+### `hermes gateway start`
+
+| Option | Description |
+|--------|-------------|
+| `--all` | Kill all stale gateway processes across all profiles before starting. Useful in multi-profile setups to ensure a clean start. |
+| `--system` | Target the system-level systemd service instead of user-level. |
+
+### `hermes gateway stop`
+
+| Option | Description |
+|--------|-------------|
+| `--all` | Stop all gateway processes across all profiles, not just the current one. |
+| `--system` | Target the system-level systemd service instead of user-level. |
+
+### `hermes gateway restart`
+
+| Option | Description |
+|--------|-------------|
+| `--all` | Kill all gateway processes across all profiles before restarting. |
+| `--system` | Target the system-level systemd service instead of user-level. |
+
 :::tip WSL users
 Use `hermes gateway run` instead of `hermes gateway start` — WSL's systemd support is unreliable. Wrap it in tmux for persistence: `tmux new -s hermes 'hermes gateway run'`. See [WSL FAQ](/docs/reference/faq#wsl-gateway-keeps-disconnecting-or-hermes-gateway-start-fails) for details.
 :::


### PR DESCRIPTION
## Summary

Documents the `--all` and `--system` flags for `hermes gateway start`, `stop`, and `restart` in the CLI reference at `website/docs/reference/cli-commands.md`.

## What changed

Added per-subcommand option tables for `gateway start`, `gateway stop`, and `gateway restart` showing:

- `--all` — Kill/stop all gateway processes across all profiles (added in #10043 for `start` and `restart`; already existed for `stop`)
- `--system` — Target the system-level systemd service instead of user-level

The main subcommand overview table is preserved as-is.

## Why

PR #10043 added `--all` flag support to `gateway start` and `gateway restart` but the CLI reference was not updated. The `--system` flag was also undocumented for all three subcommands.

Closes #10062