### PR TITLE
fix(gateway): enrich /status with model, tokens, context bar, cost, duration

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -409,6 +409,8 @@ group_sessions_per_user: true
 # Stream tokens to messaging platforms in real-time. The bot sends a message
 # on first token, then progressively edits it as more tokens arrive.
 # Disabled by default — enable to try the streaming UX on Telegram/Discord/Slack.
+# Strongly recommended for Feishu/Lark — enables native CardKit streaming cards
+# with typewriter effect instead of progressive message edits.
 streaming:
   enabled: false
   # transport: edit           # "edit" = progressive editMessageText

--- a/cli.py
+++ b/cli.py
@@ -3666,57 +3666,67 @@ class HermesCLI:
         )
 
     def _show_session_status(self):
-        """Show gateway-style status for the current CLI session."""
+        """Show rich session status panel for the current CLI session."""
+        from rich.panel import Panel
+        from rich.text import Text
+
+        snap = self._get_status_bar_snapshot()
+
         session_meta = {}
         if self._session_db:
             try:
                 session_meta = self._session_db.get_session(self.session_id) or {}
             except Exception:
-                session_meta = {}
-
-        title = (session_meta.get("title") or "").strip()
-
-        created_at = self.session_start
-        started_at = session_meta.get("started_at")
-        if started_at:
-            try:
-                created_at = datetime.fromtimestamp(float(started_at))
-            except Exception:
-                created_at = self.session_start
-
-        updated_at = created_at
-        for field in ("updated_at", "last_updated_at", "last_activity_at"):
-            value = session_meta.get(field)
-            if not value:
-                continue
-            try:
-                updated_at = datetime.fromtimestamp(float(value))
-                break
-            except Exception:
                 pass
 
-        agent = getattr(self, "agent", None)
-        total_tokens = getattr(agent, "session_total_tokens", 0) or 0
+        title = (session_meta.get("title") or "").strip()
         provider = getattr(self, "provider", None) or "unknown"
-        model = getattr(self, "model", None) or "(unknown)"
-        is_running = bool(getattr(self, "_agent_running", False))
 
-        lines = [
-            "Hermes CLI Status",
-            "",
-            f"Session ID: {self.session_id}",
-            f"Path: {display_hermes_home()}",
-        ]
+        # Build context window bar (20 chars wide)
+        ctx_tokens = snap["context_tokens"]
+        ctx_length = snap["context_length"]
+        ctx_pct = snap["context_percent"]
+        if ctx_length:
+            bar_width = 20
+            filled = round(bar_width * (ctx_pct or 0) / 100)
+            bar = "█" * filled + "░" * (bar_width - filled)
+            ctx_str = f"{ctx_tokens:,} / {ctx_length:,}  [{bar}] {ctx_pct}%"
+        else:
+            ctx_str = f"{ctx_tokens:,} (limit unknown)"
+
+        t = Text()
+
+        def row(label: str, value: str, label_style: str = "bold cyan", value_style: str = "") -> None:
+            t.append(f"  {label:<18}", style=label_style)
+            t.append(f"{value}\n", style=value_style)
+
         if title:
-            lines.append(f"Title: {title}")
-        lines.extend([
-            f"Model: {model} ({provider})",
-            f"Created: {created_at.strftime('%Y-%m-%d %H:%M')}",
-            f"Last Activity: {updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"Tokens: {total_tokens:,}",
-            f"Agent Running: {'Yes' if is_running else 'No'}",
-        ])
-        self.console.print("\n".join(lines), highlight=False, markup=False)
+            t.append(f"  {title}\n", style="bold white")
+            t.append("\n")
+
+        row("Session ID", self.session_id, value_style="dim")
+        row("Provider / Model", f"{provider}  ·  {snap['model_short']}")
+        t.append("\n")
+
+        row("Duration", snap["duration"])
+        row("API Calls", str(snap["session_api_calls"]))
+        row("Compressions", str(snap["compressions"]))
+        t.append("\n")
+
+        inp = snap["session_input_tokens"]
+        out = snap["session_output_tokens"]
+        total = snap["session_total_tokens"]
+        row("Tokens  in/out", f"{inp:,}  /  {out:,}  (total {total:,})")
+        row("Context window", ctx_str)
+
+        self.console.print(Panel(
+            t,
+            title="[bold cyan]Session Status[/]",
+            title_align="left",
+            border_style="cyan",
+            box=rich_box.HORIZONTALS,
+            padding=(0, 1),
+        ))
     
     def _fast_command_available(self) -> bool:
         try:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -69,6 +69,22 @@ try:
         UpdateMessageRequestBody,
     )
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+    from lark_oapi.event.callback.model.p2_card_action_trigger import P2CardActionTriggerResponse
+    from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
+    from lark_oapi.ws import Client as FeishuWSClient
+
+    FEISHU_AVAILABLE = True
+except ImportError:
+    FEISHU_AVAILABLE = False
+    lark = None  # type: ignore[assignment]
+    P2CardActionTriggerResponse = None  # type: ignore[assignment]
+    EventDispatcherHandler = None  # type: ignore[assignment]
+    FeishuWSClient = None  # type: ignore[assignment]
+    FEISHU_DOMAIN = None  # type: ignore[assignment]
+
+# CardKit imports are separated so that an older lark_oapi without cardkit.v1
+# doesn't break the entire Feishu adapter — only streaming cards are disabled.
+try:
     from lark_oapi.api.cardkit.v1 import (
         CreateCardRequest,
         CreateCardRequestBody,
@@ -77,27 +93,16 @@ try:
         SettingsCardRequest,
         SettingsCardRequestBody,
     )
