### PR TITLE
fix(copilot): add missing base_url default in credential pool resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_GITHUB_MODELS_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -167,6 +168,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider


### PR DESCRIPTION
## What

When a copilot credential is auto-seeded into the credential pool (e.g. from `gh auth token`), the pool entry lacks a `base_url` field.

`_resolve_runtime_from_pool_entry()` handles copilot at line 168 but only sets `api_mode` — unlike every other provider branch (`openai-codex`, `qwen-oauth`, `anthropic`, `openrouter`) which all apply a default `base_url` fallback. This causes:

```
Provider resolver returned an empty base URL
```

## Why

The non-pool path (line 840–878) works correctly because `resolve_api_key_provider_credentials()` returns the `base_url` from `PROVIDER_REGISTRY`. The regression was exposed after the credential pool seeder began auto-populating copilot entries from gh CLI tokens (commit 2a9e50c1, Apr 13 — "fix(copilot): resolve GHE token poisoning when GITHUB_TOKEN is set").

## Fix

Add `base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL` to the copilot branch in `_resolve_runtime_from_pool_entry()`, matching the pattern used by all other providers:

```python
# Before (broken):
elif provider == "copilot":
    api_mode = _copilot_runtime_api_mode(model_cfg, ...)

# After (fixed):
elif provider == "copilot":
    api_mode = _copilot_runtime_api_mode(model_cfg, ...)
    base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
```

## How to reproduce

1. Have a valid `gh auth` session
2. Run `hermes update` (pulls commits from Apr 13+)
3. Set `model.provider: copilot` in `~/.hermes/config.yaml`
4. Run `hermes` → `Provider resolver returned an empty base URL`

The credential pool seeder auto-creates a copilot pool entry from the gh CLI token. The pool entry has `access_token` but no `base_url`. When `_resolve_runtime_from_pool_entry` is called for copilot, `base_url` stays empty.

## Testing

- Verified the import resolves correctly (`DEFAULT_GITHUB_MODELS_BASE_URL` is already exported from `hermes_cli.auth`)
- Tested on Linux (Pop!_OS), Python 3.11
- Confirmed copilot provider resolves to `https://api.githubcopilot.com` after the fix
