### PR TITLE
feat(tools): elastic hot/cold memory with FTS5 search

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -152,7 +152,9 @@ MEMORY_GUIDANCE = (
     "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO "
     "state to memory; use session_search to recall those from past transcripts. "
     "If you've discovered a new way to do something, solved a problem that could be "
-    "necessary later, save it as a skill with the skill tool."
+    "necessary later, save it as a skill with the skill tool.\n"
+    "When hot memory is near capacity, use memory(action='archive') to move lower-priority "
+    "entries to cold storage. Use memory(action='search') to recall archived facts."
 )
 
 SESSION_SEARCH_GUIDANCE = (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -89,6 +89,19 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+
+CREATE TABLE IF NOT EXISTS memory_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target TEXT NOT NULL DEFAULT 'memory',
+    content TEXT NOT NULL,
+    source TEXT DEFAULT 'manual',
+    created_at REAL NOT NULL,
+    last_accessed_at REAL,
+    access_count INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_entries_target ON memory_entries(target);
+CREATE INDEX IF NOT EXISTS idx_memory_entries_accessed ON memory_entries(last_accessed_at DESC);
 """
 
 FTS_SQL = """
@@ -109,6 +122,27 @@ END;
 CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, old.content);
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+END;
+"""
+
+MEMORY_FTS_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_entries_fts USING fts5(
+    content,
+    content=memory_entries,
+    content_rowid=id
+);
+
+CREATE TRIGGER IF NOT EXISTS memory_fts_insert AFTER INSERT ON memory_entries BEGIN
+    INSERT INTO memory_entries_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_fts_delete AFTER DELETE ON memory_entries BEGIN
+    INSERT INTO memory_entries_fts(memory_entries_fts, rowid, content) VALUES('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS memory_fts_update AFTER UPDATE ON memory_entries BEGIN
+    INSERT INTO memory_entries_fts(memory_entries_fts, rowid, content) VALUES('delete', old.id, old.content);
+    INSERT INTO memory_entries_fts(rowid, content) VALUES (new.id, new.content);
 END;
 """
 
@@ -337,6 +371,25 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 7")
+            if current_version < 8:
+                # v8: add memory_entries table for cold memory storage
+                # (Elastic Memory: Hot/Cold split)
+                cursor.executescript("""
+                    CREATE TABLE IF NOT EXISTS memory_entries (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        target TEXT NOT NULL DEFAULT 'memory',
+                        content TEXT NOT NULL,
+                        source TEXT DEFAULT 'manual',
+                        created_at REAL NOT NULL,
+                        last_accessed_at REAL,
+                        access_count INTEGER DEFAULT 0
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_memory_entries_target
+                        ON memory_entries(target);
+                    CREATE INDEX IF NOT EXISTS idx_memory_entries_accessed
+                        ON memory_entries(last_accessed_at DESC);
+                """)
+                cursor.execute("UPDATE schema_version SET version = 8")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -353,6 +406,12 @@ class SessionDB:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
         except sqlite3.OperationalError:
             cursor.executescript(FTS_SQL)
+
+        # Memory entries FTS5 setup
+        try:
+            cursor.execute("SELECT * FROM memory_entries_fts LIMIT 0")
+        except sqlite3.OperationalError:
+            cursor.executescript(MEMORY_FTS_SQL)
 
         self._conn.commit()
 
@@ -1297,3 +1356,134 @@ class SessionDB:
             return len(session_ids)
 
         return self._execute_write(_do)
