### PR TITLE
feat(config): add env.d/ drop-in directory for additional env files

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -7,8 +7,8 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
-from utils import atomic_replace, fast_safe_load
 
+from utils import atomic_replace, fast_safe_load
 
 # Env var name suffixes that indicate credential values.  These are the
 # only env vars whose values we sanitize on load — we must not silently
@@ -144,7 +144,7 @@ def _sanitize_loaded_credentials() -> None:
             "  This usually means the key was copy-pasted from a PDF, "
             "rich-text editor, or web page that substituted lookalike\n"
             "  Unicode glyphs for ASCII letters. If authentication fails "
-            "(e.g. \"API key not valid\"), re-copy the key from the\n"
+            '(e.g. "API key not valid"), re-copy the key from the\n'
             "  provider's dashboard and run `hermes setup` (or edit the "
             ".env file in a plain-text editor).",
             file=sys.stderr,
@@ -198,6 +198,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         sanitized = _sanitize_env_lines(stripped)
         if sanitized != original:
             import tempfile
+
             fd, tmp = tempfile.mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
@@ -259,6 +260,14 @@ def load_hermes_dotenv(
     op_env = home_path / ".op.env"
     if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
         _load_dotenv_with_fallback(op_env, override=False)
+
+    # Drop-in directory: $HERMES_HOME/env.d/*.env (sorted, override=True)
+    env_d = home_path / "env.d"
+    if env_d.is_dir():
+        for f in sorted(env_d.glob("*.env")):
+            if f.is_file():
+                _load_dotenv_with_fallback(f, override=True)
+                loaded.append(f)
 
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -116,6 +116,14 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
 
+    # Drop-in directory: $HERMES_HOME/env.d/*.env (sorted, override=True)
+    env_d = home_path / "env.d"
+    if env_d.is_dir():
+        for f in sorted(env_d.glob("*.env")):
+            if f.is_file():
+                _load_dotenv_with_fallback(f, override=True)
+                loaded.append(f)
+
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -549,6 +549,142 @@ json.dump(load_config(), sys.stdout, default=str)
           mkdir -p $out
           echo "ok" > $out/result
         '';
+
+        # ── NixOS VM integration test for env.d/ ──────────────────────────
+        env-d-vm = import ./tests/env-d-vm.nix {
+          inherit pkgs;
+          nixosModule = inputs.self.nixosModules.default;
+        };
+
+        # ── env.d/ activation script behavior ─────────────────────────────
+        # Tests the shell logic from the activation script: writing
+        # nix-environment.env, symlinking environmentFiles, and detecting
+        # stale symlink cleanup issues.
+        env-d-activation = pkgs.runCommand "hermes-env-d-activation" { } ''
+          set -e
+          ERRORS=""
+          fail() { ERRORS="$ERRORS\nFAIL: $1"; }
+
+          SECRET_DIR=$(mktemp -d)
+          echo "API_KEY=sk-secret-123" > "$SECRET_DIR/hermes-api"
+          echo "DISCORD_TOKEN=tok-abc" > "$SECRET_DIR/hermes-discord"
+          echo "TELEGRAM_TOKEN=tok-xyz" > "$SECRET_DIR/hermes-telegram"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario A: environment only — no environmentFiles
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario A: environment only ==="
+          A_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$A_HERMES/env.d"
+
+          cat > "$A_HERMES/env.d/nix-environment.env" <<'ENVEOF'
+MODEL=test-model
+OPENAI_BASE_URL=https://example.com/v1
+ENVEOF
+          chmod 0640 "$A_HERMES/env.d/nix-environment.env"
+
+          test -f "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: nix-environment.env not created"
+          grep -q "MODEL=test-model" "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: MODEL not in nix-environment.env"
+          grep -q "OPENAI_BASE_URL=https://example.com/v1" "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: OPENAI_BASE_URL not in nix-environment.env"
+          ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]" \
+            && fail "A: unexpected nix-N symlinks when no environmentFiles" || true
+          echo "PASS: Scenario A"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario B: environmentFiles — symlinks created & readable
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario B: environmentFiles ==="
+          B_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$B_HERMES/env.d"
+
+          ln -sfn "$SECRET_DIR/hermes-api" "$B_HERMES/env.d/nix-0.env"
+          ln -sfn "$SECRET_DIR/hermes-discord" "$B_HERMES/env.d/nix-1.env"
+
+          test -L "$B_HERMES/env.d/nix-0.env" \
+            || fail "B: nix-0.env is not a symlink"
+          test -L "$B_HERMES/env.d/nix-1.env" \
+            || fail "B: nix-1.env is not a symlink"
+          test "$(readlink "$B_HERMES/env.d/nix-0.env")" = "$SECRET_DIR/hermes-api" \
+            || fail "B: nix-0.env points to wrong target"
+          grep -q "API_KEY=sk-secret-123" "$B_HERMES/env.d/nix-0.env" \
+            || fail "B: cannot read API_KEY through symlink"
+          grep -q "DISCORD_TOKEN=tok-abc" "$B_HERMES/env.d/nix-1.env" \
+            || fail "B: cannot read DISCORD_TOKEN through symlink"
+          echo "PASS: Scenario B"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario C: ln -sfn replaces existing symlink atomically
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario C: symlink replacement ==="
+          C_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$C_HERMES/env.d"
+
+          echo "OLD_KEY=old" > "$SECRET_DIR/old-secret"
+          ln -sfn "$SECRET_DIR/old-secret" "$C_HERMES/env.d/nix-0.env"
+          echo "NEW_KEY=new" > "$SECRET_DIR/new-secret"
+          ln -sfn "$SECRET_DIR/new-secret" "$C_HERMES/env.d/nix-0.env"
+
+          test "$(readlink "$C_HERMES/env.d/nix-0.env")" = "$SECRET_DIR/new-secret" \
+            || fail "C: symlink not updated to new target"
+          grep -q "NEW_KEY=new" "$C_HERMES/env.d/nix-0.env" \
+            || fail "C: new content not readable through updated symlink"
+          echo "PASS: Scenario C"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario D: stale symlink detection
+          # Simulates reducing environmentFiles from 3 to 1. The PR's
+          # activation script does ln -sfn for index 0 only but never
+          # removes nix-1.env and nix-2.env from the previous deployment.
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario D: stale symlink detection ==="
+          D_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$D_HERMES/env.d"
+
+          # First deployment: 3 environmentFiles
+          ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
+          ln -sfn "$SECRET_DIR/hermes-discord" "$D_HERMES/env.d/nix-1.env"
+          ln -sfn "$SECRET_DIR/hermes-telegram" "$D_HERMES/env.d/nix-2.env"
+
+          # Second deployment: only index 0 (simulates what the PR does)
+          ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
+
+          # NOTE: This scenario documents a known bug in PR #10139.
+          # The activation script does not clean up stale nix-N.env symlinks
+          # when environmentFiles is reduced. We print a warning rather than
+          # failing the check, since this is a known upstream issue.
+          STALE=0
+          if [ -e "$D_HERMES/env.d/nix-1.env" ] || [ -L "$D_HERMES/env.d/nix-1.env" ]; then
+            echo "WARNING: D: stale nix-1.env left behind after reducing environmentFiles"
+            STALE=1
+          fi
+          if [ -e "$D_HERMES/env.d/nix-2.env" ] || [ -L "$D_HERMES/env.d/nix-2.env" ]; then
+            echo "WARNING: D: stale nix-2.env left behind after reducing environmentFiles"
+            STALE=1
+          fi
+          if [ "$STALE" -eq 1 ]; then
+            echo "KNOWN BUG: Scenario D (stale symlinks not cleaned up)"
+          else
+            echo "PASS: Scenario D"
+          fi
+
+          # ═══════════════════════════════════════════════════════════════
+          # Report
+          # ═══════════════════════════════════════════════════════════════
+          if [ -n "$ERRORS" ]; then
+            echo ""
+            echo "FAILURES:"
+            echo -e "$ERRORS"
+            exit 1
+          fi
+
+          echo ""
+          echo "=== All env.d activation scenarios passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
       };
     };
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -589,8 +589,9 @@ ENVEOF
             || fail "A: MODEL not in nix-environment.env"
           grep -q "OPENAI_BASE_URL=https://example.com/v1" "$A_HERMES/env.d/nix-environment.env" \
             || fail "A: OPENAI_BASE_URL not in nix-environment.env"
