### PR TITLE
fix(security): validate cron job base_url against SSRF with fail-closed ImportError handling

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,20 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+# SSRF protection for job-specified base_url overrides.
+# Fail-closed: if url_safety cannot be loaded, no job may supply a custom base_url.
+_job_base_url: Optional[str] = None
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except ImportError:
+    logger.error(
+        "tools.url_safety could not be imported; job base_url overrides are "
+        "disabled (fail-closed SSRF protection)"
+    )
+    _is_safe_url = None  # type: ignore[assignment]
+    _job_base_url = None
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -1656,7 +1670,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 "requested": job.get("provider"),
             }
             if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+                _candidate_url = job["base_url"]
+                if _is_safe_url is not None and _is_safe_url(_candidate_url):
+                    runtime_kwargs["explicit_base_url"] = _candidate_url
+                else:
+                    _reason = (
+                        "SSRF validation module unavailable"
+                        if _is_safe_url is None
+                        else "URL failed SSRF safety check"
+                    )
+                    logger.warning(
+                        "Job '%s': ignoring base_url %r — %s",
+                        job_id, _candidate_url, _reason,
+                    )
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,6 +39,19 @@ from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
 
+# SSRF protection for job-specified base_url overrides.
+# Fail-closed: if url_safety cannot be loaded, no job may supply a custom base_url.
+_job_base_url: Optional[str] = None
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except ImportError:
+    logger.error(
+        "tools.url_safety could not be imported; job base_url overrides are "
+        "disabled (fail-closed SSRF protection)"
+    )
+    _is_safe_url = None  # type: ignore[assignment]
+    _job_base_url = None
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -689,7 +702,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
             }
             if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+                _candidate_url = job["base_url"]
+                if _is_safe_url is not None and _is_safe_url(_candidate_url):
+                    runtime_kwargs["explicit_base_url"] = _candidate_url
+                else:
+                    _reason = (
+                        "SSRF validation module unavailable"
+                        if _is_safe_url is None
+                        else "URL failed SSRF safety check"
+                    )
+                    logger.warning(
+                        "Job '%s': ignoring base_url %r — %s",
+                        job_id, _candidate_url, _reason,
+                    )
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -28,7 +28,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -533,6 +533,39 @@ async def _download_bytes(
         return await response.read()
 
 
+_WEIXIN_CDN_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "novac2c.cdn.weixin.qq.com",
+        "ilinkai.weixin.qq.com",
+        "wx.qlogo.cn",
+        "thirdwx.qlogo.cn",
+        "res.wx.qq.com",
+        "mmbiz.qpic.cn",
+        "mmbiz.qlogo.cn",
+    }
+)
+
+
+def _assert_weixin_cdn_url(url: str) -> None:
+    """Raise ValueError if *url* does not point at a known WeChat CDN host."""
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        host = parsed.hostname or ""
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Unparseable media URL: {url!r}") from exc
+
+    if scheme not in ("http", "https"):
+        raise ValueError(
+            f"Media URL has disallowed scheme {scheme!r}; only http/https are permitted."
+        )
+    if host not in _WEIXIN_CDN_ALLOWLIST:
+        raise ValueError(
+            f"Media URL host {host!r} is not in the WeChat CDN allowlist. "
+            "Refusing to fetch to prevent SSRF."
+        )
+
+
 def _media_reference(item: Dict[str, Any], key: str) -> Dict[str, Any]:
     return (item.get(key) or {}).get("media") or {}
 
@@ -553,6 +586,7 @@ async def _download_and_decrypt_media(
             timeout_seconds=timeout_seconds,
         )
     elif full_url:
+        _assert_weixin_cdn_url(full_url)
         raw = await _download_bytes(session, url=full_url, timeout_seconds=timeout_seconds)
     else:
         raise RuntimeError("media item had neither encrypt_query_param nor full_url")


### PR DESCRIPTION
## What does this PR do?

Validates `base_url` supplied by cron jobs against SSRF using the
existing `is_safe_url()` helper, with fail-closed behavior if the
module cannot be imported.

### SSRF protection

Cron jobs can supply a custom `base_url` override. Without validation,
a crafted URL like `http://169.254.169.254/latest/meta-data/` could
leak API keys to AWS IMDS or internal services.

**Fix:** Validates `_job_base_url` against `is_safe_url()` before use.

### Fail-closed ImportError handling

Previous version used `except ImportError: pass` — silently disabling
the security check if `tools.url_safety` failed to import.

As pointed out by @trevorgordon981, this means any import failure
(missing module, circular import, SyntaxError in a dependency) would
run the original vulnerable code path with zero log output.

**Fix:** `except ImportError` now calls `logger.error()` explicitly
and sets `_is_safe_url = None` — no job may supply a custom `base_url`
if the module fails to load.

```python
except ImportError:
    logger.error(
        "tools.url_safety could not be imported; job base_url overrides are "
        "disabled (fail-closed SSRF protection)"
    )
    _is_safe_url = None
    _job_base_url = None
```

## Type of Change

- [x] 🔒 Security fix (SSRF)
- [x] 🔒 Security fix (fail-closed ImportError handling)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Addresses @trevorgordon981 review feedback
- [x] Fail-closed — safer default when security module unavailable