+
+    # =========================================================================
+    # Cold Memory (Elastic Memory Hot/Cold split)
+    # =========================================================================
+
+    def add_cold_memory(self, target: str, content: str,
+                        source: str = "manual") -> int:
+        """Add an entry to cold memory storage. Returns the new entry ID."""
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                """INSERT INTO memory_entries (target, content, source,
+                   created_at, last_accessed_at, access_count)
+                   VALUES (?, ?, ?, ?, ?, 0)""",
+                (target, content, source, now, now),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def search_cold_memory(self, query: str, target: str = None,
+                           limit: int = 10) -> List[Dict[str, Any]]:
+        """FTS5 search over cold memory entries.
+
+        Returns matching entries with snippets, ordered by relevance.
+        """
+        sanitized = self._sanitize_fts5_query(query)
+        if not sanitized:
+            return []
+
+        with self._lock:
+            if target:
+                rows = self._conn.execute(
+                    """SELECT m.id, m.target, m.content, m.source,
+                              m.created_at, m.last_accessed_at, m.access_count,
+                              snippet(memory_entries_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                       FROM memory_entries_fts fts
+                       JOIN memory_entries m ON m.id = fts.rowid
+                       WHERE memory_entries_fts MATCH ? AND m.target = ?
+                       ORDER BY rank
+                       LIMIT ?""",
+                    (sanitized, target, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT m.id, m.target, m.content, m.source,
+                              m.created_at, m.last_accessed_at, m.access_count,
+                              snippet(memory_entries_fts, 0, '>>>', '<<<', '...', 40) as snippet
+                       FROM memory_entries_fts fts
+                       JOIN memory_entries m ON m.id = fts.rowid
+                       WHERE memory_entries_fts MATCH ?
+                       ORDER BY rank
+                       LIMIT ?""",
+                    (sanitized, limit),
+                ).fetchall()
+
+        return [dict(row) for row in rows]
+
+    def get_cold_memory(self, entry_id: int) -> Optional[Dict[str, Any]]:
+        """Get a single cold memory entry by ID."""
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT id, target, content, source,
+                          created_at, last_accessed_at, access_count
+                   FROM memory_entries WHERE id = ?""",
+                (entry_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def remove_cold_memory(self, entry_id: int) -> bool:
+        """Remove a cold memory entry. Returns True if found and removed."""
+        def _do(conn):
+            cursor = conn.execute(
+                "DELETE FROM memory_entries WHERE id = ?", (entry_id,)
+            )
+            return cursor.rowcount > 0
+
+        return self._execute_write(_do)
+
+    def list_cold_memory(self, target: str = None,
+                         limit: int = 50) -> List[Dict[str, Any]]:
+        """List cold memory entries, most recently accessed first."""
+        with self._lock:
+            if target:
+                rows = self._conn.execute(
+                    """SELECT id, target, content, source,
+                              created_at, last_accessed_at, access_count
+                       FROM memory_entries
+                       WHERE target = ?
+                       ORDER BY last_accessed_at DESC NULLS LAST
+                       LIMIT ?""",
+                    (target, limit),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """SELECT id, target, content, source,
+                              created_at, last_accessed_at, access_count
+                       FROM memory_entries
+                       ORDER BY last_accessed_at DESC NULLS LAST
+                       LIMIT ?""",
+                    (limit,),
+                ).fetchall()
+        return [dict(row) for row in rows]
+
+    def touch_cold_memory(self, entry_id: int) -> None:
+        """Bump access_count and last_accessed_at for a cold entry."""
+        def _do(conn):
+            conn.execute(
+                """UPDATE memory_entries
+                   SET access_count = access_count + 1,
+                       last_accessed_at = ?
+                   WHERE id = ?""",
+                (time.time(), entry_id),
+            )
+
+        self._execute_write(_do)
+
+    def cold_memory_count(self, target: str = None) -> int:
+        """Return count of cold memory entries."""
+        with self._lock:
+            if target:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM memory_entries WHERE target = ?",
+                    (target,),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM memory_entries"
+                ).fetchone()
+        return row[0] if row else 0

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -65,6 +65,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    summary TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -329,6 +330,13 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add summary column to sessions for auto session summaries
+                try:
+                    cursor.execute("ALTER TABLE sessions ADD COLUMN summary TEXT")
+                except sqlite3.OperationalError:
+                    pass  # Column already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -390,6 +398,59 @@ class SessionDB:
                 (time.time(), end_reason, session_id),
             )
         self._execute_write(_do)
+
+    def save_summary(self, session_id: str, summary: str) -> None:
+        """Store a generated summary for a session."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET summary = ? WHERE id = ?",
+                (summary, session_id),
+            )
+        self._execute_write(_do)
+
+    def get_recent_summaries(
+        self,
+        limit: int = 3,
+        exclude_session_id: str = None,
+        source: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Retrieve recent session summaries for context injection.
+
+        Returns sessions that have a non-null summary, ordered by most recent.
+        Each result is a dict with: session_id, title, summary, started_at, source.
+        """
+        conn = self._conn
+        conditions = ["summary IS NOT NULL"]
+        params: list = []
+        if exclude_session_id:
+            # Exclude the current session and its lineage (compression children)
+            conditions.append("id != ?")
+            params.append(exclude_session_id)
+            conditions.append("parent_session_id IS NULL OR parent_session_id != ?")
+            params.append(exclude_session_id)
+        if source:
+            conditions.append("source = ?")
+            params.append(source)
+        where = " AND ".join(conditions)
+        params.append(limit)
+        rows = conn.execute(
+            f"""SELECT id, title, summary, started_at, source
+                FROM sessions
+                WHERE {where}
+                ORDER BY started_at DESC
+                LIMIT ?""",
+            params,
+        ).fetchall()
+        results = []
+        for row in rows:
+            results.append({
+                "session_id": row[0],
+                "title": row[1],
+                "summary": row[2],
+                "started_at": row[3],
+                "source": row[4],
+            })
+        return results
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -1149,6 +1149,7 @@ class AIAgent:
                     self._memory_store = MemoryStore(
                         memory_char_limit=mem_config.get("memory_char_limit", 2200),
                         user_char_limit=mem_config.get("user_char_limit", 1375),
+                        session_db=self._session_db,
                     )
                     self._memory_store.load_from_disk()
             except Exception:
@@ -3278,6 +3279,13 @@ class AIAgent:
                             result = memory_store.add(target, content)
                             if result.get("success"):
                                 applied += 1
+                            elif not result.get("success") and "exceed" in result.get("error", ""):
+                                # Hot memory full — fall back to cold storage
+                                cold_result = memory_store.add_to_cold(
+                                    target, content, source="auto_extract"
+                                )
+                                if cold_result.get("success"):
+                                    applied += 1
                         elif action == "replace" and old_text and content:
                             result = memory_store.replace(target, old_text, content)
                             if result.get("success"):

--- a/run_agent.py
+++ b/run_agent.py
@@ -3039,7 +3039,265 @@ class AIAgent:
                 )
             except Exception:
                 pass