-    from lark_oapi.event.callback.model.p2_card_action_trigger import P2CardActionTriggerResponse
-    from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
-    from lark_oapi.ws import Client as FeishuWSClient
 
-    FEISHU_AVAILABLE = True
     FEISHU_CARDKIT_AVAILABLE = True
 except ImportError:
-    FEISHU_AVAILABLE = False
     FEISHU_CARDKIT_AVAILABLE = False
-    lark = None  # type: ignore[assignment]
     CreateCardRequest = None  # type: ignore[assignment]
     CreateCardRequestBody = None  # type: ignore[assignment]
     ContentCardElementRequest = None  # type: ignore[assignment]
     ContentCardElementRequestBody = None  # type: ignore[assignment]
     SettingsCardRequest = None  # type: ignore[assignment]
     SettingsCardRequestBody = None  # type: ignore[assignment]
-    P2CardActionTriggerResponse = None  # type: ignore[assignment]
-    EventDispatcherHandler = None  # type: ignore[assignment]
-    FeishuWSClient = None  # type: ignore[assignment]
-    FEISHU_DOMAIN = None  # type: ignore[assignment]
-    LARK_DOMAIN = None  # type: ignore[assignment]
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
@@ -1577,7 +1582,7 @@ class FeishuAdapter(BasePlatformAdapter):
         Returns *True* on success.  Safe to call even if the message is not a
         streaming card (returns *True* immediately).
         """
-        sc = self._streaming_cards.pop(message_id, None)
+        sc = self._streaming_cards.get(message_id)
         if sc is None:
             return True
         if not self._client:
@@ -1601,6 +1606,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._client.cardkit.v1.card.settings, req,
             )
             if resp and resp.code == 0:
+                self._streaming_cards.pop(message_id, None)
                 logger.debug("[Feishu] Stopped streaming card %s", sc.card_id)
                 return True
             logger.warning("[Feishu] Failed to stop streaming card %s: code=%s msg=%s",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -69,14 +69,30 @@ try:
         UpdateMessageRequestBody,
     )
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+    from lark_oapi.api.cardkit.v1 import (
+        CreateCardRequest,
+        CreateCardRequestBody,
+        ContentCardElementRequest,
+        ContentCardElementRequestBody,
+        SettingsCardRequest,
+        SettingsCardRequestBody,
+    )
     from lark_oapi.event.callback.model.p2_card_action_trigger import P2CardActionTriggerResponse
     from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
     from lark_oapi.ws import Client as FeishuWSClient
 
     FEISHU_AVAILABLE = True
+    FEISHU_CARDKIT_AVAILABLE = True
 except ImportError:
     FEISHU_AVAILABLE = False
+    FEISHU_CARDKIT_AVAILABLE = False
     lark = None  # type: ignore[assignment]
+    CreateCardRequest = None  # type: ignore[assignment]
+    CreateCardRequestBody = None  # type: ignore[assignment]
+    ContentCardElementRequest = None  # type: ignore[assignment]
+    ContentCardElementRequestBody = None  # type: ignore[assignment]
+    SettingsCardRequest = None  # type: ignore[assignment]
+    SettingsCardRequestBody = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
     EventDispatcherHandler = None  # type: ignore[assignment]
     FeishuWSClient = None  # type: ignore[assignment]
@@ -169,6 +185,14 @@ _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup win
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 _FEISHU_ACK_EMOJI = "OK"
+# ---------------------------------------------------------------------------
+# Streaming card constants
+# ---------------------------------------------------------------------------
+
+_STREAMING_CARD_ELEMENT_ID = "streaming_md_1"
+_STREAMING_CARD_PRINT_FREQUENCY_MS = 50
+_STREAMING_CARD_PRINT_STEP = 2
+_STREAMING_CARD_PRINT_STRATEGY = "fast"
 # ---------------------------------------------------------------------------
 # Fallback display strings
 # ---------------------------------------------------------------------------
@@ -293,6 +317,16 @@ class FeishuBatchState:
     events: Dict[str, MessageEvent] = field(default_factory=dict)
     tasks: Dict[str, asyncio.Task] = field(default_factory=dict)
     counts: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class _FeishuStreamingCard:
+    """Tracks state for a single streaming card session."""
+
+    card_id: str
+    element_id: str
+    message_id: str
+    sequence: int = 1  # Strictly increasing across all card operations
 
 
 # ---------------------------------------------------------------------------
@@ -1056,6 +1090,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
+        # CardKit streaming card state (message_id → _FeishuStreamingCard)
+        self._streaming_cards: Dict[str, _FeishuStreamingCard] = {}
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1372,10 +1408,21 @@ class FeishuAdapter(BasePlatformAdapter):
         message_id: str,
         content: str,
     ) -> SendResult:
-        """Edit a previously sent Feishu text/post message."""
+        """Edit a previously sent Feishu text/post message.
+
+        If the *message_id* is associated with an active streaming card
+        (created via :meth:`send_streaming_card`), the edit is performed via
+        the CardKit streaming text update API instead of the regular IM update.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # --- CardKit streaming card path ---
+        sc = self._streaming_cards.get(message_id)
+        if sc is not None:
+            return await self._update_streaming_card_content(sc, content)
+
+        # --- Regular IM update path ---
         try:
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
@@ -1397,6 +1444,196 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    # =========================================================================
+    # CardKit streaming card support
+    # =========================================================================
+
+    @property
+    def streaming_cards_enabled(self) -> bool:
+        """Return *True* if the CardKit streaming API is usable."""
+        return bool(FEISHU_CARDKIT_AVAILABLE and self._client)
+
+    async def send_streaming_card(
+        self,
+        chat_id: str,
+        content: str = "",
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Create a streaming card entity and send it as a message.
+
+        Returns a :class:`SendResult` whose *message_id* can be used with
+        :meth:`edit_message` (which will route through the CardKit streaming
+        text update API) and finally :meth:`stop_streaming_card`.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        if not FEISHU_CARDKIT_AVAILABLE:
+            return SendResult(success=False, error="CardKit SDK not available")
+
+        try:
+            # 1. Create card entity with streaming_mode enabled
+            card_json = self._build_streaming_card_json(content)
+            create_body = (
+                CreateCardRequestBody.builder()
+                .type("card_json")
+                .data(json.dumps(card_json, ensure_ascii=False))
+                .build()
+            )
+            create_req = (
+                CreateCardRequest.builder()
+                .request_body(create_body)
+                .build()
+            )
+            create_resp = await asyncio.to_thread(
+                self._client.cardkit.v1.card.create, create_req,
+            )
+            if not create_resp or create_resp.code != 0:
+                err_msg = getattr(create_resp, "msg", "unknown error") if create_resp else "no response"
+                logger.warning("[Feishu] CardKit card.create failed: code=%s msg=%s",
+                               getattr(create_resp, "code", "?"), err_msg)
+                return SendResult(success=False, error=f"CardKit create failed: {err_msg}")
+
+            card_id = create_resp.data.card_id
+            logger.debug("[Feishu] Created streaming card: %s", card_id)
+
+            # 2. Send the card as a message via IM API
+            card_content = json.dumps(
+                {"type": "card", "data": {"card_id": card_id}},
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=card_content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send streaming card failed")
+            if not result.success:
+                return result
+
+            message_id = result.message_id
+            # 3. Track the streaming card state
+            sc = _FeishuStreamingCard(
+                card_id=card_id,
+                element_id=_STREAMING_CARD_ELEMENT_ID,
+                message_id=message_id,
+                sequence=1,
+            )
+            self._streaming_cards[message_id] = sc
+            logger.debug("[Feishu] Streaming card %s linked to message %s", card_id, message_id)
+            return result
+
+        except Exception as exc:
+            logger.error("[Feishu] send_streaming_card error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def _update_streaming_card_content(
+        self,
+        sc: "_FeishuStreamingCard",
+        content: str,
+    ) -> SendResult:
+        """Push a streaming text update to a card element.
+
+        *content* should be the **full accumulated text** — the Feishu platform
+        diffs it against the previous value and renders the delta with a
+        typewriter effect.
+        """
+        try:
+            sc.sequence += 1
+            body = (
+                ContentCardElementRequestBody.builder()
+                .uuid(str(uuid.uuid4()))
+                .sequence(sc.sequence)
+                .content(content)
+                .build()
+            )
+            req = (
+                ContentCardElementRequest.builder()
+                .card_id(sc.card_id)
+                .element_id(sc.element_id)
+                .request_body(body)
+                .build()
+            )
+            resp = await asyncio.to_thread(
+                self._client.cardkit.v1.card_element.content, req,
+            )
+            if resp and resp.code == 0:
+                return SendResult(success=True, message_id=sc.message_id)
+            err_msg = getattr(resp, "msg", "unknown") if resp else "no response"
+            logger.warning("[Feishu] Streaming card content update failed: code=%s msg=%s",
+                           getattr(resp, "code", "?"), err_msg)
+            return SendResult(success=False, error=f"streaming update failed: {err_msg}")
+        except Exception as exc:
+            logger.error("[Feishu] _update_streaming_card_content error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def stop_streaming_card(self, message_id: str) -> bool:
+        """Disable streaming mode on a card and clean up tracking state.
+
+        Returns *True* on success.  Safe to call even if the message is not a
+        streaming card (returns *True* immediately).
+        """
+        sc = self._streaming_cards.pop(message_id, None)
+        if sc is None:
+            return True
+        if not self._client:
+            return False
+        try:
+            sc.sequence += 1
+            settings_json = json.dumps({"config": {"streaming_mode": False}}, ensure_ascii=False)
+            body = (
+                SettingsCardRequestBody.builder()
+                .settings(settings_json)
+                .sequence(sc.sequence)
+                .build()
+            )
+            req = (
+                SettingsCardRequest.builder()
+                .card_id(sc.card_id)
+                .request_body(body)
+                .build()
+            )
+            resp = await asyncio.to_thread(
+                self._client.cardkit.v1.card.settings, req,
+            )
+            if resp and resp.code == 0:
+                logger.debug("[Feishu] Stopped streaming card %s", sc.card_id)
+                return True
+            logger.warning("[Feishu] Failed to stop streaming card %s: code=%s msg=%s",
+                           sc.card_id, getattr(resp, "code", "?"), getattr(resp, "msg", "?"))
+            return False
+        except Exception as exc:
+            logger.error("[Feishu] stop_streaming_card error: %s", exc, exc_info=True)
+            return False
+
+    @staticmethod
+    def _build_streaming_card_json(initial_content: str = "") -> dict:
+        """Build a Card JSON 2.0 structure with streaming mode enabled."""
+        return {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": ""},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": _STREAMING_CARD_PRINT_FREQUENCY_MS},
+                    "print_step": {"default": _STREAMING_CARD_PRINT_STEP},
+                    "print_strategy": _STREAMING_CARD_PRINT_STRATEGY,
+                },
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": initial_content,
+                        "element_id": _STREAMING_CARD_ELEMENT_ID,
+                    }
+                ],
+            },
+        }
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4383,15 +4383,28 @@ class GatewayRunner:
         return "\n".join(lines)
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
-        """Handle /status command."""
+        """Handle /status command — rich session panel matching CLI view."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
 
         connected_platforms = [p.value for p in self.adapters.keys()]
 
-        # Check if there's an active agent
         session_key = session_entry.session_key
         is_running = session_key in self._running_agents
+
+        # Try to get the live agent for richer stats
+        agent = self._running_agents.get(session_key)
+        if agent is _AGENT_PENDING_SENTINEL:
+            agent = None
+        if agent is None:
+            # Check the completed-agent cache
+            try:
+                _cache = getattr(self, "_recent_agents", {})
+                cached = _cache.get(session_key)
+                if cached:
+                    agent = cached[0]
+            except Exception:
+                pass
 
         title = None
         if self._session_db:
@@ -4400,21 +4413,98 @@ class GatewayRunner:
             except Exception:
                 title = None
 
-        lines = [
-            "📊 **Hermes Gateway Status**",
-            "",
-            f"**Session ID:** `{session_entry.session_id}`",
-        ]
+        lines = ["📊 **Session Status**", ""]
+
+        # Session identity
+        lines.append(f"**Session ID:** `{session_entry.session_id}`")
         if title:
             lines.append(f"**Title:** {title}")
-        lines.extend([
-            f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
-            f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
-            "",
-            f"**Connected Platforms:** {', '.join(connected_platforms)}",
-        ])
+
+        # Model / provider
+        if agent:
+            provider = getattr(agent, "provider", None) or "unknown"
+            model = getattr(agent, "model", None) or "unknown"
+            lines.append(f"**Provider / Model:** {provider}  ·  {model}")
+
+        lines.append("")
+
+        # Timing
+        created = session_entry.created_at.strftime("%Y-%m-%d %H:%M")
+        updated = session_entry.updated_at.strftime("%Y-%m-%d %H:%M")
+        lines.append(f"**Created:** {created}")
+        lines.append(f"**Last Activity:** {updated}")
+
+        if agent:
+            session_start = getattr(agent, "session_start", None)
+            if session_start:
+                from datetime import datetime as _dt
+                elapsed = _dt.now() - session_start
+                total_sec = int(elapsed.total_seconds())
+                hours, rem = divmod(total_sec, 3600)
+                mins = rem // 60
+                if hours:
+                    dur = f"{hours}h {mins}m" if mins else f"{hours}h"
+                elif mins:
+                    dur = f"{mins}m"
+                else:
+                    dur = f"{total_sec}s"
+                lines.append(f"**Duration:** {dur}")
+            api_calls = getattr(agent, "session_api_calls", 0)
+            lines.append(f"**API Calls:** {api_calls}")
+            compressions = getattr(agent.context_compressor, "compression_count", 0) if hasattr(agent, "context_compressor") else 0
+            if compressions:
+                lines.append(f"**Compressions:** {compressions}")
+
+        lines.append("")
+
+        # Token breakdown
+        if agent and hasattr(agent, "session_total_tokens"):
+            inp = getattr(agent, "session_input_tokens", 0) or 0
+            out = getattr(agent, "session_output_tokens", 0) or 0
+            total = getattr(agent, "session_total_tokens", 0) or 0
+            cache_read = getattr(agent, "session_cache_read_tokens", 0) or 0
+            cache_write = getattr(agent, "session_cache_write_tokens", 0) or 0
+            lines.append(f"**Tokens in / out:** {inp:,}  /  {out:,}  (total {total:,})")
+            if cache_read or cache_write:
+                lines.append(f"**Cache read / write:** {cache_read:,}  /  {cache_write:,}")
+
+            # Context window bar
+            ctx_len = getattr(agent.context_compressor, "context_length", 0) if hasattr(agent, "context_compressor") else 0
+            if ctx_len:
+                ctx_tokens = inp + cache_read
+                pct = min(100, round(ctx_tokens / ctx_len * 100))
+                bar_width = 20
+                filled = round(bar_width * pct / 100)
+                bar = "█" * filled + "░" * (bar_width - filled)
+                lines.append(f"**Context window:** {ctx_tokens:,} / {ctx_len:,}  [{bar}] {pct}%")
+
+            # Cost estimate
+            try:
+                from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+                cost_result = estimate_usage_cost(
+                    agent.model,
+                    CanonicalUsage(
+                        input_tokens=inp,
+                        output_tokens=out,
+                        cache_read_tokens=cache_read,
+                        cache_write_tokens=cache_write,
+                    ),
+                    provider=getattr(agent, "provider", None),
+                    base_url=getattr(agent, "base_url", None),
+                )
+                if cost_result.amount_usd is not None:
+                    prefix = "~" if cost_result.status == "estimated" else ""
+                    lines.append(f"**Cost:** {prefix}${float(cost_result.amount_usd):.4f}")
+                elif cost_result.status == "included":
+                    lines.append("**Cost:** included")
+            except Exception:
+                pass
+        else:
+            lines.append(f"**Tokens:** {session_entry.total_tokens:,}")
+
+        lines.append("")
+        lines.append(f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}")
+        lines.append(f"**Connected Platforms:** {', '.join(connected_platforms)}")
 
         return "\n".join(lines)
     

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -76,6 +76,8 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # Feishu CardKit streaming card support
+        self._uses_streaming_card = getattr(adapter, "streaming_cards_enabled", False) is True
 
     @property
     def already_sent(self) -> bool:
@@ -154,11 +156,13 @@ class GatewayStreamConsumer:
                             # remaining continuation without dropping content.
                             break
                         self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                        # Stop the current streaming card before starting a new one
+                        await self._stop_streaming_card_if_active()
                         self._message_id = None
                         self._last_sent_text = ""
 
                     display_text = self._accumulated
-                    if not got_done and not got_segment_break:
+                    if not got_done and not got_segment_break and not self._uses_streaming_card:
                         display_text += self.cfg.cursor
 
                     await self._send_or_edit(display_text)
@@ -176,6 +180,8 @@ class GatewayStreamConsumer:
                             await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             await self._send_or_edit(self._accumulated)
+                    # Finalize any active streaming card
+                    await self._stop_streaming_card_if_active()
                     return
 
                 # Tool boundary: the should_edit block above already flushed
@@ -183,6 +189,7 @@ class GatewayStreamConsumer:
                 # text chunk creates a fresh message below any tool-progress
                 # messages the gateway sent in between.
                 if got_segment_break:
+                    await self._stop_streaming_card_if_active()
                     self._message_id = None
                     self._accumulated = ""
                     self._last_sent_text = ""
@@ -198,8 +205,16 @@ class GatewayStreamConsumer:
                     await self._send_or_edit(self._accumulated)
                 except Exception:
                     pass
+            try:
+                await self._stop_streaming_card_if_active()
+            except Exception:
+                pass
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
+            try:
+                await self._stop_streaming_card_if_active()
+            except Exception:
+                pass
 
     # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
     # Matches the simple cleanup regex used by the non-streaming path in
@@ -344,11 +359,18 @@ class GatewayStreamConsumer:
                     pass
             else:
                 # First message — send new
-                result = await self.adapter.send(
-                    chat_id=self.chat_id,
-                    content=text,
-                    metadata=self.metadata,
-                )
+                if self._uses_streaming_card:
+                    result = await self.adapter.send_streaming_card(
+                        chat_id=self.chat_id,
+                        content=text,
+                        metadata=self.metadata,
+                    )
+                else:
+                    result = await self.adapter.send(
+                        chat_id=self.chat_id,
+                        content=text,
+                        metadata=self.metadata,
+                    )
                 if result.success and result.message_id:
                     self._message_id = result.message_id
                     self._already_sent = True
@@ -369,3 +391,10 @@ class GatewayStreamConsumer:
                     self._edit_supported = False
         except Exception as e:
             logger.error("Stream send/edit error: %s", e)
+
+    async def _stop_streaming_card_if_active(self) -> None:
+        """Stop the streaming card if the adapter supports it and one is active."""
+        if self._uses_streaming_card and self._message_id is not None:
+            stop_fn = getattr(self.adapter, "stop_streaming_card", None)
+            if stop_fn is not None:
+                await stop_fn(self._message_id)

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -17,6 +17,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# lark_oapi is an optional dependency (hermes-agent[feishu]) — skip the entire
+# module when it is not installed so CI doesn't fail in minimal environments.
+pytest.importorskip("lark_oapi", reason="lark_oapi not installed — skipping Feishu streaming card tests")
+
 
 @patch.dict(os.environ, {}, clear=True)
 class TestBuildStreamingCardJson(unittest.TestCase):

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -1,0 +1,421 @@
+"""Tests for Feishu CardKit streaming card support.
+
+Covers:
+- send_streaming_card(): card creation + message send + state tracking
+- edit_message() routing to CardKit streaming API for active cards
+- stop_streaming_card(): finalization + state cleanup
+- _build_streaming_card_json(): card JSON structure
+- GatewayStreamConsumer integration with streaming cards
+"""
+
+import asyncio
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestBuildStreamingCardJson(unittest.TestCase):
+    """Test the static card JSON builder."""
+
+    def test_card_json_has_streaming_mode_enabled(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_streaming_card_json("")
+        assert card["schema"] == "2.0"
+        assert card["config"]["streaming_mode"] is True
+
+    def test_card_json_has_streaming_config(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_streaming_card_json("")
+        sc = card["config"]["streaming_config"]
+        assert "print_frequency_ms" in sc
+        assert "print_step" in sc
+        assert sc["print_strategy"] in ("fast", "delay")
+
+    def test_card_json_has_markdown_element_with_id(self):
+        from gateway.platforms.feishu import FeishuAdapter, _STREAMING_CARD_ELEMENT_ID
+
+        card = FeishuAdapter._build_streaming_card_json("hello")
+        elements = card["body"]["elements"]
+        assert len(elements) == 1
+        assert elements[0]["tag"] == "markdown"
+        assert elements[0]["content"] == "hello"
+        assert elements[0]["element_id"] == _STREAMING_CARD_ELEMENT_ID
+
+    def test_card_json_default_empty_content(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_streaming_card_json()
+        assert card["body"]["elements"][0]["content"] == ""
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestSendStreamingCard(unittest.TestCase):
+    """Test send_streaming_card flow."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        return adapter
+
+    def _mock_cardkit_and_im(self, adapter, card_id="card_123", message_id="om_456"):
+        """Wire up mock client with cardkit + im APIs."""
+        captured = {"cardkit_create": None, "im_create": None}
+
+        class _CardAPI:
+            def create(self, request):
+                captured["cardkit_create"] = request
+                return SimpleNamespace(
+                    code=0,
+                    msg="success",
+                    data=SimpleNamespace(card_id=card_id),
+                )
+
+            def settings(self, request):
+                captured["cardkit_settings"] = request
+                return SimpleNamespace(code=0, msg="success")
+
+        class _CardElementAPI:
+            def content(self, request):
+                captured["cardkit_content"] = request
+                return SimpleNamespace(code=0, msg="success")
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["im_create"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id=message_id),
+                )
+
+            def update(self, request):
+                captured["im_update"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(
+                v1=SimpleNamespace(
+                    card=_CardAPI(),
+                    card_element=_CardElementAPI(),
+                )
+            ),
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            ),
+        )
+        return captured
+
+    def test_send_streaming_card_creates_card_and_sends_message(self):
+        adapter = self._make_adapter()
+        captured = self._mock_cardkit_and_im(adapter)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send_streaming_card(
+                    chat_id="oc_chat",
+                    content="initial",
+                )
+            )
+
+        assert result.success
+        assert result.message_id == "om_456"
+        # Card entity was created
+        assert captured["cardkit_create"] is not None
+        create_body = captured["cardkit_create"].request_body
+        assert create_body.type == "card_json"
+        card_data = json.loads(create_body.data)
+        assert card_data["config"]["streaming_mode"] is True
+        assert card_data["body"]["elements"][0]["content"] == "initial"
+        # Message was sent with card_id reference
+        assert captured["im_create"] is not None
+        im_content = json.loads(captured["im_create"].request_body.content)
+        assert im_content["type"] == "card"
+        assert im_content["data"]["card_id"] == "card_123"
+        # Streaming card state is tracked
+        assert "om_456" in adapter._streaming_cards
+        sc = adapter._streaming_cards["om_456"]
+        assert sc.card_id == "card_123"
+        assert sc.sequence == 1
+
+    def test_send_streaming_card_fails_when_not_connected(self):
+        adapter = self._make_adapter()
+        adapter._client = None
+        result = asyncio.run(
+            adapter.send_streaming_card(chat_id="oc_chat", content="test")
+        )
+        assert not result.success
+        assert "Not connected" in result.error
+
+    def test_send_streaming_card_fails_on_card_create_error(self):
+        adapter = self._make_adapter()
+
+        class _CardAPI:
+            def create(self, request):
+                return SimpleNamespace(code=300001, msg="invalid card data", data=None)
+
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(
+                v1=SimpleNamespace(card=_CardAPI())
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send_streaming_card(chat_id="oc_chat", content="test")
+            )
+        assert not result.success
+        assert "CardKit create failed" in result.error
+
+    def test_edit_message_routes_to_streaming_card_when_active(self):
+        adapter = self._make_adapter()
+        captured = self._mock_cardkit_and_im(adapter)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            # First create the streaming card
+            asyncio.run(adapter.send_streaming_card(chat_id="oc_chat"))
+            # Now edit — should go through CardKit streaming API
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_456",
+                    content="streamed text update",
+                )
+            )
+
+        assert result.success
+        assert result.message_id == "om_456"
+        # Verify CardKit content API was called
+        content_req = captured["cardkit_content"]
+        assert content_req.card_id == "card_123"
+        assert content_req.request_body.content == "streamed text update"
+        assert content_req.request_body.sequence == 2  # incremented from 1
+
+    def test_edit_message_falls_through_to_regular_path_when_no_streaming_card(self):
+        adapter = self._make_adapter()
+        captured = self._mock_cardkit_and_im(adapter)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_regular",
+                    content="regular edit",
+                )
+            )
+
+        assert result.success
+        # Should have used IM update, not CardKit
+        assert captured.get("cardkit_content") is None
+
+    def test_stop_streaming_card_disables_streaming_mode(self):
+        adapter = self._make_adapter()
+        captured = self._mock_cardkit_and_im(adapter)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            # Create streaming card first
+            asyncio.run(adapter.send_streaming_card(chat_id="oc_chat"))
+            assert "om_456" in adapter._streaming_cards
+
+            # Stop streaming
+            ok = asyncio.run(adapter.stop_streaming_card("om_456"))
+
+        assert ok is True
+        # State is cleaned up
+        assert "om_456" not in adapter._streaming_cards
+        # Settings API was called
+        settings_req = captured["cardkit_settings"]
+        assert settings_req.card_id == "card_123"
+        settings_json = json.loads(settings_req.request_body.settings)
+        assert settings_json["config"]["streaming_mode"] is False
+
+    def test_stop_streaming_card_noop_for_unknown_message(self):
+        adapter = self._make_adapter()
+        adapter._client = SimpleNamespace()  # minimal mock
+        ok = asyncio.run(adapter.stop_streaming_card("om_unknown"))
+        assert ok is True
+
+    def test_streaming_cards_enabled_property(self):
+        from gateway.platforms.feishu import FEISHU_CARDKIT_AVAILABLE
+
+        adapter = self._make_adapter()
+        adapter._client = None
+        assert adapter.streaming_cards_enabled is False
+
+        adapter._client = SimpleNamespace()
+        expected = bool(FEISHU_CARDKIT_AVAILABLE)
+        assert adapter.streaming_cards_enabled == expected
+
+    def test_sequence_increments_across_operations(self):
+        adapter = self._make_adapter()
+        captured = self._mock_cardkit_and_im(adapter)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            asyncio.run(adapter.send_streaming_card(chat_id="oc_chat"))
+            # Do multiple updates
+            asyncio.run(adapter.edit_message("oc_chat", "om_456", "text 1"))
+            asyncio.run(adapter.edit_message("oc_chat", "om_456", "text 2"))
+            asyncio.run(adapter.edit_message("oc_chat", "om_456", "text 3"))
+            # Stop
+            asyncio.run(adapter.stop_streaming_card("om_456"))
+
+        # sequence should have been: 1 (create) → 2,3,4 (updates) → 5 (stop)
+        assert captured["cardkit_settings"].request_body.sequence == 5
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestStreamConsumerFeishuIntegration:
+    """Test GatewayStreamConsumer with Feishu streaming cards."""
+
+    @pytest.mark.asyncio
+    async def test_consumer_uses_streaming_card_when_enabled(self):
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = AsyncMock()
+        adapter.streaming_cards_enabled = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_card.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.edit_message.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.stop_streaming_card.return_value = True
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="oc_test",
+            config=StreamConsumerConfig(edit_interval=0.01),
+        )
+
+        assert consumer._uses_streaming_card is True
+
+        consumer.on_delta("Hello ")
+        consumer.on_delta("World!")
+        consumer.finish()
+        await consumer.run()
+
+        # Should have used send_streaming_card, not send
+        adapter.send_streaming_card.assert_called()
+        adapter.send.assert_not_called()
+        # Should have called stop_streaming_card at the end
+        adapter.stop_streaming_card.assert_called_once_with("om_stream")
+
+    @pytest.mark.asyncio
+    async def test_consumer_does_not_add_cursor_for_streaming_cards(self):
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = AsyncMock()
+        adapter.streaming_cards_enabled = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_card.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.edit_message.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.stop_streaming_card.return_value = True
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="oc_test",
+            config=StreamConsumerConfig(edit_interval=0.01, cursor=" ▌"),
+        )
+
+        consumer.on_delta("Hello")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await consumer.run()
+
+        # Verify cursor was NOT added to any call
+        for call in adapter.edit_message.call_args_list:
+            content = call.kwargs.get("content", call.args[2] if len(call.args) > 2 else "")
+            assert "▌" not in content
+
+    @pytest.mark.asyncio
+    async def test_consumer_falls_back_when_streaming_not_enabled(self):
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = AsyncMock()
+        adapter.streaming_cards_enabled = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send.return_value = SimpleNamespace(
+            success=True, message_id="om_regular"
+        )
+        adapter.edit_message.return_value = SimpleNamespace(
+            success=True, message_id="om_regular"
+        )
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="oc_test",
+            config=StreamConsumerConfig(edit_interval=0.01),
+        )
+
+        assert consumer._uses_streaming_card is False
+
+        consumer.on_delta("Hello")
+        consumer.finish()
+        await consumer.run()
+
+        # Should use regular send, not streaming card
+        adapter.send.assert_called()
+        adapter.send_streaming_card.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_consumer_stops_streaming_card_on_segment_break(self):
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = AsyncMock()
+        adapter.streaming_cards_enabled = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_card.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.edit_message.return_value = SimpleNamespace(
+            success=True, message_id="om_stream"
+        )
+        adapter.stop_streaming_card.return_value = True
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="oc_test",
+            config=StreamConsumerConfig(edit_interval=0.01),
+        )
+
+        consumer.on_delta("First segment")
+        await asyncio.sleep(0.05)
+        consumer.on_delta(None)  # Tool boundary / segment break
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await consumer.run()
+
+        # Should have called stop at least once for the segment break
+        assert adapter.stop_streaming_card.call_count >= 1

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -249,13 +249,32 @@ File upload routing is automatic based on extension:
 - `.pdf`, `.doc(x)`, `.xls(x)`, `.ppt(x)` → uploaded with their document type
 - Everything else → uploaded as a generic stream file
 