-          ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]" \
-            && fail "A: unexpected nix-N symlinks when no environmentFiles" || true
+          if ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]"; then
+            fail "A: unexpected nix-N symlinks when no environmentFiles"
+          fi
           echo "PASS: Scenario A"
 
           # ═══════════════════════════════════════════════════════════════
@@ -634,12 +635,12 @@ ENVEOF
           echo "PASS: Scenario C"
 
           # ═══════════════════════════════════════════════════════════════
-          # Scenario D: stale symlink detection
-          # Simulates reducing environmentFiles from 3 to 1. The PR's
-          # activation script does ln -sfn for index 0 only but never
-          # removes nix-1.env and nix-2.env from the previous deployment.
+          # Scenario D: stale symlink cleanup
+          # Simulates reducing environmentFiles from 3 to 1. The
+          # find -delete cleanup (added to nixosModules.nix) should
+          # remove old nix-N.env entries before creating new ones.
           # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario D: stale symlink detection ==="
+          echo "=== Scenario D: stale symlink cleanup ==="
           D_HERMES=$(mktemp -d)/.hermes
           mkdir -p "$D_HERMES/env.d"
 
@@ -648,27 +649,19 @@ ENVEOF
           ln -sfn "$SECRET_DIR/hermes-discord" "$D_HERMES/env.d/nix-1.env"
           ln -sfn "$SECRET_DIR/hermes-telegram" "$D_HERMES/env.d/nix-2.env"
 
-          # Second deployment: only index 0 (simulates what the PR does)
+          # Second deployment: cleanup then recreate only index 0
+          find "$D_HERMES/env.d" -maxdepth 1 -name 'nix-[0-9]*.env' -delete
           ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
 
-          # NOTE: This scenario documents a known bug in PR #10139.
-          # The activation script does not clean up stale nix-N.env symlinks
-          # when environmentFiles is reduced. We print a warning rather than
-          # failing the check, since this is a known upstream issue.
-          STALE=0
           if [ -e "$D_HERMES/env.d/nix-1.env" ] || [ -L "$D_HERMES/env.d/nix-1.env" ]; then
-            echo "WARNING: D: stale nix-1.env left behind after reducing environmentFiles"
-            STALE=1
+            fail "D: stale nix-1.env left behind after cleanup"
           fi
           if [ -e "$D_HERMES/env.d/nix-2.env" ] || [ -L "$D_HERMES/env.d/nix-2.env" ]; then
-            echo "WARNING: D: stale nix-2.env left behind after reducing environmentFiles"
-            STALE=1
+            fail "D: stale nix-2.env left behind after cleanup"
           fi
-          if [ "$STALE" -eq 1 ]; then
-            echo "KNOWN BUG: Scenario D (stale symlinks not cleaned up)"
-          else
-            echo "PASS: Scenario D"
-          fi
+          test -L "$D_HERMES/env.d/nix-0.env" \
+            || fail "D: nix-0.env missing after cleanup + recreate"
+          echo "PASS: Scenario D"
 
           # ═══════════════════════════════════════════════════════════════
           # Report

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -378,8 +378,9 @@ ENVEOF
             || fail "A: MODEL not in nix-environment.env"
           grep -q "OPENAI_BASE_URL=https://example.com/v1" "$A_HERMES/env.d/nix-environment.env" \
             || fail "A: OPENAI_BASE_URL not in nix-environment.env"
-          ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]" \
-            && fail "A: unexpected nix-N symlinks when no environmentFiles" || true
+          if ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]"; then
+            fail "A: unexpected nix-N symlinks when no environmentFiles"
+          fi
           echo "PASS: Scenario A"
 
           # ═══════════════════════════════════════════════════════════════
@@ -423,12 +424,12 @@ ENVEOF
           echo "PASS: Scenario C"
 
           # ═══════════════════════════════════════════════════════════════
-          # Scenario D: stale symlink detection
-          # Simulates reducing environmentFiles from 3 to 1. The PR's
-          # activation script does ln -sfn for index 0 only but never
-          # removes nix-1.env and nix-2.env from the previous deployment.
+          # Scenario D: stale symlink cleanup
+          # Simulates reducing environmentFiles from 3 to 1. The
+          # find -delete cleanup (added to nixosModules.nix) should
+          # remove old nix-N.env entries before creating new ones.
           # ═══════════════════════════════════════════════════════════════
-          echo "=== Scenario D: stale symlink detection ==="
+          echo "=== Scenario D: stale symlink cleanup ==="
           D_HERMES=$(mktemp -d)/.hermes
           mkdir -p "$D_HERMES/env.d"
 
@@ -437,27 +438,19 @@ ENVEOF
           ln -sfn "$SECRET_DIR/hermes-discord" "$D_HERMES/env.d/nix-1.env"
           ln -sfn "$SECRET_DIR/hermes-telegram" "$D_HERMES/env.d/nix-2.env"
 
-          # Second deployment: only index 0 (simulates what the PR does)
+          # Second deployment: cleanup then recreate only index 0
+          find "$D_HERMES/env.d" -maxdepth 1 -name 'nix-[0-9]*.env' -delete
           ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
 
-          # NOTE: This scenario documents a known bug in PR #10139.
-          # The activation script does not clean up stale nix-N.env symlinks
-          # when environmentFiles is reduced. We print a warning rather than
-          # failing the check, since this is a known upstream issue.
-          STALE=0
           if [ -e "$D_HERMES/env.d/nix-1.env" ] || [ -L "$D_HERMES/env.d/nix-1.env" ]; then
-            echo "WARNING: D: stale nix-1.env left behind after reducing environmentFiles"
-            STALE=1
+            fail "D: stale nix-1.env left behind after cleanup"
           fi
           if [ -e "$D_HERMES/env.d/nix-2.env" ] || [ -L "$D_HERMES/env.d/nix-2.env" ]; then
-            echo "WARNING: D: stale nix-2.env left behind after reducing environmentFiles"
-            STALE=1
+            fail "D: stale nix-2.env left behind after cleanup"
           fi
-          if [ "$STALE" -eq 1 ]; then
-            echo "KNOWN BUG: Scenario D (stale symlinks not cleaned up)"
-          else
-            echo "PASS: Scenario D"
-          fi
+          test -L "$D_HERMES/env.d/nix-0.env" \
+            || fail "D: nix-0.env missing after cleanup + recreate"
+          echo "PASS: Scenario D"
 
           # ═══════════════════════════════════════════════════════════════
           # Report

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -338,6 +338,142 @@ json.dump(load_config(), sys.stdout, default=str)
           mkdir -p $out
           echo "ok" > $out/result
         '';
