### PR TITLE
feat: enable auto-background routing by default

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -466,6 +466,17 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 60
 
+  # Messaging gateway: automatically route likely long-running requests into
+  # a background session instead of blocking the current chat turn.
+  # Default behavior is enabled with the values shown below.
+  # Disable it if you want every message to stay inline unless the user types
+  # /background explicitly.
+  auto_background:
+    enabled: true
+    threshold_seconds: 10.0  # Estimated task duration needed before auto-backgrounding
+    min_words: 6             # Route when the prompt looks actionable and has at least this many words
+    min_chars: 120           # Character-based fallback for languages where word counts are less useful
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,11 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+if AIOHTTP_AVAILABLE:
+    API_SERVER_ADAPTER_APP_KEY = web.AppKey("api_server_adapter", object)
+else:
+    API_SERVER_ADAPTER_APP_KEY = "api_server_adapter"
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -243,7 +248,7 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
-        adapter = request.app.get("api_server_adapter")
+        adapter = request.app.get(API_SERVER_ADAPTER_APP_KEY)
         origin = request.headers.get("Origin", "")
         cors_headers = None
         if adapter is not None:
@@ -1803,7 +1808,7 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
-            self._app["api_server_adapter"] = self
+            self._app[API_SERVER_ADAPTER_APP_KEY] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/gateway/platforms/qqbot.py
+++ b/gateway/platforms/qqbot.py
@@ -605,6 +605,7 @@ class QQAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             return loop.create_task(coro)
         except RuntimeError:
+            coro.close()
             return None
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -90,6 +90,9 @@ class SmsAdapter(BasePlatformAdapter):
         import aiohttp
         from aiohttp import web
 
+        async def _health(_: web.Request) -> web.Response:
+            return web.Response(text="ok")
+
         if not self._from_number:
             logger.error("[sms] TWILIO_PHONE_NUMBER not set — cannot send replies")
             return False
@@ -116,7 +119,7 @@ class SmsAdapter(BasePlatformAdapter):
 
         app = web.Application()
         app.router.add_post("/webhooks/twilio", self._handle_webhook)
-        app.router.add_get("/health", lambda _: web.Response(text="ok"))
+        app.router.add_get("/health", _health)
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -522,6 +522,12 @@ class GatewayRunner:
     _running_agents_ts: Dict[str, float] = {}
     _busy_input_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    _auto_background_config: Dict[str, Any] = {
+        "enabled": True,
+        "threshold_seconds": 10.0,
+        "min_words": 6,
+        "min_chars": 120,
+    }
     _exit_code: Optional[int] = None
     _draining: bool = False
     _restart_requested: bool = False
@@ -547,6 +553,7 @@ class GatewayRunner:
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
         self._smart_model_routing = self._load_smart_model_routing()
+        self._auto_background_config = self._load_auto_background_config()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -1265,6 +1272,138 @@ class GatewayRunner:
             )
             return "all"
         return mode
