### PR TITLE
fix(gateway): handle macOS GUI domain sleep/lock for headless servers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -514,6 +514,19 @@ DEFAULT_CONFIG = {
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
+
+    # Gateway service configuration
+    "gateway": {
+        # macOS launchd domain type: "gui" (default) or "user"
+        # "gui" - Uses the Aqua session (GUI login). Works best for interactive use but
+        #         requires an active GUI session. When the Mac is locked and display sleeps
+        #         for extended periods, the gui domain enters "on-demand-only" mode and
+        #         the service cannot be started until the screen is unlocked.
+        # "user" - Uses the user bootstrap domain. Survives lock/sleep but requires the
+        #          user to be logged in. Recommended for headless servers or when running
+        #          Hermes gateway via SSH without a persistent GUI session.
+        "macos_launchd_domain": "gui",
+    },
     
     # Text-to-speech configuration
     "tts": {

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1282,9 +1282,39 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
-def _launchd_domain() -> str:
+def _launchd_domain(domain_type: str = "gui") -> str:
+    """Return the launchd domain target for the current user.
+    
+    Args:
+        domain_type: Either "gui" (default, requires Aqua session) or "user" 
+                    (works in headless/SSH sessions but requires user login)
+    
+    The "gui" domain is tied to the Aqua session (GUI login). When the Mac
+    is locked and the display sleeps for extended periods, the gui domain
+    enters "on-demand-only" mode and services cannot be started.
+    
+    The "user" domain survives lock/sleep but requires the user to be logged in.
+    """
     import os
+    if domain_type == "user":
+        return f"user/{os.getuid()}"
     return f"gui/{os.getuid()}"
+
+
+def _get_launchd_domain_type() -> str:
+    """Get the configured launchd domain type from config.
+    
+    Returns "gui" or "user" based on config, defaulting to "gui".
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        domain = config.get("gateway", {}).get("macos_launchd_domain", "gui")
+        if domain in ("gui", "user"):
+            return domain
+    except Exception:
+        pass
+    return "gui"
 
 
 def generate_launchd_plist() -> str:
@@ -1447,31 +1477,54 @@ def launchd_uninstall():
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    domain_type = _get_launchd_domain_type()
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
     if not plist_path.exists():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap_and_start(plist_path, label, domain_type)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain(domain_type)}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
-        if e.returncode not in (3, 113):
+        if e.returncode == 125:
+            # Domain does not support specified action - likely gui domain is in on-demand-only mode
+            if domain_type == "gui":
+                print("⚠ GUI domain unavailable (screen locked/sleeping). Trying user domain...")
+                print("  Tip: Set gateway.macos_launchd_domain: 'user' in config.yaml to avoid this.")
+                try:
+                    _launchd_bootstrap_and_start(plist_path, label, "user")
+                    print("✓ Service started (using user domain)")
+                    return
+                except subprocess.CalledProcessError:
+                    print("✗ Failed to start with user domain as well.")
+                    print("  The Mac may be in deep sleep. Please unlock the screen and try again.")
+                    raise
+            else:
+                print("✗ User domain also unavailable. The system may require a GUI session.")
+                raise
+        elif e.returncode not in (3, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap_and_start(plist_path, label, domain_type)
     print("✓ Service started")
+
+
+def _launchd_bootstrap_and_start(plist_path: Path, label: str, domain_type: str):
+    """Bootstrap the plist and start the service in the specified domain."""
+    domain = _launchd_domain(domain_type)
+    subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], check=True, timeout=30)
+    subprocess.run(["launchctl", "kickstart", f"{domain}/{label}"], check=True, timeout=30)
 
 def launchd_stop():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    domain_type = _get_launchd_domain_type()
+    target = f"{_launchd_domain(domain_type)}/{label}"
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
     # immediately restarts it because KeepAlive.SuccessfulExit = false.
@@ -1479,7 +1532,17 @@ def launchd_stop():
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
     except subprocess.CalledProcessError as e:
-        if e.returncode in (3, 113):
+        if e.returncode == 125 and domain_type == "gui":
+            # Try user domain if GUI domain is unavailable
+            target = f"{_launchd_domain('user')}/{label}"
+            try:
+                subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
+            except subprocess.CalledProcessError as e2:
+                if e2.returncode in (3, 113):
+                    pass
+                else:
+                    raise
+        elif e.returncode in (3, 113):
             pass  # Already unloaded — nothing to stop.
         else:
             raise
@@ -1530,7 +1593,8 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    domain_type = _get_launchd_domain_type()
+    target = f"{_launchd_domain(domain_type)}/{label}"
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
@@ -1551,14 +1615,28 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
-        if e.returncode not in (3, 113):
+        if e.returncode == 125 and domain_type == "gui":
+            # Try user domain if GUI domain is unavailable
+            print("⚠ GUI domain unavailable (screen locked/sleeping). Trying user domain...")
+            target = f"{_launchd_domain('user')}/{label}"
+            try:
+                plist_path = get_launchd_plist_path()
+                subprocess.run(["launchctl", "bootstrap", _launchd_domain('user'), str(plist_path)], check=True, timeout=30)
+                subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+                print("✓ Service restarted (using user domain)")
+            except subprocess.CalledProcessError:
+                print("✗ Failed to restart with user domain as well.")
+                print("  The Mac may be in deep sleep. Please unlock the screen and try again.")
+                raise
+        elif e.returncode not in (3, 113):
             raise
-        # Job not loaded — bootstrap and start fresh
-        print("↻ launchd job was unloaded; reloading")
-        plist_path = get_launchd_plist_path()
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
-        print("✓ Service restarted")
+        else:
+            # Job not loaded — bootstrap and start fresh
+            print("↻ launchd job was unloaded; reloading")
+            plist_path = get_launchd_plist_path()
+            subprocess.run(["launchctl", "bootstrap", _launchd_domain(domain_type), str(plist_path)], check=True, timeout=30)
+            subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+            print("✓ Service restarted")
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()


### PR DESCRIPTION
# Fix: Handle macOS GUI domain sleep/lock for headless servers

This commit fixes the issue where hermes gateway fails to start/restart when the Mac is locked and the display has been sleeping for extended periods (GUI domain enters 'on-demand-only' mode).

Changes:
- Add _launchd_domain() parameter to support both 'gui' and 'user' domains
- Add _get_launchd_domain_type() to read config for preferred domain
- Add error code 125 handling in launchd_start/stop/restart
- Add automatic fallback to 'user' domain when GUI domain is unavailable
- Add gateway.macos_launchd_domain config option (default: 'gui')
- Add helpful error messages guiding users to config option

The 'user' domain survives lock/sleep but requires user login. The 'gui' domain (default) works best for interactive use.

Fixes the issue where gateway service dies overnight on headless Macs and cannot be restarted via SSH until screen is unlocked.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

On macOS, `hermes gateway start` fails with error code 125 when the Mac is locked and the display has been sleeping for extended periods. This happens because the `gui/{uid}` domain (Aqua session) enters "on-demand-only" mode and services cannot be started.

**Root Cause:**
- macOS `gui/{uid}` domain is tied to the Aqua session (GUI login)
- When Mac locks + display sleeps for extended periods (typically hours), the GUI domain enters "on-demand-only" mode
- This commonly affects headless Mac servers accessed via SSH

**Solution:**
1. **Automatic fallback to `user/` domain**: When GUI domain returns error 125, automatically try the `user/{uid}` domain which survives lock/sleep
2. **Configuration option**: Add `gateway.macos_launchd_domain` setting to allow users to prefer `user` domain for headless setups
3. **Better error messages**: Clear guidance when domain is unavailable

This approach is backwards compatible - default behavior unchanged (`gui` domain), automatic fallback only activates on error 125.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes # (no existing issue found for this specific problem)

Related to:
- #4820 (deprecated launchctl commands - different but related area)
- #3318 (launchd plist recovery - different root cause)

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/gateway.py`:
  - Modified `_launchd_domain()` to accept `domain_type` parameter ("gui" or "user")
  - Added `_get_launchd_domain_type()` to read config preference
  - Added `_launchd_bootstrap_and_start()` helper function
  - Updated `launchd_start()`, `launchd_stop()`, `launchd_restart()` to handle error code 125 with automatic fallback
  
- `hermes_cli/config.py`:
  - Added `gateway` section to `DEFAULT_CONFIG`
  - Added `macos_launchd_domain` option with detailed documentation

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

### Automated Tests
```bash
# Run the test script
cd ~/hermes-agent-fork
python3 test_simple.py
```

### Manual Testing

**Test 1: Normal startup (GUI domain available)**
1. Ensure screen is not locked
2. Run: `hermes gateway stop && hermes gateway start`
3. Expected: `✓ Service started`

**Test 2: Configuration option**
1. Add to `~/.hermes/config.yaml`:
   ```yaml
   gateway:
     macos_launchd_domain: "user"
   ```
2. Run: `hermes gateway restart`
3. Expected: Service starts using user domain

**Test 3: Automatic fallback (requires waiting)**
1. Use default config (gui domain)
2. Start gateway: `hermes gateway start`
3. Lock screen and wait 2+ hours (or set `sudo pmset displaysleep 1` and wait 10 min)
4. Via SSH, run: `hermes gateway restart`
5. Expected:
   ```
   ⚠ GUI domain unavailable (screen locked/sleeping). Trying user domain...
   ✓ Service restarted (using user domain)
   ```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I've checked [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Apple Silicon)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - **Note**: Config key is in `DEFAULT_CONFIG` in `config.py`, not in example file
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
  - **Note**: Changes are macOS-only (inside `if sys.platform == "darwin"` blocks)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A - This is not a new skill

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

### Before fix:
```
$ hermes gateway start
Could not kickstart service "ai.hermes.gateway": 125: Domain does not support specified action
Traceback (most recent call last):
  ...
subprocess.CalledProcessError: Command '['launchctl', 'kickstart', 'gui/501/ai.hermes.gateway']' returned non-zero exit status 125.
```

### After fix:
```
$ hermes gateway start
⚠ GUI domain unavailable (screen locked/sleeping). Trying user domain...
  Tip: Set gateway.macos_launchd_domain: 'user' in config.yaml to avoid this.
✓ Service started (using user domain)
```

### Domain accessibility test:
```
$ python3 test_simple.py
============================================================
Simple Launchd Domain Test
============================================================

Testing domain generation...
  GUI domain: gui/501
  User domain: user/501
  ✓ Domain generation works

Testing launchctl access...
  Testing gui domain (gui/501)...
    ✓ gui domain accessible
  Testing user domain (user/501)...
    ✓ user domain accessible

Tests completed
============================================================
```
