### PR TITLE
fix: gracefully recover from invalid_encrypted_content

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -48,6 +48,7 @@ class FailoverReason(enum.Enum):
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
+    invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
@@ -558,6 +559,21 @@ def _classify_400(
 ) -> ClassifiedError:
     """Classify 400 Bad Request — context overflow, format error, or generic."""
 
+    error_code_lower = (error_code or "").lower()
+    if (
+        error_code_lower == "invalid_encrypted_content"
+        or "invalid_encrypted_content" in error_msg
+        or (
+            "encrypted content for item" in error_msg
+            and "could not be verified" in error_msg
+        )
+    ):
+        return result_fn(
+            FailoverReason.invalid_encrypted_content,
+            retryable=True,
+            should_fallback=False,
+        )
+
     # Context overflow from 400
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):
         return result_fn(
@@ -654,6 +670,13 @@ def _classify_by_error_code(
             FailoverReason.context_overflow,
             retryable=True,
             should_compress=True,
+        )
+
+    if code_lower == "invalid_encrypted_content":
+        return result_fn(
+            FailoverReason.invalid_encrypted_content,
+            retryable=True,
+            should_fallback=False,
         )
 
     return None
@@ -792,11 +815,40 @@ def _extract_error_code(body: dict) -> str:
     """Extract an error code string from the response body."""
     if not body:
         return ""
+
+    def _code_from_payload(payload: dict) -> str:
+        if not isinstance(payload, dict):
+            return ""
+        payload_error = payload.get("error", {})
+        if isinstance(payload_error, dict):
+            nested = payload_error.get("code") or payload_error.get("type") or ""
+            if isinstance(nested, str) and nested.strip() and nested.strip() != "400":
+                return nested.strip()
+        code = payload.get("code") or payload.get("error_code") or ""
+        if isinstance(code, (str, int)):
+            text = str(code).strip()
+            if text and text != "400":
+                return text
+        return ""
+
     error_obj = body.get("error", {})
     if isinstance(error_obj, dict):
         code = error_obj.get("code") or error_obj.get("type") or ""
-        if isinstance(code, str) and code.strip():
+        if isinstance(code, str) and code.strip() and code.strip() != "400":
             return code.strip()
+
+        message = error_obj.get("message")
+        if isinstance(message, str) and message.strip().startswith("{"):
+            try:
+                import json
+
+                inner = json.loads(message)
+            except (json.JSONDecodeError, TypeError):
+                inner = None
+            nested_code = _code_from_payload(inner)
+            if nested_code:
+                return nested_code
+
     # Top-level code
     code = body.get("code") or body.get("error_code") or ""
     if isinstance(code, (str, int)):

--- a/run_agent.py
+++ b/run_agent.py
@@ -1078,6 +1078,12 @@ class AIAgent:
         
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
+
+        # Responses encrypted reasoning replay state. Some OpenAI-compatible
+        # routes accept GPT-5 Responses requests but later reject replayed
+        # encrypted reasoning blobs. When that happens we disable replay for the
+        # rest of the session and fall back to stateless continuity.
+        self._codex_reasoning_replay_enabled = True
         
         # Cached system prompt -- built once per session, only rebuilt on compression
         self._cached_system_prompt: Optional[str] = None
@@ -2720,6 +2726,23 @@ class AIAgent:
 
         return context
 
+    def _disable_codex_reasoning_replay(self, messages: Optional[List[Dict[str, Any]]] = None) -> Dict[str, int]:
+        """Disable Responses encrypted reasoning replay and strip cached replay state."""
+        stripped_messages = 0
+        stripped_items = 0
+        target_messages = messages if isinstance(messages, list) else []
+
+        for msg in target_messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            items = msg.pop("codex_reasoning_items", None)
+            if isinstance(items, list) and items:
+                stripped_messages += 1
+                stripped_items += len(items)
+
+        self._codex_reasoning_replay_enabled = False
+        return {"messages": stripped_messages, "items": stripped_items}
+
     def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
         if response is None:
@@ -3540,6 +3563,7 @@ class AIAgent:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
         seen_item_ids: set = set()
+        replay_enabled = bool(getattr(self, "_codex_reasoning_replay_enabled", True))
 
         for msg in messages:
             if not isinstance(msg, dict):
@@ -3555,7 +3579,7 @@ class AIAgent:
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
                     # so the API can maintain coherent reasoning chains.
-                    codex_reasoning = msg.get("codex_reasoning_items")
+                    codex_reasoning = msg.get("codex_reasoning_items") if replay_enabled else None
                     has_codex_reasoning = False
                     if isinstance(codex_reasoning, list):
                         for ri in codex_reasoning:
@@ -6133,6 +6157,7 @@ class AIAgent:
                 self.provider == "openai-codex"
                 or "chatgpt.com/backend-api/codex" in self.base_url.lower()
             )
+            replay_enabled = bool(getattr(self, "_codex_reasoning_replay_enabled", True))
 
             # Resolve reasoning effort: config > default (medium)
             reasoning_effort = "medium"
@@ -6172,7 +6197,7 @@ class AIAgent:
                         kwargs["reasoning"] = github_reasoning
                 else:
                     kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
