### PR TITLE
feat(tools): add terminal output transform hook

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -54,6 +54,7 @@ logger = logging.getLogger(__name__)
 VALID_HOOKS: Set[str] = {
     "pre_tool_call",
     "post_tool_call",
+    "transform_terminal_output",
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -245,7 +245,7 @@ TIPS = [
     "Three plugin types: general (tools/hooks), memory providers, and context engines.",
     "hermes plugins install owner/repo installs plugins directly from GitHub.",
     "8 external memory providers available: Honcho, OpenViking, Mem0, Hindsight, and more.",
-    "Plugin hooks include pre_tool_call, post_tool_call, pre_llm_call, and post_llm_call.",
+    "Plugin hooks include pre_tool_call, post_tool_call, pre_llm_call, post_llm_call, and transform_terminal_output for foreground terminal output canonicalization.",
 
     # --- Miscellaneous ---
     "Prompt caching (Anthropic) reduces costs by reusing cached system prompt prefixes.",
@@ -344,6 +344,5 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -199,6 +199,7 @@ class TestPluginHooks:
     def test_valid_hooks_include_request_scoped_api_hooks(self):
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
+        assert "transform_terminal_output" in VALID_HOOKS
 
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""
@@ -294,6 +295,30 @@ class TestPluginHooks:
             max_tokens=8192,
         )
         assert results == [{"seen": 2, "mc": 5, "tc": 3}]
+
+    def test_transform_terminal_output_hook_can_be_registered_and_invoked(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir, "transform_hook",
+            register_body=(
+                'ctx.register_hook("transform_terminal_output", '
+                'lambda **kw: f"{kw[\'command\']}|{kw[\'returncode\']}|{kw[\'env_type\']}|{kw[\'task_id\']}|{len(kw[\'output\'])}")'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        results = mgr.invoke_hook(
+            "transform_terminal_output",
+            command="echo hello",
+            output="abcdef",
+            returncode=7,
+            task_id="task-1",
+            env_type="local",
+        )
+        assert results == ["echo hello|7|local|task-1|6"]
 
     def test_invalid_hook_name_warns(self, tmp_path, monkeypatch, caplog):
         """Registering an unknown hook name logs a warning."""

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -1,0 +1,195 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import hermes_cli.plugins as plugins_mod
+import tools.terminal_tool as terminal_tool_module
+
+
+_UNSET = object()
+
+
+def _make_env_config(tmp_path, **overrides):
+    config = {
+        "env_type": "local",
+        "timeout": 30,
+        "cwd": str(tmp_path),
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    config.update(overrides)
+    return config
+
+
+def _run_terminal(
+    monkeypatch,
+    tmp_path,
+    *,
+    output,
+    returncode=0,
+    invoke_hook=_UNSET,
+    approval=None,
+    command="echo hello",
+):
+    mock_env = MagicMock()
+    mock_env.execute.return_value = {"output": output, "returncode": returncode}
+
+    monkeypatch.setattr(
+        terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
+    )
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: approval or {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", mock_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    if invoke_hook is not _UNSET:
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
+
+    result = json.loads(terminal_tool_module.terminal_tool(command=command))
+    return result, mock_env
+
+
+def test_terminal_output_unchanged_when_transform_hook_not_registered(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(monkeypatch, tmp_path, output="plain output")
+
+    assert result["output"] == "plain output"
+    assert result["exit_code"] == 0
+    assert result["error"] is None
+
+
+def test_terminal_output_unchanged_for_none_hook_result(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=lambda hook_name, **kwargs: [None],
+    )
+
+    assert result["output"] == "plain output"
+
+
+def test_terminal_output_ignores_invalid_hook_results(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=lambda hook_name, **kwargs: [{"bad": True}, 123, ["nope"]],
+    )
+
+    assert result["output"] == "plain output"
+
+
+def test_terminal_output_uses_first_valid_string_from_hooks(monkeypatch, tmp_path):
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=lambda hook_name, **kwargs: [None, {"bad": True}, "first", "second"],
+    )
+
+    assert result["output"] == "first"
+
+
+def test_terminal_output_transform_still_truncates_long_replacement(monkeypatch, tmp_path):
+    transformed_output = "PLUGIN-HEAD\n" + ("A" * 60000) + "\nPLUGIN-TAIL"
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="short output",
+        invoke_hook=lambda hook_name, **kwargs: [transformed_output],
+    )
+
+    assert "PLUGIN-HEAD" in result["output"]
+    assert "PLUGIN-TAIL" in result["output"]
+    assert "[OUTPUT TRUNCATED" in result["output"]
+    assert transformed_output != result["output"]
+
+
+def test_terminal_output_transform_still_runs_strip_and_redact(monkeypatch, tmp_path):
+    secret = "sk-proj-abc123def456ghi789jkl012mno345"
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=lambda hook_name, **kwargs: [f" \x1b[31mOPENAI_API_KEY={secret}\x1b[0m "],
+    )
+
+    assert "\x1b" not in result["output"]
+    assert secret not in result["output"]
+    assert "OPENAI_API_KEY=" in result["output"]
+    assert "***" in result["output"]
+
+
+def test_terminal_output_transform_hook_exception_falls_back(monkeypatch, tmp_path):
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="plain output",
+        invoke_hook=_raise,
+    )
+
+    assert result["output"] == "plain output"
+    assert result["exit_code"] == 0
+    assert result["error"] is None
+
+
+def test_terminal_output_transform_does_not_change_approval_or_exit_code_meaning(monkeypatch, tmp_path):
+    approval = {
+        "approved": True,
+        "user_approved": True,
+        "description": "dangerous command",
+    }
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="original output",
+        returncode=1,
+        approval=approval,
+        command="grep foo bar",
+        invoke_hook=lambda hook_name, **kwargs: ["replaced output"],
+    )
+
+    assert result["output"] == "replaced output"
+    assert result["approval"] == (
+        "Command required approval (dangerous command) and was approved by the user."
+    )
+    assert result["exit_code_meaning"] == "No matches found (not an error)"
+
+
+def test_terminal_output_transform_integration_with_real_plugin(monkeypatch, tmp_path):
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugins_dir = hermes_home / "plugins"
+    plugin_dir = plugins_dir / "terminal_transform"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: terminal_transform\n", encoding="utf-8")
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        '    ctx.register_hook("transform_terminal_output", '
+        'lambda **kw: "PLUGIN-HEAD\\n" + kw["output"] + "\\nPLUGIN-TAIL")\n',
+        encoding="utf-8",
+    )
+
+    plugins_mod.discover_plugins()
+
+    long_output = "X" * 60000
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output=long_output,
+    )
+
+    assert "PLUGIN-HEAD" in result["output"]
+    assert "PLUGIN-TAIL" in result["output"]
+    assert "[OUTPUT TRUNCATED" in result["output"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1476,6 +1476,27 @@ def terminal_tool(
             
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
+
+            # Foreground terminal output canonicalization seam: plugins receive
+            # the full output string before default truncation and may only
+            # replace it by returning a string from transform_terminal_output.
+            # The hook is fail-open, and the first valid string return wins.
+            try:
+                from hermes_cli.plugins import invoke_hook
+                hook_results = invoke_hook(
+                    "transform_terminal_output",
+                    command=command,
+                    output=output,
+                    returncode=returncode,
+                    task_id=effective_task_id or "",
+                    env_type=env_type,
+                )
+                for hook_result in hook_results:
+                    if isinstance(hook_result, str):
+                        output = hook_result
+                        break
+            except Exception:
+                pass
             
             # Truncate output if too long, keeping both head and tail
             MAX_OUTPUT_CHARS = 50000


### PR DESCRIPTION
## What does this PR do?

Adds a minimal plugin hook for terminal foreground output: `transform_terminal_output`.

This gives plugins a narrow canonicalization seam for terminal `output: str` before the default `50k` truncation runs, without changing the existing `post_tool_call` contract or exposing live mutable result objects.

The hook is intentionally scoped to the foreground `terminal()` path only, is fail-open, and only accepts string replacements.

This hook is intentionally limited to string-level canonicalization and does not provide a structured persistence channel; plugins that want to retain extra artifacts must do so via their own side effects and describe any follow-up access path in the returned text.

This keeps the change focused on the concrete issue: allowing plugins to summarize or otherwise shrink oversized terminal output before Hermes applies its normal truncation/redaction pipeline.

## Related Issue

Closes #8933

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `transform_terminal_output` to `VALID_HOOKS` in `hermes_cli/plugins.py`
- Wired the hook into the foreground terminal execution path in `tools/terminal_tool.py`
- Kept the hook narrow and fail-open
- Plugins receive `command`, `output`, `returncode`, `task_id`, and `env_type`
- `None` means no-op
- The first valid `str` return replaces the output
- Invalid return types are ignored
- Plugin errors fall back to existing terminal behavior
- Preserved the existing downstream pipeline after hook execution: default `50k` truncation, `strip_ansi`, `redact_sensitive_text`, `exit_code_meaning`, and normal JSON result assembly
- Added targeted plugin-system coverage in `tests/hermes_cli/test_plugins.py`
- Added terminal hook behavior coverage, including a lightweight real-plugin integration path, in `tests/tools/test_terminal_output_transform_hook.py`
- Clarified the foreground-only scope in `tools/terminal_tool.py` comments and updated the plugin hooks tip in `hermes_cli/tips.py`

## How to Test

1. Activate the environment:
   ```bash
   source venv/bin/activate
   ```
2. Run targeted tests:
   ```bash
   python -m pytest tests/hermes_cli/test_plugins.py -q
   python -m pytest tests/tools/test_terminal_output_transform_hook.py -q
   ```
3. Optional manual verification: see the example in the Screenshots / Logs section below.
   - install/register a test plugin that returns a shorter string from `transform_terminal_output`
   - run a foreground `terminal()` command with very large output
   - confirm the plugin replacement happens before the normal truncation/redaction pipeline

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
Manual TUI verification screenshots attached.
- `Before`: without the plugin transform, the middle `ERROR_KEYWORD` is lost after the default truncation path.
<img width="1150" height="562" alt="image" src="https://github.com/user-attachments/assets/d11e2dad-04d6-45d2-98cb-f55bef10a393" />

- `After`: with `transform_terminal_output`, the plugin extracts the middle error keyword before truncation and returns a compact canonical preview that preserves the keyword value.
<img width="1298" height="560" alt="image" src="https://github.com/user-attachments/assets/38ceb585-bb4f-40e0-9d16-361ba15bbfc5" />

The demo output was constructed so the keyword appears only in the middle of a large terminal result, isolating the value of the new hook from the default head/tail truncation behavior.

Targeted tests passed:

`python -m pytest tests/hermes_cli/test_plugins.py -q` → `30 passed`

`python -m pytest tests/tools/test_terminal_output_transform_hook.py -q` → `9 passed`

`pytest tests/ -v` still shows existing upstream failures, but the same stable failing subset reproduces on `origin/main`, so this PR does not appear to introduce any new failures or regressions.

`codex review` also did not find any discrete, actionable issues relative to `upstream/main`; the new terminal-output hook matches the existing plugin hook patterns, and the focused hook/terminal tests pass.