-    
+        # Auto Session Summary — generate structured summary in background
+        self._spawn_auto_summary(messages or [])
+        # Auto Memory Extraction — extract facts/preferences from conversation
+        self._spawn_auto_extraction(messages or [])
+
+    def _spawn_auto_summary(self, messages: list) -> None:
+        """Generate a structured session summary in a background thread.
+
+        Uses the current provider (via call_llm) to produce a compact summary
+        of the conversation, then stores it in the session DB. The summary is
+        injected into future sessions' system prompts for cross-session context.
+
+        Only runs when:
+        - There is a session DB and session ID
+        - The conversation has meaningful content (>= 2 user/assistant turns)
+        - Auto-summary is not disabled via config
+        """
+        if not self._session_db or not self.session_id:
+            return
+
+        # Check config — allow disabling via memory.auto_summary: false
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            if not cfg.get("memory", {}).get("auto_summary", True):
+                return
+        except Exception:
+            pass
+
+        # Only summarize if there's meaningful content
+        user_assistant_msgs = [
+            m for m in messages
+            if isinstance(m, dict) and m.get("role") in ("user", "assistant")
+            and m.get("content") and isinstance(m.get("content"), str)
+            and len(m["content"].strip()) > 10
+        ]
+        if len(user_assistant_msgs) < 2:
+            return
+
+        session_id = self.session_id
+        session_db = self._session_db
+
+        # Build a compact conversation digest for summarization
+        digest_parts = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role", "")
+            content = m.get("content", "")
+            if role == "system" or not content or not isinstance(content, str):
+                continue
+            # Truncate individual messages to keep digest reasonable
+            text = content.strip()
+            if len(text) > 1500:
+                text = text[:1500] + "..."
+            if role == "tool":
+                tool_name = m.get("tool_name", "tool")
+                digest_parts.append(f"[{tool_name} result]: {text[:500]}")
+            elif role in ("user", "assistant"):
+                digest_parts.append(f"[{role}]: {text}")
+        # Cap total digest
+        digest = "\n".join(digest_parts)
+        if len(digest) > 15000:
+            digest = digest[:15000] + "\n...(truncated)"
+
+        def _generate_summary():
+            try:
+                from agent.auxiliary_client import call_llm
+                summary_prompt = (
+                    "You are a session summarizer. Produce a concise structured summary "
+                    "of this conversation in the SAME LANGUAGE the user spoke. Keep it under "
+                    "500 characters. Format:\n"
+                    "Topic: (1-line topic)\n"
+                    "Key Actions: (bullet list of what was done)\n"
+                    "Decisions: (important decisions made)\n"
+                    "Open Items: (unfinished tasks, if any)\n\n"
+                    "Conversation:\n"
+                ) + digest
+
+                response = call_llm(
+                    task="compression",  # reuse compression task's provider config
+                    messages=[{"role": "user", "content": summary_prompt}],
+                    max_tokens=400,
+                    temperature=0.0,
+                )
+                summary_text = response.choices[0].message.content
+                if summary_text and summary_text.strip():
+                    session_db.save_summary(session_id, summary_text.strip()[:1000])
+                    logger.info("Auto session summary saved for %s", session_id)
+            except Exception as e:
+                logger.debug("Auto session summary failed: %s", e)
+
+        t = threading.Thread(target=_generate_summary, daemon=True, name="auto-summary")
+        t.start()
+
+    def _spawn_auto_extraction(self, messages: list) -> None:
+        """Extract durable facts from conversation and write to memory.
+
+        Runs in a background thread after session ends. Uses a cheap LLM to
+        analyze the conversation and identify new facts, preferences, corrections,
+        and environment details worth persisting. Outputs structured JSON
+        operations that are applied to the MemoryStore.
+
+        Only runs when:
+        - Memory store is available and enabled
+        - The conversation has meaningful content (>= 3 user/assistant turns)
+        - Auto-extraction is not disabled via config (memory.auto_extraction)
+        """
+        if not self._memory_store or not self._memory_enabled:
+            return
+
+        # Check config — allow disabling via memory.auto_extraction: false
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            if not cfg.get("memory", {}).get("auto_extraction", True):
+                return
+        except Exception:
+            pass
+
+        # Only extract if there's meaningful content (need enough context)
+        user_assistant_msgs = [
+            m for m in messages
+            if isinstance(m, dict) and m.get("role") in ("user", "assistant")
+            and m.get("content") and isinstance(m.get("content"), str)
+            and len(m["content"].strip()) > 10
+        ]
+        if len(user_assistant_msgs) < 3:
+            return
+
+        memory_store = self._memory_store
+
+        # Read current memory state for dedup context
+        _delim = "\n§\n"
+        current_memory = _delim.join(memory_store.memory_entries) if memory_store.memory_entries else "(empty)"
+        current_user = _delim.join(memory_store.user_entries) if memory_store.user_entries else "(empty)"
+        mem_limit = memory_store._char_limit("memory")
+        user_limit = memory_store._char_limit("user")
+        mem_used = memory_store._char_count("memory")
+        user_used = memory_store._char_count("user")
+
+        # Build conversation digest (same pattern as auto_summary)
+        digest_parts = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role", "")
+            content = m.get("content", "")
+            if role == "system" or not content or not isinstance(content, str):
+                continue
+            text = content.strip()
+            if len(text) > 1500:
+                text = text[:1500] + "..."
+            if role == "tool":
+                tool_name = m.get("tool_name", "tool")
+                digest_parts.append(f"[{tool_name} result]: {text[:500]}")
+            elif role in ("user", "assistant"):
+                digest_parts.append(f"[{role}]: {text}")
+        digest = "\n".join(digest_parts)
+        if len(digest) > 15000:
+            digest = digest[:15000] + "\n...(truncated)"
+
+        def _run_extraction():
+            try:
+                from agent.auxiliary_client import call_llm
+
+                extraction_prompt = (
+                    "You are a memory extraction system. Analyze this conversation and identify "
+                    "information worth persisting to long-term memory. Focus on:\n"
+                    "1. User preferences, corrections, or behavioral instructions\n"
+                    "2. Environment/system facts discovered (tools, configs, versions)\n"
+                    "3. Project details, decisions, or conventions established\n"
+                    "4. Corrections the user made (things the agent got wrong)\n\n"
+                    "RULES:\n"
+                    "- Do NOT extract task progress, session outcomes, or temporary state\n"
+                    "- Do NOT duplicate information already in existing memory\n"
+                    "- Each entry must be a compact, self-contained fact (1-2 lines)\n"
+                    "- If existing memory has outdated info, suggest a replace operation\n"
+                    "- If nothing new is worth remembering, return empty operations array\n"
+                    "- Respect capacity limits shown below\n\n"
+                    f"=== EXISTING MEMORY (agent notes) [{mem_used}/{mem_limit} chars] ===\n"
+                    f"{current_memory}\n\n"
+                    f"=== EXISTING USER PROFILE [{user_used}/{user_limit} chars] ===\n"
+                    f"{current_user}\n\n"
+                    "=== CONVERSATION ===\n"
+                    f"{digest}\n\n"
+                    "Output ONLY a JSON array of operations. Each operation:\n"
+                    '{"action": "add|replace|remove", "target": "memory|user", '
+                    '"content": "new entry text", "old_text": "substring to match for replace/remove"}\n'
+                    "For add: content required. For replace: old_text + content. For remove: old_text only.\n"
+                    "Return [] if nothing new to extract. Output raw JSON only, no markdown fences."
+                )
+
+                response = call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": extraction_prompt}],
+                    max_tokens=1000,
+                    temperature=0.0,
+                )
+                result_text = response.choices[0].message.content
+                if not result_text or not result_text.strip():
+                    return
+
+                # Parse JSON operations
+                import json as _json
+                text = result_text.strip()
+                # Strip markdown fences if model added them
+                if text.startswith("```"):
+                    text = text.split("\n", 1)[-1]
+                    if text.endswith("```"):
+                        text = text[:-3]
+                    text = text.strip()
+
+                try:
+                    operations = _json.loads(text)
+                except _json.JSONDecodeError:
+                    logger.debug("Auto extraction: failed to parse JSON: %s", text[:200])
+                    return
+
+                if not isinstance(operations, list) or not operations:
+                    return
+
+                applied = 0
+                for op in operations[:10]:  # cap at 10 operations per session
+                    if not isinstance(op, dict):
+                        continue
+                    action = op.get("action", "")
+                    target = op.get("target", "memory")
+                    content = op.get("content", "")
+                    old_text = op.get("old_text", "")
+
+                    if target not in ("memory", "user"):
+                        continue
+
+                    try:
+                        if action == "add" and content:
+                            result = memory_store.add(target, content)
+                            if result.get("success"):
+                                applied += 1
+                        elif action == "replace" and old_text and content:
+                            result = memory_store.replace(target, old_text, content)
+                            if result.get("success"):
+                                applied += 1
+                        elif action == "remove" and old_text:
+                            result = memory_store.remove(target, old_text)
+                            if result.get("success"):
+                                applied += 1
+                    except Exception as e:
+                        logger.debug("Auto extraction op failed: %s %s: %s", action, target, e)
+
+                if applied > 0:
+                    logger.info("Auto memory extraction: %d operations applied", applied)
+
+            except Exception as e:
+                logger.debug("Auto memory extraction failed: %s", e)
+
+        t = threading.Thread(target=_run_extraction, daemon=True, name="auto-extraction")
+        t.start()
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -3244,6 +3502,30 @@ class AIAgent:
                 _ext_mem_block = self._memory_manager.build_system_prompt()
                 if _ext_mem_block:
                     prompt_parts.append(_ext_mem_block)