-                    kwargs["include"] = ["reasoning.encrypted_content"]
+                    kwargs["include"] = ["reasoning.encrypted_content"] if replay_enabled else []
             elif not is_github_responses:
                 kwargs["include"] = []
 
@@ -8283,6 +8308,7 @@ class AIAgent:
             anthropic_auth_retry_attempted=False
             nous_auth_retry_attempted=False
             thinking_sig_retry_attempted = False
+            invalid_encrypted_content_retry_attempted = False
             has_retried_429 = False
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
@@ -9078,6 +9104,35 @@ class AIAgent:
                             "%sThinking block signature recovery: stripped "
                             "reasoning_details from %d messages",
                             self.log_prefix, len(messages),
+                        )
+                        continue
+
+                    if (
+                        classified.reason == FailoverReason.invalid_encrypted_content
+                        and not invalid_encrypted_content_retry_attempted
+                        and self.api_mode == "codex_responses"
+                        and bool(getattr(self, "_codex_reasoning_replay_enabled", True))
+                        and any(
+                            isinstance(_m, dict)
+                            and _m.get("role") == "assistant"
+                            and isinstance(_m.get("codex_reasoning_items"), list)
+                            and _m.get("codex_reasoning_items")
+                            for _m in messages
+                        )
+                    ):
+                        invalid_encrypted_content_retry_attempted = True
+                        replay_stats = self._disable_codex_reasoning_replay(messages)
+                        self._vprint(
+                            f"{self.log_prefix}⚠️  Encrypted reasoning replay was rejected by the provider — "
+                            f"disabled replay and stripped {replay_stats['items']} item(s) from "
+                            f"{replay_stats['messages']} message(s), retrying...",
+                            force=True,
+                        )
+                        logging.warning(
+                            "%sInvalid encrypted reasoning recovery: disabled replay and stripped %d items from %d messages",
+                            self.log_prefix,
+                            replay_stats["items"],
+                            replay_stats["messages"],
                         )
                         continue
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -55,7 +55,7 @@ class TestFailoverReason:
             "auth", "auth_permanent", "billing", "rate_limit",
             "overloaded", "server_error", "timeout",
             "context_overflow", "payload_too_large",
-            "model_not_found", "format_error",
+            "model_not_found", "format_error", "invalid_encrypted_content",
             "thinking_signature", "long_context_tier", "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -138,6 +138,19 @@ class TestExtractErrorCode:
     def test_from_top_level_code(self):
         body = {"code": "model_not_found"}
         assert _extract_error_code(body) == "model_not_found"
+
+    def test_from_wrapped_json_message(self):
+        body = {
+            "error": {
+                "message": (
+                    '{"error":{"message":"The encrypted content for item rs_001 could not be verified. '
+                    'Reason: Encrypted content could not be decrypted or parsed.",'
+                    '"type":"invalid_request_error","param":"","code":"invalid_encrypted_content"}}'
+                ),
+                "type": "400",
+            }
+        }
+        assert _extract_error_code(body) == "invalid_encrypted_content"
 
     def test_empty_when_no_code(self):
         assert _extract_error_code({}) == ""
@@ -380,6 +393,51 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="openrouter", approx_tokens=0)
         # Without "thinking" in the message, it shouldn't be thinking_signature
         assert result.reason != FailoverReason.thinking_signature
+
+    def test_invalid_encrypted_content_classified_as_retryable_replay_failure(self):
+        body = {
+            "error": {
+                "message": (
+                    '{"error":{"message":"The encrypted content for item rs_001 could not be verified. '
+                    'Reason: Encrypted content could not be decrypted or parsed.",'
+                    '"type":"invalid_request_error","param":"","code":"invalid_encrypted_content"}}'
+                ),
+                "type": "400",
+            }
+        }
+        e = MockAPIError(
+            "Error code: 400 - invalid_encrypted_content",
+            status_code=400,
+            body=body,
+        )
+        result = classify_api_error(e, provider="custom", model="gpt-5.4")
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_invalid_encrypted_content_broad_message_match_does_not_catch_generic_parse_error(self):
+        message = "Encrypted content could not be decrypted or parsed."
+        e = MockAPIError(
+            message,
+            status_code=400,
+            body={"error": {"message": message}},
+        )
+        result = classify_api_error(e, provider="custom", model="gpt-5.4")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize("error_code", ["Invalid_Encrypted_Content", "INVALID_ENCRYPTED_CONTENT"])
+    def test_invalid_encrypted_content_code_is_case_insensitive_for_400(self, error_code):
+        e = MockAPIError(
+            "Error code: 400 - bad request",
+            status_code=400,
+            body={"error": {"code": error_code, "message": "Bad request"}},
+        )
+        result = classify_api_error(e, provider="custom", model="gpt-5.4")
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
 
     # ── Provider-specific: Anthropic long-context tier ──
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1276,3 +1276,107 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     assert reasoning_ids.count("rs_xyz") == 1
     assert reasoning_ids.count("rs_zzz") == 1
     assert len(reasoning_items) == 2
