### PR TITLE
fix(telegram): handle ChatMigrated error gracefully on send

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -831,6 +831,11 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
+            try:
+                from telegram.error import ChatMigrated as _ChatMigrated
+            except (ImportError, AttributeError):
+                _ChatMigrated = None  # type: ignore[assignment,misc]
+
             for i, chunk in enumerate(chunks):
                 should_thread = self._should_thread_reply(reply_to, i)
                 reply_to_id = int(reply_to) if should_thread else None
@@ -905,6 +910,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         else:
                             raise
                     except Exception as send_err:
+                        if _ChatMigrated and isinstance(send_err, _ChatMigrated):
+                            new_chat_id = send_err.new_chat_id
+                            logger.warning(
+                                "[%s] Group migrated to supergroup, updating chat_id %s -> %s and retrying",
+                                self.name, chat_id, new_chat_id,
+                            )
+                            chat_id = str(new_chat_id)
+                            continue
                         retry_after = getattr(send_err, "retry_after", None)
                         if retry_after is not None or "retry after" in str(send_err).lower():
                             if _send_attempt < 2:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1729,6 +1729,19 @@ class TelegramAdapter(BasePlatformAdapter):
         s = str(exc).lower()
         return "unsupported" in s or "not implemented" in s
 
+    @staticmethod
+    def _chat_migrated_new_chat_id(exc: Exception) -> Optional[str]:
+        """Return Telegram's replacement chat id for a ChatMigrated error."""
+        try:
+            from telegram.error import ChatMigrated as _ChatMigrated
+        except (ImportError, AttributeError):
+            return None
+
+        if not isinstance(exc, _ChatMigrated):
+            return None
+        new_chat_id = getattr(exc, "new_chat_id", None)
+        return str(new_chat_id) if new_chat_id is not None else None
+
     def _compute_single_send_routing(
         self,
         chat_id: str,
@@ -1812,55 +1825,68 @@ class TelegramAdapter(BasePlatformAdapter):
             # quietly drop the reply anchor instead of erroring.
             payload["reply_parameters"] = {"message_id": reply_to_id}
 
-        try:
-            # Take the raw Bot API result (dict under real PTB). Passing
-            # return_type=Message would make PTB deserialize a Bot API 10.1
-            # response shape it does not fully model yet; a post-delivery parse
-            # error must not be mistaken for a sendable failure.
-            msg = await self._bot.do_api_request(
-                "sendRichMessage", api_kwargs=payload
-            )
-        except Exception as exc:
-            if self._is_rich_fallback_error(exc):
-                if self._is_rich_capability_error(exc):
-                    # Endpoint missing (old PTB/server) — latch rich off so
-                    # every later send doesn't pay a doomed extra roundtrip.
-                    self._rich_send_disabled = True
-                logger.debug(
-                    "[%s] sendRichMessage rejected (%s) — falling back to MarkdownV2",
-                    self.name, _redact_telegram_error_text(exc),
-                )
-                return None
-            # Transient / network / unknown: the request may have reached
-            # Telegram. Do NOT legacy-resend (duplicate risk); surface a
-            # failure with retry semantics mirroring the legacy send() except.
-            err_str = str(exc).lower()
+        for send_attempt in range(2):
             try:
-                from telegram.error import TimedOut as _TimedOut
-            except (ImportError, AttributeError):
-                _TimedOut = None
-            is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
-            is_connect_timeout = self._looks_like_connect_timeout(exc)
-            # Extract server-requested retry_after for flood control so the
-            # base retry layer honors Telegram's backoff instead of its own
-            # short exponential schedule.
-            _retry_after = getattr(exc, "retry_after", None)
-            if _retry_after is None:
-                import re as _re
-                _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
-                if _m:
-                    _retry_after = float(_m.group(1))
-            safe_error = _redact_telegram_error_text(exc)
-            logger.warning(
-                "[%s] sendRichMessage transient failure (no legacy resend): %s",
-                self.name, safe_error,
-            )
-            return SendResult(
-                success=False,
-                error=safe_error,
-                retryable=(is_connect_timeout or not is_timeout),
-                retry_after=_retry_after,
-            )
+                # Take the raw Bot API result (dict under real PTB). Passing
+                # return_type=Message would make PTB deserialize a Bot API 10.1
+                # response shape it does not fully model yet; a post-delivery parse
+                # error must not be mistaken for a sendable failure.
+                payload["chat_id"] = normalize_telegram_chat_id(chat_id)
+                msg = await self._bot.do_api_request(
+                    "sendRichMessage", api_kwargs=payload
+                )
+                break
+            except Exception as exc:
+                migrated_chat_id = self._chat_migrated_new_chat_id(exc)
+                if migrated_chat_id is not None and send_attempt == 0:
+                    logger.info(
+                        "[%s] Telegram chat migrated from %s to %s; retrying rich send",
+                        self.name,
+                        chat_id,
+                        migrated_chat_id,
+                    )
+                    chat_id = migrated_chat_id
+                    continue
+                if self._is_rich_fallback_error(exc):
+                    if self._is_rich_capability_error(exc):
+                        # Endpoint missing (old PTB/server) — latch rich off so
+                        # every later send doesn't pay a doomed extra roundtrip.
+                        self._rich_send_disabled = True
+                    logger.debug(
+                        "[%s] sendRichMessage rejected (%s) — falling back to MarkdownV2",
+                        self.name, _redact_telegram_error_text(exc),
+                    )
+                    return None
+                # Transient / network / unknown: the request may have reached
+                # Telegram. Do NOT legacy-resend (duplicate risk); surface a
+                # failure with retry semantics mirroring the legacy send() except.
+                err_str = str(exc).lower()
+                try:
+                    from telegram.error import TimedOut as _TimedOut
+                except (ImportError, AttributeError):
+                    _TimedOut = None
+                is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
+                is_connect_timeout = self._looks_like_connect_timeout(exc)
+                # Extract server-requested retry_after for flood control so the
+                # base retry layer honors Telegram's backoff instead of its own
+                # short exponential schedule.
+                _retry_after = getattr(exc, "retry_after", None)
+                if _retry_after is None:
+                    import re as _re
+                    _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
+                    if _m:
+                        _retry_after = float(_m.group(1))
+                safe_error = _redact_telegram_error_text(exc)
+                logger.warning(
+                    "[%s] sendRichMessage transient failure (no legacy resend): %s",
+                    self.name, safe_error,
+                )
+                return SendResult(
+                    success=False,
+                    error=safe_error,
+                    retryable=(is_connect_timeout or not is_timeout),
+                    retry_after=_retry_after,
+                )
 
         message_id = None
         if isinstance(msg, dict):
@@ -4489,6 +4515,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                 raise
                         break  # success
                     except _NetErr as send_err:
+                        migrated_chat_id = self._chat_migrated_new_chat_id(send_err)
+                        if migrated_chat_id is not None and _send_attempt == 0:
+                            logger.info(
+                                "[%s] Telegram chat migrated from %s to %s; retrying send",
+                                self.name,
+                                chat_id,
+                                migrated_chat_id,
+                            )
+                            chat_id = migrated_chat_id
+                            continue
                         # BadRequest is a subclass of NetworkError in
                         # python-telegram-bot but represents permanent errors
                         # (not transient network issues). Detect and handle
@@ -4591,6 +4627,16 @@ class TelegramAdapter(BasePlatformAdapter):
                         else:
                             raise
                     except Exception as send_err:
+                        migrated_chat_id = self._chat_migrated_new_chat_id(send_err)
+                        if migrated_chat_id is not None and _send_attempt == 0:
+                            logger.info(
+                                "[%s] Telegram chat migrated from %s to %s; retrying send",
+                                self.name,
+                                chat_id,
+                                migrated_chat_id,
+                            )
+                            chat_id = migrated_chat_id
+                            continue
                         retry_after = getattr(send_err, "retry_after", None)
                         if retry_after is not None or "retry after" in str(send_err).lower():
                             if _send_attempt < 2:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -44,6 +44,12 @@ class FakeTimedOut(FakeNetworkError):
     pass
 
 
+class FakeChatMigrated(FakeBadRequest):
+    def __init__(self, new_chat_id):
+        super().__init__(f"Group migrated to supergroup chat {new_chat_id}")
+        self.new_chat_id = new_chat_id
+
+
 class FakeRetryAfter(Exception):
     def __init__(self, seconds):
         super().__init__(f"Retry after {seconds}")
@@ -80,6 +86,7 @@ _fake_telegram.InputMediaPhoto = _FakeInputMediaPhoto
 _fake_telegram_error = types.ModuleType("telegram.error")
 _fake_telegram_error.NetworkError = FakeNetworkError
 _fake_telegram_error.BadRequest = FakeBadRequest
+_fake_telegram_error.ChatMigrated = FakeChatMigrated
 _fake_telegram_error.TimedOut = FakeTimedOut
 _fake_telegram.error = _fake_telegram_error
 _fake_telegram_constants = types.ModuleType("telegram.constants")
@@ -723,4 +730,48 @@ async def test_thread_fallback_only_fires_once():
     # was cleared per-chunk but the metadata doesn't change between chunks)
     # The key point: the message was delivered despite the invalid thread
 
+
+@pytest.mark.asyncio
+async def test_send_retries_with_new_chat_id_on_chat_migrated():
+    """Chat migration retries once with Telegram's replacement chat id."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeChatMigrated(-100456)
+        return SimpleNamespace(message_id=44)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(chat_id="-123", content="test message")
+
+    assert result.success is True
+    assert result.message_id == "44"
+    assert [call["chat_id"] for call in call_log] == [-123, -100456]
+
+
+@pytest.mark.asyncio
+async def test_rich_send_retries_with_new_chat_id_on_chat_migrated(monkeypatch):
+    """Rich sends retry the replacement id without falling back to legacy."""
+    adapter = _make_adapter()
+    adapter._rich_messages_enabled = True
+    call_log = []
+
+    async def mock_do_api_request(method, api_kwargs):
+        call_log.append((method, dict(api_kwargs)))
+        if len(call_log) == 1:
+            raise FakeChatMigrated(-100456)
+        return {"message_id": 45}
+
+    monkeypatch.setattr(adapter, "_should_attempt_rich", lambda content, metadata=None: True)
+    monkeypatch.setattr(adapter, "_bot_supports_rich", lambda: True)
+    adapter._bot = SimpleNamespace(do_api_request=mock_do_api_request)
+
+    result = await adapter.send(chat_id="-123", content="| a | b |\n| - | - |")
+
+    assert result.success is True
+    assert result.message_id == "45"
+    assert [payload["chat_id"] for _, payload in call_log] == [-123, -100456]
 


### PR DESCRIPTION
## Summary

- Recover from Telegram `ChatMigrated` errors in legacy and rich send paths.
- Retry once with Telegram's replacement chat ID.
- Add focused regression tests for both delivery paths.

## Problem

After a group migrates to a supergroup, Telegram rejects sends to the old chat ID and provides the replacement ID in the error.

## Validation

- `python -m pytest tests/gateway/test_telegram_thread_fallback.py -q` (22 passed)
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_thread_fallback.py`