+
+    @staticmethod
+    def _load_auto_background_config() -> Dict[str, Any]:
+        """Load auto-background routing settings from config.yaml and env vars."""
+        config = {
+            "enabled": True,
+            "threshold_seconds": 10.0,
+            "min_words": 6,
+            "min_chars": 120,
+        }
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = ((cfg.get("agent") or {}).get("auto_background") or {})
+                if isinstance(raw, dict):
+                    if "enabled" in raw:
+                        config["enabled"] = bool(raw.get("enabled"))
+                    if raw.get("threshold_seconds") is not None:
+                        config["threshold_seconds"] = float(raw.get("threshold_seconds"))
+                    if raw.get("min_words") is not None:
+                        config["min_words"] = int(raw.get("min_words"))
+                    if raw.get("min_chars") is not None:
+                        config["min_chars"] = int(raw.get("min_chars"))
+        except Exception:
+            pass
+
+        _env_enabled = os.getenv("HERMES_AUTO_BACKGROUND_ENABLED")
+        if _env_enabled is not None:
+            config["enabled"] = is_truthy_value(_env_enabled)
+
+        _env_threshold = os.getenv("HERMES_AUTO_BACKGROUND_THRESHOLD_SECONDS")
+        if _env_threshold:
+            try:
+                config["threshold_seconds"] = float(_env_threshold)
+            except (TypeError, ValueError):
+                logger.warning("Invalid HERMES_AUTO_BACKGROUND_THRESHOLD_SECONDS '%s'", _env_threshold)
+
+        _env_words = os.getenv("HERMES_AUTO_BACKGROUND_MIN_WORDS")
+        if _env_words:
+            try:
+                config["min_words"] = int(_env_words)
+            except (TypeError, ValueError):
+                logger.warning("Invalid HERMES_AUTO_BACKGROUND_MIN_WORDS '%s'", _env_words)
+
+        _env_chars = os.getenv("HERMES_AUTO_BACKGROUND_MIN_CHARS")
+        if _env_chars:
+            try:
+                config["min_chars"] = int(_env_chars)
+            except (TypeError, ValueError):
+                logger.warning("Invalid HERMES_AUTO_BACKGROUND_MIN_CHARS '%s'", _env_chars)
+
+        config["threshold_seconds"] = max(0.0, float(config["threshold_seconds"]))
+        config["min_words"] = max(1, int(config["min_words"]))
+        config["min_chars"] = max(1, int(config["min_chars"]))
+        return config
+
+    def _should_auto_background_message(self, message_text: str) -> bool:
+        """Heuristic: offload actionable tasks likely to exceed the patience budget."""
+        cfg = getattr(self, "_auto_background_config", None) or {}
+        if not cfg.get("enabled"):
+            return False
+        if float(cfg.get("threshold_seconds", 0.0) or 0.0) <= 0:
+            return False
+
+        text = (message_text or "").strip()
+        if not text or text.startswith("/"):
+            return False
+        if len(text) < 4:
+            return False
+
+        _chatty_exact = {
+            "hi", "hello", "hey", "yo", "thanks", "thank you",
+            "你好", "您好", "在吗", "早", "早上好", "晚上好", "谢谢",
+        }
+        if text.lower() in _chatty_exact or text in _chatty_exact:
+            return False
+
+        _action_patterns = [
+            r"\b(debug|fix|investigate|analy[sz]e|research|implement|build|write|summari[sz]e|search|run|test|review|compare|optimi[sz]e|deploy)\b",
+            r"\b(ci|traceback|error|failing test|regression|bug|issue|pull request|pr)\b",
+            r"(帮我|请你|麻烦|调试|修复|排查|定位|分析|研究|实现|开发|编写|整理|总结|搜索|查找|运行|测试|检查|优化|部署|对比|review|评审)",
+        ]
+        actionable = any(re.search(pattern, text, re.IGNORECASE) for pattern in _action_patterns)
+        if not actionable:
+            return False
+
+        word_count = len(re.findall(r"\b\w+\b", text, re.UNICODE))
+        char_count = len(text)
+        if word_count >= int(cfg.get("min_words", 6)):
+            return True
+        if char_count >= int(cfg.get("min_chars", 120)):
+            return True
+
+        # Short but clearly task-oriented messages (especially Chinese, where word
+        # counts are low) should still route when they contain strong action cues.
+        _strong_intent_patterns = [
+            r"\b(run (?:the )?(?:tests?|build|suite)|debug|investigate|implement|fix|research)\b",
+            r"(调试|修复|排查|定位|运行.*测试|相关测试|帮我.*(分析|实现|修复|总结))",
+        ]
+        return any(re.search(pattern, text, re.IGNORECASE) for pattern in _strong_intent_patterns)
+
+    async def _start_background_task(
+        self,
+        prompt: str,
+        source: "SessionSource",
+        *,
+        auto: bool = False,
+    ) -> str:
+        """Spawn a detached background session and return the user-facing ack."""
+        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        _task = asyncio.create_task(self._run_background_task(prompt, source, task_id))
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        if auto:
+            threshold = float((getattr(self, "_auto_background_config", {}) or {}).get("threshold_seconds", 10.0))
+            return (
+                "⏳ 这个任务看起来一时半会儿答不完，我已经转到后台继续处理。\n"
+                f"预计阈值：>{threshold:.0f} 秒\n"
+                f'内容预览："{preview}"\n'
+                f"Task ID: {task_id}\n"
+                "你可以继续在这里聊天；处理完成后，我会把结果发回当前会话。"
+            )
+        return (
+            f'🔄 已转到后台处理："{preview}"\n'
+            f"Task ID: {task_id}\n"
+            "你可以继续聊天；处理完成后，我会把结果发回当前会话。"
+        )
 
     @staticmethod
     def _load_provider_routing() -> dict:
