### PR TITLE
fix: detect receive_id_type dynamically in Feishu adapter

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3289,8 +3289,25 @@ class FeishuAdapter(BasePlatformAdapter):
             content=payload,
             uuid_value=str(uuid.uuid4()),
         )
-        request = self._build_create_message_request("chat_id", body)
+        receive_id_type = self._detect_receive_id_type(chat_id)
+        request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
+
+    @staticmethod
+    def _detect_receive_id_type(receive_id: str) -> str:
+        """Detect the correct receive_id_type based on ID prefix.
+
+        Feishu's im.message.create API requires different receive_id_type values:
+        - User open_id (prefix 'ou_') → 'open_id'
+        - Group chat_id (prefix 'oc_') → 'chat_id'
+        - Union ID (prefix 'on_') → 'union_id'
+        """
+        if receive_id.startswith("ou_"):
+            return "open_id"
+        if receive_id.startswith("on_"):
+            return "union_id"
+        # Default to chat_id for group chats (oc_) and any other format
+        return "chat_id"
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2855,3 +2855,27 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+class TestDetectReceiveIdType(unittest.TestCase):
+    """Regression tests for #9980: receive_id_type detection based on ID prefix."""
+
+    def test_open_id_prefix(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self.assertEqual(FeishuAdapter._detect_receive_id_type("ou_245ad75b"), "open_id")
+
+    def test_chat_id_prefix(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self.assertEqual(FeishuAdapter._detect_receive_id_type("oc_1234567890"), "chat_id")
+
+    def test_union_id_prefix(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self.assertEqual(FeishuAdapter._detect_receive_id_type("on_abcdef"), "union_id")
+
+    def test_unknown_prefix_defaults_to_chat_id(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self.assertEqual(FeishuAdapter._detect_receive_id_type("some_unknown_id"), "chat_id")
+
+    def test_empty_string_defaults_to_chat_id(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self.assertEqual(FeishuAdapter._detect_receive_id_type(""), "chat_id")


### PR DESCRIPTION
## Summary
Fixes `[230001] invalid receive_id` errors when sending messages to Feishu users via open_id.

## Root Cause
`_send_raw_message()` in `gateway/platforms/feishu.py` hardcodes `receive_id_type='chat_id'` when calling the `im.message.create` API. Feishu requires different `receive_id_type` values based on ID format:
- User open_id (prefix `ou_`) → `open_id`
- Group chat_id (prefix `oc_`) → `chat_id`
- Union ID (prefix `on_`) → `union_id`

## Fix
Added `_detect_receive_id_type()` static helper that inspects the ID prefix and returns the correct type. Called dynamically in `_send_raw_message()` instead of hardcoding.

## Test Plan
- [x] 5 new unit tests pass (TestDetectReceiveIdType)
- [ ] Manual verification: cron job with `deliver=feishu:ou_xxxx` delivers successfully

Closes NousResearch/hermes-agent#9980