+            except Exception:
+                pass
+
+        # Auto Session Summaries — inject recent session summaries for cross-session context
+        if self._session_db and self.session_id:
+            try:
+                recent_summaries = self._session_db.get_recent_summaries(
+                    limit=3,
+                    exclude_session_id=self.session_id,
+                )
+                if recent_summaries:
+                    from datetime import datetime as _dt, timezone as _tz
+                    summary_lines = ["## Recent Session Context\n"]
+                    for s in recent_summaries:
+                        ts = s.get("started_at", 0)
+                        try:
+                            time_str = _dt.fromtimestamp(ts, tz=_tz.utc).strftime("%Y-%m-%d %H:%M UTC")
+                        except Exception:
+                            time_str = "unknown"
+                        title = s.get("title") or "Untitled"
+                        summary_lines.append(f"### {title} ({time_str})")
+                        summary_lines.append(s["summary"])
+                        summary_lines.append("")
+                    prompt_parts.append("\n".join(summary_lines))
             except Exception:
                 pass
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -935,7 +935,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -996,7 +996,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -111,13 +111,22 @@ class MemoryStore:
         Never mutated mid-session. Keeps prefix cache stable.
       - memory_entries / user_entries: live state, mutated by tool calls, persisted to disk.
         Tool responses always reflect this live state.
