### PR TITLE
fix(cli): /model picker shows curated models instead of full catalog

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4588,16 +4588,19 @@ class HermesCLI:
                 self._close_model_picker()
                 return
             provider_data = providers[selected]
-            model_list = []
-            try:
-                from hermes_cli.models import provider_model_ids
-                live = provider_model_ids(provider_data["slug"])
-                if live:
-                    model_list = live
-            except Exception:
-                pass
+            # Use the curated model list from list_authenticated_providers()
+            # (same lists as `hermes model` and gateway pickers).
+            # Only fall back to the live provider catalog when the curated
+            # list is empty (e.g. user-defined endpoints with no curated list).
+            model_list = provider_data.get("models", [])
             if not model_list:
-                model_list = provider_data.get("models", [])
+                try:
+                    from hermes_cli.models import provider_model_ids
+                    live = provider_model_ids(provider_data["slug"])
+                    if live:
+                        model_list = live
+                except Exception:
+                    pass
             state["stage"] = "model"
             state["provider_data"] = provider_data
             state["model_list"] = model_list


### PR DESCRIPTION
## Summary

The `/model` slash command's interactive picker was showing hundreds of models (the full live API catalog) instead of the same curated list that `hermes model` and the Telegram/Discord pickers show.

**Root cause:** In `_handle_model_picker_selection()`, when a user selected a provider, the code called `provider_model_ids(slug)` which fetches the FULL live catalog from the provider's API (hundreds of models for Anthropic, Copilot, AI Gateway, Nous, etc.). The curated list from `list_authenticated_providers()` — which was carefully assembled from `_PROVIDER_MODELS` / `OPENROUTER_MODELS` — was only used as a fallback when the live fetch failed.

**Fix:** Flip the priority. Use the curated list first (consistent with `hermes model` and gateway pickers). Only fall back to `provider_model_ids()` when the curated list is empty (e.g. user-defined endpoints that don't have a curated list).

## Comparison

| Path | Before | After |
|------|--------|-------|
| `hermes model` | Curated list ✓ | Curated list ✓ |
| `/model` CLI picker | Full live catalog ✗ | Curated list ✓ |
| `/model` Telegram/Discord | Curated list ✓ | Curated list ✓ |

## Test plan
- 124 model-related tests pass
- py_compile verified