### PR TITLE
fix(gateway): load Hermes env before standalone delivery config resolution

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -21,6 +21,30 @@ from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
+_ENV_LOADED = False
+
+
+def _ensure_hermes_env_loaded() -> None:
+    """Best-effort load of ~/.hermes/.env before resolving gateway platforms.
+
+    Standalone contexts such as cron delivery and direct-send helpers can call
+    ``load_gateway_config()`` without a launcher having sourced the Hermes env
+    file first. Reuse the shared Hermes env loader here so gateway config sees
+    the same env values and sanitization behavior as other entrypoints.
+    """
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return
+
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except Exception as e:
+        logger.debug("Failed to load Hermes env before gateway config: %s", e)
+    finally:
+        _ENV_LOADED = True
+
 
 def _coerce_bool(value: Any, default: bool = True) -> bool:
     """Coerce bool-ish config values, preserving a caller-provided default."""
@@ -442,6 +466,7 @@ def load_gateway_config() -> GatewayConfig:
     3. ~/.hermes/gateway.json (legacy — provides defaults under config.yaml)
     4. Built-in defaults
     """
+    _ensure_hermes_env_loaded()
     _home = get_hermes_home()
     gw_data: dict = {}
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -237,6 +237,31 @@ class TestDeliverResultWrapping:
         assert "Here is today's summary." in sent_content
         assert "The agent cannot see this message" in sent_content
 
+    def test_delivery_loads_hermes_env_for_standalone_gateway_config(self, monkeypatch, tmp_path):
+        """Standalone delivery should auto-load ~/.hermes/.env before resolving platforms."""
+        import gateway.config as gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text("TELEGRAM_BOT_TOKEN=test-token\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setattr(gateway_config, "_ENV_LOADED", False)
+
+        async_send = AsyncMock(return_value={"success": True})
+        with patch("tools.send_message_tool._send_to_platform", new=async_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "env-load-job",
+                "deliver": "telegram:123",
+            }
+            result = _deliver_result(job, "hello from standalone delivery")
+
+        assert result is None
+        assert os.environ["TELEGRAM_BOT_TOKEN"] == "test-token"
+        async_send.assert_awaited_once()
+
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
         from gateway.config import Platform


### PR DESCRIPTION
## What does this PR do?

Fixes standalone delivery paths that can call `gateway.config.load_gateway_config()` before `~/.hermes/.env` has been loaded into `os.environ`.

In that situation, credentials such as `TELEGRAM_BOT_TOKEN` may exist on disk but still be invisible to gateway config resolution, causing false delivery failures like:

- `platform 'telegram' not configured/enabled`

This PR takes the smallest project-native approach:
- add a small guard in `gateway/config.py`
- reuse the shared `hermes_cli.env_loader.load_hermes_dotenv()` helper
- keep the rest of gateway config resolution unchanged

This approach is the right one because Hermes already has a shared env-loading path with the correct sanitization and fallback behavior. Reusing it avoids adding an ad hoc dotenv parser or duplicating config-loading logic.

## Related Issue

No dedicated issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py`
  - add `_ensure_hermes_env_loaded()`
  - call it at the start of `load_gateway_config()`
  - reuse `hermes_cli.env_loader.load_hermes_dotenv()` so standalone gateway config resolution sees the same env values as other Hermes entrypoints
- `tests/cron/test_scheduler.py`
  - add a regression test covering standalone delivery when `TELEGRAM_BOT_TOKEN` exists only in `HERMES_HOME/.env`

## How to Test

1. Create a temporary `HERMES_HOME` with a `.env` file containing `TELEGRAM_BOT_TOKEN`, and ensure the variable is not already present in `os.environ`.
2. Trigger `_deliver_result()` through the standalone delivery path.
3. Verify delivery succeeds and run:
   - `pytest -n 0 tests/cron/test_scheduler.py -q`
   - `pytest -n 0 tests/cron/test_jobs.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation run:

```text
$ pytest -n 0 tests/cron/test_scheduler.py -q
62 passed in 1.46s

$ pytest -n 0 tests/cron/test_jobs.py -q
55 passed in 0.16s
```

Relevant failure mode before this fix:

```text
platform 'telegram' not configured/enabled
```
