### PR TITLE
fix(terminal): prevent corrupted session snapshots during init

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -157,6 +157,22 @@ class TestInitSessionFailure:
 
         assert env._snapshot_ready is False
 
+    def test_snapshot_ready_false_on_nonzero_bootstrap_exit(self):
+        """A non-zero bootstrap result should trigger fallback mode."""
+        env = _TestableEnv()
+
+        def mock_run_bash(*args, **kwargs):
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 127
+            mock.stdout = iter([])
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+
+        assert env._snapshot_ready is False
+
     def test_login_flag_when_snapshot_not_ready(self):
         """When _snapshot_ready=False, execute() should pass login=True to _run_bash."""
         env = _TestableEnv()

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -141,6 +141,22 @@ class TestInitSessionFailure:
 
         assert env._snapshot_ready is False
 
+    def test_snapshot_ready_false_on_nonzero_bootstrap_exit(self):
+        """A non-zero bootstrap result should trigger fallback mode."""
+        env = _TestableEnv()
+
+        def mock_run_bash(*args, **kwargs):
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 127
+            mock.stdout = iter([])
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+
+        assert env._snapshot_ready is False
+
     def test_login_flag_when_snapshot_not_ready(self):
         """When _snapshot_ready=False, execute() should pass login=True to _run_bash."""
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -334,14 +334,17 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
-        # Full capture: env vars, functions (filtered), aliases, shell options.
+        # Full capture: env vars, functions, aliases, shell options.
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
         _quoted_cwd = shlex.quote(self.cwd)
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
+            # Avoid line-based filtering of function dumps. Grep can remove only
+            # function headers (e.g. names starting with "_") while leaving body
+            # lines behind, which corrupts the snapshot and breaks all commands.
+            f"declare -f >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"
@@ -353,6 +356,10 @@ class BaseEnvironment(ABC):
         try:
             proc = self._run_bash(bootstrap, login=True, timeout=self._snapshot_timeout)
             result = self._wait_for_process(proc, timeout=self._snapshot_timeout)
+            if int(result.get("returncode") or 0) != 0:
+                raise RuntimeError(
+                    f"snapshot bootstrap failed with exit code {result.get('returncode')}"
+                )
             self._snapshot_ready = True
             self._update_cwd(result)
             logger.info(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -293,10 +293,13 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
-        # Full capture: env vars, functions (filtered), aliases, shell options.
+        # Full capture: env vars, functions, aliases, shell options.
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
+            # Avoid line-based filtering of function dumps. Grep can remove only
+            # function headers (e.g. names starting with "_") while leaving body
+            # lines behind, which corrupts the snapshot and breaks all commands.
+            f"declare -f >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"
@@ -307,6 +310,10 @@ class BaseEnvironment(ABC):
         try:
             proc = self._run_bash(bootstrap, login=True, timeout=self._snapshot_timeout)
             result = self._wait_for_process(proc, timeout=self._snapshot_timeout)
+            if int(result.get("returncode") or 0) != 0:
+                raise RuntimeError(
+                    f"snapshot bootstrap failed with exit code {result.get('returncode')}"
+                )
             self._snapshot_ready = True
             self._update_cwd(result)
             logger.info(


### PR DESCRIPTION
## Summary
Fixes a terminal regression where commands can start returning exit code 127 after session init.

## Root Cause
init_session generated a snapshot with this command:
declare -f | grep -vE ^_[^_]

That line-based filter can remove a function header while leaving body lines behind, producing an invalid snapshot script. Once sourced, subsequent commands can fail unexpectedly.

## Changes
- Replace filtered function dump with declare -f directly (no line-based truncation).
- Treat non-zero bootstrap return code as snapshot init failure, so execution safely falls back to login-shell mode.
- Add a regression test asserting snapshot_ready remains false when bootstrap exits non-zero.

## Validation
- pytest tests/tools/test_base_environment.py -q
- Result: 16 passed