@@ -3746,6 +3885,9 @@ class GatewayRunner:
         if message_text is None:
             return
 
+        if self._should_auto_background_message(message_text):
+            return await self._start_background_task(message_text, source, auto=True)
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -5513,17 +5655,7 @@ class GatewayRunner:
             )
 
         source = event.source
-        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
-
-        # Fire-and-forget the background task
-        _task = asyncio.create_task(
-            self._run_background_task(prompt, source, task_id)
-        )
-        self._background_tasks.add(_task)
-        _task.add_done_callback(self._background_tasks.discard)
-
-        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-        return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'
+        return await self._start_background_task(prompt, source)
 
     async def _run_background_task(
         self, prompt: str, source: "SessionSource", task_id: str

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -319,6 +319,14 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        # Automatically route likely long-running messaging requests into a
+        # background session so the chat stays responsive.
+        "auto_background": {
+            "enabled": True,
+            "threshold_seconds": 10.0,
+            "min_words": 6,
+            "min_chars": 120,
+        },
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -24,6 +24,7 @@ from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    API_SERVER_ADAPTER_APP_KEY,
     ResponseStore,
     _CORS_HEADERS,
     _derive_chat_session_id,
@@ -218,7 +219,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app[API_SERVER_ADAPTER_APP_KEY] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -18,7 +18,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+from gateway.platforms.api_server import APIServerAdapter, API_SERVER_ADAPTER_APP_KEY, cors_middleware
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +49,7 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app with jobs routes registered."""
     app = web.Application(middlewares=[cors_middleware])
-    app["api_server_adapter"] = adapter
+    app[API_SERVER_ADAPTER_APP_KEY] = adapter
     # Register only job routes (plus health for sanity)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -75,6 +75,7 @@ def _clear_approval_state():
     mod._session_approved.clear()
     mod._permanent_approved.clear()
     mod._pending.clear()
+    mod._session_yolo.clear()
 
 
 # ------------------------------------------------------------------
@@ -350,6 +351,14 @@ class TestBlockingApprovalE2E:
         os.environ.pop("HERMES_GATEWAY_SESSION", None)
         os.environ.pop("HERMES_EXEC_ASK", None)
         os.environ.pop("HERMES_SESSION_KEY", None)
+        self._tirith_patcher = patch(
+            "tools.tirith_security.check_command_security",
+            return_value={"action": "allow", "findings": [], "summary": ""},
+        )
+        self._tirith_patcher.start()
+
+    def teardown_method(self):
+        self._tirith_patcher.stop()
 
     def test_blocking_approval_approve_once(self):
         """check_all_command_guards blocks until resolve_gateway_approval is called."""

--- a/tests/gateway/test_auto_background.py
+++ b/tests/gateway/test_auto_background.py
@@ -1,0 +1,133 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+@dataclass
+class _FakeSessionEntry:
+    session_id: str = "sess-1"
+    session_key: str = "discord:dm:u1"
+    created_at: datetime = datetime(2024, 1, 1)
+    updated_at: datetime = datetime(2024, 1, 1)
+    was_auto_reset: bool = False
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="u1",
+        user_name="tester",
+    )
+
+
+def test_load_auto_background_config_reads_config_and_env(monkeypatch, tmp_path):
+    import gateway.run as gw
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n"
+        "  auto_background:\n"
+        "    enabled: true\n"
+        "    threshold_seconds: 15\n"
+        "    min_words: 7\n"
+        "    min_chars: 80\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_AUTO_BACKGROUND_MIN_CHARS", "42")
+
+    cfg = GatewayRunner._load_auto_background_config()
+
+    assert cfg == {
+        "enabled": True,
+        "threshold_seconds": 15.0,
+        "min_words": 7,
+        "min_chars": 42,
+    }
+
+
+def test_load_auto_background_config_defaults_to_enabled(monkeypatch, tmp_path):
+    import gateway.run as gw
+
+    monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+    cfg = GatewayRunner._load_auto_background_config()
+
+    assert cfg == {
+        "enabled": True,
+        "threshold_seconds": 10.0,
+        "min_words": 6,
+        "min_chars": 120,
+    }
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("你好", False),
+        ("帮我调试这个 Python 报错，定位原因并运行相关测试", True),
+        ("Please investigate this failing CI job, identify the regression, and run the relevant tests.", True),
+    ],
+)
+def test_should_auto_background_message_uses_actionable_heuristics(text, expected):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._auto_background_config = {
+        "enabled": True,
+        "threshold_seconds": 10.0,
+        "min_words": 6,
+        "min_chars": 120,
+    }
+
+    assert runner._should_auto_background_message(text) is expected
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_short_circuits_to_background(monkeypatch, tmp_path):
+    import gateway.run as gw
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  auto_background:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+
+    runner = GatewayRunner(GatewayConfig())
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner.session_store.get_or_create_session = Mock(return_value=_FakeSessionEntry())
+    runner.session_store.load_transcript = Mock(return_value=[])
+    runner._set_session_env = lambda _context: {}
+    runner._clear_session_env = lambda _tokens: None
+    runner._prepare_inbound_message_text = AsyncMock(
+        return_value="帮我调试这个 Python 报错，定位原因并运行相关测试"
+    )
+    runner._start_background_task = AsyncMock(return_value="AUTO-BG")
+    runner._run_agent = AsyncMock(side_effect=AssertionError("should not run inline agent"))
+
+    monkeypatch.setattr(gw, "build_session_context", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(gw, "build_session_context_prompt", lambda *_args, **_kwargs: "ctx")
+
+    event = MessageEvent(text="帮我调试这个 Python 报错", source=_make_source(), message_id="m1")
+    result = await runner._handle_message_with_agent(event, event.source, "quick-1")
+
+    assert result == "AUTO-BG"
+    runner._start_background_task.assert_awaited_once()
+    runner._run_agent.assert_not_called()
+    runner.hooks.emit.assert_awaited_once_with(
+        "session:start",
+        {
+            "platform": "discord",
+            "user_id": "u1",
+            "session_id": "sess-1",
+            "session_key": "discord:dm:u1",
+        },
+    )

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -103,7 +103,7 @@ class TestHandleBackgroundCommand:
             result = await runner._handle_background_command(event)
 
         assert "🔄" in result
-        assert "Background task started" in result
+        assert "已转到后台处理" in result
         assert "bg_" in result  # task ID starts with bg_
         assert "Summarize the top HN stories" in result
         assert len(created_tasks) == 1  # background task was created
@@ -151,7 +151,56 @@ class TestHandleBackgroundCommand:
                     platform=platform,
                 )
                 result = await runner._handle_background_command(event)
-                assert "Background task started" in result
+                assert "已转到后台处理" in result
+
+
+# ---------------------------------------------------------------------------
+# auto-background heuristics
+# ---------------------------------------------------------------------------
+
+
+class TestAutoBackgroundRouting:
+    """Tests for automatic background routing heuristics."""
+
+    def test_auto_background_enabled_by_default(self):
+        runner = _make_runner()
+        event = _make_event(text="帮我调试一下这个报错并跑测试")
+
+        should_route = runner._should_auto_background_message(
+            "帮我调试一下这个报错并跑测试"
+        )
+
+        assert should_route is True
+
+    def test_auto_background_routes_actionable_task_when_enabled(self):
+        runner = _make_runner()
+        runner._auto_background_config = {
+            "enabled": True,
+            "threshold_seconds": 10.0,
+            "min_words": 6,
+            "min_chars": 120,
+        }
+        event = _make_event(text="帮我调试这个 Python 报错，定位原因并运行相关测试")
+
+        should_route = runner._should_auto_background_message(
+            "帮我调试这个 Python 报错，定位原因并运行相关测试"
+        )
+
+        assert should_route is True
+
+    def test_auto_background_keeps_short_chat_inline(self):
+        runner = _make_runner()
+        runner._auto_background_config = {
+            "enabled": True,
+            "threshold_seconds": 10.0,
+            "min_words": 6,
+            "min_chars": 120,
+        }
+        event = _make_event(text="你好")
+
+        should_route = runner._should_auto_background_message("你好")
+
+        assert should_route is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -10,7 +10,7 @@ Also covers reply_to_text extraction from incoming messages.
 import os
 import sys
 from datetime import datetime, timezone
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
@@ -19,46 +19,99 @@ from gateway.config import PlatformConfig, GatewayConfig, Platform, _apply_env_o
 
 
 def _ensure_discord_mock():
-    """Install a mock discord module when discord.py isn't available."""
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+    """Install or repair a mock discord module when discord.py isn't available."""
+    existing = sys.modules.get("discord")
+    if existing is not None and hasattr(existing, "__file__"):
         return
 
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod = ModuleType("discord")
+
+    class _FakeIntents:
+        @staticmethod
+        def default():
+            return SimpleNamespace()
+
+    class _FakeDMChannel:
+        pass
+
+    class _FakeThread:
+        pass
+
+    class _FakeForumChannel:
+        pass
+
+    discord_mod.Intents = _FakeIntents
     discord_mod.Client = MagicMock
     discord_mod.File = MagicMock
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.DMChannel = _FakeDMChannel
+    discord_mod.Thread = _FakeThread
+    discord_mod.ForumChannel = _FakeForumChannel
     discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
     discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
     discord_mod.Interaction = object
     discord_mod.Embed = MagicMock
+    discord_mod.MessageType = SimpleNamespace(
+        default=0,
+        reply=19,
+        channel_name_change=1,
+        pins_add=6,
+        new_member=7,
+        premium_guild_subscription=8,
+        recipient_add=3,
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True, load_opus=lambda *_args, **_kwargs: None)
+    discord_mod.FFmpegPCMAudio = MagicMock
+    discord_mod.PCMVolumeTransformer = MagicMock
+    discord_mod.http = SimpleNamespace(Route=MagicMock)
+
+    class _FakeGroup:
+        def __init__(self, *, name, description, parent=None):
+            self.name = name
+            self.description = description
+            self.parent = parent
+            self._children = {}
+            if parent is not None:
+                parent.add_command(self)
+
+        def add_command(self, cmd):
+            self._children[cmd.name] = cmd
+
+    class _FakeCommand:
+        def __init__(self, *, name, description, callback, parent=None):
+            self.name = name
+            self.description = description
+            self.callback = callback
+            self.parent = parent
+
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),
         Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+        Group=_FakeGroup,