-## Markdown Rendering and Post Fallback
+## Markdown Rendering and Card Fallback
 
-When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **post** message with an embedded `md` tag rather than as plain text. This enables rich rendering in the Feishu client.
+When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **Card 2.0** interactive message with a `markdown` element rather than as plain text. This enables rich rendering — including tables — in the Feishu client.
 
-If the Feishu API rejects the post payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
+If the Feishu API rejects the card payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
 
 Plain text messages (no markdown detected) are sent as the simple `text` message type.
+
+## Streaming Cards (Typewriter Effect)
+
+When streaming is enabled in `config.yaml`, the Feishu adapter uses **CardKit streaming cards** to deliver a native typewriter effect. Instead of repeatedly editing a message, the adapter:
+
+```yaml
+streaming:
+  enabled: true
+```
+
+1. Creates a streaming card via the CardKit API with `streaming_mode: true`
+2. Appends content progressively via the CardKit element content API
+3. Finalizes the card by disabling streaming mode when the response completes
+
+This provides a smooth, real-time typing animation with a native loading indicator — no cursor character (`▉`) is needed. The chat list preview shows `[生成中...]` while the response is being generated.
+
+:::tip
+Streaming is strongly recommended for Feishu. Other platforms (Telegram, Discord, etc.) use progressive message edits with a cursor character, but Feishu's CardKit provides a much smoother native experience.
+:::
 
 ## ACK Emoji Reactions
 
