### PR TITLE
fix: parse string schedule in cron update_job()

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -501,6 +501,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
             updated["schedule_display"] = updates.get(
                 "schedule_display",
                 updated_schedule.get("display", updated.get("schedule_display")),

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -279,6 +279,25 @@ class TestUpdateJob:
         result = update_job("nonexistent_id", {"name": "X"})
         assert result is None
 
+    def test_update_schedule_with_string(self, tmp_cron_dir):
+        """update_job() should accept a string schedule and parse it into a dict."""
+        job = create_job(prompt="Daily report", schedule="every 1h")
+        assert job["schedule"]["kind"] == "interval"
+        assert job["schedule"]["minutes"] == 60
+
+        updated = update_job(job["id"], {"schedule": "every 10m"})
+        assert updated is not None
+        assert isinstance(updated["schedule"], dict)
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["schedule"]["minutes"] == 10
+        assert updated["schedule_display"] == "every 10m"
+
+        # Verify persisted to disk
+        fetched = get_job(job["id"])
+        assert fetched["schedule"]["kind"] == "interval"
+        assert fetched["schedule"]["minutes"] == 10
+        assert fetched["schedule_display"] == "every 10m"
+
 
 class TestPauseResumeJob:
     def test_pause_sets_state(self, tmp_cron_dir):

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -351,6 +351,29 @@ class TestUpdateJob:
                 data = await resp.json()
                 assert "No valid fields" in data["error"]
 
+    @pytest.mark.asyncio
+    async def test_update_job_string_schedule(self, adapter):
+        """PATCH /api/jobs/{id} with a string schedule passes it through."""
+        app = _create_app(adapter)
+        updated_job = {**SAMPLE_JOB, "schedule": {"kind": "interval", "minutes": 10, "display": "every 10m"}}
+        mock_update = MagicMock(return_value=updated_job)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                APIServerAdapter, "_CRON_AVAILABLE", True
+            ), patch.object(
+                APIServerAdapter, "_cron_update", mock_update
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"schedule": "every 10m"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["job"] == updated_job
+                mock_update.assert_called_once()
+                call_args = mock_update.call_args
+                assert call_args[0][1]["schedule"] == "every 10m"
+
 
 # ---------------------------------------------------------------------------
 # 13. test_delete_job


### PR DESCRIPTION
## Summary

Fixes #10129 — `update_job()` crashes with `AttributeError: 'str' object has no attribute 'get'` when the `schedule` field is passed as a string (e.g. `"every 10m"`).

## Root Cause

`update_job()` in `cron/jobs.py` assumed `updates["schedule"]` was always a parsed dict. The create path (`create_job()`) calls `parse_schedule()` to normalize string inputs, but the update path skipped this step.

When the API server forwards a payload like `{"schedule": "every 10m"}`, the string reaches `updated_schedule.get("display", ...)` which raises `AttributeError`.

## Fix

Added a 3-line isinstance check at the top of the `if schedule_changed:` block in `update_job()`:

```python
if isinstance(updated_schedule, str):
    updated_schedule = parse_schedule(updated_schedule)
    updated["schedule"] = updated_schedule
```

This normalizes string schedules via the existing `parse_schedule()` function before accessing dict methods, matching the behavior of `create_job()`.

## Tests

- Added `test_update_schedule_with_string` in `tests/cron/test_jobs.py` — creates a job, updates with a string schedule, verifies parsing and persistence
- Added `test_update_job_string_schedule` in `tests/gateway/test_api_server_jobs.py` — verifies the API endpoint passes string schedules through correctly

All existing tests continue to pass (11368 passed, failures are pre-existing upstream issues in `test_web_server.py`).