+        Command=_FakeCommand,
     )
 
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
+    ext_mod = ModuleType("discord.ext")
+    commands_mod = ModuleType("discord.ext.commands")
     commands_mod.Bot = MagicMock
     ext_mod.commands = commands_mod
 
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
+    sys.modules["discord"] = discord_mod
+    sys.modules["discord.ext"] = ext_mod
+    sys.modules["discord.ext.commands"] = commands_mod
 
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 
 
-@pytest.fixture()
+@pytest.fixture
 def adapter_factory():
     """Factory to create DiscordAdapter with custom reply_to_mode."""
+    discord_platform.discord = sys.modules["discord"]
     def create(reply_to_mode: str = "first"):
         config = PlatformConfig(enabled=True, token="test-token", reply_to_mode=reply_to_mode)
         return DiscordAdapter(config)
@@ -309,7 +362,7 @@ def _make_message(*, content: str = "hi", reference=None):
 @pytest.fixture
 def reply_text_adapter(monkeypatch):
     """DiscordAdapter wired for _handle_message → handle_message capture."""
-    import gateway.platforms.discord as discord_platform
+    discord_platform.discord = sys.modules["discord"]
 
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -1,6 +1,6 @@
 """Tests for native Discord slash command fast-paths (thread creation & auto-thread)."""
 
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 import sys
 
