### PR TITLE
fix: clarify failed watch pattern notifications

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1191,12 +1191,33 @@ def _format_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[SYSTEM: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
+        text = None
+        try:
+            from tools.ansi_strip import strip_ansi
+            from tools.process_registry import process_registry
+
+            _session = process_registry.get(_sid)
+            if _session and getattr(_session, "exited", False) and getattr(_session, "exit_code", None) not in (None, 0):
+                _final = strip_ansi(getattr(_session, "output_buffer", "")[-2000:])
+                text = (
+                    f"[SYSTEM: Background process {_sid} matched "
+                    f"watch pattern \"{_pat}\", but the process exited with code "
+                    f"{_session.exit_code}.\n"
+                    f"Command: {_cmd}\n"
+                    f"Matched output:\n{_out}"
+                )
+                if _final and _final.strip() and _final.strip() != _out.strip():
+                    text += f"\nFinal output:\n{_final}"
+        except Exception:
+            text = None
+
+        if text is None:
+            text = (
+                f"[SYSTEM: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+                f"Command: {_cmd}\n"
+                f"Matched output:\n{_out}"
+            )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -495,12 +495,33 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[SYSTEM: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
+        text = None
+        try:
+            from tools.ansi_strip import strip_ansi
+            from tools.process_registry import process_registry
+
+            _session = process_registry.get(_sid)
+            if _session and getattr(_session, "exited", False) and getattr(_session, "exit_code", None) not in (None, 0):
+                _final = strip_ansi(getattr(_session, "output_buffer", "")[-2000:])
+                text = (
+                    f"[SYSTEM: Background process {_sid} matched "
+                    f"watch pattern \"{_pat}\", but the process exited with code "
+                    f"{_session.exit_code}.\n"
+                    f"Command: {_cmd}\n"
+                    f"Matched output:\n{_out}"
+                )
+                if _final and _final.strip() and _final.strip() != _out.strip():
+                    text += f"\nFinal output:\n{_final}"
+        except Exception:
+            text = None
+
+        if text is None:
+            text = (
+                f"[SYSTEM: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+                f"Command: {_cmd}\n"
+                f"Matched output:\n{_out}"
+            )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"

--- a/tests/tools/test_process_watch_notifications.py
+++ b/tests/tools/test_process_watch_notifications.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cli import _format_process_notification
+from gateway.run import _format_gateway_process_notification
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def reset_process_registry_get(monkeypatch):
+    monkeypatch.setattr(process_registry, "get", lambda _sid: None)
+
+
+def test_cli_watch_match_reports_failed_process_context(monkeypatch):
+    monkeypatch.setattr(
+        process_registry,
+        "get",
+        lambda _sid: SimpleNamespace(
+            exited=True,
+            exit_code=1,
+            output_buffer=(
+                "INFO:     Application startup complete.\n"
+                "ERROR:    [Errno 98] error while attempting to bind on address "
+                "('127.0.0.1', 18085): address already in use\n"
+            ),
+        ),
+    )
+    evt = {
+        "type": "watch_match",
+        "session_id": "proc_test",
+        "command": "python3 -m uvicorn app:app --port 18085",
+        "pattern": "Application startup complete",
+        "output": "INFO:     Application startup complete.",
+        "suppressed": 0,
+    }
+
+    text = _format_process_notification(evt)
+
+    assert "exited with code 1" in text
+    assert "address already in use" in text
+    assert "Matched output" in text
+    assert "Final output" in text
+
+
+def test_gateway_watch_match_reports_failed_process_context(monkeypatch):
+    monkeypatch.setattr(
+        process_registry,
+        "get",
+        lambda _sid: SimpleNamespace(
+            exited=True,
+            exit_code=1,
+            output_buffer="INFO:     Application startup complete.\nERROR: bind failed\n",
+        ),
+    )
+    evt = {
+        "type": "watch_match",
+        "session_id": "proc_test",
+        "command": "python3 -m uvicorn app:app --port 18085",
+        "pattern": "Application startup complete",
+        "output": "INFO:     Application startup complete.",
+        "suppressed": 0,
+    }
+
+    text = _format_gateway_process_notification(evt)
+
+    assert "exited with code 1" in text
+    assert "bind failed" in text
+    assert "Final output" in text


### PR DESCRIPTION
## Summary
- port the existing PAB-163 watch-notification fix onto a clean branch from `origin/main`
- clarify watch-pattern notifications when the matched process has already exited with a non-zero status
- add regression coverage for CLI and gateway formatting so failed startup matches include final error output

## Test Plan
- `PYTHONPATH=/tmp/pab163-reconcile pytest /tmp/pab163-reconcile/tests/tools/test_process_watch_notifications.py -q`

## Context
- Linear: PAB-163
- Verified existing implementation from local branch `fix/pab-163-watch-notification` and reconciled it into a clean shipping branch.