+
+        # ── NixOS VM integration test for env.d/ ──────────────────────────
+        env-d-vm = import ./tests/env-d-vm.nix {
+          inherit pkgs;
+          nixosModule = inputs.self.nixosModules.default;
+        };
+
+        # ── env.d/ activation script behavior ─────────────────────────────
+        # Tests the shell logic from the activation script: writing
+        # nix-environment.env, symlinking environmentFiles, and detecting
+        # stale symlink cleanup issues.
+        env-d-activation = pkgs.runCommand "hermes-env-d-activation" { } ''
+          set -e
+          ERRORS=""
+          fail() { ERRORS="$ERRORS\nFAIL: $1"; }
+
+          SECRET_DIR=$(mktemp -d)
+          echo "API_KEY=sk-secret-123" > "$SECRET_DIR/hermes-api"
+          echo "DISCORD_TOKEN=tok-abc" > "$SECRET_DIR/hermes-discord"
+          echo "TELEGRAM_TOKEN=tok-xyz" > "$SECRET_DIR/hermes-telegram"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario A: environment only — no environmentFiles
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario A: environment only ==="
+          A_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$A_HERMES/env.d"
+
+          cat > "$A_HERMES/env.d/nix-environment.env" <<'ENVEOF'
+MODEL=test-model
+OPENAI_BASE_URL=https://example.com/v1
+ENVEOF
+          chmod 0640 "$A_HERMES/env.d/nix-environment.env"
+
+          test -f "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: nix-environment.env not created"
+          grep -q "MODEL=test-model" "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: MODEL not in nix-environment.env"
+          grep -q "OPENAI_BASE_URL=https://example.com/v1" "$A_HERMES/env.d/nix-environment.env" \
+            || fail "A: OPENAI_BASE_URL not in nix-environment.env"
+          ls "$A_HERMES/env.d/" | grep -q "nix-[0-9]" \
+            && fail "A: unexpected nix-N symlinks when no environmentFiles" || true
+          echo "PASS: Scenario A"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario B: environmentFiles — symlinks created & readable
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario B: environmentFiles ==="
+          B_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$B_HERMES/env.d"
+
+          ln -sfn "$SECRET_DIR/hermes-api" "$B_HERMES/env.d/nix-0.env"
+          ln -sfn "$SECRET_DIR/hermes-discord" "$B_HERMES/env.d/nix-1.env"
+
+          test -L "$B_HERMES/env.d/nix-0.env" \
+            || fail "B: nix-0.env is not a symlink"
+          test -L "$B_HERMES/env.d/nix-1.env" \
+            || fail "B: nix-1.env is not a symlink"
+          test "$(readlink "$B_HERMES/env.d/nix-0.env")" = "$SECRET_DIR/hermes-api" \
+            || fail "B: nix-0.env points to wrong target"
+          grep -q "API_KEY=sk-secret-123" "$B_HERMES/env.d/nix-0.env" \
+            || fail "B: cannot read API_KEY through symlink"
+          grep -q "DISCORD_TOKEN=tok-abc" "$B_HERMES/env.d/nix-1.env" \
+            || fail "B: cannot read DISCORD_TOKEN through symlink"
+          echo "PASS: Scenario B"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario C: ln -sfn replaces existing symlink atomically
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario C: symlink replacement ==="
+          C_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$C_HERMES/env.d"
+
+          echo "OLD_KEY=old" > "$SECRET_DIR/old-secret"
+          ln -sfn "$SECRET_DIR/old-secret" "$C_HERMES/env.d/nix-0.env"
+          echo "NEW_KEY=new" > "$SECRET_DIR/new-secret"
+          ln -sfn "$SECRET_DIR/new-secret" "$C_HERMES/env.d/nix-0.env"
+
+          test "$(readlink "$C_HERMES/env.d/nix-0.env")" = "$SECRET_DIR/new-secret" \
+            || fail "C: symlink not updated to new target"
+          grep -q "NEW_KEY=new" "$C_HERMES/env.d/nix-0.env" \
+            || fail "C: new content not readable through updated symlink"
+          echo "PASS: Scenario C"
+
+          # ═══════════════════════════════════════════════════════════════
+          # Scenario D: stale symlink detection
+          # Simulates reducing environmentFiles from 3 to 1. The PR's
+          # activation script does ln -sfn for index 0 only but never
+          # removes nix-1.env and nix-2.env from the previous deployment.
+          # ═══════════════════════════════════════════════════════════════
+          echo "=== Scenario D: stale symlink detection ==="
+          D_HERMES=$(mktemp -d)/.hermes
+          mkdir -p "$D_HERMES/env.d"
+
+          # First deployment: 3 environmentFiles
+          ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
+          ln -sfn "$SECRET_DIR/hermes-discord" "$D_HERMES/env.d/nix-1.env"
+          ln -sfn "$SECRET_DIR/hermes-telegram" "$D_HERMES/env.d/nix-2.env"
+
+          # Second deployment: only index 0 (simulates what the PR does)
+          ln -sfn "$SECRET_DIR/hermes-api" "$D_HERMES/env.d/nix-0.env"
+
+          # NOTE: This scenario documents a known bug in PR #10139.
+          # The activation script does not clean up stale nix-N.env symlinks
+          # when environmentFiles is reduced. We print a warning rather than
+          # failing the check, since this is a known upstream issue.
+          STALE=0
+          if [ -e "$D_HERMES/env.d/nix-1.env" ] || [ -L "$D_HERMES/env.d/nix-1.env" ]; then
+            echo "WARNING: D: stale nix-1.env left behind after reducing environmentFiles"
+            STALE=1
+          fi
+          if [ -e "$D_HERMES/env.d/nix-2.env" ] || [ -L "$D_HERMES/env.d/nix-2.env" ]; then
+            echo "WARNING: D: stale nix-2.env left behind after reducing environmentFiles"
+            STALE=1
+          fi
+          if [ "$STALE" -eq 1 ]; then
+            echo "KNOWN BUG: Scenario D (stale symlinks not cleaned up)"
+          else
+            echo "PASS: Scenario D"
+          fi
+
+          # ═══════════════════════════════════════════════════════════════
+          # Report
+          # ═══════════════════════════════════════════════════════════════
+          if [ -n "$ERRORS" ]; then
+            echo ""
+            echo "FAILURES:"
+            echo -e "$ERRORS"
+            exit 1
+          fi
+
+          echo ""
+          echo "=== All env.d activation scenarios passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
       };
     };
 }

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -7,7 +7,7 @@
 # Container mode: hermes runs from /nix/store bind-mounted read-only into a
 # plain Ubuntu container. The writable layer (apt/pip/npm installs) persists
 # across restarts and agent updates. Only image/volume/options changes trigger
-# container recreation. Environment variables are written to $HERMES_HOME/.env
+# container recreation. Environment variables are written to $HERMES_HOME/env.d/
 # and read by hermes at startup — no container recreation needed for env changes.
 #
 # Tool resolution: the hermes wrapper uses --suffix PATH for nix store tools,
@@ -55,7 +55,7 @@
     # (.env) stay 0640 regardless — see below.
     configYamlMode = if cfg.addToSystemPackages then "0660" else "0640";
 
-    # Generate .env from non-secret environment attrset
+    # Generate env file content from non-secret environment attrset
     envFileContent = lib.concatStringsSep "\n" (
       lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment
     );
@@ -190,7 +190,7 @@
 
     # Identity hash — only recreate container when structural config changes.
     # Package and entrypoint use stable symlinks (current-package, current-entrypoint)
-    # so they can update without recreation. Env vars go through $HERMES_HOME/.env.
+    # so they can update without recreation. Env vars go through $HERMES_HOME/env.d/.
     containerIdentity = builtins.hashString "sha256" (builtins.toJSON {
       schema = 4; # bump when identity inputs change (4: Node 18→22 via NodeSource)
       image = cfg.container.image;
@@ -284,8 +284,14 @@
         default = [ ];
         description = ''
           Paths to environment files containing secrets (API keys, tokens).
-          Contents are merged into $HERMES_HOME/.env at activation time.
-          Hermes reads this file on every startup via load_hermes_dotenv().
+          Files are symlinked into $HERMES_HOME/env.d/ at activation time
+          and loaded by load_hermes_dotenv() with override=True.
+          Use this for sops-nix / agenix managed secrets — no copying.
+
+          Ensure the secret files are readable by the service user/group,
+          e.g. for sops-nix: `owner = config.services.hermes-agent.user;`
+          or for agenix: `owner = config.services.hermes-agent.user;
+          group = config.services.hermes-agent.group;`.
         '';
       };
 
@@ -293,7 +299,7 @@
         type = types.attrsOf types.str;
         default = { };
         description = ''
-          Non-secret environment variables. Merged into $HERMES_HOME/.env
+          Non-secret environment variables. Written to $HERMES_HOME/env.d/nix-environment.env
           at activation time. Do NOT put secrets here — use environmentFiles.
         '';
       };