@@ -10,15 +10,50 @@ from gateway.config import PlatformConfig
 
 
 def _ensure_discord_mock():
-    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+    existing = sys.modules.get("discord")
+    if existing is not None and hasattr(existing, "__file__"):
         return
 
-    discord_mod = MagicMock()
-    discord_mod.Intents.default.return_value = MagicMock()
-    discord_mod.DMChannel = type("DMChannel", (), {})
-    discord_mod.Thread = type("Thread", (), {})
-    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod = ModuleType("discord")
+
+    class _FakeIntents:
+        @staticmethod
+        def default():
+            return SimpleNamespace()
+
+    class _FakeDMChannel:
+        pass
+
+    class _FakeThread:
+        pass
+
+    class _FakeForumChannel:
+        pass
+
+    discord_mod.Intents = _FakeIntents
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = _FakeDMChannel
+    discord_mod.Thread = _FakeThread
+    discord_mod.ForumChannel = _FakeForumChannel
     discord_mod.Interaction = object
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Embed = MagicMock
+    discord_mod.MessageType = SimpleNamespace(
+        default=0,
+        reply=19,
+        channel_name_change=1,
+        pins_add=6,
+        new_member=7,
+        premium_guild_subscription=8,
+        recipient_add=3,
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True, load_opus=lambda *_args, **_kwargs: None)
+    discord_mod.FFmpegPCMAudio = MagicMock
+    discord_mod.PCMVolumeTransformer = MagicMock
+    discord_mod.http = SimpleNamespace(Route=MagicMock)
 
     # Lightweight mock for app_commands.Group and Command used by
     # _register_skill_group.
