### PR TITLE
fix(send_message): accept Matrix room IDs and user MXIDs as explicit targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -752,6 +752,38 @@ class TestParseTargetRefDiscord:
         assert is_explicit is True
 
 
+class TestParseTargetRefMatrix:
+    """_parse_target_ref correctly handles Matrix room IDs and user MXIDs."""
+
+    def test_matrix_room_id_is_explicit(self):
+        """Matrix room IDs (!) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "!HLOQwxYGgFPMPJUSNR:matrix.org")
+        assert chat_id == "!HLOQwxYGgFPMPJUSNR:matrix.org"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_matrix_user_mxid_is_explicit(self):
+        """Matrix user MXIDs (@) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "@hermes:matrix.org")
+        assert chat_id == "@hermes:matrix.org"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_matrix_alias_is_not_explicit(self):
+        """Matrix room aliases (#) are NOT explicit — they need resolution."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "#general:matrix.org")
+        assert chat_id is None
+        assert is_explicit is False
+
+    def test_matrix_prefix_only_matches_matrix_platform(self):
+        """! and @ prefixes are only treated as explicit for the matrix platform."""
+        chat_id, _, is_explicit = _parse_target_ref("telegram", "!something")
+        assert is_explicit is False
+
+        chat_id, _, is_explicit = _parse_target_ref("discord", "@someone")
+        assert is_explicit is False
+
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -248,6 +248,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return match.group(1), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
+    # Matrix room IDs (start with !) and user IDs (start with @) are explicit
+    if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
+        return target_ref, None, True
     return None, None, False
 
 


### PR DESCRIPTION
## Summary
Salvage of PR #6144 by @bkadish (cherry-picked onto current main).

`_parse_target_ref()` had explicit-reference branches for Telegram, Feishu, Discord, and numeric IDs, but none for Matrix. Room IDs (`!abc:server`) and user MXIDs (`@user:server`) fell through to `(None, None, False)`, causing channel name resolution to fail — making it impossible to send to specific Matrix rooms via the `send_message` tool.

## What changed
- `tools/send_message_tool.py`: Recognize `!` (room ID) and `@` (user MXID) prefixes as explicit targets when platform is `matrix`
- `tests/tools/test_send_message_tool.py`: 4 regression tests covering room ID, MXID, alias (intentionally non-explicit), and platform isolation

## Design note
Room aliases (`#general:server`) intentionally continue through the resolve path — the Matrix C-S API endpoint requires the opaque room ID, not an alias.

Fixes part of the Matrix sending issue reported by community users.