### PR TITLE
fix(skills): fix falsy-zero coordinate bug in find-nearby and add missing field validation in gws_bridge

### DIFF
--- a/skills/leisure/find-nearby/scripts/find_nearby.py
+++ b/skills/leisure/find-nearby/scripts/find_nearby.py
@@ -98,7 +98,7 @@ def find_nearby(lat: float, lon: float, types: list[str], radius: int = 1500, li
         # Get coordinates (nodes have lat/lon directly, ways/relations use center)
         plat = el.get("lat") or (el.get("center", {}) or {}).get("lat")
         plon = el.get("lon") or (el.get("center", {}) or {}).get("lon")
-        if not plat or not plon:
+        if plat is None or plon is None:
             continue
 
         dist = haversine(lat, lon, plat, plon)

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -25,6 +25,13 @@ def refresh_token(token_data: dict) -> dict:
     import urllib.parse
     import urllib.request
 
+    required_keys = ["client_id", "client_secret", "refresh_token", "token_uri"]
+    missing = [k for k in required_keys if k not in token_data]
+    if missing:
+        print(f"ERROR: google_token.json is missing required fields: {', '.join(missing)}", file=sys.stderr)
+        print("Please re-authenticate by running the Google Workspace setup script.", file=sys.stderr)
+        sys.exit(1)
+
     params = urllib.parse.urlencode({
         "client_id": token_data["client_id"],
         "client_secret": token_data["client_secret"],


### PR DESCRIPTION
Fixes two bugs in bundled skill scripts.

**Bug 1 — find-nearby drops valid locations on the equator/prime meridian**

File: `skills/leisure/find-nearby/scripts/find_nearby.py`

The script checks `if not plat or not plon:` to skip results with missing coordinates. In Python, `0.0` is falsy, so any location with a latitude or longitude of exactly 0 (equator, prime meridian — parts of Ghana, Gulf of Guinea, Greenwich) gets silently discarded. Fixed by changing to `if plat is None or plon is None:` which only skips truly missing values.

**Bug 2 — gws_bridge crashes with raw KeyError on incomplete token files**

File: `skills/productivity/google-workspace/scripts/gws_bridge.py`

The `refresh_token()` function directly indexes `token_data["client_id"]`, `["client_secret"]`, `["refresh_token"]`, and `["token_uri"]` without checking if the keys exist. If `google_token.json` is incomplete or corrupted (e.g. from a partial migration), users get a raw Python KeyError traceback instead of a helpful error message. Fixed by validating required keys before access and printing a clear re-authentication message.