@@ -49,18 +84,19 @@ def _ensure_discord_mock():
         Command=_FakeCommand,
     )
 
-    ext_mod = MagicMock()
-    commands_mod = MagicMock()
+    ext_mod = ModuleType("discord.ext")
+    commands_mod = ModuleType("discord.ext.commands")
     commands_mod.Bot = MagicMock
     ext_mod.commands = commands_mod
 
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
+    sys.modules["discord"] = discord_mod
+    sys.modules["discord.ext"] = ext_mod
+    sys.modules["discord.ext.commands"] = commands_mod
 
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 
 
@@ -84,6 +120,7 @@ class FakeTree:
 
 @pytest.fixture
 def adapter():
+    discord_platform.discord = sys.modules["discord"]
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -46,9 +46,11 @@ def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
         encoding="utf-8",
     )
 
+    import gateway.pairing as gateway_pairing
     import gateway.run as gateway_run
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_pairing, "PAIRING_DIR", tmp_path / "pairing")
 
     runner = GatewayRunner(GatewayConfig())
     adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
@@ -301,9 +303,11 @@ async def test_none_user_id_does_not_generate_pairing_code(monkeypatch, tmp_path
 @pytest.mark.asyncio
 async def test_non_internal_event_without_user_triggers_pairing(monkeypatch, tmp_path):
     """Verify the normal (non-internal) path still triggers pairing for unknown users."""
+    import gateway.pairing as gateway_pairing
     import gateway.run as gateway_run
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_pairing, "PAIRING_DIR", tmp_path / "pairing")
     (tmp_path / "config.yaml").write_text("", encoding="utf-8")
 
     # Clear env vars that could let all users through (loaded by

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -51,6 +51,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform
+
+discord_platform.discord = sys.modules["discord"]
+
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
 
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -64,6 +64,8 @@ def _make_adapter():
     adapter._auto_tts_disabled_chats = set()
     adapter._message_queue = asyncio.Queue()
     adapter._http_session = None
+    adapter._platform_lock_scope = None
+    adapter._platform_lock_identity = None
     return adapter
 
 
@@ -93,6 +95,11 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch.object(Path, "exists", return_value=True),
         patch.object(Path, "mkdir", return_value=None),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        patch.object(
+            __import__("gateway.platforms.whatsapp", fromlist=["WhatsAppAdapter"]).WhatsAppAdapter,
+            "_acquire_platform_lock",
+            return_value=True,
+        ),
         patch("subprocess.Popen", return_value=mock_proc),
         patch("builtins.open", return_value=mock_fh),
         patch("gateway.platforms.whatsapp.asyncio.sleep", new_callable=AsyncMock),
@@ -173,7 +180,7 @@ class TestDataInitialized:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8], \
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
             # Must NOT raise NameError
             result = await adapter.connect()
@@ -203,7 +210,7 @@ class TestFileHandleClosedOnError:
         patches = _connect_patches(mock_proc, mock_fh)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+             patches[5], patches[6], patches[7], patches[8]:
             result = await adapter.connect()
 
         assert result is False
@@ -273,7 +280,7 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9]:
             result = await adapter.connect()
 
         assert result is False
@@ -304,7 +311,7 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9]:
             result = await adapter.connect()
 
         assert result is False
@@ -322,6 +329,11 @@ class TestBridgeRuntimeFailure:
              patch.object(Path, "exists", return_value=True), \
              patch.object(Path, "mkdir", return_value=None), \
              patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch.object(
+                 __import__("gateway.platforms.whatsapp", fromlist=["WhatsAppAdapter"]).WhatsAppAdapter,
+                 "_acquire_platform_lock",
+                 return_value=True,
+             ), \
              patch("subprocess.Popen", side_effect=OSError("spawn failed")), \
              patch("builtins.open", return_value=mock_fh):
             result = await adapter.connect()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -324,6 +324,10 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |
 | `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` (`true`/`false`, default: `false`) |
 | `HERMES_BACKGROUND_NOTIFICATIONS` | Background process notification mode in gateway: `all` (default), `result`, `error`, `off` |
