### PR TITLE
feat(gemini): add Google OAuth provider with PKCE authorization flow

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -1,0 +1,510 @@
+"""Google OAuth 2.0 for Gemini API — Authorization Code + PKCE (S256).
+
+Provides browser-based OAuth login against Google's authorization server,
+with a localhost callback server to capture the authorization code.
+Follows the same pattern as the Anthropic adapter in this codebase.
+
+Auth flow:
+  1. Generate PKCE code_verifier + code_challenge
+  2. Open browser to Google authorization URL
+  3. Localhost server on port 8085 captures the callback
+  4. Exchange authorization code for access + refresh tokens
+  5. Persist tokens to ~/.hermes/gemini_oauth.json
+  6. Before API calls: check expiry, refresh if within 5 minutes
+
+Token storage:
+  - File: ~/.hermes/gemini_oauth.json
+  - Permissions: 0o600
+  - Fields: client_id, client_secret, access_token, refresh_token,
+            expires_at, email
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ── Google OAuth endpoints ──────────────────────────────────────────────
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# ── Scopes ──────────────────────────────────────────────────────────────
+GOOGLE_OAUTH_SCOPES = (
+    "https://www.googleapis.com/auth/cloud-platform "
+    "https://www.googleapis.com/auth/userinfo.email"
+)
+
+# ── Default OAuth client (Desktop app — secrets are non-confidential) ──
+# These should be registered by the project maintainer on a GCP project
+# with the Generative Language API enabled.  Desktop-type OAuth client IDs
+# are public by design (security relies on PKCE, not client_secret).
+# Override for local development via HERMES_GEMINI_CLIENT_ID / HERMES_GEMINI_CLIENT_SECRET.
+#
+# TODO(maintainer): Register a GCP OAuth Desktop client and fill these in,
+#   similar to how Anthropic, Copilot, Codex, and Qwen all ship a built-in
+#   public client_id.
+_DEFAULT_CLIENT_ID = ""   # e.g. "123456789-abcdef.apps.googleusercontent.com"
+_DEFAULT_CLIENT_SECRET = ""   # GOCSPX-... (non-confidential for Desktop apps)
+
+# ── Localhost callback ──────────────────────────────────────────────────
+_REDIRECT_PORT = 8085
+_REDIRECT_URI = f"http://localhost:{_REDIRECT_PORT}/oauth2callback"
+
+# ── Token file ──────────────────────────────────────────────────────────
+_OAUTH_FILE = get_hermes_home() / "gemini_oauth.json"
+
+# ── Refresh margin (seconds) ────────────────────────────────────────────
+_REFRESH_MARGIN = 5 * 60  # refresh if within 5 minutes of expiry
+
+
+# ---------------------------------------------------------------------------
+# PKCE helpers
+# ---------------------------------------------------------------------------
+
+def _generate_pkce() -> Tuple[str, str]:
+    """Generate PKCE code_verifier and code_challenge (S256).
+
+    Returns (verifier, challenge) both as URL-safe base64 strings.
+    """
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+# ---------------------------------------------------------------------------
+# Credential file I/O
+# ---------------------------------------------------------------------------
+
+def _get_client_id() -> str:
+    return os.getenv("HERMES_GEMINI_CLIENT_ID", "") or _DEFAULT_CLIENT_ID
+
+
+def _get_client_secret() -> str:
+    return os.getenv("HERMES_GEMINI_CLIENT_SECRET", "") or _DEFAULT_CLIENT_SECRET
+
+
+def save_credentials(data: Dict[str, Any]) -> None:
+    """Persist OAuth credentials to ~/.hermes/gemini_oauth.json (mode 0600)."""
+    _OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _OAUTH_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.chmod(str(tmp), 0o600)
+    tmp.replace(_OAUTH_FILE)
+    logger.debug("Saved Gemini OAuth credentials to %s", _OAUTH_FILE)
+
+
+def load_credentials() -> Optional[Dict[str, Any]]:
+    """Load stored Gemini OAuth credentials. Returns None if absent/corrupt."""
+    if not _OAUTH_FILE.exists():
+        return None
+    try:
+        data = json.loads(_OAUTH_FILE.read_text(encoding="utf-8"))
+        if data.get("access_token"):
+            return data
+    except (json.JSONDecodeError, OSError, IOError) as exc:
+        logger.debug("Failed to read Gemini OAuth credentials: %s", exc)
+    return None
+
+
+def clear_credentials() -> bool:
+    """Remove stored Gemini OAuth credentials. Returns True if file existed."""
+    if _OAUTH_FILE.exists():
+        _OAUTH_FILE.unlink(missing_ok=True)
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Localhost callback server
+# ---------------------------------------------------------------------------
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler to capture the OAuth callback from Google."""
+
+    auth_code: Optional[str] = None
+    error: Optional[str] = None
+
+    def do_GET(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        if "error" in params:
+            _OAuthCallbackHandler.error = params["error"][0]
+            self._respond("Authorization failed. You can close this tab.")
+            return
+
+        code = params.get("code", [None])[0]
+        if code:
+            _OAuthCallbackHandler.auth_code = code
+            self._respond(
+                "Authorization successful! You can close this tab and return to Hermes."
+            )
+        else:
+            _OAuthCallbackHandler.error = "no_code"
+            self._respond("No authorization code received. Please try again.")
+
+    def _respond(self, message: str):
+        html = (
+            "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+            "<title>Hermes — Google Authorization</title>"
+            "<style>body{font-family:system-ui,sans-serif;display:flex;"
+            "justify-content:center;align-items:center;min-height:80vh;"
+            "background:#f8f9fa;margin:0}div{text-align:center;padding:2rem;"
+            "background:#fff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,.1)}"
+            "h2{margin:0 0 .5rem}</style></head><body><div>"
+            f"<h2>Hermes Agent</h2><p>{message}</p></div></body></html>"
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def log_message(self, format, *args):  # noqa: A002
+        """Silence default stderr logging."""
+        pass
+
+
+def _wait_for_callback(timeout: float = 120.0) -> Optional[str]:
+    """Start a localhost server and wait for the OAuth callback.
+
+    Returns the authorization code, or None on timeout/error.
+    """
+    _OAuthCallbackHandler.auth_code = None
+    _OAuthCallbackHandler.error = None
+
+    server = HTTPServer(("127.0.0.1", _REDIRECT_PORT), _OAuthCallbackHandler)
+    server.timeout = timeout
+
+    def _serve():
+        while _OAuthCallbackHandler.auth_code is None and _OAuthCallbackHandler.error is None:
+            server.handle_request()
+
+    thread = threading.Thread(target=_serve, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+
+    try:
+        server.server_close()
+    except Exception:
+        pass
+
+    if _OAuthCallbackHandler.error:
+        logger.error("Google OAuth error: %s", _OAuthCallbackHandler.error)
+        return None
+    return _OAuthCallbackHandler.auth_code
+
+
+# ---------------------------------------------------------------------------
+# Token exchange
+# ---------------------------------------------------------------------------
+
+def exchange_code(
+    code: str,
+    verifier: str,
+    *,
+    client_id: str = "",
+    client_secret: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Exchange authorization code for tokens via Google's token endpoint.
+
+    Returns dict with access_token, refresh_token, expires_in, etc.
+    or None on failure.
+    """
+    import urllib.request
+
+    client_id = client_id or _get_client_id()
+    client_secret = client_secret or _get_client_secret()
+
+    payload = urlencode({
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "redirect_uri": _REDIRECT_URI,
+        "code_verifier": verifier,
+    }).encode()
+
+    req = urllib.request.Request(
+        GOOGLE_TOKEN_URL,
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        logger.error("Gemini token exchange failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Token refresh
+# ---------------------------------------------------------------------------
+
+def refresh_access_token(
+    refresh_token: str,
+    *,
+    client_id: str = "",
+    client_secret: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Refresh the access token using a stored refresh_token.
+
+    Returns dict with new access_token, expires_in, etc. or None.
+    """
+    import urllib.request
+
+    client_id = client_id or _get_client_id()
+    client_secret = client_secret or _get_client_secret()
+
+    payload = urlencode({
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "refresh_token": refresh_token,
+    }).encode()
+
+    req = urllib.request.Request(
+        GOOGLE_TOKEN_URL,
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        logger.error("Gemini token refresh failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# get_valid_access_token — the main entry point for callers
+# ---------------------------------------------------------------------------
+
+def get_valid_access_token() -> Optional[str]:
+    """Return a valid access token, refreshing if needed.
+
+    Reads stored credentials, checks expiry, refreshes if within 5 minutes
+    of expiration, persists updated tokens, and returns the access_token.
+    Returns None if no credentials exist or refresh fails.
+    """
+    creds = load_credentials()
+    if not creds:
+        return None
+
+    access_token = creds.get("access_token", "")
+    refresh_token = creds.get("refresh_token", "")
+    expires_at = creds.get("expires_at", 0)
+
+    now = time.time()
+    if access_token and expires_at > now + _REFRESH_MARGIN:
+        return access_token
+
+    # Need refresh
+    if not refresh_token:
+        logger.warning("Gemini OAuth access token expired and no refresh token available.")
+        return None
+
+    result = refresh_access_token(
+        refresh_token,
+        client_id=creds.get("client_id", ""),
+        client_secret=creds.get("client_secret", ""),
+    )
+    if not result or "access_token" not in result:
+        logger.error("Gemini token refresh returned no access_token")
+        return None
+
+    # Update stored credentials
+    creds["access_token"] = result["access_token"]
+    creds["expires_at"] = now + result.get("expires_in", 3600)
+    # Google may issue a new refresh_token (rotation)
+    if result.get("refresh_token"):
+        creds["refresh_token"] = result["refresh_token"]
+    save_credentials(creds)
+
+    return result["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Full OAuth login flow
+# ---------------------------------------------------------------------------
+
+def run_google_oauth_login(
+    *,
+    client_id: str = "",
+    client_secret: str = "",
+    open_browser: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Run the full Google OAuth PKCE flow.
+
+    Opens a browser for authorization, captures the callback on localhost,
+    exchanges the code for tokens, and returns credential dict suitable for
+    ``save_credentials()``.
+
+    Returns dict with: access_token, refresh_token, expires_at, client_id,
+    client_secret, email (if available). Returns None on failure/cancel.
+    """
+    import webbrowser
+
+    client_id = client_id or _get_client_id()
+    client_secret = client_secret or _get_client_secret()
+
+    if not client_id:
+        print("  ✗ Gemini OAuth is not yet configured (missing client_id).")
+        print("    This feature requires a GCP OAuth client to be registered by the project.")
+        print("    In the meantime, use an API key from https://aistudio.google.com/apikey")
+        return None
+
+    verifier, challenge = _generate_pkce()
+
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": _REDIRECT_URI,
+        "scope": GOOGLE_OAUTH_SCOPES,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "access_type": "offline",  # request refresh_token
+        "prompt": "consent",  # force consent to always get refresh_token
+    }
+
+    auth_url = f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
+
+    print()
+    print("  Authorize Hermes with your Google account.")
+    print()
+    print("  ╭─ Google Authorization ──────────────────────────────╮")
+    print("  │                                                     │")
+    print("  │  A browser window will open for you to sign in.     │")
+    print("  │  If it doesn't, copy the URL below into a browser.  │")
+    print("  ╰─────────────────────────────────────────────────────╯")
+    print()
+    print(f"  {auth_url}")
+    print()
+
+    if open_browser:
+        try:
+            webbrowser.open(auth_url)
+            print("  (Browser opened automatically)")
+        except Exception:
+            pass
+
+    print()
+    print("  Waiting for authorization...")
+
+    code = _wait_for_callback(timeout=120.0)
+
+    if not code:
+        # Fallback: manual paste for headless environments
+        print()
+        print("  Localhost callback not received. Paste the full callback URL")
+        print("  or authorization code below (or press Enter to cancel):")
+        print()
+        try:
+            raw = input("  Code/URL: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            return None
+
+        if not raw:
+            return None
+
+        # Handle pasted full URL
+        if raw.startswith("http"):
+            parsed = parse_qs(urlparse(raw).query)
+            code = parsed.get("code", [None])[0]
+        else:
+            code = raw
+
+        if not code:
+            print("  No authorization code found.")
+            return None
+
+    # Exchange code for tokens
+    result = exchange_code(code, verifier, client_id=client_id, client_secret=client_secret)
+    if not result or "access_token" not in result:
+        print("  ✗ Token exchange failed.")
+        return None
+
+    now = time.time()
+    expires_in = result.get("expires_in", 3600)
+
+    # Try to fetch user email for labeling
+    email = _fetch_user_email(result["access_token"])
+
+    creds = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "access_token": result["access_token"],
+        "refresh_token": result.get("refresh_token", ""),
+        "expires_at": now + expires_in,
+        "email": email or "",
+    }
+
+    print(f"  ✓ Authorized{f' as {email}' if email else ''}.")
+    return creds
+
+
+def _fetch_user_email(access_token: str) -> Optional[str]:
+    """Fetch the authenticated user's email from Google userinfo endpoint."""
+    import urllib.request
+
+    req = urllib.request.Request(
+        "https://www.googleapis.com/oauth2/v2/userinfo",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("email")
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# High-level login-and-save (convenience for CLI)
+# ---------------------------------------------------------------------------
+
+def run_gemini_oauth_login_and_save(**kwargs) -> Optional[Dict[str, Any]]:
+    """Run OAuth flow and persist credentials. Returns creds dict or None."""
+    creds = run_google_oauth_login(**kwargs)
+    if creds:
+        save_credentials(creds)
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# Pure login for credential pool (returns dict compatible with PooledCredential)
+# ---------------------------------------------------------------------------
+
+def run_gemini_oauth_login_pure(**kwargs) -> Optional[Dict[str, Any]]:
+    """Run OAuth flow and return credentials without persisting.
+
+    Returns dict with: access_token, refresh_token, expires_at_ms.
+    Compatible with the credential pool system in auth_commands.py.
+    """
+    creds = run_google_oauth_login(**kwargs)
+    if not creds:
+        return None
+
+    return {
+        "access_token": creds["access_token"],
+        "refresh_token": creds.get("refresh_token", ""),
+        "expires_at_ms": int(creds.get("expires_at", time.time() + 3600) * 1000),
+    }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2424,6 +2424,16 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "copilot-acp":
         return get_external_process_provider_status(target)
+    # Gemini — check OAuth credentials first, then fall through to API-key
+    if target == "gemini":
+        try:
+            from agent.google_oauth import load_credentials as _load_gemini_oauth
+            oauth_creds = _load_gemini_oauth()
+            if oauth_creds and oauth_creds.get("access_token"):
+                return {"logged_in": True, "auth_type": "google_oauth", "email": oauth_creds.get("email", "")}
+        except Exception:
+            pass
+        # Fall through to API-key check
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -32,7 +32,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "gemini", "nous", "openai-codex", "qwen-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -147,7 +147,7 @@ def auth_add_command(args) -> None:
         if provider.startswith(CUSTOM_POOL_PREFIX):
             requested_type = AUTH_TYPE_API_KEY
         else:
-            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "nous", "openai-codex", "qwen-oauth"} else AUTH_TYPE_API_KEY
+            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "gemini", "nous", "openai-codex", "qwen-oauth"} else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
 
@@ -192,6 +192,32 @@ def auth_add_command(args) -> None:
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
             source=f"{SOURCE_MANUAL}:hermes_pkce",
+            access_token=creds["access_token"],
+            refresh_token=creds.get("refresh_token"),
+            expires_at_ms=creds.get("expires_at_ms"),
+            base_url=_provider_base_url(provider),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "gemini":
+        from agent import google_oauth as google_oauth_mod
+
+        creds = google_oauth_mod.run_gemini_oauth_login_pure()
+        if not creds:
+            raise SystemExit("Gemini OAuth login did not return credentials.")
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["access_token"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:google_pkce",
             access_token=creds["access_token"],
             refresh_token=creds.get("refresh_token"),
             expires_at_ms=creds.get("expires_at_ms"),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1072,11 +1072,11 @@ def select_provider_and_model(args=None):
         ("qwen-oauth", "Qwen OAuth (reuses local Qwen CLI login)"),
         ("copilot", "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
         ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
+        ("gemini", "Google AI Studio (Gemini — OAuth or API key)"),
     ]
 
     extended_providers = [
         ("copilot-acp", "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
-        ("gemini", "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),
@@ -1197,9 +1197,11 @@ def select_provider_and_model(args=None):
         _remove_custom_provider(config)
     elif selected_provider == "anthropic":
         _model_flow_anthropic(config, current_model)
+    elif selected_provider == "gemini":
+        _model_flow_gemini(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────
@@ -2662,6 +2664,141 @@ def _run_anthropic_oauth_flow(save_env_value):
             return True
         print("  Cancelled — install Claude Code and try again.")
         return False
+
+
+def _model_flow_gemini(config, current_model=""):
+    """Flow for Gemini provider — OAuth (Google account) or API key."""
+    import os
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    pconfig = PROVIDER_REGISTRY["gemini"]
+
+    # Check existing credentials — OAuth file or API key env vars
+    oauth_available = False
+    try:
+        from agent.google_oauth import load_credentials as _load_gemini_creds, get_valid_access_token
+        stored = _load_gemini_creds()
+        if stored and stored.get("access_token"):
+            # Verify it's still refreshable
+            token = get_valid_access_token()
+            if token:
+                oauth_available = True
+    except Exception:
+        pass
+
+    existing_key = ""
+    for ev in pconfig.api_key_env_vars:
+        existing_key = get_env_value(ev) or os.getenv(ev, "")
+        if existing_key:
+            break
+
+    has_creds = oauth_available or bool(existing_key)
+    needs_auth = not has_creds
+
+    if has_creds:
+        if oauth_available:
+            email = ""
+            try:
+                email = stored.get("email", "") if stored else ""
+            except Exception:
+                pass
+            print(f"  Google OAuth credentials: ✓{f' ({email})' if email else ''}")
+        elif existing_key:
+            print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
+        print()
+        print("    1. Use existing credentials")
+        print("    2. Reauthenticate (new login)")
+        print("    3. Cancel")
+        print()
+        try:
+            choice = input("  Choice [1/2/3]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            choice = "1"
+
+        if choice == "2":
+            needs_auth = True
+        elif choice == "3":
+            return
+        # choice == "1" or default: use existing, proceed to model selection
+
+    if needs_auth:
+        print()
+        print("  Choose authentication method:")
+        print()
+        print("    1. Google account (OAuth login)")
+        print("    2. Google AI Studio API key")
+        print("    3. Cancel")
+        print()
+        try:
+            choice = input("  Choice [1/2/3]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+
+        if choice == "1":
+            try:
+                from agent.google_oauth import run_gemini_oauth_login_and_save
+                creds = run_gemini_oauth_login_and_save()
+                if not creds:
+                    print("  OAuth login cancelled or failed.")
+                    return
+            except Exception as exc:
+                print(f"  OAuth login failed: {exc}")
+                return
+
+        elif choice == "2":
+            print()
+            print("  Get an API key at: https://aistudio.google.com/apikey")
+            print()
+            try:
+                import getpass
+                api_key = getpass.getpass("  API key: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return
+            if not api_key:
+                print("  Cancelled.")
+                return
+            key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else "GOOGLE_API_KEY"
+            save_env_value(key_env, api_key)
+            print("  ✓ API key saved.")
+
+        else:
+            print("  No change.")
+            return
+    print()
+
+    # Model selection
+    model_list = _PROVIDER_MODELS.get("gemini", [])
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name (e.g., gemini-2.5-flash): ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "gemini"
+        model.pop("base_url", None)
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"Default model set to: {selected} (via Google AI Studio)")
+    else:
+        print("No change.")
 
 
 def _model_flow_anthropic(config, current_model=""):
@@ -4744,7 +4881,7 @@ For more help on a command:
     )
     login_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex"],
+        choices=["nous", "openai-codex", "gemini"],
         default=None,
         help="Provider to authenticate with (default: nous)"
     )
@@ -4798,7 +4935,7 @@ For more help on a command:
     )
     logout_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex"],
+        choices=["nous", "openai-codex", "gemini"],
         default=None,
         help="Provider to log out from (default: active provider)"
     )

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -189,6 +189,11 @@ ALIASES: Dict[str, str] = {
     "claude": "anthropic",
     "claude-code": "anthropic",
 
+    # gemini / google
+    "google": "gemini",
+    "google-gemini": "gemini",
+    "google-ai-studio": "gemini",
+
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
     "github": "github-copilot",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -154,6 +154,13 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "qwen-oauth":
         api_mode = "chat_completions"
         base_url = base_url or DEFAULT_QWEN_BASE_URL
+    elif provider == "gemini":
+        api_mode = "chat_completions"
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if cfg_provider == "gemini":
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        base_url = cfg_base_url or base_url or "https://generativelanguage.googleapis.com/v1beta/openai"
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -781,6 +788,29 @@ def resolve_runtime_provider(
             "source": "env",
             "requested_provider": requested_provider,
         }
+
+    # Gemini — try OAuth credentials first, fall back to API key
+    if provider == "gemini":
+        try:
+            from agent.google_oauth import get_valid_access_token as _gemini_oauth_token
+            oauth_token = _gemini_oauth_token()
+        except Exception:
+            oauth_token = None
+        if oauth_token:
+            cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+            cfg_base_url = ""
+            if cfg_provider == "gemini":
+                cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+            base_url = cfg_base_url or "https://generativelanguage.googleapis.com/v1beta/openai"
+            return {
+                "provider": "gemini",
+                "api_mode": "chat_completions",
+                "base_url": base_url,
+                "api_key": oauth_token,
+                "source": "google_oauth",
+                "requested_provider": requested_provider,
+            }
+        # No OAuth token — fall through to API-key resolution below
 
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)

--- a/tests/agent/test_google_oauth.py
+++ b/tests/agent/test_google_oauth.py
@@ -1,0 +1,311 @@
+"""Tests for Google OAuth module (agent/google_oauth.py).
+
+Covers PKCE generation, credential I/O, token refresh logic, and the full
+OAuth login flow (mocked — no real network/browser activity).
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from agent.google_oauth import (
+    _generate_pkce,
+    _REDIRECT_URI,
+    _REDIRECT_PORT,
+    GOOGLE_AUTH_URL,
+    GOOGLE_TOKEN_URL,
+    GOOGLE_OAUTH_SCOPES,
+    exchange_code,
+    get_valid_access_token,
+    load_credentials,
+    refresh_access_token,
+    run_gemini_oauth_login_pure,
+    run_google_oauth_login,
+    save_credentials,
+    clear_credentials,
+)
+
+
+# ── PKCE ──
+
+class TestPKCE:
+    def test_generates_verifier_and_challenge(self):
+        verifier, challenge = _generate_pkce()
+        assert isinstance(verifier, str)
+        assert isinstance(challenge, str)
+        assert len(verifier) > 20
+        assert len(challenge) > 20
+
+    def test_different_each_call(self):
+        v1, c1 = _generate_pkce()
+        v2, c2 = _generate_pkce()
+        assert v1 != v2
+        assert c1 != c2
+
+    def test_s256_challenge(self):
+        """Verify the challenge is SHA-256 of the verifier, base64url-encoded."""
+        import base64
+        import hashlib
+
+        verifier, challenge = _generate_pkce()
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+        assert challenge == expected
+
+
+# ── Credential I/O ──
+
+class TestCredentialIO:
+    @pytest.fixture(autouse=True)
+    def _patch_oauth_file(self, tmp_path, monkeypatch):
+        self.cred_file = tmp_path / "gemini_oauth.json"
+        monkeypatch.setattr("agent.google_oauth._OAUTH_FILE", self.cred_file)
+
+    def test_save_and_load(self):
+        creds = {
+            "client_id": "test-id",
+            "client_secret": "test-secret",
+            "access_token": "ya29.test",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() + 3600,
+            "email": "test@example.com",
+        }
+        save_credentials(creds)
+        loaded = load_credentials()
+        assert loaded is not None
+        assert loaded["access_token"] == "ya29.test"
+        assert loaded["email"] == "test@example.com"
+
+    def test_load_nonexistent(self):
+        assert load_credentials() is None
+
+    def test_load_corrupt(self):
+        self.cred_file.write_text("not json", encoding="utf-8")
+        assert load_credentials() is None
+
+    def test_load_empty_token(self):
+        self.cred_file.write_text('{"access_token":""}', encoding="utf-8")
+        assert load_credentials() is None
+
+    def test_file_permissions(self):
+        save_credentials({"access_token": "test"})
+        stat = os.stat(str(self.cred_file))
+        assert stat.st_mode & 0o777 == 0o600
+
+    def test_clear_credentials(self):
+        save_credentials({"access_token": "test"})
+        assert self.cred_file.exists()
+        assert clear_credentials() is True
+        assert not self.cred_file.exists()
+        assert clear_credentials() is False  # already gone
+
+
+# ── Token Refresh Logic ──
+
+class TestGetValidAccessToken:
+    @pytest.fixture(autouse=True)
+    def _patch_oauth_file(self, tmp_path, monkeypatch):
+        self.cred_file = tmp_path / "gemini_oauth.json"
+        monkeypatch.setattr("agent.google_oauth._OAUTH_FILE", self.cred_file)
+
+    def test_returns_none_when_no_creds(self):
+        assert get_valid_access_token() is None
+
+    def test_returns_token_when_fresh(self):
+        save_credentials({
+            "access_token": "ya29.fresh",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() + 7200,  # 2 hours from now
+        })
+        assert get_valid_access_token() == "ya29.fresh"
+
+    def test_returns_none_when_expired_no_refresh(self):
+        save_credentials({
+            "access_token": "ya29.expired",
+            "refresh_token": "",
+            "expires_at": time.time() - 100,  # already expired
+        })
+        assert get_valid_access_token() is None
+
+    @patch("agent.google_oauth.refresh_access_token")
+    def test_refreshes_when_near_expiry(self, mock_refresh):
+        mock_refresh.return_value = {
+            "access_token": "ya29.refreshed",
+            "expires_in": 3600,
+        }
+        save_credentials({
+            "access_token": "ya29.about-to-expire",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() + 60,  # within 5-min margin
+        })
+        token = get_valid_access_token()
+        assert token == "ya29.refreshed"
+        mock_refresh.assert_called_once()
+
+        # Verify file was updated
+        updated = load_credentials()
+        assert updated["access_token"] == "ya29.refreshed"
+
+    @patch("agent.google_oauth.refresh_access_token")
+    def test_refresh_failure_returns_none(self, mock_refresh):
+        mock_refresh.return_value = None
+        save_credentials({
+            "access_token": "ya29.expired",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() - 100,
+        })
+        assert get_valid_access_token() is None
+
+
+# ── Token Exchange ──
+
+class TestExchangeCode:
+    @patch("urllib.request.urlopen")
+    def test_successful_exchange(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "access_token": "ya29.new",
+            "refresh_token": "1//new-refresh",
+            "expires_in": 3600,
+        }).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = exchange_code(
+            "test-code", "test-verifier",
+            client_id="test-id", client_secret="test-secret",
+        )
+        assert result is not None
+        assert result["access_token"] == "ya29.new"
+
+    @patch("urllib.request.urlopen")
+    def test_exchange_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("network error")
+        result = exchange_code("code", "verifier", client_id="id", client_secret="s")
+        assert result is None
+
+
+# ── Token Refresh ──
+
+class TestRefreshAccessToken:
+    @patch("urllib.request.urlopen")
+    def test_successful_refresh(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "access_token": "ya29.refreshed",
+            "expires_in": 3600,
+        }).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = refresh_access_token(
+            "1//old-refresh",
+            client_id="test-id", client_secret="test-secret",
+        )
+        assert result is not None
+        assert result["access_token"] == "ya29.refreshed"
+
+    @patch("urllib.request.urlopen")
+    def test_refresh_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("401 Unauthorized")
+        result = refresh_access_token("1//bad", client_id="id", client_secret="s")
+        assert result is None
+
+
+# ── Full Login Flow ──
+
+class TestRunGoogleOAuthLogin:
+    @patch("agent.google_oauth._fetch_user_email", return_value="user@gmail.com")
+    @patch("agent.google_oauth.exchange_code")
+    @patch("agent.google_oauth._wait_for_callback")
+    @patch("webbrowser.open")
+    def test_full_flow(self, mock_wb, mock_callback, mock_exchange, mock_email):
+        mock_callback.return_value = "test-auth-code"
+        mock_exchange.return_value = {
+            "access_token": "ya29.full-flow",
+            "refresh_token": "1//full-refresh",
+            "expires_in": 3600,
+        }
+
+        result = run_google_oauth_login(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            open_browser=False,
+        )
+
+        assert result is not None
+        assert result["access_token"] == "ya29.full-flow"
+        assert result["refresh_token"] == "1//full-refresh"
+        assert result["email"] == "user@gmail.com"
+        assert result["client_id"] == "test-client-id"
+        assert "expires_at" in result
+
+    @patch("agent.google_oauth._wait_for_callback")
+    @patch("webbrowser.open")
+    def test_no_client_id(self, mock_wb, mock_callback):
+        with patch("agent.google_oauth._get_client_id", return_value=""):
+            result = run_google_oauth_login(open_browser=False)
+            assert result is None
+
+    @patch("agent.google_oauth._wait_for_callback")
+    @patch("webbrowser.open")
+    def test_callback_timeout_manual_cancel(self, mock_wb, mock_callback):
+        mock_callback.return_value = None  # timeout
+        with patch("builtins.input", return_value=""):
+            result = run_google_oauth_login(
+                client_id="test-id",
+                client_secret="test-secret",
+                open_browser=False,
+            )
+            assert result is None
+
+
+# ── Pure Login (for credential pool) ──
+
+class TestRunGeminiOAuthLoginPure:
+    @patch("agent.google_oauth.run_google_oauth_login")
+    def test_returns_pool_compatible_dict(self, mock_login):
+        mock_login.return_value = {
+            "access_token": "ya29.pool",
+            "refresh_token": "1//pool-refresh",
+            "expires_at": time.time() + 3600,
+            "client_id": "test",
+            "client_secret": "test",
+            "email": "pool@test.com",
+        }
+        result = run_gemini_oauth_login_pure()
+        assert result is not None
+        assert result["access_token"] == "ya29.pool"
+        assert result["refresh_token"] == "1//pool-refresh"
+        assert "expires_at_ms" in result
+        assert isinstance(result["expires_at_ms"], int)
+
+    @patch("agent.google_oauth.run_google_oauth_login")
+    def test_returns_none_on_failure(self, mock_login):
+        mock_login.return_value = None
+        assert run_gemini_oauth_login_pure() is None
+
+
+# ── Constants ──
+
+class TestConstants:
+    def test_redirect_uri(self):
+        assert _REDIRECT_URI == f"http://localhost:{_REDIRECT_PORT}/oauth2callback"
+        assert _REDIRECT_PORT == 8085
+
+    def test_auth_url(self):
+        assert "accounts.google.com" in GOOGLE_AUTH_URL
+
+    def test_token_url(self):
+        assert "googleapis.com" in GOOGLE_TOKEN_URL
+
+    def test_scopes(self):
+        assert "cloud-platform" in GOOGLE_OAUTH_SCOPES
+        assert "userinfo.email" in GOOGLE_OAUTH_SCOPES

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -271,3 +271,72 @@ class TestGeminiModelsDev:
         assert "gemini-2.5-flash-preview-tts" not in result  # no tool_call
         assert "gemini-live-2.5-flash" not in result     # noise: live-
         assert "gemini-2.5-flash-preview-04-17" not in result  # noise: dated preview
+
+
+# ── OAuth Integration ──
+
+class TestGeminiOAuth:
+    """Tests for Gemini OAuth integration with existing provider infrastructure."""
+
+    def test_gemini_in_oauth_capable_providers(self):
+        from hermes_cli.auth_commands import _OAUTH_CAPABLE_PROVIDERS
+        assert "gemini" in _OAUTH_CAPABLE_PROVIDERS
+
+    def test_gemini_runtime_uses_oauth_when_available(self, monkeypatch, tmp_path):
+        """When OAuth credentials exist, runtime_provider prefers them over API key."""
+        import json, time
+
+        # Set up OAuth credentials file
+        cred_file = tmp_path / "gemini_oauth.json"
+        cred_file.write_text(json.dumps({
+            "access_token": "ya29.oauth-token",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() + 7200,
+        }))
+        monkeypatch.setattr("agent.google_oauth._OAUTH_FILE", cred_file)
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="gemini")
+        assert result["provider"] == "gemini"
+        assert result["api_key"] == "ya29.oauth-token"
+        assert result["source"] == "google_oauth"
+        assert result["api_mode"] == "chat_completions"
+
+    def test_gemini_runtime_falls_back_to_api_key(self, monkeypatch, tmp_path):
+        """When no OAuth credentials exist, fall back to API key."""
+        # No OAuth file
+        cred_file = tmp_path / "nonexistent_gemini_oauth.json"
+        monkeypatch.setattr("agent.google_oauth._OAUTH_FILE", cred_file)
+
+        monkeypatch.setenv("GOOGLE_API_KEY", "api-key-fallback")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="gemini")
+        assert result["provider"] == "gemini"
+        assert result["api_key"] == "api-key-fallback"
+        assert result["source"] != "google_oauth"
+
+    def test_gemini_auth_status_with_oauth(self, monkeypatch, tmp_path):
+        """get_auth_status reports OAuth status when credentials exist."""
+        import json, time
+
+        cred_file = tmp_path / "gemini_oauth.json"
+        cred_file.write_text(json.dumps({
+            "access_token": "ya29.status-test",
+            "refresh_token": "1//refresh",
+            "expires_at": time.time() + 7200,
+            "email": "test@example.com",
+        }))
+        monkeypatch.setattr("agent.google_oauth._OAUTH_FILE", cred_file)
+
+        from hermes_cli.auth import get_auth_status
+        status = get_auth_status("gemini")
+        assert status["logged_in"] is True
+        assert status.get("auth_type") == "google_oauth"
+        assert status.get("email") == "test@example.com"
+
+    def test_providers_py_aliases(self):
+        """providers.py ALIASES includes Google → gemini mappings."""
+        from hermes_cli.providers import ALIASES
+        assert ALIASES.get("google") == "gemini"
+        assert ALIASES.get("google-gemini") == "gemini"
+        assert ALIASES.get("google-ai-studio") == "gemini"


### PR DESCRIPTION
## Summary

Add first-class Google OAuth (Authorization Code + PKCE S256) as an authentication method for the Gemini provider, alongside the existing API key support. This implements the Gemini OAuth Provider described in `plans/gemini-oauth-provider.md` (Path A — Standard Gemini API).

## Motivation

Currently Gemini only supports API key authentication. Other major providers (Anthropic, Copilot, Codex, Qwen) all offer OAuth login for a smoother user experience — no need to manually create and paste API keys. This PR brings Gemini to parity.

## Solution

**Architecture**: Follows the same patterns established by the Anthropic OAuth adapter — PKCE flow with localhost callback server, token persistence, auto-refresh.

**Auth flow**:
1. Generate PKCE code_verifier + code_challenge (S256)
2. Open browser → Google authorization URL
3. Localhost server on port 8085 captures the callback
4. Exchange authorization code for access + refresh tokens
5. Persist to `~/.hermes/gemini_oauth.json` (mode 0600)
6. Auto-refresh when token expires within 5 minutes

**Runtime resolution**: OAuth credentials take priority; falls back to API key if no OAuth token is available. Zero breaking changes to existing API key users.

**TUI flow**: `hermes model` → Gemini (promoted to top-level menu) → choice of "Google account (OAuth login)" or "API key".

## Changes

| File | Change |
|------|--------|
| `agent/google_oauth.py` | **New** — OAuth PKCE core module (~510 lines): PKCE generation, localhost callback server, code exchange, token refresh, credential I/O, user email fetch |
| `hermes_cli/auth.py` | Modified — Added Gemini OAuth status detection in `get_auth_status()` |
| `hermes_cli/auth_commands.py` | Modified — Added `gemini` to `_OAUTH_CAPABLE_PROVIDERS`, added OAuth login flow branch |
| `hermes_cli/main.py` | Modified — Added `_model_flow_gemini()` (dual auth: OAuth + API key), promoted Gemini to top-level provider menu, added gemini to login/logout parser choices |
| `hermes_cli/providers.py` | Modified — Added google/gemini aliases in ALIASES dict |
| `hermes_cli/runtime_provider.py` | Modified — Added Gemini OAuth runtime branch (tries OAuth first, falls back to API key), added gemini branch in pool entry resolution |
| `tests/agent/test_google_oauth.py` | **New** — 27 unit tests covering PKCE, credential I/O, token exchange, refresh, full login flow |
| `tests/hermes_cli/test_gemini_provider.py` | Modified — Added 5 OAuth integration tests (OAuth-capable set, runtime resolution, auth status, provider aliases) |

## Testing

```
199 passed, 2 deselected, 1 warning in 6.27s
```

- 27 unit tests for `google_oauth.py`: PKCE generation, credential save/load/roundtrip, token exchange (success + failure), token refresh (success + failure), auto-refresh logic, full OAuth login flow, headless fallback
- 5 integration tests: OAuth-capable providers set, runtime resolution with/without OAuth, auth status reporting, provider aliases
- All existing tests continue passing (zero regressions)

## Note: OAuth Client ID

The `_DEFAULT_CLIENT_ID` in `google_oauth.py` is currently a placeholder. This follows the same pattern as other providers — Anthropic, Copilot, Codex, and Qwen all ship a built-in public client_id registered by the project/platform. For Gemini, this requires registering a GCP OAuth Desktop client with the Generative Language API enabled.

**Action needed**: Register a GCP OAuth client (Desktop app type) and fill in `_DEFAULT_CLIENT_ID` / `_DEFAULT_CLIENT_SECRET`. Desktop OAuth client IDs are public by design — security relies on PKCE, not client_secret confidentiality.

In the meantime, developers can test via environment variables: `HERMES_GEMINI_CLIENT_ID` / `HERMES_GEMINI_CLIENT_SECRET`.

## Backward Compatibility

- No breaking changes — existing API key authentication continues to work identically
- Gemini's `auth_type` in `PROVIDER_REGISTRY` remains `"api_key"` (same pattern as Anthropic)
- OAuth is additive: if no OAuth credentials exist, behavior is unchanged
