### PR TITLE
fix: quote $PYTHON_PATH in install.sh to handle paths with spaces

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -255,7 +255,7 @@ check_python() {
         if command -v python >/dev/null 2>&1; then
             PYTHON_PATH="$(command -v python)"
             if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
-                PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+                PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
                 log_success "Python found: $PYTHON_FOUND_VERSION"
                 return 0
             fi
@@ -264,7 +264,7 @@ check_python() {
         log_info "Installing Python via pkg..."
         pkg install -y python >/dev/null
         PYTHON_PATH="$(command -v python)"
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -275,7 +275,7 @@ check_python() {
     # First check if a suitable Python is already available
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -284,7 +284,7 @@ check_python() {
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"


### PR DESCRIPTION
## Summary
Fixes silent installation failure on macOS when Python path contains spaces (e.g., `~/Library/Application Support/uv/...`).

## Root Cause
The `check_python()` function in `scripts/install.sh` uses unquoted variable expansion (`$PYTHON_PATH`) inside command substitutions. With `set -e` enabled, paths with spaces cause the shell to split the path and attempt to execute a non-existent command, triggering silent exit.

## Fix
Quoted all 4 instances of `$PYTHON_PATH` inside command substitutions:
- Line 258: `$PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version)`
- Line 267: same fix
- Line 278: same fix  
- Line 287: same fix

## Test Plan
- [ ] Run `bash install.sh` on macOS with Python installed via uv (path contains spaces)
- [ ] Verify installation completes without silent failure

Closes NousResearch/hermes-agent#10009