### PR TITLE
fix(terminal): forward docker_forward_env and docker_env to container_config

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1249,6 +1249,8 @@ def terminal_tool(
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                                "docker_forward_env": config.get("docker_forward_env", []),
+                                "docker_env": config.get("docker_env", {}),
                             }
 
                         local_config = None


### PR DESCRIPTION
## What does this PR do?

The `container_config` builder in `tools/terminal_tool.py` (~line 1244) was missing `docker_forward_env` and `docker_env` keys. Both settings from `config.yaml` (and the `TERMINAL_DOCKER_FORWARD_ENV` env var) were parsed correctly by `_get_env_config()`, but then silently dropped when constructing the `container_config` dict that gets passed to `_create_environment()`.

This meant **no environment variables could be injected into Docker containers** via the documented `docker_forward_env` or `docker_env` configuration mechanisms.

### Root cause chain

1. `_get_env_config()` correctly reads `docker_forward_env` from config.yaml / `TERMINAL_DOCKER_FORWARD_ENV` env var → stored in `config` dict
2. `container_config` dict builder (~line 1244) does **NOT** include `docker_forward_env` or `docker_env` keys
3. `_create_environment()` reads `cc.get("docker_forward_env", [])` from `container_config` → always gets `[]`
4. Docker container starts with zero forwarded env vars, regardless of user configuration

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: Added two missing keys to the `container_config` dict in the Docker/Singularity/Modal/Daytona branch:

```python
"docker_forward_env": config.get("docker_forward_env", []),
"docker_env": config.get("docker_env", {}),
```

## How to Test

1. Add environment variables to `~/.hermes/.env`:
   ```bash
   echo 'MY_TEST_VAR=hello' >> ~/.hermes/.env
   ```

2. Add `docker_forward_env` to `~/.hermes/config.yaml`:
   ```yaml
   docker_forward_env:
     - MY_TEST_VAR
   ```

3. Apply the fix in `tools/terminal_tool.py`, then delete existing container and restart gateway:
   ```bash
   docker rm -f $(docker ps -aq --filter name=hermes)
   hermes gateway
   ```

4. Verify env vars are injected into the new container:
   ```bash
   echo $MY_TEST_VAR    # should print: hello
   ```

5. Verify the vars work end-to-end by making an API call that depends on them (e.g. obtain a tenant_access_token using the injected credentials).

### Verified

- [x] `FEISHU_APP_ID` and `FEISHU_APP_SECRET` correctly injected into Docker container after fix
- [x] `tenant_access_token` API call succeeds using injected credentials

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Docker backend

### Documentation & Housekeeping

- [x] N/A — no config keys added or changed, no architecture changes