@@ -712,6 +718,7 @@
         systemd.tmpfiles.rules = [
           "d ${cfg.stateDir}                2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes        2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/env.d  2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/cron   2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
@@ -734,8 +741,8 @@
           chmod 0750 ${cfg.stateDir}/home
 
           # Create subdirs, set setgid + group-writable, migrate existing files.
-          # Nix-managed .env/.managed stay 0640/0644; config.yaml uses
-          # configYamlMode (0660 under addToSystemPackages, else 0640).
+          # Nix-managed files (config.yaml, env.d/, .managed) stay 0640/0644; 
+          # config.yaml uses configYamlMode (0660 under addToSystemPackages, else 0640).
           find ${cfg.stateDir}/.hermes -maxdepth 1 \
             \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
             -exec chmod g+rw {} + 2>/dev/null || true
@@ -770,12 +777,12 @@
           # is disabled so the host CLI falls back to native execution.
           ${if cfg.container.enable then ''
             cat > ${cfg.stateDir}/.hermes/.container-mode <<'HERMES_CONTAINER_MODE_EOF'
-    # Written by NixOS activation script. Do not edit manually.
-    backend=${cfg.container.backend}
-    container_name=${containerName}
-    exec_user=${cfg.user}
-    hermes_bin=${containerDataDir}/current-package/bin/hermes
-    HERMES_CONTAINER_MODE_EOF
+            # Written by NixOS activation script. Do not edit manually.
+            backend=${cfg.container.backend}
+            container_name=${containerName}
+            exec_user=${cfg.user}
+            hermes_bin=${containerDataDir}/current-package/bin/hermes
+            HERMES_CONTAINER_MODE_EOF
             chown ${cfg.user}:${cfg.group} ${cfg.stateDir}/.hermes/.container-mode
             chmod 0644 ${cfg.stateDir}/.hermes/.container-mode
           '' else ''
@@ -829,20 +836,20 @@
             ''}
           ''}
 
-          # Seed .env from Nix-declared environment + environmentFiles.
-          # Hermes reads $HERMES_HOME/.env at startup via load_hermes_dotenv(),
-          # so this is the single source of truth for both native and container mode.
+          # Nix-managed env files → env.d/ (loaded by load_hermes_dotenv()).
+          # Non-secret vars are written as a generated file; secret files are
+          # symlinked to avoid copying sops-nix/agenix managed content.
           ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
