### PR TITLE
fix(discord): fix /skill command sync failure (HTTP 400 error 50035)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -713,7 +713,8 @@ class DiscordAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
+            extra = getattr(e, '_errors', None)
+            logger.warning("[%s] Slash command sync failed: %s | raw_errors=%s", self.name, e, extra, exc_info=True)
 
     async def _add_reaction(self, message: Any, emoji: str) -> bool:
         """Add an emoji reaction to a Discord message."""
@@ -1776,26 +1777,49 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # ── Helper: build a callback for a skill command key ──
             def _make_handler(_key: str):
-                @discord.app_commands.describe(args="Optional arguments for the skill")
+                @discord.app_commands.describe(args="Args")
                 async def _handler(interaction: discord.Interaction, args: str = ""):
                     await self._run_simple_slash(interaction, f"{_key} {args}".strip())
                 _handler.__name__ = f"skill_{_key.lstrip('/').replace('-', '_')}"
                 return _handler
 
-            # ── Uncategorized (root-level) skills → direct subcommands ──
-            for discord_name, description, cmd_key in uncategorized:
-                cmd = discord.app_commands.Command(
-                    name=discord_name,
-                    description=description or f"Run the {discord_name} skill",
-                    callback=_make_handler(cmd_key),
+            # Discord limits the total /skill command payload to 8000 bytes.
+            # With 90+ skills, full descriptions blow that limit.
+            # Use very short descriptions (≤45 chars) for skill subcommands.
+            def _clamp_desc(d: str) -> str:
+                return d[:42] + "..." if len(d) > 45 else d
+
+            # ── Uncategorized skills ──
+            # Discord forbids mixing direct subcommands with subcommand groups
+            # at the same level.  If categories exist, wrap uncategorized skills
+            # in an "other" subgroup; otherwise register them directly.
+            if uncategorized and categories:
+                other_group = discord.app_commands.Group(
+                    name="other",
+                    description="Other skills",
+                    parent=skill_group,
                 )
-                skill_group.add_command(cmd)
+                for discord_name, description, cmd_key in uncategorized:
+                    cmd = discord.app_commands.Command(
+                        name=discord_name,
+                        description=_clamp_desc(description or f"Run the {discord_name} skill"),
+                        callback=_make_handler(cmd_key),
+                    )
+                    other_group.add_command(cmd)
+            elif uncategorized:
+                for discord_name, description, cmd_key in uncategorized:
+                    cmd = discord.app_commands.Command(
+                        name=discord_name,
+                        description=_clamp_desc(description or f"Run the {discord_name} skill"),
+                        callback=_make_handler(cmd_key),
+                    )
+                    skill_group.add_command(cmd)
 
             # ── Category subcommand groups ──
             for cat_name in sorted(categories):
                 cat_desc = f"{cat_name.replace('-', ' ').title()} skills"
-                if len(cat_desc) > 100:
-                    cat_desc = cat_desc[:97] + "..."
+                if len(cat_desc) > 45:
+                    cat_desc = cat_desc[:42] + "..."
                 cat_group = discord.app_commands.Group(
                     name=cat_name,
                     description=cat_desc,
@@ -1804,7 +1828,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 for discord_name, description, cmd_key in categories[cat_name]:
                     cmd = discord.app_commands.Command(
                         name=discord_name,
-                        description=description or f"Run the {discord_name} skill",
+                        description=_clamp_desc(description or f"Run the {discord_name} skill"),
                         callback=_make_handler(cmd_key),
                     )
                     cat_group.add_command(cmd)


### PR DESCRIPTION
## Problem

`/skill` slash command sync fails on every gateway startup with HTTP 400 error code 50035 (`APPLICATION_COMMAND_TOO_LARGE` / `Invalid Form Body`) when skills are installed. Discord log shows:

```
CommandSyncFailure: Failed to upload commands to Discord (HTTP status 400, error code 50035)
In group 'skill' defined in module 'gateway.platforms.discord'
```

Three compounding bugs:

## Bug 1 — Mixed subcommands + subcommand groups at the same level

Discord forbids a `Group` from having both direct subcommands and nested subcommand groups simultaneously. When uncategorized skills (e.g. `dogfood`, `xlsx`) exist alongside category groups, the registration fails.

**Fix:** when uncategorized skills coexist with category groups, wrap uncategorized skills in an `other` subgroup so all children of `skill` are groups.

## Bug 2 — Command payload exceeds Discord's 8000-byte limit

With 90+ installed skills, the combined payload of command names + descriptions + `args` option descriptions exceeds Discord's 8000-byte per-command cap. The `args` option description `"Optional arguments for the skill"` (38 chars) repeated across 90 commands alone is ~3420 bytes.

**Fix:** clamp skill command and category descriptions to 45 chars; shorten `args` option description to `"Args"`.

## Bug 3 — Skill descriptions not clamped to Discord's 100-char limit

Category descriptions had a 100-char truncation guard, but skill command descriptions did not.

**Fix:** Added `_clamp_desc()` helper applied consistently to all skill and category descriptions.

## Bonus: improved error logging

Added `raw_errors=` to the sync failure log line so the actual Discord field-level error is visible without digging through discord.py internals.

## Tested on

- Hermes 0.9.0, 90 skills across 19 categories + 2 uncategorized
- Ubuntu 24.04, Discord bot with `applications.commands` scope