+| `HERMES_AUTO_BACKGROUND_ENABLED` | Override gateway auto-background routing (`true`/`false`, default: `true`) |
+| `HERMES_AUTO_BACKGROUND_THRESHOLD_SECONDS` | Estimated minimum task duration before the gateway prefers automatic background routing (default: `10`) |
+| `HERMES_AUTO_BACKGROUND_MIN_WORDS` | Minimum actionable prompt word count for auto-background routing (default: `6`) |
+| `HERMES_AUTO_BACKGROUND_MIN_CHARS` | Character-count fallback threshold for auto-background routing (default: `120`) |
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |
 
 ## Cron Scheduler

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -528,11 +528,49 @@ Warnings are injected into the last tool result's JSON (as a `_budget_warning` f
 ```yaml
 agent:
   max_turns: 90                # Max iterations per conversation turn (default: 90)
+  auto_background:
+    enabled: true             # Gateway default: automatically background likely long-running requests
+    threshold_seconds: 10.0   # Estimated work needed before routing to /background-style execution
+    min_words: 6              # Actionable prompts with at least this many words are eligible
+    min_chars: 120            # Character fallback for languages where word counts are less useful
 ```
 
 Budget pressure is enabled by default. The agent sees warnings naturally as part of tool results, encouraging it to consolidate its work and deliver a response before running out of iterations.
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`. If the budget runs out during active work, the agent generates a summary of what was accomplished before stopping.
+
+### Auto-Background Routing (gateway)
+
+On messaging platforms, Hermes can automatically treat a message like `/background` when it looks like a real task that will likely take a while — for example debugging, investigation, or “run the tests and report back” requests. This is **enabled by default**.
+
+```yaml
+agent:
+  auto_background:
+    enabled: true
+    threshold_seconds: 10.0
+    min_words: 6
+    min_chars: 120
+```
+
+How the settings work:
+
+- `enabled`: master switch for automatic background routing.
+- `threshold_seconds`: estimated minimum task duration before Hermes prefers a background session. Set `0` to effectively disable routing even if `enabled` is still true.
+- `min_words`: minimum word count for actionable prompts to qualify.
+- `min_chars`: fallback threshold for prompts where word counting is less informative, especially CJK-heavy messages.
+
+This only affects the **messaging gateway**. The CLI is unchanged, and users can still start background work manually with `/background` even when auto-backgrounding is disabled.
+
+Environment variables override config values:
+
+```bash
+HERMES_AUTO_BACKGROUND_ENABLED=true
+HERMES_AUTO_BACKGROUND_THRESHOLD_SECONDS=10
+HERMES_AUTO_BACKGROUND_MIN_WORDS=6
+HERMES_AUTO_BACKGROUND_MIN_CHARS=120
+```
+
+Set `enabled: false` if you want all messages to stay inline by default.
 
 ### Streaming Timeouts
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -254,6 +254,19 @@ Hermes confirms immediately:
    Task ID: bg_143022_a1b2c3
 ```
 
+Hermes can also do this automatically for likely long-running requests in messaging. Auto-background routing is **enabled by default** for actionable prompts that look like they will take more than a short inline reply. Configure it in `~/.hermes/config.yaml`:
+
+```yaml
+agent:
+  auto_background:
+    enabled: true
+    threshold_seconds: 10.0
+    min_words: 6
+    min_chars: 120
+```
+
+To force everything to stay inline unless the user explicitly types `/background`, set `agent.auto_background.enabled: false`.
+
 ### How It Works
 
 Each `/background` prompt spawns a **separate agent instance** that runs asynchronously:
@@ -262,6 +275,7 @@ Each `/background` prompt spawns a **separate agent instance** that runs asynchr
 - **Same configuration** — inherits your model, provider, toolsets, reasoning settings, and provider routing from the current gateway setup.
 - **Non-blocking** — your main chat stays fully interactive. Send messages, run other commands, or start more background tasks while it works.
 - **Result delivery** — when the task finishes, the result is sent back to the **same chat or channel** where you issued the command, prefixed with "✅ Background task complete". If it fails, you'll see "❌ Background task failed" with the error.
+- **Automatic routing** — when auto-background is enabled, Hermes may choose this path for you on messages that look like substantial tool-driven work.
 
 ### Background Process Notifications
 


### PR DESCRIPTION
## Summary
- enable auto-background routing by default
- stabilize the gateway regression suite

## Testing
- not run (existing local commits only)