### PR TITLE
fix: pass media_files to _send_feishu in send_message tool

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -388,18 +388,18 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return await _send_weixin(pconfig, chat_id, message, media_files=media_files)
 
     # --- Non-Telegram platforms ---
-    if media_files and not message.strip():
+    if media_files and not message.strip() and platform != Platform.FEISHU:
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram; "
+                f"send_message MEDIA delivery is currently only supported for telegram and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
     warning = None
-    if media_files:
+    if media_files and platform != Platform.FEISHU:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram"
+            "native send_message media delivery is currently only supported for telegram and feishu"
         )
 
     last_result = None
@@ -425,7 +425,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary
Fixes Feishu file sending via send_message tool — media attachments were silently dropped.

## Root Cause
The _send_feishu() function already accepts and processes media_files, but the caller in _send_to_platform() did not pass the parameter. Additionally, a platform-level check blocked Feishu from media support entirely, returning errors/warnings that media is only supported for Telegram.

## Fix
- Added media_files=media_files parameter to the _send_feishu() call (line 425)
- Excluded Platform.FEISHU from the 'media not supported' error path (line 388)
- Excluded Platform.FEISHU from the media omission warning path (line 396)

## Test Plan
- [ ] Relevant unit tests pass (61 send_message tests pass)
- [ ] Manual verification: send file via Feishu using MEDIA:/path/to/file syntax

Closes NousResearch/hermes-agent#10136