### PR TITLE
fix(session): end SQLite sessions when suspending to prevent zombie sessions (#9090)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -786,16 +786,24 @@ class SessionStore:
         """Mark a session as suspended so it auto-resets on next access.
 
         Used by ``/stop`` to prevent stuck sessions from being resumed
-        after a gateway restart (#7536).  Returns True if the session
-        existed and was marked.
+        after a gateway restart (#7536).  Also ends the session in the
+        SQLite DB so ended_at is populated and zombie sessions are
+        prevented (#9090).  Returns True if the session existed and
+        was marked.
         """
+        db_end_session_id = None
         with self._lock:
             self._ensure_loaded_locked()
             if session_key in self._entries:
                 self._entries[session_key].suspended = True
+                db_end_session_id = self._entries[session_key].session_id
                 self._save()
-                return True
-        return False
+        if self._db and db_end_session_id:
+            try:
+                self._db.end_session(db_end_session_id, "suspended")
+            except Exception as e:
+                logger.debug("Session DB end_session failed: %s", e)
+        return db_end_session_id is not None
 
     def suspend_recently_active(self, max_age_seconds: int = 120) -> int:
         """Mark recently-active sessions as suspended.
@@ -804,21 +812,29 @@ class SessionStore:
         in-flight when the gateway last exited from being blindly resumed
         (#7536).  Only suspends sessions updated within *max_age_seconds*
         to avoid resetting long-idle sessions that are harmless to resume.
+        Also ends each suspended session in the SQLite DB so ended_at is
+        populated and zombie sessions are prevented (#9090).
         Returns the number of sessions that were suspended.
         """
         from datetime import timedelta
 
         cutoff = _now() - timedelta(seconds=max_age_seconds)
-        count = 0
+        suspended_ids: list[tuple[str, str]] = []  # (session_key, session_id)
         with self._lock:
             self._ensure_loaded_locked()
             for entry in self._entries.values():
                 if not entry.suspended and entry.updated_at >= cutoff:
                     entry.suspended = True
-                    count += 1
-            if count:
+                    suspended_ids.append((entry.session_key, entry.session_id))
+            if suspended_ids:
                 self._save()
-        return count
+        if self._db:
+            for session_key, session_id in suspended_ids:
+                try:
+                    self._db.end_session(session_id, "suspended")
+                except Exception as e:
+                    logger.debug("Session DB end_session failed for %s: %s", session_key, e)
+        return len(suspended_ids)
 
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""


### PR DESCRIPTION
## Summary

`SessionStore.suspend_session()` and `suspend_recently_active()` only set `suspended=True` in `sessions.json` but never wrote `ended_at` to SQLite. When a session is later auto-reset on next access, `get_or_create_session()` calls `end_session()` with reason `'session_reset'`, BUT only if the entry is still in `_entries`. If the gateway crashed and the session was NOT re-loaded from disk (e.g. Feishu WebSocket sessions not yet persisted), the zombie session remains in SQLite with `ended_at=NULL` forever.

Fix: both `suspend_session()` and `suspend_recently_active()` now also call `self._db.end_session(session_id, 'suspended')` when the DB is available, ensuring `ended_at` is always populated when a session is suspended. When the session is later accessed and auto-reset, the UPDATE re-runs with `end_reason='session_reset'`, which is the correct final state.

Closes #9090.

## Changes

- `gateway/session.py`: `suspend_session()` — now also calls `self._db.end_session()` to populate SQLite `ended_at`
- `gateway/session.py`: `suspend_recently_active()` — same, iterates all suspended sessions and ends each in SQLite

## Test plan

```bash
python -m pytest -o addopts='' tests/gateway/test_session.py -q
python -m py_compile gateway/session.py
```