+
+    Hot/Cold Architecture:
+      - Hot memory: MEMORY.md / USER.md files, injected into system prompt every turn.
+        Bounded by char limits (~3575 chars total). High-frequency, recent entries.
+      - Cold memory: SQLite memory_entries table with FTS5 search. Unlimited capacity.
+        Accessible via search/archive/promote tool actions. Stores demoted or
+        overflow entries for long-term accumulation.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 session_db=None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        self._session_db = session_db  # For cold memory operations
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
@@ -459,6 +468,196 @@ class MemoryStore:
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
+    # -- Cold Memory Operations --
+
+    def archive(self, target: str, old_text: str) -> Dict[str, Any]:
+        """Move an entry from hot memory to cold storage (demote).
+
+        Finds the hot entry matching old_text, removes it from hot,
+        and writes it to the cold memory DB table.
+        """
+        if not self._session_db:
+            return {"success": False, "error": "Cold memory storage not available (no session DB)."}
+
+        old_text = old_text.strip()
+        if not old_text:
+            return {"success": False, "error": "old_text cannot be empty."}
+
+        with self._file_lock(self._path_for(target)):
+            self._reload_target(target)
+            entries = self._entries_for(target)
+            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+
+            if not matches:
+                return {"success": False, "error": f"No hot entry matched '{old_text}'."}
+
+            if len(matches) > 1:
+                unique_texts = set(e for _, e in matches)
+                if len(unique_texts) > 1:
+                    previews = [e[:80] + ("..." if len(e) > 80 else "") for _, e in matches]
+                    return {
+                        "success": False,
+                        "error": f"Multiple entries matched '{old_text}'. Be more specific.",
+                        "matches": previews,
+                    }
+
+            idx, content = matches[0]
+            # Write to cold storage
+            try:
+                entry_id = self._session_db.add_cold_memory(target, content, source="demoted")
+            except Exception as e:
+                return {"success": False, "error": f"Failed to write to cold storage: {e}"}
+
+            # Remove from hot
+            entries.pop(idx)
+            self._set_entries(target, entries)
+            self.save_to_disk(target)
+
+        return self._cold_success_response(
+            target, f"Entry archived to cold memory (id={entry_id})."
+        )
+
+    def promote(self, target: str, entry_id: int) -> Dict[str, Any]:
+        """Move an entry from cold storage back to hot memory.
+
+        Retrieves the cold entry by ID, adds it to hot memory (if space allows),
+        and removes it from cold storage.
+        """
+        if not self._session_db:
+            return {"success": False, "error": "Cold memory storage not available (no session DB)."}
+
+        # Fetch from cold
+        cold_entry = self._session_db.get_cold_memory(entry_id)
+        if not cold_entry:
+            return {"success": False, "error": f"No cold memory entry with id={entry_id}."}
+
+        content = cold_entry["content"]
+        cold_target = cold_entry["target"]
+        if cold_target != target:
+            return {
+                "success": False,
+                "error": f"Entry {entry_id} belongs to target '{cold_target}', not '{target}'.",
+            }
+
+        # Try to add to hot
+        with self._file_lock(self._path_for(target)):
+            self._reload_target(target)
+            entries = self._entries_for(target)
+            limit = self._char_limit(target)
+
+            # Check for duplicates
+            if content in entries:
+                # Already in hot, just remove from cold
+                self._session_db.remove_cold_memory(entry_id)
+                return self._cold_success_response(
+                    target, "Entry already exists in hot memory. Removed cold duplicate."
+                )
+
+            new_entries = entries + [content]
+            new_total = len(ENTRY_DELIMITER.join(new_entries))
+
+            if new_total > limit:
+                current = self._char_count(target)
+                return {
+                    "success": False,
+                    "error": (
+                        f"Hot memory at {current:,}/{limit:,} chars. "
+                        f"Promoting this entry ({len(content)} chars) would exceed the limit. "
+                        f"Archive or remove existing hot entries first."
+                    ),
+                }
+
+            entries.append(content)
+            self._set_entries(target, entries)
+            self.save_to_disk(target)
+
+        # Remove from cold after successful hot add
+        self._session_db.remove_cold_memory(entry_id)
+
+        return self._cold_success_response(
+            target, f"Entry promoted from cold to hot memory."
+        )
+
+    def search_cold(self, query: str, target: str = None,
+                    limit: int = 10) -> Dict[str, Any]:
+        """Search cold memory using FTS5 full-text search."""
+        if not self._session_db:
+            return {"success": False, "error": "Cold memory storage not available (no session DB)."}
+
+        results = self._session_db.search_cold_memory(query, target=target, limit=limit)
+        # Touch accessed entries
+        for r in results:
+            try:
+                self._session_db.touch_cold_memory(r["id"])
+            except Exception:
+                pass
+
+        total = self._session_db.cold_memory_count(target)
+        return {
+            "success": True,
+            "query": query,
+            "results": [
+                {
+                    "id": r["id"],
+                    "target": r["target"],
+                    "content": r["content"],
+                    "source": r.get("source", ""),
+                    "access_count": r.get("access_count", 0),
+                }
+                for r in results
+            ],
+            "result_count": len(results),
+            "total_cold_entries": total,
+        }
+
+    def add_to_cold(self, target: str, content: str,
+                    source: str = "manual") -> Dict[str, Any]:
+        """Add an entry directly to cold memory (bypassing hot)."""
+        if not self._session_db:
+            return {"success": False, "error": "Cold memory storage not available (no session DB)."}
+
+        content = content.strip()
+        if not content:
+            return {"success": False, "error": "Content cannot be empty."}
+
+        scan_error = _scan_memory_content(content)
+        if scan_error:
+            return {"success": False, "error": scan_error}
+
+        try:
+            entry_id = self._session_db.add_cold_memory(target, content, source=source)
+        except Exception as e:
+            return {"success": False, "error": f"Failed to write to cold storage: {e}"}
+
+        total = self._session_db.cold_memory_count(target)
+        return {
+            "success": True,
+            "message": f"Entry added to cold memory (id={entry_id}).",
+            "entry_id": entry_id,
+            "total_cold_entries": total,
+        }
+
+    def _cold_success_response(self, target: str,
+                               message: str = None) -> Dict[str, Any]:
+        """Build response combining hot and cold memory stats."""
+        entries = self._entries_for(target)
+        current = self._char_count(target)
+        limit = self._char_limit(target)
+        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+        cold_count = self._session_db.cold_memory_count(target) if self._session_db else 0
+
+        resp = {
+            "success": True,
+            "target": target,
+            "hot_entries": entries,
+            "hot_usage": f"{pct}% — {current:,}/{limit:,} chars",
+            "hot_entry_count": len(entries),
+            "cold_entry_count": cold_count,
+        }
+        if message:
+            resp["message"] = message
+        return resp
+
 
 def memory_tool(
     action: str,
@@ -495,8 +694,31 @@ def memory_tool(
             return tool_error("old_text is required for 'remove' action.", success=False)
         result = store.remove(target, old_text)
 
+    elif action == "search":
+        # Search cold (archival) memory via FTS5
+        query = content or old_text or ""
+        if not query:
+            return tool_error("Provide search query in 'content' parameter.", success=False)
+        result = store.search_cold(query, target=target)
+
+    elif action == "archive":
+        # Demote: move from hot to cold storage
+        if not old_text:
+            return tool_error("old_text is required for 'archive' action.", success=False)
+        result = store.archive(target, old_text)
+
+    elif action == "promote":
+        # Promote: move from cold back to hot memory
+        if not content:
+            return tool_error("content (cold entry ID as string) is required for 'promote'.", success=False)
+        try:
+            entry_id = int(content)
+        except (ValueError, TypeError):
+            return tool_error(f"'content' must be the numeric cold entry ID, got: {content}", success=False)
+        result = store.promote(target, entry_id)
+
     else:
-        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove, search, archive, promote", success=False)
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -531,8 +753,18 @@ MEMORY_SCHEMA = {
         "TWO TARGETS:\n"
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
-        "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "HOT/COLD MEMORY:\n"
+        "- Hot memory (add/replace/remove): injected into every turn, limited capacity (~2200+1375 chars). "
+        "Keep only high-value, frequently-needed facts here.\n"
+        "- Cold memory (search/archive/promote): unlimited archival storage with FTS5 search. "
+        "Use 'archive' to move low-priority entries from hot to cold. "
+        "Use 'search' to find archived entries. "
+        "Use 'promote' to bring a cold entry back to hot (pass the cold entry ID as content).\n\n"
+        "ACTIONS: add (new hot entry), replace (update hot entry -- old_text identifies it), "
+        "remove (delete hot entry -- old_text identifies it), "
+        "search (query cold memory -- pass query as content), "
+        "archive (move hot→cold -- old_text identifies it), "
+        "promote (move cold→hot -- pass cold entry ID as content).\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -540,7 +772,7 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
+                "enum": ["add", "replace", "remove", "search", "archive", "promote"],
                 "description": "The action to perform."
             },
             "target": {
@@ -550,11 +782,11 @@ MEMORY_SCHEMA = {
             },
             "content": {
                 "type": "string",
-                "description": "The entry content. Required for 'add' and 'replace'."
+                "description": "The entry content. Required for 'add' and 'replace'. For 'search': the search query. For 'promote': the cold entry ID (as string)."
             },
             "old_text": {
                 "type": "string",
-                "description": "Short unique substring identifying the entry to replace or remove."
+                "description": "Short unique substring identifying the entry to replace, remove, or archive."
             },
         },
         "required": ["action", "target"],


### PR DESCRIPTION
## What & Why

Extends the memory system with a **cold storage tier** backed by SQLite FTS5, solving the hard character limit on hot memory (~3,575 chars). Hot memory stays in the system prompt every turn; cold memory is unlimited and searchable on demand.

```
Hot Memory (MEMORY.md / USER.md)     Cold Memory (SQLite memory_entries)
├─ ~3,575 chars total                ├─ Unlimited capacity
├─ Injected into system prompt       ├─ FTS5 full-text searchable
├─ Every turn, always visible        ├─ On-demand via tool actions
└─ Fast but limited                  └─ Deep but requires search
```

**Depends on:** #10120 (auto session context — provides the auto-extraction fallback path)

## Changes

### `hermes_state.py`
- Schema v7 → v8: new `memory_entries` table (id, target, content, source, created_at, last_accessed_at, access_count)
- `memory_entries_fts` FTS5 virtual table with insert/delete/update triggers
- 7 new SessionDB methods: `add_cold_memory`, `get_cold_memory`, `search_cold_memory`, `remove_cold_memory`, `list_cold_memory`, `touch_cold_memory`, `cold_memory_count`

### `tools/memory_tool.py`
- MemoryStore: `session_db` parameter, 5 new methods (`archive`, `promote`, `add_to_cold`, `search_cold`, `_cold_success_response`)
- `memory_tool()`: 3 new actions — `search` (FTS5 query), `archive` (hot→cold), `promote` (cold→hot)
- `MEMORY_SCHEMA`: updated action enum + descriptions

### `run_agent.py`
- MemoryStore instantiation passes `session_db`
- Auto-extraction fallback: hot full → auto stores to cold

### `agent/prompt_builder.py`
- `MEMORY_GUIDANCE` updated with cold storage instructions

## How to Test

```bash
# Unit tests
pytest tests/ -v -k 'memory or hermes_state'

# Manual integration
python -c "
from pathlib import Path
import tempfile, os
tmp = tempfile.mkdtemp()
os.environ['HERMES_HOME'] = tmp
Path(tmp, 'memories').mkdir()
Path(tmp, 'memories/MEMORY.md').write_text('test')
Path(tmp, 'memories/USER.md').write_text('test')
from hermes_state import SessionDB
from tools.memory_tool import MemoryStore
db = SessionDB(Path(tmp) / 'test.db')
store = MemoryStore(session_db=db); store.load_from_disk()
r = store.add_to_cold('memory', 'Test cold entry')
print('add_to_cold:', r)
r = store.search_cold('Test')
print('search_cold:', r)
print('ALL PASSED')
"
```

## Platforms Tested
- Ubuntu 24.04 (Azure VM)

## Stats
- 4 files, +441 lines
- Zero external dependencies (pure SQLite FTS5)
- Backward compatible: existing hot memory workflow unchanged