+
+
+def test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "custom"
+    agent.base_url = "https://api.example.com/v1"
+
+    request_payloads = []
+
+    class _InvalidEncryptedContentError(Exception):
+        def __init__(self):
+            super().__init__(
+                "Error code: 400 - The encrypted content for item rs_001 could not be verified. "
+                "Reason: Encrypted content could not be decrypted or parsed."
+            )
+            self.status_code = 400
+            self.body = {
+                "error": {
+                    "message": (
+                        '{"error":{"message":"The encrypted content for item rs_001 could not be verified. '
+                        'Reason: Encrypted content could not be decrypted or parsed.",'
+                        '"type":"invalid_request_error","param":"","code":"invalid_encrypted_content"}}'
+                    ),
+                    "type": "400",
+                }
+            }
+
+    responses = [_InvalidEncryptedContentError(), _codex_message_response("Recovered without replay.")]
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        current = responses.pop(0)
+        if isinstance(current, Exception):
+            raise current
+        return current
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_001", "encrypted_content": "enc_bad", "summary": []},
+            ],
+        }
+    ]
+
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered without replay."
+    assert len(request_payloads) == 2
+    assert any(item.get("type") == "reasoning" for item in request_payloads[0]["input"])
+    assert not any(item.get("type") == "reasoning" for item in request_payloads[1]["input"])
+    assert request_payloads[0].get("include") == ["reasoning.encrypted_content"]
+    assert request_payloads[1].get("include") == []
+    assert result["messages"][0].get("codex_reasoning_items") is None
+    assert agent._codex_reasoning_replay_enabled is False
+
+
+def test_run_conversation_codex_invalid_encrypted_content_without_replay_state_does_not_disable_replay(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "custom"
+    agent.base_url = "https://api.example.com/v1"
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *args, **kwargs: 0)
+
+    request_payloads = []
+
+    class _InvalidEncryptedContentError(Exception):
+        def __init__(self):
+            super().__init__("Error code: 400 - bad request")
+            self.status_code = 400
+            self.body = {
+                "error": {
+                    "code": "INVALID_ENCRYPTED_CONTENT",
+                    "message": "Bad request",
+                }
+            }
+
+    responses = [_InvalidEncryptedContentError(), _codex_message_response("Recovered after generic retry.")]
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        current = responses.pop(0)
+        if isinstance(current, Exception):
+            raise current
+        return current
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation(
+        "continue",
+        conversation_history=[{"role": "assistant", "content": "No replay state here."}],
+    )
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after generic retry."
+    assert len(request_payloads) == 2
+    assert all(payload.get("include") == ["reasoning.encrypted_content"] for payload in request_payloads)
+    assert all(not any(item.get("type") == "reasoning" for item in payload["input"]) for payload in request_payloads)
+    assert agent._codex_reasoning_replay_enabled is True
+    assert result["messages"][0].get("codex_reasoning_items") is None


### PR DESCRIPTION
## What does this PR do?

Gracefully recovers from GPT-5 Responses `invalid_encrypted_content` failures instead of aborting the whole session.

This change treats the error as an encrypted reasoning replay compatibility failure on some OpenAI-compatible/custom routes. On the first hit, Hermes now disables replayed `codex_reasoning_items`, strips cached replay state from assistant history, and retries once without encrypted reasoning replay.

It also tightens the classifier so we do not over-match generic encrypted-content parse errors, and adds regression coverage for mixed-case error codes plus the no-replay-state path.

## Related Issue

Fixes #10175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `FailoverReason.invalid_encrypted_content` and classify wrapped / mixed-case provider codes correctly.
- Narrow the 400-message fallback so only replay-style `encrypted content for item ... could not be verified` errors take the replay-recovery path.
- Add session-level replay gating in `run_agent.py` via `_codex_reasoning_replay_enabled`.
- On the first replay verification failure in `codex_responses`, disable replay, strip stored `codex_reasoning_items`, and retry once.
- Add targeted regression tests for:
  - wrapped JSON error-code extraction
  - case-insensitive 400 code handling
  - avoiding broad misclassification of generic encrypted-content parse errors
  - replay disable + retry behavior
  - no-replay-state guard behavior

## How to Test

1. Reproduce a GPT-5 Responses request that returns `invalid_encrypted_content` while replaying historical `codex_reasoning_items`.
2. Confirm Hermes does **not** abort the session on the first failure.
3. Confirm Hermes retries once with encrypted reasoning replay disabled and continues the conversation without replayed reasoning state.
4. Run targeted regression tests:
   - `python -m pytest tests/agent/test_error_classifier.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_413_compression.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A for user-facing docs; internal comments/docstrings were updated in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no contributor workflow or architecture docs changed)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Python-only runtime recovery path, no OS-specific behavior introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema/description changes)

## Screenshots / Logs

Targeted regression suite:

```text
python -m pytest tests/agent/test_error_classifier.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_413_compression.py -q
175 passed
```

I also attempted the full `tests/` suite locally, but the current local baseline still has unrelated failures in `tests/agent/test_auxiliary_client.py`, so the full-suite checkbox is intentionally left unchecked.