@@ -409,7 +428,8 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
-| Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
+| Card messages show as plain text | The Feishu API rejected the card payload; this is normal fallback behavior. Check logs for details. |
+| Streaming cards not working | Ensure `streaming.enabled: true` in `config.yaml` and that `lark_oapi` is installed with CardKit support. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
 | Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -249,11 +249,11 @@ File upload routing is automatic based on extension:
 - `.pdf`, `.doc(x)`, `.xls(x)`, `.ppt(x)` → uploaded with their document type
 - Everything else → uploaded as a generic stream file
 
-## Markdown Rendering and Card Fallback
+## Markdown Rendering and Post Fallback
 
-When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **Card 2.0** interactive message with a `markdown` element rather than as plain text. This enables rich rendering — including tables — in the Feishu client.
+When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **post** message with an embedded `md` tag rather than as plain text. This enables rich rendering in the Feishu client.
 
-If the Feishu API rejects the card payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
+If the Feishu API rejects the post payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
 
 Plain text messages (no markdown detected) are sent as the simple `text` message type.
 
@@ -428,7 +428,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
-| Card messages show as plain text | The Feishu API rejected the card payload; this is normal fallback behavior. Check logs for details. |
+| Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Streaming cards not working | Ensure `streaming.enabled: true` in `config.yaml` and that `lark_oapi` is installed with CardKit support. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
 | Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |


### PR DESCRIPTION
Ports the enhanced `/status` view from CLI to the gateway.\n\nBefore: flat 6-line summary with no model/token breakdown.\nAfter: rich panel with provider/model, duration, API calls, tokens in/out, cache breakdown, context window bar, cost estimate.\n\nFalls back gracefully to session-store data when no live agent is available.