### PR TITLE
fix: strip whitespace in tool_call_id comparison in sanitizer

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3319,8 +3319,8 @@ class AIAgent:
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("id", "") or ""
-        return getattr(tc, "id", "") or ""
+            return (tc.get("id", "") or "").strip()
+        return (getattr(tc, "id", "") or "").strip()
 
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
@@ -3356,7 +3356,7 @@ class AIAgent:
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = (msg.get("tool_call_id") or "").strip()
                 if cid:
                     result_call_ids.add(cid)
 
@@ -3365,7 +3365,7 @@ class AIAgent:
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (m.get("role") == "tool" and (m.get("tool_call_id") or "").strip() in orphaned_results)
             ]
             logger.debug(
                 "Pre-call sanitizer: removed %d orphaned tool result(s)",

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -108,6 +108,35 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_tool_call_id_whitespace_stripped(self):
+        """Regression test for #9999: tool_call_id with surrounding whitespace
+        should still match the corresponding assistant tool call."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("functions.cronjob:24")]},
+            tool_result(" functions.cronjob:24 ", "actual result"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Should NOT inject a stub — the real result should be preserved
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert "Result unavailable" not in tool_msgs[0]["content"]
+        assert tool_msgs[0]["content"] == "actual result"
+
+    def test_tool_call_id_whitespace_orphan_detection(self):
+        """Orphan detection should also work with whitespace-padded IDs."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("c1")]},
+            tool_result("  c_ORPHAN  "),  # whitespace-padded orphan
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # The orphan (c_ORPHAN) should be removed, and a stub should be injected for c1
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1  # only the stub for c1
+        assert tool_msgs[0]["tool_call_id"] == "c1"  # stub, not the orphan
+        assert "Result unavailable" in tool_msgs[0]["content"]
+        # Confirm the orphan is gone
+        assert all(m.get("tool_call_id") != "c_ORPHAN" and m.get("tool_call_id") != "  c_ORPHAN  " for m in tool_msgs)
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## Summary
Fixes misclassification of valid tool results as orphaned when `tool_call_id` contains leading/trailing whitespace.

## Root Cause
`_sanitize_api_messages()` in `run_agent.py` compared raw `tool_call_id` strings without stripping whitespace. When the assistant-side tool call uses `functions.cronjob:24` but the persisted tool result has `" functions.cronjob:24"`, the IDs don't match and the sanitizer injects a stub `[Result unavailable]` even though the real result exists.

## Fix
1. Strip whitespace in `_get_tool_call_id_static()` for both dict and object tool calls
2. Strip whitespace when collecting `result_call_ids` from tool messages
3. Strip whitespace in the orphaned results filter comparison

## Test Plan
- [x] New regression tests pass (9/9 in TestSanitizeApiMessages)
- [ ] Manual verification with session containing whitespace-padded tool_call_ids

Closes NousResearch/hermes-agent#9999