### PR TITLE
fix(tests): clear VIRTUAL_ENV in venv detection tests (#8620 follow-up)

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -613,6 +613,7 @@ class TestDetectVenvDir:
         # Not inside a virtualenv
         monkeypatch.setattr("sys.prefix", "/usr")
         monkeypatch.setattr("sys.base_prefix", "/usr")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
 
         dot_venv = tmp_path / ".venv"
@@ -624,6 +625,7 @@ class TestDetectVenvDir:
     def test_falls_back_to_venv_directory(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.prefix", "/usr")
         monkeypatch.setattr("sys.base_prefix", "/usr")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
 
         venv = tmp_path / "venv"
@@ -635,6 +637,7 @@ class TestDetectVenvDir:
     def test_prefers_dot_venv_over_venv(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.prefix", "/usr")
         monkeypatch.setattr("sys.base_prefix", "/usr")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
 
         (tmp_path / ".venv").mkdir()
@@ -646,6 +649,7 @@ class TestDetectVenvDir:
     def test_returns_none_when_no_virtualenv(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.prefix", "/usr")
         monkeypatch.setattr("sys.base_prefix", "/usr")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", tmp_path)
 
         result = gateway_cli._detect_venv_dir()


### PR DESCRIPTION
## Problem

The 4 `TestDetectVenvDir` fallback tests in `test_gateway_service.py` fail when run inside any virtualenv (both locally and in CI).

## Root Cause

After #10093 added `VIRTUAL_ENV` env-var detection to `_detect_venv_dir()`, the tests that exercise the `PROJECT_ROOT` fallback path break — `VIRTUAL_ENV` is set in CI's virtualenv, so `_detect_venv_dir()` returns the real venv dir before reaching the fallback logic each test targets.

## Fix

Add `monkeypatch.delenv('VIRTUAL_ENV', raising=False)` to the 4 affected tests so the `PROJECT_ROOT` fallback is actually exercised.

## Verification

```
python -m pytest tests/hermes_cli/test_gateway_service.py -q --override-ini='addopts='
# 70 passed
```

Signed-off-by: Kagura <kagura.chen28@gmail.com>