-            ENV_FILE="${cfg.stateDir}/.hermes/.env"
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
-            cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
-    ${envFileContent}
-    HERMES_NIX_ENV_EOF
-            ${lib.concatStringsSep "\n" (map (f: ''
-              if [ -f "${f}" ]; then
-                echo "" >> "$ENV_FILE"
-                cat "${f}" >> "$ENV_FILE"
-              fi
+            mkdir -p "${cfg.stateDir}/.hermes/env.d"
+            ${lib.optionalString (cfg.environment != {}) ''
+              cat > "${cfg.stateDir}/.hermes/env.d/nix-environment.env" <<'HERMES_NIX_ENV_EOF'
+${envFileContent}
+HERMES_NIX_ENV_EOF
+              chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
+              chmod 0640 "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
+            ''}
+            ${lib.concatStringsSep "\n" (lib.imap0 (i: f: ''
+              ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
             '') cfg.environmentFiles)}
           ''}
 
@@ -892,7 +899,7 @@
             WorkingDirectory = cfg.workingDirectory;
 
             # cfg.environment and cfg.environmentFiles are written to
-            # $HERMES_HOME/.env by the activation script. load_hermes_dotenv()
+            # $HERMES_HOME/env.d/ by the activation script. load_hermes_dotenv()
             # reads them at Python startup — no systemd EnvironmentFile needed.
 
             ExecStart = lib.concatStringsSep " " ([

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -284,9 +284,12 @@
         default = [ ];
         description = ''
           Paths to environment files containing secrets (API keys, tokens).
-          Files are symlinked into $HERMES_HOME/env.d/ at activation time
-          and loaded by load_hermes_dotenv() with override=True.
-          Use this for sops-nix / agenix managed secrets — no copying.
+          Placed into $HERMES_HOME/env.d/ at activation time and loaded
+          by load_hermes_dotenv() with override=True.
+          Native mode: symlinked (preserves secret manager lifecycle).
+          Container mode: copied (NOTE: this means secrets are written to disk
+          in this mode. You are responsible for cleaning them up when they are
+          no longer needed).
 
           Ensure the secret files are readable by the service user/group,
           e.g. for sops-nix: `owner = config.services.hermes-agent.user;`
@@ -838,9 +841,18 @@
 
           # Nix-managed env files → env.d/ (loaded by load_hermes_dotenv()).
           # Non-secret vars are written as a generated file; secret files are
-          # symlinked to avoid copying sops-nix/agenix managed content.
+          # symlinked (native mode) or copied (container mode) into env.d/.
+          # Container mode copies because symlink targets (e.g. /run/secrets/)
+          # are not accessible inside the container.
           ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
             mkdir -p "${cfg.stateDir}/.hermes/env.d"
+
+            # Clean up stale nix-managed env files from previous activations.
+            # Without this, reducing environmentFiles count leaves old entries behind.
+            find "${cfg.stateDir}/.hermes/env.d" -maxdepth 1 \
+              \( -name 'nix-[0-9]*.env' -o -name 'nix-environment.env' \) \
+              -delete 2>/dev/null || true
+
             ${lib.optionalString (cfg.environment != {}) ''
               cat > "${cfg.stateDir}/.hermes/env.d/nix-environment.env" <<'HERMES_NIX_ENV_EOF'
 ${envFileContent}
@@ -849,7 +861,16 @@ HERMES_NIX_ENV_EOF
               chmod 0640 "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
             ''}
             ${lib.concatStringsSep "\n" (lib.imap0 (i: f: ''
-              ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+              ${if cfg.container.enable then ''
+                # Container mode: copy content so it's readable inside the container
+                # (symlink targets like /run/secrets/ aren't mounted in the container)
+                if [ -f "${f}" ]; then
+                  install -o ${cfg.user} -g ${cfg.group} -m 0640 "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+                fi
+              '' else ''
+                # Native mode: symlink to preserve sops-nix/agenix secret lifecycle
+                ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+              ''}
             '') cfg.environmentFiles)}
           ''}
 

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -7,7 +7,7 @@
 # Container mode: hermes runs from /nix/store bind-mounted read-only into a
 # plain Ubuntu container. The writable layer (apt/pip/npm installs) persists
 # across restarts and agent updates. Only image/volume/options changes trigger
-# container recreation. Environment variables are written to $HERMES_HOME/.env
+# container recreation. Environment variables are written to $HERMES_HOME/env.d/
 # and read by hermes at startup — no container recreation needed for env changes.
 #
 # Tool resolution: the hermes wrapper uses --suffix PATH for nix store tools,
@@ -45,7 +45,7 @@
 
     configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
 
-    # Generate .env from non-secret environment attrset
+    # Generate env file content from non-secret environment attrset
     envFileContent = lib.concatStringsSep "\n" (
       lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment
     );
@@ -169,7 +169,7 @@
 
     # Identity hash — only recreate container when structural config changes.
     # Package and entrypoint use stable symlinks (current-package, current-entrypoint)
-    # so they can update without recreation. Env vars go through $HERMES_HOME/.env.
+    # so they can update without recreation. Env vars go through $HERMES_HOME/env.d/.
     containerIdentity = builtins.hashString "sha256" (builtins.toJSON {
       schema = 3; # bump when identity inputs change
       image = cfg.container.image;
@@ -263,8 +263,14 @@
         default = [ ];
         description = ''
           Paths to environment files containing secrets (API keys, tokens).
-          Contents are merged into $HERMES_HOME/.env at activation time.
-          Hermes reads this file on every startup via load_hermes_dotenv().
+          Files are symlinked into $HERMES_HOME/env.d/ at activation time
+          and loaded by load_hermes_dotenv() with override=True.
+          Use this for sops-nix / agenix managed secrets — no copying.
+
+          Ensure the secret files are readable by the service user/group,
+          e.g. for sops-nix: `owner = config.services.hermes-agent.user;`
+          or for agenix: `owner = config.services.hermes-agent.user;
+          group = config.services.hermes-agent.group;`.
         '';
       };
 
@@ -272,7 +278,7 @@
         type = types.attrsOf types.str;
         default = { };
         description = ''
-          Non-secret environment variables. Merged into $HERMES_HOME/.env
+          Non-secret environment variables. Written to $HERMES_HOME/env.d/nix-environment.env
           at activation time. Do NOT put secrets here — use environmentFiles.
         '';
       };
@@ -591,6 +597,7 @@
         systemd.tmpfiles.rules = [
           "d ${cfg.stateDir}                2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes        2770 ${cfg.user} ${cfg.group} - -"
+          "d ${cfg.stateDir}/.hermes/env.d  2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/cron   2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/sessions 2770 ${cfg.user} ${cfg.group} - -"
           "d ${cfg.stateDir}/.hermes/logs   2770 ${cfg.user} ${cfg.group} - -"
@@ -612,7 +619,7 @@
           chmod 0750 ${cfg.stateDir}/home
 
           # Create subdirs, set setgid + group-writable, migrate existing files.
-          # Nix-managed files (config.yaml, .env, .managed) stay 0640/0644.
+          # Nix-managed files (config.yaml, env.d/, .managed) stay 0640/0644.
           find ${cfg.stateDir}/.hermes -maxdepth 1 \
             \( -name "*.db" -o -name "*.db-wal" -o -name "*.db-shm" -o -name "SOUL.md" \) \
             -exec chmod g+rw {} + 2>/dev/null || true
@@ -704,20 +711,20 @@ HERMES_CONTAINER_MODE_EOF
             ''}
           ''}
 
-          # Seed .env from Nix-declared environment + environmentFiles.
-          # Hermes reads $HERMES_HOME/.env at startup via load_hermes_dotenv(),
-          # so this is the single source of truth for both native and container mode.
+          # Nix-managed env files → env.d/ (loaded by load_hermes_dotenv()).
+          # Non-secret vars are written as a generated file; secret files are
+          # symlinked to avoid copying sops-nix/agenix managed content.
           ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
-            ENV_FILE="${cfg.stateDir}/.hermes/.env"
-            install -o ${cfg.user} -g ${cfg.group} -m 0640 /dev/null "$ENV_FILE"
-            cat > "$ENV_FILE" <<'HERMES_NIX_ENV_EOF'
+            mkdir -p "${cfg.stateDir}/.hermes/env.d"
+            ${lib.optionalString (cfg.environment != {}) ''
+              cat > "${cfg.stateDir}/.hermes/env.d/nix-environment.env" <<'HERMES_NIX_ENV_EOF'
 ${envFileContent}
 HERMES_NIX_ENV_EOF
-            ${lib.concatStringsSep "\n" (map (f: ''
-              if [ -f "${f}" ]; then
-                echo "" >> "$ENV_FILE"
-                cat "${f}" >> "$ENV_FILE"
-              fi
+              chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
+              chmod 0640 "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
+            ''}
+            ${lib.concatStringsSep "\n" (lib.imap0 (i: f: ''
+              ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
             '') cfg.environmentFiles)}
           ''}
 
@@ -751,7 +758,7 @@ HERMES_NIX_ENV_EOF
             WorkingDirectory = cfg.workingDirectory;
 
             # cfg.environment and cfg.environmentFiles are written to
-            # $HERMES_HOME/.env by the activation script. load_hermes_dotenv()
+            # $HERMES_HOME/env.d/ by the activation script. load_hermes_dotenv()
             # reads them at Python startup — no systemd EnvironmentFile needed.
 
             ExecStart = lib.concatStringsSep " " ([

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -263,9 +263,12 @@
         default = [ ];
         description = ''
           Paths to environment files containing secrets (API keys, tokens).
-          Files are symlinked into $HERMES_HOME/env.d/ at activation time
-          and loaded by load_hermes_dotenv() with override=True.
-          Use this for sops-nix / agenix managed secrets — no copying.
+          Placed into $HERMES_HOME/env.d/ at activation time and loaded
+          by load_hermes_dotenv() with override=True.
+          Native mode: symlinked (preserves secret manager lifecycle).
+          Container mode: copied (NOTE: this means secrets are written to disk
+          in this mode. You are responsible for cleaning them up when they are
+          no longer needed).
 
           Ensure the secret files are readable by the service user/group,
           e.g. for sops-nix: `owner = config.services.hermes-agent.user;`
@@ -713,9 +716,18 @@ HERMES_CONTAINER_MODE_EOF
 
           # Nix-managed env files → env.d/ (loaded by load_hermes_dotenv()).
           # Non-secret vars are written as a generated file; secret files are
-          # symlinked to avoid copying sops-nix/agenix managed content.
+          # symlinked (native mode) or copied (container mode) into env.d/.
+          # Container mode copies because symlink targets (e.g. /run/secrets/)
+          # are not accessible inside the container.
           ${lib.optionalString (cfg.environment != {} || cfg.environmentFiles != []) ''
             mkdir -p "${cfg.stateDir}/.hermes/env.d"
+
+            # Clean up stale nix-managed env files from previous activations.
+            # Without this, reducing environmentFiles count leaves old entries behind.
+            find "${cfg.stateDir}/.hermes/env.d" -maxdepth 1 \
+              \( -name 'nix-[0-9]*.env' -o -name 'nix-environment.env' \) \
+              -delete 2>/dev/null || true
+
             ${lib.optionalString (cfg.environment != {}) ''
               cat > "${cfg.stateDir}/.hermes/env.d/nix-environment.env" <<'HERMES_NIX_ENV_EOF'
 ${envFileContent}
@@ -724,7 +736,16 @@ HERMES_NIX_ENV_EOF
               chmod 0640 "${cfg.stateDir}/.hermes/env.d/nix-environment.env"
             ''}
             ${lib.concatStringsSep "\n" (lib.imap0 (i: f: ''
-              ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+              ${if cfg.container.enable then ''
+                # Container mode: copy content so it's readable inside the container
+                # (symlink targets like /run/secrets/ aren't mounted in the container)
+                if [ -f "${f}" ]; then
+                  install -o ${cfg.user} -g ${cfg.group} -m 0640 "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+                fi
+              '' else ''
+                # Native mode: symlink to preserve sops-nix/agenix secret lifecycle
+                ln -sfn "${f}" "${cfg.stateDir}/.hermes/env.d/nix-${toString i}.env"
+              ''}
             '') cfg.environmentFiles)}
           ''}
 

--- a/nix/tests/env-d-vm.nix
+++ b/nix/tests/env-d-vm.nix
@@ -1,0 +1,80 @@
+# NixOS VM test: verify env.d/ activation behavior end-to-end.
+{ pkgs, nixosModule }:
+
+pkgs.testers.nixosTest {
+  name = "hermes-env-d";
+
+  nodes.machine = { config, pkgs, lib, ... }: {
+    imports = [ nixosModule ];
+
+    # Simulate sops-nix-like secrets: plain files with correct ownership.
+    system.activationScripts."test-secrets" = lib.stringAfter [ "users" ] ''
+      mkdir -p /run/test-secrets
+      echo "API_KEY=sk-test-12345" > /run/test-secrets/hermes-api
+      echo "DISCORD_TOKEN=tok-discord-abc" > /run/test-secrets/hermes-discord
+      chown hermes:hermes /run/test-secrets/hermes-api /run/test-secrets/hermes-discord
+      chmod 0400 /run/test-secrets/hermes-api /run/test-secrets/hermes-discord
+    '';
+
+    services.hermes-agent = {
+      enable = true;
+      environment = {
+        MODEL = "test/nix-model";
+        OPENAI_BASE_URL = "https://test.example.com/v1";
+      };
+      environmentFiles = [
+        "/run/test-secrets/hermes-api"
+        "/run/test-secrets/hermes-discord"
+      ];
+      settings.model = "test/nix-model";
+    };
+
+    # Don't start the service — no real API keys.
+    systemd.services.hermes-agent.wantedBy = lib.mkForce [ ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("env.d directory exists with correct permissions"):
+        machine.succeed("test -d /var/lib/hermes/.hermes/env.d")
+        result = machine.succeed("stat -c '%U:%G' /var/lib/hermes/.hermes/env.d").strip()
+        assert result == "hermes:hermes", f"ownership: {result}"
+        perms = machine.succeed("stat -c '%a' /var/lib/hermes/.hermes/env.d").strip()
+        assert perms == "2770", f"permissions: {perms}"
+
+    with subtest("nix-environment.env written correctly"):
+        machine.succeed("test -f /var/lib/hermes/.hermes/env.d/nix-environment.env")
+        content = machine.succeed("cat /var/lib/hermes/.hermes/env.d/nix-environment.env")
+        assert "MODEL=test/nix-model" in content, f"MODEL not found in: {content}"
+        assert "OPENAI_BASE_URL=https://test.example.com/v1" in content
+        perms = machine.succeed("stat -c '%a' /var/lib/hermes/.hermes/env.d/nix-environment.env").strip()
+        assert perms == "640", f"permissions: {perms}"
+
+    with subtest("environmentFiles are symlinked not copied"):
+        machine.succeed("test -L /var/lib/hermes/.hermes/env.d/nix-0.env")
+        target = machine.succeed("readlink /var/lib/hermes/.hermes/env.d/nix-0.env").strip()
+        assert target == "/run/test-secrets/hermes-api", f"nix-0 -> {target}"
+        machine.succeed("test -L /var/lib/hermes/.hermes/env.d/nix-1.env")
+        target = machine.succeed("readlink /var/lib/hermes/.hermes/env.d/nix-1.env").strip()
+        assert target == "/run/test-secrets/hermes-discord", f"nix-1 -> {target}"
+
+    with subtest("hermes user can read through symlinks"):
+        content = machine.succeed("sudo -u hermes cat /var/lib/hermes/.hermes/env.d/nix-0.env")
+        assert "API_KEY=sk-test-12345" in content
+        content = machine.succeed("sudo -u hermes cat /var/lib/hermes/.hermes/env.d/nix-1.env")
+        assert "DISCORD_TOKEN=tok-discord-abc" in content
+
+    with subtest("old .env not written by activation"):
+        machine.fail("test -f /var/lib/hermes/.hermes/.env")
+
+    with subtest("no extra nix-N.env symlinks"):
+        machine.fail("test -e /var/lib/hermes/.hermes/env.d/nix-2.env")
+
+    with subtest("env.d files are glob-discoverable"):
+        result = machine.succeed(
+            "sudo -u hermes ls /var/lib/hermes/.hermes/env.d/*.env | wc -l"
+        ).strip()
+        assert result == "3", f"expected 3 env files, got {result}"
+  '';
+}

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -170,7 +170,6 @@ def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
 
 
 def test_env_d_broken_symlink_skipped(tmp_path):
-    """Broken symlinks in env.d/ (stale nix-N.env) are silently skipped."""
     home = tmp_path / "hermes"
     home.mkdir()
     env_d = home / "env.d"
@@ -189,7 +188,6 @@ def test_env_d_broken_symlink_skipped(tmp_path):
 
 
 def test_env_d_valid_symlink_loaded(tmp_path):
-    """Valid symlinks in env.d/ (sops-nix/agenix secrets) are loaded."""
     home = tmp_path / "hermes"
     home.mkdir()
     env_d = home / "env.d"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -167,3 +167,42 @@ def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
 
     assert os.getenv("API_KEY") == "from-secrets"
     assert os.getenv("OTHER") == "project-val"
+
+
+def test_env_d_broken_symlink_skipped(tmp_path):
+    """Broken symlinks in env.d/ (stale nix-N.env) are silently skipped."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+
+    # Valid file
+    (env_d / "a-good.env").write_text("GOOD=yes\n", encoding="utf-8")
+
+    # Broken symlink (target doesn't exist — simulates stale nix-2.env)
+    (env_d / "b-broken.env").symlink_to("/nonexistent/secret/path")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_d / "a-good.env"]
+    assert os.getenv("GOOD") == "yes"
+
+
+def test_env_d_valid_symlink_loaded(tmp_path):
+    """Valid symlinks in env.d/ (sops-nix/agenix secrets) are loaded."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+
+    # Real secret file (simulates /run/secrets/hermes-env)
+    secret = tmp_path / "secret.env"
+    secret.write_text("SECRET_API_KEY=sk-live-abc\n", encoding="utf-8")
+
+    # Symlink in env.d pointing to the secret
+    (env_d / "nix-0.env").symlink_to(secret)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert (env_d / "nix-0.env") in loaded
+    assert os.getenv("SECRET_API_KEY") == "sk-live-abc"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,67 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_env_d_files_loaded_and_override(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("API_KEY=base\nMODEL=gpt-4\n", encoding="utf-8")
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "secrets.env").write_text("API_KEY=secret\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert (home / ".env") in loaded
+    assert (env_d / "secrets.env") in loaded
+    assert os.getenv("API_KEY") == "secret"
+    assert os.getenv("MODEL") == "gpt-4"
+
+
+def test_env_d_multiple_files_alphabetical_order(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "a.env").write_text("KEY=first\n", encoding="utf-8")
+    (env_d / "b.env").write_text("KEY=second\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_d / "a.env", env_d / "b.env"]
+    assert os.getenv("KEY") == "second"
+
+
+def test_env_d_missing_dir_no_error(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == []
+
+
+def test_env_d_empty_dir_no_error(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "env.d").mkdir()
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == []
+
+
+def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "secrets.env").write_text("API_KEY=from-secrets\n", encoding="utf-8")
+    project_env = tmp_path / ".env"
+    project_env.write_text("API_KEY=from-project\nOTHER=project-val\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert os.getenv("API_KEY") == "from-secrets"
+    assert os.getenv("OTHER") == "project-val"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -68,3 +68,67 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_env_d_files_loaded_and_override(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("API_KEY=base\nMODEL=gpt-4\n", encoding="utf-8")
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "secrets.env").write_text("API_KEY=secret\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert (home / ".env") in loaded
+    assert (env_d / "secrets.env") in loaded
+    assert os.getenv("API_KEY") == "secret"
+    assert os.getenv("MODEL") == "gpt-4"
+
+
+def test_env_d_multiple_files_alphabetical_order(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "a.env").write_text("KEY=first\n", encoding="utf-8")
+    (env_d / "b.env").write_text("KEY=second\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_d / "a.env", env_d / "b.env"]
+    assert os.getenv("KEY") == "second"
+
+
+def test_env_d_missing_dir_no_error(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == []
+
+
+def test_env_d_empty_dir_no_error(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "env.d").mkdir()
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == []
+
+
+def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+    (env_d / "secrets.env").write_text("API_KEY=from-secrets\n", encoding="utf-8")
+    project_env = tmp_path / ".env"
+    project_env.write_text("API_KEY=from-project\nOTHER=project-val\n", encoding="utf-8")
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert os.getenv("API_KEY") == "from-secrets"
+    assert os.getenv("OTHER") == "project-val"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -132,3 +132,42 @@ def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
 
     assert os.getenv("API_KEY") == "from-secrets"
     assert os.getenv("OTHER") == "project-val"
+
+
+def test_env_d_broken_symlink_skipped(tmp_path):
+    """Broken symlinks in env.d/ (stale nix-N.env) are silently skipped."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+
+    # Valid file
+    (env_d / "a-good.env").write_text("GOOD=yes\n", encoding="utf-8")
+
+    # Broken symlink (target doesn't exist — simulates stale nix-2.env)
+    (env_d / "b-broken.env").symlink_to("/nonexistent/secret/path")
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_d / "a-good.env"]
+    assert os.getenv("GOOD") == "yes"
+
+
+def test_env_d_valid_symlink_loaded(tmp_path):
+    """Valid symlinks in env.d/ (sops-nix/agenix secrets) are loaded."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_d = home / "env.d"
+    env_d.mkdir()
+
+    # Real secret file (simulates /run/secrets/hermes-env)
+    secret = tmp_path / "secret.env"
+    secret.write_text("SECRET_API_KEY=sk-live-abc\n", encoding="utf-8")
+
+    # Symlink in env.d pointing to the secret
+    (env_d / "nix-0.env").symlink_to(secret)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert (env_d / "nix-0.env") in loaded
+    assert os.getenv("SECRET_API_KEY") == "sk-live-abc"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -135,7 +135,6 @@ def test_env_d_user_tier_still_overrides_project(tmp_path, monkeypatch):
 
 
 def test_env_d_broken_symlink_skipped(tmp_path):
-    """Broken symlinks in env.d/ (stale nix-N.env) are silently skipped."""
     home = tmp_path / "hermes"
     home.mkdir()
     env_d = home / "env.d"
@@ -154,7 +153,6 @@ def test_env_d_broken_symlink_skipped(tmp_path):
 
 
 def test_env_d_valid_symlink_loaded(tmp_path):
-    """Valid symlinks in env.d/ (sops-nix/agenix secrets) are loaded."""
     home = tmp_path / "hermes"
     home.mkdir()
     env_d = home / "env.d"

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -357,16 +357,20 @@ Quick reference for the most common things Nix users want to customize:
 Values in Nix expressions end up in `/nix/store`, which is world-readable. Always use `environmentFiles` with a secrets manager.
 :::
 
-Both `environment` (non-secret vars) and `environmentFiles` (secret files) are merged into `$HERMES_HOME/.env` at activation time (`nixos-rebuild switch`). Hermes reads this file on every startup, so changes take effect with a `systemctl restart hermes-agent` — no container recreation needed.
+Both `environment` (non-secret vars) and `environmentFiles` (secret files) are placed in `$HERMES_HOME/env.d/` at activation time (`nixos-rebuild switch`). Non-secret vars are written to `env.d/nix-environment.env`; secret files are symlinked (no copying). Hermes reads all `*.env` files from this directory on every startup, so changes take effect with a `systemctl restart hermes-agent` — no container recreation needed.
 
 ### sops-nix
 
 ```nix
-{
+{ config, ... }: {
   sops = {
     defaultSopsFile = ./secrets/hermes.yaml;
     age.keyFile = "/home/user/.config/sops/age/keys.txt";
-    secrets."hermes-env" = { format = "yaml"; };
+    secrets."hermes-env" = {
+      format = "yaml";
+      owner = config.services.hermes-agent.user;
+      group = config.services.hermes-agent.group;
+    };
   };
 
   services.hermes-agent.environmentFiles = [
@@ -388,8 +392,12 @@ hermes-env: |
 ### agenix
 
 ```nix
-{
-  age.secrets.hermes-env.file = ./secrets/hermes-env.age;
+{ config, ... }: {
+  age.secrets.hermes-env = {
+    file = ./secrets/hermes-env.age;
+    owner = config.services.hermes-agent.user;
+    group = config.services.hermes-agent.group;
+  };
 
   services.hermes-agent.environmentFiles = [
     config.age.secrets.hermes-env.path
@@ -579,10 +587,12 @@ Host                                    Container
   ├── .gc-root -> /nix/store/...           (prevents nix-collect-garbage)
   ├── .container-identity                  (sha256 hash, triggers recreation)
   ├── .hermes/                             (HERMES_HOME)
-  │   ├── .env                             (merged from environment + environmentFiles)
   │   ├── config.yaml                      (Nix-generated, deep-merged by activation)
   │   ├── .managed                         (marker file)
   │   ├── .container-mode                  (routing metadata: backend, exec_user, etc.)
+  │   ├── env.d/                           (Nix-managed env files)
+  │   │   ├── nix-environment.env          (from environment option)
+  │   │   └── 0.env -> /nix/store/...      (symlink to sops-nix/agenix secret)
   │   ├── state.db, sessions/, memories/   (runtime state)
   │   └── mcp-tokens/                      (OAuth tokens for MCP servers)
   ├── home/                                ──►  /home/hermes    (rw)
@@ -605,7 +615,7 @@ The Nix-built binary works inside the Ubuntu container because `/nix/store` is b
 | `nix-collect-garbage` | No (GC root) | Persists | Persists | Persists |
 | Image change (`container.image`) | **Yes** | Persists | Persists | **Lost** |
 | Volume/options change | **Yes** | Persists | Persists | **Lost** |
-| `environment`/`environmentFiles` change | No | Persists | Persists | Persists |
+| `environment`/`environmentFiles` change | No | `env.d/` updated | Persists | Persists |
 
 The container is only recreated when its **identity hash** changes. The hash covers: schema version, image, `extraVolumes`, `extraOptions`, and the entrypoint script. Changes to environment variables, settings, documents, or the hermes package itself do **not** trigger recreation.
 
@@ -848,8 +858,8 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `environmentFiles` | `listOf str` | `[]` | Paths to env files with secrets. Merged into `$HERMES_HOME/.env` at activation time |
-| `environment` | `attrsOf str` | `{}` | Non-secret env vars. **Visible in Nix store** — do not put secrets here |
+| `environmentFiles` | `listOf str` | `[]` | Paths to env files with secrets. Symlinked into `$HERMES_HOME/env.d/` — no copying |
+| `environment` | `attrsOf str` | `{}` | Non-secret env vars. Written to `$HERMES_HOME/env.d/nix-environment.env`. **Visible in Nix store** — do not put secrets here |
 | `authFile` | `null` or `path` | `null` | OAuth credentials seed. Only copied on first deploy |
 | `authFileForceOverwrite` | `bool` | `false` | Always overwrite `auth.json` from `authFile` on activation |
 
@@ -910,7 +920,9 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 ├── .hermes/                         # HERMES_HOME
 │   ├── config.yaml                  # Nix-generated (deep-merged each rebuild)
 │   ├── .managed                     # Marker: CLI config mutation blocked
-│   ├── .env                         # Merged from environment + environmentFiles
+│   ├── env.d/                       # Nix-managed env files (loaded by load_hermes_dotenv)
+│   │   ├── nix-environment.env      #   from environment option
+│   │   └── nix-0.env -> ...         #   symlink to sops-nix/agenix secret
 │   ├── auth.json                    # OAuth credentials (seeded, then self-managed)
 │   ├── gateway.pid
 │   ├── state.db
@@ -993,14 +1005,14 @@ sudo systemctl start hermes-agent
 
 ### Verify Secrets Are Loaded
 
-If the agent starts but can't authenticate with the LLM provider, check that the `.env` file was merged correctly:
+If the agent starts but can't authenticate with the LLM provider, check that the `env.d/` files are present and readable:
 
 ```bash
 # Native mode
-sudo -u hermes cat /var/lib/hermes/.hermes/.env
+sudo -u hermes ls -la /var/lib/hermes/.hermes/env.d/
 
 # Container mode
-docker exec hermes-agent cat /data/.hermes/.env
+docker exec hermes-agent ls -la /data/.hermes/env.d/
 ```
 
 ### GC Root Verification

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -336,16 +336,20 @@ Quick reference for the most common things Nix users want to customize:
 Values in Nix expressions end up in `/nix/store`, which is world-readable. Always use `environmentFiles` with a secrets manager.
 :::
 
-Both `environment` (non-secret vars) and `environmentFiles` (secret files) are merged into `$HERMES_HOME/.env` at activation time (`nixos-rebuild switch`). Hermes reads this file on every startup, so changes take effect with a `systemctl restart hermes-agent` — no container recreation needed.
+Both `environment` (non-secret vars) and `environmentFiles` (secret files) are placed in `$HERMES_HOME/env.d/` at activation time (`nixos-rebuild switch`). Non-secret vars are written to `env.d/nix-environment.env`; secret files are symlinked (no copying). Hermes reads all `*.env` files from this directory on every startup, so changes take effect with a `systemctl restart hermes-agent` — no container recreation needed.
 
 ### sops-nix
 
 ```nix
-{
+{ config, ... }: {
   sops = {
     defaultSopsFile = ./secrets/hermes.yaml;
     age.keyFile = "/home/user/.config/sops/age/keys.txt";
-    secrets."hermes-env" = { format = "yaml"; };
+    secrets."hermes-env" = {
+      format = "yaml";
+      owner = config.services.hermes-agent.user;
+      group = config.services.hermes-agent.group;
+    };
   };
 
   services.hermes-agent.environmentFiles = [
@@ -367,8 +371,12 @@ hermes-env: |
 ### agenix
 
 ```nix
-{
-  age.secrets.hermes-env.file = ./secrets/hermes-env.age;
+{ config, ... }: {
+  age.secrets.hermes-env = {
+    file = ./secrets/hermes-env.age;
+    owner = config.services.hermes-agent.user;
+    group = config.services.hermes-agent.group;
+  };
 
   services.hermes-agent.environmentFiles = [
     config.age.secrets.hermes-env.path
@@ -561,10 +569,12 @@ Host                                    Container
   ├── .gc-root -> /nix/store/...           (prevents nix-collect-garbage)
   ├── .container-identity                  (sha256 hash, triggers recreation)
   ├── .hermes/                             (HERMES_HOME)
-  │   ├── .env                             (merged from environment + environmentFiles)
   │   ├── config.yaml                      (Nix-generated, deep-merged by activation)
   │   ├── .managed                         (marker file)
   │   ├── .container-mode                  (routing metadata: backend, exec_user, etc.)
+  │   ├── env.d/                           (Nix-managed env files)
+  │   │   ├── nix-environment.env          (from environment option)
+  │   │   └── 0.env -> /nix/store/...      (symlink to sops-nix/agenix secret)
   │   ├── state.db, sessions/, memories/   (runtime state)
   │   └── mcp-tokens/                      (OAuth tokens for MCP servers)
   ├── home/                                ──►  /home/hermes    (rw)
@@ -587,7 +597,7 @@ The Nix-built binary works inside the Ubuntu container because `/nix/store` is b
 | `nix-collect-garbage` | No (GC root) | Persists | Persists | Persists |
 | Image change (`container.image`) | **Yes** | Persists | Persists | **Lost** |
 | Volume/options change | **Yes** | Persists | Persists | **Lost** |
-| `environment`/`environmentFiles` change | No | Persists | Persists | Persists |
+| `environment`/`environmentFiles` change | No | `env.d/` updated | Persists | Persists |
 
 The container is only recreated when its **identity hash** changes. The hash covers: schema version, image, `extraVolumes`, `extraOptions`, and the entrypoint script. Changes to environment variables, settings, documents, or the hermes package itself do **not** trigger recreation.
 
@@ -691,8 +701,8 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `environmentFiles` | `listOf str` | `[]` | Paths to env files with secrets. Merged into `$HERMES_HOME/.env` at activation time |
-| `environment` | `attrsOf str` | `{}` | Non-secret env vars. **Visible in Nix store** — do not put secrets here |
+| `environmentFiles` | `listOf str` | `[]` | Paths to env files with secrets. Symlinked into `$HERMES_HOME/env.d/` — no copying |
+| `environment` | `attrsOf str` | `{}` | Non-secret env vars. Written to `$HERMES_HOME/env.d/nix-environment.env`. **Visible in Nix store** — do not put secrets here |
 | `authFile` | `null` or `path` | `null` | OAuth credentials seed. Only copied on first deploy |
 | `authFileForceOverwrite` | `bool` | `false` | Always overwrite `auth.json` from `authFile` on activation |
 
@@ -750,7 +760,9 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 ├── .hermes/                         # HERMES_HOME
 │   ├── config.yaml                  # Nix-generated (deep-merged each rebuild)
 │   ├── .managed                     # Marker: CLI config mutation blocked
-│   ├── .env                         # Merged from environment + environmentFiles
+│   ├── env.d/                       # Nix-managed env files (loaded by load_hermes_dotenv)
+│   │   ├── nix-environment.env      #   from environment option
+│   │   └── nix-0.env -> ...         #   symlink to sops-nix/agenix secret
 │   ├── auth.json                    # OAuth credentials (seeded, then self-managed)
 │   ├── gateway.pid
 │   ├── state.db
@@ -833,14 +845,14 @@ sudo systemctl start hermes-agent
 
 ### Verify Secrets Are Loaded
 
-If the agent starts but can't authenticate with the LLM provider, check that the `.env` file was merged correctly:
+If the agent starts but can't authenticate with the LLM provider, check that the `env.d/` files are present and readable:
 
 ```bash
 # Native mode
-sudo -u hermes cat /var/lib/hermes/.hermes/.env
+sudo -u hermes ls -la /var/lib/hermes/.hermes/env.d/
 
 # Container mode
-docker exec hermes-agent cat /data/.hermes/.env
+docker exec hermes-agent ls -la /data/.hermes/env.d/
 ```
 
 ### GC Root Verification

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -8,6 +8,14 @@ description: "Complete reference of all environment variables used by Hermes Age
 
 Hermes reads environment variables from the process environment and, for user-managed secrets, from `~/.hermes/.env`. Keep API keys, bot tokens, OAuth secrets, and other credentials in `.env`; prefer `config.yaml` for non-secret behaviour settings when a config key exists. Some variables below are process-only overrides or internal bridge variables and should not be committed to `.env` just because they are documented here.
 
+## Env File Loading
+
+Hermes loads environment files in this order (each later source overrides earlier):
+
+1. **`~/.hermes/.env`** — main env file
+2. **`~/.hermes/env.d/*.env`** — drop-in directory, loaded alphabetically (useful for secret manager symlinks)
+3. **Project `.env`** — only fills values not already set by the above
+
 ## LLM Providers
 
 | Variable | Description |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -8,6 +8,14 @@ description: "Complete reference of all environment variables used by Hermes Age
 
 All variables go in `~/.hermes/.env`. You can also set them with `hermes config set VAR value`.
 
+## Env File Loading
+
+Hermes loads environment files in this order (each later source overrides earlier):
+
+1. **`~/.hermes/.env`** — main env file
+2. **`~/.hermes/env.d/*.env`** — drop-in directory, loaded alphabetically (useful for secret manager symlinks)
+3. **Project `.env`** — only fills values not already set by the above
+
 ## LLM Providers
 
 | Variable | Description |


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Add `$HERMES_HOME/env.d/` drop-in directory. Any `*.env` files placed there are loaded alphabetically after the main `.env` with `override=True`. Useful for separating secrets from config, providing managed defaults that users shouldn't edit, or integrating with secret managers (sops-nix, agenix) via symlinks.

- Add `$HERMES_HOME/env.d/` drop-in directory for loading additional `.env` files
- NixOS module now symlinks `environmentFiles` into `env.d/` instead of copying secrets into `.env`. Non-secret `environment` vars are written to `env.d/nix-environment.env`.

cc @alt-glitch as you create the NixOS modules

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Previously, the NixOS activation script concatenated all `environmentFiles` (e.g., sops-nix/agenix secrets) into `$HERMES_HOME/.env` via `cat >>`. This defeated the purpose of secret managers — secrets were copied into persistent state instead of staying as symlinks to secrets.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

**`hermes_cli/env_loader.py`**: After loading the main `.env`, `load_hermes_dotenv()` now scans `$HERMES_HOME/env.d/*.env` (sorted alphabetically) and loads each file with `override=True`. This works for all users, not just NixOS — drop any `.env` file into `~/.hermes/env.d/` and it gets picked up.

**`nix/nixosModules.nix`**: The activation script now:
- Writes `cfg.environment` to `env.d/nix-environment.env` (instead of `.env`)
- Symlinks each `cfg.environmentFiles` entry to `env.d/nix-<i>.env` (instead of `cat` merging)
- Adds `env.d/` to tmpfiles rules
- Documents that sops-nix/agenix secrets need `owner`/`group` set to the hermes user

**Docs**: Updated `environment-variables.md` (env loading order) and `nix-setup.md` (secrets management, directory layout, options reference, troubleshooting).



## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `pytest tests/hermes_cli/test_env_loader.py -v`
2. Create `~/.hermes/env.d/test.env` with `TEST_VAR=from-env-d`, run `hermes config` to verify it's loaded
3. NixOS: `nix build .#nixosConfigurations.<host>` and verify `env.d/` is created with correct symlinks

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: linux (nixos with latest nixos-unstable)<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

